### PR TITLE
[storage] Make pruning crash-safe with buffered operations

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -558,7 +558,12 @@ where
         // Sync the Merkle structure before pruning the journal, otherwise its last element could
         // end up behind the journal's first element after a crash, and there would be no way to
         // replay the items between the structure's last element and the journal's first element.
-        self.merkle.sync().await?;
+        // Commit the journal alongside: the prune target may be justified by a buffered append
+        // (e.g. a commit operation), and pruning does not guarantee buffered appends are durable.
+        try_join!(
+            self.journal.commit().map_err(Error::Journal),
+            self.merkle.sync().map_err(Error::Merkle)
+        )?;
 
         let journal_pruned = self.journal.prune(*prune_loc).await?;
         let bounds = self.journal.bounds();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1039,6 +1039,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Readers holding earlier snapshots keep reading pruned blobs through their own handles;
     /// later snapshots observe [Error::ItemPruned].
     ///
+    /// Prune first makes all retained items recoverable, as [Self::commit] does, so a crash
+    /// never recovers a journal whose surviving items fail to justify its pruning boundary.
+    ///
     /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
     /// event of failure as items are always pruned in order from oldest to newest.
     pub async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
@@ -1048,6 +1051,16 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
         let min_blob = std::cmp::min(target_blob, tail_blob);
 
+        // Make all dirty blobs durable before removing any: the prune target is often
+        // justified by an appended-but-unflushed item (e.g. a consumer's commit record), and
+        // removals are durable, so pruning without this barrier could leave a recovered
+        // journal whose surviving items no longer justify its boundary. Dirty blobs below the
+        // prune point are flushed too: removal is oldest-first and may be interrupted, and
+        // recovery truncates at the first torn item, so an unsynced survivor below the
+        // boundary could discard every synced blob behind it.
+        self.flush_dirty_blobs().await?;
+        self.dirty_from_blob = None;
+
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok(false);
         }
@@ -1056,9 +1069,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.blobs.prune(min_blob).await?;
         self.bounds.start = new_boundary;
 
-        if let Some(dirty_from) = self.dirty_from_blob {
-            self.dirty_from_blob = Some(dirty_from.max(min_blob));
-        }
         self.metrics.update(
             self.bounds.end,
             self.bounds.start,

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1039,9 +1039,6 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Readers holding earlier snapshots keep reading pruned blobs through their own handles;
     /// later snapshots observe [Error::ItemPruned].
     ///
-    /// Prune first makes all retained items recoverable, as [Self::commit] does, so a crash
-    /// never recovers a journal whose surviving items fail to justify its pruning boundary.
-    ///
     /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
     /// event of failure as items are always pruned in order from oldest to newest.
     pub async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
@@ -1051,20 +1048,19 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
         let min_blob = std::cmp::min(target_blob, tail_blob);
 
-        // Make all dirty blobs durable before removing any: the prune target is often
-        // justified by an appended-but-unflushed item (e.g. a consumer's commit record), and
-        // removals are durable, so pruning without this barrier could leave a recovered
-        // journal whose surviving items no longer justify its boundary. Dirty blobs below the
-        // prune point are flushed too: removal is oldest-first and may be interrupted, and
-        // recovery truncates at the first torn item, so an unsynced survivor below the
-        // boundary could discard every synced blob behind it. Runs even when no blob will
-        // be removed: every prune call makes retained items recoverable.
-        self.flush_dirty_blobs().await?;
-        self.dirty_from_blob = None;
-
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok(false);
         }
+
+        // Make all dirty blobs durable before removing any: the prune target may be
+        // justified by an appended-but-unflushed item (e.g. a consumer's commit record), and
+        // removals are durable, so pruning without this barrier could leave a recovered
+        // journal whose surviving items no longer justify its boundary. Dirty blobs below the
+        // prune point are flushed too: removal may be interrupted, and recovery truncates at
+        // the first torn item, so an unsynced survivor below the boundary could discard
+        // every synced blob behind it.
+        self.flush_dirty_blobs().await?;
+        self.dirty_from_blob = None;
 
         let new_boundary = super::blob_first_position(min_blob, self.items_per_blob.get())?;
         self.blobs.prune(min_blob).await?;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3311,6 +3311,44 @@ mod tests {
         });
     }
 
+    /// A crash right after pruning must not lose retained items that were appended but never
+    /// synced. Blob removal is durable, so prune flushes every dirty blob first: otherwise the
+    /// unsynced tail would vanish with the crash and recovery would truncate the journal to
+    /// empty even though the removal survived.
+    #[test_traced]
+    fn test_fixed_recovery_prune_crash_retains_unsynced_tail() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(10));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Durably persist blob 0 (positions 0..10), then append positions 10..25 across
+            // blobs 1 and 2 without syncing.
+            for i in 0..10u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            for i in 10..25u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+
+            // Prune away blob 0, then crash before any sync.
+            assert!(journal.prune(10).await.unwrap());
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..25);
+            for i in 10..25u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
     /// Test recovery when the oldest blob is empty but a newer blob still holds durable items.
     ///
     /// This is the fixed-journal analog of the variable-journal empty-oldest-blob gap bug. A
@@ -4124,8 +4162,10 @@ mod tests {
         });
     }
 
+    /// Prune flushes every dirty blob and clears the dirty state, so a commit issued right
+    /// after must not attempt to sync the removed blobs.
     #[test_traced]
-    fn test_fixed_journal_prune_adjusts_dirty_boundary() {
+    fn test_fixed_journal_commit_after_prune() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
@@ -4141,7 +4181,7 @@ mod tests {
             journal
                 .commit()
                 .await
-                .expect("commit should not try to sync pruned dirty blobs");
+                .expect("commit should not try to sync pruned blobs");
             assert_eq!(journal.bounds(), 5..12);
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1057,7 +1057,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         // journal whose surviving items no longer justify its boundary. Dirty blobs below the
         // prune point are flushed too: removal is oldest-first and may be interrupted, and
         // recovery truncates at the first torn item, so an unsynced survivor below the
-        // boundary could discard every synced blob behind it.
+        // boundary could discard every synced blob behind it. Runs even when no blob will
+        // be removed: every prune call makes retained items recoverable.
         self.flush_dirty_blobs().await?;
         self.dirty_from_blob = None;
 

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -261,6 +261,8 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// - If `min_position > bounds.end`, the prune is capped to `bounds.end` (no error is returned)
     /// - Some items with positions less than `min_position` may be retained due to
     ///   section/blob alignment
+    /// - Prune first makes all retained items recoverable, as a commit does, so a crash never
+    ///   recovers a journal whose surviving items fail to justify its pruning boundary
     /// - This operation is not atomic, but implementations guarantee the journal is left in a
     ///   recoverable state if a crash occurs during pruning
     ///

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -261,8 +261,6 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// - If `min_position > bounds.end`, the prune is capped to `bounds.end` (no error is returned)
     /// - Some items with positions less than `min_position` may be retained due to
     ///   section/blob alignment
-    /// - Prune first makes all retained items recoverable, as a commit does, so a crash never
-    ///   recovers a journal whose surviving items fail to justify its pruning boundary
     /// - This operation is not atomic, but implementations guarantee the journal is left in a
     ///   recoverable state if a crash occurs during pruning
     ///

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1590,7 +1590,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // journal whose surviving items no longer justify its boundary. Dirty blobs below the
         // prune point are flushed too: removal is oldest-first and may be interrupted, and
         // recovery truncates at the first torn item, so an unsynced survivor below the
-        // boundary could discard every synced blob behind it.
+        // boundary could discard every synced blob behind it. Runs even when no blob will
+        // be removed: every prune call makes retained items recoverable.
         self.flush_dirty_data().await?;
         self.dirty_from_blob = None;
 
@@ -1603,6 +1604,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // Offsets entries for retained items must survive the same crash: recovery treats an
         // offsets journal that ends behind the surviving data as corruption. Data is flushed
         // first (above), matching the ordering every other durability path maintains.
+        // Deferred until the prune is known effective: offsets only need to be durable
+        // before a removal.
         self.offsets.commit().await?;
 
         self.blobs.prune(min_blob).await?;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1560,9 +1560,6 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Returns `true` if any data was pruned, `false` otherwise.
     ///
-    /// Prune first makes all retained items recoverable, as [Self::commit] does, so a crash
-    /// never recovers a journal whose surviving items fail to justify its pruning boundary.
-    ///
     /// # Errors
     ///
     /// Returns an error if the underlying storage operation fails.
@@ -1575,29 +1572,25 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let tail_blob = position_to_blob(self.bounds.end, items_per_blob);
         let min_blob = target_blob.min(tail_blob);
 
-        // Make all dirty blobs durable before removing any: the prune target is often
-        // justified by an appended-but-unflushed item (e.g. a consumer's commit record), and
-        // removals are durable, so pruning without this barrier could leave a recovered
-        // journal whose surviving items no longer justify its boundary. Dirty blobs below the
-        // prune point are flushed too: removal is oldest-first and may be interrupted, and
-        // recovery truncates at the first torn item, so an unsynced survivor below the
-        // boundary could discard every synced blob behind it. Runs even when no blob will
-        // be removed: every prune call makes retained items recoverable.
-        self.flush_dirty_data().await?;
-        self.dirty_from_blob = None;
-
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok(false);
         }
 
         let new_boundary = blob_first_position(min_blob, items_per_blob)?;
 
-        // Offsets entries for retained items must survive the same crash: recovery rebuilds
-        // offsets that end behind the surviving data's end by replaying data, but offsets that
-        // end behind its start are unrecoverable because the data needed to rebuild the missing
-        // entries is about to be removed. Data is flushed first (above), matching the ordering
-        // every other durability path maintains. Deferred until the prune is known effective:
-        // offsets only need to be durable before a removal.
+        // Make all dirty blobs durable before removing any: the prune target may be
+        // justified by an appended-but-unflushed item (e.g. a consumer's commit record), and
+        // removals are durable, so pruning without this barrier could leave a recovered
+        // journal whose surviving items no longer justify its boundary. Dirty blobs below the
+        // prune point are flushed too: removal may be interrupted, and recovery truncates at
+        // the first torn item, so an unsynced survivor below the boundary could discard
+        // every synced blob behind it. Offsets entries for retained items must survive the
+        // same crash: recovery rebuilds offsets that end behind the surviving data's end by
+        // replaying data, but offsets that end behind its start are unrecoverable because
+        // the data needed to rebuild the missing entries is about to be removed. Data is
+        // flushed first, matching the ordering every other durability path maintains.
+        self.flush_dirty_data().await?;
+        self.dirty_from_blob = None;
         self.offsets.commit().await?;
 
         self.blobs.prune(min_blob).await?;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -420,6 +420,11 @@ pub struct Journal<E: Context, V: Codec> {
     /// Earliest data blob modified since the last `commit()` or `sync()`.
     dirty_from_blob: Option<u64>,
 
+    /// Test-only: park [Self::prune] after the data-blob removal, before the offsets prune,
+    /// so tests can drop the pending future at that exact point.
+    #[cfg(test)]
+    halt_before_offsets_prune: bool,
+
     /// The number of items per blob.
     ///
     /// # Invariant
@@ -1130,6 +1135,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             offsets,
             bounds,
             dirty_from_blob: None,
+            #[cfg(test)]
+            halt_before_offsets_prune: false,
             items_per_blob: cfg.items_per_section,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
@@ -1193,6 +1200,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
             offsets,
             bounds: size..size,
             dirty_from_blob: None,
+            #[cfg(test)]
+            halt_before_offsets_prune: false,
             items_per_blob: cfg.items_per_section,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
@@ -1558,24 +1567,6 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Returns an error if the underlying storage operation fails.
     pub async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
-        let Some(new_boundary) = self.prune_data(min_position).await? else {
-            return Ok(false);
-        };
-
-        // Prune data before offsets so a crash leaves offsets behind, which init repairs by
-        // pruning offsets to match.
-        self.offsets.prune(new_boundary).await?;
-        self.metrics.update(
-            self.bounds.end,
-            self.bounds.start,
-            self.items_per_blob.get(),
-        );
-
-        Ok(true)
-    }
-
-    /// Flush dirty data and remove blobs before updating the offsets journal.
-    async fn prune_data(&mut self, min_position: u64) -> Result<Option<u64>, Error> {
         let items_per_blob = self.items_per_blob.get();
 
         // Calculate the blob that would contain min_position, capped to the tail (which is
@@ -1596,7 +1587,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         self.dirty_from_blob = None;
 
         if min_blob <= self.blobs.oldest_blob_index() {
-            return Ok(None);
+            return Ok(false);
         }
 
         let new_boundary = blob_first_position(min_blob, items_per_blob)?;
@@ -1610,7 +1601,22 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         self.blobs.prune(min_blob).await?;
         self.bounds.start = new_boundary;
-        Ok(Some(new_boundary))
+
+        #[cfg(test)]
+        if self.halt_before_offsets_prune {
+            std::future::pending::<()>().await;
+        }
+
+        // Prune data before offsets so a crash leaves offsets behind, which init repairs by
+        // pruning offsets to match.
+        self.offsets.prune(new_boundary).await?;
+        self.metrics.update(
+            self.bounds.end,
+            self.bounds.start,
+            self.items_per_blob.get(),
+        );
+
+        Ok(true)
     }
 
     /// Make dirty data blobs durable.
@@ -3487,9 +3493,18 @@ mod tests {
                 journal.append(&(i * 100)).await.unwrap();
             }
 
-            // Crash after prune's durability barrier and data removal, but before offsets.prune
-            // has made the appended offsets durable.
-            assert!(journal.prune_data(10).await.unwrap().is_some());
+            // Drop the production prune future while it is parked after the data-blob
+            // removal, before offsets.prune has made the appended offsets durable: a
+            // genuine cancellation at that await.
+            journal.halt_before_offsets_prune = true;
+            {
+                let fut = journal.prune(10);
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before offsets.prune"
+                );
+            }
             drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1592,11 +1592,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
         let new_boundary = blob_first_position(min_blob, items_per_blob)?;
 
-        // Offsets entries for retained items must survive the same crash: recovery treats an
-        // offsets journal that ends behind the surviving data as corruption. Data is flushed
-        // first (above), matching the ordering every other durability path maintains.
-        // Deferred until the prune is known effective: offsets only need to be durable
-        // before a removal.
+        // Offsets entries for retained items must survive the same crash: recovery rebuilds
+        // offsets that end behind the surviving data's end by replaying data, but offsets that
+        // end behind its start are unrecoverable because the data needed to rebuild the missing
+        // entries is about to be removed. Data is flushed first (above), matching the ordering
+        // every other durability path maintains. Deferred until the prune is known effective:
+        // offsets only need to be durable before a removal.
         self.offsets.commit().await?;
 
         self.blobs.prune(min_blob).await?;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1551,10 +1551,31 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Returns `true` if any data was pruned, `false` otherwise.
     ///
+    /// Prune first makes all retained items recoverable, as [Self::commit] does, so a crash
+    /// never recovers a journal whose surviving items fail to justify its pruning boundary.
+    ///
     /// # Errors
     ///
     /// Returns an error if the underlying storage operation fails.
     pub async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
+        let Some(new_boundary) = self.prune_data(min_position).await? else {
+            return Ok(false);
+        };
+
+        // Prune data before offsets so a crash leaves offsets behind, which init repairs by
+        // pruning offsets to match.
+        self.offsets.prune(new_boundary).await?;
+        self.metrics.update(
+            self.bounds.end,
+            self.bounds.start,
+            self.items_per_blob.get(),
+        );
+
+        Ok(true)
+    }
+
+    /// Flush dirty data and remove blobs before updating the offsets journal.
+    async fn prune_data(&mut self, min_position: u64) -> Result<Option<u64>, Error> {
         let items_per_blob = self.items_per_blob.get();
 
         // Calculate the blob that would contain min_position, capped to the tail (which is
@@ -1563,28 +1584,30 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let tail_blob = position_to_blob(self.bounds.end, items_per_blob);
         let min_blob = target_blob.min(tail_blob);
 
+        // Make all dirty blobs durable before removing any: the prune target is often
+        // justified by an appended-but-unflushed item (e.g. a consumer's commit record), and
+        // removals are durable, so pruning without this barrier could leave a recovered
+        // journal whose surviving items no longer justify its boundary. Dirty blobs below the
+        // prune point are flushed too: removal is oldest-first and may be interrupted, and
+        // recovery truncates at the first torn item, so an unsynced survivor below the
+        // boundary could discard every synced blob behind it.
+        self.flush_dirty_data().await?;
+        self.dirty_from_blob = None;
+
         if min_blob <= self.blobs.oldest_blob_index() {
-            return Ok(false);
+            return Ok(None);
         }
 
         let new_boundary = blob_first_position(min_blob, items_per_blob)?;
 
-        // Prune data before offsets so a crash leaves offsets behind, which init repairs by
-        // pruning offsets to match.
+        // Offsets entries for retained items must survive the same crash: recovery treats an
+        // offsets journal that ends behind the surviving data as corruption. Data is flushed
+        // first (above), matching the ordering every other durability path maintains.
+        self.offsets.commit().await?;
+
         self.blobs.prune(min_blob).await?;
         self.bounds.start = new_boundary;
-        self.offsets.prune(new_boundary).await?;
-
-        if let Some(dirty_from) = self.dirty_from_blob {
-            self.dirty_from_blob = Some(dirty_from.max(min_blob));
-        }
-        self.metrics.update(
-            self.bounds.end,
-            self.bounds.start,
-            self.items_per_blob.get(),
-        );
-
-        Ok(true)
+        Ok(Some(new_boundary))
     }
 
     /// Make dirty data blobs durable.
@@ -2196,6 +2219,14 @@ impl<E: Context, V: CodecShared> authenticated::Inner<E> for Journal<E, V> {
 
 #[cfg(test)]
 impl<E: Context, V: CodecShared> Journal<E, V> {
+    /// Test helper: Run prune through data removal, then simulate a crash before offsets pruning.
+    pub(crate) async fn test_prune_before_offsets(
+        &mut self,
+        min_position: u64,
+    ) -> Result<bool, Error> {
+        Ok(self.prune_data(min_position).await?.is_some())
+    }
+
     /// Test helper: Prune the data blobs directly (simulates crash scenario).
     pub(crate) async fn test_prune_data(&mut self, min_blob: u64) -> Result<bool, Error> {
         let min_blob = min_blob.min(self.blobs.tail_blob_index());
@@ -3429,6 +3460,51 @@ mod tests {
             assert_eq!(variable.read(39).await.unwrap(), 3900);
 
             variable.destroy().await.unwrap();
+        });
+    }
+
+    /// A crash after data pruning but before offsets pruning must remain recoverable even when
+    /// the last durable offsets end is below the new data boundary.
+    #[test_traced]
+    fn test_variable_recovery_prune_crash_offsets_end_behind() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "recovery-prune-offsets-end-behind".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Persist offsets only through position 7, then append enough unsynced items for a
+            // prune to advance the data boundary beyond that durable offsets end.
+            for i in 0..7u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+            for i in 7..12u64 {
+                journal.append(&(i * 100)).await.unwrap();
+            }
+
+            // Crash after prune's durability barrier and data removal, but before offsets.prune
+            // has made the appended offsets durable.
+            journal.test_prune_before_offsets(10).await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("prune crash must leave a recoverable journal");
+            assert_eq!(journal.bounds(), 10..12);
+            for i in 10..12u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+            journal.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -389,8 +389,9 @@ impl<C> Config<C> {
 /// temporarily diverge during crashes. Divergences are automatically aligned during init():
 /// * If offsets are behind data after the recovery watermark: rebuild missing offsets by replaying
 ///   data from the recovery anchor.
-/// * If offsets are ahead of the retained data prefix: rewind offsets to match the data-backed
-///   size.
+/// * If offsets are ahead of the retained data prefix but the data still reaches the recovery
+///   watermark: rewind offsets to match the data-backed size. Retained data ending before the
+///   watermark is corruption because acknowledged data is missing.
 /// * If offsets.bounds().start < the oldest data blob's start: prune offsets to match (this can
 ///   happen if we crash after pruning the data blobs but before pruning the offsets journal).
 ///
@@ -400,12 +401,14 @@ impl<C> Config<C> {
 ///
 /// ## 2. Offsets Recovery Watermark
 ///
-/// The offsets journal's recovery watermark records a preferred point for replaying data to
-/// rebuild offset entries after a crash. Fixed-journal recovery rejects watermarks beyond the
-/// recovered offsets size as corruption. If the watermark is otherwise unusable, such as being
-/// below the recovered offsets start or beyond the retained data prefix, init falls back to the
-/// offsets start. Replay after the anchor stops at the first short data blob and truncates newer
-/// blobs so the recovered journal remains a contiguous prefix.
+/// The offsets journal's recovery watermark records a durable lower bound on the journal size and
+/// a preferred point for replaying data to rebuild offset entries after a crash. Fixed-journal
+/// recovery rejects watermarks beyond the recovered offsets size as corruption. A watermark below
+/// the recovered offsets start is stale after a prune, so init falls back to the offsets start. If
+/// retained data exists but ends before the watermark, init returns corruption because acknowledged
+/// data is missing. If no retained data exists, init reconciles both sides to an empty journal.
+/// Replay after a valid anchor stops at the first short data blob and truncates newer blobs so the
+/// recovered journal remains a contiguous prefix.
 pub struct Journal<E: Context, V: Codec> {
     /// The data blobs: sealed history plus the writable tail.
     blobs: Writable<E>,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2219,14 +2219,6 @@ impl<E: Context, V: CodecShared> authenticated::Inner<E> for Journal<E, V> {
 
 #[cfg(test)]
 impl<E: Context, V: CodecShared> Journal<E, V> {
-    /// Test helper: Run prune through data removal, then simulate a crash before offsets pruning.
-    pub(crate) async fn test_prune_before_offsets(
-        &mut self,
-        min_position: u64,
-    ) -> Result<bool, Error> {
-        Ok(self.prune_data(min_position).await?.is_some())
-    }
-
     /// Test helper: Prune the data blobs directly (simulates crash scenario).
     pub(crate) async fn test_prune_data(&mut self, min_blob: u64) -> Result<bool, Error> {
         let min_blob = min_blob.min(self.blobs.tail_blob_index());
@@ -3494,7 +3486,7 @@ mod tests {
 
             // Crash after prune's durability barrier and data removal, but before offsets.prune
             // has made the appended offsets durable.
-            journal.test_prune_before_offsets(10).await.unwrap();
+            assert!(journal.prune_data(10).await.unwrap().is_some());
             drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -426,8 +426,8 @@ where
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
     ///
-    /// Buffered operations are committed first, so pruning is crash-safe even immediately
-    /// after an uncommitted batch.
+    /// `prune` requires no prior commit. After a crash, the database remains recoverable;
+    /// uncommitted operations are not guaranteed to survive.
     #[tracing::instrument(
         name = "qmdb.any.db.prune",
         level = "info",

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -425,6 +425,9 @@ where
 
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
+    ///
+    /// Buffered operations are committed first, so pruning is crash-safe even immediately
+    /// after an uncommitted batch.
     #[tracing::instrument(
         name = "qmdb.any.db.prune",
         level = "info",

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -552,6 +552,66 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
+    /// Pruning to a floor advanced by an applied-but-uncommitted batch must not durably outrun
+    /// the last durable commit: after a crash, the recovered commit's floor would lie below the
+    /// pruned boundary and the database could never reopen.
+    pub(crate) async fn test_any_db_prune_after_unsynced_floor_recovery<
+        F: Family,
+        D,
+        V: Clone + CodecShared,
+    >(
+        context: Context,
+        mut db: D,
+        reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
+        make_value: impl Fn(u64) -> V,
+    ) where
+        D: DbAny<F, Key = Digest, Value = V, Digest = Digest>,
+    {
+        const ELEMENTS: u64 = 1000;
+
+        // Establish a durable state whose last commit declares an early inactivity floor.
+        {
+            let mut batch = db.new_batch();
+            for i in 0u64..ELEMENTS {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, Some(make_value(i)));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+        }
+        db.commit().await.unwrap();
+        let durable_floor = db.inactivity_floor_loc();
+
+        // Apply (but do not commit) a batch that advances the in-memory floor well past the
+        // durable commit's floor.
+        {
+            let mut batch = db.new_batch();
+            for i in 0u64..ELEMENTS {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, Some(make_value(i + 1)));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            db.apply_batch(merkleized).await.unwrap();
+        }
+        let unsynced_floor = db.inactivity_floor_loc();
+        assert!(unsynced_floor > durable_floor);
+
+        // Prune to the in-memory floor, then crash before any further commit.
+        db.prune(db.sync_boundary()).await.unwrap();
+        let root = db.root();
+        let op_count = db.size();
+        drop(db);
+
+        // Reopening must succeed: pruning made the floor-declaring commit durable before the
+        // journal durably advanced its boundary past positions that commit still needs.
+        let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
+        assert_eq!(db.size(), op_count);
+        assert_eq!(db.inactivity_floor_loc(), unsynced_floor);
+        assert_eq!(db.root(), root);
+
+        db.destroy().await.unwrap();
+    }
+
     /// Test rewinding to a prior committed state and recovering that state after reopen.
     pub(crate) async fn test_any_db_rewind_recovery<D, V>(
         context: Context,
@@ -1451,6 +1511,7 @@ pub(crate) mod test {
     test_for_all_variants!(with_reopen: test_any_db_non_empty_recovery, "WARN");
     test_for_all_variants!(with_reopen: test_any_db_empty_recovery, "WARN");
     test_for_all_variants!(with_reopen: test_any_db_commit_after_sync_recovery, "WARN");
+    test_for_all_variants!(with_reopen: test_any_db_prune_after_unsynced_floor_recovery, "WARN");
     test_for_mmr_variants!(with_reopen: test_any_db_rewind_recovery, "WARN");
 
     fn key(i: u64) -> Digest {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -157,6 +157,11 @@ pub struct Db<
 
     /// Metrics for the Current layer.
     pub(super) metrics: Metrics<E>,
+
+    /// Test-only: park [Self::prune] after the pruning-metadata sync, before the log prune,
+    /// so tests can drop the pending future at that exact point.
+    #[cfg(test)]
+    pub(super) halt_before_prune_log: bool,
 }
 
 // Shared read-only functionality.
@@ -515,6 +520,13 @@ where
             return Err(Error::PruneBeyondMinRequired(prune_loc, sync_boundary));
         }
 
+        // The sync boundary may be advanced by applied-but-uncommitted operations, and the
+        // pruning metadata persisted below durably records it. Commit the log first so
+        // recovery can replay to that boundary: otherwise a crash before the log prune
+        // recovers the older durable floor alongside newer pruning metadata and fails to
+        // initialize the bitmap.
+        self.any.log.commit().await?;
+
         // Prune the bitmap to the sync boundary (most aggressive safe location).
         self.any.prune_bitmap(sync_boundary);
         self.prune_grafted_tree_to_bitmap()?;
@@ -525,6 +537,11 @@ where
         // simply records peaks that haven't been pruned yet. The reverse order would be unsafe:
         // a pruned log with stale metadata would lose peak digests permanently.
         self.sync_metadata().await?;
+
+        #[cfg(test)]
+        if self.halt_before_prune_log {
+            std::future::pending::<()>().await;
+        }
 
         self.any.prune_log(prune_loc).await?;
         self.any.update_metrics();
@@ -1391,6 +1408,62 @@ mod tests {
         let merkleized = batch.merkleize(db, None).await.unwrap();
         db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
+    }
+
+    /// A prune dropped between the pruning-metadata sync and the log prune must remain
+    /// recoverable: the metadata durably records a bitmap boundary derived from a floor that
+    /// may exist only in buffered operations, and reopening panics if the recovered floor
+    /// lies below that boundary.
+    #[test_traced]
+    fn test_current_prune_dropped_before_log_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let mut db = MmrDb::init(
+                ctx.child("storage"),
+                fixed_config::<OneCap>("prune-park", &ctx),
+            )
+            .await
+            .unwrap();
+
+            // Establish a durable state, then apply (but do not commit) a batch that rewrites
+            // every key, advancing the in-memory floor well past the durable commit's floor.
+            populate_fixed_db::<mmr::Family, _>(&mut db, 0, 512).await;
+            let durable_floor = db.inactivity_floor_loc();
+            {
+                let mut batch = db.new_batch();
+                for idx in 0..512u64 {
+                    let key = Sha256::hash(&idx.to_be_bytes());
+                    let value = Sha256::hash(&(idx + 1024).to_be_bytes());
+                    batch = batch.write(key, Some(value));
+                }
+                let merkleized = batch.merkleize(&db, None).await.unwrap();
+                db.apply_batch(merkleized).await.unwrap();
+            }
+            assert!(db.sync_boundary() > durable_floor);
+
+            // Drop the production prune future while it is parked after the metadata sync,
+            // before the log prune: a genuine cancellation at that await.
+            db.halt_before_prune_log = true;
+            {
+                let fut = db.prune(db.sync_boundary());
+                futures::pin_mut!(fut);
+                assert!(
+                    futures::poll!(fut.as_mut()).is_pending(),
+                    "prune must park before the log prune"
+                );
+            }
+            drop(db);
+
+            // Reopening must succeed: prune committed the buffered operations before durably
+            // recording the pruning metadata that depends on them.
+            let db = MmrDb::init(
+                ctx.child("reopen"),
+                fixed_config::<OneCap>("prune-park", &ctx),
+            )
+            .await
+            .expect("prune crash must leave the db recoverable");
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test_traced]

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -500,6 +500,9 @@ where
     /// Prunes historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
     ///
+    /// `prune` requires no prior commit. After a crash, the database remains recoverable;
+    /// uncommitted operations are not guaranteed to survive.
+    ///
     /// `prune_loc` must be at most [`Self::sync_boundary`]: the ops log's lower bound must not
     /// advance past the point where the grafting overlay has been pruned. The bitmap and grafted
     /// tree advance to the sync boundary regardless of `prune_loc`.

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1440,6 +1440,9 @@ mod tests {
                 db.apply_batch(merkleized).await.unwrap();
             }
             assert!(db.sync_boundary() > durable_floor);
+            let bounds = db.bounds();
+            let floor = db.inactivity_floor_loc();
+            let root = db.root();
 
             // Drop the production prune future while it is parked after the metadata sync,
             // before the log prune: a genuine cancellation at that await.
@@ -1452,16 +1455,24 @@ mod tests {
                     "prune must park before the log prune"
                 );
             }
+            let pruned_bits = db.any.bitmap.pruned_bits();
+            assert!(pruned_bits > *durable_floor);
             drop(db);
 
-            // Reopening must succeed: prune committed the buffered operations before durably
-            // recording the pruning metadata that depends on them.
+            // Reopening must succeed and recover the post-batch state: prune committed the
+            // buffered operations before durably recording the pruning metadata that depends
+            // on them. Asserting the advanced floor, root, and persisted pruned boundary
+            // proves the drop happened after both the commit and the metadata sync.
             let db = MmrDb::init(
                 ctx.child("reopen"),
                 fixed_config::<OneCap>("prune-park", &ctx),
             )
             .await
             .expect("prune crash must leave the db recoverable");
+            assert_eq!(db.bounds(), bounds);
+            assert_eq!(db.inactivity_floor_loc(), floor);
+            assert_eq!(db.root(), root);
+            assert_eq!(db.any.bitmap.pruned_bits(), pruned_bits);
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -484,6 +484,8 @@ where
         strategy,
         root,
         metrics,
+        #[cfg(test)]
+        halt_before_prune_log: false,
     };
     db.update_metrics();
     Ok(db)

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -222,6 +222,8 @@ where
         strategy,
         root,
         metrics,
+        #[cfg(test)]
+        halt_before_prune_log: false,
     };
     current_db.update_metrics();
 

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -302,6 +302,18 @@ mod tests {
         });
     }
 
+    #[test_traced("WARN")]
+    fn test_fixed_prune_after_uncommitted_apply_batch_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_prune_after_uncommitted_apply_batch_recovery(
+                ctx,
+                open::<mmr::Family>,
+            )
+            .await;
+        });
+    }
+
     #[test_traced("DEBUG")]
     fn test_fixed_batch_chain() {
         let executor = deterministic::Runner::default();

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -485,8 +485,8 @@ where
     /// Prune operations prior to `prune_loc`. This does not affect the db's root, but it will
     /// affect retrieval of any keys that were set prior to `prune_loc`.
     ///
-    /// Pruning is irreversible. Retained operations -- including the floor-raising commit that
-    /// justifies `loc` -- are made recoverable before anything is removed, so pruning is
+    /// Pruning is irreversible. Retained operations, including the floor-raising commit that
+    /// justifies `loc`, are made recoverable before anything is removed, so pruning is
     /// crash-safe even immediately after an uncommitted [`Immutable::apply_batch`].
     ///
     /// # Errors

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -485,8 +485,8 @@ where
     /// Prune operations prior to `prune_loc`. This does not affect the db's root, but it will
     /// affect retrieval of any keys that were set prior to `prune_loc`.
     ///
-    /// Pruning is irreversible. Retained operations, including the floor-raising commit that
-    /// justifies `loc`, are made recoverable before anything is removed, so pruning is
+    /// Pruning is irreversible. Buffered operations are committed first, so the floor-raising
+    /// commit that justifies `loc` is durable before anything is removed and pruning is
     /// crash-safe even immediately after an uncommitted [`Immutable::apply_batch`].
     ///
     /// # Errors

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -485,9 +485,8 @@ where
     /// Prune operations prior to `prune_loc`. This does not affect the db's root, but it will
     /// affect retrieval of any keys that were set prior to `prune_loc`.
     ///
-    /// Pruning is irreversible. Buffered operations are committed first, so the floor-raising
-    /// commit that justifies `loc` is durable before anything is removed and pruning is
-    /// crash-safe even immediately after an uncommitted [`Immutable::apply_batch`].
+    /// Pruning is irreversible and requires no prior commit. After a crash, the database remains
+    /// recoverable; uncommitted operations are not guaranteed to survive.
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -1027,6 +1027,71 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
+    /// Pruning immediately after an uncommitted batch must leave the database recoverable. Since
+    /// prune is not a durability boundary, recovery may return either the durable baseline or the
+    /// buffered state, but never a mixture whose floor references pruned operations.
+    #[boxed]
+    pub(crate) async fn test_immutable_prune_after_uncommitted_apply_batch_recovery<
+        F: Family,
+        V,
+        C,
+    >(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
+        C::Item: EncodeShared,
+    {
+        let mut db = open_db(context.child("first")).await;
+
+        // Fill more than one journal blob and establish a durable baseline whose floor still
+        // requires the oldest blob.
+        let mut batch = db.new_batch();
+        for i in 0..6u8 {
+            batch = batch.set(Sha256::fill(i), Sha256::fill(i.wrapping_add(10)));
+        }
+        db.apply_batch(batch.merkleize(&db, None, Location::new(0)).await)
+            .await
+            .unwrap();
+        db.sync().await.unwrap();
+        let durable_state = (db.root(), db.inactivity_floor_loc(), db.bounds().end);
+
+        // Apply, but do not commit, a batch that advances the floor far enough for prune to
+        // remove the oldest blob.
+        let buffered_floor = db.bounds().end;
+        let key = Sha256::fill(100);
+        let value = Sha256::fill(101);
+        db.apply_batch(
+            db.new_batch()
+                .set(key, value)
+                .merkleize(&db, None, buffered_floor)
+                .await,
+        )
+        .await
+        .unwrap();
+        let buffered_state = (db.root(), db.inactivity_floor_loc(), db.bounds().end);
+        assert_ne!(buffered_state, durable_state);
+
+        db.prune(buffered_floor).await.unwrap();
+        assert!(db.bounds().start > Location::new(0));
+        drop(db);
+
+        // Reopen must produce one coherent state. In particular, it must not recover the old
+        // floor after the prune has removed operations that floor still needs.
+        let db = open_db(context.child("second")).await;
+        assert!(db.bounds().start <= db.inactivity_floor_loc());
+        let recovered_state = (db.root(), db.inactivity_floor_loc(), db.bounds().end);
+        assert!(
+            recovered_state == durable_state || recovered_state == buffered_state,
+            "recovered state is neither the durable baseline nor the buffered state"
+        );
+
+        db.destroy().await.unwrap();
+    }
+
     #[boxed]
     pub(crate) async fn test_immutable_batch_chain<F: Family, V, C>(
         context: deterministic::Context,

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -485,11 +485,9 @@ where
     /// Prune operations prior to `prune_loc`. This does not affect the db's root, but it will
     /// affect retrieval of any keys that were set prior to `prune_loc`.
     ///
-    /// Pruning is irreversible. Callers must ensure any floor-raising batch has been durably
-    /// committed (via [`Immutable::commit`] or [`Immutable::sync`]) before pruning. The
-    /// inactivity floor used to gate pruning is updated by [`Immutable::apply_batch`] before
-    /// the batch is durable. If the batch is lost on crash, recovery replays from the prior
-    /// durable floor, which may reference data that has already been pruned.
+    /// Pruning is irreversible. Retained operations -- including the floor-raising commit that
+    /// justifies `loc` -- are made recoverable before anything is removed, so pruning is
+    /// crash-safe even immediately after an uncommitted [`Immutable::apply_batch`].
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -363,6 +363,9 @@ where
 
     /// Prune historical operations prior to `loc`. This does not affect the db's root.
     ///
+    /// Buffered operations are committed first, so pruning is crash-safe even immediately
+    /// after an uncommitted batch.
+    ///
     /// # Errors
     ///
     /// - Returns [`Error::PruneBeyondMinRequired`] if `loc` > the inactivity floor declared by

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -363,8 +363,8 @@ where
 
     /// Prune historical operations prior to `loc`. This does not affect the db's root.
     ///
-    /// Buffered operations are committed first, so pruning is crash-safe even immediately
-    /// after an uncommitted batch.
+    /// `prune` requires no prior commit. After a crash, the database remains recoverable;
+    /// uncommitted operations are not guaranteed to survive.
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -368,8 +368,7 @@ where
     ///
     /// # Errors
     ///
-    /// - Returns [`Error::PruneBeyondMinRequired`] if `loc` > the inactivity floor declared by
-    ///   the last committed batch.
+    /// - Returns [`Error::PruneBeyondMinRequired`] if `loc` > the inactivity floor.
     #[tracing::instrument(name = "qmdb.keyless.db.prune", level = "info", skip_all)]
     pub async fn prune(&mut self, loc: Location<F>) -> Result<(), Error<F>> {
         let _timer = self.metrics.prune_timer();

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -311,6 +311,9 @@ where
 
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root
     /// or current snapshot.
+    ///
+    /// Buffered operations are committed first, so pruning is crash-safe even immediately
+    /// after an uncommitted batch.
     pub async fn prune(&mut self, prune_loc: Location) -> Result<(), Error> {
         if prune_loc > self.inactivity_floor_loc {
             return Err(Error::PruneBeyondMinRequired(
@@ -318,6 +321,11 @@ where
                 self.inactivity_floor_loc,
             ));
         }
+
+        // The floor justifying the boundary may exist only in buffered operations (it
+        // advances before its batch is durable), and pruning does not guarantee buffered
+        // appends are durable. Commit so the justification survives the prune.
+        self.log.commit().await?;
 
         // Prune the log. The log will prune at section boundaries, so the actual oldest retained
         // location may be less than requested.

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -898,6 +898,49 @@ mod test {
         });
     }
 
+    /// Pruning to a floor advanced by applied-but-uncommitted entries must not durably outrun
+    /// the last durable commit: after a crash, the recovered floor would lie below the pruned
+    /// boundary and the store could never reopen.
+    #[test_traced("WARN")]
+    pub fn test_store_db_prune_after_unsynced_floor_recovery() {
+        let executor = deterministic::Runner::default();
+        const ELEMENTS: u64 = 1000;
+        executor.start(|context| async move {
+            let mut db = create_test_store(context.child("store").with_attribute("index", 0)).await;
+
+            // Establish a durable state whose last commit declares an early inactivity floor.
+            for i in 0u64..ELEMENTS {
+                let k = Blake3::hash(&i.to_be_bytes());
+                let v = vec![(i % 255) as u8; ((i % 13) + 7) as usize];
+                apply_entries(&mut db, [(k, Some(v))]).await;
+            }
+            db.commit().await.unwrap();
+            let durable_floor = db.inactivity_floor_loc;
+
+            // Apply (but do not commit) entries that advance the in-memory floor past the
+            // durable commit's floor.
+            for i in 0u64..ELEMENTS {
+                let k = Blake3::hash(&i.to_be_bytes());
+                let v = vec![((i + 1) % 255) as u8; ((i % 13) + 8) as usize];
+                apply_entries(&mut db, [(k, Some(v))]).await;
+            }
+            let unsynced_floor = db.inactivity_floor_loc;
+            assert!(unsynced_floor > durable_floor);
+
+            // Prune to the in-memory floor, then crash before any further commit.
+            db.prune(unsynced_floor).await.unwrap();
+            let op_count = db.bounds().end;
+            drop(db);
+
+            // Reopening must succeed: prune committed the buffered operations first, so the
+            // replayed log reproduces the advanced floor.
+            let db = create_test_store(context.child("store").with_attribute("index", 1)).await;
+            assert_eq!(db.bounds().end, op_count);
+            assert_eq!(db.inactivity_floor_loc, unsynced_floor);
+            db.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced("WARN")]
     pub fn test_store_db_recovery() {
         let executor = deterministic::Runner::default();

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -312,8 +312,8 @@ where
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root
     /// or current snapshot.
     ///
-    /// Buffered operations are committed first, so pruning is crash-safe even immediately
-    /// after an uncommitted batch.
+    /// `prune` requires no prior commit. After a crash, the database remains recoverable;
+    /// uncommitted operations are not guaranteed to survive.
     pub async fn prune(&mut self, prune_loc: Location) -> Result<(), Error> {
         if prune_loc > self.inactivity_floor_loc {
             return Err(Error::PruneBeyondMinRequired(


### PR DESCRIPTION
## Summary

- fixes a pre-existing crash bug that left qmdb permanently unopenable: `apply_batch` advances the inactivity floor in memory, and pruning to it without a commit durably removed operations that the last recoverable commit still needed — every reopen then failed with `ItemPruned`
- an effective contiguous-journal prune flushes all dirty blobs (and, in the variable journal, commits its offsets journal) before removing anything, so a crash mid-prune never leaves survivors that fail to justify the boundary; contiguous-journal prunes that remove no blobs perform no storage I/O
- `Mutable::prune` makes no durability promise for buffered appends: consumers that advance an in-memory floor ahead of durability protect their own justification — the authenticated journal commits the inner journal alongside its Merkle sync (covering `any`, `immutable`, and `keyless`), and the standalone store commits before pruning
- regression tests: the qmdb floor crash across all sixteen db variants plus the standalone store; journal-level crash-point regressions for the offsets gap (found by Cursor Bugbot) and for an unsynced tail surviving a prune-then-crash; a Current mid-prune cancellation regression

## Design

Two concerns, two layers:

**Journal-internal crash consistency (implementation, not contract).** Removals are durable and may be interrupted, so an effective prune first makes every dirty blob durable: recovery truncates at the first torn item, so an unsynced survivor below the boundary could discard every synced blob behind it. The variable journal also commits its offsets journal before removing data blobs — recovery can rebuild offsets that end behind the surviving data's end by replaying data, but offsets ending behind the surviving data's *start* are unrecoverable because the data needed to rebuild them is being removed. Data flushes before offsets, matching the ordering every other durability path maintains. The added pre-removal durability barrier performs no I/O for a clean journal — the common case, since consumers usually prune right after committing — and no recovery metadata advances.

**Durability of the prune's justification (the consumer's job).** `Mutable::prune` deliberately promises nothing about buffered appends surviving a prune plus crash, keeping its contract aligned with every other journal type and leaving future implementations free to narrow the internal flush (e.g. under #4235's durable prune record). Consumers whose prune target may be justified only by a buffered operation commit first: the authenticated journal does this once for all its users (`try_join`ed with its existing Merkle sync), and the standalone `store::Db` commits its raw journal before pruning. `Current::prune` needs the barrier earlier still — it durably persists bitmap and grafted-tree pruning metadata derived from the sync boundary before reaching the log prune, so it commits the log before mutating any of that metadata; a crash between the metadata sync and the log prune otherwise recovers the older durable floor alongside newer pruning metadata and panics while initializing the shared bitmap. These QMDB prune paths are crash-safe immediately after an uncommitted batch — the obligation lives in the database layer, not on its callers.

The offsets-gap state was already reachable on `main` via `commit` → `prune` → crash between data and offsets pruning; this PR's flush made it reachable from any prune of a dirty tail, and the offsets commit closes it.
