### PR TITLE
[storage/journal] Durably record the pruning boundary for recovery

### DIFF
--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -52,19 +52,19 @@ hash = "13b3e99a8c74b50dc18150194a92306de670b94e6642758feb6d9b6e9881f827"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmbWorkload>"]
 n_cases = 256
-hash = "74d03c4e36ba59834df32aa131bc6ad659dc55b1dab5e5926b9aa033d0ed821f"
+hash = "09ef68a7c611fdddd3f50a652a50f5f2285df1cb4d013758244b1d5208200f48"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmrWorkload>"]
 n_cases = 256
-hash = "9eec5df6e9016f6d3fb2317bc0d1e0a969ee3ef6efa4ee6a04770a1e533116b8"
+hash = "957528c511c98526b446682f08b02ce2584fe5cd8ae28a3c7bbef4df51451643"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousFixedWorkload>"]
 n_cases = 512
-hash = "627ba252d6f69ef04e74cc493024712e8701ffc3fc27576858eb67995532e5a9"
+hash = "6447f8cef7cf37a8630fda92d20ba3699af77836232116b49c682e1195d6f8ad"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousVariableWorkload>"]
 n_cases = 512
-hash = "595d3b70ca5c4482669d6d1356b63870f319a78b9365211517b03b526eb25f64"
+hash = "5b2544c90344ef545d934294a9e3ac15209b0562bc419bf2de1493e81d263ac0"
 
 ["commonware_storage::journal::conformance::StorageConformance<SegmentedFixedWorkload>"]
 n_cases = 512
@@ -92,11 +92,11 @@ hash = "4078ce1f5e242f8edb1d41575d51e166af620404036124f8094fc74d4b401047"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmbFullWorkload>"]
 n_cases = 256
-hash = "e1bb3e91b15311352a0696ab40600747292876fcaf3f8e1188d071d603761b7d"
+hash = "e70b383bae642ebce9ab36851e671b90a7e3f4fb08f7985c037ce63dfbe60281"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmrFullWorkload>"]
 n_cases = 256
-hash = "a6e586229899a2361b90cb2a208953ecaec6b23c98ec356d4a50c57be5eeb645"
+hash = "82de36ff726be9938d37eec0da7462f40767c1c0b0d50581b8063b73cf9cb384"
 
 ["commonware_storage::merkle::mmr::proof::tests::conformance::CodecConformance<Proof<Family,Sha256Digest>>"]
 n_cases = 65536
@@ -300,131 +300,131 @@ hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "8865dbff79b343e15be6248f7c9b9ecbcee4ce62fc6ce6ad74a10aeba0b037ca"
+hash = "4455e1c211dee60b7747f5e9feda5097bb02706a77b8d514cf3b92b06e2c884c"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "08fa4a62f53a26a2bdebd93302dcf961aab3f50b11a576239b9e65cfb135a7e0"
+hash = "fd4bea9f5e075b3df215fde79feb5afcba3b7a204bcaea2d94615a88e6d5c124"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "e27ea4efaa3ca3fb1a9bda6e1e4989f6636f9b064aabbbca70dbaab906f0bc01"
+hash = "94da5e3acc8c6e95e034d2d0dc8aa53f7a0fae25ac0b953ff0f0bd85617b60f2"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "4bcfc84a06a52c0a27de3d1bf87ffce490a0fe2150bd5350908c49020c5e820d"
+hash = "bbd2626b2b30816704b4f630e190fcc2812200774e68aff2561e38ebfccacd26"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "2c31e793a22f349c713cbe43fae4494ee39b9eb91e7085ee1ba9add1509c1b6b"
+hash = "d08fee3fdd7c0a28b671ea9a31fd0d9a1db0c300535213c448531f51d57929ea"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "45cb75ee32c6455b2cbefbc9e6c791f782f1992e39713b548c7d61894597a4d8"
+hash = "7873145822ead2aee2bae9a23fb21e147cfc5fcf14ca82d8180a4aea84994751"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "6ec3a1e38743976cf2132583e80dce3429ea8cc59b8a765a7eb293eaeddb3055"
+hash = "ac92cf0083384b995d5494c7ed755da15c096b7237d982f9e4784ca40e4ad0ab"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "3025d50d87c472227cc38a59c939454f2c9ca07d5c4b8fe614a9a54d961c3f45"
+hash = "424a41e4c83824c1d96955b2c17c39cb3093fa606624bb711725e6771d72f252"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "52203c4160810631e6f8f02697970ed2db6a15be433be848eeb3de311a5ca1ac"
+hash = "d16ae606c70b0ebee4de825c8bbdab1ff39388a3c477d21828667593719a2578"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "9b859e3d42869a0305e538584d914b691fc7a236de01ce3da68093eb26111aba"
+hash = "daec073ff1ed335711bcea47f2b09d6460479ffe844b573b521cb70bac0dc46f"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "a33d79be75ae3db4f7c8f706cbb9707326adf070cb67ddf673fabcd17afab6eb"
+hash = "1dc7af1e6d8a8c3f5e98418f2fa71376a1257cb95623bfac8aad27d2d0169637"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "244811c362aa673e3f573f233b58c379671c64c26784acbb49343a3144fb90b0"
+hash = "94cc4d90b01a77e578e10a9366bb40546062e309371fb9ff1fd945a8dfab9821"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "abb6e4b1281d59e7fb5a223bc906c1989b3fd652533c2f94bea14c1b8cf4de08"
+hash = "e30d27b12ee37b7de6f9ae35773b7069a34626bd69527a88654a87a34c3213ec"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "f2f7bd0129408519e54778487759de2e8ea7dedc239229cf389529f5e1621179"
+hash = "a47c0234abcb0e61c5915695223ea2666c459c79da4b776b541e85313d6831be"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "7bf844eb896054ec13e2912e53c26f464fa56ac7431e1f7200cd6a8a4dcec944"
+hash = "d68a86a8601da83bb60b0b04f7b50df5881ace0b82c3acefe17524b66c4e26f7"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "02d3fa9305fed943c9ade46fe6c6e9eba9c06621aa120f02bbd79b3f81589540"
+hash = "2ca587ce1475a18cc4298ba86ec04c9aa876ca55eeaf2a00edd4825c888ea2ac"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactFixedStorage>"]
 n_cases = 64
-hash = "a0c9acaef2b9fada1d623fb9bae7f7835539aebe408fdd0d801986c86eddd125"
+hash = "eba62ddd620593b21554b278b2b7a25e8b71a0ac083c270a7a9cf7afe759fe08"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactVariableStorage>"]
 n_cases = 64
-hash = "15bb7b90c800f1c8d27f9bec2ca765c9f14782a341bdcb9144e09d836c7cc8ca"
+hash = "230ba2bde654e75ed3b03c869be9452614a8847bad6b7edc9077493c78213328"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbFixedStorage>"]
 n_cases = 64
-hash = "312105a085f950c933da73418c5bb1e7595247d27e52a2c3c7589ac4db75cdeb"
+hash = "e26ab335232e91eea4b7b2ec4693e1557459a3ff4d23581970edc31cdefd5b71"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbVariableStorage>"]
 n_cases = 64
-hash = "83a12aee531340131135b182651b53de86325e71122796be29b6b9708acfdaa9"
+hash = "10e883cf5aff7d01207b1e41d7214787f58214daf69f8038fe053d0e3c206d6e"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactFixedStorage>"]
 n_cases = 64
-hash = "767a38711571e2893ff641f8ffce454b3dc890c4c848e711902b4c90a320646b"
+hash = "9a0375c4d7459bc885a95d408b340c2fd21a19a88f8dc1cc64ca47080cb74541"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactVariableStorage>"]
 n_cases = 64
-hash = "5d82b14cbc49e2cd878d0c683ea88219b04c20d90d76ddeae8793b6bae797f7a"
+hash = "bbb9b2029f22ad1a8ebcf7d56b629d69f87a6336a17e0a0e825cd7f91a95ce95"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrFixedStorage>"]
 n_cases = 64
-hash = "3cf7ae2e5798fc7c78699f59c835552b49ee8b4355f4e8d49cd9659ba20bfd21"
+hash = "17e7189063aefb1d7fba70f19e56f8056c878b6c477eaf297f5295114eae23d4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrVariableStorage>"]
 n_cases = 64
-hash = "9f48c1fa5f420774726c6271f3f1180ab293c5fdb39cfd3e7e1c3be3551d57fe"
+hash = "15031032405fea2371556f10914178d2f86ffed85d1829819ac390e1d4196e25"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactFixedStorage>"]
 n_cases = 64
-hash = "6a0b77ab225335c548d5c8e49cf41361c8900a116ddb5a2e68f581bd13cdf1cd"
+hash = "37d36d7f19f6f7c7e7d86ec9380666a278a67112e3c7209a72d8af2183ec2a60"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactVariableStorage>"]
 n_cases = 64
-hash = "418eec9ff6e231951bc5c9f0e6021f5af643bfed7859eb4695af403344eb6fcb"
+hash = "24ea97fda72e95b7a7e864bec96787af6508dd6071a0a7245504d34879df200a"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbFixedStorage>"]
 n_cases = 64
-hash = "46bb0f05abd856a34be672ee5ef1a319a1fc4bc724d9f45439b4490d43e071b8"
+hash = "467f6b37ce6910d15fdedcbeb5a37adbe9455ac86f07cdd6f8ee267aecd54f9e"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbVariableStorage>"]
 n_cases = 64
-hash = "98f24f75150d38e7c7151887dc0deb4ad5eb1190d1790ba304aaf78141e970f8"
+hash = "825010594b4aeea14b1b450d174fea61cca0f34191af8edef96cf3b90ff3b1d2"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactFixedStorage>"]
 n_cases = 64
-hash = "ee43661be83069608fe7b4c9956480efb6925ea1b51af1c2b1e71bbabfb0a9c1"
+hash = "08b18b45b2806a820993f86470b28dbca6f2e8880c46538e9bf67b81438b2229"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactVariableStorage>"]
 n_cases = 64
-hash = "3945b645594d6f803b7dc4279b8bb17e92ce23bbb30dae2e98646ceaa0f6425d"
+hash = "606895a36b4b451b35d6626994da3da4a1eac09e48bbe84993bb1dd8a4e6d05d"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrFixedStorage>"]
 n_cases = 64
-hash = "182b01f2749b189e6a4c14c3a5c10e1c06600c6aedf01496c119cd01fbd5ba0e"
+hash = "4eed2162666a7165e36c60ee51ee1a5823f3133927bd8a4308e5a7fe81289f27"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrVariableStorage>"]
 n_cases = 64
-hash = "a023b1399b8656e8e113787f935d10013606440d43c8cb7c818749f6f09fc2fd"
+hash = "e8fff8f1e79298a97f7b3cb3d6fb1ed23d53f0fdab05903211ce3cf875733f6e"
 
 ["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
 n_cases = 65536
@@ -508,4 +508,4 @@ hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::StorageConformance<QueueWorkload>"]
 n_cases = 512
-hash = "af39c4e1fccf63cac68a7866703d7764c3baf3be3e3906460dc4fab9c7ffd19d"
+hash = "5b80dfb32dfa15c6f79442989f356c3798f25c423a486f660a83f8d814b1d258"

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -152,6 +152,16 @@ pub(super) struct Writable<E: Context> {
 
     /// Sync of the live tail. Kept on failure so later operations keep failing.
     tail_sync: Option<SyncCompletion>,
+
+    /// Test-only: park [Self::seal_tail] at entry so tests can drop an append future at the
+    /// roll-over await, leaving the logical end ahead of the physical tail.
+    #[cfg(test)]
+    pub(super) halt_seal_tail: bool,
+
+    /// Test-only: park [Self::prune] after tracking advances but before any unlink, so tests
+    /// can drop a prune future that leaves every condemned file behind, untracked.
+    #[cfg(test)]
+    pub(super) halt_prune_unlinks: bool,
 }
 
 impl<E: Context> Writable<E> {
@@ -221,6 +231,10 @@ impl<E: Context> Writable<E> {
             sealed_snapshot: None,
             tail_predecessor_sync: None,
             tail_sync: None,
+            #[cfg(test)]
+            halt_seal_tail: false,
+            #[cfg(test)]
+            halt_prune_unlinks: false,
         })
     }
 
@@ -267,6 +281,11 @@ impl<E: Context> Writable<E> {
 
     /// Seal the tail, start syncing it, and open the next blob as the new tail.
     pub(super) async fn seal_tail(&mut self) -> Result<(), Error> {
+        #[cfg(test)]
+        if self.halt_seal_tail {
+            std::future::pending::<()>().await;
+        }
+
         self.drain_tail_predecessor_sync().await?;
         // seal() waits only for syncs the writer started: a commit whose flush failed before its
         // sync began is retained solely in the tail sync slot, so it must be drained here too.
@@ -290,9 +309,10 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
-    /// Drop every blob below `min_blob` and remove its file, oldest-first. Safe with live readers:
-    /// snapshot readers keep their own handles, which the runtime's read-after-remove contract keeps
-    /// valid.
+    /// Drop and remove every blob below `min_blob`.
+    ///
+    /// Safe with live readers: snapshot readers keep their own handles, which the runtime's
+    /// read-after-remove contract keeps valid.
     ///
     /// # Invariants
     ///
@@ -308,11 +328,18 @@ impl<E: Context> Writable<E> {
         self.sealed_snapshot = None;
         self.oldest_blob_index = min_blob;
 
-        for blob in prev_oldest_blob_index..min_blob {
-            self.partition.remove(blob).await?;
-            self.metrics.tracked.dec();
-            self.metrics.pruned.inc();
+        #[cfg(test)]
+        if self.halt_prune_unlinks {
+            std::future::pending::<()>().await;
         }
+
+        // Remove blobs concurrently. (Some backends serialize removals internally, so concurrency
+        // is an upper bound, not a guarantee.)
+        let partition = &self.partition;
+        try_join_all((prev_oldest_blob_index..min_blob).map(|blob| partition.remove(blob))).await?;
+
+        self.metrics.tracked.dec_by(drop_count as i64);
+        self.metrics.pruned.inc_by(drop_count as u64);
         Ok(())
     }
 
@@ -388,9 +415,9 @@ impl<E: Context> Writable<E> {
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
 
-        for blob in self.oldest_blob_index..=self.tail_blob_index() {
-            self.partition.remove(blob).await?;
-        }
+        // Remove the whole partition: a cancelled prune may leave untracked blob files
+        // whose contents would become visible again after resetting the boundary.
+        Partition::remove_all(&self.partition.context, &self.partition.name).await?;
         let _ = self.metrics.tracked.try_set(0);
         self.tail = self.partition.open(tail_blob).await?;
         self.metrics.tracked.inc();

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -5,9 +5,8 @@
 //! the first one that is missing or too short, since everything after a gap is unreachable.
 //! The [Checkpoint] records the three facts that blob state alone cannot provide:
 //!
-//! - The pruning boundary, when it falls mid-blob (from
-//!   [Journal::init_at_size](super::fixed::Journal::init_at_size)): recovery needs the exact
-//!   position where the oldest blob's items begin.
+//! - The pruning boundary: recovery needs the intended first retained position so it can
+//!   complete an interrupted prune instead of inferring intent from which blobs survive.
 //! - The recovery watermark: a floor on the journal size that has been durably recorded. Items
 //!   below the watermark must survive a crash; items above it may be replayed, discarded, or (after
 //!   an in-place rewind followed by new appends) decode to a value from neither the pre- nor
@@ -20,11 +19,20 @@
 //!
 //! [Checkpoint] is a passive store; the journal upholds these by ordering its calls:
 //!
-//! - An entry advances only after the blob state it describes is durable.
+//! - The pruning boundary advances before blobs are removed, committing the prune so recovery can
+//!   finish it after a crash.
+//! - The recovery watermark advances only after the blob state it describes is durable.
+//! - Except while a clear is staged or after adopting a legacy pruning boundary, the recovery
+//!   watermark never trails the pruning boundary (`boundary <= watermark <= size`). A prune records
+//!   the just-synced size as the watermark, so the watermark covers the retained items the boundary
+//!   exposes. Recovery relies on this: a durable watermark above the boundary proves those retained
+//!   items existed, so their loss is corruption rather than a completed prune. A staged clear may
+//!   temporarily lower the watermark below the old boundary; its clear target supersedes both.
+//!   A legacy checkpoint may also carry a sub-boundary watermark, which recovery treats as stale.
 //! - An entry is lowered before blob state moves backward (rewind, clear).
 //!
-//! Together they keep the checkpoint a safe under-estimate of what is on disk: recovery may find
-//! more durable data than the checkpoint claims, never less.
+//! Together they make backward operations recoverable without requiring blob presence alone to
+//! prove what the journal intended.
 
 use crate::{
     Context,
@@ -34,8 +42,8 @@ use crate::{
 use commonware_runtime::Handle;
 use commonware_utils::sequence::VecU64;
 
-/// Key for the mid-blob pruning boundary. Absent when the boundary is blob-aligned (it is then
-/// derived from the oldest blob).
+/// Key for the pruning boundary. Legacy checkpoints may omit blob-aligned boundaries, in which
+/// case recovery derives the boundary from the oldest blob once and persists it explicitly.
 const PRUNING_BOUNDARY_KEY: u64 = 1;
 
 /// Key for the target of an in-progress clear.
@@ -47,6 +55,11 @@ const RECOVERY_WATERMARK_KEY: u64 = 3;
 /// The journal's durable recovery checkpoint.
 pub(super) struct Checkpoint<E: Context> {
     metadata: Metadata<E, u64, VecU64>,
+
+    /// Test-only: park [Self::persist] after its durable sync so a test can drop a pending prune
+    /// future at the point where the boundary is durable but the call never returns.
+    #[cfg(test)]
+    pub(super) halt_after_persist_sync: bool,
 }
 
 impl<E: Context> Checkpoint<E> {
@@ -60,7 +73,11 @@ impl<E: Context> Checkpoint<E> {
             },
         )
         .await?;
-        Ok(Self { metadata })
+        Ok(Self {
+            metadata,
+            #[cfg(test)]
+            halt_after_persist_sync: false,
+        })
     }
 
     /// Read a `u64`-valued entry, if present.
@@ -73,7 +90,7 @@ impl<E: Context> Checkpoint<E> {
         self.get(RECOVERY_WATERMARK_KEY)
     }
 
-    /// The recorded mid-blob pruning boundary, if any.
+    /// The recorded pruning boundary, if any.
     pub(super) fn boundary_hint(&self) -> Option<u64> {
         self.get(PRUNING_BOUNDARY_KEY)
     }
@@ -84,19 +101,10 @@ impl<E: Context> Checkpoint<E> {
     }
 
     /// Durably record the boundary and watermark, writing only entries that changed.
-    pub(super) async fn persist(
-        mut self,
-        items_per_blob: u64,
-        boundary: u64,
-        watermark: u64,
-    ) -> Result<Self, Error> {
-        // A blob-aligned boundary is derived from the oldest blob, so the entry is only kept
-        // while the boundary is mid-blob.
-        if boundary.is_multiple_of(items_per_blob) {
-            if self.boundary_hint().is_some() {
-                self.metadata.remove(&PRUNING_BOUNDARY_KEY);
-            }
-        } else if self.boundary_hint() != Some(boundary) {
+    pub(super) async fn persist(mut self, boundary: u64, watermark: u64) -> Result<Self, Error> {
+        // Blob-aligned boundaries are recorded too (unlike the pre-two-phase-prune behavior),
+        // so recovery need not infer pruning from the oldest surviving blob.
+        if self.boundary_hint() != Some(boundary) {
             self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
         }
         if self.watermark() != Some(watermark) {
@@ -104,7 +112,14 @@ impl<E: Context> Checkpoint<E> {
         }
         // Always sync, even if this call staged nothing: `lower_watermark` stages without syncing,
         // so skipping the sync when our own entries are unchanged could drop that pending change.
-        self.sync().await
+        self = self.sync().await?;
+
+        #[cfg(test)]
+        if self.halt_after_persist_sync {
+            std::future::pending::<()>().await;
+        }
+
+        Ok(self)
     }
 
     /// Begin raising the watermark to `watermark`, returning a completion handle. A `watermark`
@@ -147,13 +162,9 @@ impl<E: Context> Checkpoint<E> {
 
     /// Durably complete a clear to `target`: drop the intent and record `target` as both the
     /// boundary and the watermark.
-    pub(super) async fn finish_clear(
-        mut self,
-        items_per_blob: u64,
-        target: u64,
-    ) -> Result<Self, Error> {
+    pub(super) async fn finish_clear(mut self, target: u64) -> Result<Self, Error> {
         self.metadata.remove(&CLEAR_TARGET_KEY);
-        self.persist(items_per_blob, target, target).await
+        self.persist(target, target).await
     }
 
     /// Make staged entries durable.
@@ -191,7 +202,7 @@ mod tests {
             }
         }
 
-        /// Set the mid-blob pruning boundary directly.
+        /// Set the pruning boundary directly.
         pub(crate) fn set_boundary_hint(&mut self, boundary: u64) {
             self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
         }
@@ -217,7 +228,7 @@ mod tests {
             assert!(!checkpoint.lower_watermark(5));
             assert_eq!(checkpoint.watermark(), None);
 
-            checkpoint = checkpoint.persist(10, 0, 8).await.unwrap();
+            checkpoint = checkpoint.persist(0, 8).await.unwrap();
             // Equal and higher limits are not lowerings.
             assert!(!checkpoint.lower_watermark(8));
             assert!(!checkpoint.lower_watermark(12));
@@ -234,8 +245,8 @@ mod tests {
         executor.start(|context| async move {
             {
                 let checkpoint = Checkpoint::open(context.child("a"), "rt").await.unwrap();
-                // A mid-blob boundary is kept; the watermark is recorded.
-                checkpoint.persist(10, 13, 25).await.unwrap();
+                // The boundary and watermark are recorded.
+                checkpoint.persist(13, 25).await.unwrap();
             }
             let checkpoint = Checkpoint::open(context.child("b"), "rt").await.unwrap();
             assert_eq!(checkpoint.boundary_hint(), Some(13));
@@ -245,19 +256,19 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_persist_boundary_hint_tracks_alignment() {
+    fn test_persist_boundary_hint_records_aligned_boundaries() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut checkpoint = Checkpoint::open(context, "align").await.unwrap();
 
-            // A mid-blob boundary is recorded as a hint.
-            checkpoint = checkpoint.persist(10, 13, 0).await.unwrap();
+            // A mid-blob boundary is recorded.
+            checkpoint = checkpoint.persist(13, 0).await.unwrap();
             assert_eq!(checkpoint.boundary_hint(), Some(13));
 
-            // A later blob-aligned boundary drops the stale hint (it is derived from the
-            // oldest blob).
-            checkpoint = checkpoint.persist(10, 20, 0).await.unwrap();
-            assert_eq!(checkpoint.boundary_hint(), None);
+            // Blob-aligned boundaries are also recorded so recovery need not infer pruning from
+            // the oldest surviving blob.
+            checkpoint = checkpoint.persist(20, 0).await.unwrap();
+            assert_eq!(checkpoint.boundary_hint(), Some(20));
         });
     }
 
@@ -267,7 +278,7 @@ mod tests {
         executor.start(|context| async move {
             {
                 let mut checkpoint = Checkpoint::open(context.child("a"), "clear").await.unwrap();
-                checkpoint = checkpoint.persist(10, 0, 30).await.unwrap();
+                checkpoint = checkpoint.persist(0, 30).await.unwrap();
                 // Staging records the intent and lowers the watermark to the target.
                 checkpoint = checkpoint.stage_clear(20).await.unwrap();
                 assert_eq!(checkpoint.clear_target(), Some(20));
@@ -278,13 +289,12 @@ mod tests {
                 let checkpoint = Checkpoint::open(context.child("b"), "clear").await.unwrap();
                 assert_eq!(checkpoint.clear_target(), Some(20));
                 // Completing drops the intent and records the target as boundary and watermark.
-                checkpoint.finish_clear(10, 20).await.unwrap();
+                checkpoint.finish_clear(20).await.unwrap();
             }
             let checkpoint = Checkpoint::open(context.child("c"), "clear").await.unwrap();
             assert_eq!(checkpoint.clear_target(), None);
             assert_eq!(checkpoint.watermark(), Some(20));
-            // 20 is blob-aligned, so no hint is retained.
-            assert_eq!(checkpoint.boundary_hint(), None);
+            assert_eq!(checkpoint.boundary_hint(), Some(20));
         });
     }
 
@@ -293,7 +303,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let mut checkpoint = Checkpoint::open(context, "sc").await.unwrap();
-            checkpoint = checkpoint.persist(10, 0, 5).await.unwrap();
+            checkpoint = checkpoint.persist(0, 5).await.unwrap();
 
             // Target above the current watermark: the intent is recorded but the watermark holds.
             checkpoint = checkpoint.stage_clear(9).await.unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -370,6 +370,11 @@ pub(super) struct Inner<E: Context, A> {
     /// The known-durable size of the journal.
     barrier: Barrier,
 
+    /// Test-only: park [Self::prune] after the boundary commit, before any removal, so tests
+    /// can drop the pending future at that exact point.
+    #[cfg(test)]
+    pub(in crate::journal::contiguous) halt_prune_removals: bool,
+
     _phantom: PhantomData<A>,
 }
 
@@ -410,6 +415,8 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             bounds,
             items_per_blob,
             metrics: Arc::new(metrics),
+            #[cfg(test)]
+            halt_prune_removals: false,
             _phantom: PhantomData,
         }
     }
@@ -445,6 +452,12 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         // are fixed size, so a blob ending in fewer than `CHUNK_SIZE` trailing bytes is junk
         // from an incomplete write (the page-CRC layer surfaces it as a partial logical tail).
         // The truncation is synced before `recover_bounds` queries lengths.
+        //
+        // This runs before the pruning boundary is reconciled, so the "a failed init leaves
+        // surviving blobs untouched" guarantee holds for crash-reachable states: a synced blob is
+        // chunk-aligned, so an in-model crash produces trailing bytes only on the unsynced tail. A
+        // blob mutated here despite a later corruption verdict implies external corruption of an
+        // already-durable blob, which is outside the crash model.
         for (&blob, writer) in &mut pending {
             let size = writer.size();
             let valid_size = Self::items_to_bytes(size / Self::CHUNK_SIZE_U64)?;
@@ -506,6 +519,16 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             writer.sync().await?;
         }
 
+        // Complete any interrupted prune (a committed boundary ahead of physical storage) and
+        // reconcile the pruning boundary before walking blob lengths.
+        let pruning_boundary = Self::reconcile_pruning_boundary(
+            &partition,
+            &mut pending,
+            cfg.items_per_blob.get(),
+            checkpoint.boundary_hint(),
+        )
+        .await?;
+
         let RecoveredBounds {
             pruning_boundary,
             size,
@@ -514,18 +537,14 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         } = Self::recover_bounds(
             &pending,
             cfg.items_per_blob.get(),
-            checkpoint.boundary_hint(),
+            pruning_boundary,
             checkpoint.watermark(),
         )?;
 
         // Persist any lowered checkpoint before applying blob repairs that move recovered state
         // backward.
         let checkpoint = checkpoint
-            .persist(
-                cfg.items_per_blob.get(),
-                pruning_boundary,
-                recovery_watermark,
-            )
+            .persist(pruning_boundary, recovery_watermark)
             .await?;
 
         // Apply repair (if any). The short blob becomes the new tail; blobs strictly newer
@@ -583,9 +602,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         );
         let tail_blob = super::position_to_blob(clear_target, cfg.items_per_blob.get());
         let blobs = Writable::recover(partition, BTreeMap::new(), tail_blob).await?;
-        let checkpoint = checkpoint
-            .finish_clear(cfg.items_per_blob.get(), clear_target)
-            .await?;
+        let checkpoint = checkpoint.finish_clear(clear_target).await?;
 
         let metrics = Metrics::new(context);
         metrics.update(clear_target, clear_target, cfg.items_per_blob.get());
@@ -600,21 +617,17 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 
     /// Recover the journal bounds and any tail repair from the checkpoint and blob state.
     ///
-    /// A boundary hint that lags blob state is repaired from the blob boundary; a hint ahead of
-    /// blob state or a watermark beyond the recovered size is corruption. The caller persists the
-    /// checkpoint before applying the returned repair (see comment at the call site).
+    /// The pruning boundary has already been reconciled with physical blob state: an ahead
+    /// boundary completed an interrupted prune, and a boundary whose blob is missing while later
+    /// blobs survive was rejected as corruption. A watermark beyond the recovered size is
+    /// corruption. The caller persists the checkpoint before applying the returned repair (see
+    /// comment at the call site).
     fn recover_bounds(
         pending: &BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
-        boundary_hint: Option<u64>,
+        pruning_boundary: u64,
         watermark_hint: Option<u64>,
     ) -> Result<RecoveredBounds, Error> {
-        let pruning_boundary = Self::recover_pruning_boundary(
-            boundary_hint,
-            pending.keys().next().copied(),
-            items_per_blob,
-        )?;
-
         let (size, repair) =
             Self::recover_by_walking_lengths(pending, items_per_blob, pruning_boundary)?;
 
@@ -652,55 +665,62 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         })
     }
 
-    /// Recover the pruning boundary from the checkpoint hint if it still matches the oldest
-    /// retained blob.
+    /// Reconcile blobs against the recorded pruning boundary before recovering lengths.
     ///
-    /// A missing or blob-aligned hint means the blob boundary is authoritative. A mid-blob hint
-    /// is trusted only when it belongs to the current oldest blob.
-    fn recover_pruning_boundary(
-        boundary_hint: Option<u64>,
-        oldest_blob: Option<u64>,
+    /// New checkpoints always record the boundary. If it is ahead of physical storage, a prune
+    /// was interrupted after committing its boundary and recovery finishes the removals. A
+    /// boundary whose blob is missing while later blobs survive is corruption: the boundary is
+    /// recorded before any removal and removals never touch the boundary blob, so its absence
+    /// means the retained data was lost, not pruned. Legacy checkpoints without a recorded
+    /// boundary derive it from the oldest blob.
+    async fn reconcile_pruning_boundary(
+        partition: &Partition<E>,
+        pending: &mut BTreeMap<u64, Writer<E::Blob>>,
         items_per_blob: u64,
+        boundary_hint: Option<u64>,
     ) -> Result<u64, Error> {
-        let blob_boundary = match oldest_blob {
-            Some(oldest) => super::blob_first_position(oldest, items_per_blob)?,
-            None => 0,
+        let Some(boundary) = boundary_hint else {
+            return pending.keys().next().copied().map_or(Ok(0), |oldest| {
+                super::blob_first_position(oldest, items_per_blob)
+            });
         };
+        let boundary_blob = super::position_to_blob(boundary, items_per_blob);
 
-        let Some(boundary_hint) = boundary_hint else {
-            return Ok(blob_boundary);
-        };
-        if boundary_hint.is_multiple_of(items_per_blob) {
-            return Ok(blob_boundary);
+        // The boundary is recorded before any blob is removed, and removals never touch the
+        // boundary blob, so a missing boundary blob with any surviving blob means the retained
+        // data was lost, not pruned. Classify before removing the stale prefix below the
+        // boundary, so a failed init leaves every surviving blob untouched.
+        if !pending.contains_key(&boundary_blob)
+            && let Some((&survivor, _)) = pending.first_key_value()
+        {
+            return Err(Error::Corruption(format!(
+                "blob at pruning boundary {boundary} is missing \
+                 (oldest surviving blob is {survivor})"
+            )));
         }
 
-        let hint_blob = super::position_to_blob(boundary_hint, items_per_blob);
-        match oldest_blob {
-            Some(oldest_blob) if hint_blob == oldest_blob => Ok(boundary_hint),
-            Some(oldest_blob) if hint_blob < oldest_blob => {
-                warn!(
-                    hint_blob,
-                    oldest_blob, "crash repair: boundary hint stale, computing from blobs"
-                );
-                Ok(blob_boundary)
+        // A recorded boundary ahead of the oldest blob is a committed prune that crashed before
+        // finishing its removals. Remove the files concurrently; the durable boundary makes
+        // removal order irrelevant to recovery.
+        let stale: Vec<u64> = pending
+            .range(..boundary_blob)
+            .map(|(&blob, _)| blob)
+            .collect();
+        if !stale.is_empty() {
+            warn!(
+                count = stale.len(),
+                boundary, "crash repair: completing interrupted prune"
+            );
+            for blob in &stale {
+                drop(pending.remove(blob));
             }
-            Some(oldest_blob) => {
-                // A hint ahead of blob state should never arise: prune removes blobs before
-                // sync persists the checkpoint, and clear_to_size stages a clear intent.
-                Err(Error::Corruption(format!(
-                    "boundary hint references blob {hint_blob} \
-                     but oldest blob is blob {oldest_blob}"
-                )))
-            }
-            None => {
-                // A mid-blob hint with no blobs should never arise: a staged clear is completed
-                // before we get here, and no other operation removes all blobs without updating
-                // the checkpoint.
-                Err(Error::Corruption(format!(
-                    "boundary hint references blob {hint_blob} but no blobs exist"
-                )))
-            }
+            try_join_all(stale.into_iter().map(|blob| partition.remove(blob))).await?;
         }
+
+        // After the corruption check, the boundary blob is present (and now the oldest, since the
+        // stale prefix was removed) or no blob survives. Either way the recorded boundary is
+        // authoritative.
+        Ok(boundary)
     }
 
     /// Classify a blob's untrusted on-disk length against its capacity. A missing blob counts
@@ -729,7 +749,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     /// Recover size by walking blob lengths from oldest to newest, truncating at the
     /// first short or missing non-tail blob.
     ///
-    /// `pruning_boundary` is trusted (already reconciled by `recover_pruning_boundary`); blob
+    /// `pruning_boundary` is trusted (already reconciled by `reconcile_pruning_boundary`); blob
     /// lengths are untrusted disk state. The returned size is chunk-exact and the retained
     /// prefix is contiguous.
     fn recover_by_walking_lengths(
@@ -886,10 +906,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let handle = self.blobs.start_sync().await;
         handle.await?;
         self.barrier.mark_durable(size);
-        self.checkpoint = self
-            .checkpoint
-            .persist(self.items_per_blob.get(), self.bounds.start, size)
-            .await?;
+        self.checkpoint = self.checkpoint.persist(self.bounds.start, size).await?;
         Ok(self)
     }
 
@@ -1081,31 +1098,55 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         mut self: Box<Self>,
         min_item_pos: u64,
     ) -> Result<(Box<Self>, bool), Error> {
-        // Calculate the blob that would contain min_item_pos, capped to the tail (which is
-        // guaranteed to exist by our invariant).
+        // Cap the target at the physical tail, but never below the adopted boundary's blob.
+        // This handles cancelled rollovers and prune cleanup.
         let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
-        let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
-        let min_blob = std::cmp::min(target_blob, tail_blob);
+        let min_blob = target_blob
+            .min(self.blobs.tail_blob_index())
+            .max(super::position_to_blob(
+                self.bounds.start,
+                self.items_per_blob.get(),
+            ));
 
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok((self, false));
         }
 
-        // Make all data durable before removing any: the prune target may be justified by an
-        // appended-but-unflushed item (e.g. a consumer's commit record), and removals are
-        // durable, so pruning without this sync could leave a recovered journal whose
-        // surviving items no longer justify its boundary. The sync also covers unsynced
-        // survivors above the boundary: removal may be interrupted, and recovery truncates at
-        // the first torn item, so an unsynced survivor could discard every synced blob
-        // behind it.
+        // Make all data durable before persisting a boundary that authorizes removal: the target
+        // may be justified by an appended-but-unflushed item, and a committed boundary lets
+        // recovery complete removals, so an unsynced survivor above the boundary could otherwise be
+        // lost. `start_sync` joins the tail and its predecessor (the only blobs that can be
+        // unsynced), so awaiting it is a full barrier.
         let sync = self.blobs.start_sync().await;
         sync.await?;
         self.barrier.mark_durable(self.bounds.end);
 
-        let new_boundary = super::blob_first_position(min_blob, self.items_per_blob.get())?;
-        self.blobs.prune(min_blob).await?;
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
+        let new_boundary =
+            super::blob_first_position(min_blob, self.items_per_blob.get())?.max(self.bounds.start);
+
+        // Adopt the boundary in memory before persisting it. A dropped prune future consumes the
+        // journal, discarding this in-memory advance; the durable boundary persisted below is
+        // what recovery completes on reopen.
         self.bounds.start = new_boundary;
 
+        // Commit the boundary before removing blobs. Recovery treats an ahead boundary as an
+        // interrupted prune and completes it, so blob removal never has to finish atomically
+        // or in order. The sync above proved every item through `bounds.end` durable, so that is
+        // the watermark to record: persisting the older checkpoint watermark would under-record
+        // durability and let recovery accept the loss of the just-synced retained items as pruned
+        // history.
+        self.checkpoint = self
+            .checkpoint
+            .persist(new_boundary, self.bounds.end)
+            .await?;
+
+        #[cfg(test)]
+        if self.halt_prune_removals {
+            std::future::pending::<()>().await;
+        }
+
+        self.blobs.prune(min_blob).await?;
         self.metrics.update(
             self.bounds.end,
             self.bounds.start,
@@ -1151,10 +1192,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         self.barrier = Barrier::new(new_size);
 
         // Complete the clear in the checkpoint.
-        self.checkpoint = self
-            .checkpoint
-            .finish_clear(self.items_per_blob.get(), new_size)
-            .await?;
+        self.checkpoint = self.checkpoint.finish_clear(new_size).await?;
 
         self.metrics.update(
             self.bounds.end,
@@ -1359,8 +1397,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Readers holding earlier snapshots keep reading pruned blobs through their own handles;
     /// later snapshots observe [Error::ItemPruned].
     ///
-    /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
-    /// event of failure as items are always pruned in order from oldest to newest.
+    /// Note that this operation is NOT atomic and does not remove blobs in order: a failure or
+    /// crash can leave gaps below the committed pruning boundary. Recovery tolerates this because
+    /// the boundary is durably recorded before any removal, so reopening discards everything below
+    /// it regardless of which blobs survive. A binary built before two-phase pruning must not open
+    /// a journal left in that state; it infers the boundary from the oldest surviving blob and
+    /// would misread a gap as retained history.
     pub async fn prune(mut self, min_item_pos: u64) -> Result<(Self, bool), Error> {
         let (inner, pruned) = self.0.prune(min_item_pos).await?;
         self.0 = inner;
@@ -1734,6 +1776,55 @@ impl<E: Context, A: CodecFixedShared> authenticated::Backing<E> for Journal<E, A
 
     async fn init(context: E, cfg: Self::Config) -> Result<Self, Error> {
         Self::init(context, cfg).await
+    }
+}
+
+#[cfg(test)]
+impl<E: Context, A: CodecFixedShared> Inner<E, A> {
+    /// Test helper: the boundary-commit half of [Self::prune] (sync then persist the boundary)
+    /// without removing any blob, reproducing the state a prune future dropped at its removal
+    /// park leaves behind. Returns the first retained blob when the prune is effective.
+    async fn commit_prune(
+        mut self: Box<Self>,
+        min_item_pos: u64,
+    ) -> Result<(Box<Self>, Option<u64>), Error> {
+        let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
+        let min_blob = target_blob
+            .min(self.blobs.tail_blob_index())
+            .max(super::position_to_blob(
+                self.bounds.start,
+                self.items_per_blob.get(),
+            ));
+        if min_blob <= self.blobs.oldest_blob_index() {
+            return Ok((self, None));
+        }
+
+        let sync = self.blobs.start_sync().await;
+        sync.await?;
+        self.barrier.mark_durable(self.bounds.end);
+
+        let new_boundary =
+            super::blob_first_position(min_blob, self.items_per_blob.get())?.max(self.bounds.start);
+        self.bounds.start = new_boundary;
+        self.checkpoint = self
+            .checkpoint
+            .persist(new_boundary, self.bounds.end)
+            .await?;
+        Ok((self, Some(min_blob)))
+    }
+}
+
+#[cfg(test)]
+impl<E: Context, A: CodecFixedShared> Journal<E, A> {
+    /// Test helper: commit and adopt the prune boundary without removing any blob, the state
+    /// a prune future dropped at the removal await leaves behind.
+    pub(crate) async fn test_prune_commit_only(
+        mut self,
+        min_item_pos: u64,
+    ) -> Result<(Self, bool), Error> {
+        let (inner, min_blob) = self.0.commit_prune(min_item_pos).await?;
+        self.0 = inner;
+        Ok((self, min_blob.is_some()))
     }
 }
 
@@ -2133,6 +2224,12 @@ mod tests {
         /// Test helper: Get the oldest blob from the blob store.
         pub(crate) const fn test_oldest_blob(&self) -> Option<u64> {
             Some(self.blobs.oldest_blob_index())
+        }
+
+        /// Test helper: park [Checkpoint::persist] after its durable sync so a pending prune
+        /// future can be dropped with the boundary durable but the call unreturned.
+        pub(in crate::journal::contiguous) fn test_halt_checkpoint_persist(&mut self, halt: bool) {
+            self.checkpoint.halt_after_persist_sync = halt;
         }
 
         /// Test helper: Get the newest blob from the blob store.
@@ -2822,12 +2919,7 @@ mod tests {
             // Persist the recovered metadata (watermark=9) as init_with_checkpoint does before
             // applying the rewind repair. This simulates a crash after metadata sync but before
             // the repair removes stale blobs.
-            journal.0.checkpoint = journal
-                .0
-                .checkpoint
-                .persist(cfg.items_per_blob.get(), 0, 9)
-                .await
-                .unwrap();
+            journal.0.checkpoint = journal.0.checkpoint.persist(0, 9).await.unwrap();
             drop(journal);
 
             // Shorten blob 1 to simulate a short non-tail blob. Recovery will compute
@@ -3022,133 +3114,10 @@ mod tests {
         });
     }
 
+    /// Prune commits its boundary before removing blobs. Recovery completes the removals when a
+    /// crash leaves that boundary ahead of physical storage.
     #[test_traced]
-    fn test_fixed_journal_stale_pruning_metadata_preserves_watermark() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let cfg = test_cfg(&context, NZU64!(5));
-            let mut journal =
-                Journal::<_, Digest>::init_at_size(context.child("first"), cfg.clone(), 7)
-                    .await
-                    .expect("failed to initialize journal at size");
-
-            for i in 0..10u64 {
-                (journal, _) = journal
-                    .append(&test_digest(i))
-                    .await
-                    .expect("failed to append data");
-            }
-            let journal = journal.sync().await.expect("failed to sync journal");
-            assert_eq!(journal.bounds(), 7..17);
-
-            // Stage the stale forward-looking watermark while the journal is alive (so we go
-            // through the public metadata path), then drop and corrupt the underlying blob.
-            let journal = journal
-                .test_set_recovery_watermark(12)
-                .await
-                .expect("failed to sync recovery watermark");
-            drop(journal);
-
-            // Shorten blob 2 to two items via Append::resize so the on-disk logical view
-            // matches the staged watermark of 12.
-            {
-                let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
-                let (blob, blob_size) = context
-                    .open(&blob_partition(&cfg), &2u64.to_be_bytes())
-                    .await
-                    .expect("failed to open blob 2");
-                let mut append = Writer::new(blob, blob_size, 2048, cache_ref)
-                    .await
-                    .expect("failed to wrap blob 2");
-                append
-                    .resize(2 * Digest::SIZE as u64)
-                    .await
-                    .expect("failed to shorten anchored blob");
-                append.sync().await.expect("failed to sync blob 2");
-            }
-
-            // Remove the checkpoint's oldest blob so the boundary hint of 7 is stale. The
-            // watermark is preserved because length-based recovery ends at the same point.
-            context
-                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
-                .await
-                .expect("failed to remove stale oldest blob");
-
-            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("failed to recover journal");
-            assert_eq!(journal.bounds(), 10..12);
-            assert_eq!(journal.0.recovery_watermark(), 12);
-            assert_eq!(journal.read(10).await.unwrap(), test_digest(3));
-            assert_eq!(journal.read(11).await.unwrap(), test_digest(4));
-            assert!(matches!(
-                journal.read(12).await,
-                Err(Error::ItemOutOfRange(12))
-            ));
-
-            journal.destroy().await.unwrap();
-        });
-    }
-
-    #[test_traced]
-    fn test_fixed_journal_stale_pruning_metadata_without_watermark_walks_lengths() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let cfg = test_cfg(&context, NZU64!(5));
-            let mut journal =
-                Journal::<_, Digest>::init_at_size(context.child("first"), cfg.clone(), 7)
-                    .await
-                    .expect("failed to initialize journal at size");
-
-            for i in 0..10u64 {
-                (journal, _) = journal
-                    .append(&test_digest(i))
-                    .await
-                    .expect("failed to append data");
-            }
-            let mut journal = journal.sync().await.expect("failed to sync journal");
-            assert_eq!(journal.bounds(), 7..17);
-
-            {
-                journal.0.checkpoint.set_watermark(None);
-                journal.0.checkpoint = journal
-                    .0
-                    .checkpoint
-                    .sync()
-                    .await
-                    .expect("failed to remove recovery watermark");
-            }
-            drop(journal);
-
-            // Remove the checkpoint's oldest blob so the boundary hint of 7 is stale. Without a
-            // recovery watermark, recovery must still walk lengths from the recovered blob boundary.
-            context
-                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
-                .await
-                .expect("failed to remove stale oldest blob");
-
-            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
-                .await
-                .expect("failed to recover journal");
-            assert_eq!(journal.bounds(), 10..17);
-            // No watermark: watermark at the tail blob start, not size.
-            assert_eq!(journal.0.recovery_watermark(), 15);
-            assert_eq!(journal.read(10).await.unwrap(), test_digest(3));
-            assert_eq!(journal.read(16).await.unwrap(), test_digest(9));
-
-            // After sync, watermark advances to the full recovered size.
-            journal = journal.sync().await.expect("failed to sync");
-            assert_eq!(journal.0.recovery_watermark(), 17);
-
-            journal.destroy().await.unwrap();
-        });
-    }
-
-    /// A boundary hint ahead of the oldest blob is not a reachable crash state: prune removes
-    /// blobs before sync persists the checkpoint, and clear_to_size stages a clear intent for
-    /// atomicity. Verify it is rejected as corruption.
-    #[test_traced]
-    fn test_fixed_journal_boundary_hint_ahead_of_blobs_is_corruption() {
+    fn test_fixed_journal_completes_prune_from_ahead_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
@@ -3164,24 +3133,25 @@ mod tests {
             let mut journal = journal.sync().await.unwrap();
             assert_eq!(journal.bounds(), 3..15);
 
-            // Set the boundary hint to 8 (blob 1) and lower the watermark so it won't
-            // independently trigger the watermark > size corruption check. Then remove blob 1's
-            // blob so blob 0 is the oldest. The boundary hint now references a blob ahead
-            // of the oldest blob, which is the corruption we're testing.
+            // Persist the boundary that prune records before deleting blobs, then simulate a
+            // crash before the first deletion.
             {
-                journal.0.checkpoint.set_boundary_hint(8);
-                journal.0.checkpoint.set_watermark(Some(3));
+                journal.0.checkpoint.set_boundary_hint(10);
                 journal.0.checkpoint = journal.0.checkpoint.sync().await.unwrap();
             }
             drop(journal);
 
-            context
-                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
-
-            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(result, Err(Error::Corruption(_))));
+            assert_eq!(journal.bounds(), 10..15);
+            for position in 10..15 {
+                assert_eq!(
+                    journal.read(position).await.unwrap(),
+                    test_digest(position - 3)
+                );
+            }
+            journal.destroy().await.unwrap();
         });
     }
 
@@ -3335,7 +3305,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_fixed_journal_prune_to_blob_boundary_removes_pruning_metadata() {
+    fn test_fixed_journal_prune_to_blob_boundary_persists_pruning_metadata() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
@@ -3361,7 +3331,7 @@ mod tests {
             let checkpoint = Checkpoint::open(context.child("metadata"), &cfg.partition)
                 .await
                 .expect("failed to reopen checkpoint");
-            assert!(checkpoint.boundary_hint().is_none());
+            assert_eq!(checkpoint.boundary_hint(), Some(10));
             drop(checkpoint);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -3369,6 +3339,54 @@ mod tests {
                 .expect("failed to reopen journal");
             assert_eq!(journal.bounds(), 10..15);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(3));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped at the removal await consumes the journal but leaves the boundary
+    /// durably committed. Recovery completes the interrupted prune from that boundary regardless
+    /// of which blobs a partial concurrent removal happened to unlink first.
+    #[test_traced]
+    fn test_fixed_journal_prune_interrupted_removal_keeps_committed_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop a prune parked before its removals: the consuming future destroys the journal,
+            // but the boundary is durably committed and no blob has been removed yet.
+            journal.0.halt_prune_removals = true;
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the removals"
+                );
+            }
+
+            // Simulate one concurrent unlink having completed before the crash: blob 1 is removed
+            // while blob 0 survives, leaving the physical prefix partially removed.
+            context
+                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            // Recovery completes the interrupted prune from the committed boundary regardless of
+            // which blobs the partial removal left behind.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
             journal.destroy().await.unwrap();
         });
     }
@@ -3392,7 +3410,7 @@ mod tests {
             drop(journal);
 
             // Inject an extra item into blob 0 at the blob level so its length exceeds
-            // items_per_blob -- this is what `recover_bounds` validates and rejects as Corruption.
+            // items_per_blob; this is what `recover_bounds` validates and rejects as Corruption.
             {
                 let extra = test_digest(99);
                 let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
@@ -4137,6 +4155,203 @@ mod tests {
         });
     }
 
+    /// After a cancelled prune adopted (and possibly persisted) a boundary the physical
+    /// state has not caught up to, a smaller prune request must not move the boundary
+    /// backward. Its physical cleanup still catches up to the adopted boundary.
+    #[test_traced]
+    fn test_fixed_prune_boundary_is_monotonic() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Cancel a prune parked before its removals: the consuming future destroys the
+            // journal, but boundary 10 is durably committed and the blobs are not yet removed.
+            journal.0.halt_prune_removals = true;
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the removals"
+                );
+            }
+
+            // Recovery adopts the committed boundary and completes the removals.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen with the committed boundary");
+            assert_eq!(journal.bounds(), 10..15);
+            assert!(matches!(journal.read(7).await, Err(Error::ItemPruned(7))));
+
+            // A smaller request must not lower the recovered boundary: the cleanup is already
+            // complete, so it is a no-op that leaves the boundary at 10.
+            let (journal, pruned) = journal.prune(5).await.unwrap();
+            assert!(!pruned);
+            assert_eq!(journal.pruning_boundary(), 10);
+
+            // The condemned blobs were removed by recovery.
+            let names = scan_partition(&context, &blob_partition(&cfg)).await;
+            assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped mid-unlink leaves condemned files the journal no longer
+    /// tracks. A later clear_to_size must not adopt one as its fresh tail, which would
+    /// resurrect the condemned items.
+    #[test_traced]
+    fn test_fixed_clear_after_prune_dropped_mid_unlink() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the prune after its boundary commit but mid-unlink (before any condemned file
+            // is removed): the dropped future consumes the journal, but the committed boundary is
+            // durable and blobs 0 and 1 survive on disk.
+            journal.0.blobs.halt_prune_unlinks = true;
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the unlinks"
+                );
+            }
+
+            // Re-open: recovery completes the interrupted prune, removing the leftover condemned
+            // files, so a subsequent clear whose tail index collides with a formerly-condemned
+            // blob still starts from a genuinely empty tail.
+            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            journal.0 = journal.0.clear_to_size(5).await.unwrap();
+            assert_eq!(journal.bounds(), 5..5);
+            let pos;
+            (journal, pos) = journal.append(&test_digest(100)).await.unwrap();
+            assert_eq!(pos, 5);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(5).await.unwrap(), test_digest(100));
+
+            drop(journal);
+            let journal = Journal::<_, Digest>::init(context.child("third"), cfg.clone())
+                .await
+                .expect("journal must reopen after the clear");
+            assert_eq!(journal.bounds(), 5..6);
+            assert_eq!(journal.read(5).await.unwrap(), test_digest(100));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped inside the checkpoint persist consumes the journal but can leave
+    /// the new boundary durable (the persist's sync completed before the drop). Recovery
+    /// completes the prune from that durable boundary.
+    #[test_traced]
+    fn test_fixed_prune_dropped_during_persist_adopts_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop a prune parked inside the checkpoint persist, after its durable sync: the
+            // consuming future destroys the journal, but the boundary is already durable.
+            journal.0.test_halt_checkpoint_persist(true);
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park inside the checkpoint persist"
+                );
+            }
+
+            // Recovery completes the prune from the durable boundary.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after the dropped prune");
+            assert_eq!(journal.bounds(), 10..12);
+            for i in 10..12u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Lower-level state test: the logical size can lead the physical tail (the shape a roll-over
+    /// interrupted mid-`seal_tail` leaves). The consuming public `append` cannot leave a live
+    /// handle in that state, so the borrowed inner append constructs it directly. A prune issued
+    /// then must cap its boundary at the physical tail rather than panic on the missing next blob.
+    #[test_traced]
+    fn test_fixed_prune_after_cancelled_seal_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..9u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drive the borrowed inner append and drop it parked at the tail roll-over,
+            // constructing a state the consuming public `append` cannot leave a live handle in:
+            // the logical size leads the physical tail by one blob (blob 2 is never created).
+            journal.0.blobs.halt_seal_tail = true;
+            let item = test_digest(9);
+            {
+                let fut = journal.0.append(&item);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "append must park at the tail roll-over"
+                );
+            }
+            journal.0.blobs.halt_seal_tail = false;
+            assert_eq!(journal.size(), 10);
+
+            // Prune to the logical end: capped at the physical tail, pruning only blob 0.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            assert_eq!(journal.bounds(), 5..10);
+            for i in 5..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+
+            drop(journal);
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after a capped prune");
+            assert_eq!(journal.bounds(), 5..10);
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// A crash right after pruning must not lose retained items that were appended but never
     /// synced. Blob removal is durable, so prune makes all data durable first: otherwise the
     /// unsynced tail would vanish with the crash and recovery would truncate the journal to
@@ -4173,6 +4388,228 @@ mod tests {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
             }
             journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Pruning after unsynced appends makes the retained data durable, so the committed boundary
+    /// must record a watermark that covers it. Persisting the stale checkpoint watermark instead
+    /// would let recovery accept the loss of that just-synced retained data as pruned history and
+    /// reopen an empty journal. Losing the retained region must be reported as corruption.
+    #[test_traced]
+    fn test_fixed_recovery_prune_watermark_covers_retained_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Append 20 items across four blobs without an intervening sync, so the checkpoint
+            // watermark still lags bounds.end when the prune runs.
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+
+            // Prune away the first two blobs. The prune syncs all data durable, so the retained
+            // items 10..20 are acknowledged and the committed watermark must record that.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose every retained data blob. The watermark proves items 10..20 were durable, so
+            // their disappearance is corruption, not a completed prune to an empty journal.
+            for name in context.scan(&blob_partition(&cfg)).await.unwrap() {
+                context
+                    .remove(&blob_partition(&cfg), Some(&name))
+                    .await
+                    .unwrap();
+            }
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, Digest>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A recorded mid-blob boundary (from `init_at_size`) whose blob is missing while later blobs
+    /// survive is rejected as corruption, uniformly with the blob-aligned case: the boundary is
+    /// recorded before any removal, so a missing boundary blob means the retained data was lost,
+    /// not pruned. Recovery leaves the survivors untouched and is stable across retries.
+    #[test_traced]
+    fn test_fixed_recovery_rejects_lagging_mid_blob_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            // init_at_size(7) records a mid-blob boundary at 7 (blob 1).
+            let mut journal =
+                Journal::<_, Digest>::init_at_size(context.child("first"), cfg.clone(), 7)
+                    .await
+                    .unwrap();
+            for i in 0..8u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.bounds(), 7..15);
+            drop(journal);
+
+            // Lose the boundary blob (blob 1) while a later blob survives.
+            context
+                .remove(&blob_partition(&cfg), Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving blob above the lost boundary blob is left intact for diagnosis.
+            assert!(
+                context
+                    .open(&blob_partition(&cfg), &2u64.to_be_bytes())
+                    .await
+                    .is_ok()
+            );
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, Digest>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A blob-aligned boundary is recorded before any removal, so it can never lag physical
+    /// state. If its blob is missing while later blobs survive, recovery must report
+    /// corruption rather than silently reclassifying the retained items as pruned.
+    #[test_traced]
+    fn test_fixed_recovery_rejects_missing_aligned_boundary_blob() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the blob at the recorded boundary while later blobs survive.
+            context
+                .remove(&blob_partition(&cfg), Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving suffix is left intact for diagnosis.
+            assert!(
+                context
+                    .open(&blob_partition(&cfg), &3u64.to_be_bytes())
+                    .await
+                    .is_ok()
+            );
+        });
+    }
+
+    /// A failed init must not mutate the blob set: when a committed prune's removals were
+    /// interrupted and the aligned boundary blob is then lost, the missing-boundary corruption
+    /// verdict must be reached before the stale prefix below the boundary is unlinked, and the
+    /// verdict must be stable across retries.
+    #[test_traced]
+    fn test_fixed_recovery_missing_boundary_preserves_stale_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(5));
+            cfg.partition = "missing-boundary-preserves-prefix".into();
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Commit the boundary without removing any blob, as a prune interrupted after its
+            // checkpoint persist would.
+            let (journal, pruned) = journal.test_prune_commit_only(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the blob at the committed boundary while a later blob survives.
+            context
+                .remove(&blob_partition(&cfg), Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // Every surviving blob is untouched, including the stale prefix below the boundary.
+            let names = context.scan(&blob_partition(&cfg)).await.unwrap();
+            assert!(names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&1u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&3u64.to_be_bytes().to_vec()));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, Digest>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A missing aligned boundary blob is corruption even when nothing survives past it: an
+    /// interrupted prune never removes its boundary blob, so a surviving stale prefix alone
+    /// proves the retained blobs were lost. The verdict must be reached before the prefix is
+    /// unlinked and must be stable across retries.
+    #[test_traced]
+    fn test_fixed_recovery_missing_boundary_with_only_stale_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context, NZU64!(5));
+            cfg.partition = "missing-boundary-only-prefix".into();
+
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Commit the boundary without removing any blob, as a prune interrupted after its
+            // checkpoint persist would.
+            let (journal, pruned) = journal.test_prune_commit_only(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose every blob at and after the committed boundary, leaving only the stale
+            // prefix below it.
+            for name in context.scan(&blob_partition(&cfg)).await.unwrap() {
+                let blob = u64::from_be_bytes(name.as_slice().try_into().unwrap());
+                if blob >= 2 {
+                    context
+                        .remove(&blob_partition(&cfg), Some(&name))
+                        .await
+                        .unwrap();
+                }
+            }
+
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The failed init left the stale prefix untouched.
+            let names = context.scan(&blob_partition(&cfg)).await.unwrap();
+            assert!(names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&1u64.to_be_bytes().to_vec()));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, Digest>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -389,11 +389,6 @@ struct Inner<E: Context, V: Codec> {
     /// The readable positions; `bounds.end` is the next append position.
     bounds: Range<u64>,
 
-    /// Test-only: park [Self::prune] after the data-blob removal, before the offsets prune,
-    /// so tests can drop the pending future at that exact point.
-    #[cfg(test)]
-    halt_before_offsets_prune: bool,
-
     /// The number of items per blob.
     ///
     /// # Invariant
@@ -1169,8 +1164,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             blobs,
             offsets,
             bounds,
-            #[cfg(test)]
-            halt_before_offsets_prune: false,
             items_per_blob: cfg.items_per_section,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
@@ -1233,8 +1226,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             blobs,
             offsets,
             bounds: size..size,
-            #[cfg(test)]
-            halt_before_offsets_prune: false,
             items_per_blob: cfg.items_per_section,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
@@ -1536,46 +1527,41 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
     ) -> Result<(Box<Self>, bool), Error> {
         let items_per_blob = self.items_per_blob.get();
 
-        // Calculate the blob that would contain min_position, capped to the tail (which is
-        // guaranteed to exist by our invariant).
+        // Cap the target at the physical tail, but never below the adopted boundary's blob.
+        // This handles cancelled rollovers and prune cleanup.
         let target_blob = position_to_blob(min_position, items_per_blob);
-        let tail_blob = position_to_blob(self.bounds.end, items_per_blob);
-        let min_blob = target_blob.min(tail_blob);
+        let min_blob = target_blob
+            .min(self.blobs.tail_blob_index())
+            .max(position_to_blob(self.bounds.start, items_per_blob));
 
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok((self, false));
         }
 
-        let new_boundary = blob_first_position(min_blob, items_per_blob)?;
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
+        let new_boundary = blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
 
-        // Make all data durable before removing any: the prune target may be justified by an
-        // appended-but-unflushed item (e.g. a consumer's commit record), and removals are
-        // durable, so pruning without this sync could leave a recovered journal whose
-        // surviving items no longer justify its boundary. The sync also covers unsynced
-        // survivors above the boundary: removal may be interrupted, and recovery truncates at
-        // the first torn item, so an unsynced survivor could discard every synced blob behind
-        // it. Offsets entries for retained items must survive the same crash: recovery rebuilds
-        // offsets that end behind the surviving data's end by replaying data, but offsets that
-        // end behind its start are unrecoverable because the data needed to rebuild the missing
-        // entries is about to be removed. Data is flushed first, matching the ordering every
-        // other durability path maintains.
+        // Make all data durable before the offsets journal commits the boundary that authorizes
+        // removal: the target may be justified by an appended-but-unflushed item, and offsets
+        // entries for retained items must survive the same crash (recovery rebuilds offsets that
+        // end behind the surviving data's end by replaying data, but not offsets that end behind
+        // its start, since that data is about to be removed). `start_sync` joins the tail and its
+        // predecessor (the only blobs that can be unsynced), so awaiting it is a full barrier.
         let data_sync = self.blobs.start_sync().await;
         data_sync.await?;
-        self.offsets = self.offsets.commit().await?;
         self.barrier.mark_durable(self.bounds.end);
 
-        self.blobs.prune(min_blob).await?;
-        self.bounds.start = new_boundary;
-
-        #[cfg(test)]
-        if self.halt_before_offsets_prune {
-            std::future::pending::<()>().await;
-        }
-
-        // Prune data before offsets so a crash leaves offsets behind, which init repairs by
-        // pruning offsets to match.
+        // The offsets journal is the durable prune record. Prune it (persisting the boundary and
+        // removing its stale blobs) before removing data, then mirror the boundary into bounds.
+        // Committing the boundary before removal lets recovery complete an interrupted prune; the
+        // offsets journal's own `halt_prune_removals` parks after that commit for crash tests.
         let (offsets, _) = self.offsets.prune(new_boundary).await?;
         self.offsets = offsets;
+        self.bounds.start = new_boundary;
+
+        // Remove data after the boundary is durable. A crash here leaves data ahead of the
+        // committed offsets boundary; recovery finishes the removal on reopen.
+        self.blobs.prune(min_blob).await?;
         self.metrics.update(
             self.bounds.end,
             self.bounds.start,
@@ -1704,8 +1690,71 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         codec_config: &V::Cfg,
         compressed: bool,
     ) -> Result<(Box<fixed::Inner<E, u64>>, Range<u64>), Error> {
-        // Find the newest item-bearing blob, truncating torn trailing bytes along the way (the
-        // first invalid frame is the end of the journal).
+        // Reconcile pruning before inspecting data: stale prefix blobs are outside
+        // the retained range. A mid-blob boundary is valid within the same blob.
+        let offsets_bounds = offsets.pruning_boundary()..offsets.size();
+        let offsets_start_blob = position_to_blob(offsets_bounds.start, items_per_blob);
+        {
+            let Some(&oldest_blob) = pending.keys().next() else {
+                return Self::align_empty(partition, pending, offsets, items_per_blob).await;
+            };
+            let data_oldest_pos = blob_first_position(oldest_blob, items_per_blob)?;
+
+            // The offsets journal ending before the oldest retained data blob represents an
+            // impossible state under normal crash/prune sequences, indicating external corruption.
+            if offsets_bounds.end < data_oldest_pos {
+                return Err(Error::Corruption(format!(
+                    "offsets journal size {} is behind data oldest position {data_oldest_pos}",
+                    offsets_bounds.end
+                )));
+            }
+            match offsets_start_blob.cmp(&oldest_blob) {
+                std::cmp::Ordering::Less => {
+                    // Pruning removes data blobs only after the offsets boundary is durably
+                    // committed, so data ahead of the boundary means the blobs at and after
+                    // it were lost, not pruned.
+                    return Err(Error::Corruption(format!(
+                        "data blob {offsets_start_blob} at the pruning boundary is missing \
+                         (oldest surviving blob is {oldest_blob})"
+                    )));
+                }
+                std::cmp::Ordering::Equal => {}
+                std::cmp::Ordering::Greater => {
+                    // An interrupted prune preserves its boundary blob. Check before deleting
+                    // the stale prefix so corruption remains detectable on retry.
+                    if !pending.contains_key(&offsets_start_blob) {
+                        return Err(Error::Corruption(format!(
+                            "data blob {offsets_start_blob} at the pruning boundary is missing"
+                        )));
+                    }
+
+                    // The offsets boundary commits a prune before data blobs are removed. Finish
+                    // an interrupted prune by deleting data below it, removing the files
+                    // concurrently; the durable boundary makes removal order irrelevant.
+                    let stale: Vec<u64> = pending
+                        .range(..offsets_start_blob)
+                        .map(|(&blob, _)| blob)
+                        .collect();
+                    if !stale.is_empty() {
+                        warn!(
+                            count = stale.len(),
+                            "crash repair: completing interrupted data prune"
+                        );
+                        for blob in &stale {
+                            drop(pending.remove(blob));
+                        }
+                        try_join_all(stale.into_iter().map(|blob| partition.remove(blob))).await?;
+                    }
+                }
+            }
+        }
+
+        // Find the newest item-bearing retained blob, truncating torn trailing bytes along the
+        // way (the first invalid frame is the end of the journal). Like the fixed journal's
+        // trailing-byte trim, this runs before the recovery watermark is checked, so the
+        // "corruption leaves survivors untouched" guarantee holds for crash-reachable states: a
+        // synced blob has no torn frame, so a retained blob trimmed despite a later corruption
+        // verdict implies external corruption of already-durable data, outside the crash model.
         let scanned: Vec<u64> = pending.keys().rev().copied().collect();
         let mut items_in_newest = 0;
         let mut newest_blob = None;
@@ -1735,11 +1784,19 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         }
 
         // The tail blob (where the next append lands) is one past the newest full blob, the
-        // newest partial blob, or the oldest blob when empty (resolved by `align_empty`). Any
-        // blob above it is an empty crash artifact; the loop below removes them.
+        // newest partial blob, or the oldest blob when empty (resolved by `align_empty`). A
+        // blob the pruning boundary starts within is full at correspondingly fewer items. Any
+        // blob above the tail is an empty crash artifact; the loop below removes them.
         let tail_blob = match newest_blob {
-            Some(blob) if items_in_newest == items_per_blob => blob.saturating_add(1),
-            Some(blob) => blob,
+            Some(blob) => {
+                let newest_start = blob_first_position(blob, items_per_blob)?;
+                let capacity = items_per_blob - offsets_bounds.start.saturating_sub(newest_start);
+                if items_in_newest == capacity {
+                    blob.saturating_add(1)
+                } else {
+                    blob
+                }
+            }
             None => pending.keys().next().copied().unwrap_or(0),
         };
         for &blob in &scanned {
@@ -1754,44 +1811,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let Some(newest_blob) = newest_blob else {
             return Self::align_empty(partition, pending, offsets, items_per_blob).await;
         };
-
-        // Align pruning state at the blob level. After alignment, the offsets journal starts in
-        // the oldest data blob; a mid-blob offsets start (from `init_at_size`) is valid within
-        // the same blob.
-        let oldest_blob = *pending.keys().next().expect("pending is non-empty");
-        let data_oldest_pos = blob_first_position(oldest_blob, items_per_blob)?;
-        {
-            let offsets_bounds = offsets.pruning_boundary()..offsets.size();
-
-            // The offsets journal ending before the oldest retained data blob represents an
-            // impossible state under normal crash/prune sequences, indicating external corruption.
-            if offsets_bounds.end < data_oldest_pos {
-                return Err(Error::Corruption(format!(
-                    "offsets journal size {} is behind data oldest position {data_oldest_pos}",
-                    offsets_bounds.end
-                )));
-            }
-            let offsets_start_blob = position_to_blob(offsets_bounds.start, items_per_blob);
-            match offsets_start_blob.cmp(&oldest_blob) {
-                std::cmp::Ordering::Less => {
-                    warn!("crash repair: pruning offsets journal to {data_oldest_pos}");
-                    let (pruned, _) = offsets.prune(data_oldest_pos).await?;
-                    offsets = pruned;
-                }
-                std::cmp::Ordering::Equal => {}
-                std::cmp::Ordering::Greater => {
-                    // Prune always removes data before offsets, so offsets should never be
-                    // ahead by a blob.
-                    return Err(Error::Corruption(format!(
-                        "offsets start blob {offsets_start_blob} ahead of \
-                         oldest data blob {oldest_blob}"
-                    )));
-                }
-            }
-        }
-
-        // Re-fetch bounds since prune may have been called above.
-        let offsets_bounds = offsets.pruning_boundary()..offsets.size();
 
         // The newest item-bearing blob bounds how far recovery can possibly go. If it is also
         // the oldest retained blob, its logical start may be a mid-blob pruning boundary.
@@ -1830,13 +1849,14 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             // the only populated blob, so no contiguous data-backed prefix exists). In that case
             // there is no oldest blob to anchor against; otherwise offsets and data must start in
             // the same blob.
-            if !offsets_bounds.is_empty()
-                && position_to_blob(offsets_bounds.start, items_per_blob) != oldest_blob
-            {
-                return Err(Error::Corruption(format!(
-                    "recovered offsets and data start in different blobs: {} != {oldest_blob}",
-                    position_to_blob(offsets_bounds.start, items_per_blob)
-                )));
+            if !offsets_bounds.is_empty() {
+                let oldest_blob = *pending.keys().next().expect("pending is non-empty");
+                if position_to_blob(offsets_bounds.start, items_per_blob) != oldest_blob {
+                    return Err(Error::Corruption(format!(
+                        "recovered offsets and data start in different blobs: {} != {oldest_blob}",
+                        position_to_blob(offsets_bounds.start, items_per_blob)
+                    )));
+                }
             }
 
             // Return bounds.start from offsets as the true boundary.
@@ -1863,13 +1883,23 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
     ) -> Result<(Box<fixed::Inner<E, u64>>, Range<u64>), Error> {
         let offsets_bounds = offsets.pruning_boundary()..offsets.size();
 
+        // A watermark past the pruning boundary proves retained items were durable, so their
+        // data blobs were lost, not pruned; a surviving empty tail cannot vouch for them.
+        // Check before any branch or repair so the result is stable across retries.
+        if offsets.recovery_watermark() > offsets_bounds.start {
+            return Err(Error::Corruption(format!(
+                "no item-bearing data blobs survive the committed pruning boundary {}",
+                offsets_bounds.start
+            )));
+        }
+
         let Some(&blob) = pending.keys().next() else {
-            // No data blobs at all: a fresh partition, or a crash after pruning the data blobs
-            // but before pruning the offsets journal. Clear (rather than prune) the offsets so
-            // bounds collapse even when the size is mid-blob.
+            // No data blobs at all: a fresh partition or a journal with no retained durable
+            // items. Clear (rather than prune) the offsets so bounds collapse even when the
+            // size is mid-blob.
             let size = offsets_bounds.end;
             if !offsets_bounds.is_empty() {
-                warn!("crash repair: clearing offsets to {size} (prune-all crash)");
+                warn!("crash repair: clearing offsets to {size} (no data blobs)");
                 offsets = offsets.clear_to_size(size).await?;
             }
             return Ok((offsets, size..size));
@@ -1898,8 +1928,10 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         Ok((offsets, target..target))
     }
 
-    /// Choose the position to rebuild offsets from. A watermark below the pruning boundary is
-    /// stale after a prune, while a watermark beyond retained data indicates corruption.
+    /// Choose the position to rebuild offsets from. A watermark below the pruning boundary is a
+    /// legacy artifact (an older prune left a stale sub-boundary watermark; current prunes record
+    /// a watermark covering the retained range), while a watermark beyond retained data indicates
+    /// corruption.
     fn recovery_anchor(
         offsets: &fixed::Inner<E, u64>,
         offsets_bounds: &Range<u64>,
@@ -2123,26 +2155,29 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 ///
 /// ## 1. Data Blobs are the Source of Truth
 ///
-/// The data blobs are always the source of truth. The offsets journal is an index that may
-/// temporarily diverge during crashes. Divergences are automatically aligned during init():
+/// The data blobs are always the source of truth for item contents. The offsets journal is an
+/// index that may temporarily diverge during crashes. Divergences are automatically aligned
+/// during init():
 /// * If offsets are behind data after the recovery watermark: rebuild missing offsets by replaying
 ///   data from the recovery anchor.
 /// * If offsets are ahead of the retained data prefix but the data still reaches the recovery
 ///   watermark: rewind offsets to match the data-backed size. Retained data ending before the
 ///   watermark is corruption because acknowledged data is missing.
-/// * If offsets.bounds().start < the oldest data blob's start: prune offsets to match (this can
-///   happen if we crash after pruning the data blobs but before pruning the offsets journal).
 ///
-/// Offsets may start after the data's blob-aligned start when both are in the same blob, as in a
-/// mid-blob `init_at_size`. Offsets starting in a later blob imply corruption because we
-/// always prune the data blobs before the offsets journal.
+/// The offsets journal's pruning boundary is the committed prune record: it is durably advanced
+/// before any data blob is removed. Offsets starting in a later blob than the oldest data blob
+/// therefore mark an interrupted prune, which init completes by removing the stale data prefix.
+/// Data starting in a later blob than the offsets boundary means retained blobs were lost, not
+/// pruned, and init reports corruption. Offsets may start after the data's blob-aligned start
+/// when both are in the same blob, as in a mid-blob `init_at_size`.
 ///
 /// ## 2. Offsets Recovery Watermark
 ///
 /// The offsets journal's recovery watermark records a durable lower bound on the journal size and
 /// a preferred point for replaying data to rebuild offset entries after a crash. Fixed-journal
 /// recovery rejects watermarks beyond the recovered offsets size as corruption. A watermark below
-/// the recovered offsets start is stale after a prune, so init falls back to the offsets start. If
+/// the recovered offsets start is a stale legacy watermark (an older prune left a sub-boundary
+/// value), so init falls back to the offsets start. If
 /// retained data exists but ends before the watermark, init returns corruption because acknowledged
 /// data is missing. If no retained data exists, init reconciles both sides to an empty journal.
 /// Replay after a valid anchor stops at the first short data blob and truncates newer blobs so the
@@ -2477,6 +2512,12 @@ impl<E: Context, V: CodecShared> authenticated::Backing<E> for Journal<E, V> {
 
 #[cfg(test)]
 impl<E: Context, V: CodecShared> Journal<E, V> {
+    /// Test helper: park the production prune after the offsets journal's boundary commit,
+    /// before any blob removal, so a test can drop the pending prune future at that point.
+    pub(crate) fn test_halt_offsets_prune_removals(&mut self, halt: bool) {
+        self.0.offsets.halt_prune_removals = halt;
+    }
+
     /// Test helper: Prune the data blobs directly (simulates crash scenario).
     pub(crate) async fn test_prune_data(&mut self, min_blob: u64) -> Result<bool, Error> {
         let min_blob = min_blob.min(self.0.blobs.tail_blob_index());
@@ -3484,15 +3525,10 @@ mod tests {
         });
     }
 
-    /// Test that init aligns state when data is pruned/lost but offsets survives.
-    ///
-    /// This handles both:
-    /// 1. Crash during prune-all (data pruned, offsets not yet)
-    /// 2. External data partition loss
-    ///
-    /// In both cases, we align by pruning offsets to match.
+    /// Losing the data partition while the watermark proves durable retained items is
+    /// corruption that is stable across retries, not a completed prune-all to accept silently.
     #[test_traced]
-    fn test_variable_align_data_offsets_mismatch() {
+    fn test_variable_recovery_rejects_data_partition_loss() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
@@ -3504,12 +3540,9 @@ mod tests {
                 write_buffer: NZUsize!(1024),
             };
 
-            // === Setup: Create journal with data ===
             let mut variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-
-            // Append 20 items across 2 blobs
             for i in 0..20u64 {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
@@ -3517,38 +3550,111 @@ mod tests {
             let variable = variable.sync().await.unwrap();
             drop(variable);
 
-            // === Simulate data loss: Delete data partition but keep offsets ===
             context
                 .remove(&cfg.data_partition(), None)
                 .await
                 .expect("Failed to remove data partition");
 
-            // === Verify init aligns the mismatch ===
-            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Pruning after unsynced appends makes the retained data durable, so the offsets journal
+    /// (the durable prune record) must commit its boundary with a watermark that covers the
+    /// retained items. Persisting a stale watermark would let recovery accept the loss of that
+    /// just-synced retained data as a completed prune-all. Losing the retained data must be
+    /// reported as corruption.
+    #[test_traced]
+    fn test_variable_recovery_prune_watermark_covers_retained_data() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-watermark-covers-retained".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
-                .expect("Should align offsets to match empty data");
+                .unwrap();
 
-            // Size should be preserved
-            assert_eq!(journal.size(), 20);
-
-            // But no items remain (both journals pruned)
-            assert!(journal.bounds().is_empty());
-
-            // All reads should fail with ItemPruned
-            for i in 0..20 {
-                assert!(matches!(
-                    journal.read(i).await,
-                    Err(crate::journal::Error::ItemPruned(_))
-                ));
+            // Append 20 items across four blobs without an intervening sync, so the offsets
+            // watermark still lags when the prune runs.
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
-            // Can append new data starting at position 20
-            let pos;
-            (journal, pos) = journal.append(&999).await.unwrap();
-            assert_eq!(pos, 20);
-            assert_eq!(journal.read(20).await.unwrap(), 999);
+            // Prune away the first two blobs. The prune syncs all data durable, so the retained
+            // items 10..20 are acknowledged and the committed watermark must record that.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
 
-            journal.destroy().await.unwrap();
+            // Lose the data partition. The watermark proves items 10..20 were durable, so their
+            // disappearance is corruption, not a completed prune-all.
+            context
+                .remove(&cfg.data_partition(), None)
+                .await
+                .expect("Failed to remove data partition");
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Companion to the prune-watermark test on the non-empty recovery path: losing only PART of
+    /// the retained data after a prune (a later retained blob) must still be corruption. The
+    /// committed watermark covers the retained range, so `recovery_anchor` rejects a retained data
+    /// end short of it instead of silently truncating.
+    #[test_traced]
+    fn test_variable_recovery_prune_watermark_rejects_partial_retained_loss() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-watermark-partial-loss".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+
+            // Prune to 10, making retained items 10..20 (data blobs 2 and 3) durable.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose only the newest retained data blob (blob 3, positions 15..20); blob 2 survives.
+            context
+                .remove(&cfg.data_partition(), Some(&3u64.to_be_bytes()))
+                .await
+                .expect("Failed to remove retained data blob");
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 
@@ -3948,12 +4054,13 @@ mod tests {
         });
     }
 
-    /// Test recovery from crash after data blobs pruned but before offsets journal.
+    /// Data pruned ahead of the committed boundary (the pre-two-phase prune ordering) is
+    /// intentionally unsupported: recovery reports corruption, stable across retries, rather
+    /// than inferring the prune from blob absence.
     #[test_traced]
-    fn test_variable_recovery_prune_crash_offsets_behind() {
+    fn test_variable_recovery_rejects_data_pruned_ahead_of_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            // === Setup: Create Variable wrapper with data ===
             let cfg = Config {
                 partition: "recovery-prune-crash".into(),
                 items_per_section: NZU64!(10),
@@ -3966,8 +4073,6 @@ mod tests {
             let mut variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-
-            // Append 40 items across 4 blobs to both journals
             for i in 0..40u64 {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
@@ -3976,46 +4081,29 @@ mod tests {
             let (mut variable, _) = variable.prune(10).await.unwrap();
             assert_eq!(variable.bounds().start, 10);
 
-            // === Simulate crash: Prune data blobs but not offsets journal ===
-            // Manually prune data blobs to blob 2 (position 20)
+            // Remove data blobs past the committed boundary, as a crash under the
+            // pre-two-phase prune ordering could.
             variable.test_prune_data(2).await.unwrap();
-            // Offsets journal still has data from position 10-19
-
             variable.sync().await.unwrap();
 
-            // === Verify recovery ===
-            let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
 
-            // Init should auto-repair: offsets journal pruned to match data blobs
-            let bounds = variable.bounds();
-            assert_eq!(bounds.start, 20);
-            assert_eq!(bounds.end, 40);
-
-            // Reads before position 20 should fail (pruned from both journals)
-            assert!(matches!(
-                variable.read(10).await,
-                Err(crate::journal::Error::ItemPruned(_))
-            ));
-
-            // Reads at position 20+ should succeed
-            assert_eq!(variable.read(20).await.unwrap(), 2000);
-            assert_eq!(variable.read(39).await.unwrap(), 3900);
-
-            variable.destroy().await.unwrap();
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 
-    /// A crash after data pruning but before offsets pruning must remain recoverable even when
-    /// the last durable offsets end is below the new data boundary.
+    /// After a cancelled prune adopted a boundary the physical state has not caught up to,
+    /// a smaller prune request must not move the boundary backward.
     #[test_traced]
-    fn test_variable_recovery_prune_crash_offsets_end_behind() {
+    fn test_variable_prune_boundary_is_monotonic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
-                partition: "recovery-prune-offsets-end-behind".into(),
-                items_per_section: NZU64!(10),
+                partition: "prune-boundary-monotonic".into(),
+                items_per_section: NZU64!(5),
                 compression: None,
                 codec_config: (),
                 page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
@@ -4025,33 +4113,82 @@ mod tests {
             let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-
-            // Persist offsets only through position 7, then append enough unsynced items for a
-            // prune to advance the data boundary beyond that durable offsets end.
-            for i in 0..7u64 {
+            for i in 0..15u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             let mut journal = journal.sync().await.unwrap();
-            for i in 7..12u64 {
-                (journal, _) = journal.append(&(i * 100)).await.unwrap();
-            }
 
-            // Drop the production prune future while it is parked after the data-blob
-            // removal, before offsets.prune has made the appended offsets durable: a
-            // genuine cancellation at that await.
-            journal.0.halt_before_offsets_prune = true;
+            // Cancel a prune parked inside the offsets prune, before any removal: the consuming
+            // future destroys the journal, but boundary 10 is durably committed in the offsets.
+            journal.test_halt_offsets_prune_removals(true);
             {
                 let fut = journal.prune(10);
                 futures::pin_mut!(fut);
                 assert!(
                     futures::poll!(fut.as_mut()).is_pending(),
-                    "prune must park before offsets.prune"
+                    "prune must park before the offsets removals"
                 );
             }
 
+            // Recovery adopts the committed boundary.
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
-                .expect("prune crash must leave a recoverable journal");
+                .expect("journal must reopen with the committed boundary");
+            assert_eq!(journal.bounds(), 10..15);
+            assert!(matches!(journal.read(7).await, Err(Error::ItemPruned(7))));
+
+            // A smaller request must not lower the recovered boundary: it is a no-op.
+            let (journal, pruned) = journal.prune(5).await.unwrap();
+            assert!(!pruned);
+            assert_eq!(journal.bounds().start, 10);
+
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A prune future dropped inside the offsets checkpoint persist consumes the journal but can
+    /// leave the boundary durable (the persist's sync completed before the drop). Recovery
+    /// completes the prune from that durable boundary.
+    #[test_traced]
+    fn test_variable_prune_dropped_during_persist_adopts_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-dropped-during-persist".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..12u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop a prune parked inside the offsets checkpoint persist, after its durable sync:
+            // the consuming future destroys the journal, but the boundary is already durable.
+            journal.0.offsets.test_halt_checkpoint_persist(true);
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park inside the offsets checkpoint persist"
+                );
+            }
+
+            // Recovery completes the prune from the durable boundary.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after the dropped prune");
             assert_eq!(journal.bounds(), 10..12);
             for i in 10..12u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
@@ -4060,12 +4197,70 @@ mod tests {
         });
     }
 
-    /// Test recovery detects corruption when offsets journal pruned ahead of data blobs.
-    ///
-    /// Simulates an impossible state (offsets journal pruned more than data blobs) which
-    /// should never happen due to write ordering. Verifies that init() returns corruption error.
+    /// Lower-level state test: the logical end can lead the physical tail (the shape a roll-over
+    /// interrupted mid-`seal_tail` leaves), which the borrowed inner append constructs directly
+    /// because the consuming public `append` destroys the journal on such a drop. A prune issued
+    /// then must cap at the physical tail rather than commit a boundary into the never-created
+    /// next blob, and the result stays recoverable.
     #[test_traced]
-    fn test_variable_recovery_offsets_ahead_corruption() {
+    fn test_variable_prune_after_cancelled_seal_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-after-cancelled-seal".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..9u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drive the borrowed inner append and drop it parked at the tail roll-over,
+            // constructing a state the consuming public `append` cannot leave a live handle in:
+            // the logical end advances to 10 but data blob 2 is never created.
+            journal.0.blobs.halt_seal_tail = true;
+            {
+                let fut = journal.0.append(&900);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "append must park at the tail roll-over"
+                );
+            }
+            journal.0.blobs.halt_seal_tail = false;
+            assert_eq!(journal.size(), 10);
+
+            // Prune to the logical end: the boundary caps at the physical tail, pruning
+            // only blob 0 rather than committing a boundary into the missing blob 2.
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            assert_eq!(journal.bounds(), 5..10);
+            for i in 5..10u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+
+            // The journal remains recoverable.
+            drop(journal);
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("journal must reopen after a capped prune");
+            assert_eq!(journal.bounds(), 5..10);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// The offsets boundary commits a prune before data removal. Recovery completes the data
+    /// removal when a crash leaves offsets ahead.
+    #[test_traced]
+    fn test_variable_recovery_completes_offsets_ahead_prune() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // === Setup: Create Variable wrapper with data ===
@@ -4087,16 +4282,397 @@ mod tests {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
-            // Prune offsets journal ahead of data blobs (impossible state)
-            let (mut variable, _) = variable.test_prune_offsets(20).await.unwrap(); // Prune to position 20
+            // Persist the offsets prune, then remove only part of the data prefix.
+            variable = variable.test_prune_offsets(20).await.unwrap().0; // Prune to position 20
             variable.test_prune_data(1).await.unwrap(); // Only prune data blobs to blob 1 (position 10)
 
             let variable = variable.sync().await.unwrap();
             drop(variable);
 
-            // === Verify corruption detected ===
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 20..40);
+            for i in 20..40u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A mid-blob journal pruned exactly to the next blob boundary must recover from a crash
+    /// between the offsets prune and the data prune: the stale mid-blob data blob is removed
+    /// and the journal resumes empty at the committed boundary.
+    #[test_traced]
+    fn test_variable_recovery_completes_mid_blob_interrupted_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "mid-blob-interrupted-prune".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            // A mid-blob journal: blob 1 holds positions 7..10, blob 2 is the empty tail.
+            let mut journal =
+                Journal::<_, u64>::init_at_size(context.child("first"), cfg.clone(), 7)
+                    .await
+                    .unwrap();
+            for i in 7..10u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Commit the offsets boundary without removing any data blob, simulating a prune
+            // that crashed between the offsets prune and the data prune.
+            let (journal, _) = journal.test_prune_offsets(10).await.unwrap();
+            drop(journal);
+
+            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..10);
+
+            // The interrupted prune completed: the stale mid-blob data blob is gone.
+            let names = context.scan(&cfg.data_partition()).await.unwrap();
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+
+            // The journal resumes normally at the boundary.
+            let pos;
+            (journal, pos) = journal.append(&1000).await.unwrap();
+            assert_eq!(pos, 10);
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(journal.read(10).await.unwrap(), 1000);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A variable prune future dropped during the offsets prune consumes the journal but has
+    /// already committed the boundary. Recovery adopts it: the reopened journal never reports
+    /// bounds whose offsets were pruned, and retained items stay readable.
+    #[test_traced]
+    fn test_variable_prune_interrupted_removal_keeps_committed_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-interrupted-keeps-boundary".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop a prune parked inside the offsets prune, before data removal: the consuming
+            // future destroys the journal, but the offsets boundary is durably committed.
+            journal.test_halt_offsets_prune_removals(true);
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the offsets removals"
+                );
+            }
+
+            // Recovery completes the interrupted prune: bounds agree with the committed boundary,
+            // retained items are readable, and pruned positions are reported as pruned.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(5))));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A variable prune future dropped during the offsets-blob removal has already committed
+    /// the boundary but removed no blob anywhere. Dropping the future discards the journal
+    /// (mutating methods consume it), and recovery must complete both removal layers of the
+    /// interrupted prune.
+    #[test_traced]
+    fn test_variable_prune_dropped_during_offsets_removal() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "prune-dropped-during-offsets-removal".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Drop the production prune future while it is parked after the offsets
+            // journal's boundary commit, before any blob removal: a genuine cancellation
+            // at the removal await. The journal is consumed with the dropped future; its
+            // durable state holds the committed boundary with every blob still present.
+            journal.test_halt_offsets_prune_removals(true);
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park at the halt before offsets-blob removal"
+                );
+            }
+
+            // Recovery completes both removal layers of the interrupted prune.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            let names = context.scan(&cfg.data_partition()).await.unwrap();
+            assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// If the data blob at the committed pruning boundary is missing, recovery must report
+    /// corruption rather than deleting the surviving suffix and treating its items as pruned.
+    #[test_traced]
+    fn test_variable_recovery_rejects_missing_boundary_blob() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "missing-durable-boundary".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, _) = journal.test_prune_offsets(20).await.unwrap();
+            drop(journal);
+
+            let data_partition = cfg.data_partition();
+            context
+                .remove(&data_partition, Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
             assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving blobs are left intact for diagnosis or external recovery.
+            let names = context.scan(&data_partition).await.unwrap();
+            assert!(names.contains(&0u64.to_be_bytes().to_vec()));
+            assert!(names.contains(&3u64.to_be_bytes().to_vec()));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// If every data blob at or above the committed pruning boundary is missing while stale
+    /// prefix blobs survive an interrupted prune, recovery must report corruption rather than
+    /// collapsing the retained range to a completed prune-all.
+    #[test_traced]
+    fn test_variable_recovery_rejects_lost_retained_range() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "lost-retained-range".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Commit the offsets boundary without removing any data blob, simulating a prune
+            // that crashed before its first data removal.
+            let (journal, _) = journal.test_prune_offsets(20).await.unwrap();
+            drop(journal);
+
+            // Lose every data blob at or above the boundary; the stale prefix survives.
+            let data_partition = cfg.data_partition();
+            for blob in 2u64..5 {
+                let _ = context
+                    .remove(&data_partition, Some(&blob.to_be_bytes()))
+                    .await;
+            }
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Losing the boundary blob after a fully completed prune is corruption, stable across
+    /// retries: with no stale prefix left, the loss surfaces as data ahead of the committed
+    /// boundary rather than as an interrupted prune.
+    #[test_traced]
+    fn test_variable_recovery_rejects_boundary_loss_after_completed_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "completed-prune-boundary-loss".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(20).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the blob at the committed boundary; later blobs survive.
+            let data_partition = cfg.data_partition();
+            context
+                .remove(&data_partition, Some(&2u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The surviving suffix is left intact, and the result is stable across retries.
+            let names = context.scan(&data_partition).await.unwrap();
+            assert!(names.contains(&3u64.to_be_bytes().to_vec()));
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// Losing every retained blob after a fully completed prune is corruption, stable across
+    /// retries: the watermark proves acknowledged items were lost, not pruned.
+    #[test_traced]
+    fn test_variable_recovery_rejects_retained_loss_after_completed_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "completed-prune-retained-loss".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(20).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose every retained blob at or above the boundary.
+            let data_partition = cfg.data_partition();
+            for blob in 2u64..5 {
+                let _ = context
+                    .remove(&data_partition, Some(&blob.to_be_bytes()))
+                    .await;
+            }
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A surviving empty tail cannot vouch for lost acknowledged blobs: recovery must report
+    /// corruption, stable across retries, rather than adopting the tail's position as the
+    /// pruning boundary.
+    #[test_traced]
+    fn test_variable_recovery_rejects_item_blob_loss_with_surviving_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "item-loss-surviving-tail".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
+            drop(journal);
+
+            // Lose the only item-bearing retained blob; the empty tail survives.
+            let data_partition = cfg.data_partition();
+            context
+                .remove(&data_partition, Some(&1u64.to_be_bytes()))
+                .await
+                .unwrap();
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The corruption result is stable across retries.
+            let retry = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(retry, Err(Error::Corruption(_))));
         });
     }
 
@@ -5084,69 +5660,6 @@ mod tests {
             assert_eq!(journal.read(20).await.unwrap(), 2000);
 
             journal.destroy().await.unwrap();
-        });
-    }
-
-    /// Test recovery from multiple prune operations with crash.
-    #[test_traced]
-    fn test_variable_recovery_multiple_prunes_crash() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // === Setup: Create Variable wrapper with data ===
-            let cfg = Config {
-                partition: "recovery-multiple-prunes".into(),
-                items_per_section: NZU64!(10),
-                compression: None,
-                codec_config: (),
-                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
-                write_buffer: NZUsize!(1024),
-            };
-
-            let mut variable = Journal::<_, u64>::init(context.child("first"), cfg.clone())
-                .await
-                .unwrap();
-
-            // Append 50 items across 5 blobs to both journals
-            for i in 0..50u64 {
-                (variable, _) = variable.append(&(i * 100)).await.unwrap();
-            }
-
-            // Prune to position 10 normally (both data and offsets journals pruned)
-            let (mut variable, _) = variable.prune(10).await.unwrap();
-            assert_eq!(variable.bounds().start, 10);
-
-            // === Simulate crash: Multiple prunes on data blobs, not on offsets journal ===
-            // Manually prune data blobs to blob 3 (position 30)
-            variable.test_prune_data(3).await.unwrap();
-            // Offsets journal still thinks oldest is position 10
-
-            variable.sync().await.unwrap();
-
-            // === Verify recovery ===
-            let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
-
-            // Init should auto-repair: offsets journal pruned to match data blobs
-            let bounds = variable.bounds();
-            assert_eq!(bounds.start, 30);
-            assert_eq!(bounds.end, 50);
-
-            // Reads before position 30 should fail (pruned from both journals)
-            assert!(matches!(
-                variable.read(10).await,
-                Err(crate::journal::Error::ItemPruned(_))
-            ));
-            assert!(matches!(
-                variable.read(20).await,
-                Err(crate::journal::Error::ItemPruned(_))
-            ));
-
-            // Reads at position 30+ should succeed
-            assert_eq!(variable.read(30).await.unwrap(), 3000);
-            assert_eq!(variable.read(49).await.unwrap(), 4900);
-
-            variable.destroy().await.unwrap();
         });
     }
 
@@ -6578,67 +7091,6 @@ mod tests {
             for i in 0..8u64 {
                 assert_eq!(journal.read(7 + i).await.unwrap(), 700 + i);
             }
-
-            journal.destroy().await.unwrap();
-        });
-    }
-
-    /// Regression test: data-empty crash repair must preserve mid-blob pruning boundary.
-    #[test_traced]
-    fn test_align_journals_data_empty_mid_blob_pruning_boundary() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            let cfg = Config {
-                partition: "align-journals-mid-blob-pruning-boundary".into(),
-                items_per_section: NZU64!(5),
-                compression: None,
-                codec_config: (),
-                page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
-                write_buffer: NZUsize!(1024),
-            };
-
-            // Phase 1: Create data and offsets, then simulate data-only pruning crash.
-            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
-                .await
-                .unwrap();
-            for i in 0..7u64 {
-                (journal, _) = journal.append(&(100 + i)).await.unwrap();
-            }
-            journal = journal.sync().await.unwrap();
-
-            // Simulate crash after data was cleared but before offsets were pruned.
-            drop(journal);
-            Partition::<deterministic::Context>::remove_all(&context, &cfg.data_partition())
-                .await
-                .unwrap();
-
-            // Phase 2: Init triggers data-empty repair and should treat journal as fully pruned at size 7.
-            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
-                .await
-                .unwrap();
-            let bounds = journal.bounds();
-            assert_eq!(bounds.end, 7);
-            assert!(bounds.is_empty());
-
-            // Append one item at position 7.
-            let pos;
-            (journal, pos) = journal.append(&777).await.unwrap();
-            assert_eq!(pos, 7);
-            assert_eq!(journal.size(), 8);
-            assert_eq!(journal.read(7).await.unwrap(), 777);
-
-            // Sync only the data blobs to simulate a crash before offsets are synced.
-            journal.0.blobs.start_sync().await.await.unwrap();
-            drop(journal);
-
-            // Phase 3: Reopen and verify we did not lose the appended item.
-            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
-                .await
-                .unwrap();
-            let bounds = journal.bounds();
-            assert_eq!(bounds.end, 8);
-            assert_eq!(bounds.start, 7);
-            assert_eq!(journal.read(7).await.unwrap(), 777);
 
             journal.destroy().await.unwrap();
         });


### PR DESCRIPTION
## Summary

Pruning derives its boundary from whichever old blobs happen to survive on disk, so recovery cannot distinguish a legitimately pruned prefix from lost retained data: an interrupted prune — or an externally corrupted survivor below the boundary — is silently reclassified as pruned history, and the journal reopens as a shorter but seemingly valid state. This PR records the pruning boundary durably **before** removing any blob, so recovery *knows* the boundary instead of inferring it.

Rebased onto and built on top of #4310 (durability `Barrier` + best-effort recovery watermark in `start_sync`); it keeps #4310's prune structure and consuming API and adds the durable boundary + recovery hardening on top, rather than replacing them.

## What changed

- **`persist` records every boundary.** `Checkpoint::persist` now records all pruning boundaries, including blob-aligned ones, dropping the aligned-drop optimization that inferred aligned boundaries from the oldest surviving blob. Inference is what makes lost retained data indistinguishable from a legitimate prune; recording the boundary removes that ambiguity.
- **Prune commits the boundary before removal, with a watermark that covers it.** The fixed journal persists the boundary to its checkpoint before removing blobs; the variable journal prunes the offsets journal (its durable prune record) before removing data. The prune first syncs all data durable, then records that proven size (`bounds.end`) as the recovery watermark — so the just-synced retained items are covered rather than left below a stale watermark. A committed boundary lets recovery complete an interrupted prune, so blob removal no longer has to finish atomically or in order. This composes with #4310's `Barrier`: the pre-removal data sync marks the barrier durable, and the boundary is committed after it.
- **Recovery treats the recorded boundary as authoritative.** A boundary whose blob is missing while later blobs survive is reported as corruption — uniformly for aligned and mid-blob boundaries — instead of being masked as pruned history or silently adopting the oldest survivor. The verdict is reached before any surviving blob is removed and is stable across retried inits. Recovery also truncates a torn interior page in the two newest blobs (the only ones that can hold non-durable data), and completes interrupted prunes and clears.

## Recovery semantics

With a recorded boundary, init reconciles physical state against it:

- blobs below the boundary are removed, completing an interrupted prune;
- the boundary is recorded before any removal and removals never touch the boundary blob, so a missing boundary blob with surviving later blobs is **always** corruption — for both aligned and mid-blob boundaries — a loss state that inference previously masked as pruned history (and that the mid-blob path previously adopted silently);
- the prune records a watermark covering the data it just made durable, so losing that retained data after a prune is corruption rather than a journal that reopens empty (a stale watermark previously under-recorded durability here);
- variable journals use the offsets journal's pruning boundary as the committed data-prune record; because the offsets boundary is committed before data removal, a crash mid-removal leaves the data prefix ahead of the boundary, which recovery finishes removing (offsets-ahead-of-data is an interrupted prune, not corruption);
- data ahead of the committed variable-journal boundary — including a missing boundary blob — is corruption, as is a recovery watermark beyond the recoverable size.

Corruption verdicts leave surviving blobs untouched and are stable across retried inits **for crash-reachable states**: the pre-reconcile trailing-byte trim runs before the boundary is validated, so a synced (chunk-aligned) blob is never trimmed by an in-model crash; a blob it mutates despite a later corruption verdict implies external corruption of already-durable data, outside the crash model.

## Compatibility

A recorded pruning boundary is authoritative, which changes one upgrade case: a journal that crashed **mid-prune under a pre-#4235 binary** can leave a recorded boundary that lags physical storage (an `init_at_size` mid-blob boundary whose blob the old prune removed before the next sync persisted the update). Old code adopted the surviving blobs; this PR reports corruption. **Sync/drain cleanly before upgrading from a pre-#4235 binary.** Journals with no recorded boundary at all still derive it from the oldest blob on first init and then persist it explicitly, so aligned upgrades (where #4310 recorded no boundary) are unaffected.

## Costs

- Each prune performs one durable metadata sync (fixed) / offsets prune (variable) before removing blobs; previously an aligned prune wrote no boundary metadata and left its boundary implicit in which blobs survived.
- The first init after upgrade persists the derived boundary once.

## Validation

- `just test -p commonware-storage` — full suite (2865 tests), including failing-first prune-watermark regressions (`test_fixed_recovery_prune_watermark_covers_retained_data`, `test_variable_recovery_prune_watermark_covers_retained_data`) and the uniform missing-boundary corruption test (`test_fixed_recovery_rejects_lagging_mid_blob_boundary`, a real `init_at_size` journal with its boundary blob removed).
- `just test-conformance -p commonware-storage` — 128 tests pass. The always-recorded-boundary change regenerated the contiguous and journal-backed qmdb/adb fixtures earlier in this PR; the recovery fixes moved no further hashes (the watermark is internal recovery state).
- `just fix-fmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo
