### PR TITLE
[glue] Expose initial sync targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1600,6 +1600,7 @@ dependencies = [
  "prometheus-client",
  "rand 0.10.2",
  "rand_core 0.10.1",
+ "rstest",
  "thiserror 2.0.17",
  "tracing",
  "tracing-subscriber",

--- a/glue/Cargo.toml
+++ b/glue/Cargo.toml
@@ -45,6 +45,7 @@ commonware-parallel.workspace = true
 commonware-resolver.workspace = true
 commonware-storage.workspace = true
 rand = { workspace = true, features = ["alloc"] }
+rstest.workspace = true
 tracing-subscriber.workspace = true
 
 [features]

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -25,6 +25,7 @@ use commonware_storage::{
         any::{
             batch::{MerkleizedBatch, Staged, UnmerkleizedBatch},
             db::Db,
+            initial_root,
             operation::{Operation, Update},
             ordered, unordered,
             value::{self, FixedEncoding, ValueEncoding, VariableEncoding},
@@ -514,6 +515,13 @@ where
         <Self>::init(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        AnySyncTarget::new(
+            initial_root::<F, unordered::Update<K, FixedEncoding<V>>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         AnyUnmerkleized {
@@ -609,6 +617,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        AnySyncTarget::new(
+            initial_root::<F, unordered::Update<K, VariableEncoding<V>>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -24,6 +24,7 @@ use commonware_storage::{
     merkle::{Graftable, Location},
     qmdb::{
         any::{
+            initial_root,
             operation::{Operation, Update},
             ordered, unordered,
             value::{self, FixedEncoding, ValueEncoding, VariableEncoding},
@@ -512,6 +513,13 @@ where
         <Self>::init(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        CurrentSyncTarget::new(
+            initial_root::<F, unordered::Update<K, FixedEncoding<V>>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         CurrentUnmerkleized {
@@ -604,6 +612,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        CurrentSyncTarget::new(
+            initial_root::<F, ordered::Update<K, FixedEncoding<V>>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
@@ -777,6 +792,13 @@ where
         open::variable(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        CurrentSyncTarget::new(
+            initial_root::<F, unordered::Update<K, VariableEncoding<V>>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         CurrentUnmerkleized {
@@ -874,6 +896,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         open::ordered_variable(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        CurrentSyncTarget::new(
+            initial_root::<F, ordered::Update<K, VariableEncoding<V>>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -16,7 +16,8 @@ use commonware_storage::{
     qmdb::{
         any::value::{FixedEncoding, FixedValue, ValueEncoding, VariableEncoding, VariableValue},
         immutable::{
-            fixed, variable, CompactDb, CompactMerkleizedBatch, CompactUnmerkleizedBatch, Operation,
+            fixed, initial_root, variable, CompactDb, CompactMerkleizedBatch,
+            CompactUnmerkleizedBatch, Operation,
         },
         operation::Key,
         sync::{self},
@@ -217,6 +218,13 @@ where
         <Self>::init(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        sync::compact::Target::new(
+            initial_root::<F, K, FixedEncoding<V>, H>(),
+            Location::new(1),
+        )
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         ImmutableUnjournaledUnmerkleized {
@@ -275,6 +283,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        sync::compact::Target::new(
+            initial_root::<F, K, VariableEncoding<V>, H>(),
+            Location::new(1),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -21,7 +21,7 @@ use commonware_storage::{
         any::value::{FixedEncoding, FixedValue, ValueEncoding, VariableEncoding, VariableValue},
         immutable::{
             batch::{MerkleizedBatch, UnmerkleizedBatch},
-            fixed, variable, Immutable, Operation,
+            fixed, initial_root, variable, Immutable, Operation,
         },
         operation::Key,
         sync::{self, resolver::Resolver, Target as AnySyncTarget},
@@ -286,6 +286,13 @@ where
         <Self>::init(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        AnySyncTarget::new(
+            initial_root::<F, K, FixedEncoding<V>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         ImmutableUnmerkleized {
@@ -369,6 +376,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        AnySyncTarget::new(
+            initial_root::<F, K, VariableEncoding<V>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -16,7 +16,8 @@ use commonware_storage::{
     qmdb::{
         any::value::{FixedEncoding, FixedValue, ValueEncoding, VariableEncoding, VariableValue},
         keyless::{
-            fixed, variable, CompactDb, CompactMerkleizedBatch, CompactUnmerkleizedBatch, Operation,
+            fixed, initial_root, variable, CompactDb, CompactMerkleizedBatch,
+            CompactUnmerkleizedBatch, Operation,
         },
         sync::{self},
         Error,
@@ -207,6 +208,10 @@ where
         <Self>::init(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        sync::compact::Target::new(initial_root::<F, FixedEncoding<V>, H>(), Location::new(1))
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         KeylessUnjournaledUnmerkleized {
@@ -264,6 +269,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        sync::compact::Target::new(
+            initial_root::<F, VariableEncoding<V>, H>(),
+            Location::new(1),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -22,7 +22,7 @@ use commonware_storage::{
         any::value::{FixedEncoding, FixedValue, ValueEncoding, VariableEncoding, VariableValue},
         keyless::{
             batch::{MerkleizedBatch, UnmerkleizedBatch},
-            fixed, variable, Keyless, Operation,
+            fixed, initial_root, variable, Keyless, Operation,
         },
         sync::{self, resolver::Resolver, Target as AnySyncTarget},
         Error,
@@ -258,6 +258,13 @@ where
         <Self>::init(context, config).await
     }
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        AnySyncTarget::new(
+            initial_root::<F, FixedEncoding<V>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
+    }
+
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
         let inner = db.read().await;
         KeylessUnmerkleized {
@@ -334,6 +341,13 @@ where
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
+    }
+
+    fn initial_sync_target() -> Self::SyncTarget {
+        AnySyncTarget::new(
+            initial_root::<F, VariableEncoding<V>, H>(),
+            non_empty_range!(Location::new(0), Location::new(1)),
+        )
     }
 
     async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1519,6 +1519,378 @@ mod tests {
         time::Duration,
     };
 
+    mod initial_sync_targets {
+        use super::ManagedDb;
+        use commonware_cryptography::{sha256::Digest, Sha256};
+        use commonware_parallel::Sequential;
+        use commonware_runtime::{
+            buffer::paged::CacheRef, deterministic, Runner as _, Supervisor as _,
+        };
+        use commonware_storage::{
+            journal::contiguous::{
+                fixed::Config as FixedJournalConfig, variable::Config as VariableJournalConfig,
+            },
+            merkle::{full::Config as MerkleConfig, mmr},
+            qmdb::{
+                any as storage_any, current as storage_current, immutable as storage_immutable,
+                keyless as storage_keyless,
+            },
+            translator::TwoCap,
+        };
+        use commonware_utils::{sequence::U64, NZUsize, NZU16, NZU64};
+        use rstest::rstest;
+        use std::{fmt::Debug, marker::PhantomData};
+
+        type Context = deterministic::Context;
+
+        type AnyFixed = storage_any::unordered::fixed::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            Sequential,
+        >;
+        type AnyVariable = storage_any::unordered::variable::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            Sequential,
+        >;
+
+        type CurrentUnorderedFixed = storage_current::unordered::fixed::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            64,
+            Sequential,
+        >;
+        type CurrentOrderedFixed = storage_current::ordered::fixed::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            64,
+            Sequential,
+        >;
+        type CurrentUnorderedVariable = storage_current::unordered::variable::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            64,
+            Sequential,
+        >;
+        type CurrentOrderedVariable = storage_current::ordered::variable::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            64,
+            Sequential,
+        >;
+
+        type ImmutableFixed = storage_immutable::fixed::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            Sequential,
+        >;
+        type ImmutableVariable = storage_immutable::variable::Db<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            TwoCap,
+            Sequential,
+        >;
+        type ImmutableCompactFixed = storage_immutable::fixed::CompactDb<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            Sequential,
+        >;
+        type ImmutableCompactVariable = storage_immutable::variable::CompactDb<
+            mmr::Family,
+            Context,
+            Digest,
+            U64,
+            Sha256,
+            ((), ()),
+            Sequential,
+        >;
+
+        type KeylessFixed =
+            storage_keyless::fixed::Db<mmr::Family, Context, U64, Sha256, Sequential>;
+        type KeylessVariable =
+            storage_keyless::variable::Db<mmr::Family, Context, U64, Sha256, Sequential>;
+        type KeylessCompactFixed =
+            storage_keyless::fixed::CompactDb<mmr::Family, Context, U64, Sha256, Sequential>;
+        type KeylessCompactVariable =
+            storage_keyless::variable::CompactDb<mmr::Family, Context, U64, Sha256, (), Sequential>;
+
+        fn page_cache(context: &Context) -> CacheRef {
+            CacheRef::from_pooler(context, NZU16!(101), NZUsize!(11))
+        }
+
+        fn merkle_config(context: &Context, suffix: &str) -> MerkleConfig<Sequential> {
+            MerkleConfig {
+                journal_partition: format!("initial-target-{suffix}-merkle-journal"),
+                metadata_partition: format!("initial-target-{suffix}-merkle-metadata"),
+                items_per_blob: NZU64!(11),
+                write_buffer: NZUsize!(1024),
+                strategy: Sequential,
+                page_cache: page_cache(context),
+            }
+        }
+
+        fn fixed_journal_config(context: &Context, suffix: &str) -> FixedJournalConfig {
+            FixedJournalConfig {
+                partition: format!("initial-target-{suffix}-log"),
+                items_per_blob: NZU64!(7),
+                page_cache: page_cache(context),
+                write_buffer: NZUsize!(1024),
+            }
+        }
+
+        fn variable_journal_config<C>(
+            context: &Context,
+            suffix: &str,
+            codec_config: C,
+        ) -> VariableJournalConfig<C> {
+            VariableJournalConfig {
+                partition: format!("initial-target-{suffix}-log"),
+                items_per_section: NZU64!(7),
+                compression: None,
+                codec_config,
+                page_cache: page_cache(context),
+                write_buffer: NZUsize!(1024),
+            }
+        }
+
+        fn any_fixed_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_any::FixedConfig<TwoCap, Sequential> {
+            storage_any::Config {
+                merkle_config: merkle_config(context, suffix),
+                journal_config: fixed_journal_config(context, suffix),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+            }
+        }
+
+        fn any_variable_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_any::VariableConfig<TwoCap, ((), ()), Sequential> {
+            storage_any::Config {
+                merkle_config: merkle_config(context, suffix),
+                journal_config: variable_journal_config(context, suffix, ((), ())),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+            }
+        }
+
+        fn current_fixed_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_current::FixedConfig<TwoCap, Sequential> {
+            storage_current::Config {
+                merkle_config: merkle_config(context, suffix),
+                journal_config: fixed_journal_config(context, suffix),
+                grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+            }
+        }
+
+        fn current_variable_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_current::VariableConfig<TwoCap, ((), ()), Sequential> {
+            storage_current::Config {
+                merkle_config: merkle_config(context, suffix),
+                journal_config: variable_journal_config(context, suffix, ((), ())),
+                grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+            }
+        }
+
+        fn immutable_fixed_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_immutable::fixed::Config<TwoCap, Sequential> {
+            storage_immutable::Config {
+                merkle_config: merkle_config(context, suffix),
+                log: fixed_journal_config(context, suffix),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+            }
+        }
+
+        fn immutable_variable_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_immutable::variable::Config<TwoCap, ((), ()), Sequential> {
+            storage_immutable::Config {
+                merkle_config: merkle_config(context, suffix),
+                log: variable_journal_config(context, suffix, ((), ())),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+            }
+        }
+
+        fn keyless_fixed_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_keyless::fixed::Config<Sequential> {
+            storage_keyless::Config {
+                merkle: merkle_config(context, suffix),
+                log: fixed_journal_config(context, suffix),
+            }
+        }
+
+        fn keyless_variable_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_keyless::variable::Config<(), Sequential> {
+            storage_keyless::Config {
+                merkle: merkle_config(context, suffix),
+                log: variable_journal_config(context, suffix, ()),
+            }
+        }
+
+        fn immutable_compact_fixed_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_immutable::fixed::CompactConfig<Sequential> {
+            storage_immutable::CompactConfig {
+                strategy: Sequential,
+                witness: variable_journal_config(context, suffix, ()),
+                commit_codec_config: (),
+            }
+        }
+
+        fn immutable_compact_variable_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_immutable::variable::CompactConfig<((), ()), Sequential> {
+            storage_immutable::CompactConfig {
+                strategy: Sequential,
+                witness: variable_journal_config(context, suffix, ()),
+                commit_codec_config: ((), ()),
+            }
+        }
+
+        fn keyless_compact_fixed_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_keyless::fixed::CompactConfig<Sequential> {
+            storage_keyless::CompactConfig {
+                strategy: Sequential,
+                witness: variable_journal_config(context, suffix, ()),
+                commit_codec_config: (),
+            }
+        }
+
+        fn keyless_compact_variable_config(
+            context: &Context,
+            suffix: &str,
+        ) -> storage_keyless::variable::CompactConfig<(), Sequential> {
+            storage_keyless::CompactConfig {
+                strategy: Sequential,
+                witness: variable_journal_config(context, suffix, ()),
+                commit_codec_config: (),
+            }
+        }
+
+        async fn assert_initial_sync_target<T>(context: Context, config: T::Config)
+        where
+            T: ManagedDb<Context>,
+            T::SyncTarget: Debug,
+        {
+            let initial = T::initial_sync_target();
+            let db = T::init(context, config).await.unwrap();
+            assert_eq!(initial, db.sync_target());
+        }
+
+        #[rstest]
+        #[case::any_fixed(PhantomData::<AnyFixed>, any_fixed_config)]
+        #[case::any_variable(PhantomData::<AnyVariable>, any_variable_config)]
+        #[case::current_unordered_fixed(
+            PhantomData::<CurrentUnorderedFixed>,
+            current_fixed_config
+        )]
+        #[case::current_ordered_fixed(
+            PhantomData::<CurrentOrderedFixed>,
+            current_fixed_config
+        )]
+        #[case::current_unordered_variable(
+            PhantomData::<CurrentUnorderedVariable>,
+            current_variable_config
+        )]
+        #[case::current_ordered_variable(
+            PhantomData::<CurrentOrderedVariable>,
+            current_variable_config
+        )]
+        #[case::immutable_fixed(PhantomData::<ImmutableFixed>, immutable_fixed_config)]
+        #[case::immutable_variable(
+            PhantomData::<ImmutableVariable>,
+            immutable_variable_config
+        )]
+        #[case::immutable_compact_fixed(
+            PhantomData::<ImmutableCompactFixed>,
+            immutable_compact_fixed_config
+        )]
+        #[case::immutable_compact_variable(
+            PhantomData::<ImmutableCompactVariable>,
+            immutable_compact_variable_config
+        )]
+        #[case::keyless_fixed(PhantomData::<KeylessFixed>, keyless_fixed_config)]
+        #[case::keyless_variable(PhantomData::<KeylessVariable>, keyless_variable_config)]
+        #[case::keyless_compact_fixed(
+            PhantomData::<KeylessCompactFixed>,
+            keyless_compact_fixed_config
+        )]
+        #[case::keyless_compact_variable(
+            PhantomData::<KeylessCompactVariable>,
+            keyless_compact_variable_config
+        )]
+        fn initial_sync_target_matches_initialized_database<T>(
+            #[case] _db: PhantomData<T>,
+            #[case] config: fn(&Context, &str) -> T::Config,
+        ) where
+            T: ManagedDb<Context> + 'static,
+            T::SyncTarget: Debug,
+        {
+            deterministic::Runner::default().start(|context| async move {
+                let config = config(&context, "db");
+                assert_initial_sync_target::<T>(context.child("db"), config).await;
+            });
+        }
+    }
+
     #[derive(Default)]
     struct TestDb;
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1572,7 +1572,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("CountingRewindDb is constructed directly in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -183,6 +183,11 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
         config: Self::Config,
     ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
+    /// Return the sync target produced by a newly initialized database.
+    ///
+    /// This must match [`sync_target`](Self::sync_target) after opening an empty partition.
+    fn initial_sync_target() -> Self::SyncTarget;
+
     /// Create a new unmerkleized batch rooted at the database's committed
     /// state.
     ///
@@ -258,6 +263,9 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
 
     /// Construct the database set from its configuration.
     fn init(context: E, config: Self::Config) -> impl Future<Output = Self> + Send;
+
+    /// Return the sync targets produced by a newly initialized database set.
+    fn initial_sync_targets() -> Self::SyncTargets;
 
     /// Create unmerkleized batches from each database's committed state.
     ///
@@ -438,6 +446,10 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Shared<T> {
             .await
             .expect("database init failed");
         Self::new(TracedAsyncRwLock::new("stateful.db", db))
+    }
+
+    fn initial_sync_targets() -> Self::SyncTargets {
+        T::initial_sync_target()
     }
 
     async fn new_batches(&self) -> Self::Unmerkleized {
@@ -667,6 +679,10 @@ macro_rules! impl_database_set {
                     },
                 )+);
                 result
+            }
+
+            fn initial_sync_targets() -> Self::SyncTargets {
+                ($($T::initial_sync_target(),)+)
             }
 
             async fn new_batches(&self) -> Self::Unmerkleized {
@@ -1522,6 +1538,8 @@ mod tests {
         type Config = ();
         type SyncTarget = ();
 
+        fn initial_sync_target() -> Self::SyncTarget {}
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             Ok(Self)
         }
@@ -1552,6 +1570,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("CountingRewindDb is constructed directly in tests")
@@ -1586,6 +1608,8 @@ mod tests {
         type Error = Infallible;
         type Config = Arc<AtomicUsize>;
         type SyncTarget = ();
+
+        fn initial_sync_target() -> Self::SyncTarget {}
 
         async fn init(_context: E, prune_count: Self::Config) -> Result<Self, Self::Error> {
             Ok(Self { prune_count })
@@ -1692,6 +1716,8 @@ mod tests {
         type Config = ();
         type SyncTarget = ();
 
+        fn initial_sync_target() -> Self::SyncTarget {}
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             Ok(Self)
         }
@@ -1774,6 +1800,8 @@ mod tests {
         type Config = ();
         type SyncTarget = ();
 
+        fn initial_sync_target() -> Self::SyncTarget {}
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("BlockingFinalizeDb is constructed directly in tests")
         }
@@ -1810,6 +1838,10 @@ mod tests {
         type Config = ();
         type SyncTarget = u64;
 
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("SlowSyncDb is only constructed through state sync in tests")
         }
@@ -1841,6 +1873,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!(
@@ -1876,6 +1912,10 @@ mod tests {
         type Config = ();
         type SyncTarget = u64;
 
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("FastSyncDb is only constructed through state sync in tests")
         }
@@ -1907,6 +1947,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("FailingStateSyncDb is only constructed through state sync in tests")
@@ -1940,6 +1984,10 @@ mod tests {
         type Config = ();
         type SyncTarget = u64;
 
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("MismatchedTargetSyncDb is only constructed through state sync in tests")
         }
@@ -1971,6 +2019,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("ImmediateStateSyncDb is only constructed through state sync in tests")
@@ -2004,6 +2056,10 @@ mod tests {
         type Config = ();
         type SyncTarget = u64;
 
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("FinishClosedSyncDb is only constructed through state sync in tests")
         }
@@ -2035,6 +2091,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("ObservedSlowSyncDb is only constructed through state sync in tests")
@@ -2068,6 +2128,10 @@ mod tests {
         type Config = ();
         type SyncTarget = u64;
 
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
+
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("ObservedFastSyncDb is only constructed through state sync in tests")
         }
@@ -2099,6 +2163,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!(
@@ -2242,6 +2310,10 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+
+        fn initial_sync_target() -> Self::SyncTarget {
+            0
+        }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
             unreachable!("StaleReachedSyncDb is only constructed through state sync in tests")

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1839,7 +1839,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("SlowSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -1875,7 +1875,9 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!(
+                "RejectDuplicateTargetSyncDb is only constructed through state sync in tests"
+            )
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -1913,7 +1915,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("FastSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -1949,7 +1951,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("FailingStateSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -1985,7 +1987,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("MismatchedTargetSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -2021,7 +2023,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("ImmediateStateSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -2057,7 +2059,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("FinishClosedSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -2093,7 +2095,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("ObservedSlowSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -2129,7 +2131,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("ObservedFastSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -2165,7 +2167,9 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!(
+                "DistinctObservedFastSyncDb is only constructed through state sync in tests"
+            )
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
@@ -2312,7 +2316,7 @@ mod tests {
         type SyncTarget = u64;
 
         fn initial_sync_target() -> Self::SyncTarget {
-            0
+            unreachable!("StaleReachedSyncDb is only constructed through state sync in tests")
         }
 
         async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -59,6 +59,10 @@ impl<E: Send> ManagedDb<E> for TestDb {
     type Config = ();
     type SyncTarget = u64;
 
+    fn initial_sync_target() -> Self::SyncTarget {
+        0
+    }
+
     async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
         Ok(Self)
     }

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -60,7 +60,7 @@ impl<E: Send> ManagedDb<E> for TestDb {
     type SyncTarget = u64;
 
     fn initial_sync_target() -> Self::SyncTarget {
-        0
+        unreachable!("TestDb is constructed directly in tests")
     }
 
     async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -35,15 +35,12 @@ use commonware_consensus::{
 };
 use commonware_cryptography::{
     certificate::{mocks::Fixture, ConstantProvider},
-    ed25519,
-    sha256::{self, Digest as Sha256Digest},
-    Digest as _, Digestible, Hasher, Sha256, Signer as _,
+    ed25519, sha256, Digest as _, Digestible, Hasher, Sha256, Signer as _,
 };
-use commonware_formatting::hex;
 use commonware_p2p::utils::mux::Muxer;
 use commonware_parallel::Sequential;
 use commonware_runtime::{
-    buffer::paged::CacheRef, Buf, BufMut, Handle, Quota, Spawner, Supervisor as _,
+    buffer::paged::CacheRef, deterministic, Buf, BufMut, Handle, Quota, Spawner, Supervisor as _,
 };
 use commonware_storage::{
     archive::prunable,
@@ -524,20 +521,14 @@ impl EngineDefinition for MultiDbEngine {
         .await
         .expect("failed to initialize blocks archive");
 
-        let genesis_block = {
-            let empty_db_root = Sha256Digest::from(hex!(
-                "ea6e0567a525372add5e4ef4d0600c18ed47fa5dd041a0ab0d25b60ea8c35978"
-            ));
-            let empty_compact_db_root = Sha256Digest::from(hex!(
-                "290cbd39f3eaaca7cb4a92f4a2740fc438cabb99144258b24ba0cf54b3f4cfec"
-            ));
-            Block::genesis(
-                empty_db_root,
-                non_empty_range!(Location::new(0), Location::new(1)),
-                empty_compact_db_root,
-                non_empty_range!(Location::new(0), Location::new(1)),
-            )
-        };
+        let (initial_a, initial_b) =
+            <MultiDatabaseSet<deterministic::Context> as DatabaseSet<_>>::initial_sync_targets();
+        let genesis_block = Block::genesis(
+            initial_a.root,
+            initial_a.range,
+            initial_b.root,
+            non_empty_range!(Location::new(0), initial_b.leaf_count),
+        );
 
         let stateful_startup_context = context.child("stateful_startup");
         let mut plan = SyncPlan::init(&stateful_startup_context, partition_prefix.clone()).await;

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -35,14 +35,11 @@ use commonware_consensus::{
 };
 use commonware_cryptography::{
     certificate::{mocks::Fixture, ConstantProvider},
-    ed25519,
-    sha256::{self, Digest as Sha256Digest},
-    Digest as _, Digestible, Hasher, Sha256, Signer as _,
+    ed25519, sha256, Digest as _, Digestible, Hasher, Sha256, Signer as _,
 };
-use commonware_formatting::hex;
 use commonware_parallel::Sequential;
 use commonware_runtime::{
-    buffer::paged::CacheRef, Buf, BufMut, Handle, Quota, Spawner, Supervisor as _,
+    buffer::paged::CacheRef, deterministic, Buf, BufMut, Handle, Quota, Spawner, Supervisor as _,
 };
 use commonware_storage::{
     archive::prunable,
@@ -424,15 +421,9 @@ impl EngineDefinition for SingleDbEngine {
         .await
         .expect("failed to initialize blocks archive");
 
-        let genesis_block = {
-            let empty_db_root = Sha256Digest::from(hex!(
-                "ea6e0567a525372add5e4ef4d0600c18ed47fa5dd041a0ab0d25b60ea8c35978"
-            ));
-            Block::genesis(
-                empty_db_root,
-                non_empty_range!(Location::new(0), Location::new(1)),
-            )
-        };
+        let initial_target =
+            <SingleDatabaseSet<deterministic::Context> as DatabaseSet<_>>::initial_sync_targets();
+        let genesis_block = Block::genesis(initial_target.root, initial_target.range);
 
         let stateful_startup_context = context.child("stateful_startup");
         let mut plan = SyncPlan::init(&stateful_startup_context, partition_prefix.clone()).await;

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -75,12 +75,12 @@ use crate::{
         bitmap::Shared,
         metrics::Metrics,
         operation::Committable,
-        ROOT_BAGGING,
+        root_from_initial_commit, ROOT_BAGGING,
     },
     translator::Translator,
     Context,
 };
-use commonware_codec::CodecShared;
+use commonware_codec::{CodecShared, Encode};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
@@ -98,6 +98,17 @@ pub use value::{FixedValue, ValueEncoding, VariableValue};
 pub mod ordered;
 pub(crate) mod sync;
 pub mod unordered;
+
+/// Compute the authenticated root of a newly initialized database without opening storage.
+pub fn initial_root<F, U, H>() -> H::Digest
+where
+    F: Family,
+    H: Hasher,
+    U: Update,
+    Operation<F, U>: Encode,
+{
+    root_from_initial_commit::<F, H>(&Operation::<F, U>::CommitFloor(None, Location::new(0)))
+}
 
 pub(crate) const BITMAP_CHUNK_BYTES: usize = 64;
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -75,7 +75,7 @@ use crate::{
         bitmap::Shared,
         metrics::Metrics,
         operation::Committable,
-        root_from_initial_commit, ROOT_BAGGING,
+        single_operation_root, ROOT_BAGGING,
     },
     translator::Translator,
     Context,
@@ -107,7 +107,7 @@ where
     U: Update,
     Operation<F, U>: Encode,
 {
-    root_from_initial_commit::<F, H>(&Operation::<F, U>::CommitFloor(None, Location::new(0)))
+    single_operation_root::<F, H>(&Operation::<F, U>::CommitFloor(None, Location::new(0)))
 }
 
 pub(crate) const BITMAP_CHUNK_BYTES: usize = 64;

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -100,6 +100,9 @@ pub(crate) mod sync;
 pub mod unordered;
 
 /// Compute the authenticated root of a newly initialized database without opening storage.
+///
+/// The initial commit never carries metadata, so this root always represents
+/// `CommitFloor(None, 0)`.
 pub fn initial_root<F, U, H>() -> H::Digest
 where
     F: Family,

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -86,7 +86,7 @@ use crate::{
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
         any::ValueEncoding, build_snapshot_from_log, metrics::Metrics, operation::Key,
-        root_from_initial_commit, Error,
+        single_operation_root, Error,
     },
     translator::Translator,
     Context,
@@ -122,7 +122,7 @@ where
     H: Hasher,
     Operation<F, K, V>: EncodeShared,
 {
-    root_from_initial_commit::<F, H>(&Operation::<F, K, V>::Commit(None, Location::new(0)))
+    single_operation_root::<F, H>(&Operation::<F, K, V>::Commit(None, Location::new(0)))
 }
 
 /// Configuration for an [Immutable] authenticated db.

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -114,6 +114,8 @@ pub use compact::{
 pub use operation::Operation;
 
 /// Compute the authenticated root of a newly initialized database without opening storage.
+///
+/// The initial commit never carries metadata, so this root always represents `Commit(None, 0)`.
 pub fn initial_root<F, K, V, H>() -> H::Digest
 where
     F: Family,

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -84,7 +84,10 @@ use crate::{
         contiguous::{Contiguous, Mutable},
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
-    qmdb::{any::ValueEncoding, build_snapshot_from_log, metrics::Metrics, operation::Key, Error},
+    qmdb::{
+        any::ValueEncoding, build_snapshot_from_log, metrics::Metrics, operation::Key,
+        root_from_initial_commit, Error,
+    },
     translator::Translator,
     Context,
 };
@@ -109,6 +112,18 @@ pub use compact::{
     UnmerkleizedBatch as CompactUnmerkleizedBatch,
 };
 pub use operation::Operation;
+
+/// Compute the authenticated root of a newly initialized database without opening storage.
+pub fn initial_root<F, K, V, H>() -> H::Digest
+where
+    F: Family,
+    K: Key,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, K, V>: EncodeShared,
+{
+    root_from_initial_commit::<F, H>(&Operation::<F, K, V>::Commit(None, Location::new(0)))
+}
 
 /// Configuration for an [Immutable] authenticated db.
 #[derive(Clone)]

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -50,7 +50,7 @@ use crate::{
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
     qmdb::{
-        any::value::ValueEncoding, batch_chain, metrics::Metrics, root_from_initial_commit, Error,
+        any::value::ValueEncoding, batch_chain, metrics::Metrics, single_operation_root, Error,
     },
     Context,
 };
@@ -81,7 +81,7 @@ where
     H: Hasher,
     Operation<F, V>: EncodeShared,
 {
-    root_from_initial_commit::<F, H>(&Operation::<F, V>::Commit(None, Location::new(0)))
+    single_operation_root::<F, H>(&Operation::<F, V>::Commit(None, Location::new(0)))
 }
 
 /// Configuration for a [Keyless] authenticated db.

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -74,6 +74,8 @@ pub use compact::{
 pub use operation::Operation;
 
 /// Compute the authenticated root of a newly initialized database without opening storage.
+///
+/// The initial commit never carries metadata, so this root always represents `Commit(None, 0)`.
 pub fn initial_root<F, V, H>() -> H::Digest
 where
     F: Family,

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -49,7 +49,9 @@ use crate::{
         contiguous::{Contiguous, Mutable},
     },
     merkle::{full::Config as MerkleConfig, Family, Location, Proof},
-    qmdb::{any::value::ValueEncoding, batch_chain, metrics::Metrics, Error},
+    qmdb::{
+        any::value::ValueEncoding, batch_chain, metrics::Metrics, root_from_initial_commit, Error,
+    },
     Context,
 };
 use commonware_codec::EncodeShared;
@@ -70,6 +72,17 @@ pub use compact::{
     UnmerkleizedBatch as CompactUnmerkleizedBatch,
 };
 pub use operation::Operation;
+
+/// Compute the authenticated root of a newly initialized database without opening storage.
+pub fn initial_root<F, V, H>() -> H::Digest
+where
+    F: Family,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, V>: EncodeShared,
+{
+    root_from_initial_commit::<F, H>(&Operation::<F, V>::Commit(None, Location::new(0)))
+}
 
 /// Configuration for a [Keyless] authenticated db.
 #[derive(Clone)]

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -47,9 +47,13 @@ use crate::{
         contiguous::{Contiguous, Mutable},
         Error as JournalError,
     },
-    merkle::{hasher::Standard as StandardHasher, Bagging, Family, Location},
+    merkle::{
+        hasher::{Hasher as MerkleHasher, Standard as StandardHasher},
+        Bagging, Family, Location,
+    },
     qmdb::operation::Operation,
 };
+use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
 use commonware_utils::{cache::Clock, NZUsize};
 use core::num::NonZeroUsize;
@@ -82,6 +86,17 @@ pub(crate) const ROOT_BAGGING: Bagging = Bagging::BackwardFold;
 /// Return the Merkle hasher configuration used by QMDB operation roots and proofs.
 pub const fn hasher<H: Hasher>() -> StandardHasher<H> {
     StandardHasher::new(ROOT_BAGGING)
+}
+
+fn root_from_initial_commit<F: Family, H: Hasher>(operation: &impl Encode) -> H::Digest {
+    let hasher = hasher::<H>();
+    let leaf = MerkleHasher::<F>::leaf_digest(
+        &hasher,
+        F::location_to_position(Location::new(0)),
+        &operation.encode(),
+    );
+    MerkleHasher::<F>::root(&hasher, Location::new(1), 0, [&leaf])
+        .expect("a single-leaf Merkle root is always valid")
 }
 
 /// Look up the inactivity floor declared at the commit immediately preceding `op_count`.

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -88,7 +88,11 @@ pub const fn hasher<H: Hasher>() -> StandardHasher<H> {
     StandardHasher::new(ROOT_BAGGING)
 }
 
-fn root_from_initial_commit<F: Family, H: Hasher>(operation: &impl Encode) -> H::Digest {
+/// Return the root of an operation log containing only `operation`.
+///
+/// This lets database variants derive their initial root from the bootstrap commit without
+/// opening a database.
+fn single_operation_root<F: Family, H: Hasher>(operation: &impl Encode) -> H::Digest {
     let hasher = hasher::<H>();
     let leaf = MerkleHasher::<F>::leaf_digest(
         &hasher,


### PR DESCRIPTION
## Overview

Make initial state sync setup simpler for applications: callers can ask their database set for initial targets instead of knowing QMDB internals, hard-coding roots, or opening throwaway databases.

This adds cheap initial-target computation and updates the glue fixtures to use it.