### PR TITLE
[consensus/marshal] Reduce `Block` clone pressure

### DIFF
--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -17,7 +17,7 @@ use commonware_utils::{channel::oneshot, futures::Pool, vec::Bounded, NZUsize, T
 use futures::FutureExt as _;
 use libfuzzer_sys::fuzz_target;
 use rand::seq::SliceRandom;
-use std::{collections::BTreeMap, num::NonZeroU32, time::Duration};
+use std::{collections::BTreeMap, num::NonZeroU32, sync::Arc, time::Duration};
 
 /// Default rate limit set high enough to not interfere with normal operation
 const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
@@ -35,7 +35,7 @@ const MAX_SLEEP_DURATION_MS: u64 = 1000;
 const MAX_RECENT_DIGESTS: usize = (u8::MAX as usize) + 1;
 
 /// Subscription result paired with the digest requested so completions can be validated.
-type Subscription = (Digest, Result<FuzzMessage, oneshot::error::RecvError>);
+type Subscription = (Digest, Result<Arc<FuzzMessage>, oneshot::error::RecvError>);
 
 #[derive(Clone, Debug, Arbitrary)]
 pub enum RecipientPattern {

--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -16,13 +16,16 @@ use commonware_utils::{
     channel::{fallible::OneshotExt, oneshot},
     ordered::Set,
 };
-use std::collections::{BTreeMap, VecDeque};
+use std::{
+    collections::{BTreeMap, VecDeque},
+    sync::Arc,
+};
 use tracing::{debug, error, trace, warn};
 
 /// A responder waiting for a message.
 struct Waiter<M> {
     /// The responder to send the message to.
-    responder: oneshot::Sender<M>,
+    responder: oneshot::Sender<Arc<M>>,
 }
 
 /// Result of buffering an incoming or locally sent digest (inserted, duplicate, or ineligible).
@@ -82,7 +85,7 @@ where
     // Cache
     ////////////////////////////////////////
     /// All cached messages by digest.
-    items: BTreeMap<M::Digest, M>,
+    items: BTreeMap<M::Digest, Arc<M>>,
 
     /// A LRU cache of the latest received digests from each peer.
     ///
@@ -250,7 +253,7 @@ where
     ///
     /// If the message is already in the cache, the responder is immediately sent the message.
     /// Otherwise, the responder is stored in the waiters list.
-    fn handle_subscribe(&mut self, digest: M::Digest, responder: oneshot::Sender<M>) {
+    fn handle_subscribe(&mut self, digest: M::Digest, responder: oneshot::Sender<Arc<M>>) {
         // Check if the message is already in the cache
         if let Some(item) = self.items.get(&digest).cloned() {
             self.respond_subscribe(responder, item);
@@ -265,7 +268,7 @@ where
     }
 
     /// Handles a `get` request from the application.
-    fn handle_get(&mut self, digest: M::Digest, responder: oneshot::Sender<Option<M>>) {
+    fn handle_get(&mut self, digest: M::Digest, responder: oneshot::Sender<Option<Arc<M>>>) {
         let item = self.items.get(&digest).cloned();
         self.respond_get(responder, item);
     }
@@ -297,13 +300,25 @@ where
     /// Waiters are notified even when a sender is not eligible to keep a
     /// buffered cache entry resident.
     fn insert_message(&mut self, peer: P, digest: M::Digest, msg: M) -> InsertMessageResult {
-        // Send the message to the waiters, if any
         if let Some(waiters) = self.waiters.remove(&digest) {
+            let msg = Arc::new(msg);
             for waiter in waiters {
-                self.respond_subscribe(waiter.responder, msg.clone());
+                self.respond_subscribe(waiter.responder, Arc::clone(&msg));
             }
+            return self.insert_cache_entry(peer, digest, || Arc::clone(&msg));
         }
 
+        self.insert_cache_entry(peer, digest, || Arc::new(msg))
+    }
+
+    /// Records a peer's reference to a message, constructing the shared value
+    /// only when this is the first reference retained by the cache.
+    fn insert_cache_entry(
+        &mut self,
+        peer: P,
+        digest: M::Digest,
+        msg: impl FnOnce() -> Arc<M>,
+    ) -> InsertMessageResult {
         // Only peers listed in `latest.primary` may buffer
         if self.latest_primary_peers.position(&peer).is_none() {
             return InsertMessageResult::Ineligible;
@@ -333,8 +348,9 @@ where
             .entry(digest)
             .and_modify(|c| *c = c.checked_add(1).unwrap())
             .or_insert(1);
-        if *count == 1 {
-            let existing = self.items.insert(digest, msg);
+        let first = *count == 1;
+        if first {
+            let existing = self.items.insert(digest, msg());
             assert!(existing.is_none());
         }
 
@@ -385,7 +401,7 @@ where
 
     /// Respond to a waiter with a message.
     /// Increments the appropriate metric based on the result.
-    fn respond_subscribe(&mut self, responder: oneshot::Sender<M>, msg: M) {
+    fn respond_subscribe(&mut self, responder: oneshot::Sender<Arc<M>>, msg: Arc<M>) {
         self.metrics.subscribe.inc(if responder.send_lossy(msg) {
             Status::Success
         } else {
@@ -395,7 +411,7 @@ where
 
     /// Respond to a get request.
     /// Increments the appropriate metric based on the result.
-    fn respond_get(&mut self, responder: oneshot::Sender<Option<M>>, msg: Option<M>) {
+    fn respond_get(&mut self, responder: oneshot::Sender<Option<Arc<M>>>, msg: Option<Arc<M>>) {
         let found = msg.is_some();
         self.metrics.get.inc(if responder.send_lossy(msg) {
             if found {

--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -239,14 +239,14 @@ where
         &mut self,
         sender: &mut WrappedSender<Sr, M>,
         recipients: Recipients<P>,
-        msg: M,
+        msg: Arc<M>,
     ) {
         // Store the message, continue even if it was already stored
         let digest = msg.digest();
-        let _ = self.insert_message(self.public_key.clone(), digest, msg.clone());
+        let _ = self.insert_shared_message(self.public_key.clone(), digest, &msg);
 
         // Broadcast the message to the network
-        sender.send(recipients, msg, self.priority);
+        sender.send_ref(recipients, msg.as_ref(), self.priority);
     }
 
     /// Handles a `subscribe` request from the application.
@@ -302,13 +302,25 @@ where
     fn insert_message(&mut self, peer: P, digest: M::Digest, msg: M) -> InsertMessageResult {
         if let Some(waiters) = self.waiters.remove(&digest) {
             let msg = Arc::new(msg);
-            for waiter in waiters {
-                self.respond_subscribe(waiter.responder, Arc::clone(&msg));
-            }
+            self.respond_waiters(waiters, &msg);
             return self.insert_cache_entry(peer, digest, || Arc::clone(&msg));
         }
 
         self.insert_cache_entry(peer, digest, || Arc::new(msg))
+    }
+
+    /// Inserts a shared message into the cache.
+    fn insert_shared_message(
+        &mut self,
+        peer: P,
+        digest: M::Digest,
+        msg: &Arc<M>,
+    ) -> InsertMessageResult {
+        if let Some(waiters) = self.waiters.remove(&digest) {
+            self.respond_waiters(waiters, msg);
+        }
+
+        self.insert_cache_entry(peer, digest, || Arc::clone(msg))
     }
 
     /// Records a peer's reference to a message, acquiring an `Arc` only when
@@ -406,6 +418,12 @@ where
         } else {
             Status::Dropped
         });
+    }
+
+    fn respond_waiters(&mut self, waiters: Vec<Waiter<M>>, msg: &Arc<M>) {
+        for waiter in waiters {
+            self.respond_subscribe(waiter.responder, Arc::clone(msg));
+        }
     }
 
     /// Respond to a get request.

--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -311,13 +311,13 @@ where
         self.insert_cache_entry(peer, digest, || Arc::new(msg))
     }
 
-    /// Records a peer's reference to a message, constructing the shared value
-    /// only when this is the first reference retained by the cache.
+    /// Records a peer's reference to a message, acquiring an `Arc` only when
+    /// the cache needs to store the message.
     fn insert_cache_entry(
         &mut self,
         peer: P,
         digest: M::Digest,
-        msg: impl FnOnce() -> Arc<M>,
+        make_shared: impl FnOnce() -> Arc<M>,
     ) -> InsertMessageResult {
         // Only peers listed in `latest.primary` may buffer
         if self.latest_primary_peers.position(&peer).is_none() {
@@ -349,7 +349,7 @@ where
             .and_modify(|c| *c = c.checked_add(1).unwrap())
             .or_insert(1);
         if *count == 1 {
-            let existing = self.items.insert(digest, msg());
+            let existing = self.items.insert(digest, make_shared());
             assert!(existing.is_none());
         }
 

--- a/broadcast/src/buffered/engine.rs
+++ b/broadcast/src/buffered/engine.rs
@@ -348,8 +348,7 @@ where
             .entry(digest)
             .and_modify(|c| *c = c.checked_add(1).unwrap())
             .or_insert(1);
-        let first = *count == 1;
-        if first {
+        if *count == 1 {
             let existing = self.items.insert(digest, msg());
             assert!(existing.is_none());
         }

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -112,19 +112,6 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
         receiver
     }
 
-    /// Subscribe to a message by digest with an externally prepared responder.
-    ///
-    /// The responder will be sent the message when it is available; either
-    /// instantly (if cached) or when it is received from the network. The request can be canceled
-    /// by dropping the responder.
-    ///
-    /// If the engine has shut down, this is a no-op.
-    pub fn subscribe_prepared(&self, digest: M::Digest, responder: oneshot::Sender<Arc<M>>) {
-        let _ = self
-            .sender
-            .enqueue(Message::Subscribe { digest, responder });
-    }
-
     /// Get a message by digest.
     ///
     /// If the engine has shut down, returns `None`.

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -14,7 +14,7 @@ pub(crate) enum Message<P: PublicKey, M: Digestible> {
     /// Broadcast a [crate::Broadcaster::Message] to the network.
     Broadcast {
         recipients: Recipients<P>,
-        message: M,
+        message: Arc<M>,
     },
 
     /// Subscribe to receive a message by digest.
@@ -120,6 +120,16 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
         let _ = self.sender.enqueue(Message::Get { digest, responder });
         receiver.await.unwrap_or_default()
     }
+
+    /// Broadcast a shared message to recipients.
+    ///
+    /// If the engine has shut down, returns [`Feedback::Closed`].
+    pub fn broadcast_shared(&self, recipients: Recipients<P>, message: Arc<M>) -> Feedback {
+        self.sender.enqueue(Message::Broadcast {
+            recipients,
+            message,
+        })
+    }
 }
 
 impl<P: PublicKey, M: Digestible + Codec> Broadcaster for Mailbox<P, M> {
@@ -130,9 +140,6 @@ impl<P: PublicKey, M: Digestible + Codec> Broadcaster for Mailbox<P, M> {
     ///
     /// If the engine has shut down, returns [`Feedback::Closed`].
     fn broadcast(&self, recipients: Self::Recipients, message: Self::Message) -> Feedback {
-        self.sender.enqueue(Message::Broadcast {
-            recipients,
-            message,
-        })
+        self.broadcast_shared(recipients, Arc::new(message))
     }
 }

--- a/broadcast/src/buffered/ingress.rs
+++ b/broadcast/src/buffered/ingress.rs
@@ -7,7 +7,7 @@ use commonware_codec::Codec;
 use commonware_cryptography::{Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 /// Message types that can be sent to the `Mailbox`
 pub(crate) enum Message<P: PublicKey, M: Digestible> {
@@ -24,13 +24,13 @@ pub(crate) enum Message<P: PublicKey, M: Digestible> {
     /// by dropping the responder.
     Subscribe {
         digest: M::Digest,
-        responder: oneshot::Sender<M>,
+        responder: oneshot::Sender<Arc<M>>,
     },
 
     /// Get a message by digest.
     Get {
         digest: M::Digest,
-        responder: oneshot::Sender<Option<M>>,
+        responder: oneshot::Sender<Option<Arc<M>>>,
     },
 }
 
@@ -104,7 +104,7 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
     /// by dropping the responder.
     ///
     /// If the engine has shut down, the returned receiver will resolve to `Canceled`.
-    pub fn subscribe(&self, digest: M::Digest) -> oneshot::Receiver<M> {
+    pub fn subscribe(&self, digest: M::Digest) -> oneshot::Receiver<Arc<M>> {
         let (responder, receiver) = oneshot::channel();
         let _ = self
             .sender
@@ -119,7 +119,7 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
     /// by dropping the responder.
     ///
     /// If the engine has shut down, this is a no-op.
-    pub fn subscribe_prepared(&self, digest: M::Digest, responder: oneshot::Sender<M>) {
+    pub fn subscribe_prepared(&self, digest: M::Digest, responder: oneshot::Sender<Arc<M>>) {
         let _ = self
             .sender
             .enqueue(Message::Subscribe { digest, responder });
@@ -128,7 +128,7 @@ impl<P: PublicKey, M: Digestible + Codec> Mailbox<P, M> {
     /// Get a message by digest.
     ///
     /// If the engine has shut down, returns `None`.
-    pub async fn get(&self, digest: M::Digest) -> Option<M> {
+    pub async fn get(&self, digest: M::Digest) -> Option<Arc<M>> {
         let (responder, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::Get { digest, responder });
         receiver.await.unwrap_or_default()

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -397,7 +397,7 @@ mod tests {
                 let digest = message.digest();
                 let receiver = mailbox.subscribe(digest);
                 let received_message = receiver.await.ok();
-                assert_eq!(received_message.unwrap(), message.clone());
+                assert_eq!(received_message.unwrap().as_ref(), &message);
             }
 
             // Send another message
@@ -416,7 +416,7 @@ mod tests {
                 let digest = message.digest();
                 let receiver = mailbox.get(digest).await;
                 if let Some(receiver) = receiver {
-                    assert_eq!(receiver, message.clone());
+                    assert_eq!(receiver.as_ref(), &message);
                     found += 1;
                 }
             }
@@ -455,11 +455,11 @@ mod tests {
             let msg_before = receiver_before
                 .await
                 .expect("Pre-broadcast retrieval failed");
-            assert_eq!(msg_before, m1);
+            assert_eq!(msg_before.as_ref(), &m1);
 
             // Attempt immediate retrieval after broadcasting
             let receiver_after = mailbox_a.get(digest_m1).await;
-            assert_eq!(receiver_after, Some(m1.clone()));
+            assert_eq!(receiver_after.as_deref(), Some(&m1));
 
             // Perform a second retrieval after the broadcast
             let receiver_after = mailbox_a.subscribe(digest_m1);
@@ -472,7 +472,7 @@ mod tests {
             let duration = context.current().duration_since(start).unwrap();
 
             // Verify the second retrieval matches the original message
-            assert_eq!(msg_after, m1);
+            assert_eq!(msg_after.as_ref(), &m1);
 
             // Verify the second retrieval was instant (less than 10ms)
             assert!(duration < A_JIFFY, "get not instant");
@@ -549,7 +549,7 @@ mod tests {
             let start = context.current();
             let received = receiver.await.expect("failed to get cached message");
             let duration = context.current().duration_since(start).unwrap();
-            assert_eq!(received, message);
+            assert_eq!(received.as_ref(), &message);
             assert!(duration < A_JIFFY, "get not instant",);
         });
     }
@@ -586,7 +586,7 @@ mod tests {
 
             // Check receiver1 gets the message, receiver2 was dropped
             let received = receiver.await.expect("receiver1 should get message");
-            assert_eq!(received, message);
+            assert_eq!(received.as_ref(), &message);
         });
     }
 
@@ -618,7 +618,7 @@ mod tests {
             let peer_mailbox = mailboxes.get(&peers[1]).unwrap().clone();
             for msg in messages.iter().skip(1) {
                 let result = peer_mailbox.subscribe(msg.digest()).await.unwrap();
-                assert_eq!(result, msg.clone());
+                assert_eq!(result.as_ref(), msg);
             }
 
             // Check first message times out
@@ -671,7 +671,7 @@ mod tests {
             // Verify B can still get M1 (in C's deque)
             let receiver = mailbox_b.subscribe(digest_m1);
             let received = receiver.await.expect("M1 should be retrievable");
-            assert_eq!(received, m1);
+            assert_eq!(received.as_ref(), &m1);
 
             // Peer C broadcasts 10 new messages to evict M1 from C's deque
             let mut new_messages_c = Vec::with_capacity(CACHE_SIZE);
@@ -722,7 +722,7 @@ mod tests {
                 .clone()
                 .get(msg.digest())
                 .await;
-            assert_eq!(got_target, Some(msg.clone()));
+            assert_eq!(got_target.as_deref(), Some(&msg));
 
             // Non-target peer should not retrieve the message.
             let got_other = mailboxes
@@ -763,7 +763,7 @@ mod tests {
             context.sleep(NETWORK_SPEED_WITH_BUFFER).await;
 
             // observer must get it now
-            assert_eq!(obs.get(digest).await, Some(dup.clone()));
+            assert_eq!(obs.get(digest).await.as_deref(), Some(&dup));
 
             // Evict from p0's deque only
             for i in 0..CACHE_SIZE {
@@ -771,7 +771,7 @@ mod tests {
                 assert!(mb0.broadcast(Recipients::All, spam).accepted());
             }
             context.sleep(NETWORK_SPEED_WITH_BUFFER).await;
-            assert_eq!(obs.get(digest).await, Some(dup.clone()));
+            assert_eq!(obs.get(digest).await.as_deref(), Some(&dup));
 
             // Evict from p1's deque as well
             for i in 0..CACHE_SIZE {
@@ -862,7 +862,7 @@ mod tests {
                 .subscribe(message.digest())
                 .await
                 .expect("victim should receive valid message after malformed payload");
-            assert_eq!(received, message);
+            assert_eq!(received.as_ref(), &message);
         });
     }
 
@@ -1076,7 +1076,7 @@ mod tests {
             // Verify message received
             let peer_mailbox = mailboxes.get(&peers[1]).unwrap().clone();
             let received = peer_mailbox.get(message.digest()).await;
-            assert_eq!(received, Some(message));
+            assert_eq!(received.as_deref(), Some(&message));
 
             // Abort all engine handles
             for handle in handles {
@@ -1153,8 +1153,8 @@ mod tests {
             // Peer B should have cached the message (received from A).
             let mailbox_b = mailboxes.get(&peer_b).unwrap().clone();
             assert_eq!(
-                mailbox_b.get(msg.digest()).await,
-                Some(msg.clone()),
+                mailbox_b.get(msg.digest()).await.as_deref(),
+                Some(&msg),
                 "peer B should have the message before eviction"
             );
 
@@ -1264,8 +1264,8 @@ mod tests {
 
             let mailbox_b = mailboxes.get(&peer_b).unwrap().clone();
             assert_eq!(
-                mailbox_b.get(msg.digest()).await,
-                Some(msg.clone()),
+                mailbox_b.get(msg.digest()).await.as_deref(),
+                Some(&msg),
                 "peer B should have the message before eviction"
             );
 
@@ -1429,8 +1429,8 @@ mod tests {
             engine.start(network);
 
             assert_eq!(
-                mailbox.get(msg.digest()).await,
-                Some(msg),
+                mailbox.get(msg.digest()).await.as_deref(),
+                Some(&msg),
                 "sender is already in the initial latest.primary set, so its local broadcast should be cached"
             );
         });
@@ -1534,7 +1534,7 @@ mod tests {
                 .accepted());
             context.sleep(NETWORK_SPEED_WITH_BUFFER).await;
 
-            assert_eq!(mailbox_b.get(after.digest()).await, Some(after));
+            assert_eq!(mailbox_b.get(after.digest()).await.as_deref(), Some(&after));
         });
     }
 
@@ -1593,7 +1593,7 @@ mod tests {
 
             // B has the message in both A's and C's deques (ref count = 2).
             let mailbox_b = mailboxes.get(&peer_b).unwrap().clone();
-            assert_eq!(mailbox_b.get(msg.digest()).await, Some(msg.clone()));
+            assert_eq!(mailbox_b.get(msg.digest()).await.as_deref(), Some(&msg));
 
             // Evict peer A only; C is still in the latest primary set.
             let remaining = commonware_utils::ordered::Set::from_iter_dedup(vec![peer_b, peer_c]);
@@ -1602,8 +1602,8 @@ mod tests {
 
             // Message should still be available (C's deque still holds it).
             assert_eq!(
-                mailbox_b.get(msg.digest()).await,
-                Some(msg.clone()),
+                mailbox_b.get(msg.digest()).await.as_deref(),
+                Some(&msg),
                 "message should survive when another peer in the primary set still references it"
             );
         });

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -60,6 +60,7 @@ mod tests {
     use std::{
         collections::{BTreeMap, VecDeque},
         num::NonZeroU32,
+        sync::Arc,
         time::Duration,
     };
 
@@ -476,6 +477,27 @@ mod tests {
 
             // Verify the second retrieval was instant (less than 10ms)
             assert!(duration < A_JIFFY, "get not instant");
+        });
+    }
+
+    #[test_traced]
+    fn test_shared_broadcast_reuses_message() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(5));
+        runner.start(|context| async move {
+            let (peers, mut registrations, oracle) =
+                initialize_simulation(context.child("network"), 1, 1.0).await;
+            let mailboxes =
+                spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
+            let mailbox = mailboxes.get(&peers[0]).unwrap();
+
+            let message = Arc::new(TestMessage::shared(b"shared broadcast"));
+            let digest = message.digest();
+            assert!(mailbox
+                .broadcast_shared(Recipients::All, Arc::clone(&message))
+                .accepted());
+
+            let cached = mailbox.get(digest).await.expect("message should be cached");
+            assert!(Arc::ptr_eq(&message, &cached));
         });
     }
 

--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -2,10 +2,10 @@
 
 use crate::error::Error;
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc::{sync::Arc, vec::Vec};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 #[cfg(feature = "std")]
-use std::vec::Vec;
+use std::{sync::Arc, vec::Vec};
 
 /// Trait for types with a known, fixed encoded size.
 ///
@@ -166,6 +166,30 @@ pub trait Write {
         for item in values {
             item.write_bufs(buf);
         }
+    }
+}
+
+impl<T: EncodeSize + ?Sized> EncodeSize for Arc<T> {
+    #[inline]
+    fn encode_size(&self) -> usize {
+        self.as_ref().encode_size()
+    }
+
+    #[inline]
+    fn encode_inline_size(&self) -> usize {
+        self.as_ref().encode_inline_size()
+    }
+}
+
+impl<T: Write + ?Sized> Write for Arc<T> {
+    #[inline]
+    fn write(&self, buf: &mut impl BufMut) {
+        self.as_ref().write(buf);
+    }
+
+    #[inline]
+    fn write_bufs(&self, buf: &mut impl BufsMut) {
+        self.as_ref().write_bufs(buf);
     }
 }
 

--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -447,6 +447,14 @@ mod tests {
     }
 
     #[test]
+    fn test_arc_encode() {
+        let value = Arc::new(vec![1u8, 2, 3]);
+
+        assert_eq!(value.encode(), value.as_ref().encode());
+        assert_eq!(value.encode_size(), value.as_ref().encode_size());
+    }
+
+    #[test]
     #[should_panic(expected = "Can't encode 4 bytes into 5 bytes")]
     fn test_encode_fixed_panic() {
         let _: [u8; 5] = 42u32.encode_fixed();

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -60,7 +60,7 @@
 //!   [Encode], [Codec], [EncodeFixed], and [CodecFixed] when `T: FixedSize`.
 //! - Collections: [`Vec`], [`Option`], `BTreeMap`, `BTreeSet`
 //! - Tuples: `(T1, T2, ...)` (up to 12 elements)
-//! - Common External Types: [::bytes::Bytes]
+//! - Common External Types: [::bytes::Bytes], `Arc` (encoding only)
 //!
 //! With the `std` feature (enabled by default):
 //! - Networking:

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -17,7 +17,7 @@ use std::{
 };
 
 /// A stream of blocks used by application propose and verify calls.
-pub trait Ancestry<B: Block>: Stream<Item = B> + Send + Unpin + 'static {
+pub trait Ancestry<B: Block>: Stream<Item = Arc<B>> + Send + Unpin + 'static {
     /// Peeks at the latest block in the stream without consuming it. Returns [None]
     /// if the stream does not yet have a block available or has been exhausted.
     fn peek(&self) -> Option<&B>;
@@ -27,7 +27,7 @@ pub trait Ancestry<B: Block>: Stream<Item = B> + Send + Unpin + 'static {
 ///
 /// Blocks are yielded in iterator order and no parent fetching is performed. This is useful when
 /// the caller wants to bound the ancestry available to the application.
-pub fn from_iter<B>(blocks: impl IntoIterator<Item = B>) -> impl Ancestry<B>
+pub fn from_iter<B>(blocks: impl IntoIterator<Item = Arc<B>>) -> impl Ancestry<B>
 where
     B: Block,
 {
@@ -37,19 +37,19 @@ where
 }
 
 struct BoundedAncestry<B: Block> {
-    blocks: VecDeque<B>,
+    blocks: VecDeque<Arc<B>>,
 }
 
 impl<B: Block> Unpin for BoundedAncestry<B> {}
 
 impl<B: Block> Ancestry<B> for BoundedAncestry<B> {
     fn peek(&self) -> Option<&B> {
-        self.blocks.front()
+        self.blocks.front().map(Arc::as_ref)
     }
 }
 
 impl<B: Block> Stream for BoundedAncestry<B> {
-    type Item = B;
+    type Item = Arc<B>;
 
     fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(self.blocks.pop_front())
@@ -76,14 +76,15 @@ pub trait BlockProvider: Send + 'static {
     fn subscribe_parent(
         &self,
         block: &Self::Block,
-    ) -> impl Future<Output = Option<Self::Block>> + Send + 'static;
+    ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static;
 }
 
 // Expected parent height and digest for a pending fetch.
 struct ExpectedParent<D>(Height, D);
 
 // Pending parent fetch paired with the relationship it must satisfy.
-type PendingFetch<B> = BoxFuture<'static, Option<(ExpectedParent<<B as Digestible>::Digest>, B)>>;
+type PendingFetch<B> =
+    BoxFuture<'static, Option<(ExpectedParent<<B as Digestible>::Digest>, Arc<B>)>>;
 
 impl<D: Digest> ExpectedParent<D> {
     fn from_child<B: Block<Digest = D>>(child: &B) -> Self {
@@ -138,7 +139,7 @@ where
 /// height-zero genesis block if it is available.
 #[pin_project]
 pub struct AncestorStream<M: BlockProvider, C: Clock> {
-    buffered: Vec<M::Block>,
+    buffered: Vec<Arc<M::Block>>,
     marshal: M,
     fetch_duration: Timed,
     clock: Arc<C>,
@@ -155,11 +156,11 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
     pub(crate) fn new(
         clock: Arc<C>,
         marshal: M,
-        initial: impl IntoIterator<Item = M::Block>,
+        initial: impl IntoIterator<Item = Arc<M::Block>>,
         fetch_duration: Timed,
     ) -> Self {
-        let mut buffered = initial.into_iter().collect::<Vec<M::Block>>();
-        buffered.sort_by_key(Heightable::height);
+        let mut buffered = initial.into_iter().collect::<Vec<_>>();
+        buffered.sort_by_key(|block| block.height());
 
         // Check that the initial blocks are contiguous in height.
         buffered.windows(2).for_each(|window| {
@@ -187,7 +188,7 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
     /// Peeks at the latest block in the stream without consuming it. Returns [None]
     /// if the stream does not yet have a block available or has been exhausted.
     pub fn peek(&self) -> Option<&M::Block> {
-        self.buffered.last()
+        self.buffered.last().map(Arc::as_ref)
     }
 }
 
@@ -206,7 +207,7 @@ where
     M: BlockProvider,
     C: Clock,
 {
-    type Item = M::Block;
+    type Item = Arc<M::Block>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         const END_BOUND: Height = Height::zero();
@@ -227,7 +228,7 @@ where
                 // buffer it for the next poll.
                 match this.pending.as_mut().poll(cx) {
                     Poll::Ready(Some(Some((expected, parent)))) => {
-                        expected.assert_matches(&parent);
+                        expected.assert_matches(parent.as_ref());
                         this.buffered.push(parent);
                     }
                     Poll::Ready(Some(None)) => {
@@ -250,7 +251,7 @@ where
                 Poll::Ready(None)
             }
             Poll::Ready(Some(Some((expected, block)))) => {
-                expected.assert_matches(&block);
+                expected.assert_matches(block.as_ref());
                 let height = block.height();
                 let should_walk_parent = height > END_BOUND;
                 if should_walk_parent {
@@ -262,7 +263,7 @@ where
                     // buffer it for the next poll.
                     match this.pending.as_mut().poll(cx) {
                         Poll::Ready(Some(Some((expected, parent)))) => {
-                            expected.assert_matches(&parent);
+                            expected.assert_matches(parent.as_ref());
                             this.buffered.push(parent);
                         }
                         Poll::Ready(Some(None)) => {
@@ -304,9 +305,15 @@ mod test {
         fn subscribe_parent(
             &self,
             block: &Self::Block,
-        ) -> impl Future<Output = Option<Self::Block>> + Send + 'static {
+        ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
             let parent = block.parent;
-            std::future::ready(self.0.iter().find(|b| b.digest() == parent).cloned())
+            std::future::ready(
+                self.0
+                    .iter()
+                    .find(|b| b.digest() == parent)
+                    .cloned()
+                    .map(Arc::new),
+            )
         }
     }
 
@@ -318,8 +325,8 @@ mod test {
         fn subscribe_parent(
             &self,
             _block: &Self::Block,
-        ) -> impl Future<Output = Option<Self::Block>> + Send + 'static {
-            std::future::ready(Some(self.0.clone()))
+        ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
+            std::future::ready(Some(Arc::new(self.0.clone())))
         }
     }
 
@@ -341,7 +348,12 @@ mod test {
     {
         let stream_context = context.child("ancestor_stream");
         let fetch_duration = timed(&stream_context);
-        AncestorStream::new(Arc::new(stream_context), marshal, initial, fetch_duration)
+        AncestorStream::new(
+            Arc::new(stream_context),
+            marshal,
+            initial.into_iter().map(Arc::new),
+            fetch_duration,
+        )
     }
 
     #[test]
@@ -425,7 +437,7 @@ mod test {
         }
 
         let block = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
-        let ancestry = from_iter([block.clone()]);
+        let ancestry = from_iter([Arc::new(block.clone())]);
 
         assert_eq!(peek_height(ancestry), Some(block.height()));
     }
@@ -435,12 +447,12 @@ mod test {
         deterministic::Runner::default().start(|_| async move {
             let parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
             let child = Block::new::<Sha256>((), parent.digest(), Height::new(2), 2);
-            let mut ancestry = from_iter([child.clone(), parent.clone()]);
+            let mut ancestry = from_iter([Arc::new(child.clone()), Arc::new(parent.clone())]);
 
             assert_eq!(ancestry.peek(), Some(&child));
-            assert_eq!(ancestry.next().await, Some(child));
+            assert_eq!(ancestry.next().await.as_deref(), Some(&child));
             assert_eq!(ancestry.peek(), Some(&parent));
-            assert_eq!(ancestry.next().await, Some(parent));
+            assert_eq!(ancestry.next().await.as_deref(), Some(&parent));
             assert_eq!(ancestry.peek(), None);
             assert_eq!(ancestry.next().await, None);
         });
@@ -456,7 +468,7 @@ mod test {
             let stream = stream(&context, provider, [child.clone()]);
 
             let results = stream.collect::<Vec<_>>().await;
-            assert_eq!(results, vec![child, genesis]);
+            assert_eq!(results, vec![Arc::new(child), Arc::new(genesis)]);
         });
     }
 
@@ -480,7 +492,10 @@ mod test {
             let stream = stream(&context, provider, [block3.clone()]);
 
             let results = stream.collect::<Vec<_>>().await;
-            assert_eq!(results, vec![block3, block2, block1]);
+            assert_eq!(
+                results,
+                vec![Arc::new(block3), Arc::new(block2), Arc::new(block1)]
+            );
         });
     }
 
@@ -499,7 +514,10 @@ mod test {
             );
 
             let results = stream.collect::<Vec<_>>().await;
-            assert_eq!(results, vec![block3, block2, block1]);
+            assert_eq!(
+                results,
+                vec![Arc::new(block3), Arc::new(block2), Arc::new(block1)]
+            );
         });
     }
 
@@ -514,7 +532,7 @@ mod test {
             let stream = stream(&context, provider, [block3.clone()]);
 
             let results = stream.collect::<Vec<_>>().await;
-            assert_eq!(results, vec![block3]);
+            assert_eq!(results, vec![Arc::new(block3)]);
         });
     }
 }

--- a/consensus/src/marshal/application/validation.rs
+++ b/consensus/src/marshal/application/validation.rs
@@ -8,6 +8,7 @@ use crate::{
     types::{Epoch, Epocher, Height, Round},
 };
 use commonware_cryptography::certificate::Scheme;
+use std::sync::Arc;
 
 /// Which marshal cache should hold a structurally valid candidate.
 ///
@@ -31,7 +32,7 @@ impl Stage {
         self,
         marshal: &Mailbox<S, V>,
         round: Round,
-        block: V::Block,
+        block: Arc<V::Block>,
     ) -> bool {
         match self {
             Self::Verified => marshal.verified(round, block).await,

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -317,7 +317,7 @@ where
         &mut self,
         consensus_context: Context<Commitment, <Z::Scheme as Verifier>::PublicKey>,
         commitment: Commitment,
-        prefetched_block: Option<CodedBlock<B, C, H>>,
+        prefetched_block: Option<Arc<CodedBlock<B, C, H>>>,
         stage: Stage,
     ) -> oneshot::Receiver<bool> {
         let marshal = self.marshal.clone();
@@ -387,7 +387,7 @@ where
                 // candidate availability/recovery, not a validity decision. This
                 // task gates the finalize vote by resolving true only after both
                 // app verification succeeds and the store is durable.
-                let store = stage.store(&marshal, round, block.clone());
+                let store = stage.store(&marshal, round, Arc::clone(&block));
                 let verify = async {
                     // Await the parent fetch we started above.
                     let parent = select! {
@@ -409,8 +409,8 @@ where
 
                     if let Err(err) = validate_block::<H, _, _>(
                         &epocher,
-                        &block,
-                        &parent,
+                        block.as_ref(),
+                        parent.as_ref(),
                         &consensus_context,
                         commitment,
                         parent_commitment,
@@ -432,7 +432,7 @@ where
 
                     let ancestry_stream = marshal.ancestor_stream(
                         Arc::new(runtime_context.child("ancestor_stream")),
-                        [block.clone(), parent],
+                        [block.inner_shared(), parent.inner_shared()],
                         ancestor_fetch_duration,
                     );
                     let validity_request = application
@@ -811,7 +811,7 @@ where
 
                 let ancestor_stream = marshal.ancestor_stream(
                     Arc::new(runtime_context.child("ancestor_stream")),
-                    [parent],
+                    [parent.inner_shared()],
                     ancestor_fetch_duration,
                 );
                 let build_request = application

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -113,7 +113,7 @@ mod tests {
 
     type TestCodingVariant = Coding<CodingB, ReedSolomon<Sha256>, Sha256, K>;
     type TestCodedBlock = CodedBlock<CodingB, ReedSolomon<Sha256>, Sha256>;
-    type CodingSendRecord = (Round, TestCodedBlock, Recipients<K>);
+    type CodingSendRecord = (Round, Arc<TestCodedBlock>, Recipients<K>);
 
     // Smallest valid coding config used to build trusted genesis commitments.
     const GENESIS_CODING_CONFIG: CodingConfig = CodingConfig {
@@ -176,7 +176,7 @@ mod tests {
 
         fn finalized(&self, _commitment: Commitment) {}
 
-        fn send(&self, round: Round, block: TestCodedBlock, recipients: Recipients<K>) {
+        fn send(&self, round: Round, block: Arc<TestCodedBlock>, recipients: Recipients<K>) {
             self.sends.lock().push((round, block, recipients));
         }
     }

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -130,8 +130,8 @@ mod tests {
     /// A coding buffer that records subscriptions and never resolves them.
     #[derive(Clone, Default)]
     struct RecordingCodingBuffer {
-        digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<TestCodedBlock>>>>,
-        commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<TestCodedBlock>>>>,
+        digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<TestCodedBlock>>>>>,
+        commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<TestCodedBlock>>>>>,
         sends: Arc<Mutex<Vec<CodingSendRecord>>>,
     }
 
@@ -148,15 +148,18 @@ mod tests {
     impl core::Buffer<TestCodingVariant> for RecordingCodingBuffer {
         type PublicKey = K;
 
-        async fn find_by_digest(&self, _digest: D) -> Option<TestCodedBlock> {
+        async fn find_by_digest(&self, _digest: D) -> Option<Arc<TestCodedBlock>> {
             None
         }
 
-        async fn find_by_commitment(&self, _commitment: Commitment) -> Option<TestCodedBlock> {
+        async fn find_by_commitment(&self, _commitment: Commitment) -> Option<Arc<TestCodedBlock>> {
             None
         }
 
-        fn subscribe_by_digest(&self, _digest: D) -> Option<oneshot::Receiver<TestCodedBlock>> {
+        fn subscribe_by_digest(
+            &self,
+            _digest: D,
+        ) -> Option<oneshot::Receiver<Arc<TestCodedBlock>>> {
             let (sender, receiver) = oneshot::channel();
             self.digest_subscriptions.lock().push(sender);
             Some(receiver)
@@ -165,7 +168,7 @@ mod tests {
         fn subscribe_by_commitment(
             &self,
             _commitment: Commitment,
-        ) -> Option<oneshot::Receiver<TestCodedBlock>> {
+        ) -> Option<oneshot::Receiver<Arc<TestCodedBlock>>> {
             let (sender, receiver) = oneshot::channel();
             self.commitment_subscriptions.lock().push(sender);
             Some(receiver)

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -177,6 +177,7 @@ use rand_core::Rng;
 use std::{
     collections::{BTreeMap, VecDeque},
     num::NonZeroUsize,
+    sync::Arc,
 };
 use thiserror::Error;
 use tracing::{debug, warn};
@@ -276,7 +277,7 @@ where
     H: Hasher,
 {
     round: Round,
-    block: CodedBlock<B, C, H>,
+    block: Arc<CodedBlock<B, C, H>>,
 }
 
 /// A network layer for broadcasting and receiving [`CodedBlock`]s as [`Shard`]s.
@@ -363,7 +364,7 @@ where
     /// the keyed [`Commitment`].
     #[allow(clippy::type_complexity)]
     block_subscriptions:
-        BTreeMap<BlockSubscriptionKey<B::Digest>, Vec<oneshot::Sender<CodedBlock<B, C, H>>>>,
+        BTreeMap<BlockSubscriptionKey<B::Digest>, Vec<oneshot::Sender<Arc<CodedBlock<B, C, H>>>>>,
 
     /// Metrics for the shard engine.
     metrics: ShardMetrics<P>,
@@ -637,7 +638,7 @@ where
     fn try_reconstruct(
         &mut self,
         commitment: Commitment,
-    ) -> Result<Option<CodedBlock<B, C, H>>, Error<C>> {
+    ) -> Result<Option<Arc<CodedBlock<B, C, H>>>, Error<C>> {
         if let Some(entry) = self.reconstructed_blocks.get(&commitment) {
             return Ok(Some(entry.block.clone()));
         }
@@ -693,8 +694,7 @@ where
 
         // Construct a coding block with a _trusted_ commitment. `S::decode` verified the blob's
         // integrity against the commitment, so shards can be lazily re-constructed if need be.
-        let block = CodedBlock::new_trusted(inner, commitment);
-        self.cache_block(round, block.clone());
+        let block = self.cache_block(round, CodedBlock::new_trusted(inner, commitment));
         self.metrics.blocks_reconstructed_total.inc();
         Ok(Some(block))
     }
@@ -880,16 +880,22 @@ where
     }
 
     /// Cache a block and notify all subscribers waiting on it.
-    fn cache_block(&mut self, round: Round, block: CodedBlock<B, C, H>) {
+    fn cache_block(
+        &mut self,
+        round: Round,
+        block: CodedBlock<B, C, H>,
+    ) -> Arc<CodedBlock<B, C, H>> {
+        let block = Arc::new(block);
         let commitment = block.commitment();
         self.reconstructed_blocks.insert(
             commitment,
             ReconstructedBlock {
                 round,
-                block: block.clone(),
+                block: Arc::clone(&block),
             },
         );
-        self.notify_block_subscribers(block);
+        self.notify_block_subscribers(Arc::clone(&block));
+        block
     }
 
     /// Broadcasts the shards of a [`CodedBlock`] and caches the block.
@@ -900,7 +906,7 @@ where
         &mut self,
         sender: &mut WrappedSender<Sr, Shard<C, H>>,
         round: Round,
-        mut block: CodedBlock<B, C, H>,
+        block: CodedBlock<B, C, H>,
     ) {
         let commitment = block.commitment();
 
@@ -1072,7 +1078,7 @@ where
     fn handle_block_subscription(
         &mut self,
         key: BlockSubscriptionKey<B::Digest>,
-        response: oneshot::Sender<CodedBlock<B, C, H>>,
+        response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
     ) {
         let block = match key {
             BlockSubscriptionKey::Commitment(commitment) => self
@@ -1087,7 +1093,7 @@ where
 
         // Answer immediately if we have the block cached.
         if let Some(block) = block {
-            response.send_lossy(block.clone());
+            response.send_lossy(Arc::clone(block));
             return;
         }
 
@@ -1111,7 +1117,7 @@ where
     }
 
     /// Notifies and cleans up any subscriptions for a reconstructed block.
-    fn notify_block_subscribers(&mut self, block: CodedBlock<B, C, H>) {
+    fn notify_block_subscribers(&mut self, block: Arc<CodedBlock<B, C, H>>) {
         let commitment = block.commitment();
         let digest = block.digest();
 
@@ -1121,7 +1127,7 @@ where
             .remove(&BlockSubscriptionKey::Commitment(commitment))
         {
             for subscriber in subscribers.drain(..) {
-                subscriber.send_lossy(block.clone());
+                subscriber.send_lossy(Arc::clone(&block));
             }
         }
 
@@ -1131,7 +1137,7 @@ where
             .remove(&BlockSubscriptionKey::Digest(digest))
         {
             for subscriber in subscribers.drain(..) {
-                subscriber.send_lossy(block.clone());
+                subscriber.send_lossy(Arc::clone(&block));
             }
         }
     }

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -694,7 +694,7 @@ where
 
         // Construct a coding block with a _trusted_ commitment. `S::decode` verified the blob's
         // integrity against the commitment, so shards can be lazily re-constructed if need be.
-        let block = self.cache_block(round, CodedBlock::new_trusted(inner, commitment));
+        let block = self.cache_block(round, Arc::new(CodedBlock::new_trusted(inner, commitment)));
         self.metrics.blocks_reconstructed_total.inc();
         Ok(Some(block))
     }
@@ -883,9 +883,8 @@ where
     fn cache_block(
         &mut self,
         round: Round,
-        block: CodedBlock<B, C, H>,
+        block: Arc<CodedBlock<B, C, H>>,
     ) -> Arc<CodedBlock<B, C, H>> {
-        let block = Arc::new(block);
         let commitment = block.commitment();
         self.reconstructed_blocks.insert(
             commitment,
@@ -906,7 +905,7 @@ where
         &mut self,
         sender: &mut WrappedSender<Sr, Shard<C, H>>,
         round: Round,
-        block: CodedBlock<B, C, H>,
+        block: Arc<CodedBlock<B, C, H>>,
     ) {
         let commitment = block.commitment();
 

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -24,7 +24,7 @@ where
     /// A request to broadcast a proposed [`CodedBlock`] to all peers.
     Proposed {
         /// The erasure coded block.
-        block: CodedBlock<B, C, H>,
+        block: Arc<CodedBlock<B, C, H>>,
         /// The round in which the block was proposed.
         round: Round,
     },
@@ -217,6 +217,10 @@ where
 
     /// Broadcast a proposed erasure coded block's shards to the participants.
     pub fn proposed(&self, round: Round, block: CodedBlock<B, C, H>) {
+        self.proposed_shared(round, Arc::new(block));
+    }
+
+    pub(crate) fn proposed_shared(&self, round: Round, block: Arc<CodedBlock<B, C, H>>) {
         let _ = self.sender.enqueue(Message::Proposed { block, round });
     }
 

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -9,7 +9,7 @@ use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_coding::Scheme as CodingScheme;
 use commonware_cryptography::{Hasher, PublicKey};
 use commonware_utils::channel::oneshot;
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 
 /// A message that can be sent to the coding [`Engine`].
 ///
@@ -53,14 +53,14 @@ where
         /// The [`Commitment`] of the block to get.
         commitment: Commitment,
         /// The response channel.
-        response: oneshot::Sender<Option<CodedBlock<B, C, H>>>,
+        response: oneshot::Sender<Option<Arc<CodedBlock<B, C, H>>>>,
     },
     /// A request to get a reconstructed block by its digest, if available.
     GetByDigest {
         /// The digest of the block to get.
         digest: B::Digest,
         /// The response channel.
-        response: oneshot::Sender<Option<CodedBlock<B, C, H>>>,
+        response: oneshot::Sender<Option<Arc<CodedBlock<B, C, H>>>>,
     },
     /// A request to open a subscription for assigned shard verification.
     ///
@@ -84,7 +84,7 @@ where
         /// The block's digest.
         commitment: Commitment,
         /// The response channel.
-        response: oneshot::Sender<CodedBlock<B, C, H>>,
+        response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
     },
     /// A request to open a subscription for the reconstruction of a [`CodedBlock`]
     /// by its digest.
@@ -92,7 +92,7 @@ where
         /// The block's digest.
         digest: B::Digest,
         /// The response channel.
-        response: oneshot::Sender<CodedBlock<B, C, H>>,
+        response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
     },
     /// A request to prune all caches at and below the given commitment.
     Prune {
@@ -242,7 +242,7 @@ where
     }
 
     /// Request a reconstructed block by its [`Commitment`].
-    pub async fn get(&self, commitment: Commitment) -> Option<CodedBlock<B, C, H>> {
+    pub async fn get(&self, commitment: Commitment) -> Option<Arc<CodedBlock<B, C, H>>> {
         let (response, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::GetByCommitment {
             commitment,
@@ -252,7 +252,7 @@ where
     }
 
     /// Request a reconstructed block by its digest.
-    pub async fn get_by_digest(&self, digest: B::Digest) -> Option<CodedBlock<B, C, H>> {
+    pub async fn get_by_digest(&self, digest: B::Digest) -> Option<Arc<CodedBlock<B, C, H>>> {
         let (response, receiver) = oneshot::channel();
         let _ = self
             .sender
@@ -285,7 +285,7 @@ where
     }
 
     /// Subscribe to the reconstruction of a [`CodedBlock`] by its [`Commitment`].
-    pub fn subscribe(&self, commitment: Commitment) -> oneshot::Receiver<CodedBlock<B, C, H>> {
+    pub fn subscribe(&self, commitment: Commitment) -> oneshot::Receiver<Arc<CodedBlock<B, C, H>>> {
         let (responder, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::SubscribeByCommitment {
             commitment,
@@ -295,7 +295,10 @@ where
     }
 
     /// Subscribe to the reconstruction of a [`CodedBlock`] by its digest.
-    pub fn subscribe_by_digest(&self, digest: B::Digest) -> oneshot::Receiver<CodedBlock<B, C, H>> {
+    pub fn subscribe_by_digest(
+        &self,
+        digest: B::Digest,
+    ) -> oneshot::Receiver<Arc<CodedBlock<B, C, H>>> {
         let (responder, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::SubscribeByDigest {
             digest,

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -242,6 +242,11 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
         Arc::clone(&self.inner)
     }
 
+    /// Takes the shared inner [`Block`].
+    pub fn into_inner_shared(self) -> Arc<B> {
+        self.inner
+    }
+
     /// Takes the inner [`Block`].
     pub fn into_inner(self) -> B {
         Arc::unwrap_or_clone(self.inner)

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -152,9 +152,7 @@ pub struct CodedBlock<B: Block, C: Scheme, H: Hasher> {
     commitment: C::Commitment,
     /// The coded shards.
     ///
-    /// These shards are optional to enable lazy construction. If the block is
-    /// constructed with [`Self::new_trusted`], the shards are computed lazily
-    /// via [`Self::shards`].
+    /// These shards are lazily-constructed when [`CodedBlock`] is formed with [`Self::new_trusted`].
     shards: OnceLock<Arc<[C::Shard]>>,
     /// Phantom data for the hasher.
     _hasher: PhantomData<H>,

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -713,6 +713,7 @@ mod test {
         let coded_block = CodedBlock::<Block, RS, H>::new(block, CONFIG, &Sequential);
         let cloned = coded_block.clone();
 
+        assert!(Arc::ptr_eq(&coded_block.inner, &cloned.inner));
         assert!(Arc::ptr_eq(
             coded_block.shards.get().unwrap(),
             cloned.shards.get().unwrap()

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -9,7 +9,10 @@ use commonware_coding::{Config as CodingConfig, Scheme};
 use commonware_cryptography::{Committable, Digestible, Hasher};
 use commonware_parallel::{Sequential, Strategy};
 use commonware_utils::{Faults, N3f1, NZU16};
-use std::{marker::PhantomData, sync::Arc};
+use std::{
+    marker::PhantomData,
+    sync::{Arc, OnceLock},
+};
 
 /// A broadcastable shard of erasure coded data, including the coding commitment and
 /// the configuration used to code the data.
@@ -152,7 +155,7 @@ pub struct CodedBlock<B: Block, C: Scheme, H: Hasher> {
     /// These shards are optional to enable lazy construction. If the block is
     /// constructed with [`Self::new_trusted`], the shards are computed lazily
     /// via [`Self::shards`].
-    shards: Option<Arc<[C::Shard]>>,
+    shards: OnceLock<Arc<[C::Shard]>>,
     /// Phantom data for the hasher.
     _hasher: PhantomData<H>,
 }
@@ -178,19 +181,22 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
             inner: Arc::new(inner),
             config,
             commitment,
-            shards: Some(shards.into()),
+            shards: OnceLock::from(Arc::<[C::Shard]>::from(shards)),
             _hasher: PhantomData,
         }
     }
 
-    /// Create a new [`CodedBlock`] from an owned or shared [`Block`] and
-    /// trusted [`Commitment`].
-    pub fn new_trusted(inner: impl Into<Arc<B>>, commitment: Commitment) -> Self {
+    /// Create a new [`CodedBlock`] from a [`Block`] and trusted [`Commitment`].
+    pub fn new_trusted(inner: B, commitment: Commitment) -> Self {
+        Self::new_trusted_shared(Arc::new(inner), commitment)
+    }
+
+    fn new_trusted_shared(inner: Arc<B>, commitment: Commitment) -> Self {
         Self {
-            inner: inner.into(),
+            inner,
             config: commitment.config(),
             commitment: commitment.root(),
-            shards: None,
+            shards: OnceLock::new(),
             _hasher: PhantomData,
         }
     }
@@ -203,21 +209,17 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     /// Returns a reference to the shards in this coded block.
     ///
     /// If the shards have not yet been generated, they will be created via [`Scheme::encode`].
-    pub fn shards(&mut self, strategy: &impl Strategy) -> &[C::Shard] {
-        match self.shards {
-            Some(ref shards) => shards,
-            None => {
-                let (commitment, shards) = Self::encode(&self.inner, self.config, strategy);
+    pub fn shards(&self, strategy: &impl Strategy) -> &[C::Shard] {
+        self.shards.get_or_init(|| {
+            let (commitment, shards) = Self::encode(&self.inner, self.config, strategy);
 
-                assert_eq!(
-                    commitment, self.commitment,
-                    "coded block constructed with trusted commitment does not match commitment"
-                );
+            assert_eq!(
+                commitment, self.commitment,
+                "coded block constructed with trusted commitment does not match commitment"
+            );
 
-                self.shards = Some(shards.into());
-                self.shards.as_ref().unwrap()
-            }
-        }
+            shards.into()
+        })
     }
 
     /// Returns a [`Shard`] at the given index, if the index is valid.
@@ -228,7 +230,7 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
         Some(Shard::new(
             self.commitment(),
             index,
-            self.shards.as_ref()?.get(usize::from(index))?.clone(),
+            self.shards.get()?.get(usize::from(index))?.clone(),
         ))
     }
 
@@ -237,13 +239,18 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
         &self.inner
     }
 
+    /// Returns a shared reference to the inner [`Block`].
+    pub fn inner_shared(&self) -> Arc<B> {
+        Arc::clone(&self.inner)
+    }
+
     /// Takes the inner [`Block`].
     pub fn into_inner(self) -> B {
         Arc::unwrap_or_clone(self.inner)
     }
 }
 
-impl<B: CertifiableBlock + Clone, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
+impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
     for StoredCodedBlock<B, C, H>
 {
     fn from(block: CodedBlock<B, C, H>) -> Self {
@@ -354,7 +361,7 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
             inner: Arc::new(inner),
             config,
             commitment,
-            shards: Some(shards.into()),
+            shards: OnceLock::from(Arc::<[C::Shard]>::from(shards)),
             _hasher: PhantomData,
         })
     }
@@ -431,10 +438,9 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> StoredCodedBlock<B, C, H> {
 
     /// Convert back to a [`CodedBlock`] using the trusted commitment.
     ///
-    /// The returned [`CodedBlock`] will have `shards: None`, meaning shards
-    /// will be lazily generated if needed via [`CodedBlock::shards`].
+    /// The returned [`CodedBlock`] generates shards lazily if they are needed.
     pub fn into_coded_block(self) -> CodedBlock<B, C, H> {
-        CodedBlock::new_trusted(self.inner, self.commitment)
+        CodedBlock::new_trusted_shared(self.inner, self.commitment)
     }
 
     /// Returns a reference to the inner block.
@@ -446,7 +452,7 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> StoredCodedBlock<B, C, H> {
 /// Converts a [`StoredCodedBlock`] back to a [`CodedBlock`].
 impl<B: Block, C: Scheme, H: Hasher> From<StoredCodedBlock<B, C, H>> for CodedBlock<B, C, H> {
     fn from(stored: StoredCodedBlock<B, C, H>) -> Self {
-        Self::new_trusted(stored.inner, stored.commitment)
+        Self::new_trusted_shared(stored.inner, stored.commitment)
     }
 }
 
@@ -697,7 +703,7 @@ mod test {
     }
 
     #[test]
-    fn test_coded_block_clone_shares_storage() {
+    fn test_coded_block_clone_shares_shards() {
         const CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(2),
@@ -707,10 +713,9 @@ mod test {
         let coded_block = CodedBlock::<Block, RS, H>::new(block, CONFIG, &Sequential);
         let cloned = coded_block.clone();
 
-        assert!(Arc::ptr_eq(&coded_block.inner, &cloned.inner));
         assert!(Arc::ptr_eq(
-            coded_block.shards.as_ref().unwrap(),
-            cloned.shards.as_ref().unwrap()
+            coded_block.shards.get().unwrap(),
+            cloned.shards.get().unwrap()
         ));
     }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -88,6 +88,10 @@ where
         block.inner_shared()
     }
 
+    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+        block.into_inner_shared()
+    }
+
     fn from_application_block(
         block: Self::ApplicationBlock,
         payload: Self::Commitment,
@@ -134,9 +138,9 @@ where
         self.prune(commitment);
     }
 
-    fn send(&self, round: Round, block: CodedBlock<B, C, H>, _recipients: Recipients<P>) {
+    fn send(&self, round: Round, block: Arc<CodedBlock<B, C, H>>, _recipients: Recipients<P>) {
         // Targeted forwarding is not supported by the coding variant.
-        self.proposed(round, block);
+        self.proposed_shared(round, block);
     }
 }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -16,7 +16,7 @@ use commonware_coding::Scheme as CodingScheme;
 use commonware_cryptography::{certificate::Scheme, Committable, Digestible, Hasher, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 /// The coding variant of Marshal, which uses erasure coding for block dissemination.
 ///
@@ -84,6 +84,10 @@ where
         block.into_inner()
     }
 
+    fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock> {
+        block.inner_shared()
+    }
+
     fn from_application_block(
         block: Self::ApplicationBlock,
         payload: Self::Commitment,
@@ -104,25 +108,25 @@ where
     async fn find_by_digest(
         &self,
         digest: <CodedBlock<B, C, H> as Digestible>::Digest,
-    ) -> Option<CodedBlock<B, C, H>> {
+    ) -> Option<Arc<CodedBlock<B, C, H>>> {
         self.get_by_digest(digest).await
     }
 
-    async fn find_by_commitment(&self, commitment: Commitment) -> Option<CodedBlock<B, C, H>> {
+    async fn find_by_commitment(&self, commitment: Commitment) -> Option<Arc<CodedBlock<B, C, H>>> {
         self.get(commitment).await
     }
 
     fn subscribe_by_digest(
         &self,
         digest: <CodedBlock<B, C, H> as Digestible>::Digest,
-    ) -> Option<oneshot::Receiver<CodedBlock<B, C, H>>> {
+    ) -> Option<oneshot::Receiver<Arc<CodedBlock<B, C, H>>>> {
         Some(self.subscribe_by_digest(digest))
     }
 
     fn subscribe_by_commitment(
         &self,
         commitment: Commitment,
-    ) -> Option<oneshot::Receiver<CodedBlock<B, C, H>>> {
+    ) -> Option<oneshot::Receiver<Arc<CodedBlock<B, C, H>>>> {
         Some(self.subscribe(commitment))
     }
 
@@ -149,7 +153,7 @@ where
     fn subscribe_parent(
         &self,
         block: &Self::Block,
-    ) -> impl Future<Output = Option<Self::Block>> + Send + 'static {
+    ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
         let receiver = block.height().previous().map(|parent_height| {
             self.subscribe_by_commitment(
                 block.context().parent.1,
@@ -158,13 +162,7 @@ where
                 },
             )
         });
-        async move {
-            let receiver = receiver?;
-            receiver
-                .await
-                .ok()
-                .map(<Coding<B, C, H, P> as Variant>::into_inner)
-        }
+        async move { receiver?.await.ok().map(|block| block.inner_shared()) }
     }
 }
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -644,7 +644,7 @@ where
                 // the handle still covering the original write's durability.
                 let handle = self
                     .cache
-                    .put_verified(round, digest, block.as_ref().clone().into())
+                    .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
                     .await;
                 ack.expect("durable ack present").send_lossy(handle);
             }
@@ -667,7 +667,7 @@ where
                     self.cache.start_sync_verified(round).await
                 } else {
                     self.cache
-                        .put_notarized(round, digest, block.as_ref().clone().into())
+                        .put_notarized(round, digest, Arc::unwrap_or_clone(block).into())
                         .await
                 };
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -54,7 +54,7 @@ use futures::{
     try_join,
 };
 use rand_core::CryptoRng;
-use std::{collections::BTreeMap, future::Future, num::NonZeroUsize};
+use std::{collections::BTreeMap, future::Future, num::NonZeroUsize, sync::Arc};
 use tracing::{debug, info_span, warn, Instrument as _, Span};
 
 // Resolver request keys are expressed in the variant commitment type, which
@@ -119,7 +119,7 @@ where
 
     // ---------- State ----------
     // Last proposed block
-    last_proposed_block: Option<(Round, V::Commitment, V::Block)>,
+    last_proposed_block: Option<(Round, V::Commitment, Arc<V::Block>)>,
     // Current processed floor and any pending floor update
     floor: Floor<P::Scheme, V::Commitment>,
     // Application delivery cursor
@@ -353,7 +353,7 @@ where
         Buf: Buffer<V, PublicKey = <P::Scheme as Verifier>::PublicKey>,
     {
         // Create a local pool for waiter futures.
-        let mut waiters = AbortablePool::<Result<V::Block, SubscriptionKeyFor<V>>>::default();
+        let mut waiters = AbortablePool::<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>::default();
 
         // Observe durable syncs that no consensus caller awaits (the notarization
         // path). A flush failure inside `start_sync` is reported only through the
@@ -420,7 +420,7 @@ where
             // Handle waiter completions first
             Ok(completion) = waiters.next_completed() else continue => match completion {
                 Ok(block) => {
-                    self.ingest(&block, &mut buffer, &mut application, &mut resolver)
+                    self.ingest(block, &mut buffer, &mut application, &mut resolver)
                         .await;
                 }
                 Err(key) => {
@@ -540,7 +540,7 @@ where
         &mut self,
         message: Message<P::Scheme, V>,
         resolver: &mut R,
-        waiters: &mut AbortablePool<Result<V::Block, SubscriptionKeyFor<V>>>,
+        waiters: &mut AbortablePool<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>,
         syncs: &mut Pool<bool>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
@@ -604,12 +604,13 @@ where
                         block
                     }
                 };
-                buffer.send(round, block, recipients);
+                buffer.send(round, Arc::unwrap_or_clone(block), recipients);
             }
             Message::Proposed {
                 round, block, ack, ..
             } => {
-                self.ingest(&block, buffer, application, resolver).await;
+                self.ingest(Arc::clone(&block), buffer, application, resolver)
+                    .await;
                 let digest = block.digest();
 
                 // If the round has already been pruned by tip advancement,
@@ -619,7 +620,7 @@ where
                 // the handle still covering the original write's durability.
                 let handle = self
                     .cache
-                    .put_verified(round, digest, block.clone().into())
+                    .put_verified(round, digest, block.as_ref().clone().into())
                     .await;
 
                 // Retain the block in memory so the subsequent `Forward` can
@@ -632,7 +633,8 @@ where
             Message::Verified {
                 round, block, ack, ..
             } => {
-                self.ingest(&block, buffer, application, resolver).await;
+                self.ingest(Arc::clone(&block), buffer, application, resolver)
+                    .await;
                 let digest = block.digest();
 
                 // If the round has already been pruned by tip advancement,
@@ -640,13 +642,17 @@ where
                 // the retention floor (and no longer is required by consensus
                 // to make progress). A duplicate delivery is also a no-op, with
                 // the handle still covering the original write's durability.
-                let handle = self.cache.put_verified(round, digest, block.into()).await;
+                let handle = self
+                    .cache
+                    .put_verified(round, digest, block.as_ref().clone().into())
+                    .await;
                 ack.expect("durable ack present").send_lossy(handle);
             }
             Message::Certified {
                 round, block, ack, ..
             } => {
-                self.ingest(&block, buffer, application, resolver).await;
+                self.ingest(Arc::clone(&block), buffer, application, resolver)
+                    .await;
                 let digest = block.digest();
 
                 // A block the verified archive already holds needs no second copy:
@@ -660,7 +666,9 @@ where
                     debug!(?round, "certified block covered by verified write");
                     self.cache.start_sync_verified(round).await
                 } else {
-                    self.cache.put_notarized(round, digest, block.into()).await
+                    self.cache
+                        .put_notarized(round, digest, block.as_ref().clone().into())
+                        .await
                 };
 
                 // Hold the certify barrier until the round's notarization
@@ -694,11 +702,15 @@ where
                 // data. If the block is not locally available, remember the
                 // certificate and wait for a later finalization/repair path.
                 if let Some(block) = self.find_block_by_commitment(buffer, commitment).await {
-                    self.ingest(&block, buffer, application, resolver).await;
+                    self.ingest(Arc::clone(&block), buffer, application, resolver)
+                        .await;
                     if self.cache.has_verified(round, &digest).await {
                         debug!(?round, "notarized block covered by verified write");
                     } else {
-                        let handle = self.cache.put_notarized(round, digest, block.into()).await;
+                        let handle = self
+                            .cache
+                            .put_notarized(round, digest, block.as_ref().clone().into())
+                            .await;
                         syncs.push(handle.durable(round, "notarized"));
                     }
                 } else {
@@ -719,7 +731,10 @@ where
                 if let Some(block) = self.find_block_by_commitment(buffer, commitment).await {
                     // The anchor path stores the floor block and finalization,
                     // advances floors, prunes below them, and resumes dispatch.
-                    if self.ingest(&block, buffer, application, resolver).await {
+                    if self
+                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .await
+                    {
                         return;
                     }
 
@@ -727,7 +742,13 @@ where
                     self.update_processed_round_floor(height, round, resolver)
                         .await;
                     if self
-                        .store_finalization(height, digest, block, Some(finalization), application)
+                        .store_finalization(
+                            height,
+                            digest,
+                            Arc::unwrap_or_clone(block),
+                            Some(finalization),
+                            application,
+                        )
                         .await
                     {
                         // If a floor anchor is pending, repair and dispatch are
@@ -755,7 +776,10 @@ where
                 ..
             } => match identifier {
                 BlockID::Digest(digest) => {
-                    let result = self.find_block_by_digest(buffer, digest).await;
+                    let result = self
+                        .find_block_by_digest(buffer, digest)
+                        .await
+                        .map(Arc::unwrap_or_clone);
                     response.send_lossy(result);
                 }
                 BlockID::Height(height) => {
@@ -766,7 +790,8 @@ where
                     let block = match self.get_latest().await {
                         Some((_, digest, _)) => self.find_block_by_digest(buffer, digest).await,
                         None => None,
-                    };
+                    }
+                    .map(Arc::unwrap_or_clone);
                     response.send_lossy(block);
                 }
             },
@@ -1003,9 +1028,9 @@ where
         span: Span,
         fallback: CommitmentFallback,
         key: SubscriptionKeyFor<V>,
-        response: oneshot::Sender<V::Block>,
+        response: oneshot::Sender<Arc<V::Block>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
-        waiters: &mut AbortablePool<Result<V::Block, SubscriptionKeyFor<V>>>,
+        waiters: &mut AbortablePool<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>,
         buffer: &mut Buf,
     ) {
         let digest = match key {
@@ -1013,7 +1038,6 @@ where
             SubscriptionKey::Commitment(commitment) => V::commitment_to_inner(commitment),
         };
 
-        // Check for block locally.
         let block = match key {
             SubscriptionKey::Digest(digest) => self.find_block_by_digest(buffer, digest).await,
             SubscriptionKey::Commitment(commitment) => {
@@ -1131,7 +1155,7 @@ where
 
         if let Some(block) = self.find_block_by_commitment(buffer, commitment).await {
             self.floor.await_anchor(finalization);
-            assert!(self.ingest(&block, buffer, application, resolver).await);
+            assert!(self.ingest(block, buffer, application, resolver).await);
             return;
         }
 
@@ -1163,23 +1187,34 @@ where
     /// Returns true if the block was consumed as the floor anchor.
     async fn ingest<Buf: Buffer<V>>(
         &mut self,
-        block: &V::Block,
+        block: Arc<V::Block>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> bool {
-        self.block_subscriptions.notify(block);
+        self.block_subscriptions.notify(Arc::clone(&block));
 
-        let commitment = V::commitment(block);
-        if !self.floor.matches_pending_anchor(commitment) {
+        if !self.floor.matches_pending_anchor(V::commitment(&block)) {
             return false;
         }
 
+        self.apply_pending_floor(block, buffer, application, resolver)
+            .await;
+        true
+    }
+
+    async fn apply_pending_floor<Buf: Buffer<V>>(
+        &mut self,
+        block: Arc<V::Block>,
+        buffer: &mut Buf,
+        application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
+        resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
+    ) {
         // Floor anchors can bypass the local proposal-verification path. Check
         // the parent relationship before using a non-genesis anchor for walkback.
         let height = block.height();
         if height > Height::zero() {
-            let parent_commitment = V::parent_commitment(block);
+            let parent_commitment = V::parent_commitment(&block);
             assert!(
                 block.parent() == V::commitment_to_inner(parent_commitment),
                 "floor block parent commitment mismatch"
@@ -1205,7 +1240,7 @@ where
                 self.sync_finalized().await;
             }
             self.try_dispatch_blocks(application).await;
-            return true;
+            return;
         }
 
         let digest = block.digest();
@@ -1217,7 +1252,7 @@ where
         try_join!(
             async {
                 self.finalized_blocks
-                    .put((*block).clone().into())
+                    .put(block.as_ref().clone().into())
                     .await
                     .map_err(Box::new)?;
                 Ok::<_, BoxedError>(())
@@ -1268,7 +1303,6 @@ where
             self.sync_finalized().await;
         }
         self.try_dispatch_blocks(application).await;
-        true
     }
 
     /// Handle a deliver message from the resolver. Block delivers are handled
@@ -1306,7 +1340,11 @@ where
                 // This block may match the pending floor request. Whether it
                 // installs or is rejected as the floor anchor, do not also
                 // process it as an ordinary block delivery.
-                if self.ingest(&block, buffer, application, resolver).await {
+                let block = Arc::new(block);
+                if self
+                    .ingest(Arc::clone(&block), buffer, application, resolver)
+                    .await
+                {
                     response.send_lossy(true);
                     return false;
                 }
@@ -1333,8 +1371,14 @@ where
                         .iter()
                         .any(|annotation| matches!(annotation, Annotation::Finalized(_)))
                 {
-                    self.store_finalization(height, digest, block, finalization, application)
-                        .await
+                    self.store_finalization(
+                        height,
+                        digest,
+                        Arc::unwrap_or_clone(block),
+                        finalization,
+                        application,
+                    )
+                    .await
                 } else {
                     if annotations
                         .iter()
@@ -1343,7 +1387,12 @@ where
                     {
                         if let Some(bounds) = self.epocher.containing(height) {
                             self.cache
-                                .put_certified(bounds.epoch(), height, digest, block.into())
+                                .put_certified(
+                                    bounds.epoch(),
+                                    height,
+                                    digest,
+                                    block.as_ref().clone().into(),
+                                )
                                 .await;
                         }
                     }
@@ -1541,7 +1590,10 @@ where
                 } => {
                     // Valid finalization received.
                     response.send_lossy(true);
-                    let block = V::from_application_block(block, finalization.proposal.payload);
+                    let block = Arc::new(V::from_application_block(
+                        block,
+                        finalization.proposal.payload,
+                    ));
                     let round = finalization.round();
                     let height = block.height();
                     let digest = block.digest();
@@ -1549,7 +1601,10 @@ where
 
                     // The floor-anchor path fully handles this finalization
                     // and moves the lower bound past it.
-                    if self.ingest(&block, buffer, application, resolver).await {
+                    if self
+                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .await
+                    {
                         continue;
                     }
 
@@ -1557,7 +1612,13 @@ where
                         .await;
 
                     wrote |= self
-                        .store_finalization(height, digest, block, Some(finalization), application)
+                        .store_finalization(
+                            height,
+                            digest,
+                            Arc::unwrap_or_clone(block),
+                            Some(finalization),
+                            application,
+                        )
                         .await;
                 }
                 PendingVerification::Notarized {
@@ -1576,9 +1637,10 @@ where
                     // durable (or the runtime is shutting down) so the repair
                     // bookkeeping below never runs ahead of storage.
                     let height = block.height();
+                    let block = Arc::new(block);
                     let block_sync = self
                         .cache
-                        .put_notarized(round, digest, block.clone().into())
+                        .put_notarized(round, digest, block.as_ref().clone().into())
                         .await;
                     let notarization_sync = self
                         .cache
@@ -1592,7 +1654,10 @@ where
 
                     // A notarized delivery can carry the pending floor block
                     // after the finalization is cached.
-                    if self.ingest(&block, buffer, application, resolver).await {
+                    if self
+                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .await
+                    {
                         continue;
                     }
 
@@ -1610,7 +1675,7 @@ where
                             .store_finalization(
                                 height,
                                 digest,
-                                block,
+                                Arc::unwrap_or_clone(block),
                                 Some(finalization),
                                 application,
                             )
@@ -1703,7 +1768,7 @@ where
 
             let (height, commitment) = (block.height(), V::commitment(&block));
             let (ack, ack_waiter) = A::handle();
-            application.report(Update::Block(V::into_inner(block), ack));
+            application.report(Update::Block(V::into_inner_shared(Arc::new(block)), ack));
             self.pending_acks.enqueue(PendingAck {
                 height,
                 commitment,
@@ -1716,7 +1781,7 @@ where
 
     /// If a block previously accepted via [`Message::Proposed`] matches the
     /// supplied `(round, commitment)`, remove and return it.
-    fn take_proposed(&mut self, round: Round, commitment: V::Commitment) -> Option<V::Block> {
+    fn take_proposed(&mut self, round: Round, commitment: V::Commitment) -> Option<Arc<V::Block>> {
         let (cached_round, cached_commitment, _) = self.last_proposed_block.as_ref()?;
         if *cached_round != round || *cached_commitment != commitment {
             return None;
@@ -1940,11 +2005,11 @@ where
         &self,
         buffer: &Buf,
         digest: <V::Block as Digestible>::Digest,
-    ) -> Option<V::Block> {
+    ) -> Option<Arc<V::Block>> {
         if let Some(block) = buffer.find_by_digest(digest).await {
             return Some(block);
         }
-        self.find_block_in_storage(digest).await
+        self.find_block_in_storage(digest).await.map(Arc::new)
     }
 
     /// Looks for a block anywhere in local storage using the full commitment.
@@ -1955,11 +2020,13 @@ where
         &self,
         buffer: &Buf,
         commitment: V::Commitment,
-    ) -> Option<V::Block> {
+    ) -> Option<Arc<V::Block>> {
         if let Some(block) = buffer.find_by_commitment(commitment).await {
             return Some(block);
         }
-        self.find_block_in_storage_by_commitment(commitment).await
+        self.find_block_in_storage_by_commitment(commitment)
+            .await
+            .map(Arc::new)
     }
 
     /// Attempt to repair any identified gaps in the finalized blocks archive. The total
@@ -2010,7 +2077,7 @@ where
                         .store_finalization(
                             last_finalized,
                             digest,
-                            block,
+                            Arc::unwrap_or_clone(block),
                             Some(finalization),
                             application,
                         )
@@ -2060,7 +2127,13 @@ where
                     let finalization = self.cache.get_finalization_for(parent_digest).await;
                     let next = (block.height(), block.parent(), V::parent_commitment(&block));
                     wrote |= self
-                        .store_finalization(next.0, parent_digest, block, finalization, application)
+                        .store_finalization(
+                            next.0,
+                            parent_digest,
+                            Arc::unwrap_or_clone(block),
+                            finalization,
+                            application,
+                        )
                         .await;
                     debug!(height = %next.0, "repaired block");
                     (height, parent_digest, parent_commitment) = next;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -604,7 +604,7 @@ where
                         block
                     }
                 };
-                buffer.send(round, Arc::unwrap_or_clone(block), recipients);
+                buffer.send(round, block, recipients);
             }
             Message::Proposed {
                 round, block, ack, ..
@@ -709,7 +709,7 @@ where
                     } else {
                         let handle = self
                             .cache
-                            .put_notarized(round, digest, block.as_ref().clone().into())
+                            .put_notarized(round, digest, Arc::unwrap_or_clone(block).into())
                             .await;
                         syncs.push(handle.durable(round, "notarized"));
                     }
@@ -1203,6 +1203,11 @@ where
         true
     }
 
+    /// Applies the pending floor transition using its matching anchor block.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no pending floor anchor is installed.
     async fn apply_pending_floor<Buf: Buffer<V>>(
         &mut self,
         block: Arc<V::Block>,
@@ -1252,7 +1257,7 @@ where
         try_join!(
             async {
                 self.finalized_blocks
-                    .put(block.as_ref().clone().into())
+                    .put(Arc::unwrap_or_clone(block).into())
                     .await
                     .map_err(Box::new)?;
                 Ok::<_, BoxedError>(())
@@ -1391,7 +1396,7 @@ where
                                     bounds.epoch(),
                                     height,
                                     digest,
-                                    block.as_ref().clone().into(),
+                                    Arc::unwrap_or_clone(block).into(),
                                 )
                                 .await;
                         }
@@ -1768,7 +1773,7 @@ where
 
             let (height, commitment) = (block.height(), V::commitment(&block));
             let (ack, ack_waiter) = A::handle();
-            application.report(Update::Block(V::into_inner_shared(Arc::new(block)), ack));
+            application.report(Update::Block(V::owned_into_inner_shared(block), ack));
             self.pending_acks.enqueue(PendingAck {
                 height,
                 commitment,

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -100,7 +100,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// How marshal should behave if the block is missing locally.
         fallback: DigestFallback,
         /// A channel to send the retrieved block.
-        response: oneshot::Sender<V::Block>,
+        response: oneshot::Sender<Arc<V::Block>>,
     },
     /// A request to subscribe to a block by its commitment.
     SubscribeByCommitment {
@@ -111,7 +111,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// How marshal should behave if the block is missing locally.
         fallback: CommitmentFallback,
         /// A channel to send the retrieved block.
-        response: oneshot::Sender<V::Block>,
+        response: oneshot::Sender<Arc<V::Block>>,
     },
     /// A hint to fetch a notarized block by round without adding another local subscriber.
     ///
@@ -152,7 +152,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round in which the block was proposed.
         round: Round,
         /// The proposed block.
-        block: V::Block,
+        block: Arc<V::Block>,
         /// A channel sent once the block sync has started.
         ack: Option<oneshot::Sender<Handle<()>>>,
     },
@@ -163,7 +163,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round in which the block was verified.
         round: Round,
         /// The verified block.
-        block: V::Block,
+        block: Arc<V::Block>,
         /// A channel sent once the block sync has started.
         ack: Option<oneshot::Sender<Handle<()>>>,
     },
@@ -174,7 +174,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round in which the block was certified.
         round: Round,
         /// The certified block.
-        block: V::Block,
+        block: Arc<V::Block>,
         /// A channel sent once the block and notarization syncs have started; the
         /// handle covers both.
         ack: Option<oneshot::Sender<Handle<()>>>,
@@ -637,15 +637,10 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     ) -> impl Ancestry<V::ApplicationBlock> + use<S, V, I, C>
     where
         Self: BlockProvider<Block = V::ApplicationBlock>,
-        I: IntoIterator<Item = V::Block>,
+        I: IntoIterator<Item = Arc<V::ApplicationBlock>>,
         C: Clock,
     {
-        AncestorStream::new(
-            clock,
-            self.clone(),
-            initial.into_iter().map(V::into_inner),
-            fetch_duration,
-        )
+        AncestorStream::new(clock, self.clone(), initial, fetch_duration)
     }
 
     /// Retrieve `(height, digest)` for a finalized block by height, digest, or latest.
@@ -748,7 +743,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         &self,
         digest: <V::Block as Digestible>::Digest,
         fallback: DigestFallback,
-    ) -> oneshot::Receiver<V::Block> {
+    ) -> oneshot::Receiver<Arc<V::Block>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.sender.enqueue(Message::SubscribeByDigest {
             span: info_span!("marshal.mailbox.subscribe_by_digest", digest = %digest),
@@ -778,7 +773,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         &self,
         commitment: V::Commitment,
         fallback: CommitmentFallback,
-    ) -> oneshot::Receiver<V::Block> {
+    ) -> oneshot::Receiver<Arc<V::Block>> {
         let (tx, rx) = oneshot::channel();
         let _ = self.sender.enqueue(Message::SubscribeByCommitment {
             span: info_span!("marshal.mailbox.subscribe_by_commitment", commitment = %commitment),
@@ -827,10 +822,10 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         C: Clock,
     {
         let receiver = self.subscribe_by_digest(start_digest, fallback);
-        receiver
-            .await
-            .ok()
-            .map(|block| self.ancestor_stream(clock, [block], fetch_duration))
+        receiver.await.ok().map(|block| {
+            let block = V::into_inner_shared(block);
+            self.ancestor_stream(clock, [block], fetch_duration)
+        })
     }
 
     /// Returns the verified block previously persisted for `round`, if any.
@@ -862,13 +857,13 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     pub fn proposed_deferred(
         &self,
         round: Round,
-        block: V::Block,
+        block: impl Into<Arc<V::Block>>,
     ) -> oneshot::Receiver<Handle<()>> {
         let (ack, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::Proposed {
             span: info_span!("marshal.mailbox.proposed", round = %round),
             round,
-            block,
+            block: block.into(),
             ack: Some(ack),
         });
         receiver
@@ -881,7 +876,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// propose path should use [Self::proposed_deferred], which must enqueue before
     /// broadcasting the digest and await durability only at certify.
     #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn proposed(&self, round: Round, block: V::Block) -> bool {
+    pub async fn proposed(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
         let Ok(handle) = self.proposed_deferred(round, block).await else {
             return false;
         };
@@ -901,13 +896,13 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     pub fn verified_deferred(
         &self,
         round: Round,
-        block: V::Block,
+        block: impl Into<Arc<V::Block>>,
     ) -> oneshot::Receiver<Handle<()>> {
         let (ack, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::Verified {
             span: info_span!("marshal.mailbox.verified", round = %round),
             round,
-            block,
+            block: block.into(),
             ack: Some(ack),
         });
         receiver
@@ -921,7 +916,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// [Self::verified_deferred], which must enqueue before broadcasting and await
     /// durability only at certify.
     #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn verified(&self, round: Round, block: V::Block) -> bool {
+    pub async fn verified(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
         let Ok(handle) = self.verified_deferred(round, block).await else {
             return false;
         };
@@ -932,12 +927,12 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     ///
     /// Returns after the block is durably persisted.
     #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn certified(&self, round: Round, block: V::Block) -> bool {
+    pub async fn certified(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
         let (ack, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::Certified {
             span: info_span!("marshal.mailbox.certified", round = %round),
             round,
-            block,
+            block: block.into(),
             ack: Some(ack),
         });
         let Ok(handle) = receiver.await else {
@@ -1075,7 +1070,7 @@ mod tests {
             TestMessage::Proposed {
                 span: Span::none(),
                 round: round(height),
-                block: block(height),
+                block: block(height).into(),
                 ack: Some(ack),
             },
             receiver,
@@ -1088,7 +1083,7 @@ mod tests {
             TestMessage::Verified {
                 span: Span::none(),
                 round: round(height),
-                block: block(height),
+                block: block(height).into(),
                 ack: Some(ack),
             },
             receiver,
@@ -1101,7 +1096,7 @@ mod tests {
             TestMessage::Certified {
                 span: Span::none(),
                 round: round(height),
-                block: block(height),
+                block: block(height).into(),
                 ack: Some(ack),
             },
             receiver,
@@ -1137,7 +1132,7 @@ mod tests {
         )
     }
 
-    fn subscribe_by_digest(height: u64) -> (TestMessage, oneshot::Receiver<harness::B>) {
+    fn subscribe_by_digest(height: u64) -> (TestMessage, oneshot::Receiver<Arc<harness::B>>) {
         let (response, receiver) = oneshot::channel();
         (
             TestMessage::SubscribeByDigest {
@@ -1155,7 +1150,7 @@ mod tests {
     fn subscribe_by_commitment_message(
         height: u64,
         fallback: CommitmentFallback,
-    ) -> (TestMessage, oneshot::Receiver<harness::B>) {
+    ) -> (TestMessage, oneshot::Receiver<Arc<harness::B>>) {
         let (response, receiver) = oneshot::channel();
         (
             TestMessage::SubscribeByCommitment {

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -102,18 +102,14 @@ impl<V: Variant> Subscriptions<V> {
                 entry.get_mut().subscribers.push(subscriber);
             }
             Entry::Vacant(entry) => {
-                let aborter = match key {
-                    Key::Digest(digest) => buffer.subscribe_by_digest(digest).map(|rx| {
-                        waiters.push(async move { rx.await.map_err(|_| Key::Digest(digest)) })
-                    }),
-                    Key::Commitment(commitment) => {
-                        buffer.subscribe_by_commitment(commitment).map(|rx| {
-                            waiters.push(async move {
-                                rx.await.map_err(|_| Key::Commitment(commitment))
-                            })
-                        })
-                    }
+                let rx = match key {
+                    Key::Digest(digest) => buffer.subscribe_by_digest(digest),
+                    Key::Commitment(commitment) => buffer.subscribe_by_commitment(commitment),
                 };
+                let aborter = rx.map(|rx| {
+                    let waiter_key = key;
+                    waiters.push(async move { rx.await.map_err(|_| waiter_key) })
+                });
                 entry.insert(BlockSubscription {
                     subscribers: vec![subscriber],
                     _aborter: aborter,
@@ -195,7 +191,7 @@ mod tests {
 
         fn finalized(&self, _commitment: Digest) {}
 
-        fn send(&self, _round: Round, _block: TestBlock, _recipients: Recipients<PublicKey>) {}
+        fn send(&self, _round: Round, _block: Arc<TestBlock>, _recipients: Recipients<PublicKey>) {}
     }
 
     fn block(height: u64, timestamp: u64) -> TestBlock {

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -4,7 +4,10 @@ use commonware_utils::{
     channel::{fallible::OneshotExt, oneshot},
     futures::{AbortablePool, Aborter},
 };
-use std::collections::{btree_map::Entry, BTreeMap};
+use std::{
+    collections::{btree_map::Entry, BTreeMap},
+    sync::Arc,
+};
 use tracing::{info_span, Span};
 
 /// A set of local subscribers waiting for one block.
@@ -18,14 +21,14 @@ struct BlockSubscription<V: Variant> {
 /// A waiter for a block, carrying the span of its mailbox request.
 struct Subscriber<V: Variant> {
     span: Span,
-    sender: oneshot::Sender<V::Block>,
+    sender: oneshot::Sender<Arc<V::Block>>,
 }
 
 /// Delivers a block to a subscriber inside the dequeue-side child of its
 /// carried span, marking fulfillment in the trace.
-fn deliver<V: Variant>(subscriber: Subscriber<V>, block: &V::Block) {
+fn deliver<V: Variant>(subscriber: Subscriber<V>, block: &Arc<V::Block>) {
     let _guard = info_span!(parent: &subscriber.span, "marshal.actor.notify").entered();
-    subscriber.sender.send_lossy(block.clone());
+    subscriber.sender.send_lossy(Arc::clone(block));
 }
 
 /// The key used to track block subscriptions.
@@ -65,17 +68,19 @@ impl<V: Variant> Subscriptions<V> {
         });
     }
 
-    /// Notify any digest- or commitment-scoped subscribers for the provided block.
-    pub(super) fn notify(&mut self, block: &V::Block) {
-        if let Some(mut subscription) = self.entries.remove(&Key::Digest(block.digest())) {
+    /// Notify subscribers waiting for the provided block.
+    pub(super) fn notify(&mut self, block: Arc<V::Block>) {
+        let digest_key = Key::Digest(block.digest());
+        let commitment_key = Key::Commitment(V::commitment(&block));
+
+        if let Some(mut subscription) = self.entries.remove(&digest_key) {
             for subscriber in subscription.subscribers.drain(..) {
-                deliver(subscriber, block);
+                deliver(subscriber, &block);
             }
         }
-        if let Some(mut subscription) = self.entries.remove(&Key::Commitment(V::commitment(block)))
-        {
+        if let Some(mut subscription) = self.entries.remove(&commitment_key) {
             for subscriber in subscription.subscribers.drain(..) {
-                deliver(subscriber, block);
+                deliver(subscriber, &block);
             }
         }
     }
@@ -84,8 +89,8 @@ impl<V: Variant> Subscriptions<V> {
         &mut self,
         span: Span,
         key: KeyFor<V>,
-        response: oneshot::Sender<V::Block>,
-        waiters: &mut AbortablePool<Result<V::Block, KeyFor<V>>>,
+        response: oneshot::Sender<Arc<V::Block>>,
+        waiters: &mut AbortablePool<Result<Arc<V::Block>, KeyFor<V>>>,
         buffer: &Buf,
     ) {
         let subscriber = Subscriber {
@@ -97,14 +102,18 @@ impl<V: Variant> Subscriptions<V> {
                 entry.get_mut().subscribers.push(subscriber);
             }
             Entry::Vacant(entry) => {
-                let rx = match key {
-                    Key::Digest(digest) => buffer.subscribe_by_digest(digest),
-                    Key::Commitment(commitment) => buffer.subscribe_by_commitment(commitment),
+                let aborter = match key {
+                    Key::Digest(digest) => buffer.subscribe_by_digest(digest).map(|rx| {
+                        waiters.push(async move { rx.await.map_err(|_| Key::Digest(digest)) })
+                    }),
+                    Key::Commitment(commitment) => {
+                        buffer.subscribe_by_commitment(commitment).map(|rx| {
+                            waiters.push(async move {
+                                rx.await.map_err(|_| Key::Commitment(commitment))
+                            })
+                        })
+                    }
                 };
-                let aborter = rx.map(|rx| {
-                    let waiter_key = key;
-                    waiters.push(async move { rx.await.map_err(|_| waiter_key) })
-                });
                 entry.insert(BlockSubscription {
                     subscribers: vec![subscriber],
                     _aborter: aborter,
@@ -135,8 +144,8 @@ mod tests {
 
     type TestBlock = Block<Digest, ()>;
     type TestVariant = Standard<TestBlock>;
-    type TestWaiters = AbortablePool<Result<TestBlock, KeyFor<TestVariant>>>;
-    type Subscriber = oneshot::Sender<TestBlock>;
+    type TestWaiters = AbortablePool<Result<Arc<TestBlock>, KeyFor<TestVariant>>>;
+    type Subscriber = oneshot::Sender<Arc<TestBlock>>;
     type Subscribers = Arc<Mutex<Vec<Subscriber>>>;
 
     #[derive(Clone, Default)]
@@ -158,15 +167,18 @@ mod tests {
     impl Buffer<TestVariant> for TestBuffer {
         type PublicKey = PublicKey;
 
-        async fn find_by_digest(&self, _digest: Digest) -> Option<TestBlock> {
+        async fn find_by_digest(&self, _digest: Digest) -> Option<Arc<TestBlock>> {
             None
         }
 
-        async fn find_by_commitment(&self, _commitment: Digest) -> Option<TestBlock> {
+        async fn find_by_commitment(&self, _commitment: Digest) -> Option<Arc<TestBlock>> {
             None
         }
 
-        fn subscribe_by_digest(&self, _digest: Digest) -> Option<oneshot::Receiver<TestBlock>> {
+        fn subscribe_by_digest(
+            &self,
+            _digest: Digest,
+        ) -> Option<oneshot::Receiver<Arc<TestBlock>>> {
             let (sender, receiver) = oneshot::channel();
             self.digest_subscribers.lock().push(sender);
             Some(receiver)
@@ -175,7 +187,7 @@ mod tests {
         fn subscribe_by_commitment(
             &self,
             _commitment: Digest,
-        ) -> Option<oneshot::Receiver<TestBlock>> {
+        ) -> Option<oneshot::Receiver<Arc<TestBlock>>> {
             let (sender, receiver) = oneshot::channel();
             self.commitment_subscribers.lock().push(sender);
             Some(receiver)
@@ -190,7 +202,7 @@ mod tests {
         Block::new::<Sha256>((), Sha256::fill(0), Height::new(height), timestamp)
     }
 
-    fn assert_receives(receiver: oneshot::Receiver<TestBlock>, expected: &TestBlock) {
+    fn assert_receives(receiver: oneshot::Receiver<Arc<TestBlock>>, expected: &TestBlock) {
         let received = receiver
             .now_or_never()
             .expect("receiver should be ready")
@@ -226,7 +238,7 @@ mod tests {
         assert_eq!(test_buffer.digest_subscription_count(), 1);
         assert_eq!(subscriptions.entries.len(), 1);
 
-        subscriptions.notify(&block);
+        subscriptions.notify(Arc::new(block.clone()));
         assert_receives(first_receiver, &block);
         assert_receives(second_receiver, &block);
         assert!(subscriptions.entries.is_empty());
@@ -261,7 +273,7 @@ mod tests {
         assert_eq!(test_buffer.commitment_subscription_count(), 1);
         assert_eq!(subscriptions.entries.len(), 2);
 
-        subscriptions.notify(&block);
+        subscriptions.notify(Arc::new(block.clone()));
         assert_receives(digest_receiver, &block);
         assert_receives(commitment_receiver, &block);
         assert!(subscriptions.entries.is_empty());
@@ -299,7 +311,7 @@ mod tests {
             .expect("open subscriber should remain");
         assert_eq!(subscription.subscribers.len(), 1);
 
-        subscriptions.notify(&block);
+        subscriptions.notify(Arc::new(block.clone()));
         assert_receives(open_receiver, &block);
         assert!(subscriptions.entries.is_empty());
     }
@@ -348,7 +360,7 @@ mod tests {
         );
 
         assert_eq!(subscriptions.entries.len(), 1);
-        subscriptions.notify(&block);
+        subscriptions.notify(Arc::new(block.clone()));
         assert_receives(receiver, &block);
         assert!(subscriptions.entries.is_empty());
     }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -88,9 +88,7 @@ pub trait Variant: Clone + Send + Sync + 'static {
     fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock>;
 
     /// Converts an owned working block to a shared application block.
-    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
-        Arc::new(Self::into_inner(block))
-    }
+    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock>;
 
     /// Reconstructs a working block from an application block and trusted payload.
     fn from_application_block(

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -17,7 +17,7 @@ use commonware_codec::{Codec, Read};
 use commonware_cryptography::{Digest, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::{future::Future, marker::PhantomData};
+use std::{future::Future, marker::PhantomData, sync::Arc};
 
 /// A marker trait describing the types used by a variant of Marshal.
 pub trait Variant: Clone + Send + Sync + 'static {
@@ -25,18 +25,16 @@ pub trait Variant: Clone + Send + Sync + 'static {
     ///
     /// Must be convertible to `StoredBlock` via `Into` for archival.
     type Block: Block<Digest = <Self::ApplicationBlock as Digestible>::Digest>
-        + Into<Self::StoredBlock>
-        + Clone;
+        + Into<Self::StoredBlock>;
 
     /// The application block type.
-    type ApplicationBlock: Block + Clone;
+    type ApplicationBlock: Block;
 
     /// The type of block stored in the archive.
     ///
     /// Must be convertible back to the working block type via `Into`.
     type StoredBlock: Block<Digest = <Self::Block as Digestible>::Digest>
         + Into<Self::Block>
-        + Clone
         + Codec<Cfg = <Self::ApplicationBlock as Read>::Cfg>;
 
     /// The [`Digest`] type used by consensus.
@@ -86,6 +84,9 @@ pub trait Variant: Clone + Send + Sync + 'static {
     /// `ApplicationBlock` (e.g., `CodedBlock<B, C, H> -> B`).
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock;
 
+    /// Converts a shared working block to a shared application block.
+    fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock>;
+
     /// Reconstructs a working block from an application block and trusted payload.
     fn from_application_block(
         block: Self::ApplicationBlock,
@@ -116,7 +117,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn find_by_digest(
         &self,
         digest: <V::Block as Digestible>::Digest,
-    ) -> impl Future<Output = Option<V::Block>> + Send;
+    ) -> impl Future<Output = Option<Arc<V::Block>>> + Send;
 
     /// Attempt to find a block by its commitment.
     ///
@@ -129,7 +130,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn find_by_commitment(
         &self,
         commitment: V::Commitment,
-    ) -> impl Future<Output = Option<V::Block>> + Send;
+    ) -> impl Future<Output = Option<Arc<V::Block>>> + Send;
 
     /// Subscribe to a block's availability by its digest.
     ///
@@ -141,7 +142,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn subscribe_by_digest(
         &self,
         digest: <V::Block as Digestible>::Digest,
-    ) -> Option<oneshot::Receiver<V::Block>>;
+    ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
     /// Subscribe to a block's availability by its commitment.
     ///
@@ -156,7 +157,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn subscribe_by_commitment(
         &self,
         commitment: V::Commitment,
-    ) -> Option<oneshot::Receiver<V::Block>>;
+    ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
     /// Notify the buffer that a block has been finalized.
     ///
@@ -195,22 +196,25 @@ where
 {
     type PublicKey = P;
 
-    async fn find_by_digest(&self, _: <V::Block as Digestible>::Digest) -> Option<V::Block> {
+    async fn find_by_digest(&self, _: <V::Block as Digestible>::Digest) -> Option<Arc<V::Block>> {
         None
     }
 
-    async fn find_by_commitment(&self, _: V::Commitment) -> Option<V::Block> {
+    async fn find_by_commitment(&self, _: V::Commitment) -> Option<Arc<V::Block>> {
         None
     }
 
     fn subscribe_by_digest(
         &self,
         _: <V::Block as Digestible>::Digest,
-    ) -> Option<oneshot::Receiver<V::Block>> {
+    ) -> Option<oneshot::Receiver<Arc<V::Block>>> {
         None
     }
 
-    fn subscribe_by_commitment(&self, _: V::Commitment) -> Option<oneshot::Receiver<V::Block>> {
+    fn subscribe_by_commitment(
+        &self,
+        _: V::Commitment,
+    ) -> Option<oneshot::Receiver<Arc<V::Block>>> {
         None
     }
 

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -87,6 +87,11 @@ pub trait Variant: Clone + Send + Sync + 'static {
     /// Converts a shared working block to a shared application block.
     fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock>;
 
+    /// Converts an owned working block to a shared application block.
+    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+        Arc::new(Self::into_inner(block))
+    }
+
     /// Reconstructs a working block from an application block and trusted payload.
     fn from_application_block(
         block: Self::ApplicationBlock,
@@ -165,7 +170,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn finalized(&self, commitment: V::Commitment);
 
     /// Send a block to peers.
-    fn send(&self, round: Round, block: V::Block, recipients: Recipients<Self::PublicKey>);
+    fn send(&self, round: Round, block: Arc<V::Block>, recipients: Recipients<Self::PublicKey>);
 }
 
 /// A buffer implementation that never stores, subscribes, finalizes, or sends blocks.
@@ -220,5 +225,5 @@ where
 
     fn finalized(&self, _: V::Commitment) {}
 
-    fn send(&self, _: Round, _: V::Block, _: Recipients<Self::PublicKey>) {}
+    fn send(&self, _: Round, _: Arc<V::Block>, _: Recipients<Self::PublicKey>) {}
 }

--- a/consensus/src/marshal/mocks/application.rs
+++ b/consensus/src/marshal/mocks/application.rs
@@ -13,7 +13,7 @@ use std::{
 /// A mock application that stores finalized blocks.
 #[derive(Clone)]
 pub struct Application<B: Block> {
-    blocks: Arc<Mutex<BTreeMap<Height, B>>>,
+    blocks: Arc<Mutex<BTreeMap<Height, Arc<B>>>>,
     #[allow(clippy::type_complexity)]
     tip: Arc<Mutex<Option<(Height, B::Digest)>>>,
     pending_acks: Arc<Mutex<VecDeque<(Height, Exact)>>>,
@@ -43,7 +43,7 @@ impl<B: Block> Application<B> {
     }
 
     /// Returns the finalized blocks.
-    pub fn blocks(&self) -> BTreeMap<Height, B> {
+    pub fn blocks(&self) -> BTreeMap<Height, Arc<B>> {
         self.blocks.lock().clone()
     }
 

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -72,6 +72,7 @@ use crate::{
 use commonware_cryptography::Digest;
 use commonware_storage::archive;
 use commonware_utils::{acknowledgement::Exact, Acknowledgement};
+use std::sync::Arc;
 
 mod config;
 pub use config::{Config, Start};
@@ -142,11 +143,11 @@ pub enum Update<B: Block, A: Acknowledgement = Exact> {
     /// until the application explicitly acknowledges the update. If the [Acknowledgement] is dropped before
     /// handling, marshal will exit (assuming the application is shutting down).
     ///
-    /// Because the [Acknowledgement] is clonable, the application can pass [Update] to multiple consumers
-    /// (and marshal will only consider the block delivered once all consumers have acknowledged it).
+    /// Cloning the update shares the immutable block, so applications can fan it out without requiring
+    /// block clones. Marshal only considers the block delivered once every acknowledgement is handled.
     ///
     /// Marshal only emits a block after it has durably persisted the said block. This ensures applications
     /// that make stateful changes based on a block in other locations can access the same block on restart (often
     /// some logic on startup attempts on infallible read on the last processed block).
-    Block(B, A),
+    Block(Arc<B>, A),
 }

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -239,8 +239,8 @@ where
     async fn deferred_verify(
         &mut self,
         context: <Self as Automaton>::Context,
-        block: B,
-        parent_request: oneshot::Receiver<B>,
+        block: Arc<B>,
+        parent_request: oneshot::Receiver<Arc<B>>,
         stage: Stage,
     ) -> oneshot::Receiver<bool> {
         let marshal = self.marshal.clone();
@@ -267,12 +267,12 @@ where
                 // candidate availability/recovery, not a validity decision. This
                 // task gates the finalize vote by resolving true only after both
                 // app verification succeeds and the store is durable.
-                let store = stage.store(&marshal, round, block.clone());
+                let store = stage.store(&marshal, round, Arc::clone(&block));
                 let verify = async {
                     // Validate the parent we already started fetching.
                     let parent = match await_and_validate_parent(
                         context.parent.1,
-                        &block,
+                        block.as_ref(),
                         parent_request,
                         &mut tx,
                     )
@@ -285,7 +285,7 @@ where
                     run_app_verify(
                         runtime_context,
                         context,
-                        &block,
+                        Arc::clone(&block),
                         parent,
                         &mut application,
                         &marshal,

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -509,13 +509,13 @@ where
                 // verdict (a notarization implies f+1 honest validators already
                 // verified), and the store still completes through the join, so
                 // the fallback rides the verified write instead of re-persisting.
-                let store = marshal.verified(round, block.clone());
+                let store = marshal.verified(round, Arc::clone(&block));
                 let verify_then_vote = async {
                     // Non-reproposal path: validate the parent we already started
                     // fetching.
                     let parent = match await_and_validate_parent(
                         context.parent.1,
-                        &block,
+                        block.as_ref(),
                         parent_request,
                         &mut tx,
                     )
@@ -531,7 +531,7 @@ where
                     let valid = run_app_verify(
                         runtime_context,
                         context,
-                        &block,
+                        Arc::clone(&block),
                         parent,
                         &mut application,
                         &marshal,

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3205,8 +3205,8 @@ mod tests {
     #[derive(Clone, Default)]
     struct RecordingBuffer {
         blocks: Arc<Mutex<Vec<B>>>,
-        digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<B>>>>,
-        commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<B>>>>,
+        digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
+        commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         sends: Arc<Mutex<Vec<BufferSend>>>,
     }
 
@@ -3231,29 +3231,31 @@ mod tests {
     impl crate::marshal::core::Buffer<Standard<B>> for RecordingBuffer {
         type PublicKey = PublicKey;
 
-        async fn find_by_digest(&self, digest: D) -> Option<B> {
+        async fn find_by_digest(&self, digest: D) -> Option<Arc<B>> {
             self.blocks
                 .lock()
                 .iter()
                 .find(|block| block.digest() == digest)
                 .cloned()
+                .map(Arc::new)
         }
 
-        async fn find_by_commitment(&self, commitment: D) -> Option<B> {
+        async fn find_by_commitment(&self, commitment: D) -> Option<Arc<B>> {
             self.blocks
                 .lock()
                 .iter()
                 .find(|block| block.digest() == commitment)
                 .cloned()
+                .map(Arc::new)
         }
 
-        fn subscribe_by_digest(&self, _digest: D) -> Option<oneshot::Receiver<B>> {
+        fn subscribe_by_digest(&self, _digest: D) -> Option<oneshot::Receiver<Arc<B>>> {
             let (sender, receiver) = oneshot::channel();
             self.digest_subscriptions.lock().push(sender);
             Some(receiver)
         }
 
-        fn subscribe_by_commitment(&self, _commitment: D) -> Option<oneshot::Receiver<B>> {
+        fn subscribe_by_commitment(&self, _commitment: D) -> Option<oneshot::Receiver<Arc<B>>> {
             let (sender, receiver) = oneshot::channel();
             self.commitment_subscriptions.lock().push(sender);
             Some(receiver)

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3198,7 +3198,7 @@ mod tests {
     }
 
     /// Recorded `send` call on the [`RecordingBuffer`].
-    type BufferSend = (Round, B, Recipients<PublicKey>);
+    type BufferSend = (Round, Arc<B>, Recipients<PublicKey>);
 
     /// A buffer that records each `send` invocation, keeps subscriptions open,
     /// and optionally serves locally inserted blocks.
@@ -3263,7 +3263,7 @@ mod tests {
 
         fn finalized(&self, _commitment: D) {}
 
-        fn send(&self, round: Round, block: B, recipients: Recipients<PublicKey>) {
+        fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
             self.sends.lock().push((round, block, recipients));
         }
     }

--- a/consensus/src/marshal/standard/validation.rs
+++ b/consensus/src/marshal/standard/validation.rs
@@ -73,8 +73,8 @@ pub(super) async fn precheck_epoch_and_reproposal<ES, S, B>(
     marshal: &Mailbox<S, Standard<B>>,
     context: &Context<B::Digest, S::PublicKey>,
     digest: B::Digest,
-    block: B,
-) -> Option<Decision<B>>
+    block: Arc<B>,
+) -> Option<Decision<Arc<B>>>
 where
     ES: Epocher,
     S: Scheme,
@@ -133,9 +133,9 @@ pub(super) enum ParentCheck<B> {
 pub(super) async fn await_and_validate_parent<B>(
     parent_commitment: B::Digest,
     block: &B,
-    parent_request: oneshot::Receiver<B>,
+    parent_request: oneshot::Receiver<Arc<B>>,
     tx: &mut oneshot::Sender<bool>,
-) -> Option<ParentCheck<B>>
+) -> Option<ParentCheck<Arc<B>>>
 where
     B: Block,
 {
@@ -187,8 +187,8 @@ where
 pub(super) async fn run_app_verify<E, S, A, B>(
     runtime_context: E,
     context: Context<B::Digest, S::PublicKey>,
-    block: &B,
-    parent: B,
+    block: Arc<B>,
+    parent: Arc<B>,
     application: &mut A,
     marshal: &Mailbox<S, Standard<B>>,
     tx: &mut oneshot::Sender<bool>,
@@ -203,7 +203,7 @@ where
     let (parent_view, parent_commitment) = context.parent;
     let ancestry_stream = marshal.ancestor_stream(
         Arc::new(runtime_context.child("ancestor_stream")),
-        [block.clone(), parent],
+        [Arc::clone(&block), parent],
         ancestor_fetch_duration,
     );
     let validity_request = application

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -12,7 +12,7 @@ use crate::{
     types::Round,
     Block,
 };
-use commonware_broadcast::{buffered, Broadcaster};
+use commonware_broadcast::buffered;
 use commonware_codec::Read;
 use commonware_cryptography::{certificate::Scheme, Digestible, PublicKey};
 use commonware_p2p::Recipients;
@@ -110,8 +110,8 @@ where
         // No cleanup needed in standard mode - the buffer handles its own pruning
     }
 
-    fn send(&self, _round: Round, block: B, recipients: Recipients<K>) {
-        Broadcaster::broadcast(self, recipients, block);
+    fn send(&self, _round: Round, block: Arc<B>, recipients: Recipients<K>) {
+        self.broadcast_shared(recipients, block);
     }
 }
 

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -75,6 +75,10 @@ where
         block
     }
 
+    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+        Arc::new(block)
+    }
+
     fn from_application_block(
         block: Self::ApplicationBlock,
         _payload: Self::Commitment,

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -17,7 +17,7 @@ use commonware_codec::Read;
 use commonware_cryptography::{certificate::Scheme, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 /// The standard variant of Marshal, which broadcasts complete blocks.
 ///
@@ -71,6 +71,10 @@ where
         block
     }
 
+    fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock> {
+        block
+    }
+
     fn from_application_block(
         block: Self::ApplicationBlock,
         _payload: Self::Commitment,
@@ -86,21 +90,19 @@ where
 {
     type PublicKey = K;
 
-    async fn find_by_digest(&self, digest: B::Digest) -> Option<B> {
+    async fn find_by_digest(&self, digest: B::Digest) -> Option<Arc<B>> {
         self.get(digest).await
     }
 
-    async fn find_by_commitment(&self, commitment: B::Digest) -> Option<B> {
+    async fn find_by_commitment(&self, commitment: B::Digest) -> Option<Arc<B>> {
         self.find_by_digest(commitment).await
     }
 
-    fn subscribe_by_digest(&self, digest: B::Digest) -> Option<oneshot::Receiver<B>> {
-        let (tx, rx) = oneshot::channel();
-        self.subscribe_prepared(digest, tx);
-        Some(rx)
+    fn subscribe_by_digest(&self, digest: B::Digest) -> Option<oneshot::Receiver<Arc<B>>> {
+        Some(self.subscribe(digest))
     }
 
-    fn subscribe_by_commitment(&self, commitment: B::Digest) -> Option<oneshot::Receiver<B>> {
+    fn subscribe_by_commitment(&self, commitment: B::Digest) -> Option<oneshot::Receiver<Arc<B>>> {
         self.subscribe_by_digest(commitment)
     }
 
@@ -123,7 +125,7 @@ where
     fn subscribe_parent(
         &self,
         block: &Self::Block,
-    ) -> impl Future<Output = Option<Self::Block>> + Send + 'static {
+    ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
         let receiver = block.height().previous().map(|parent_height| {
             self.subscribe_by_commitment(
                 block.parent(),
@@ -132,9 +134,6 @@ where
                 },
             )
         });
-        async move {
-            let receiver = receiver?;
-            receiver.await.ok()
-        }
+        async move { receiver?.await.ok() }
     }
 }

--- a/examples/reshare/src/dkg/actor.rs
+++ b/examples/reshare/src/dkg/actor.rs
@@ -40,7 +40,10 @@ use commonware_runtime::{
 };
 use commonware_utils::{ordered::Set, Acknowledgement as _, N3f1, NZU32};
 use rand_core::CryptoRng;
-use std::num::{NonZeroU32, NonZeroUsize};
+use std::{
+    num::{NonZeroU32, NonZeroUsize},
+    sync::Arc,
+};
 use tracing::{debug, info, warn};
 
 /// Per-peer label.
@@ -484,8 +487,9 @@ where
                         }
                     }
                     MailboxMessage::Finalized { block, response } => {
+                        let block_height = block.height;
                         let bounds = epocher
-                            .containing(block.height)
+                            .containing(block_height)
                             .expect("block height covered by epoch strategy");
                         let block_epoch = bounds.epoch();
                         let phase = bounds.phase();
@@ -499,8 +503,9 @@ where
                             continue;
                         }
 
-                        // Process dealer log from block if present
-                        if let Some(log) = block.log {
+                        let log = Arc::try_unwrap(block)
+                            .map_or_else(|block| block.log.clone(), |block| block.log);
+                        if let Some(log) = log {
                             if let Some((dealer, dealer_log)) = log.check(&round) {
                                 // `log.check` only authenticates the self-signature, not
                                 // dealer-set membership. A validly self-signed log from a
@@ -545,7 +550,7 @@ where
                         }
 
                         // Continue if not the last block in the epoch
-                        if block.height != bounds.last() {
+                        if block_height != bounds.last() {
                             // Acknowledge block processing
                             response.acknowledge();
                             continue;

--- a/examples/reshare/src/dkg/ingress.rs
+++ b/examples/reshare/src/dkg/ingress.rs
@@ -13,7 +13,7 @@ use commonware_cryptography::{
     Hasher, Signer,
 };
 use commonware_utils::{acknowledgement::Exact, channel::oneshot, Acknowledgement};
-use std::collections::VecDeque;
+use std::{collections::VecDeque, sync::Arc};
 use tracing::error;
 
 /// A message that can be sent to the [Actor].
@@ -35,7 +35,10 @@ where
     },
 
     /// A new block has been finalized.
-    Finalized { block: Block<H, C, V>, response: A },
+    Finalized {
+        block: Arc<Block<H, C, V>>,
+        response: A,
+    },
 }
 
 impl<H, C, V, A> Policy for Message<H, C, V, A>

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -14,11 +14,11 @@ use commonware_runtime::{telemetry::traces::TracedExt as _, Clock, Metrics, Spaw
 use commonware_utils::{acknowledgement::Exact, channel::oneshot};
 use futures::Stream;
 use rand_core::Rng;
-use std::{collections::VecDeque, pin::Pin};
+use std::{collections::VecDeque, pin::Pin, sync::Arc};
 use tracing::{info_span, Span};
 
 /// Type alias for an ancestor stream sent through the actor mailbox.
-pub(crate) type ErasedAncestorStream<B> = Pin<Box<dyn Stream<Item = B> + Send>>;
+pub(crate) type ErasedAncestorStream<B> = Pin<Box<dyn Stream<Item = Arc<B>> + Send>>;
 
 /// Messages processed by the actor loop.
 pub(crate) enum Message<E, A>
@@ -45,7 +45,7 @@ where
     /// A reporting of a new finalized block.
     Finalized {
         span: Span,
-        block: A::Block,
+        block: Arc<A::Block>,
         acknowledgement: Exact,
     },
 
@@ -206,7 +206,7 @@ where
     async fn propose(
         &mut self,
         context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send + 'static,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send + 'static,
     ) -> Option<Self::Block> {
         let (response, receiver) = oneshot::channel();
         let span = info_span!(
@@ -226,7 +226,7 @@ where
     async fn verify(
         &mut self,
         context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send + 'static,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send + 'static,
     ) -> bool {
         // We must panic if we don't get a response; We cannot override the decision
         // of the application based on the availabilitiy of the actor.

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -144,12 +144,15 @@ where
                     let prune = async {
                         if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
                             self.processor
-                                .notify_finalized(self.context.as_present(), &block)
+                                .notify_finalized(self.context.as_present(), block.as_ref())
                                 .await;
                             acknowledgement.acknowledge();
                             return None;
                         }
-                        let (status, prune) = self.processor.finalize(&self.context, block).await;
+                        let (status, prune) = self
+                            .processor
+                            .finalize(&self.context, block.as_ref())
+                            .await;
                         if let FinalizeStatus::Persisted { height } = status {
                             debug!(height = height.get(), "persisted finalized database batch");
                         }

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -196,12 +196,12 @@ where
     /// Processes a finalized block during state sync.
     async fn process_finalized(
         &mut self,
-        block: A::Block,
+        block: Arc<A::Block>,
         acknowledgement: Exact,
-    ) -> Option<FinalizedHandoff<A::Block>> {
+    ) -> Option<FinalizedHandoff<Arc<A::Block>>> {
         if self.artifact.is_none() {
-            let anchor = Anchor::from(&block);
-            let targets = A::sync_targets(&block);
+            let anchor = Anchor::from(block.as_ref());
+            let targets = A::sync_targets(block.as_ref());
 
             // Do not acknowledge marshal until the live sync session has recorded this
             // block's tip update. If we ack after merely enqueueing it, sync can still
@@ -239,7 +239,7 @@ where
 
     /// Transitions to [`Processing`] state once the database set has converged
     /// on the state sync [`Anchor`].
-    async fn transition(mut self, handoff: Option<FinalizedHandoff<A::Block>>) {
+    async fn transition(mut self, handoff: Option<FinalizedHandoff<Arc<A::Block>>>) {
         let artifact = self.artifact.take().expect("transition must have artifact");
         let synced_height = artifact.anchor.height;
 
@@ -262,13 +262,14 @@ where
             match handoff {
                 FinalizedHandoff::Reflected(block, acknowledgement) => {
                     processor
-                        .notify_finalized(self.context.as_present(), &block)
+                        .notify_finalized(self.context.as_present(), block.as_ref())
                         .await;
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
-                    let (status, prune) =
-                        processor.finalize(self.context.as_present(), block).await;
+                    let (status, prune) = processor
+                        .finalize(self.context.as_present(), block.as_ref())
+                        .await;
                     if let Some(prune) = prune {
                         prune.run(processor.databases_mut(), &self.marshal).await;
                     }
@@ -475,7 +476,7 @@ mod tests {
 
             let action = harness
                 .syncing
-                .process_finalized(TestBlock::new(7, 9), acknowledgement)
+                .process_finalized(Arc::new(TestBlock::new(7, 9)), acknowledgement)
                 .await;
 
             assert!(poll!(&mut waiter).is_pending());
@@ -493,7 +494,7 @@ mod tests {
 
             let action = harness
                 .syncing
-                .process_finalized(TestBlock::new(8, 10), acknowledgement)
+                .process_finalized(Arc::new(TestBlock::new(8, 10)), acknowledgement)
                 .await;
 
             assert!(waiter.now_or_never().is_none());
@@ -514,7 +515,7 @@ mod tests {
             let (acknowledgement, _waiter) = Exact::handle();
             let _ = harness
                 .syncing
-                .process_finalized(TestBlock::new(7, 10), acknowledgement)
+                .process_finalized(Arc::new(TestBlock::new(7, 10)), acknowledgement)
                 .await;
         });
     }
@@ -527,7 +528,7 @@ mod tests {
             let (acknowledgement, _waiter) = Exact::handle();
             let _ = harness
                 .syncing
-                .process_finalized(TestBlock::new(9, 10), acknowledgement)
+                .process_finalized(Arc::new(TestBlock::new(9, 10)), acknowledgement)
                 .await;
         });
     }
@@ -541,7 +542,7 @@ mod tests {
             let (acknowledgement, mut waiter) = Exact::handle();
 
             let transition = harness.syncing.transition(Some(FinalizedHandoff::Apply(
-                TestBlock::new(8, 10),
+                Arc::new(TestBlock::new(8, 10)),
                 acknowledgement,
             )));
             pin_mut!(transition);

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -49,6 +49,7 @@ use std::{
     collections::{BTreeMap, HashSet, VecDeque},
     future::Future,
     num::NonZeroUsize,
+    sync::Arc,
 };
 use tracing::{debug, info_span, warn};
 
@@ -247,7 +248,7 @@ where
         context: &E,
         marshal: MarshalMailbox<S, V>,
         (runtime_context, consensus_context): (E, A::Context),
-        ancestry: impl Stream<Item = A::Block> + Send + 'static,
+        ancestry: impl Stream<Item = Arc<A::Block>> + Send + 'static,
         input_provider: &mut A::InputProvider,
         mut response: oneshot::Sender<Option<A::Block>>,
     ) where
@@ -270,7 +271,7 @@ where
             }
         };
         let parent_digest = parent.digest();
-        let ancestry = stream::once(std::future::ready(parent.clone())).chain(ancestry);
+        let ancestry = stream::once(std::future::ready(Arc::clone(&parent))).chain(ancestry);
 
         let round = consensus_context.round();
         let batches = match self
@@ -339,7 +340,7 @@ where
         context: &E,
         marshal: MarshalMailbox<S, V>,
         (runtime_context, consensus_context): (E, A::Context),
-        ancestry: impl Stream<Item = A::Block> + Send + 'static,
+        ancestry: impl Stream<Item = Arc<A::Block>> + Send + 'static,
         mut response: oneshot::Sender<bool>,
     ) where
         S: Scheme,
@@ -380,8 +381,13 @@ where
         //
         // `last_processed.height` is only advanced from finalized state
         // (genesis, startup reconciliation, or finalize/ack path).
-        match is_already_processed(self.last_processed, marshal.clone(), &block, &mut response)
-            .await
+        match is_already_processed(
+            self.last_processed,
+            marshal.clone(),
+            block.as_ref(),
+            &mut response,
+        )
+        .await
         {
             Ok(true) => {
                 timer.observe(context);
@@ -529,7 +535,7 @@ where
         &mut self,
         context: &E,
         marshal: MarshalMailbox<S, V>,
-        parent: A::Block,
+        parent: Arc<A::Block>,
         response: &mut oneshot::Sender<Response>,
     ) -> Result<<A::Databases as DatabaseSet<E>>::Unmerkleized, PrepareBatchesError>
     where
@@ -572,7 +578,7 @@ where
         &mut self,
         context: &E,
         provider: P,
-        target: A::Block,
+        target: Arc<A::Block>,
         response: &mut oneshot::Sender<Response>,
     ) -> Result<(), PrepareBatchesError>
     where
@@ -694,7 +700,7 @@ where
     pub(super) async fn finalize(
         &mut self,
         context: &E,
-        block: A::Block,
+        block: &A::Block,
     ) -> (FinalizeStatus, DeferredPrune<PendingSyncTargets<A, E>>) {
         let (height, digest) = (block.height(), block.digest());
         if height < self.last_processed.height {
@@ -715,7 +721,7 @@ where
         let timer = self.metrics.finalize_duration.timer(context);
         let block_context = block.context();
         let round = block_context.round();
-        let sync_targets = A::sync_targets(&block);
+        let sync_targets = A::sync_targets(block);
 
         // Marshal finalization is ordered. A pending miss means we can replay
         // this block on top of finalized state.
@@ -730,7 +736,7 @@ where
                     .app
                     .apply(
                         (context.child("finalize_replay"), block_context),
-                        &block,
+                        block,
                         batches,
                     )
                     .await;
@@ -743,7 +749,7 @@ where
         };
 
         self.databases.finalize(batch).await;
-        self.notify_finalized(context, &block).await;
+        self.notify_finalized(context, block).await;
         let prune = self
             .pruning
             .as_mut()
@@ -1162,7 +1168,7 @@ mod tests {
         async fn propose(
             &mut self,
             context: (deterministic::Context, Self::Context),
-            ancestry: impl Stream<Item = Self::Block> + Send,
+            ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
             batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
             _input: &mut Self::InputProvider,
         ) -> Option<Proposed<Self, deterministic::Context>> {
@@ -1188,7 +1194,7 @@ mod tests {
         async fn verify(
             &mut self,
             _context: (deterministic::Context, Self::Context),
-            ancestry: impl Stream<Item = Self::Block> + Send,
+            ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
             batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
         ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
             let mut ancestry = Box::pin(ancestry);
@@ -1265,10 +1271,10 @@ mod tests {
         fn subscribe_parent(
             &self,
             block: &Self::Block,
-        ) -> impl Future<Output = Option<Self::Block>> + Send + 'static {
+        ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
             let provider = self.clone();
             let parent = block.parent();
-            async move { provider.fetch_by_digest(parent) }
+            async move { provider.fetch_by_digest(parent).map(Arc::new) }
         }
     }
 
@@ -1296,7 +1302,7 @@ mod tests {
         fn subscribe_parent(
             &self,
             block: &Self::Block,
-        ) -> impl Future<Output = Option<Self::Block>> + Send + 'static {
+        ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
             let provider = self.clone();
             let child = block.digest();
             async move {
@@ -1307,6 +1313,7 @@ mod tests {
                     .get_mut(&child)
                     .and_then(VecDeque::pop_front)
                     .flatten()
+                    .map(Arc::new)
             }
         }
     }
@@ -1484,7 +1491,7 @@ mod tests {
 
         async fn finalize(&mut self, block: Block) -> FinalizeStatus {
             self.processor
-                .finalize(self.context_cell.as_present(), block)
+                .finalize(self.context_cell.as_present(), &block)
                 .await
                 .0
         }
@@ -1503,7 +1510,7 @@ mod tests {
             >,
         ){
             self.processor
-                .finalize(self.context_cell.as_present(), block)
+                .finalize(self.context_cell.as_present(), &block)
                 .await
         }
 
@@ -1971,7 +1978,7 @@ mod tests {
                 .rebuild_pending(
                     harness.context_cell.as_present(),
                     provider,
-                    gap_block.clone(),
+                    Arc::new(gap_block.clone()),
                     &mut response,
                 )
                 .await;
@@ -2170,7 +2177,7 @@ mod tests {
                 .rebuild_pending(
                     harness.context_cell.as_present(),
                     provider,
-                    block2,
+                    Arc::new(block2),
                     &mut response,
                 )
                 .await;
@@ -2205,7 +2212,7 @@ mod tests {
                 .rebuild_pending(
                     harness.context_cell.as_present(),
                     provider.clone(),
-                    block2,
+                    Arc::new(block2),
                     &mut response,
                 )
                 .await;

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -342,12 +342,12 @@ where
             .subscribe_by_commitment(finalization.proposal.payload, CommitmentFallback::Wait)
             .await
             .expect("marshal must yield floor block");
-        V::into_inner(block)
+        V::into_inner_shared(block)
     };
 
     ResolvedFloor {
-        anchor: Anchor::from(&floor),
-        targets: A::sync_targets(&floor),
+        anchor: Anchor::from(floor.as_ref()),
+        targets: A::sync_targets(floor.as_ref()),
         marker: FloorMarker::new(floor.height(), finalization.proposal.payload),
     }
 }

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -95,7 +95,7 @@ use commonware_runtime::{Clock, Metrics, Spawner};
 use db::DatabaseSet;
 use futures::Stream;
 use rand_core::Rng;
-use std::future::Future;
+use std::{future::Future, sync::Arc};
 
 mod actor;
 pub use actor::{Config, Mailbox, PruneConfig, Stateful, SyncPlan};
@@ -185,7 +185,7 @@ where
     fn propose(
         &mut self,
         context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
         input: &mut Self::InputProvider,
     ) -> impl Future<Output = Option<Proposed<Self, E>>> + Send;
@@ -224,7 +224,7 @@ where
     fn verify(
         &mut self,
         context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> impl Future<Output = Option<<Self::Databases as DatabaseSet<E>>::Merkleized>> + Send;
 

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -186,7 +186,7 @@ impl Application<deterministic::Context> for TestApp {
     async fn propose(
         &mut self,
         _context: (deterministic::Context, Self::Context),
-        _ancestry: impl Stream<Item = Self::Block> + Send,
+        _ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         _batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
         _input: &mut Self::InputProvider,
     ) -> Option<Proposed<Self, deterministic::Context>> {
@@ -196,7 +196,7 @@ impl Application<deterministic::Context> for TestApp {
     async fn verify(
         &mut self,
         _context: (deterministic::Context, Self::Context),
-        _ancestry: impl Stream<Item = Self::Block> + Send,
+        _ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         _batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
     ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
         None

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -253,7 +253,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     async fn propose(
         &mut self,
         context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
         _input: &mut Self::InputProvider,
     ) -> Option<Proposed<Self, E>> {
@@ -287,7 +287,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     async fn verify(
         &mut self,
         _context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
         let mut ancestry = Box::pin(ancestry);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -204,7 +204,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     async fn propose(
         &mut self,
         context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
         _input: &mut Self::InputProvider,
     ) -> Option<Proposed<Self, E>> {
@@ -226,7 +226,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     async fn verify(
         &mut self,
         _context: (E, Self::Context),
-        ancestry: impl Stream<Item = Self::Block> + Send,
+        ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
         let mut ancestry = Box::pin(ancestry);

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -53,6 +53,16 @@ impl<S: Sender, V: Codec> WrappedSender<S, V> {
         message: V,
         priority: bool,
     ) -> Vec<S::PublicKey> {
+        self.send_ref(recipients, &message, priority)
+    }
+
+    /// Send a borrowed message to a set of recipients.
+    pub fn send_ref(
+        &mut self,
+        recipients: Recipients<S::PublicKey>,
+        message: &V,
+        priority: bool,
+    ) -> Vec<S::PublicKey> {
         let encoded = message.encode_with_pool(&self.pool);
         self.sender.send(recipients, encoded, priority)
     }
@@ -87,6 +97,10 @@ impl<'a, S: Sender, V: Codec> CheckedWrappedSender<'a, S, V> {
     }
 
     pub fn send(self, message: V, priority: bool) -> Unreliable<Feedback> {
+        self.send_ref(&message, priority)
+    }
+
+    pub fn send_ref(self, message: &V, priority: bool) -> Unreliable<Feedback> {
         let encoded = message.encode_with_pool(self.pool);
         self.sender.send(encoded, priority)
     }


### PR DESCRIPTION
## Overview

Share immutable blocks across marshal, application fan-out, and speculative processing paths instead of repeatedly cloning their contents. This reduces CPU and memory pressure for expensive block types while retaining owned copies only at storage and network boundaries.