### PR TITLE
[marshal] Sync finalized archives off the mailbox path

### DIFF
--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -69,6 +69,19 @@ struct ResolverDelivery<V: Variant> {
     response: oneshot::Sender<bool>,
 }
 
+/// Completion marker for entries in the actor's durability sync pool.
+enum PooledSync {
+    /// Observed only so the fatal policy in `Durable` applies; no
+    /// continuation runs on completion.
+    Observed,
+    /// A finalized-archive sync batch became durable. Carries the sequence
+    /// assigned by [`Actor::start_finalized_sync`] so the completion arm can
+    /// release the application-dispatch barrier for every batch the sync
+    /// covers (a sync makes durable every write accepted before it started,
+    /// including batches registered under earlier sequences).
+    Finalized(u64),
+}
+
 /// The [Actor] is responsible for receiving uncertified blocks from the broadcast mechanism,
 /// receiving notarizations and finalizations from consensus, and reconstructing a total order
 /// of blocks.
@@ -130,6 +143,13 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
+    // Finalized-archive write batches that are buffered but not yet durable,
+    // keyed by the sequence of the pooled sync that first covers them and
+    // holding the lowest height written in the batch. `try_dispatch_blocks`
+    // never dispatches at or above the lowest pending height.
+    pending_finalized_syncs: BTreeMap<u64, Height>,
+    // Sequence assigned to the next pooled finalized-archive sync.
+    finalized_sync_seq: u64,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -240,6 +260,8 @@ where
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
+                pending_finalized_syncs: BTreeMap::new(),
+                finalized_sync_seq: 0,
                 cache,
                 finalizations_by_height,
                 finalized_blocks,
@@ -355,11 +377,12 @@ where
         // Create a local pool for waiter futures.
         let mut waiters = AbortablePool::<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>::default();
 
-        // Observe durable syncs that no consensus caller awaits (the notarization
-        // path). A flush failure inside `start_sync` is reported only through the
-        // returned handle, so every handle must be observed to apply the fatal
-        // policy; this pool does so without blocking the actor on fsync.
-        let mut syncs = Pool::<bool>::default();
+        // Observe durable syncs that no consensus caller awaits (the
+        // notarization and finalization paths). A flush failure inside
+        // `start_sync` is reported only through the returned handle, so every
+        // handle must be observed to apply the fatal policy; this pool does so
+        // without blocking the actor on fsync.
+        let mut syncs = Pool::<PooledSync>::default();
 
         // Anchor all startup work under a single root span. Tip recovery, floor
         // installation, gap repair, and the initial dispatch all run before any
@@ -392,6 +415,9 @@ where
             }
 
             // Attempt to repair any gaps in the finalized blocks archive, if there are any.
+            //
+            // Sync inline (blocking): the mailbox is not being served yet, and
+            // the dispatch below must observe durable repairs.
             if self
                 .try_repair_gaps(&mut buffer, &mut resolver, &mut application)
                 .await
@@ -415,8 +441,15 @@ where
                 debug!("context shutdown, stopping marshal");
             },
             // Drive durability syncs: a real sync failure panics inside the
-            // pooled future (the fatal policy), aborting the actor.
-            _ = syncs.next_completed() => {},
+            // pooled future (the fatal policy), aborting the actor. A completed
+            // finalized-archive sync additionally releases the dispatch barrier
+            // for the batches it covers and resumes application dispatch.
+            sync = syncs.next_completed() => {
+                if let PooledSync::Finalized(seq) = sync {
+                    self.finalized_sync_completed(seq);
+                    self.try_dispatch_blocks(&mut application).await;
+                }
+            },
             // Handle waiter completions first
             Ok(completion) = waiters.next_completed() else continue => match completion {
                 Ok(block) => {
@@ -541,7 +574,7 @@ where
         message: Message<P::Scheme, V>,
         resolver: &mut R,
         waiters: &mut AbortablePool<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>,
-        syncs: &mut Pool<bool>,
+        syncs: &mut Pool<PooledSync>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
     ) where
@@ -696,7 +729,10 @@ where
                     .cache
                     .put_notarization(round, digest, notarization)
                     .await;
-                syncs.push(handle.durable(round, "notarization"));
+                syncs.push(async move {
+                    handle.durable(round, "notarization").await;
+                    PooledSync::Observed
+                });
 
                 // A notarization alone is not enough to fetch missing proposal
                 // data. If the block is not locally available, remember the
@@ -711,7 +747,10 @@ where
                             .cache
                             .put_notarized(round, digest, Arc::unwrap_or_clone(block).into())
                             .await;
-                        syncs.push(handle.durable(round, "notarized"));
+                        syncs.push(async move {
+                            handle.durable(round, "notarized").await;
+                            PooledSync::Observed
+                        });
                     }
                 } else {
                     debug!(?round, "notarized block unavailable locally");
@@ -753,8 +792,23 @@ where
                     {
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
-                        self.try_repair_gaps(buffer, resolver, application).await;
-                        self.sync_finalized().await;
+                        if self.try_repair_gaps(buffer, resolver, application).await {
+                            // Repair wrote blocks at heights below the new
+                            // finalization, so sync inline (blocking): the
+                            // batch's lowest height is not tracked, which the
+                            // pooled dispatch barrier would need. Repair only
+                            // runs while catching up, so the mailbox stall is
+                            // acceptable here.
+                            self.sync_finalized().await;
+                        } else {
+                            // Hot path: only `height` was written. Make it
+                            // durable on the sync pool so the mailbox keeps
+                            // serving reads (e.g. the proposer's
+                            // `get_verified`) during the fsync; dispatch of
+                            // this block is deferred to the pool-completion
+                            // arm by the barrier in `try_dispatch_blocks`.
+                            self.start_finalized_sync(height, round, syncs).await;
+                        }
                         self.try_dispatch_blocks(application).await;
                         debug!(?round, %height, "finalized block stored");
                     }
@@ -964,7 +1018,9 @@ where
 
         if needs_sync {
             // Sync archives before responding to peers so accepted repair data is
-            // durable before this node serves it.
+            // durable before this node serves it. Inline (blocking) is required:
+            // the produce responses below run in this same arm and must not be
+            // sent before the data they serve is durable.
             self.sync_finalized().await;
             self.try_dispatch_blocks(application).await;
         }
@@ -1182,7 +1238,8 @@ where
     /// shutdown, however, a subscriber may hold a block that marshal never
     /// durably stored. Subscriptions make no durability promise. Durable
     /// height-ordered delivery is provided by application dispatch, which
-    /// only sends blocks after [`Self::sync_finalized`].
+    /// only sends blocks once the finalized archives are durable (see
+    /// [`Self::try_dispatch_blocks`]).
     ///
     /// Returns true if the block was consumed as the floor anchor.
     async fn ingest<Buf: Buffer<V>>(
@@ -1241,6 +1298,9 @@ where
                 .expect("pending floor anchor missing");
             self.update_processed_round_floor(height, finalization.round(), resolver)
                 .await;
+            // Sync inline (blocking): floor transitions are rare, and repair
+            // batches do not track the lowest height the pooled dispatch
+            // barrier would need.
             if self.try_repair_gaps(buffer, resolver, application).await {
                 self.sync_finalized().await;
             }
@@ -1271,6 +1331,9 @@ where
             }
         )
         .expect("failed to store floor anchor");
+        // Sync inline (blocking): every step below (metadata sync, pruning,
+        // dispatch) requires the anchor to already be durable, and floor
+        // transitions are rare.
         self.sync_finalized().await;
 
         if height > self.tip {
@@ -1304,6 +1367,10 @@ where
         // Intentionally keep existing block subscriptions alive. Canceling
         // waiters can have catastrophic consequences (nodes can get stuck in
         // different views) as actors do not retry subscriptions on failed channels.
+        //
+        // Sync inline (blocking): floor transitions are rare, and repair
+        // batches do not track the lowest height the pooled dispatch barrier
+        // would need.
         if self.try_repair_gaps(buffer, resolver, application).await {
             self.sync_finalized().await;
         }
@@ -1725,25 +1792,30 @@ where
     /// updated later, in a subsequent `select_loop!` iteration, when the ack
     /// handler updates the processed height.
     ///
-    /// Callers must only invoke this after [`Self::sync_finalized`] has made any
-    /// preceding finalized-archive writes durable. In other words, anything fed
-    /// to the application from this method is already durably persisted in marshal.
+    /// Anything fed to the application from this method is already durably
+    /// persisted in marshal: callers must make preceding finalized-archive
+    /// writes durable with [`Self::sync_finalized`] (blocking) or register
+    /// them with [`Self::start_finalized_sync`] (pooled) before yielding to
+    /// the `select_loop!`. Registered batches gate dispatch below: no block at
+    /// or above the lowest non-durable height is dispatched until the covering
+    /// pooled sync completes, at which point the pool-completion arm re-runs
+    /// this method.
     ///
     /// Acks are processed in FIFO order so the processed floor height always
     /// advances sequentially.
     ///
     /// # Crash safety
     ///
-    /// Because `select_loop!` arms run to completion, the caller's
-    /// [`Self::sync_finalized`] always executes before the ack handler runs. This
-    /// guarantees archive data is durable before the processed floor height
-    /// advances:
+    /// Because `select_loop!` arms run to completion, archive data is always
+    /// durable before the ack handler advances the processed floor height:
     ///
     /// ```text
     /// Iteration N (caller):
-    ///   store_finalization  ->  Archive::put (buffered)
-    ///   sync_finalized      ->  archive durable
-    ///   try_dispatch_blocks  ->  sends blocks to app, enqueues pending acks
+    ///   store_finalization   ->  Archive::put (buffered)
+    ///   sync_finalized       ->  archive durable
+    ///     (or start_finalized_sync -> dispatch of the batch deferred to the
+    ///      pool-completion arm, which runs after the archive is durable)
+    ///   try_dispatch_blocks  ->  sends durable blocks to app, enqueues pending acks
     ///
     /// Iteration M (ack handler, M > N):
     ///   ack handler       ->  update_processed_height  ->  metadata buffered
@@ -1758,10 +1830,18 @@ where
             return;
         }
 
+        // Durability barrier: a pooled finalized-archive sync may still be in
+        // flight (see `start_finalized_sync`), and buffered writes are readable
+        // from the archives before they are durable.
+        let non_durable = self.pending_finalized_syncs.values().min().copied();
+
         while self.pending_acks.has_capacity() {
             let next_height = self
                 .pending_acks
                 .next_dispatch_height(self.stream.next_height());
+            if non_durable.is_some_and(|lowest| next_height >= lowest) {
+                return;
+            }
             let Some(block) = self.get_finalized_block(next_height).await else {
                 return;
             };
@@ -1794,7 +1874,8 @@ where
         self.last_proposed_block.take().map(|(_, _, block)| block)
     }
 
-    /// Sync both finalization archives to durable storage.
+    /// Sync both finalization archives to durable storage, blocking the actor
+    /// until they are durable.
     ///
     /// Must be called within the same `select_loop!` arm as any preceding
     /// [`Self::store_finalization`] / [`Self::try_repair_gaps`] writes, before yielding back
@@ -1802,6 +1883,11 @@ where
     /// [`Self::try_dispatch_blocks`] must run only after this sync completes.
     /// It also ensures archives are durable before the ack handler advances
     /// the processed floor height. See [`Self::try_dispatch_blocks`] for details.
+    ///
+    /// Blocking the actor stalls every mailbox caller behind the fsync. Paths
+    /// that know the lowest height they wrote (and do not serve the written
+    /// data later in the same arm) should prefer the non-blocking
+    /// [`Self::start_finalized_sync`].
     #[tracing::instrument(name = "marshal.actor.sync_finalized", level = "info", skip_all)]
     async fn sync_finalized(&mut self) {
         if let Err(e) = try_join!(
@@ -1819,6 +1905,78 @@ where
         ) {
             panic!("failed to sync finalization archives: {e}");
         }
+
+        // A blocking sync waits on (and covers) every previously accepted
+        // write, including batches whose pooled syncs are still in flight, so
+        // all pending batches are durable once it returns.
+        self.pending_finalized_syncs.clear();
+    }
+
+    /// Start a non-blocking sync of both finalization archives on the
+    /// durability pool.
+    ///
+    /// The pooled entry resolves to [`PooledSync::Finalized`] once every write
+    /// accepted before this call is durable. Until the pool-completion arm
+    /// observes it, [`Self::try_dispatch_blocks`] will not dispatch any block
+    /// at or above `lowest` (the lowest height written in this batch),
+    /// preserving the durability barrier described there without blocking the
+    /// mailbox on an fsync like [`Self::sync_finalized`].
+    ///
+    /// Like [`Self::sync_finalized`], this must be called within the same
+    /// `select_loop!` arm as the writes it covers, before yielding back to the
+    /// loop.
+    #[tracing::instrument(name = "marshal.actor.start_finalized_sync", level = "info", skip_all)]
+    async fn start_finalized_sync(
+        &mut self,
+        lowest: Height,
+        round: Round,
+        syncs: &mut Pool<PooledSync>,
+    ) {
+        let seq = self.finalized_sync_seq;
+        self.finalized_sync_seq += 1;
+        self.pending_finalized_syncs.insert(seq, lowest);
+
+        let (blocks, finalizations) = match try_join!(
+            async {
+                let handle = self.finalized_blocks.start_sync().await.map_err(Box::new)?;
+                Ok::<_, BoxedError>(handle)
+            },
+            async {
+                let handle = self
+                    .finalizations_by_height
+                    .start_sync()
+                    .await
+                    .map_err(Box::new)?;
+                Ok::<_, BoxedError>(handle)
+            },
+        ) {
+            Ok(handles) => handles,
+            Err(e) => panic!("failed to start finalization archive sync: {e}"),
+        };
+        syncs.push(async move {
+            let (blocks, finalizations) = join(
+                blocks.durable(round, "finalized blocks"),
+                finalizations.durable(round, "finalizations"),
+            )
+            .await;
+            if blocks && finalizations {
+                PooledSync::Finalized(seq)
+            } else {
+                // Runtime shutdown before the sync completed: nothing may be
+                // released for dispatch.
+                PooledSync::Observed
+            }
+        });
+    }
+
+    /// Releases the dispatch barrier for every finalized-archive batch covered
+    /// by the completed pooled sync `seq`.
+    ///
+    /// A sync makes durable every write accepted before it started, so all
+    /// batches with an equal or lower sequence are released, regardless of the
+    /// order in which pooled syncs complete.
+    fn finalized_sync_completed(&mut self, seq: u64) {
+        self.pending_finalized_syncs = self.pending_finalized_syncs.split_off(&(seq + 1));
     }
 
     // -------------------- Immutable Storage --------------------
@@ -1876,10 +2034,11 @@ where
     /// guarantee for downstream application state transitions on their own.
     ///
     /// Writes are buffered and not synced. The caller must call
-    /// [sync_finalized](Self::sync_finalized) before yielding to the
-    /// `select_loop!` so that archive data is durable before the ack handler
-    /// advances the processed floor height. See [`Self::try_dispatch_blocks`] for the
-    /// crash safety invariant.
+    /// [sync_finalized](Self::sync_finalized) (blocking) or
+    /// [start_finalized_sync](Self::start_finalized_sync) (pooled) before
+    /// yielding to the `select_loop!` so that archive data is durable before
+    /// the ack handler advances the processed floor height. See
+    /// [`Self::try_dispatch_blocks`] for the crash safety invariant.
     async fn store_finalization(
         &mut self,
         height: Height,

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -71,8 +71,7 @@ struct ResolverDelivery<V: Variant> {
 
 /// Completion marker for entries in the actor's durability sync pool.
 enum PooledSync {
-    /// Observed only so the fatal policy in `Durable` applies; no
-    /// continuation runs on completion.
+    /// A sync that requires no action on completion.
     Observed,
     /// A finalized-archive sync batch became durable. Carries the sequence
     /// assigned by [`Actor::start_finalized_sync`] so the completion arm can

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1776,12 +1776,12 @@ where
         // Durability barrier: buffered writes are readable from the archives
         // before they are durable. Never dispatch at or above the lowest
         // write not yet covered by a completed sync.
-        let non_durable = self.dispatch_gate.barrier();
+        let barrier = self.dispatch_gate.barrier();
         while self.pending_acks.has_capacity() {
             let next_height = self
                 .pending_acks
                 .next_dispatch_height(self.stream.next_height());
-            if non_durable.is_some_and(|lowest| next_height >= lowest) {
+            if barrier.is_some_and(|lowest| next_height >= lowest) {
                 return;
             }
             let Some(block) = self.get_finalized_block(next_height).await else {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -990,7 +990,8 @@ where
 
         // Start a pooled sync so any writes buffered by this batch become
         // durable without blocking the mailbox. Dispatch of the written
-        // heights resumes when the sync completes.
+        // heights resumes when the sync completes. A batch has no single
+        // round, so the label is the node's processed round when it started.
         self.start_finalized_sync(self.floor.processed_round(), syncs)
             .await;
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -416,9 +416,6 @@ where
             }
 
             // Attempt to repair any gaps in the finalized blocks archive, if there are any.
-            //
-            // Sync inline (blocking): the mailbox is not being served yet, and
-            // the dispatch below must observe durable repairs.
             if self
                 .try_repair_gaps(&mut buffer, &mut resolver, &mut application)
                 .await

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1002,6 +1002,10 @@ where
         // Attempt to fill gaps before handling produce requests so we can serve
         // data received earlier in the same batch.
         needs_sync |= self.try_repair_gaps(buffer, resolver, application).await;
+
+        // Start a pooled sync so the batch's buffered writes become durable
+        // without blocking the mailbox. Dispatch of the written heights
+        // resumes when the sync completes.
         if needs_sync {
             self.start_finalized_sync(self.floor.processed_round(), syncs)
                 .await;
@@ -1767,9 +1771,10 @@ where
     ///
     /// Blocks are dispatched only once durable. Every buffered
     /// finalized-archive write freezes dispatch at or above its height until
-    /// a sync covering it completes (see [`Self::record_finalized_write`]),
-    /// at which point the pool-completion arm re-runs this method. Callers
-    /// that buffer writes must still call [`Self::sync_finalized`] or
+    /// a sync covering it completes (see [`Self::record_finalized_write`]).
+    /// Dispatch is then re-attempted by the pool-completion arm for pooled
+    /// syncs and by the caller itself after a blocking sync. Callers that
+    /// buffer writes must still call [`Self::sync_finalized`] or
     /// [`Self::start_finalized_sync`] before yielding to the `select_loop!`
     /// so the freeze is released.
     ///

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -836,7 +836,7 @@ where
                 height, targets, ..
             } => {
                 // Skip if finalization is already available locally.
-                if self.get_finalization_by_height(height).await.is_some() {
+                if self.has_finalization_by_height(height).await {
                     return;
                 }
 
@@ -1934,6 +1934,15 @@ where
         {
             Ok(finalization) => finalization,
             Err(e) => panic!("failed to get finalization: {e}"),
+        }
+    }
+
+    /// Check whether a finalization exists in the archive at `height` without
+    /// fetching it.
+    async fn has_finalization_by_height(&self, height: Height) -> bool {
+        match self.finalizations_by_height.has(height).await {
+            Ok(has) => has,
+            Err(e) => panic!("failed to check finalization: {e}"),
         }
     }
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -142,12 +142,14 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
-    // Finalized-archive write batches that are buffered but not yet durable,
-    // keyed by the sequence of the pooled sync that first covers them and
-    // holding the lowest height written in the batch. `try_dispatch_blocks`
-    // never dispatches at or above the lowest pending height.
+    // Dispatch frontiers captured by in-flight pooled finalized-archive
+    // syncs, keyed by sync sequence. `try_dispatch_blocks` never dispatches
+    // at or above the lowest pending frontier.
     pending_finalized_syncs: BTreeMap<u64, Height>,
-    // Sequence assigned to the next pooled finalized-archive sync.
+    // Sequence assigned to the next pooled finalized-archive sync. Never
+    // reused: a late completion releases every entry at or below its
+    // sequence, so a reused sequence could release batches the completed
+    // sync never covered.
     finalized_sync_seq: u64,
 
     // ---------- Storage ----------
@@ -379,8 +381,8 @@ where
         // Observe durable syncs that no consensus caller awaits (the
         // notarization and finalization paths). A flush failure inside
         // `start_sync` is reported only through the returned handle, so every
-        // handle must be observed to apply the fatal policy; this pool does so
-        // without blocking the actor on fsync.
+        // handle must be observed to apply the fatal policy. This pool does
+        // so without blocking the actor on fsync.
         let mut syncs = Pool::<PooledSync>::default();
 
         // Anchor all startup work under a single root span. Tip recovery, floor
@@ -508,6 +510,7 @@ where
                     message,
                     &mut resolver_rx,
                     &mut resolver,
+                    &mut syncs,
                     &mut buffer,
                     &mut application,
                 )
@@ -791,24 +794,8 @@ where
                     {
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
-                        if self.try_repair_gaps(buffer, resolver, application).await {
-                            // Repair wrote blocks at heights below the new
-                            // finalization, so sync inline (blocking): the
-                            // batch's lowest height is not tracked, which the
-                            // pooled dispatch barrier would need. Repair only
-                            // runs while catching up, so the mailbox stall is
-                            // acceptable here.
-                            self.sync_finalized().await;
-                        } else {
-                            // Hot path: only `height` was written. Make it
-                            // durable on the sync pool so the mailbox keeps
-                            // serving reads (e.g. the proposer's
-                            // `get_verified`) during the fsync; dispatch of
-                            // this block is deferred to the pool-completion
-                            // arm by the barrier in `try_dispatch_blocks`.
-                            self.start_finalized_sync(height, round, syncs).await;
-                        }
-                        self.try_dispatch_blocks(application).await;
+                        self.try_repair_gaps(buffer, resolver, application).await;
+                        self.start_finalized_sync(round, syncs).await;
                         debug!(?round, %height, "finalized block stored");
                     }
                 } else {
@@ -945,6 +932,7 @@ where
         message: handler::Message<V::Commitment>,
         resolver_rx: &mut handler::Receiver<V::Commitment>,
         resolver: &mut R,
+        syncs: &mut Pool<PooledSync>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
     ) where
@@ -1016,12 +1004,8 @@ where
         needs_sync |= self.try_repair_gaps(buffer, resolver, application).await;
 
         if needs_sync {
-            // Sync archives before responding to peers so accepted repair data is
-            // durable before this node serves it. Inline (blocking) is required:
-            // the produce responses below run in this same arm and must not be
-            // sent before the data they serve is durable.
-            self.sync_finalized().await;
-            self.try_dispatch_blocks(application).await;
+            self.start_finalized_sync(self.floor.processed_round(), syncs)
+                .await;
         }
 
         // Handle produce requests in parallel.
@@ -1297,9 +1281,6 @@ where
                 .expect("pending floor anchor missing");
             self.update_processed_round_floor(height, finalization.round(), resolver)
                 .await;
-            // Sync inline (blocking): floor transitions are rare, and repair
-            // batches do not track the lowest height the pooled dispatch
-            // barrier would need.
             if self.try_repair_gaps(buffer, resolver, application).await {
                 self.sync_finalized().await;
             }
@@ -1330,9 +1311,6 @@ where
             }
         )
         .expect("failed to store floor anchor");
-        // Sync inline (blocking): every step below (metadata sync, pruning,
-        // dispatch) requires the anchor to already be durable, and floor
-        // transitions are rare.
         self.sync_finalized().await;
 
         if height > self.tip {
@@ -1366,10 +1344,6 @@ where
         // Intentionally keep existing block subscriptions alive. Canceling
         // waiters can have catastrophic consequences (nodes can get stuck in
         // different views) as actors do not retry subscriptions on failed channels.
-        //
-        // Sync inline (blocking): floor transitions are rare, and repair
-        // batches do not track the lowest height the pooled dispatch barrier
-        // would need.
         if self.try_repair_gaps(buffer, resolver, application).await {
             self.sync_finalized().await;
         }
@@ -1791,14 +1765,11 @@ where
     /// updated later, in a subsequent `select_loop!` iteration, when the ack
     /// handler updates the processed height.
     ///
-    /// Anything fed to the application from this method is already durably
-    /// persisted in marshal: callers must make preceding finalized-archive
-    /// writes durable with [`Self::sync_finalized`] (blocking) or register
-    /// them with [`Self::start_finalized_sync`] (pooled) before yielding to
-    /// the `select_loop!`. Registered batches gate dispatch below: no block at
-    /// or above the lowest non-durable height is dispatched until the covering
-    /// pooled sync completes, at which point the pool-completion arm re-runs
-    /// this method.
+    /// Blocks are dispatched only once durable. Callers that buffer
+    /// finalized-archive writes must call [`Self::sync_finalized`] or
+    /// [`Self::start_finalized_sync`] before yielding to the `select_loop!`.
+    /// A pooled sync freezes dispatch at the frontier it captured until it
+    /// completes, at which point the pool-completion arm re-runs this method.
     ///
     /// Acks are processed in FIFO order so the processed floor height always
     /// advances sequentially.
@@ -1812,8 +1783,6 @@ where
     /// Iteration N (caller):
     ///   store_finalization   ->  Archive::put (buffered)
     ///   sync_finalized       ->  archive durable
-    ///     (or start_finalized_sync -> dispatch of the batch deferred to the
-    ///      pool-completion arm, which runs after the archive is durable)
     ///   try_dispatch_blocks  ->  sends durable blocks to app, enqueues pending acks
     ///
     /// Iteration M (ack handler, M > N):
@@ -1883,10 +1852,9 @@ where
     /// It also ensures archives are durable before the ack handler advances
     /// the processed floor height. See [`Self::try_dispatch_blocks`] for details.
     ///
-    /// Blocking the actor stalls every mailbox caller behind the fsync. Paths
-    /// that know the lowest height they wrote (and do not serve the written
-    /// data later in the same arm) should prefer the non-blocking
-    /// [`Self::start_finalized_sync`].
+    /// Blocking the actor stalls every mailbox caller behind the fsync.
+    /// Prefer [`Self::start_finalized_sync`] unless work later in the same
+    /// arm requires the writes to already be durable.
     #[tracing::instrument(name = "marshal.actor.sync_finalized", level = "info", skip_all)]
     async fn sync_finalized(&mut self) {
         if let Err(e) = try_join!(
@@ -1916,24 +1884,23 @@ where
     ///
     /// The pooled entry resolves to [`PooledSync::Finalized`] once every write
     /// accepted before this call is durable. Until the pool-completion arm
-    /// observes it, [`Self::try_dispatch_blocks`] will not dispatch any block
-    /// at or above `lowest` (the lowest height written in this batch),
-    /// preserving the durability barrier described there without blocking the
-    /// mailbox on an fsync like [`Self::sync_finalized`].
+    /// observes it, [`Self::try_dispatch_blocks`] will not dispatch at or
+    /// above the dispatch frontier captured here. Dispatch never revisits
+    /// heights below the frontier, so freezing it preserves the durability
+    /// barrier described there without blocking the mailbox on an fsync like
+    /// [`Self::sync_finalized`].
     ///
     /// Like [`Self::sync_finalized`], this must be called within the same
     /// `select_loop!` arm as the writes it covers, before yielding back to the
-    /// loop.
+    /// loop. `round` only labels the sync in diagnostics.
     #[tracing::instrument(name = "marshal.actor.start_finalized_sync", level = "info", skip_all)]
-    async fn start_finalized_sync(
-        &mut self,
-        lowest: Height,
-        round: Round,
-        syncs: &mut Pool<PooledSync>,
-    ) {
+    async fn start_finalized_sync(&mut self, round: Round, syncs: &mut Pool<PooledSync>) {
+        let frontier = self
+            .pending_acks
+            .next_dispatch_height(self.stream.next_height());
         let seq = self.finalized_sync_seq;
         self.finalized_sync_seq += 1;
-        self.pending_finalized_syncs.insert(seq, lowest);
+        self.pending_finalized_syncs.insert(seq, frontier);
 
         let (blocks, finalizations) = match try_join!(
             async {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -77,7 +77,7 @@ enum PooledSync {
     /// assigned by [`Actor::start_finalized_sync`] so the completion arm can
     /// release the application-dispatch barrier for every batch the sync
     /// covers (a sync makes durable every write accepted before it started,
-    /// including batches registered under earlier sequences).
+    /// including batches adopted by earlier sequences).
     Finalized(u64),
 }
 
@@ -142,14 +142,18 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
-    // Lowest buffered finalized-archive write height per sync batch, keyed
-    // by sync sequence. Writes accumulate under `finalized_sync_seq` until a
-    // sync starts and adopts them. `try_dispatch_blocks` never dispatches at
-    // or above the lowest entry: buffered writes are readable from the
-    // archives before they are durable.
+    // Lowest height written to the finalized archives since the last sync
+    // (blocking or pooled) was started. Buffered writes are readable from
+    // the archives before they are durable, so `try_dispatch_blocks` never
+    // dispatches at or above this height. The next started sync adopts it
+    // into `pending_finalized_syncs`.
+    unsynced_finalized_write: Option<Height>,
+    // Lowest write height adopted by each in-flight pooled finalized-archive
+    // sync, keyed by start order. `try_dispatch_blocks` never dispatches at
+    // or above the lowest entry, and a completed sync releases every entry
+    // at or below its sequence (see `finalized_sync_completed`).
     pending_finalized_syncs: BTreeMap<u64, Height>,
-    // Sequence assigned to the next pooled finalized-archive sync and the
-    // key under which new writes accumulate until that sync starts.
+    // Sequence assigned to the next started pooled finalized-archive sync.
     finalized_sync_seq: u64,
 
     // ---------- Storage ----------
@@ -261,6 +265,7 @@ where
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
+                unsynced_finalized_write: None,
                 pending_finalized_syncs: BTreeMap::new(),
                 finalized_sync_seq: 0,
                 cache,
@@ -922,8 +927,8 @@ where
         }
     }
 
-    /// Handles a batch of resolver messages, syncing finalized archives once if
-    /// any accepted delivery buffered a write.
+    /// Handles a batch of resolver messages, starting one pooled
+    /// finalized-archive sync if any accepted delivery buffered a write.
     async fn handle_resolver_message<Buf, R>(
         &mut self,
         message: handler::Message<V::Commitment>,
@@ -936,7 +941,6 @@ where
         Buf: Buffer<V, PublicKey = <P::Scheme as Verifier>::PublicKey>,
         R: Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     {
-        let mut needs_sync = false;
         let mut handled = false;
         let mut produces = Vec::new();
         let mut delivers = Vec::new();
@@ -970,20 +974,19 @@ where
                     for (_, subscriber_span) in delivery.subscribers.iter().skip(1) {
                         span.follows_from(subscriber_span.id());
                     }
-                    needs_sync |= self
-                        .handle_deliver(
-                            ResolverDelivery {
-                                delivery,
-                                value,
-                                response,
-                            },
-                            &mut delivers,
-                            buffer,
-                            application,
-                            resolver,
-                        )
-                        .instrument(span)
-                        .await;
+                    self.handle_deliver(
+                        ResolverDelivery {
+                            delivery,
+                            value,
+                            response,
+                        },
+                        &mut delivers,
+                        buffer,
+                        application,
+                        resolver,
+                    )
+                    .instrument(span)
+                    .await;
                 }
             }
         }
@@ -992,21 +995,18 @@ where
         }
 
         // Batch verify and process all certificate-bearing deliveries.
-        needs_sync |= self
-            .verify_delivered(delivers, buffer, application, resolver)
+        self.verify_delivered(delivers, buffer, application, resolver)
             .await;
 
         // Attempt to fill gaps before handling produce requests so we can serve
         // data received earlier in the same batch.
-        needs_sync |= self.try_repair_gaps(buffer, resolver, application).await;
+        self.try_repair_gaps(buffer, resolver, application).await;
 
-        // Start a pooled sync so the batch's buffered writes become durable
-        // without blocking the mailbox. Dispatch of the written heights
-        // resumes when the sync completes.
-        if needs_sync {
-            self.start_finalized_sync(self.floor.processed_round(), syncs)
-                .await;
-        }
+        // Start a pooled sync so any writes buffered by this batch become
+        // durable without blocking the mailbox. Dispatch of the written
+        // heights resumes when the sync completes.
+        self.start_finalized_sync(self.floor.processed_round(), syncs)
+            .await;
 
         // Handle produce requests in parallel.
         join_all(
@@ -1311,7 +1311,6 @@ where
             }
         )
         .expect("failed to store floor anchor");
-        self.record_finalized_write(height);
         self.sync_finalized().await;
 
         if height > self.tip {
@@ -1354,7 +1353,6 @@ where
     /// Handle a deliver message from the resolver. Block delivers are handled
     /// immediately. Finalized/Notarized delivers are parsed and structurally
     /// validated, then collected into `delivers` for batch certificate verification.
-    /// Returns true if finalization archives were written and need syncing.
     async fn handle_deliver<Buf: Buffer<V>>(
         &mut self,
         message: ResolverDelivery<V>,
@@ -1362,7 +1360,7 @@ where
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
-    ) -> bool {
+    ) {
         let ResolverDelivery {
             delivery,
             mut value,
@@ -1376,11 +1374,11 @@ where
                 let block_cfg = V::block_cfg(&self.block_codec_config, commitment);
                 let Ok(block) = V::Block::decode_cfg(value.as_ref(), &block_cfg) else {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 };
                 if V::commitment(&block) != commitment {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 }
 
                 // This block may match the pending floor request. Whether it
@@ -1392,7 +1390,7 @@ where
                     .await
                 {
                     response.send_lossy(true);
-                    return false;
+                    return;
                 }
 
                 // The peer-visible request only says "give me this block".
@@ -1412,7 +1410,7 @@ where
                     self.update_processed_round_floor(height, finalization.round(), resolver)
                         .await;
                 }
-                let wrote = if finalization.is_some()
+                if finalization.is_some()
                     || annotations
                         .iter()
                         .any(|annotation| matches!(annotation, Annotation::Finalized(_)))
@@ -1424,29 +1422,25 @@ where
                         finalization,
                         application,
                     )
-                    .await
-                } else {
-                    if annotations
-                        .iter()
-                        .any(|annotation| matches!(annotation, Annotation::Certified { .. }))
-                        && height > self.floor.processed_height()
-                    {
-                        if let Some(bounds) = self.epocher.containing(height) {
-                            self.cache
-                                .put_certified(
-                                    bounds.epoch(),
-                                    height,
-                                    digest,
-                                    Arc::unwrap_or_clone(block).into(),
-                                )
-                                .await;
-                        }
+                    .await;
+                } else if annotations
+                    .iter()
+                    .any(|annotation| matches!(annotation, Annotation::Certified { .. }))
+                    && height > self.floor.processed_height()
+                {
+                    if let Some(bounds) = self.epocher.containing(height) {
+                        self.cache
+                            .put_certified(
+                                bounds.epoch(),
+                                height,
+                                digest,
+                                Arc::unwrap_or_clone(block).into(),
+                            )
+                            .await;
                     }
-                    false
-                };
+                }
                 debug!(?digest, %height, "received block");
                 response.send_lossy(true);
-                wrote
             }
             Key::Finalized { height } => {
                 let Some((epoch, certificate_codec_config)) =
@@ -1458,14 +1452,14 @@ where
                         "ignoring stale delivery"
                     );
                     response.send_lossy(true);
-                    return false;
+                    return;
                 };
 
                 let Ok(finalization) =
                     Finalization::read_cfg(&mut value, &certificate_codec_config)
                 else {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 };
 
                 // We decoded the certificate with the codec config for the height's epoch, so the
@@ -1473,7 +1467,7 @@ where
                 // against the wrong participant set, so reject before verification.
                 if finalization.epoch() != epoch {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 }
 
                 // Decode the block carried with the finalization. Below, it is checked against
@@ -1482,7 +1476,7 @@ where
                     V::ApplicationBlock::decode_cfg(&mut value, &self.block_codec_config)
                 else {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 };
 
                 // In contrast to the `Block` and `Notarization` deliveries, the finalization delivery
@@ -1497,14 +1491,13 @@ where
                 if block.height() != height || block.digest() != V::commitment_to_inner(commitment)
                 {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 }
                 delivers.push(PendingVerification::Finalized {
                     finalization,
                     block,
                     response,
                 });
-                false
             }
             Key::Notarized { round } => {
                 let Some(scheme) = self.provider.scheme(round.epoch()) else {
@@ -1514,21 +1507,21 @@ where
                         "ignoring stale delivery"
                     );
                     response.send_lossy(true);
-                    return false;
+                    return;
                 };
                 let certificate_codec_config = scheme.certificate_codec_config();
                 let Ok(notarization) =
                     Notarization::read_cfg(&mut value, &certificate_codec_config)
                 else {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 };
 
                 // The resolver key binds this response to `round`; a certificate for any other
                 // round is a bad response even if it decodes correctly.
                 if notarization.round() != round {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 }
 
                 // Use the notarization payload to derive the block decode config. Below, the
@@ -1536,30 +1529,28 @@ where
                 let commitment = notarization.proposal.payload;
                 if !V::check_payload(scheme.as_ref(), commitment) {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 }
                 let block_cfg = V::block_cfg(&self.block_codec_config, commitment);
                 let Ok(block) = V::Block::decode_cfg(value, &block_cfg) else {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 };
 
                 if V::commitment(&block) != notarization.proposal.payload {
                     response.send_lossy(false);
-                    return false;
+                    return;
                 }
                 delivers.push(PendingVerification::Notarized {
                     notarization,
                     block,
                     response,
                 });
-                false
             }
         }
     }
 
-    /// Batch verify pending certificates and process valid items. Returns true
-    /// if finalization archives were written and need syncing.
+    /// Batch verify pending certificates and process valid items.
     #[tracing::instrument(name = "marshal.actor.verify_delivered", level = "info", skip_all, fields(count = delivers.len().traced()))]
     async fn verify_delivered<Buf: Buffer<V>>(
         &mut self,
@@ -1567,10 +1558,10 @@ where
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
-    ) -> bool {
+    ) {
         delivers.retain(|item| !item.response_closed());
         if delivers.is_empty() {
-            return false;
+            return;
         }
 
         // Extract (subject, certificate) pairs for batch verification.
@@ -1617,7 +1608,6 @@ where
         }
 
         // Process each verified item, rejecting unverified ones.
-        let mut wrote = false;
         for (index, item) in delivers.drain(..).enumerate() {
             if !verified[index] {
                 match item {
@@ -1657,15 +1647,14 @@ where
                     self.update_processed_round_floor(height, round, resolver)
                         .await;
 
-                    wrote |= self
-                        .store_finalization(
-                            height,
-                            digest,
-                            Arc::unwrap_or_clone(block),
-                            Some(finalization),
-                            application,
-                        )
-                        .await;
+                    self.store_finalization(
+                        height,
+                        digest,
+                        Arc::unwrap_or_clone(block),
+                        Some(finalization),
+                        application,
+                    )
+                    .await;
                 }
                 PendingVerification::Notarized {
                     notarization,
@@ -1717,21 +1706,18 @@ where
 
                         // SAFETY: `digest` identifies a unique `commitment`, so this
                         // cached finalization payload must match `V::commitment(&block)`.
-                        wrote |= self
-                            .store_finalization(
-                                height,
-                                digest,
-                                Arc::unwrap_or_clone(block),
-                                Some(finalization),
-                                application,
-                            )
-                            .await;
+                        self.store_finalization(
+                            height,
+                            digest,
+                            Arc::unwrap_or_clone(block),
+                            Some(finalization),
+                            application,
+                        )
+                        .await;
                     }
                 }
             }
         }
-
-        wrote
     }
 
     /// Returns the certificate codec config for `epoch`.
@@ -1767,13 +1753,13 @@ where
     /// handler updates the processed height.
     ///
     /// Blocks are dispatched only once durable. Every buffered
-    /// finalized-archive write freezes dispatch at or above its height until
-    /// a sync covering it completes (see [`Self::record_finalized_write`]).
-    /// Dispatch is then re-attempted by the pool-completion arm for pooled
-    /// syncs and by the caller itself after a blocking sync. Callers that
-    /// buffer writes must still call [`Self::sync_finalized`] or
-    /// [`Self::start_finalized_sync`] before yielding to the `select_loop!`
-    /// so the freeze is released.
+    /// finalized-archive write freezes dispatch at or above its height, first
+    /// via `unsynced_finalized_write` and then, once a started sync adopts it,
+    /// via `pending_finalized_syncs`. Dispatch is re-attempted by the
+    /// pool-completion arm for pooled syncs and by the caller itself after a
+    /// blocking sync. Callers that buffer writes must still call
+    /// [`Self::sync_finalized`] or [`Self::start_finalized_sync`] before
+    /// yielding to the `select_loop!` so the freeze is released.
     ///
     /// Acks are processed in FIFO order so the processed floor height always
     /// advances sequentially.
@@ -1804,9 +1790,14 @@ where
 
         // Durability barrier: buffered writes are readable from the archives
         // before they are durable, and every such write is tracked in
-        // `pending_finalized_syncs` until the sync covering it completes.
-        // Never dispatch at or above the lowest one.
-        let non_durable = self.pending_finalized_syncs.values().min().copied();
+        // `unsynced_finalized_write` or `pending_finalized_syncs` until a sync
+        // covering it completes. Never dispatch at or above the lowest one.
+        let non_durable = self
+            .pending_finalized_syncs
+            .values()
+            .copied()
+            .chain(self.unsynced_finalized_write)
+            .min();
         while self.pending_acks.has_capacity() {
             let next_height = self
                 .pending_acks
@@ -1878,30 +1869,38 @@ where
         }
 
         // A blocking sync waits on (and covers) every previously accepted
-        // write, including batches whose pooled syncs are still in flight or
-        // not yet started, so all pending batches are durable once it returns.
+        // write, including writes adopted by in-flight pooled syncs and writes
+        // no sync has adopted yet, so nothing gates dispatch once it returns.
+        self.unsynced_finalized_write = None;
         self.pending_finalized_syncs.clear();
     }
 
     /// Start a non-blocking sync of both finalization archives on the
-    /// durability pool.
+    /// durability pool. A no-op if nothing was written since the last sync
+    /// (blocking or pooled) started.
     ///
     /// The pooled entry resolves to [`PooledSync::Finalized`] once every write
-    /// accepted before this call is durable. The sync adopts the batch of
-    /// writes recorded under the current sequence (see
-    /// [`Self::record_finalized_write`]), and until the pool-completion arm
-    /// observes the completion, [`Self::try_dispatch_blocks`] will not
-    /// dispatch at or above the lowest height a pending batch wrote. This
-    /// preserves the durability barrier described there without blocking the
-    /// mailbox on an fsync like [`Self::sync_finalized`].
+    /// accepted before this call is durable. The sync adopts
+    /// `unsynced_finalized_write`, and until the pool-completion arm observes
+    /// the completion, [`Self::try_dispatch_blocks`] will not dispatch at or
+    /// above the lowest height a pending batch wrote. This preserves the
+    /// durability barrier described there without blocking the mailbox on an
+    /// fsync like [`Self::sync_finalized`].
     ///
     /// Like [`Self::sync_finalized`], this must be called within the same
     /// `select_loop!` arm as the writes it covers, before yielding back to the
     /// loop. `round` only labels the sync in diagnostics.
     #[tracing::instrument(name = "marshal.actor.start_finalized_sync", level = "info", skip_all)]
     async fn start_finalized_sync(&mut self, round: Round, syncs: &mut Pool<PooledSync>) {
+        // Adopt every write since the last started sync. If there are none,
+        // every accepted write is already covered by a blocking or in-flight
+        // sync.
+        let Some(lowest) = self.unsynced_finalized_write.take() else {
+            return;
+        };
         let seq = self.finalized_sync_seq;
         self.finalized_sync_seq += 1;
+        self.pending_finalized_syncs.insert(seq, lowest);
 
         let (blocks, finalizations) = match try_join!(
             async {
@@ -1944,16 +1943,6 @@ where
     /// order in which pooled syncs complete.
     fn finalized_sync_completed(&mut self, seq: u64) {
         self.pending_finalized_syncs = self.pending_finalized_syncs.split_off(&(seq + 1));
-    }
-
-    /// Records a buffered finalized-archive write at `height` under the next
-    /// sync's sequence, deferring dispatch at or above it until that sync (or
-    /// a blocking [`Self::sync_finalized`]) makes it durable.
-    fn record_finalized_write(&mut self, height: Height) {
-        self.pending_finalized_syncs
-            .entry(self.finalized_sync_seq)
-            .and_modify(|lowest| *lowest = (*lowest).min(height))
-            .or_insert(height);
     }
 
     // -------------------- Immutable Storage --------------------
@@ -2061,7 +2050,12 @@ where
         ) {
             panic!("failed to finalize: {e}");
         }
-        self.record_finalized_write(height);
+
+        // Gate dispatch at or above this write until a sync covers it.
+        self.unsynced_finalized_write = Some(
+            self.unsynced_finalized_write
+                .map_or(height, |lowest| lowest.min(height)),
+        );
 
         // Update metrics and application
         if let Some(round) = round.filter(|_| height > self.tip) {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -2,7 +2,7 @@ use super::{
     acks::{PendingAck, PendingAcks},
     cache,
     delivery::PendingVerification,
-    durability::Durable as _,
+    durability::{DispatchGate, Durable as _},
     floor::Floor,
     mailbox::{CommitmentFallback, Mailbox, Message},
     stream::Stream,
@@ -75,9 +75,7 @@ enum PooledSync {
     Observed,
     /// A finalized-archive sync batch became durable. Carries the sequence
     /// assigned by [`Actor::start_finalized_sync`] so the completion arm can
-    /// release the application-dispatch barrier for every batch the sync
-    /// covers (a sync makes durable every write accepted before it started,
-    /// including batches adopted by earlier sequences).
+    /// release every batch the sync covers (see [`DispatchGate::release`]).
     Finalized(u64),
 }
 
@@ -142,19 +140,9 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
-    // Lowest height written to the finalized archives since the last sync
-    // (blocking or pooled) was started. Buffered writes are readable from
-    // the archives before they are durable, so `try_dispatch_blocks` never
-    // dispatches at or above this height. The next started sync adopts it
-    // into `pending_finalized_syncs`.
-    unsynced_finalized_write: Option<Height>,
-    // Lowest write height adopted by each in-flight pooled finalized-archive
-    // sync, keyed by start order. `try_dispatch_blocks` never dispatches at
-    // or above the lowest entry, and a completed sync releases every entry
-    // at or below its sequence (see `finalized_sync_completed`).
-    pending_finalized_syncs: BTreeMap<u64, Height>,
-    // Sequence assigned to the next started pooled finalized-archive sync.
-    finalized_sync_seq: u64,
+    // Defers application dispatch of finalized-archive writes until a sync
+    // covering them completes
+    dispatch_gate: DispatchGate,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -265,9 +253,7 @@ where
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
-                unsynced_finalized_write: None,
-                pending_finalized_syncs: BTreeMap::new(),
-                finalized_sync_seq: 0,
+                dispatch_gate: DispatchGate::default(),
                 cache,
                 finalizations_by_height,
                 finalized_blocks,
@@ -449,7 +435,7 @@ where
             // for the batches it covers and resumes application dispatch.
             sync = syncs.next_completed() => {
                 if let PooledSync::Finalized(seq) = sync {
-                    self.finalized_sync_completed(seq);
+                    self.dispatch_gate.release(seq);
                     self.try_dispatch_blocks(&mut application).await;
                 }
             },
@@ -1753,13 +1739,12 @@ where
     /// handler updates the processed height.
     ///
     /// Blocks are dispatched only once durable. Every buffered
-    /// finalized-archive write freezes dispatch at or above its height, first
-    /// via `unsynced_finalized_write` and then, once a started sync adopts it,
-    /// via `pending_finalized_syncs`. Dispatch is re-attempted by the
-    /// pool-completion arm for pooled syncs and by the caller itself after a
-    /// blocking sync. Callers that buffer writes must still call
-    /// [`Self::sync_finalized`] or [`Self::start_finalized_sync`] before
-    /// yielding to the `select_loop!` so the freeze is released.
+    /// finalized-archive write freezes dispatch at or above its height until
+    /// a sync covering it completes (see [`DispatchGate`]). Dispatch is
+    /// re-attempted by the pool-completion arm for pooled syncs and by the
+    /// caller itself after a blocking sync. Callers that buffer writes must
+    /// still call [`Self::sync_finalized`] or [`Self::start_finalized_sync`]
+    /// before yielding to the `select_loop!` so the freeze is released.
     ///
     /// Acks are processed in FIFO order so the processed floor height always
     /// advances sequentially.
@@ -1789,15 +1774,9 @@ where
         }
 
         // Durability barrier: buffered writes are readable from the archives
-        // before they are durable, and every such write is tracked in
-        // `unsynced_finalized_write` or `pending_finalized_syncs` until a sync
-        // covering it completes. Never dispatch at or above the lowest one.
-        let non_durable = self
-            .pending_finalized_syncs
-            .values()
-            .copied()
-            .chain(self.unsynced_finalized_write)
-            .min();
+        // before they are durable. Never dispatch at or above the lowest
+        // write not yet covered by a completed sync.
+        let non_durable = self.dispatch_gate.barrier();
         while self.pending_acks.has_capacity() {
             let next_height = self
                 .pending_acks
@@ -1868,11 +1847,9 @@ where
             panic!("failed to sync finalization archives: {e}");
         }
 
-        // A blocking sync waits on (and covers) every previously accepted
-        // write, including writes adopted by in-flight pooled syncs and writes
-        // no sync has adopted yet, so nothing gates dispatch once it returns.
-        self.unsynced_finalized_write = None;
-        self.pending_finalized_syncs.clear();
+        // Everything accepted before this sync is now durable, so nothing
+        // remains to gate dispatch.
+        self.dispatch_gate.clear();
     }
 
     /// Start a non-blocking sync of both finalization archives on the
@@ -1880,27 +1857,23 @@ where
     /// (blocking or pooled) started.
     ///
     /// The pooled entry resolves to [`PooledSync::Finalized`] once every write
-    /// accepted before this call is durable. The sync adopts
-    /// `unsynced_finalized_write`, and until the pool-completion arm observes
-    /// the completion, [`Self::try_dispatch_blocks`] will not dispatch at or
-    /// above the lowest height a pending batch wrote. This preserves the
-    /// durability barrier described there without blocking the mailbox on an
-    /// fsync like [`Self::sync_finalized`].
+    /// accepted before this call is durable. The sync adopts every deferred
+    /// write (see [`DispatchGate::adopt`]), and until the pool-completion arm
+    /// observes the completion, [`Self::try_dispatch_blocks`] will not
+    /// dispatch at or above the lowest height a pending batch wrote. This
+    /// preserves the durability barrier described there without blocking the
+    /// mailbox on an fsync like [`Self::sync_finalized`].
     ///
     /// Like [`Self::sync_finalized`], this must be called within the same
     /// `select_loop!` arm as the writes it covers, before yielding back to the
     /// loop. `round` only labels the sync in diagnostics.
     #[tracing::instrument(name = "marshal.actor.start_finalized_sync", level = "info", skip_all)]
     async fn start_finalized_sync(&mut self, round: Round, syncs: &mut Pool<PooledSync>) {
-        // Adopt every write since the last started sync. If there are none,
-        // every accepted write is already covered by a blocking or in-flight
-        // sync.
-        let Some(lowest) = self.unsynced_finalized_write.take() else {
+        // If no write needs syncing, every accepted write is already covered
+        // by a blocking or in-flight sync.
+        let Some(seq) = self.dispatch_gate.adopt() else {
             return;
         };
-        let seq = self.finalized_sync_seq;
-        self.finalized_sync_seq += 1;
-        self.pending_finalized_syncs.insert(seq, lowest);
 
         let (blocks, finalizations) = match try_join!(
             async {
@@ -1933,16 +1906,6 @@ where
                 PooledSync::Observed
             }
         });
-    }
-
-    /// Releases the dispatch barrier for every finalized-archive batch covered
-    /// by the completed pooled sync `seq`.
-    ///
-    /// A sync makes durable every write accepted before it started, so all
-    /// batches with an equal or lower sequence are released, regardless of the
-    /// order in which pooled syncs complete.
-    fn finalized_sync_completed(&mut self, seq: u64) {
-        self.pending_finalized_syncs = self.pending_finalized_syncs.split_off(&(seq + 1));
     }
 
     // -------------------- Immutable Storage --------------------
@@ -2051,11 +2014,9 @@ where
             panic!("failed to finalize: {e}");
         }
 
-        // Gate dispatch at or above this write until a sync covers it.
-        self.unsynced_finalized_write = Some(
-            self.unsynced_finalized_write
-                .map_or(height, |lowest| lowest.min(height)),
-        );
+        // The write above is buffered and readable before it is durable, so
+        // hold dispatch at or above it until a sync covers it.
+        self.dispatch_gate.defer(height);
 
         // Update metrics and application
         if let Some(round) = round.filter(|_| height > self.tip) {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -142,11 +142,14 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
-    // Dispatch frontiers captured by in-flight pooled finalized-archive
-    // syncs, keyed by sync sequence. `try_dispatch_blocks` never dispatches
-    // at or above the lowest pending frontier.
+    // Lowest buffered finalized-archive write height per sync batch, keyed
+    // by sync sequence. Writes accumulate under `finalized_sync_seq` until a
+    // sync starts and adopts them. `try_dispatch_blocks` never dispatches at
+    // or above the lowest entry: buffered writes are readable from the
+    // archives before they are durable.
     pending_finalized_syncs: BTreeMap<u64, Height>,
-    // Sequence assigned to the next pooled finalized-archive sync. Never
+    // Sequence assigned to the next pooled finalized-archive sync and the
+    // key under which new writes accumulate until that sync starts. Never
     // reused: a late completion releases every entry at or below its
     // sequence, so a reused sequence could release batches the completed
     // sync never covered.
@@ -999,7 +1002,6 @@ where
         // Attempt to fill gaps before handling produce requests so we can serve
         // data received earlier in the same batch.
         needs_sync |= self.try_repair_gaps(buffer, resolver, application).await;
-
         if needs_sync {
             self.start_finalized_sync(self.floor.processed_round(), syncs)
                 .await;
@@ -1308,6 +1310,7 @@ where
             }
         )
         .expect("failed to store floor anchor");
+        self.record_finalized_write(height);
         self.sync_finalized().await;
 
         if height > self.tip {
@@ -1762,11 +1765,13 @@ where
     /// updated later, in a subsequent `select_loop!` iteration, when the ack
     /// handler updates the processed height.
     ///
-    /// Blocks are dispatched only once durable. Callers that buffer
-    /// finalized-archive writes must call [`Self::sync_finalized`] or
-    /// [`Self::start_finalized_sync`] before yielding to the `select_loop!`.
-    /// A pooled sync freezes dispatch at the frontier it captured until it
-    /// completes, at which point the pool-completion arm re-runs this method.
+    /// Blocks are dispatched only once durable. Every buffered
+    /// finalized-archive write freezes dispatch at or above its height until
+    /// a sync covering it completes (see [`Self::record_finalized_write`]),
+    /// at which point the pool-completion arm re-runs this method. Callers
+    /// that buffer writes must still call [`Self::sync_finalized`] or
+    /// [`Self::start_finalized_sync`] before yielding to the `select_loop!`
+    /// so the freeze is released.
     ///
     /// Acks are processed in FIFO order so the processed floor height always
     /// advances sequentially.
@@ -1795,11 +1800,11 @@ where
             return;
         }
 
-        // Durability barrier: a pooled finalized-archive sync may still be in
-        // flight (see `start_finalized_sync`), and buffered writes are readable
-        // from the archives before they are durable.
+        // Durability barrier: buffered writes are readable from the archives
+        // before they are durable, and every such write is tracked in
+        // `pending_finalized_syncs` until the sync covering it completes.
+        // Never dispatch at or above the lowest one.
         let non_durable = self.pending_finalized_syncs.values().min().copied();
-
         while self.pending_acks.has_capacity() {
             let next_height = self
                 .pending_acks
@@ -1871,8 +1876,8 @@ where
         }
 
         // A blocking sync waits on (and covers) every previously accepted
-        // write, including batches whose pooled syncs are still in flight, so
-        // all pending batches are durable once it returns.
+        // write, including batches whose pooled syncs are still in flight or
+        // not yet started, so all pending batches are durable once it returns.
         self.pending_finalized_syncs.clear();
     }
 
@@ -1880,24 +1885,21 @@ where
     /// durability pool.
     ///
     /// The pooled entry resolves to [`PooledSync::Finalized`] once every write
-    /// accepted before this call is durable. Until the pool-completion arm
-    /// observes it, [`Self::try_dispatch_blocks`] will not dispatch at or
-    /// above the dispatch frontier captured here. Dispatch never revisits
-    /// heights below the frontier, so freezing it preserves the durability
-    /// barrier described there without blocking the mailbox on an fsync like
-    /// [`Self::sync_finalized`].
+    /// accepted before this call is durable. The sync adopts the batch of
+    /// writes recorded under the current sequence (see
+    /// [`Self::record_finalized_write`]), and until the pool-completion arm
+    /// observes the completion, [`Self::try_dispatch_blocks`] will not
+    /// dispatch at or above the lowest height a pending batch wrote. This
+    /// preserves the durability barrier described there without blocking the
+    /// mailbox on an fsync like [`Self::sync_finalized`].
     ///
     /// Like [`Self::sync_finalized`], this must be called within the same
     /// `select_loop!` arm as the writes it covers, before yielding back to the
     /// loop. `round` only labels the sync in diagnostics.
     #[tracing::instrument(name = "marshal.actor.start_finalized_sync", level = "info", skip_all)]
     async fn start_finalized_sync(&mut self, round: Round, syncs: &mut Pool<PooledSync>) {
-        let frontier = self
-            .pending_acks
-            .next_dispatch_height(self.stream.next_height());
         let seq = self.finalized_sync_seq;
         self.finalized_sync_seq += 1;
-        self.pending_finalized_syncs.insert(seq, frontier);
 
         let (blocks, finalizations) = match try_join!(
             async {
@@ -1940,6 +1942,16 @@ where
     /// order in which pooled syncs complete.
     fn finalized_sync_completed(&mut self, seq: u64) {
         self.pending_finalized_syncs = self.pending_finalized_syncs.split_off(&(seq + 1));
+    }
+
+    /// Records a buffered finalized-archive write at `height` under the next
+    /// sync's sequence, deferring dispatch at or above it until that sync (or
+    /// a blocking [`Self::sync_finalized`]) makes it durable.
+    fn record_finalized_write(&mut self, height: Height) {
+        self.pending_finalized_syncs
+            .entry(self.finalized_sync_seq)
+            .and_modify(|lowest| *lowest = (*lowest).min(height))
+            .or_insert(height);
     }
 
     // -------------------- Immutable Storage --------------------
@@ -2047,6 +2059,7 @@ where
         ) {
             panic!("failed to finalize: {e}");
         }
+        self.record_finalized_write(height);
 
         // Update metrics and application
         if let Some(round) = round.filter(|_| height > self.tip) {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -373,7 +373,7 @@ where
         // notarization and finalization paths). A flush failure inside
         // `start_sync` is reported only through the returned handle, so every
         // handle must be observed to apply the fatal policy. This pool does
-        // so without blocking the actor on fsync.
+        // so without blocking the actor on a sync.
         let mut syncs = Pool::<PooledSync>::default();
 
         // Anchor all startup work under a single root span. Tip recovery, floor
@@ -1827,7 +1827,7 @@ where
     /// It also ensures archives are durable before the ack handler advances
     /// the processed floor height. See [`Self::try_dispatch_blocks`] for details.
     ///
-    /// Blocking the actor stalls every mailbox caller behind the fsync.
+    /// Blocking the actor stalls every mailbox caller behind the sync.
     /// Prefer [`Self::start_finalized_sync`] unless work later in the same
     /// arm requires the writes to already be durable.
     #[tracing::instrument(name = "marshal.actor.sync_finalized", level = "info", skip_all)]
@@ -1863,7 +1863,7 @@ where
     /// observes the completion, [`Self::try_dispatch_blocks`] will not
     /// dispatch at or above the lowest height a pending batch wrote. This
     /// preserves the durability barrier described there without blocking the
-    /// mailbox on an fsync like [`Self::sync_finalized`].
+    /// mailbox on a sync like [`Self::sync_finalized`].
     ///
     /// Like [`Self::sync_finalized`], this must be called within the same
     /// `select_loop!` arm as the writes it covers, before yielding back to the

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -149,10 +149,7 @@ where
     // archives before they are durable.
     pending_finalized_syncs: BTreeMap<u64, Height>,
     // Sequence assigned to the next pooled finalized-archive sync and the
-    // key under which new writes accumulate until that sync starts. Never
-    // reused: a late completion releases every entry at or below its
-    // sequence, so a reused sequence could release batches the completed
-    // sync never covered.
+    // key under which new writes accumulate until that sync starts.
     finalized_sync_seq: u64,
 
     // ---------- Storage ----------

--- a/consensus/src/marshal/core/durability.rs
+++ b/consensus/src/marshal/core/durability.rs
@@ -1,4 +1,6 @@
-//! Fatal-policy helper for awaiting durable syncs.
+//! Durability helpers for marshal's deferred fsyncs: the fatal policy for
+//! awaiting durable syncs, and the gate that defers application dispatch
+//! until finalized-archive writes are durable.
 //!
 //! A marshal write starts its fsync eagerly: the archive spawns the sync and returns a
 //! [`Handle`] that only observes completion. The storage layer already makes those handles
@@ -8,9 +10,9 @@
 //! marshal is the failure policy: a sync failure is fatal to local storage state and must
 //! never become a recoverable verdict.
 
-use crate::types::Round;
+use crate::types::{Height, Round};
 use commonware_runtime::{Error, Handle};
-use std::future::Future;
+use std::{collections::BTreeMap, future::Future};
 use tracing::debug;
 
 /// Applies marshal's fatal policy when awaiting a durable-sync [`Handle`].
@@ -40,6 +42,69 @@ impl Durable for Handle<()> {
             }
             Err(e) => panic!("failed to sync {name} at {round}: {e}"),
         }
+    }
+}
+
+/// Defers application dispatch of finalized-archive writes until a sync
+/// covering them completes.
+///
+/// Buffered archive writes are readable before they are durable, so every
+/// write is tracked from the moment it is buffered until a sync covers it:
+/// [`Self::defer`] holds a write while no started sync covers it,
+/// [`Self::adopt`] moves the held writes into an in-flight batch when a
+/// pooled sync starts, and [`Self::release`] (pooled) or [`Self::clear`]
+/// (blocking) drops batches once they are durable. [`Self::barrier`] reports
+/// the lowest tracked height, below which dispatch must stay.
+#[derive(Default)]
+pub(super) struct DispatchGate {
+    /// Lowest deferred write no started sync covers.
+    unsynced: Option<Height>,
+    /// Lowest deferred write per in-flight pooled sync, keyed by start order.
+    inflight: BTreeMap<u64, Height>,
+    /// Sequence assigned to the next adopted batch. Monotonic across
+    /// [`Self::clear`] so a stale completion can never release a batch
+    /// adopted later.
+    next_seq: u64,
+}
+
+impl DispatchGate {
+    /// Defers dispatch at or above `height` until a sync covering this write
+    /// completes.
+    pub(super) fn defer(&mut self, height: Height) {
+        self.unsynced = Some(self.unsynced.map_or(height, |lowest| lowest.min(height)));
+    }
+
+    /// Adopts every deferred write no sync covers into a new in-flight batch,
+    /// returning the sequence its sync must [`Self::release`]. Returns `None`
+    /// if every deferred write is already covered: no sync needs to start.
+    pub(super) fn adopt(&mut self) -> Option<u64> {
+        let lowest = self.unsynced.take()?;
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        self.inflight.insert(seq, lowest);
+        Some(seq)
+    }
+
+    /// Releases every batch covered by the completed pooled sync `seq`. A
+    /// sync makes durable every write accepted before it started, so all
+    /// batches with an equal or lower sequence are released, regardless of
+    /// the order in which pooled syncs complete.
+    pub(super) fn release(&mut self, seq: u64) {
+        self.inflight = self.inflight.split_off(&(seq + 1));
+    }
+
+    /// Releases everything. A blocking sync waits on (and covers) every
+    /// previously accepted write, including writes adopted by in-flight
+    /// pooled syncs and writes no sync has adopted yet.
+    pub(super) fn clear(&mut self) {
+        self.unsynced = None;
+        self.inflight.clear();
+    }
+
+    /// Lowest height whose write may not be durable yet. Dispatch must not
+    /// send blocks at or above it.
+    pub(super) fn barrier(&self) -> Option<Height> {
+        self.inflight.values().copied().chain(self.unsynced).min()
     }
 }
 
@@ -81,5 +146,69 @@ mod tests {
             let failure = Handle::<()>::ready(Err(Error::WriteFailed));
             let _ = failure.durable(Round::zero(), "test").await;
         });
+    }
+
+    #[test]
+    fn test_gate_defer_keeps_lowest_write() {
+        let mut gate = DispatchGate::default();
+        assert_eq!(gate.barrier(), None);
+        gate.defer(Height::new(5));
+        gate.defer(Height::new(3));
+        gate.defer(Height::new(7));
+        assert_eq!(gate.barrier(), Some(Height::new(3)));
+    }
+
+    #[test]
+    fn test_gate_adopt_moves_writes_to_one_batch() {
+        let mut gate = DispatchGate::default();
+        assert_eq!(gate.adopt(), None);
+        gate.defer(Height::new(5));
+        let seq = gate.adopt().expect("deferred write must adopt");
+        assert_eq!(gate.barrier(), Some(Height::new(5)));
+        assert_eq!(gate.adopt(), None);
+        gate.release(seq);
+        assert_eq!(gate.barrier(), None);
+    }
+
+    #[test]
+    fn test_gate_release_covers_earlier_batches_only() {
+        let mut gate = DispatchGate::default();
+        gate.defer(Height::new(5));
+        let first = gate.adopt().expect("first batch");
+        gate.defer(Height::new(8));
+        let second = gate.adopt().expect("second batch");
+
+        // A completed sync covers every earlier batch, so releasing the
+        // second releases both, while releasing only the first must keep
+        // the second's write gated.
+        let mut out_of_order = DispatchGate::default();
+        out_of_order.defer(Height::new(5));
+        out_of_order.adopt().expect("first batch");
+        out_of_order.defer(Height::new(8));
+        let newest = out_of_order.adopt().expect("second batch");
+        out_of_order.release(newest);
+        assert_eq!(out_of_order.barrier(), None);
+
+        gate.release(first);
+        assert_eq!(gate.barrier(), Some(Height::new(8)));
+        gate.release(second);
+        assert_eq!(gate.barrier(), None);
+    }
+
+    #[test]
+    fn test_gate_clear_is_not_release_for_later_batches() {
+        let mut gate = DispatchGate::default();
+        gate.defer(Height::new(5));
+        let stale = gate.adopt().expect("first batch");
+        gate.defer(Height::new(3));
+        gate.clear();
+        assert_eq!(gate.barrier(), None);
+
+        // A batch adopted after the clear must not be released by a stale
+        // completion from before it.
+        gate.defer(Height::new(9));
+        gate.adopt().expect("post-clear batch");
+        gate.release(stale);
+        assert_eq!(gate.barrier(), Some(Height::new(9)));
     }
 }

--- a/consensus/src/marshal/core/durability.rs
+++ b/consensus/src/marshal/core/durability.rs
@@ -1,4 +1,4 @@
-//! Durability helpers for marshal's deferred fsyncs: the fatal policy for
+//! Durability helpers for marshal's deferred syncs: the fatal policy for
 //! awaiting durable syncs, and the gate that defers application dispatch
 //! until finalized-archive writes are durable.
 //!

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6649,6 +6649,11 @@ mod tests {
     /// height it already processed. Marshal cannot cross-check certificates
     /// against each other, so it must stay crash-safe when one lands in
     /// `apply_pending_floor`'s stale-anchor branch.
+    ///
+    /// The two repair blocks are delivered in ascending height order, so the
+    /// batch entry must keep the lowest written height. Tracking the latest
+    /// write instead would leave the gate above the first block and let it
+    /// dispatch non-durably.
     #[test_traced("WARN")]
     fn test_standard_stale_floor_anchor_holds_dispatch_until_durable() {
         const PACE: Duration = Duration::from_millis(100);
@@ -6745,10 +6750,11 @@ mod tests {
                 })
                 .expect("anchor fetch missing");
 
-            // Enqueue both deliveries back-to-back (no intervening await) so
-            // the actor drains them in a single resolver batch: first a repair
-            // block at the dispatch frontier (a buffered finalized-archive
-            // write), then the stale floor anchor.
+            // Enqueue all deliveries back-to-back (no intervening await) so
+            // the actor drains them in a single resolver batch: two repair
+            // blocks at and above the dispatch frontier (buffered
+            // finalized-archive writes, ascending), then the stale floor
+            // anchor.
             let next = make_raw_block(block.digest(), Height::new(2), 200);
             let (next_response, next_response_rx) = oneshot::channel();
             assert!(resolver
@@ -6764,6 +6770,23 @@ mod tests {
                     },
                     value: next.encode(),
                     response: next_response,
+                })
+                .accepted());
+            let above = make_raw_block(next.digest(), Height::new(3), 300);
+            let (above_response, above_response_rx) = oneshot::channel();
+            assert!(resolver
+                .enqueue(handler::Message::Deliver {
+                    delivery: Delivery {
+                        key: handler::Key::Block(StandardHarness::commitment(&above)),
+                        subscribers: NonEmptyVec::new((
+                            handler::Annotation::Finalized(handler::Finalized::ByHeight {
+                                height: Height::new(3),
+                            }),
+                            tracing::Span::none(),
+                        )),
+                    },
+                    value: above.encode(),
+                    response: above_response,
                 })
                 .accepted());
             let (anchor_response, anchor_response_rx) = oneshot::channel();
@@ -6783,6 +6806,10 @@ mod tests {
             let delivered_at = context.current();
             assert!(
                 next_response_rx.await.expect("repair response missing"),
+                "repair block delivery should validate"
+            );
+            assert!(
+                above_response_rx.await.expect("repair response missing"),
                 "repair block delivery should validate"
             );
             assert!(
@@ -6806,18 +6833,160 @@ mod tests {
             wait_until(
                 &context,
                 Duration::from_millis(50),
-                "repair block dispatched",
-                || application.blocks().contains_key(&Height::new(2)),
+                "repair blocks dispatched",
+                || application.blocks().contains_key(&Height::new(3)),
             )
             .await;
+            assert!(application.blocks().contains_key(&Height::new(2)));
             let dispatched = context
                 .current()
                 .duration_since(delivered_at)
                 .expect("time went backwards");
-            tracing::info!(?dispatched, "repair block dispatched");
+            tracing::info!(?dispatched, "repair blocks dispatched");
             assert!(
                 dispatched >= PACE,
                 "block dispatched before the paced sync completed: {dispatched:?}"
+            );
+        });
+    }
+
+    /// Overlapping pooled syncs must release the dispatch gate per batch.
+    ///
+    /// Two finalizations arrive 50ms apart, each starting its own paced 100ms
+    /// sync. The first sync covers only the first write, so block 1 must
+    /// dispatch as soon as that sync completes while block 2 stays held until
+    /// the second sync completes. This pins the sequence accounting in
+    /// `start_finalized_sync`: if a started sync failed to advance
+    /// `finalized_sync_seq`, the second write would accumulate under the
+    /// first sync's sequence and that sync's completion would release a write
+    /// it never covered.
+    #[test_traced("WARN")]
+    fn test_standard_overlapping_finalized_syncs_release_per_batch() {
+        const PACE: Duration = Duration::from_millis(100);
+        const STAGGER: Duration = Duration::from_millis(50);
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let config = Config {
+                provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                mailbox_size: NZUsize!(100),
+                view_retention_timeout: ViewDelta::new(10),
+                max_repair: NZUsize!(10),
+                max_pending_acks: NZUsize!(4),
+                block_codec_config: (),
+                partition_prefix: "overlapping-finalized-syncs".to_string(),
+                prunable_items_per_section: NZU64!(10),
+                replay_buffer: NZUsize!(1024),
+                key_write_buffer: NZUsize!(1024),
+                value_write_buffer: NZUsize!(1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                strategy: Sequential,
+            };
+            let (finalizations_by_height, finalized_blocks) =
+                paced_finalized_stores(&context, "overlapping-finalized-syncs", PACE).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                config,
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::default();
+            let _actor_handle =
+                actor.start_unbuffered(application.clone(), (resolver_rx, resolver));
+            wait_until(
+                &context,
+                Duration::from_secs(5),
+                "genesis processed",
+                || parse_processed_height(&context.encode()) == Some(0),
+            )
+            .await;
+
+            // Store both verified blocks, then finalize them one STAGGER
+            // apart so their pooled syncs overlap.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let first_round = Round::new(Epoch::zero(), View::new(1));
+            let first = make_raw_block(genesis.digest(), Height::new(1), 100);
+            assert!(mailbox.verified(first_round, first.clone()).await);
+            let second_round = Round::new(Epoch::zero(), View::new(2));
+            let second = make_raw_block(first.digest(), Height::new(2), 200);
+            assert!(mailbox.verified(second_round, second.clone()).await);
+
+            let started_at = context.current();
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    first_round,
+                    View::zero(),
+                    StandardHarness::commitment(&first),
+                ),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            context.sleep(STAGGER).await;
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    second_round,
+                    View::new(1),
+                    StandardHarness::commitment(&second),
+                ),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+
+            // Block 1 dispatches as soon as the first sync completes, without
+            // waiting for the second sync.
+            wait_until(
+                &context,
+                Duration::from_millis(150),
+                "first block dispatched",
+                || application.blocks().contains_key(&Height::new(1)),
+            )
+            .await;
+            let first_dispatched = context
+                .current()
+                .duration_since(started_at)
+                .expect("time went backwards");
+            tracing::info!(?first_dispatched, "first block dispatched");
+            assert!(
+                first_dispatched >= PACE,
+                "block dispatched before its sync completed: {first_dispatched:?}"
+            );
+            assert!(
+                first_dispatched < STAGGER + PACE,
+                "first block waited for the second sync: {first_dispatched:?}"
+            );
+
+            // Block 2 stays held until its own sync completes.
+            assert!(
+                !application.blocks().contains_key(&Height::new(2)),
+                "block dispatched before its sync completed"
+            );
+            context.sleep(Duration::from_millis(20)).await;
+            assert!(
+                !application.blocks().contains_key(&Height::new(2)),
+                "block dispatched before its sync completed"
+            );
+            wait_until(
+                &context,
+                Duration::from_millis(50),
+                "second block dispatched",
+                || application.blocks().contains_key(&Height::new(2)),
+            )
+            .await;
+            let second_dispatched = context
+                .current()
+                .duration_since(started_at)
+                .expect("time went backwards");
+            tracing::info!(?second_dispatched, "second block dispatched");
+            assert!(
+                second_dispatched >= STAGGER + PACE,
+                "block dispatched before its sync completed: {second_dispatched:?}"
             );
         });
     }

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6631,6 +6631,197 @@ mod tests {
         });
     }
 
+    /// A buffered finalized-archive write must freeze dispatch even when a
+    /// stale floor anchor triggers dispatch before the batch's sync starts.
+    ///
+    /// Within one resolver batch, a repair delivery can buffer a block at the
+    /// dispatch frontier and a later delivery can resolve a pending floor
+    /// anchor whose height is at or below the processed height. That anchor
+    /// path calls `try_dispatch_blocks` mid-batch, before the batch-end
+    /// `start_finalized_sync` runs, so dispatch must be gated by the write
+    /// itself (see `record_finalized_write`) rather than by a started sync.
+    /// Without the gate, the frontier block reaches the application while its
+    /// archive write is still buffered, and a crash after the application ack
+    /// could durably advance the processed floor past a lost write.
+    ///
+    /// The stale anchor models adversarial input: a verified finalization at
+    /// a round above the round floor naming a block marshal never stored at a
+    /// height it already processed. Marshal cannot cross-check certificates
+    /// against each other, so it must stay crash-safe when one lands in
+    /// `apply_pending_floor`'s stale-anchor branch.
+    #[test_traced("WARN")]
+    fn test_standard_stale_floor_anchor_holds_dispatch_until_durable() {
+        const PACE: Duration = Duration::from_millis(100);
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let config = Config {
+                provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                mailbox_size: NZUsize!(100),
+                view_retention_timeout: ViewDelta::new(10),
+                max_repair: NZUsize!(10),
+                max_pending_acks: NZUsize!(4),
+                block_codec_config: (),
+                partition_prefix: "stale-floor-anchor".to_string(),
+                prunable_items_per_section: NZU64!(10),
+                replay_buffer: NZUsize!(1024),
+                key_write_buffer: NZUsize!(1024),
+                value_write_buffer: NZUsize!(1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                strategy: Sequential,
+            };
+            let (finalizations_by_height, finalized_blocks) =
+                paced_finalized_stores(&context, "stale-floor-anchor", PACE).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                config,
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::default();
+            let _actor_handle =
+                actor.start_unbuffered(application.clone(), (resolver_rx, resolver.clone()));
+
+            // Finalize block 1 and wait until the application has acknowledged
+            // it, so the processed height reaches the anchor height below.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            assert!(mailbox.verified(round, block.clone()).await);
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            wait_until(
+                &context,
+                Duration::from_secs(5),
+                "block 1 processed",
+                || parse_processed_height(&context.encode()) == Some(1),
+            )
+            .await;
+
+            // Install a pending floor anchor for a forked block at height 1:
+            // a valid certificate at a round above the round floor whose block
+            // is unknown locally, so marshal fetches it. Its height (at or
+            // below the processed height) routes the arriving anchor into the
+            // stale-anchor branch.
+            let fork = make_raw_block(genesis.digest(), Height::new(1), 999);
+            let fork_finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    Round::new(Epoch::zero(), View::new(5)),
+                    View::new(4),
+                    StandardHarness::commitment(&fork),
+                ),
+                &schemes,
+                QUORUM,
+            );
+            mailbox.set_floor(fork_finalization);
+            wait_until(&context, Duration::from_secs(5), "anchor fetch", || {
+                resolver.fetches().iter().any(|fetch| {
+                    matches!(
+                        fetch.key,
+                        handler::Key::Block(commitment)
+                            if commitment == StandardHarness::commitment(&fork)
+                    )
+                })
+            })
+            .await;
+            let anchor_fetch = resolver
+                .fetches()
+                .into_iter()
+                .find(|fetch| {
+                    matches!(
+                        fetch.key,
+                        handler::Key::Block(commitment)
+                            if commitment == StandardHarness::commitment(&fork)
+                    )
+                })
+                .expect("anchor fetch missing");
+
+            // Enqueue both deliveries back-to-back (no intervening await) so
+            // the actor drains them in a single resolver batch: first a repair
+            // block at the dispatch frontier (a buffered finalized-archive
+            // write), then the stale floor anchor.
+            let next = make_raw_block(block.digest(), Height::new(2), 200);
+            let (next_response, next_response_rx) = oneshot::channel();
+            assert!(resolver
+                .enqueue(handler::Message::Deliver {
+                    delivery: Delivery {
+                        key: handler::Key::Block(StandardHarness::commitment(&next)),
+                        subscribers: NonEmptyVec::new((
+                            handler::Annotation::Finalized(handler::Finalized::ByHeight {
+                                height: Height::new(2),
+                            }),
+                            tracing::Span::none(),
+                        )),
+                    },
+                    value: next.encode(),
+                    response: next_response,
+                })
+                .accepted());
+            let (anchor_response, anchor_response_rx) = oneshot::channel();
+            assert!(resolver
+                .enqueue(handler::Message::Deliver {
+                    delivery: Delivery {
+                        key: anchor_fetch.key,
+                        subscribers: NonEmptyVec::new((
+                            anchor_fetch.subscriber,
+                            tracing::Span::none()
+                        )),
+                    },
+                    value: fork.encode(),
+                    response: anchor_response,
+                })
+                .accepted());
+            let delivered_at = context.current();
+            assert!(
+                next_response_rx.await.expect("repair response missing"),
+                "repair block delivery should validate"
+            );
+            assert!(
+                anchor_response_rx.await.expect("anchor response missing"),
+                "anchor delivery should validate"
+            );
+
+            // Durability barrier: the stale-anchor branch runs dispatch before
+            // the batch's sync starts, so the repair block at height 2 must
+            // stay held until the paced sync completes.
+            context.sleep(Duration::from_millis(1)).await;
+            assert!(
+                !application.blocks().contains_key(&Height::new(2)),
+                "block dispatched before the finalized archives were durable"
+            );
+            context.sleep(Duration::from_millis(90)).await;
+            assert!(
+                !application.blocks().contains_key(&Height::new(2)),
+                "block dispatched before the finalized archives were durable"
+            );
+            wait_until(
+                &context,
+                Duration::from_millis(50),
+                "repair block dispatched",
+                || application.blocks().contains_key(&Height::new(2)),
+            )
+            .await;
+            let dispatched = context
+                .current()
+                .duration_since(delivered_at)
+                .expect("time went backwards");
+            tracing::info!(?dispatched, "repair block dispatched");
+            assert!(
+                dispatched >= PACE,
+                "block dispatched before the paced sync completed: {dispatched:?}"
+            );
+        });
+    }
+
     /// Parse the `processed_height` gauge value from a prometheus-encoded
     /// metrics dump produced by `Metrics::encode`. Looks for any line of the
     /// form `<prefix>processed_height <value>` or

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6639,7 +6639,7 @@ mod tests {
     /// anchor whose height is at or below the processed height. That anchor
     /// path calls `try_dispatch_blocks` mid-batch, before the batch-end
     /// `start_finalized_sync` runs, so dispatch must be gated by the write
-    /// itself (see `record_finalized_write`) rather than by a started sync.
+    /// itself (via `unsynced_finalized_write`) rather than by a started sync.
     /// Without the gate, the frontier block reaches the application while its
     /// archive write is still buffered, and a crash after the application ack
     /// could durably advance the processed floor past a lost write.
@@ -6855,11 +6855,10 @@ mod tests {
     /// Two finalizations arrive 50ms apart, each starting its own paced 100ms
     /// sync. The first sync covers only the first write, so block 1 must
     /// dispatch as soon as that sync completes while block 2 stays held until
-    /// the second sync completes. This pins the sequence accounting in
-    /// `start_finalized_sync`: if a started sync failed to advance
-    /// `finalized_sync_seq`, the second write would accumulate under the
-    /// first sync's sequence and that sync's completion would release a write
-    /// it never covered.
+    /// the second sync completes. This pins the batch accounting in
+    /// `start_finalized_sync`: if the second write were folded into the first
+    /// sync's batch, that sync's completion would release a write it never
+    /// covered.
     #[test_traced("WARN")]
     fn test_standard_overlapping_finalized_syncs_release_per_batch() {
         const PACE: Duration = Duration::from_millis(100);

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6341,6 +6341,296 @@ mod tests {
         });
     }
 
+    /// A finalized-store wrapper that delays durability by `pace` of
+    /// deterministic time to model a slow fsync: `sync` blocks the caller for
+    /// the pace, while `start_sync` returns immediately with a handle that
+    /// completes after the pace (like an archive with a non-blocking sync
+    /// path, e.g. [`prunable::Archive`]).
+    struct PacedStore<T> {
+        inner: T,
+        context: deterministic::Context,
+        pace: Duration,
+    }
+
+    impl<T: crate::marshal::store::Blocks> crate::marshal::store::Blocks for PacedStore<T> {
+        type Block = T::Block;
+        type Error = T::Error;
+
+        async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
+            self.inner.put(block).await
+        }
+
+        async fn sync(&mut self) -> Result<(), Self::Error> {
+            self.context.sleep(self.pace).await;
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&mut self) -> Result<commonware_runtime::Handle<()>, Self::Error> {
+            let inner = self.inner.start_sync().await?;
+            let sleep = self.context.sleep(self.pace);
+            Ok(commonware_runtime::Handle::from_future(async move {
+                sleep.await;
+                inner.await
+            }))
+        }
+
+        async fn get(
+            &self,
+            id: commonware_storage::archive::Identifier<'_, <Self::Block as Digestible>::Digest>,
+        ) -> Result<Option<Self::Block>, Self::Error> {
+            self.inner.get(id).await
+        }
+
+        async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
+            self.inner.prune(min).await
+        }
+
+        fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
+            self.inner.missing_items(start, max)
+        }
+
+        fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
+            self.inner.next_gap(value)
+        }
+
+        fn last_index(&self) -> Option<Height> {
+            self.inner.last_index()
+        }
+    }
+
+    impl<T: crate::marshal::store::Certificates> crate::marshal::store::Certificates for PacedStore<T> {
+        type BlockDigest = T::BlockDigest;
+        type Commitment = T::Commitment;
+        type Scheme = T::Scheme;
+        type Error = T::Error;
+
+        async fn put(
+            &mut self,
+            height: Height,
+            digest: Self::BlockDigest,
+            finalization: Finalization<Self::Scheme, Self::Commitment>,
+        ) -> Result<(), Self::Error> {
+            self.inner.put(height, digest, finalization).await
+        }
+
+        async fn sync(&mut self) -> Result<(), Self::Error> {
+            self.context.sleep(self.pace).await;
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&mut self) -> Result<commonware_runtime::Handle<()>, Self::Error> {
+            let inner = self.inner.start_sync().await?;
+            let sleep = self.context.sleep(self.pace);
+            Ok(commonware_runtime::Handle::from_future(async move {
+                sleep.await;
+                inner.await
+            }))
+        }
+
+        async fn get(
+            &self,
+            id: commonware_storage::archive::Identifier<'_, Self::BlockDigest>,
+        ) -> Result<Option<Finalization<Self::Scheme, Self::Commitment>>, Self::Error> {
+            self.inner.get(id).await
+        }
+
+        async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
+            self.inner.prune(min).await
+        }
+
+        fn last_index(&self) -> Option<Height> {
+            self.inner.last_index()
+        }
+
+        fn ranges_from(&self, from: Height) -> impl Iterator<Item = (Height, Height)> {
+            self.inner.ranges_from(from)
+        }
+    }
+
+    /// Initialize paced prunable finalized stores for direct actor tests.
+    #[allow(clippy::type_complexity)]
+    async fn paced_finalized_stores(
+        context: &deterministic::Context,
+        partition_prefix: &str,
+        pace: Duration,
+    ) -> (
+        PacedStore<prunable::Archive<EightCap, deterministic::Context, D, Finalization<S, D>>>,
+        PacedStore<prunable::Archive<EightCap, deterministic::Context, D, B>>,
+    ) {
+        let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
+        let finalizations_by_height = prunable::Archive::init(
+            context.child("finalizations_by_height"),
+            prunable::Config {
+                translator: EightCap,
+                key_partition: format!("{partition_prefix}-fbh-key"),
+                key_page_cache: page_cache.clone(),
+                value_partition: format!("{partition_prefix}-fbh-value"),
+                compression: None,
+                codec_config: S::certificate_codec_config_unbounded(),
+                items_per_section: NZU64!(10),
+                key_write_buffer: NZUsize!(1024),
+                value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
+            },
+        )
+        .await
+        .expect("failed to initialize finalizations archive");
+        let finalized_blocks = prunable::Archive::init(
+            context.child("finalized_blocks"),
+            prunable::Config {
+                translator: EightCap,
+                key_partition: format!("{partition_prefix}-fb-key"),
+                key_page_cache: page_cache,
+                value_partition: format!("{partition_prefix}-fb-value"),
+                compression: None,
+                codec_config: (),
+                items_per_section: NZU64!(10),
+                key_write_buffer: NZUsize!(1024),
+                value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
+            },
+        )
+        .await
+        .expect("failed to initialize finalized blocks archive");
+        (
+            PacedStore {
+                inner: finalizations_by_height,
+                context: context.child("finalizations_pacer"),
+                pace,
+            },
+            PacedStore {
+                inner: finalized_blocks,
+                context: context.child("blocks_pacer"),
+                pace,
+            },
+        )
+    }
+
+    /// A slow finalized-archive fsync must not block the marshal mailbox.
+    ///
+    /// Processing a finalization requires making the finalized archives
+    /// durable before the block is dispatched to the application, but the
+    /// fsync itself must not serialize unrelated mailbox traffic: a proposer's
+    /// `get_verified` (a pure prunable-cache read) issued while the sync is in
+    /// flight must be answered immediately.
+    ///
+    /// Paces both finalized stores so sync completion takes 100ms of
+    /// deterministic time, processes a finalization, issues `get_verified` 1ms
+    /// later, and asserts that (1) the read is served while the sync is still
+    /// in flight and (2) the finalized block reaches the application only
+    /// after the paced sync completes (the durability barrier).
+    #[test_traced("WARN")]
+    fn test_standard_finalization_sync_does_not_block_mailbox() {
+        const PACE: Duration = Duration::from_millis(100);
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let config = Config {
+                provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                mailbox_size: NZUsize!(100),
+                view_retention_timeout: ViewDelta::new(10),
+                max_repair: NZUsize!(10),
+                max_pending_acks: NZUsize!(1),
+                block_codec_config: (),
+                partition_prefix: "paced-finalized-sync".to_string(),
+                prunable_items_per_section: NZU64!(10),
+                replay_buffer: NZUsize!(1024),
+                key_write_buffer: NZUsize!(1024),
+                value_write_buffer: NZUsize!(1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                strategy: Sequential,
+            };
+            let (finalizations_by_height, finalized_blocks) =
+                paced_finalized_stores(&context, "paced-finalized-sync", PACE).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                config,
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::default();
+            let _actor_handle =
+                actor.start_unbuffered(application.clone(), (resolver_rx, resolver));
+
+            // Wait for the genesis block to flow through dispatch so the ack
+            // pipeline is idle before the measurement starts.
+            wait_until(
+                &context,
+                Duration::from_secs(1),
+                "genesis dispatched",
+                || application.blocks().contains_key(&Height::zero()),
+            )
+            .await;
+
+            // Store a verified block for round 1 in the (unpaced) prunable cache.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            assert!(mailbox.verified(round, block.clone()).await);
+
+            // Report the finalization: the actor buffers the block into the
+            // finalized archives and starts the paced 100ms sync.
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            let finalized_at = context.current();
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+
+            // Issue a get_verified 1ms later: it must not queue behind the fsync.
+            context.sleep(Duration::from_millis(1)).await;
+            let requested_at = context.current();
+            let verified = mailbox.get_verified(round).await;
+            let elapsed = context
+                .current()
+                .duration_since(requested_at)
+                .expect("time went backwards");
+            assert_eq!(
+                verified.expect("verified block missing").digest(),
+                block.digest()
+            );
+            tracing::info!(?elapsed, "get_verified answered");
+            assert!(
+                elapsed < Duration::from_millis(5),
+                "get_verified queued behind the finalized-archive sync: took {elapsed:?}"
+            );
+
+            // Durability barrier: the finalized block must not reach the
+            // application until the paced sync completes.
+            assert!(
+                !application.blocks().contains_key(&Height::new(1)),
+                "block dispatched before the finalized archives were durable"
+            );
+            context.sleep(Duration::from_millis(90)).await;
+            assert!(
+                !application.blocks().contains_key(&Height::new(1)),
+                "block dispatched before the finalized archives were durable"
+            );
+            wait_until(
+                &context,
+                Duration::from_millis(50),
+                "finalized block dispatched",
+                || application.blocks().contains_key(&Height::new(1)),
+            )
+            .await;
+            let dispatched = context
+                .current()
+                .duration_since(finalized_at)
+                .expect("time went backwards");
+            tracing::info!(?dispatched, "finalized block dispatched");
+            assert!(
+                dispatched >= PACE,
+                "block dispatched before the paced sync completed: {dispatched:?}"
+            );
+        });
+    }
+
     /// Parse the `processed_height` gauge value from a prometheus-encoded
     /// metrics dump produced by `Metrics::encode`. Looks for any line of the
     /// form `<prefix>processed_height <value>` or

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6434,6 +6434,10 @@ mod tests {
             self.inner.get(id).await
         }
 
+        async fn has(&self, height: Height) -> Result<bool, Self::Error> {
+            self.inner.has(height).await
+        }
+
         async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
             self.inner.prune(min).await
         }

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6639,7 +6639,7 @@ mod tests {
     /// anchor whose height is at or below the processed height. That anchor
     /// path calls `try_dispatch_blocks` mid-batch, before the batch-end
     /// `start_finalized_sync` runs, so dispatch must be gated by the write
-    /// itself (via `unsynced_finalized_write`) rather than by a started sync.
+    /// itself (via `DispatchGate::defer`) rather than by a started sync.
     /// Without the gate, the frontier block reaches the application while its
     /// archive write is still buffered, and a crash after the application ack
     /// could durably advance the processed floor past a lost write.

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6342,7 +6342,7 @@ mod tests {
     }
 
     /// A finalized-store wrapper that delays durability by `pace` of
-    /// deterministic time to model a slow fsync: `sync` blocks the caller for
+    /// deterministic time to model a slow sync: `sync` blocks the caller for
     /// the pace, while `start_sync` returns immediately with a handle that
     /// completes after the pace (like an archive with a non-blocking sync
     /// path, e.g. [`prunable::Archive`]).
@@ -6510,11 +6510,11 @@ mod tests {
         )
     }
 
-    /// A slow finalized-archive fsync must not block the marshal mailbox.
+    /// A slow finalized-archive sync must not block the marshal mailbox.
     ///
     /// Processing a finalization requires making the finalized archives
     /// durable before the block is dispatched to the application, but the
-    /// fsync itself must not serialize unrelated mailbox traffic: a proposer's
+    /// sync itself must not serialize unrelated mailbox traffic: a proposer's
     /// `get_verified` (a pure prunable-cache read) issued while the sync is in
     /// flight must be answered immediately.
     ///
@@ -6587,7 +6587,7 @@ mod tests {
             let finalized_at = context.current();
             StandardHarness::report_finalization(&mut mailbox, finalization).await;
 
-            // Issue a get_verified 1ms later: it must not queue behind the fsync.
+            // Issue a get_verified 1ms later: it must not queue behind the sync.
             context.sleep(Duration::from_millis(1)).await;
             let requested_at = context.current();
             let verified = mailbox.get_verified(round).await;

--- a/consensus/src/marshal/store.rs
+++ b/consensus/src/marshal/store.rs
@@ -98,6 +98,9 @@ pub trait Certificates: Send + Sync + 'static {
         Output = Result<Option<Finalization<Self::Scheme, Self::Commitment>>, Self::Error>,
     > + Send;
 
+    /// Check whether a finalization is stored at `height` without fetching it.
+    fn has(&self, height: Height) -> impl Future<Output = Result<bool, Self::Error>> + Send;
+
     /// Prune the store to the provided minimum height (inclusive).
     ///
     /// # Arguments
@@ -280,6 +283,10 @@ where
         <Self as Archive>::get(self, id).await
     }
 
+    async fn has(&self, height: Height) -> Result<bool, Self::Error> {
+        <Self as Archive>::has(self, Identifier::Index(height.get())).await
+    }
+
     async fn prune(&mut self, _: Height) -> Result<(), Self::Error> {
         // Pruning is a no-op for immutable archives.
         Ok(())
@@ -379,6 +386,10 @@ where
         id: Identifier<'_, Self::BlockDigest>,
     ) -> Result<Option<Finalization<Self::Scheme, Self::Commitment>>, Self::Error> {
         <Self as Archive>::get(self, id).await
+    }
+
+    async fn has(&self, height: Height) -> Result<bool, Self::Error> {
+        <Self as Archive>::has(self, Identifier::Index(height.get())).await
     }
 
     async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -431,6 +431,9 @@ impl<V: Variant> Certificate<V> {
     /// Attempts to get the decoded signature.
     ///
     /// Returns `None` if the signature fails to decode.
+    // `Lazy::get` is only `const` under some feature combinations, so this
+    // cannot be `const` without breaking the default build.
+    #[allow(clippy::missing_const_for_fn)]
     pub fn get(&self) -> Option<&V::Signature> {
         self.signature.get()
     }

--- a/deployer/src/aws/services.rs
+++ b/deployer/src/aws/services.rs
@@ -1024,8 +1024,39 @@ sudo mv /home/ubuntu/pyroscope-agent.timer /etc/systemd/system/pyroscope-agent.t
     format!(
         r#"set -e
 
-# Enable BBR congestion control
-echo -e "net.core.default_qdisc=fq\nnet.ipv4.tcp_congestion_control=bbr" | sudo tee /etc/sysctl.d/99-bbr.conf >/dev/null && sudo sysctl -p /etc/sysctl.d/99-bbr.conf
+# Enable BBR congestion control and tune TCP buffers for cross-region flows
+echo -e "net.core.default_qdisc=fq\nnet.ipv4.tcp_congestion_control=bbr\nnet.core.rmem_max=16777216\nnet.core.wmem_max=16777216\nnet.ipv4.tcp_rmem=4096 2097152 16777216\nnet.ipv4.tcp_wmem=4096 262144 16777216\nnet.ipv4.tcp_slow_start_after_idle=0" | sudo tee /etc/sysctl.d/99-bbr.conf >/dev/null && sudo sysctl -p /etc/sysctl.d/99-bbr.conf
+
+# The default_qdisc sysctl only applies to interfaces attached after it is
+# set, so install fq (which enforces BBR's pacing) on every tx queue of the
+# primary interface explicitly and persist the setup across reboots.
+sudo tee /usr/local/bin/setup-qdisc.sh >/dev/null <<'EOF'
+#!/bin/bash
+set -e
+IFACE=$(ip -o route get 8.8.8.8 | awk '{{for (i = 1; i < NF; i++) if ($i == "dev") print $(i + 1)}}')
+tc qdisc replace dev "$IFACE" root handle 1: mq
+NQ=$(ls -d "/sys/class/net/$IFACE/queues/tx-"* | wc -l)
+for h in $(seq 1 "$NQ"); do
+  tc qdisc del dev "$IFACE" parent "1:$(printf '%x' "$h")" 2>/dev/null || true
+  tc qdisc add dev "$IFACE" parent "1:$(printf '%x' "$h")" fq
+done
+EOF
+sudo chmod +x /usr/local/bin/setup-qdisc.sh
+sudo tee /etc/systemd/system/setup-qdisc.service >/dev/null <<'EOF'
+[Unit]
+Description=Install fq pacing qdisc on the primary interface
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/setup-qdisc.sh
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo systemctl daemon-reload
+sudo systemctl enable --now setup-qdisc.service
 
 {image_services}
 
@@ -1529,6 +1560,10 @@ mod tests {
         assert!(setup.contains("sudo systemctl enable node_exporter"));
         assert!(setup.contains("sudo systemctl enable promtail"));
         assert!(setup.contains("sudo systemctl enable binary"));
+        assert!(setup.contains("tc qdisc replace dev \"$IFACE\" root handle 1: mq"));
+        assert!(!setup.contains("fq maxrate"));
+        assert!(setup.contains("sudo systemctl enable --now setup-qdisc.service"));
+        assert!(setup.contains("net.ipv4.tcp_rmem=4096 2097152 16777216"));
         assert!(setup.contains("sudo systemctl start node_exporter"));
         assert!(setup.contains("sudo systemctl start promtail"));
         assert!(setup.contains("sudo systemctl start binary || true"));

--- a/deployer/src/aws/services.rs
+++ b/deployer/src/aws/services.rs
@@ -1034,12 +1034,16 @@ sudo tee /usr/local/bin/setup-qdisc.sh >/dev/null <<'EOF'
 #!/bin/bash
 set -e
 IFACE=$(ip -o route get 8.8.8.8 | awk '{{for (i = 1; i < NF; i++) if ($i == "dev") print $(i + 1)}}')
-tc qdisc replace dev "$IFACE" root handle 1: mq
-NQ=$(ls -d "/sys/class/net/$IFACE/queues/tx-"* | wc -l)
-for h in $(seq 1 "$NQ"); do
-  tc qdisc del dev "$IFACE" parent "1:$(printf '%x' "$h")" 2>/dev/null || true
-  tc qdisc add dev "$IFACE" parent "1:$(printf '%x' "$h")" fq
-done
+# Single-queue interfaces reject mq, so pace on the root instead.
+if tc qdisc replace dev "$IFACE" root handle 1: mq; then
+  NQ=$(ls -d "/sys/class/net/$IFACE/queues/tx-"* | wc -l)
+  for h in $(seq 1 "$NQ"); do
+    tc qdisc del dev "$IFACE" parent "1:$(printf '%x' "$h")" 2>/dev/null || true
+    tc qdisc add dev "$IFACE" parent "1:$(printf '%x' "$h")" fq
+  done
+else
+  tc qdisc replace dev "$IFACE" root fq
+fi
 EOF
 sudo chmod +x /usr/local/bin/setup-qdisc.sh
 sudo tee /etc/systemd/system/setup-qdisc.service >/dev/null <<'EOF'
@@ -1561,6 +1565,7 @@ mod tests {
         assert!(setup.contains("sudo systemctl enable promtail"));
         assert!(setup.contains("sudo systemctl enable binary"));
         assert!(setup.contains("tc qdisc replace dev \"$IFACE\" root handle 1: mq"));
+        assert!(setup.contains("tc qdisc replace dev \"$IFACE\" root fq"));
         assert!(setup.contains("sudo systemctl enable --now setup-qdisc.service"));
         assert!(setup.contains("net.ipv4.tcp_rmem=4096 2097152 16777216"));
         assert!(setup.contains("sudo systemctl start node_exporter"));

--- a/deployer/src/aws/services.rs
+++ b/deployer/src/aws/services.rs
@@ -1561,7 +1561,6 @@ mod tests {
         assert!(setup.contains("sudo systemctl enable promtail"));
         assert!(setup.contains("sudo systemctl enable binary"));
         assert!(setup.contains("tc qdisc replace dev \"$IFACE\" root handle 1: mq"));
-        assert!(!setup.contains("fq maxrate"));
         assert!(setup.contains("sudo systemctl enable --now setup-qdisc.service"));
         assert!(setup.contains("net.ipv4.tcp_rmem=4096 2097152 16777216"));
         assert!(setup.contains("sudo systemctl start node_exporter"));

--- a/storage/src/archive/immutable/storage.rs
+++ b/storage/src/archive/immutable/storage.rs
@@ -287,7 +287,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> crate::archive::Archiv
 
         match identifier {
             Identifier::Index(index) => Ok(self.ordinal.has(index)),
-            Identifier::Key(key) => self.get_key(key).await.map(|result| result.is_some()),
+            Identifier::Key(key) => Ok(self.freezer.has(key).await?),
         }
     }
 

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -1418,6 +1418,46 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_has_key() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, NZU64!(2));
+            let mut archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+
+            // Absent key
+            let key = test_key("aaaa1");
+            assert!(!archive.has(Identifier::Key(&key)).await.unwrap());
+
+            // Exact key
+            archive.put(1, key.clone(), 10).await.unwrap();
+            assert!(archive.has(Identifier::Key(&key)).await.unwrap());
+
+            // A translated-key collision (FourCap shares the "aaaa" prefix)
+            // must not produce a false positive
+            let collision = test_key("aaaa2");
+            assert!(!archive.has(Identifier::Key(&collision)).await.unwrap());
+            archive.put(2, collision.clone(), 20).await.unwrap();
+            assert!(archive.has(Identifier::Key(&collision)).await.unwrap());
+
+            // Pruned keys report absent. Pruning is section-granular
+            // (items_per_section = 2), so prune at a section boundary that
+            // drops indices 1 and 2 while retaining index 4.
+            archive.put(4, test_key("cccc"), 30).await.unwrap();
+            archive.prune(4).await.unwrap();
+            assert!(!archive.has(Identifier::Key(&key)).await.unwrap());
+            assert!(!archive.has(Identifier::Key(&collision)).await.unwrap());
+            assert!(archive
+                .has(Identifier::Key(&test_key("cccc")))
+                .await
+                .unwrap());
+
+            archive.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_put_multi_prune() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -318,6 +318,36 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
         Ok(None)
     }
 
+    /// Check whether any retained index stores `key`.
+    ///
+    /// Confirms translated-key candidates against index journal entries,
+    /// never reading values.
+    async fn has_key(&self, key: &K) -> Result<bool, Error> {
+        for index in self.keys.get(key) {
+            // Continue if index is no longer allowed due to pruning.
+            if self.pruned(*index) {
+                continue;
+            }
+
+            // Get all positions at this index
+            if !self.indices.contains_key(index) {
+                return Err(Error::RecordCorrupted);
+            }
+            let section = self.section(*index);
+
+            for position in self.iter_positions(*index) {
+                // Fetch index entry from index journal to verify key
+                let entry = self.oversized.get(section, position).await?;
+                if entry.key.as_ref() == key.as_ref() {
+                    return Ok(true);
+                }
+                self.unnecessary_reads.inc();
+            }
+        }
+
+        Ok(false)
+    }
+
     fn has_index(&self, index: u64) -> bool {
         // Check if index exists
         self.indices.contains_key(&index)
@@ -441,7 +471,7 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
         self.has.inc();
         match identifier {
             Identifier::Index(index) => Ok(self.has_index(index)),
-            Identifier::Key(key) => self.get_key(key).await.map(|result| result.is_some()),
+            Identifier::Key(key) => self.has_key(key).await,
         }
     }
 

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -383,6 +383,56 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_has() {
+        // Initialize the deterministic context
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Initialize the freezer
+            let cfg = Config {
+                key_partition: "test-key-index".into(),
+                key_write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                value_partition: "test-value-journal".into(),
+                value_compression: None,
+                value_write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
+                value_target_size: DEFAULT_VALUE_TARGET_SIZE,
+                table_partition: "test-table".into(),
+                table_initial_size: DEFAULT_TABLE_INITIAL_SIZE,
+                table_resize_frequency: DEFAULT_TABLE_RESIZE_FREQUENCY,
+                table_resize_chunk_size: DEFAULT_TABLE_RESIZE_CHUNK_SIZE,
+                table_replay_buffer: NZUsize!(DEFAULT_TABLE_REPLAY_BUFFER),
+                codec_config: (),
+            };
+            let mut freezer =
+                Freezer::<_, FixedBytes<64>, i32>::init(context.child("storage"), cfg, None)
+                    .await
+                    .expect("Failed to initialize freezer");
+
+            // Absent key
+            let key = test_key("testkey");
+            assert!(!freezer.has(&key).await.expect("Failed to check key"));
+
+            // Present key
+            freezer
+                .put(key.clone(), 42)
+                .await
+                .expect("Failed to put data");
+            assert!(freezer.has(&key).await.expect("Failed to check key"));
+
+            // A different key remains absent
+            assert!(!freezer
+                .has(&test_key("otherkey"))
+                .await
+                .expect("Failed to check key"));
+
+            // Existence checks are counted as has, never as gets
+            let buffer = context.encode();
+            assert!(buffer.contains("has_total 3"), "{}", buffer);
+            assert!(buffer.contains("gets_total 0"), "{}", buffer);
+        });
+    }
+
+    #[test_traced]
     fn test_multiple_keys() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -427,6 +427,7 @@ pub struct Freezer<E: BufferPooler + Context, K: Array, V: CodecShared> {
     // Metrics
     puts: Counter,
     gets: Counter,
+    has: Counter,
     unnecessary_reads: Counter,
     unnecessary_writes: Counter,
     resizes: Counter,
@@ -738,6 +739,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
         // Create metrics
         let puts = context.counter("puts", "number of put operations");
         let gets = context.counter("gets", "number of get operations");
+        let has = context.counter("has", "number of has operations");
         let unnecessary_reads = context.counter(
             "unnecessary_reads",
             "number of unnecessary reads performed during key lookups",
@@ -765,6 +767,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
             resize_progress: None,
             puts,
             gets,
+            has,
             unnecessary_reads,
             unnecessary_writes,
             resizes,
@@ -901,10 +904,10 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
         Ok(value)
     }
 
-    /// Get the first value for a given key.
-    async fn get_key(&self, key: &K) -> Result<Option<V>, Error> {
-        self.gets.inc();
-
+    /// Find the first key entry matching `key`, returning it with its section.
+    ///
+    /// Reads key entries only, never values.
+    async fn find_key(&self, key: &K) -> Result<Option<(u64, Record<K>)>, Error> {
         // Get head of the chain from table
         let table_index = self.table_index(key);
         let (entry1, entry2) = Self::read_table(&self.table, table_index).await?;
@@ -919,11 +922,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
 
             // Check if this key matches
             if key_entry.key.as_ref() == key.as_ref() {
-                let value = self
-                    .oversized
-                    .get_value(section, key_entry.value_offset, key_entry.value_size)
-                    .await?;
-                return Ok(Some(value));
+                return Ok(Some((section, key_entry)));
             }
 
             // Increment unnecessary reads
@@ -940,6 +939,20 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
         Ok(None)
     }
 
+    /// Get the first value for a given key.
+    async fn get_key(&self, key: &K) -> Result<Option<V>, Error> {
+        self.gets.inc();
+
+        let Some((section, key_entry)) = self.find_key(key).await? else {
+            return Ok(None);
+        };
+        let value = self
+            .oversized
+            .get_value(section, key_entry.value_offset, key_entry.value_size)
+            .await?;
+        Ok(Some(value))
+    }
+
     /// Get the value for a given [Identifier].
     ///
     /// If a [Cursor] is known for the required key, it
@@ -949,6 +962,16 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
             Identifier::Cursor(cursor) => self.get_cursor(cursor).await.map(Some),
             Identifier::Key(key) => self.get_key(key).await,
         }
+    }
+
+    /// Check whether a value exists for a given key.
+    ///
+    /// Walks the same key index chain as [`Self::get`] with [`Identifier::Key`]
+    /// but never reads values.
+    pub async fn has(&self, key: &K) -> Result<bool, Error> {
+        self.has.inc();
+
+        Ok(self.find_key(key).await?.is_some())
     }
 
     /// Resize the table by doubling its size and split each entry into two.


### PR DESCRIPTION
## Overview

Marshal makes finalized-archive writes durable with a blocking sync inside the mailbox arm that stores them, so every mailbox caller (including pure prunable-cache reads like a proposer's `get_verified`) waits on disk latency. Durability is only required before a block is dispatched to the application, not before the actor serves its next message.

Start pooled, non-blocking archive syncs on the finalization and resolver-repair paths instead, and gate dispatch on durability with `DispatchGate`: `store_finalization` defers dispatch at or above each buffered write, `start_finalized_sync` adopts the deferred writes as a batch, and each completed sync releases every batch it covers (a later-started sync covers all earlier writes, so release is by prefix and out-of-order completion is safe). A blocking sync clears the gate. This preserves the crash-safety invariant that a block reaches the application (and its ack can advance the processed floor) only after its archive writes are durable, including when a stale floor anchor triggers dispatch mid-batch before the batch's sync starts. Floor-anchor installation and startup repair keep their blocking syncs because work later in the same arm requires durability. Stores without a non-blocking sync path (e.g. the immutable archive, whose `start_sync` completes the sync before returning a ready handle) keep today's blocking behavior with no loss of safety.

New coverage runs marshal against paced stores that model a slow sync: the mailbox stays responsive while a sync is in flight, a stale floor anchor cannot flush a buffered write to the application early, and overlapping pooled syncs release dispatch per batch.

Also included: `Archive::has(Identifier::Key)` previously delegated to a full `get` in both archive implementations, reading (and discarding) the value from the uncached value blob after confirming the key. Both now stop at the key index entry — `prunable` via a new entry-only `has_key` and `immutable` via a new `Freezer::has` — mirroring `has_at`'s "never read values" pattern. Marshal's `HintFinalized` skip-check now uses a `Certificates::has` index probe (an in-memory interval/ordinal lookup) instead of fetching and decoding the finalization it was about to discard.

Separately, the deployer now installs the `fq` qdisc on every tx queue of the primary interface (falling back to root `fq` on single-queue interfaces) and tunes TCP buffers for cross-region flows. `net.core.default_qdisc` only applies to interfaces attached after it is set, so BBR was running without `fq` pacing enforcement. A `missing_const_for_fn` allow in `bls12381` rides along for feature combinations where `Lazy::get` is not `const`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
