### PR TITLE
[glue] Resume interrupted state sync from persisted floor

### DIFF
--- a/glue/conformance.toml
+++ b/glue/conformance.toml
@@ -1,3 +1,7 @@
+["commonware_glue::stateful::actor::syncer::tests::conformance::CodecConformance<SyncState<TestScheme,Sha256Digest>>"]
+n_cases = 65536
+hash = "58ae5252c48175a94cdf1dd2dfe8b62c6755956b9c32b74bf668e14591262e43"
+
 ["commonware_glue::stateful::db::p2p::compact::handler::tests::conformance::CodecConformance<Request<mmr::Family,sha256::Digest>>"]
 n_cases = 65536
 hash = "290187801284530d0d7e82c33bb6ce975a5f4daa4b104230291cea9cffcd7686"

--- a/glue/conformance.toml
+++ b/glue/conformance.toml
@@ -1,6 +1,6 @@
 ["commonware_glue::stateful::actor::syncer::tests::conformance::CodecConformance<SyncState<TestScheme,Sha256Digest>>"]
 n_cases = 65536
-hash = "58ae5252c48175a94cdf1dd2dfe8b62c6755956b9c32b74bf668e14591262e43"
+hash = "334bc977cfa11a849de1b135da67dd6b2103608838a8a5fa2093b401ea161a78"
 
 ["commonware_glue::stateful::db::p2p::compact::handler::tests::conformance::CodecConformance<Request<mmr::Family,sha256::Digest>>"]
 n_cases = 65536

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -207,7 +207,7 @@ where
         if let Some(floor) = self.plan.floor().cloned() {
             self.start_state_sync(floor).await;
         } else if self.plan.requires_state_sync_floor() {
-            panic!("interrupted state sync must resume from a newly selected floor");
+            panic!("interrupted state sync is missing its persisted floor");
         } else {
             self.start_from_marshal().await;
         }

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -73,7 +73,7 @@ where
     pub(super) marshal: MarshalMailbox<S, V>,
 
     /// Durable state-sync metadata.
-    pub(super) sync_metadata: Arc<AsyncMutex<StateSyncMetadata<E, V::Commitment>>>,
+    pub(super) sync_metadata: Arc<AsyncMutex<StateSyncMetadata<E, S, V::Commitment>>>,
 
     /// Syncer actor mailbox.
     pub(super) syncer: syncer::Mailbox<E, A>,

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -48,7 +48,7 @@ where
     pub resolvers: R,
 
     /// Durable state-sync metadata.
-    pub sync_metadata: Arc<AsyncMutex<StateSyncMetadata<E, V::Commitment>>>,
+    pub sync_metadata: Arc<AsyncMutex<StateSyncMetadata<E, S, V::Commitment>>>,
 
     /// Finalized floor marshal should resolve before sync starts.
     pub finalization: Finalization<S, V::Commitment>,
@@ -87,7 +87,7 @@ where
     resolvers: R,
 
     /// Durable state-sync metadata.
-    sync_metadata: Arc<AsyncMutex<StateSyncMetadata<E, V::Commitment>>>,
+    sync_metadata: Arc<AsyncMutex<StateSyncMetadata<E, S, V::Commitment>>>,
 
     /// Finalized floor marshal should resolve before sync starts.
     finalization: Finalization<S, V::Commitment>,
@@ -137,7 +137,9 @@ where
             resolve_state_sync_floor::<E, A, S, V>(&self.marshal, &self.finalization).await;
         {
             let mut sync_metadata = self.sync_metadata.lock().await;
-            sync_metadata.begin_sync(resolved_floor.marker).await;
+            sync_metadata
+                .begin_sync(resolved_floor.anchor.height, self.finalization.clone())
+                .await;
         }
 
         let (mut tip_updates_tx, tip_updates_rx) = ring::channel(NZUsize!(1));

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -137,9 +137,7 @@ where
             resolve_state_sync_floor::<E, A, S, V>(&self.marshal, &self.finalization).await;
         {
             let mut sync_metadata = self.sync_metadata.lock().await;
-            sync_metadata
-                .begin_sync(resolved_floor.anchor.height, self.finalization.clone())
-                .await;
+            sync_metadata.begin_sync(self.finalization.clone()).await;
         }
 
         let (mut tip_updates_tx, tip_updates_rx) = ring::channel(NZUsize!(1));

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -35,111 +35,44 @@ const SYNC_STATE_KEY: FixedBytes<1> = fixed_bytes!("C0");
 
 type BlockDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
 
-/// Durable identity for an in-progress state sync floor.
-///
-/// The height enforces monotonic restarts, and the commitment distinguishes
-/// conflicting blocks at the same height.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct FloorMarker<C>
-where
-    C: Digest,
-{
-    height: Height,
-    commitment: C,
-}
-
-impl<C> FloorMarker<C>
-where
-    C: Digest,
-{
-    /// Constructs a durable floor marker from the resolved floor block.
-    pub(crate) const fn new(height: Height, commitment: C) -> Self {
-        Self { height, commitment }
-    }
-
-    /// Ensures a newly selected floor is compatible with this persisted one.
-    ///
-    /// Restarts may resume from the same floor or advance to a newer one, but
-    /// must never move backward or switch to a different block at the same height.
-    pub(crate) fn ensure_not_behind(&self, selected: &Self) {
-        assert!(
-            selected.height >= self.height,
-            "selected state sync floor cannot move behind the persisted in-progress floor",
-        );
-
-        if selected.height == self.height {
-            assert!(
-                selected.commitment == self.commitment,
-                "selected state sync floor conflicts with the persisted in-progress floor",
-            );
-        }
-    }
-}
-
-impl<C> Write for FloorMarker<C>
-where
-    C: Digest,
-{
-    fn write(&self, writer: &mut impl BufMut) {
-        self.height.write(writer);
-        self.commitment.write(writer);
-    }
-}
-
-impl<C> EncodeSize for FloorMarker<C>
-where
-    C: Digest,
-{
-    fn encode_size(&self) -> usize {
-        self.height.encode_size() + self.commitment.encode_size()
-    }
-}
-
-impl<C> Read for FloorMarker<C>
-where
-    C: Digest,
-{
-    type Cfg = ();
-
-    fn read_cfg(reader: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        Ok(Self {
-            height: Height::read(reader)?,
-            commitment: C::read_cfg(reader, &())?,
-        })
-    }
-}
-
 /// Durable sync progress.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum SyncState<C>
+pub(crate) enum SyncState<S, C>
 where
+    S: Scheme,
     C: Digest,
 {
-    InProgress(FloorMarker<C>),
+    InProgress {
+        height: Height,
+        floor: Finalization<S, C>,
+    },
     Complete(Height),
 }
 
-impl<C> SyncState<C>
+impl<S, C> SyncState<S, C>
 where
+    S: Scheme,
     C: Digest,
 {
     /// Returns the completed state sync height, if state sync has finished.
     pub(crate) const fn sync_height(&self) -> Option<Height> {
         match self {
-            Self::InProgress(_) => None,
+            Self::InProgress { .. } => None,
             Self::Complete(height) => Some(*height),
         }
     }
 }
 
-impl<C> Write for SyncState<C>
+impl<S, C> Write for SyncState<S, C>
 where
+    S: Scheme,
     C: Digest,
 {
     fn write(&self, writer: &mut impl BufMut) {
         match self {
-            Self::InProgress(floor) => {
+            Self::InProgress { height, floor } => {
                 0u8.write(writer);
+                height.write(writer);
                 floor.write(writer);
             }
             Self::Complete(height) => {
@@ -150,31 +83,55 @@ where
     }
 }
 
-impl<C> EncodeSize for SyncState<C>
+impl<S, C> EncodeSize for SyncState<S, C>
 where
+    S: Scheme,
     C: Digest,
 {
     fn encode_size(&self) -> usize {
         u8::SIZE
             + match self {
-                Self::InProgress(floor) => floor.encode_size(),
+                Self::InProgress { height, floor } => height.encode_size() + floor.encode_size(),
                 Self::Complete(height) => height.encode_size(),
             }
     }
 }
 
-impl<C> Read for SyncState<C>
+impl<S, C> Read for SyncState<S, C>
 where
+    S: Scheme,
     C: Digest,
 {
-    type Cfg = ();
+    type Cfg = <S::Certificate as Read>::Cfg;
 
-    fn read_cfg(reader: &mut impl Buf, _: &()) -> Result<Self, Error> {
+    fn read_cfg(reader: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
         match u8::read(reader)? {
-            0 => Ok(Self::InProgress(FloorMarker::<C>::read(reader)?)),
+            0 => Ok(Self::InProgress {
+                height: Height::read(reader)?,
+                floor: Finalization::read_cfg(reader, cfg)?,
+            }),
             1 => Ok(Self::Complete(Height::read(reader)?)),
             n => Err(Error::InvalidEnum(n)),
         }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, S, C> arbitrary::Arbitrary<'a> for SyncState<S, C>
+where
+    S: Scheme,
+    S::Certificate: for<'b> arbitrary::Arbitrary<'b>,
+    C: Digest + for<'b> arbitrary::Arbitrary<'b>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(if u.arbitrary::<bool>()? {
+            Self::InProgress {
+                height: u.arbitrary()?,
+                floor: u.arbitrary()?,
+            }
+        } else {
+            Self::Complete(u.arbitrary()?)
+        })
     }
 }
 
@@ -204,30 +161,30 @@ where
 }
 
 /// Resolved state sync floor data derived from the selected finalization.
-pub(crate) struct ResolvedFloor<E, A, C>
+pub(crate) struct ResolvedFloor<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
-    C: Digest,
 {
     pub anchor: Anchor<BlockDigest<A, E>>,
     pub targets: <A::Databases as DatabaseSet<E>>::SyncTargets,
-    pub marker: FloorMarker<C>,
 }
 
 /// Durable state-sync metadata.
-pub(crate) struct StateSyncMetadata<E, C>
+pub(crate) struct StateSyncMetadata<E, S, C>
 where
     E: Context,
+    S: Scheme,
     C: Digest,
 {
     partition_prefix: String,
-    metadata: Metadata<E, FixedBytes<1>, SyncState<C>>,
+    metadata: Metadata<E, FixedBytes<1>, SyncState<S, C>>,
 }
 
-impl<E, C> StateSyncMetadata<E, C>
+impl<E, S, C> StateSyncMetadata<E, S, C>
 where
     E: Context,
+    S: Scheme,
     C: Digest,
 {
     /// Load the durable state-sync metadata partition, creating it if needed.
@@ -237,7 +194,7 @@ where
             context.child("metadata"),
             metadata::Config {
                 partition: format!("{partition_prefix}{SYNC_METADATA_SUFFIX}"),
-                codec_config: (),
+                codec_config: S::certificate_codec_config_unbounded(),
             },
         )
         .await
@@ -265,8 +222,16 @@ where
     pub(crate) fn in_progress(&self) -> bool {
         matches!(
             self.metadata.get(&SYNC_STATE_KEY),
-            Some(SyncState::InProgress(_))
+            Some(SyncState::InProgress { .. })
         )
+    }
+
+    /// Returns the floor selected before an interrupted state sync.
+    pub(crate) fn in_progress_floor(&self) -> Option<&Finalization<S, C>> {
+        match self.metadata.get(&SYNC_STATE_KEY) {
+            Some(SyncState::InProgress { floor, .. }) => Some(floor),
+            _ => None,
+        }
     }
 
     /// Marks state sync as in progress for the resolved floor.
@@ -276,10 +241,22 @@ where
     ///
     /// If an interrupted state sync already stored a floor, the newly selected
     /// floor must resume from that same floor or a later one.
-    pub(crate) async fn begin_sync(&mut self, floor: FloorMarker<C>) {
+    pub(crate) async fn begin_sync(&mut self, height: Height, floor: Finalization<S, C>) {
         match self.metadata.get(&SYNC_STATE_KEY) {
-            Some(SyncState::InProgress(existing)) => {
-                existing.ensure_not_behind(&floor);
+            Some(SyncState::InProgress {
+                height: existing_height,
+                floor: existing,
+            }) => {
+                assert!(
+                    height >= *existing_height,
+                    "selected state sync floor cannot move behind the persisted in-progress floor",
+                );
+                if height == *existing_height {
+                    assert!(
+                        floor.proposal.payload == existing.proposal.payload,
+                        "selected state sync floor conflicts with the persisted in-progress floor",
+                    );
+                }
             }
             Some(SyncState::Complete(_)) => {
                 panic!("completed state sync cannot be marked in-progress");
@@ -288,7 +265,7 @@ where
         }
 
         self.metadata
-            .put_sync(SYNC_STATE_KEY, SyncState::InProgress(floor))
+            .put_sync(SYNC_STATE_KEY, SyncState::InProgress { height, floor })
             .await
             .expect("failed to set state sync state to in-progress");
     }
@@ -300,9 +277,12 @@ where
     /// action is irreversible.
     pub(crate) async fn set_complete(&mut self, height: Height) {
         match self.metadata.get(&SYNC_STATE_KEY) {
-            Some(SyncState::InProgress(floor)) => {
+            Some(SyncState::InProgress {
+                height: floor_height,
+                ..
+            }) => {
                 assert!(
-                    height >= floor.height,
+                    height >= *floor_height,
                     "completed state sync height cannot be behind the in-progress floor",
                 );
             }
@@ -316,18 +296,17 @@ where
         }
 
         self.metadata
-            .put_sync(SYNC_STATE_KEY, SyncState::<C>::Complete(height))
+            .put_sync(SYNC_STATE_KEY, SyncState::Complete(height))
             .await
             .expect("failed to set state sync state to complete");
     }
 }
 
-/// Resolves the selected state sync floor into the anchor, targets, and
-/// durable floor marker used by restart validation.
+/// Resolves the selected state sync floor into its anchor and targets.
 pub(crate) async fn resolve_state_sync_floor<E, A, S, V>(
     marshal: &MarshalMailbox<S, V>,
     finalization: &Finalization<S, V::Commitment>,
-) -> ResolvedFloor<E, A, V::Commitment>
+) -> ResolvedFloor<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
@@ -348,7 +327,6 @@ where
     ResolvedFloor {
         anchor: Anchor::from(floor.as_ref()),
         targets: A::sync_targets(floor.as_ref()),
-        marker: FloorMarker::new(floor.height(), finalization.proposal.payload),
     }
 }
 
@@ -381,7 +359,7 @@ pub(crate) async fn init_databases_from_marshal<E, A, S, V>(
     context: &E,
     marshal: &MarshalMailbox<S, V>,
     db_config: <A::Databases as DatabaseSet<E>>::Config,
-    mut sync_metadata: StateSyncMetadata<E, V::Commitment>,
+    mut sync_metadata: StateSyncMetadata<E, S, V::Commitment>,
 ) -> StartupResult<E, A>
 where
     E: Rng + Spawner + Context,
@@ -441,5 +419,18 @@ where
     StartupResult {
         sync: SyncResult { databases, anchor },
         skip_finalized_until,
+    }
+}
+
+#[cfg(all(test, feature = "arbitrary"))]
+mod tests {
+    mod conformance {
+        use crate::stateful::{actor::syncer::SyncState, tests::mocks::TestScheme};
+        use commonware_codec::conformance::CodecConformance;
+        use commonware_cryptography::sha256::Digest as Sha256Digest;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<SyncState<TestScheme, Sha256Digest>>,
+        }
     }
 }

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -42,10 +42,7 @@ where
     S: Scheme,
     C: Digest,
 {
-    InProgress {
-        height: Height,
-        floor: Finalization<S, C>,
-    },
+    InProgress(Finalization<S, C>),
     Complete(Height),
 }
 
@@ -57,7 +54,7 @@ where
     /// Returns the completed state sync height, if state sync has finished.
     pub(crate) const fn sync_height(&self) -> Option<Height> {
         match self {
-            Self::InProgress { .. } => None,
+            Self::InProgress(_) => None,
             Self::Complete(height) => Some(*height),
         }
     }
@@ -70,9 +67,8 @@ where
 {
     fn write(&self, writer: &mut impl BufMut) {
         match self {
-            Self::InProgress { height, floor } => {
+            Self::InProgress(floor) => {
                 0u8.write(writer);
-                height.write(writer);
                 floor.write(writer);
             }
             Self::Complete(height) => {
@@ -91,7 +87,7 @@ where
     fn encode_size(&self) -> usize {
         u8::SIZE
             + match self {
-                Self::InProgress { height, floor } => height.encode_size() + floor.encode_size(),
+                Self::InProgress(floor) => floor.encode_size(),
                 Self::Complete(height) => height.encode_size(),
             }
     }
@@ -106,10 +102,7 @@ where
 
     fn read_cfg(reader: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
         match u8::read(reader)? {
-            0 => Ok(Self::InProgress {
-                height: Height::read(reader)?,
-                floor: Finalization::read_cfg(reader, cfg)?,
-            }),
+            0 => Ok(Self::InProgress(Finalization::read_cfg(reader, cfg)?)),
             1 => Ok(Self::Complete(Height::read(reader)?)),
             n => Err(Error::InvalidEnum(n)),
         }
@@ -125,10 +118,7 @@ where
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         Ok(if u.arbitrary::<bool>()? {
-            Self::InProgress {
-                height: u.arbitrary()?,
-                floor: u.arbitrary()?,
-            }
+            Self::InProgress(u.arbitrary()?)
         } else {
             Self::Complete(u.arbitrary()?)
         })
@@ -222,14 +212,14 @@ where
     pub(crate) fn in_progress(&self) -> bool {
         matches!(
             self.metadata.get(&SYNC_STATE_KEY),
-            Some(SyncState::InProgress { .. })
+            Some(SyncState::InProgress(_))
         )
     }
 
     /// Returns the floor selected before an interrupted state sync.
     pub(crate) fn in_progress_floor(&self) -> Option<&Finalization<S, C>> {
         match self.metadata.get(&SYNC_STATE_KEY) {
-            Some(SyncState::InProgress { floor, .. }) => Some(floor),
+            Some(SyncState::InProgress(floor)) => Some(floor),
             _ => None,
         }
     }
@@ -240,21 +230,18 @@ where
     /// sync engine can reopen partial sync state and validate the next selected floor after a crash.
     ///
     /// If an interrupted state sync already stored a floor, the newly selected
-    /// floor must resume from that same floor or a later one.
-    pub(crate) async fn begin_sync(&mut self, height: Height, floor: Finalization<S, C>) {
+    /// floor must resume from the same or a later consensus round.
+    pub(crate) async fn begin_sync(&mut self, floor: Finalization<S, C>) {
         match self.metadata.get(&SYNC_STATE_KEY) {
-            Some(SyncState::InProgress {
-                height: existing_height,
-                floor: existing,
-            }) => {
+            Some(SyncState::InProgress(existing)) => {
                 assert!(
-                    height >= *existing_height,
+                    floor.round() >= existing.round(),
                     "selected state sync floor cannot move behind the persisted in-progress floor",
                 );
-                if height == *existing_height {
+                if floor.round() == existing.round() {
                     assert!(
                         floor.proposal.payload == existing.proposal.payload,
-                        "selected state sync floor conflicts with the persisted in-progress floor",
+                        "selected state sync floor conflicts with the persisted in-progress round",
                     );
                 }
             }
@@ -265,7 +252,7 @@ where
         }
 
         self.metadata
-            .put_sync(SYNC_STATE_KEY, SyncState::InProgress { height, floor })
+            .put_sync(SYNC_STATE_KEY, SyncState::InProgress(floor))
             .await
             .expect("failed to set state sync state to in-progress");
     }
@@ -276,23 +263,11 @@ where
     /// from the later of this height and marshal's processed height instead. This
     /// action is irreversible.
     pub(crate) async fn set_complete(&mut self, height: Height) {
-        match self.metadata.get(&SYNC_STATE_KEY) {
-            Some(SyncState::InProgress {
-                height: floor_height,
-                ..
-            }) => {
-                assert!(
-                    height >= *floor_height,
-                    "completed state sync height cannot be behind the in-progress floor",
-                );
-            }
-            Some(SyncState::Complete(existing)) => {
-                assert!(
-                    height >= *existing,
-                    "completed state sync height cannot move backward",
-                );
-            }
-            None => {}
+        if let Some(SyncState::Complete(existing)) = self.metadata.get(&SYNC_STATE_KEY) {
+            assert!(
+                height >= *existing,
+                "completed state sync height cannot move backward",
+            );
         }
 
         self.metadata

--- a/glue/src/stateful/actor/syncer/plan.rs
+++ b/glue/src/stateful/actor/syncer/plan.rs
@@ -174,12 +174,12 @@ mod tests {
 
     fn finalization(
         schemes: &[TestScheme],
-        height: u64,
+        view: u64,
         digest_byte: u8,
     ) -> Finalization<TestScheme, Sha256Digest> {
         let proposal = Proposal {
-            round: Round::new(Epoch::zero(), View::new(height)),
-            parent: View::new(height.saturating_sub(1)),
+            round: Round::new(Epoch::zero(), View::new(view)),
+            parent: View::new(view.saturating_sub(1)),
             payload: Sha256::fill(digest_byte),
         };
         let finalizes = schemes
@@ -229,7 +229,7 @@ mod tests {
                     .await;
             metadata.set_complete(Height::new(7)).await;
             metadata
-                .begin_sync(Height::new(8), finalization(&fixture.schemes, 8, 8))
+                .begin_sync(finalization(&fixture.schemes, 8, 8))
                 .await;
         });
     }
@@ -248,22 +248,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "completed state sync height cannot be behind the in-progress floor")]
-    fn complete_height_cannot_be_behind_in_progress_floor() {
-        deterministic::Runner::default().start(|mut context| async move {
-            let partition_prefix = "complete_height_cannot_be_behind_in_progress_floor";
-            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
-            let mut metadata =
-                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
-                    .await;
-            metadata
-                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 7))
-                .await;
-            metadata.set_complete(Height::new(6)).await;
-        });
-    }
-
-    #[test]
     fn in_progress_sync_requires_compatible_floor() {
         deterministic::Runner::default().start(|mut context| async move {
             let partition_prefix = "in_progress_sync_requires_compatible_floor";
@@ -272,7 +256,7 @@ mod tests {
             let mut metadata =
                 StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
                     .await;
-            metadata.begin_sync(Height::new(7), stored.clone()).await;
+            metadata.begin_sync(stored.clone()).await;
             drop(metadata);
 
             let mut plan =
@@ -280,9 +264,9 @@ mod tests {
             assert!(plan.may_state_sync());
             assert!(plan.requires_state_sync_floor());
             assert!(plan.should_state_sync(false));
-            plan.sync_metadata.begin_sync(Height::new(7), stored).await;
+            plan.sync_metadata.begin_sync(stored).await;
             plan.sync_metadata
-                .begin_sync(Height::new(9), finalization(&fixture.schemes, 9, 9))
+                .begin_sync(finalization(&fixture.schemes, 9, 9))
                 .await;
         });
     }
@@ -297,7 +281,7 @@ mod tests {
             let mut metadata =
                 StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
                     .await;
-            metadata.begin_sync(Height::new(7), stored.clone()).await;
+            metadata.begin_sync(stored.clone()).await;
             drop(metadata);
 
             let plan =
@@ -361,31 +345,31 @@ mod tests {
             )
             .await;
             metadata
-                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 7))
+                .begin_sync(finalization(&fixture.schemes, 7, 7))
                 .await;
             metadata
-                .begin_sync(Height::new(6), finalization(&fixture.schemes, 6, 6))
+                .begin_sync(finalization(&fixture.schemes, 6, 6))
                 .await;
         });
     }
 
     #[test]
     #[should_panic(
-        expected = "selected state sync floor conflicts with the persisted in-progress floor"
+        expected = "selected state sync floor conflicts with the persisted in-progress round"
     )]
-    fn in_progress_sync_panics_for_conflicting_floor() {
+    fn in_progress_sync_panics_for_conflicting_round() {
         deterministic::Runner::default().start(|mut context| async move {
             let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
             let mut metadata = StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(
                 &context,
-                "in_progress_sync_panics_for_conflicting_floor",
+                "in_progress_sync_panics_for_conflicting_round",
             )
             .await;
             metadata
-                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 7))
+                .begin_sync(finalization(&fixture.schemes, 7, 7))
                 .await;
             metadata
-                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 8))
+                .begin_sync(finalization(&fixture.schemes, 7, 8))
                 .await;
         });
     }

--- a/glue/src/stateful/actor/syncer/plan.rs
+++ b/glue/src/stateful/actor/syncer/plan.rs
@@ -13,9 +13,10 @@ use commonware_storage::Context;
 /// floor from peers when state sync has already completed:
 ///
 /// 1. [`SyncPlan::init`] reads the durable state sync state.
-/// 2. If [`SyncPlan::may_state_sync`] returns `true`, the caller fetches a
-///    finalized floor and attaches it via [`SyncPlan::with_floor`]. Otherwise
-///    the caller skips floor selection entirely.
+/// 2. If [`SyncPlan::may_state_sync`] returns `true`, the caller may fetch a
+///    finalized floor and attach it via [`SyncPlan::with_floor`]. An interrupted
+///    sync already has a persisted floor, while a fresh sync needs one from the
+///    caller. Otherwise the caller skips floor selection entirely.
 ///
 /// The plan owns the opened metadata store and is later consumed by
 /// [`Stateful`](crate::stateful::Stateful), so startup does not reopen the same
@@ -30,7 +31,7 @@ where
     S: Scheme,
     V: Variant,
 {
-    sync_metadata: StateSyncMetadata<E, V::Commitment>,
+    sync_metadata: StateSyncMetadata<E, S, V::Commitment>,
     floor: Option<Finalization<S, V::Commitment>>,
 }
 
@@ -49,10 +50,11 @@ where
     /// startup path.
     pub async fn init(context: &E, partition_prefix: impl AsRef<str>) -> Self {
         let sync_metadata =
-            StateSyncMetadata::<E, V::Commitment>::init(context, partition_prefix).await;
+            StateSyncMetadata::<E, S, V::Commitment>::init(context, partition_prefix).await;
+        let floor = sync_metadata.in_progress_floor().cloned();
         Self {
             sync_metadata,
-            floor: None,
+            floor,
         }
     }
 
@@ -81,18 +83,26 @@ where
         self.sync_metadata.partition_prefix()
     }
 
-    /// Returns a reference to the finalized floor attached to this plan, if any.
+    /// Returns the selected or persisted in-progress state sync floor.
     pub const fn floor(&self) -> Option<&Finalization<S, V::Commitment>> {
         self.floor.as_ref()
     }
 
     /// Attach a finalized floor to state sync from.
     ///
-    /// Has no effect if state sync has already completed.
+    /// Has no effect if state sync has already completed. When resuming an
+    /// interrupted sync, a lagging selection is ignored in favor of the
+    /// persisted floor.
     #[must_use]
     pub fn with_floor(mut self, floor: Finalization<S, V::Commitment>) -> Self {
         if !self.may_state_sync() {
             return self;
+        }
+
+        if let Some(stored) = self.sync_metadata.in_progress_floor() {
+            if floor.round() <= stored.round() {
+                return self;
+            }
         }
 
         self.floor = Some(floor);
@@ -101,21 +111,23 @@ where
 
     /// Returns marshal's startup anchor for this plan.
     ///
-    /// If a finalized floor was attached, marshal starts from that floor.
-    /// Otherwise marshal starts from genesis and relies on its own durable
-    /// progress to override that anchor when available.
+    /// If a finalized floor was attached or persisted by an interrupted sync,
+    /// marshal starts from that floor. Otherwise marshal starts from genesis
+    /// and relies on its own durable progress to override that anchor when
+    /// available.
     pub fn marshal_start<B>(&self, genesis: B) -> Start<S, V::Commitment, B> {
         self.floor
-            .clone()
+            .as_ref()
+            .cloned()
             .map_or_else(|| Start::Genesis(genesis), Start::Floor)
     }
 
-    /// Returns whether startup must attach a new state sync floor.
+    /// Returns whether startup must resume an interrupted state sync.
     ///
     /// This is `true` after a previous process crashed while state sync was
-    /// in progress. In that case [`Self::may_state_sync`] is also `true`, but
-    /// starting from marshal/genesis is not allowed because partially synced
-    /// database state must be reopened through the state-sync path.
+    /// in progress. In that case [`Self::may_state_sync`] is also `true`, and
+    /// the persisted floor keeps partially synced database state on the same
+    /// recovery path.
     pub fn requires_state_sync_floor(&self) -> bool {
         self.sync_metadata.in_progress()
     }
@@ -130,7 +142,7 @@ where
     }
 
     /// Consumes this plan and returns its durable state-sync metadata handle.
-    pub(crate) fn into_sync_metadata(self) -> StateSyncMetadata<E, V::Commitment> {
+    pub(crate) fn into_sync_metadata(self) -> StateSyncMetadata<E, S, V::Commitment> {
         self.sync_metadata
     }
 }
@@ -139,12 +151,38 @@ where
 mod tests {
     use super::SyncPlan;
     use crate::stateful::{
-        actor::syncer::{FloorMarker, StateSyncMetadata},
+        actor::syncer::StateSyncMetadata,
         tests::mocks::{TestScheme, TestVariant},
     };
-    use commonware_consensus::types::Height;
+    use commonware_consensus::{
+        marshal::Start,
+        simplex::{
+            mocks::scheme as scheme_mocks,
+            types::{Finalization, Finalize, Proposal},
+        },
+        types::{Epoch, Height, Round, View},
+    };
     use commonware_cryptography::sha256::{Digest as Sha256Digest, Sha256};
+    use commonware_parallel::Sequential;
     use commonware_runtime::{deterministic, Runner as _};
+
+    fn finalization(
+        schemes: &[TestScheme],
+        height: u64,
+        digest_byte: u8,
+    ) -> Finalization<TestScheme, Sha256Digest> {
+        let proposal = Proposal {
+            round: Round::new(Epoch::zero(), View::new(height)),
+            parent: View::new(height.saturating_sub(1)),
+            payload: Sha256::fill(digest_byte),
+        };
+        let finalizes = schemes
+            .iter()
+            .map(|scheme| Finalize::sign(scheme, proposal.clone()).expect("sign finalize"))
+            .collect::<Vec<_>>();
+        Finalization::from_finalizes(&schemes[0], &finalizes, &Sequential)
+            .expect("recover finalization")
+    }
 
     #[test]
     fn stored_sync_height_disables_state_sync() {
@@ -160,7 +198,8 @@ mod tests {
             drop(plan);
 
             let mut metadata =
-                StateSyncMetadata::<_, Sha256Digest>::init(&context, partition_prefix).await;
+                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
+                    .await;
             metadata.set_complete(Height::new(7)).await;
             drop(metadata);
 
@@ -176,13 +215,15 @@ mod tests {
     #[test]
     #[should_panic(expected = "completed state sync cannot be marked in-progress")]
     fn completed_sync_cannot_be_marked_in_progress() {
-        deterministic::Runner::default().start(|context| async move {
+        deterministic::Runner::default().start(|mut context| async move {
             let partition_prefix = "completed_sync_cannot_be_marked_in_progress";
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
             let mut metadata =
-                StateSyncMetadata::<_, Sha256Digest>::init(&context, partition_prefix).await;
+                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
+                    .await;
             metadata.set_complete(Height::new(7)).await;
             metadata
-                .begin_sync(FloorMarker::new(Height::new(8), Sha256::fill(8)))
+                .begin_sync(Height::new(8), finalization(&fixture.schemes, 8, 8))
                 .await;
         });
     }
@@ -193,7 +234,8 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let partition_prefix = "complete_height_cannot_move_backward";
             let mut metadata =
-                StateSyncMetadata::<_, Sha256Digest>::init(&context, partition_prefix).await;
+                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
+                    .await;
             metadata.set_complete(Height::new(7)).await;
             metadata.set_complete(Height::new(6)).await;
         });
@@ -202,12 +244,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "completed state sync height cannot be behind the in-progress floor")]
     fn complete_height_cannot_be_behind_in_progress_floor() {
-        deterministic::Runner::default().start(|context| async move {
+        deterministic::Runner::default().start(|mut context| async move {
             let partition_prefix = "complete_height_cannot_be_behind_in_progress_floor";
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
             let mut metadata =
-                StateSyncMetadata::<_, Sha256Digest>::init(&context, partition_prefix).await;
+                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
+                    .await;
             metadata
-                .begin_sync(FloorMarker::new(Height::new(7), Sha256::fill(7)))
+                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 7))
                 .await;
             metadata.set_complete(Height::new(6)).await;
         });
@@ -215,12 +259,14 @@ mod tests {
 
     #[test]
     fn in_progress_sync_requires_compatible_floor() {
-        deterministic::Runner::default().start(|context| async move {
+        deterministic::Runner::default().start(|mut context| async move {
             let partition_prefix = "in_progress_sync_requires_compatible_floor";
-            let stored = FloorMarker::new(Height::new(7), Sha256::fill(7));
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
+            let stored = finalization(&fixture.schemes, 7, 7);
             let mut metadata =
-                StateSyncMetadata::<_, Sha256Digest>::init(&context, partition_prefix).await;
-            metadata.begin_sync(stored.clone()).await;
+                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
+                    .await;
+            metadata.begin_sync(Height::new(7), stored.clone()).await;
             drop(metadata);
 
             let mut plan =
@@ -228,10 +274,52 @@ mod tests {
             assert!(plan.may_state_sync());
             assert!(plan.requires_state_sync_floor());
             assert!(plan.should_state_sync(false));
-            plan.sync_metadata.begin_sync(stored).await;
+            plan.sync_metadata.begin_sync(Height::new(7), stored).await;
             plan.sync_metadata
-                .begin_sync(FloorMarker::new(Height::new(9), Sha256::fill(9)))
+                .begin_sync(Height::new(9), finalization(&fixture.schemes, 9, 9))
                 .await;
+        });
+    }
+
+    #[test]
+    fn interrupted_sync_reuses_persisted_floor_when_probe_lags() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let partition_prefix = "interrupted_sync_reuses_persisted_floor";
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
+            let stored = finalization(&fixture.schemes, 7, 7);
+
+            let mut metadata =
+                StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, partition_prefix)
+                    .await;
+            metadata.begin_sync(Height::new(7), stored.clone()).await;
+            drop(metadata);
+
+            let plan =
+                SyncPlan::<_, TestScheme, TestVariant>::init(&context, partition_prefix).await;
+            assert!(plan.should_state_sync(false));
+            assert_eq!(
+                plan.floor().expect("interrupted sync must have a floor"),
+                &stored,
+            );
+            assert!(matches!(
+                plan.marshal_start(()),
+                Start::Floor(ref floor) if floor == &stored
+            ));
+
+            let plan =
+                SyncPlan::<_, TestScheme, TestVariant>::init(&context, partition_prefix).await;
+            let plan = plan.with_floor(finalization(&fixture.schemes, 6, 6));
+            assert_eq!(
+                plan.floor().expect("interrupted sync must have a floor"),
+                &stored,
+                "a lagging probe must not replace the persisted in-progress floor",
+            );
+
+            let newer = finalization(&fixture.schemes, 9, 9);
+            let plan =
+                SyncPlan::<_, TestScheme, TestVariant>::init(&context, partition_prefix).await;
+            let plan = plan.with_floor(newer.clone());
+            assert_eq!(plan.floor(), Some(&newer));
         });
     }
 
@@ -240,8 +328,20 @@ mod tests {
         expected = "selected state sync floor cannot move behind the persisted in-progress floor"
     )]
     fn in_progress_sync_panics_for_backward_floor() {
-        let stored = FloorMarker::new(Height::new(7), Sha256::fill(7));
-        stored.ensure_not_behind(&FloorMarker::new(Height::new(6), Sha256::fill(6)));
+        deterministic::Runner::default().start(|mut context| async move {
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
+            let mut metadata = StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(
+                &context,
+                "in_progress_sync_panics_for_backward_floor",
+            )
+            .await;
+            metadata
+                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 7))
+                .await;
+            metadata
+                .begin_sync(Height::new(6), finalization(&fixture.schemes, 6, 6))
+                .await;
+        });
     }
 
     #[test]
@@ -249,7 +349,19 @@ mod tests {
         expected = "selected state sync floor conflicts with the persisted in-progress floor"
     )]
     fn in_progress_sync_panics_for_conflicting_floor() {
-        let stored = FloorMarker::new(Height::new(7), Sha256::fill(7));
-        stored.ensure_not_behind(&FloorMarker::new(Height::new(7), Sha256::fill(8)));
+        deterministic::Runner::default().start(|mut context| async move {
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
+            let mut metadata = StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(
+                &context,
+                "in_progress_sync_panics_for_conflicting_floor",
+            )
+            .await;
+            metadata
+                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 7))
+                .await;
+            metadata
+                .begin_sync(Height::new(7), finalization(&fixture.schemes, 7, 8))
+                .await;
+        });
     }
 }

--- a/glue/src/stateful/actor/syncer/plan.rs
+++ b/glue/src/stateful/actor/syncer/plan.rs
@@ -6,6 +6,7 @@ use commonware_consensus::{
 };
 use commonware_cryptography::certificate::Scheme;
 use commonware_storage::Context;
+use tracing::warn;
 
 /// Startup plan that determines whether one-time peer state sync may still run.
 ///
@@ -99,8 +100,13 @@ where
             return self;
         }
 
-        if let Some(stored) = self.sync_metadata.in_progress_floor() {
-            if floor.round() <= stored.round() {
+        if let Some(selected) = &self.floor {
+            if floor.round() <= selected.round() {
+                warn!(
+                    candidate = ?floor.round(),
+                    selected = ?selected.round(),
+                    "state sync floor not updated, candidate is not newer",
+                );
                 return self;
             }
         }
@@ -319,6 +325,25 @@ mod tests {
             let plan =
                 SyncPlan::<_, TestScheme, TestVariant>::init(&context, partition_prefix).await;
             let plan = plan.with_floor(newer.clone());
+            assert_eq!(plan.floor(), Some(&newer));
+        });
+    }
+
+    #[test]
+    fn with_floor_does_not_replace_newer_selection() {
+        deterministic::Runner::default().start(|mut context| async move {
+            let fixture = scheme_mocks::fixture(&mut context, b"_COMMONWARE_GLUE_SYNC_PLAN", 1);
+            let newer = finalization(&fixture.schemes, 9, 9);
+
+            let plan = SyncPlan::<_, TestScheme, TestVariant>::init(
+                &context,
+                "with_floor_does_not_replace_newer_selection",
+            )
+            .await;
+            let plan =
+                plan.with_floor(newer.clone())
+                    .with_floor(finalization(&fixture.schemes, 8, 8));
+
             assert_eq!(plan.floor(), Some(&newer));
         });
     }

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -63,9 +63,10 @@
 //!   above `database_anchor` arrives first, the actor processes it during handoff.
 //!   Durable metadata is marked in-progress before any database mutation and is
 //!   marked complete at the converged anchor before handoff acknowledgement. A
-//!   crash before completion restarts through the state-sync path, reopening
-//!   the existing sync journals. Subsequent restarts after completion take the
-//!   marshal sync path to ensure a contiguous stream.
+//!   crash before completion restarts through the state-sync path from the
+//!   persisted floor, reopening the existing sync journals. A lagging floor
+//!   sampled during restart cannot move that floor backward. Subsequent restarts
+//!   after completion take the marshal sync path to ensure a contiguous stream.
 //!
 //! # Lazy Recovery
 //!


### PR DESCRIPTION
## Overview

An interrupted state sync currently persists only its selected floor's height and commitment. On restart, `SyncPlan` must probe for another finalization; if that probe returns a lagging floor, startup attempts to move behind the persisted floor and panics instead of reopening the existing sync journals.

Persist the full in-progress finalization so `SyncPlan` can resume directly from it, ignore probed floors that are not newer, and keep repeated `with_floor` selections monotonic. Completed state sync remains height-only, and marshal's completed-startup behavior is unchanged.

This supersedes #4230 with the narrower interrupted-state-sync fix. The separate Constantinople startup-wiring issue should be fixed in Constantinople: https://github.com/commonwarexyz/constantinople/pull/38
