### PR TITLE
[storage] Mark aligned legacy tails dirty on recovery

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -576,11 +576,15 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     "legacy journal has a short non-tail blob".into(),
                 ));
             }
-            // Legacy journals have no watermark. Under the old rollover-sync invariant, all
-            // non-tail blobs are durable; only the tail may have unfsynced data.
+            // Legacy journals have no watermark. The old writer fsynced each blob before
+            // writing to the next, so every retained blob before the one containing the last
+            // item is durable. That final blob may not be, even when full: it may never have
+            // rolled over. Start the watermark at the final blob so commit/sync includes it.
+            // An empty journal has no retained blob to mark dirty.
+            None if size == pruning_boundary => size,
             None => first_in_blob(
                 pruning_boundary,
-                super::position_to_blob(size, items_per_blob),
+                super::position_to_blob(size - 1, items_per_blob),
                 items_per_blob,
             )?,
         };
@@ -2659,6 +2663,45 @@ mod tests {
             assert!(
                 journal.commit().await.is_err(),
                 "commit must sync recovered data before the watermark can advance"
+            );
+        });
+    }
+
+    /// Regression: at a blob-aligned size, legacy recovery must mark the final non-empty blob
+    /// dirty rather than treating the empty next tail as the durability boundary.
+    #[test_traced]
+    fn test_fixed_journal_legacy_upgrade_marks_aligned_tail_dirty() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            for i in 0..10u64 {
+                journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // Remove the watermark to simulate a legacy journal.
+            journal.checkpoint.set_watermark(None);
+            journal.checkpoint.sync().await.unwrap();
+            drop(journal);
+
+            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.size(), 10);
+            assert_eq!(journal.recovery_watermark(), 5);
+
+            // The final full blob must be included in the recovered dirty range.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                sync_rate: Some(1.0),
+                ..Default::default()
+            };
+            assert!(
+                journal.commit().await.is_err(),
+                "commit must sync the final full blob after legacy recovery"
             );
         });
     }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -576,11 +576,15 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
                     "legacy journal has a short non-tail blob".into(),
                 ));
             }
-            // Legacy journals have no watermark. The old writer fsynced each blob before
-            // writing to the next, so every retained blob before the one containing the last
-            // item is durable. That final blob may not be, even when full: it may never have
-            // rolled over. Start the watermark at the final blob so commit/sync includes it.
-            // An empty journal has no retained blob to mark dirty.
+
+            // Legacy journals have no watermark. The old writer fsynced each blob before writing to
+            // the next, so every blob before the final retained blob is durable. The final blob may
+            // not be durable since it may not have successfully rolled over even when full.
+            // Conservatively start the watermark at the final blob so the next commit/sync includes
+            // it. An empty journal has no retained blob to mark dirty.
+            //
+            // (Note that this is mostly defense-in-depth on Linux since the runtime fsyncs the
+            // filesystem on startup. Other platforms provide only best-effort behavior.)
             None if size == pruning_boundary => size,
             None => first_in_blob(
                 pruning_boundary,


### PR DESCRIPTION
## Summary

- derive a legacy fixed-journal recovery watermark from the final retained item rather than the empty append frontier
- conservatively mark the final full blob dirty when the recovered size is blob-aligned
- document why Linux startup `syncfs` makes this defense-in-depth there while the generic runtime and other platforms still need it

## Problem

Legacy fixed journals do not record a recovery watermark. Recovery therefore derives one from blob layout under the legacy rollover-sync invariant. At a blob-aligned size, using the blob at the logical end selects the empty next tail and treats the preceding full data blob as durable. If that final full blob had not reached stable storage, a later crash could leave the recorded watermark beyond the recoverable data.

The production Linux runtime calls `syncfs` before any storage structure initializes ([#3950](https://github.com/commonwarexyz/monorepo/pull/3950)), so bytes visible during recovery are already durable there. That guarantee is not part of the generic `Runner` or `Storage` contract, however, and startup flushing is only best-effort on macOS/BSD and Windows. The recovery layer therefore still needs a conservative watermark for portable correctness.

## Fix

For a non-empty retained journal, derive the conservative watermark from the blob containing the final retained item. For an empty retained journal, keep the watermark at the pruning boundary. This makes commit and sync include the final full blob in their recovered dirty range.

On the production Linux runtime the extra sync is defense-in-depth. On runtimes and platforms without an equivalent durable startup flush, it prevents recovery from permanently crediting a visible-but-not-yet-durable final blob.

## Validation

- `just test -p commonware-storage legacy_upgrade_marks`
- `just test -p commonware-storage fixed_journal_legacy`
- `just clippy -p commonware-storage`
- `just check-fmt`
