### PR TITLE
[marshal] Simplify Broadcast

### DIFF
--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -1,5 +1,8 @@
-use crate::{marshal::core::durability::Durable as _, types::Round};
-use commonware_cryptography::Digest;
+use crate::{
+    marshal::core::{durability::Durable as _, Mailbox, Variant},
+    types::Round,
+};
+use commonware_cryptography::{certificate::Scheme, Digest};
 use commonware_macros::select;
 use commonware_runtime::Handle;
 use commonware_utils::{
@@ -84,6 +87,24 @@ impl<D: Digest, B> Gates<D, B> {
         self.inner.lock().proposals.remove(&(round, digest))
     }
 
+    /// Persists the staged proposal for `(round, id)` without broadcasting it,
+    /// completing the propose durability handshake.
+    ///
+    /// A staged proposal whose broadcast was never requested cannot resolve
+    /// its certification gate. Certification demands durability, so the staged
+    /// block is flushed to `marshal` for persistence, which delivers the
+    /// durable-sync handle through the staged ack. Does nothing when no
+    /// proposal is staged (the relay broadcast already took it).
+    pub(crate) fn flush<S, V>(&self, marshal: &Mailbox<S, V>, round: Round, id: D)
+    where
+        S: Scheme,
+        V: Variant<Block = B>,
+    {
+        if let Some((block, ack)) = self.take_staged(round, id) {
+            marshal.verified_deferred(round, block, ack);
+        }
+    }
+
     /// Discards all entries whose round is at or before `finalized_round`.
     ///
     /// A discarded staged proposal drops its ack, which abandons the propose
@@ -114,7 +135,7 @@ impl<D: Digest, B> Gates<D, B> {
     /// dropped ack means the marshal actor is gone or the staged entry was
     /// pruned without ever being taken, so the gate is left unresolved and
     /// `certify` falls back to its recovery fetch.
-    pub(crate) async fn stage_and_defer(
+    pub(crate) async fn wait(
         &self,
         round: Round,
         id: D,
@@ -331,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn test_stage_and_defer_handshake() {
+    fn test_wait_handshake() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let gates = TestGates::new();
@@ -340,9 +361,7 @@ mod tests {
 
             let staged = gates.clone();
             context.spawn(move |_| async move {
-                staged
-                    .stage_and_defer(round(1), digest, Arc::new(7), tx, "test")
-                    .await;
+                staged.wait(round(1), digest, Arc::new(7), tx, "test").await;
             });
 
             // The id is published only after the gate and staged block are registered.
@@ -371,9 +390,7 @@ mod tests {
 
             let staged = gates.clone();
             context.spawn(move |_| async move {
-                staged
-                    .stage_and_defer(round(1), digest, Arc::new(7), tx, "test")
-                    .await;
+                staged.wait(round(1), digest, Arc::new(7), tx, "test").await;
             });
             assert_eq!(rx.await.expect("id published"), digest);
 

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -9,12 +9,20 @@ use commonware_utils::{
 use std::{collections::HashMap, future::Future, sync::Arc};
 use tracing::debug;
 
-type GateMap<D> = HashMap<(Round, D), oneshot::Receiver<bool>>;
+/// A proposal staged for its relay broadcast: the block and the ack that
+/// delivers its durable-sync handle once marshal persists it.
+type Staged<B> = (Arc<B>, oneshot::Sender<Handle<()>>);
 
-/// A shared, thread-safe registry of in-flight certification gate tasks.
+struct Inner<D: Digest, B> {
+    tasks: HashMap<(Round, D), oneshot::Receiver<bool>>,
+    staged: HashMap<(Round, D), Staged<B>>,
+}
+
+/// A shared, thread-safe registry of in-flight certification gate tasks and
+/// staged proposals.
 ///
-/// Each task is keyed by `(Round, D)` where `D` is a commitment or digest
-/// identifying the block. The associated [`oneshot::Receiver<bool>`] is
+/// Each entry is keyed by `(Round, D)` where `D` is a commitment or digest
+/// identifying the block. The gate task's [`oneshot::Receiver<bool>`] is
 /// consumed by certification and resolves to `true` only when that path may cast
 /// a finalize vote: local proposal durability has completed, or verification
 /// accepted the block and completed the required durable store. A resolved
@@ -24,66 +32,96 @@ type GateMap<D> = HashMap<(Round, D), oneshot::Receiver<bool>>;
 /// before resolving the task.
 ///
 /// Tasks are inserted when a block enters proposal or verification handling and
-/// taken (consumed) when certification is ready to act on the result. Stale
-/// entries are pruned after finalization via [`retain_after`](Self::retain_after).
+/// taken (consumed) when certification is ready to act on the result. A staged
+/// proposal holds the block itself until consensus requests its broadcast via
+/// [`crate::Relay::broadcast`] (or certification demands durability first),
+/// keeping marshal's mailbox free of any propose-time handshake. Stale entries
+/// are pruned after finalization via [`retain_after`](Self::retain_after).
 #[derive(Clone)]
-pub(crate) struct Gates<D: Digest> {
-    inner: Arc<Mutex<GateMap<D>>>,
+pub(crate) struct Gates<D: Digest, B> {
+    inner: Arc<Mutex<Inner<D, B>>>,
 }
 
-impl<D: Digest> Default for Gates<D> {
+impl<D: Digest, B> Default for Gates<D, B> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<D: Digest> Gates<D> {
-    /// Creates an empty task registry.
+impl<D: Digest, B> Gates<D, B> {
+    /// Creates an empty registry.
     pub(crate) fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(HashMap::new())),
+            inner: Arc::new(Mutex::new(Inner {
+                tasks: HashMap::new(),
+                staged: HashMap::new(),
+            })),
         }
     }
 
     /// Registers a certification gate task for the block identified by `(round, digest)`.
     pub(crate) fn insert(&self, round: Round, digest: D, task: oneshot::Receiver<bool>) {
-        self.inner.lock().insert((round, digest), task);
+        self.inner.lock().tasks.insert((round, digest), task);
     }
 
     /// Removes and returns the certification gate task for `(round, digest)`, if present.
     pub(crate) fn take(&self, round: Round, digest: D) -> Option<oneshot::Receiver<bool>> {
-        self.inner.lock().remove(&(round, digest))
+        self.inner.lock().tasks.remove(&(round, digest))
     }
 
-    /// Discards all tasks whose round is at or before `finalized_round`.
+    /// Removes and returns the staged proposal for `(round, digest)`, if present.
+    ///
+    /// The taken block and ack are handed to marshal exactly once: by the relay
+    /// broadcast, or by certification when no broadcast was ever requested.
+    pub(crate) fn take_staged(&self, round: Round, digest: D) -> Option<Staged<B>> {
+        self.inner.lock().staged.remove(&(round, digest))
+    }
+
+    /// Discards all entries whose round is at or before `finalized_round`.
+    ///
+    /// A discarded staged proposal drops its ack, which abandons the propose
+    /// durability handshake for that (already decided) round.
     pub(crate) fn retain_after(&self, finalized_round: &Round) {
-        self.inner
-            .lock()
+        let mut inner = self.inner.lock();
+        inner
+            .tasks
             .retain(|(task_round, _), _| task_round > finalized_round);
+        inner
+            .staged
+            .retain(|(staged_round, _), _| staged_round > finalized_round);
     }
 
-    /// Completes the propose durability handshake for `(round, id)`.
+    /// Stages `block` for its relay broadcast and completes the propose
+    /// durability handshake for `(round, id)`.
     ///
-    /// Registers a certification gate, publishes `id` to consensus on `tx`, then awaits the
-    /// started block sync so [`certify`](crate::CertifiableAutomaton::certify) can require
-    /// durability before the finalize vote. The gate is registered before `id` is published so
-    /// `certify` always finds it.
+    /// Registers a certification gate and the staged block, publishes `id` to
+    /// consensus on `tx`, then awaits the durable-sync handle so
+    /// [`certify`](crate::CertifiableAutomaton::certify) can require durability
+    /// before the finalize vote. Both registrations happen before `id` is
+    /// published so the relay broadcast and `certify` always find them.
     ///
-    /// `persist` is the sync-handle receiver returned by `marshal.proposed_deferred`/`verified_deferred`,
-    /// already enqueued by the caller so a later `forward` is ordered after it. A real sync failure
-    /// panics here (the fatal policy, annotated with `name`); a dropped receiver or a runtime
-    /// shutdown means the marshal actor is gone, so the gate is left unresolved and `certify`
-    /// falls back to its recovery fetch.
-    pub(crate) async fn persist_and_defer(
+    /// The handle arrives once marshal persists the staged block, which happens
+    /// when consensus requests its broadcast (or at certification when no
+    /// broadcast was requested), so this await can outlive the round. A real
+    /// sync failure panics here (the fatal policy, annotated with `name`). A
+    /// dropped ack means the marshal actor is gone or the staged entry was
+    /// pruned without ever being taken, so the gate is left unresolved and
+    /// `certify` falls back to its recovery fetch.
+    pub(crate) async fn stage_and_defer(
         &self,
         round: Round,
         id: D,
+        block: Arc<B>,
         tx: oneshot::Sender<D>,
-        persist: oneshot::Receiver<Handle<()>>,
         name: &'static str,
     ) {
         let (durable_tx, durable_rx) = oneshot::channel();
-        self.insert(round, id, durable_rx);
+        let (ack, persist) = oneshot::channel();
+        {
+            let mut inner = self.inner.lock();
+            inner.tasks.insert((round, id), durable_rx);
+            inner.staged.insert((round, id), (block, ack));
+        }
         tx.send_lossy(id);
         let Ok(handle) = persist.await else {
             return;
@@ -165,8 +203,10 @@ mod tests {
     use super::*;
     use crate::types::{Epoch, View};
     use commonware_cryptography::{sha256::Digest as Sha256Digest, Hasher, Sha256};
+    use commonware_runtime::{deterministic, Runner, Spawner};
 
     type D = Sha256Digest;
+    type TestGates = Gates<D, u64>;
 
     fn round(view: u64) -> Round {
         Round::new(Epoch::zero(), View::new(view))
@@ -179,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_insert_and_take_returns_task() {
-        let tasks = Gates::<D>::new();
+        let tasks = TestGates::new();
         let digest = Sha256::hash(b"block");
         tasks.insert(round(1), digest, pending_task());
 
@@ -192,13 +232,13 @@ mod tests {
 
     #[test]
     fn test_take_absent_key_is_none() {
-        let tasks = Gates::<D>::new();
+        let tasks = TestGates::new();
         assert!(tasks.take(round(1), Sha256::hash(b"missing")).is_none());
     }
 
     #[test]
     fn test_take_distinguishes_rounds_and_digests() {
-        let tasks = Gates::<D>::new();
+        let tasks = TestGates::new();
         let digest_a = Sha256::hash(b"a");
         let digest_b = Sha256::hash(b"b");
         tasks.insert(round(1), digest_a, pending_task());
@@ -212,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_retain_after_drops_at_and_below_boundary() {
-        let tasks = Gates::<D>::new();
+        let tasks = TestGates::new();
         let digest = Sha256::hash(b"block");
         tasks.insert(round(1), digest, pending_task());
         tasks.insert(round(2), digest, pending_task());
@@ -236,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_retain_after_spans_epochs() {
-        let tasks = Gates::<D>::new();
+        let tasks = TestGates::new();
         let digest = Sha256::hash(b"block");
         let early = Round::new(Epoch::zero(), View::new(100));
         let late = Round::new(Epoch::new(1), View::zero());
@@ -257,14 +297,14 @@ mod tests {
 
     #[test]
     fn test_retain_after_empty_map_is_noop() {
-        let tasks = Gates::<D>::new();
+        let tasks = TestGates::new();
         tasks.retain_after(&round(5));
         assert!(tasks.take(round(5), Sha256::hash(b"x")).is_none());
     }
 
     #[test]
     fn test_default_matches_new() {
-        let default = <Gates<D> as Default>::default();
+        let default = <TestGates as Default>::default();
         let digest = Sha256::hash(b"block");
         default.insert(round(1), digest, pending_task());
         assert!(default.take(round(1), digest).is_some());
@@ -281,5 +321,60 @@ mod tests {
         // A true verdict publishes only once the store is durable.
         assert_eq!(handle(Some(true), true), Some(true));
         assert_eq!(handle(Some(true), false), None);
+    }
+
+    #[test]
+    fn test_stage_and_defer_handshake() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let gates = TestGates::new();
+            let digest = Sha256::hash(b"block");
+            let (tx, rx) = oneshot::channel();
+
+            let staged = gates.clone();
+            context.spawn(move |_| async move {
+                staged
+                    .stage_and_defer(round(1), digest, Arc::new(7), tx, "test")
+                    .await;
+            });
+
+            // The id is published only after the gate and staged block are registered.
+            assert_eq!(rx.await.expect("id published"), digest);
+            let gate = gates.take(round(1), digest).expect("gate registered");
+            let (block, ack) = gates.take_staged(round(1), digest).expect("block staged");
+            assert_eq!(*block, 7);
+            assert!(
+                gates.take_staged(round(1), digest).is_none(),
+                "taking twice should yield None"
+            );
+
+            // Delivering a durable handle resolves the gate.
+            ack.send_lossy(Handle::ready(Ok(())));
+            assert!(gate.await.expect("gate resolved"));
+        });
+    }
+
+    #[test]
+    fn test_retain_after_drops_staged_and_abandons_handshake() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let gates = TestGates::new();
+            let digest = Sha256::hash(b"block");
+            let (tx, rx) = oneshot::channel();
+
+            let staged = gates.clone();
+            context.spawn(move |_| async move {
+                staged
+                    .stage_and_defer(round(1), digest, Arc::new(7), tx, "test")
+                    .await;
+            });
+            assert_eq!(rx.await.expect("id published"), digest);
+
+            // Pruning drops the staged ack, leaving the gate unresolved.
+            let gate = gates.take(round(1), digest).expect("gate registered");
+            gates.retain_after(&round(1));
+            assert!(gates.take_staged(round(1), digest).is_none());
+            assert!(gate.await.is_err(), "gate must be abandoned, not resolved");
+        });
     }
 }

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -13,8 +13,12 @@ use tracing::debug;
 /// delivers its durable-sync handle once marshal persists it.
 type Staged<B> = (Arc<B>, oneshot::Sender<Handle<()>>);
 
+/// The registries behind [`Gates`], sharing one lock.
 struct Inner<D: Digest, B> {
+    /// In-flight certification gate tasks, consumed by certification.
     tasks: HashMap<(Round, D), oneshot::Receiver<bool>>,
+    /// Proposals staged for their relay broadcast, consumed by the relay (or
+    /// by certification when no broadcast was requested).
     staged: HashMap<(Round, D), Staged<B>>,
 }
 

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -95,7 +95,7 @@ impl<D: Digest, B> Gates<D, B> {
     /// block is flushed to `marshal` for persistence, which delivers the
     /// durable-sync handle through the staged ack. Does nothing when no
     /// proposal is staged (the relay broadcast already took it).
-    pub(crate) fn flush<S, V>(&self, marshal: &Mailbox<S, V>, round: Round, id: D)
+    pub(crate) fn flush_unrelayed<S, V>(&self, marshal: &Mailbox<S, V>, round: Round, id: D)
     where
         S: Scheme,
         V: Variant<Block = B>,
@@ -135,7 +135,7 @@ impl<D: Digest, B> Gates<D, B> {
     /// dropped ack means the marshal actor is gone or the staged entry was
     /// pruned without ever being taken, so the gate is left unresolved and
     /// `certify` falls back to its recovery fetch.
-    pub(crate) async fn wait(
+    pub(crate) async fn stage(
         &self,
         round: Round,
         id: D,
@@ -170,7 +170,7 @@ impl<D: Digest, B> Gates<D, B> {
 /// `durable` is false only when the marshal actor is gone at shutdown (a real sync failure panics
 /// at its source), so a true-but-not-durable result abandons the gate. Returns the verdict to
 /// publish, or `None` to leave the gate unresolved.
-pub(crate) const fn handle(verdict: Option<bool>, durable: bool) -> Option<bool> {
+pub(crate) const fn resolve(verdict: Option<bool>, durable: bool) -> Option<bool> {
     match verdict {
         Some(true) if !durable => None,
         other => other,
@@ -339,29 +339,31 @@ mod tests {
     }
 
     #[test]
-    fn test_handle() {
+    fn test_resolve() {
         // Verification stopped early: nothing to publish regardless of durability.
-        assert_eq!(handle(None, true), None);
-        assert_eq!(handle(None, false), None);
+        assert_eq!(resolve(None, true), None);
+        assert_eq!(resolve(None, false), None);
         // A false app verdict is a live rejection that needs no durability.
-        assert_eq!(handle(Some(false), false), Some(false));
-        assert_eq!(handle(Some(false), true), Some(false));
+        assert_eq!(resolve(Some(false), false), Some(false));
+        assert_eq!(resolve(Some(false), true), Some(false));
         // A true verdict publishes only once the store is durable.
-        assert_eq!(handle(Some(true), true), Some(true));
-        assert_eq!(handle(Some(true), false), None);
+        assert_eq!(resolve(Some(true), true), Some(true));
+        assert_eq!(resolve(Some(true), false), None);
     }
 
     #[test]
-    fn test_wait_handshake() {
+    fn test_stage_handshake() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let gates = TestGates::new();
             let digest = Sha256::hash(b"block");
             let (tx, rx) = oneshot::channel();
 
-            let staged = gates.clone();
-            context.spawn(move |_| async move {
-                staged.wait(round(1), digest, Arc::new(7), tx, "test").await;
+            context.spawn({
+                let gates = gates.clone();
+                move |_| async move {
+                    gates.stage(round(1), digest, Arc::new(7), tx, "test").await;
+                }
             });
 
             // The id is published only after the gate and staged block are registered.
@@ -388,9 +390,11 @@ mod tests {
             let digest = Sha256::hash(b"block");
             let (tx, rx) = oneshot::channel();
 
-            let staged = gates.clone();
-            context.spawn(move |_| async move {
-                staged.wait(round(1), digest, Arc::new(7), tx, "test").await;
+            context.spawn({
+                let gates = gates.clone();
+                move |_| async move {
+                    gates.stage(round(1), digest, Arc::new(7), tx, "test").await;
+                }
             });
             assert_eq!(rx.await.expect("id published"), digest);
 

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -16,10 +16,10 @@ type Staged<B> = (Arc<B>, oneshot::Sender<Handle<()>>);
 /// The registries behind [`Gates`], sharing one lock.
 struct Inner<D: Digest, B> {
     /// In-flight certification gate tasks, consumed by certification.
-    tasks: HashMap<(Round, D), oneshot::Receiver<bool>>,
+    certifications: HashMap<(Round, D), oneshot::Receiver<bool>>,
     /// Proposals staged for their relay broadcast, consumed by the relay (or
     /// by certification when no broadcast was requested).
-    staged: HashMap<(Round, D), Staged<B>>,
+    proposals: HashMap<(Round, D), Staged<B>>,
 }
 
 /// A shared, thread-safe registry of in-flight certification gate tasks and
@@ -57,20 +57,23 @@ impl<D: Digest, B> Gates<D, B> {
     pub(crate) fn new() -> Self {
         Self {
             inner: Arc::new(Mutex::new(Inner {
-                tasks: HashMap::new(),
-                staged: HashMap::new(),
+                certifications: HashMap::new(),
+                proposals: HashMap::new(),
             })),
         }
     }
 
     /// Registers a certification gate task for the block identified by `(round, digest)`.
     pub(crate) fn insert(&self, round: Round, digest: D, task: oneshot::Receiver<bool>) {
-        self.inner.lock().tasks.insert((round, digest), task);
+        self.inner
+            .lock()
+            .certifications
+            .insert((round, digest), task);
     }
 
     /// Removes and returns the certification gate task for `(round, digest)`, if present.
     pub(crate) fn take(&self, round: Round, digest: D) -> Option<oneshot::Receiver<bool>> {
-        self.inner.lock().tasks.remove(&(round, digest))
+        self.inner.lock().certifications.remove(&(round, digest))
     }
 
     /// Removes and returns the staged proposal for `(round, digest)`, if present.
@@ -78,7 +81,7 @@ impl<D: Digest, B> Gates<D, B> {
     /// The taken block and ack are handed to marshal exactly once: by the relay
     /// broadcast, or by certification when no broadcast was ever requested.
     pub(crate) fn take_staged(&self, round: Round, digest: D) -> Option<Staged<B>> {
-        self.inner.lock().staged.remove(&(round, digest))
+        self.inner.lock().proposals.remove(&(round, digest))
     }
 
     /// Discards all entries whose round is at or before `finalized_round`.
@@ -88,11 +91,11 @@ impl<D: Digest, B> Gates<D, B> {
     pub(crate) fn retain_after(&self, finalized_round: &Round) {
         let mut inner = self.inner.lock();
         inner
-            .tasks
-            .retain(|(task_round, _), _| task_round > finalized_round);
+            .certifications
+            .retain(|(round, _), _| round > finalized_round);
         inner
-            .staged
-            .retain(|(staged_round, _), _| staged_round > finalized_round);
+            .proposals
+            .retain(|(round, _), _| round > finalized_round);
     }
 
     /// Stages `block` for its relay broadcast and completes the propose
@@ -123,8 +126,8 @@ impl<D: Digest, B> Gates<D, B> {
         let (ack, persist) = oneshot::channel();
         {
             let mut inner = self.inner.lock();
-            inner.tasks.insert((round, id), durable_rx);
-            inner.staged.insert((round, id), (block, ack));
+            inner.certifications.insert((round, id), durable_rx);
+            inner.proposals.insert((round, id), (block, ack));
         }
         tx.send_lossy(id);
         let Ok(handle) = persist.await else {

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -173,7 +173,7 @@ where
     scheme_provider: Z,
     epocher: ES,
     strategy: S,
-    gates: Gates<Commitment>,
+    gates: Gates<Commitment, CodedBlock<B, C, H>>,
 
     build_duration: Timed,
     verify_duration: Timed,
@@ -604,6 +604,13 @@ where
         payload: Commitment,
         task: oneshot::Receiver<bool>,
     ) -> oneshot::Receiver<bool> {
+        // A staged proposal whose broadcast was never requested cannot resolve
+        // its gate. Certification now demands durability, so persist it
+        // (without broadcasting) to complete the handshake.
+        if let Some((block, ack)) = self.gates.take_staged(round, payload) {
+            self.marshal.verified_deferred(round, block, ack);
+        }
+
         // `verify()` intentionally waits only for local candidate data. Once
         // certification starts, a notarization exists and the same pending
         // verifier must be unblocked by round-bound recovery if local
@@ -663,11 +670,12 @@ where
     /// boundary block to avoid creating blocks that would be invalidated by the epoch transition.
     ///
     /// The proposal operation is spawned in a background task and returns a receiver that will
-    /// contain the proposed block's commitment when ready. The block's persistence is enqueued
-    /// before the commitment is delivered, and the resulting sync handle is awaited only at
-    /// certification so it overlaps consensus voting. The commitment does not imply durability
-    /// on its own; [`CertifiableAutomaton::certify`] awaits the registered certification gate
-    /// before the finalize vote.
+    /// contain the proposed block's commitment when ready. The block is staged before the
+    /// commitment is delivered and handed to marshal when consensus requests the relay
+    /// broadcast, which persists it after the shards are sent. The resulting sync handle is
+    /// awaited only at certification so it overlaps consensus voting. The commitment does not
+    /// imply durability on its own; [`CertifiableAutomaton::certify`] awaits the registered
+    /// certification gate before the finalize vote.
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.coding.propose", level = "info", skip_all, fields(round = %consensus_context.round))]
     async fn propose(
@@ -715,7 +723,8 @@ where
         context.spawn(move |runtime_context| {
             async move {
                 // On leader recovery, marshal may already hold a verified block
-                // for this round (persisted before voting in consensus).
+                // for this round (persisted by a pre-crash propose that reached
+                // its relay broadcast).
                 //
                 // The pre-crash commitment may already have been broadcast,
                 // so building a fresh block would equivocate. The stored
@@ -738,15 +747,20 @@ where
                         );
                         return;
                     }
+                    // Stage the recovered block so the relay broadcast re-sends
+                    // its shards through the same handshake as a fresh
+                    // proposal. The relay-time persist deduplicates against the
+                    // pre-crash write, with the handle covering the original.
                     let commitment = block.commitment();
                     let round = consensus_context.round;
-                    let success = tx.send_lossy(commitment);
                     debug!(
                         ?round,
                         ?commitment,
-                        success,
-                        "reused verified block from marshal on leader recovery"
+                        "reusing verified block from marshal on leader recovery"
                     );
+                    gates
+                        .stage_and_defer(round, commitment, Arc::new(block), tx, "recovered block")
+                        .await;
                     return;
                 }
 
@@ -796,13 +810,12 @@ where
                     let commitment = parent.commitment();
                     let round = consensus_context.round;
 
-                    let persist = marshal.verified_deferred(round, parent);
                     gates
-                        .persist_and_defer(
+                        .stage_and_defer(
                             round,
                             commitment,
+                            parent,
                             tx,
-                            persist,
                             "re-proposed boundary block",
                         )
                         .await;
@@ -856,9 +869,14 @@ where
                 let commitment = coded_block.commitment();
                 let round = consensus_context.round;
 
-                let persist = marshal.proposed_deferred(round, coded_block);
                 gates
-                    .persist_and_defer(round, commitment, tx, persist, "proposed block")
+                    .stage_and_defer(
+                        round,
+                        commitment,
+                        Arc::new(coded_block),
+                        tx,
+                        "proposed block",
+                    )
                     .await;
             }
             .instrument(span)
@@ -1127,7 +1145,17 @@ where
         let Plan::Propose { round } = plan else {
             return Feedback::Ok;
         };
-        self.marshal.forward(round, commitment, Recipients::All)
+
+        // The propose plan relays the staged proposal: its shards are
+        // broadcast before the block is persisted, and its ack completes the
+        // propose durability handshake. Every propose path stages its block
+        // (including leader recovery), so a missing entry means the round was
+        // already pruned by finalization and there is nothing to relay.
+        let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
+            debug!(%round, %commitment, "no staged proposal to relay");
+            return Feedback::Ok;
+        };
+        self.marshal.proposed(round, block, Recipients::All, ack)
     }
 }
 

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -1146,11 +1146,6 @@ where
             return Feedback::Ok;
         };
 
-        // The propose plan relays the staged proposal: its shards are
-        // broadcast before the block is persisted, and its ack completes the
-        // propose durability handshake. Every propose path stages its block
-        // (including leader recovery), so a missing entry means the round was
-        // already pruned by finalization and there is nothing to relay.
         let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
             debug!(%round, %commitment, "no staged proposal to relay");
             return Feedback::Ok;

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -471,7 +471,7 @@ where
                 // Publish only when the block is both valid and durable. App-invalid
                 // candidates may already be in the cache from the concurrent store above,
                 // so the gate verdict is the authority for consensus progress.
-                if let Some(application_valid) = gates::handle(verdict, durable) {
+                if let Some(application_valid) = gates::resolve(verdict, durable) {
                     tx.send_lossy(application_valid);
                 }
             }
@@ -752,7 +752,7 @@ where
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
-                        .wait(round, commitment, Arc::new(block), tx, "recovered block")
+                        .stage(round, commitment, Arc::new(block), tx, "recovered block")
                         .await;
                     return;
                 }
@@ -804,7 +804,7 @@ where
                     let round = consensus_context.round;
 
                     gates
-                        .wait(round, commitment, parent, tx, "re-proposed boundary block")
+                        .stage(round, commitment, parent, tx, "re-proposed boundary block")
                         .await;
                     return;
                 }
@@ -857,7 +857,7 @@ where
                 let round = consensus_context.round;
 
                 gates
-                    .wait(
+                    .stage(
                         round,
                         commitment,
                         Arc::new(coded_block),
@@ -1099,7 +1099,7 @@ where
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.coding.certify", level = "info", skip_all, fields(round = %round, commitment = %payload))]
     async fn certify(&mut self, round: Round, payload: Self::Digest) -> oneshot::Receiver<bool> {
-        self.gates.flush(&self.marshal, round, payload);
+        self.gates.flush_unrelayed(&self.marshal, round, payload);
 
         // First, check for an in-progress certification gate task.
         let task = self.gates.take(round, payload);

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -604,13 +604,6 @@ where
         payload: Commitment,
         task: oneshot::Receiver<bool>,
     ) -> oneshot::Receiver<bool> {
-        // A staged proposal whose broadcast was never requested cannot resolve
-        // its gate. Certification now demands durability, so persist it
-        // (without broadcasting) to complete the handshake.
-        if let Some((block, ack)) = self.gates.take_staged(round, payload) {
-            self.marshal.verified_deferred(round, block, ack);
-        }
-
         // `verify()` intentionally waits only for local candidate data. Once
         // certification starts, a notarization exists and the same pending
         // verifier must be unblocked by round-bound recovery if local
@@ -674,7 +667,7 @@ where
     /// commitment is delivered and handed to marshal when consensus requests the relay
     /// broadcast, which persists it after the shards are sent. The resulting sync handle is
     /// awaited only at certification so it overlaps consensus voting. The commitment does not
-    /// imply durability on its own; [`CertifiableAutomaton::certify`] awaits the registered
+    /// imply durability on its own. [`CertifiableAutomaton::certify`] awaits the registered
     /// certification gate before the finalize vote.
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.coding.propose", level = "info", skip_all, fields(round = %consensus_context.round))]
@@ -759,7 +752,7 @@ where
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
-                        .stage_and_defer(round, commitment, Arc::new(block), tx, "recovered block")
+                        .wait(round, commitment, Arc::new(block), tx, "recovered block")
                         .await;
                     return;
                 }
@@ -811,13 +804,7 @@ where
                     let round = consensus_context.round;
 
                     gates
-                        .stage_and_defer(
-                            round,
-                            commitment,
-                            parent,
-                            tx,
-                            "re-proposed boundary block",
-                        )
+                        .wait(round, commitment, parent, tx, "re-proposed boundary block")
                         .await;
                     return;
                 }
@@ -870,7 +857,7 @@ where
                 let round = consensus_context.round;
 
                 gates
-                    .stage_and_defer(
+                    .wait(
                         round,
                         commitment,
                         Arc::new(coded_block),
@@ -1112,6 +1099,8 @@ where
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.coding.certify", level = "info", skip_all, fields(round = %round, commitment = %payload))]
     async fn certify(&mut self, round: Round, payload: Self::Digest) -> oneshot::Receiver<bool> {
+        self.gates.flush(&self.marshal, round, payload);
+
         // First, check for an in-progress certification gate task.
         let task = self.gates.take(round, payload);
         if let Some(task) = task {
@@ -1147,8 +1136,8 @@ where
         };
 
         let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
-            debug!(%round, %commitment, "no staged proposal to relay");
-            return Feedback::Ok;
+            debug!(%round, %commitment, "no staged proposal to relay, attempting forwarding");
+            return self.marshal.forward(round, commitment, Recipients::All);
         };
         self.marshal.proposed(round, block, Recipients::All, ack)
     }

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -2826,8 +2826,9 @@ mod tests {
             };
             let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
 
-            // Drive the leader-side propose path. `propose` must persist the
-            // block before returning the commitment.
+            // Drive the leader-side propose path. `propose` stages the block
+            // and returns the commitment; durability is established by the
+            // certify flush below.
             let commitment = marshaled
                 .propose(propose_context)
                 .await

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -2829,7 +2829,7 @@ mod tests {
             let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
 
             // Drive the leader-side propose path. `propose` stages the block
-            // and returns the commitment; durability is established by the
+            // and returns the commitment. Durability is established by the
             // certify flush below.
             let commitment = marshaled
                 .propose(propose_context)

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -2877,6 +2877,113 @@ mod tests {
         });
     }
 
+    /// A propose relay with a staged proposal must send it through the shard
+    /// engine and complete the durability handshake. The freshly built block
+    /// is nowhere persisted at broadcast time, so the forward fallback has
+    /// nothing to serve: only the staged-hit path can seed the shard engine.
+    #[test_traced("WARN")]
+    fn test_marshaled_propose_relay_sends_staged_block() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(60));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let genesis_ctx = CodingCtx {
+                round: Round::zero(),
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let genesis = make_coding_block(genesis_ctx, Sha256::hash(b""), Height::zero(), 0);
+            let genesis_parent_commitment = genesis_coding_commitment::<Sha256, _>(&genesis);
+
+            let propose_round = Round::new(Epoch::zero(), View::new(1));
+            let propose_context = CodingCtx {
+                round: propose_round,
+                leader: me.clone(),
+                parent: (View::zero(), genesis_parent_commitment),
+            };
+            let block_to_propose = make_coding_block(
+                propose_context.clone(),
+                genesis.digest(),
+                Height::new(1),
+                100,
+            );
+            let block_digest = block_to_propose.digest();
+            let expected_commitment = CodedBlock::<_, ReedSolomon<Sha256>, Sha256>::new(
+                block_to_propose.clone(),
+                coding_config,
+                &Sequential,
+            )
+            .commitment();
+
+            let mock_app: MockVerifyingApp<CodingB, S> =
+                MockVerifyingApp::new().with_propose_result(block_to_propose);
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            let commitment = marshaled
+                .propose(propose_context)
+                .await
+                .await
+                .expect("propose should produce a commitment");
+            assert_eq!(commitment, expected_commitment);
+
+            // The relay must take the staged proposal and broadcast its
+            // shards, seeding the shard engine's local cache.
+            let subscription = shards.subscribe(commitment);
+            let _ = marshaled.broadcast(
+                commitment,
+                Plan::Propose {
+                    round: propose_round,
+                },
+            );
+            let cached = subscription
+                .await
+                .expect("shard engine must cache the relayed proposal");
+            assert_eq!(cached.digest(), block_digest);
+
+            // The relayed proposal is persisted through the staged ack, so
+            // certification resolves durably without a flush.
+            assert!(
+                marshaled
+                    .certify(propose_round, commitment)
+                    .await
+                    .await
+                    .expect("certify result missing"),
+                "certify must succeed for the relayed proposal"
+            );
+        });
+    }
+
     /// Regression: if marshal already holds a verified block for a round
     /// (say, persisted by a pre-crash propose whose notarize vote never
     /// reached the journal), a restarted leader's `propose` must return

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -81,13 +81,15 @@ mod tests {
                     CodingHarness, EmptyProvider, TestHarness, BLOCKS_PER_EPOCH, D, K, LINK,
                     NAMESPACE, NUM_VALIDATORS, QUORUM, S, TEST_QUOTA, UNRELIABLE_LINK, V,
                 },
-                verifying::MockVerifyingApp,
+                verifying::{GatedVerifyingApp, MockVerifyingApp},
             },
             resolver::handler,
         },
-        simplex::{scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, types::Proposal},
+        simplex::{
+            scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, types::Proposal, Plan,
+        },
         types::{coding::Commitment, Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta},
-        Automaton, Block, CertifiableAutomaton, CertifiableBlock,
+        Automaton, Block, CertifiableAutomaton, CertifiableBlock, Relay,
     };
     use bytes::Bytes;
     use commonware_actor::{mailbox, Feedback};
@@ -2880,7 +2882,10 @@ mod tests {
     /// reached the journal), a restarted leader's `propose` must return
     /// that block's commitment instead of rebuilding. The pre-crash
     /// commitment may already have been broadcast, so proposing a rebuilt
-    /// block for the same round would equivocate.
+    /// block for the same round would equivocate. The recovered proposal
+    /// must also be staged for the relay, so the broadcast re-sends its
+    /// shards and certification resolves through the deduplicated
+    /// re-persist.
     #[test_traced("WARN")]
     fn test_propose_reuses_verified_block_on_restart() {
         let runner = deterministic::Runner::timed(Duration::from_secs(60));
@@ -2932,19 +2937,13 @@ mod tests {
             let commitment_a = coded_a.commitment();
             assert!(marshal.verified(round, coded_a).await);
 
-            // After restart, a fresh application would build a different
-            // block for the same round.
-            let block_b = make_coding_block(ctx.clone(), genesis.digest(), Height::new(1), 200);
-            let coded_b: CodedBlock<_, ReedSolomon<Sha256>, Sha256> =
-                CodedBlock::new(block_b.clone(), coding_config, &Sequential);
-            let commitment_b = coded_b.commitment();
-            assert_ne!(
-                commitment_a, commitment_b,
-                "test requires distinct commitments"
-            );
-
-            let mock_app: MockVerifyingApp<CodingB, S> =
-                MockVerifyingApp::new().with_propose_result(block_b);
+            // The app cannot build (`propose` returns None) and its
+            // verification never completes, so the assertions below hold
+            // only if the stored block is reused as-is and certification
+            // resolves through the durability gate registered by the
+            // recovery staging.
+            let (mock_app, verify_started, _release_verify): (GatedVerifyingApp<CodingB, S>, _, _) =
+                GatedVerifyingApp::new();
             let cfg = MarshaledConfig {
                 application: mock_app,
                 marshal: marshal.clone(),
@@ -2964,6 +2963,24 @@ mod tests {
                 commitment, commitment_a,
                 "propose must reuse the block marshal already persisted for this round"
             );
+
+            // The relay broadcast must find the recovered proposal staged and
+            // re-persist it (a dedup no-op whose handle covers the pre-crash
+            // write), resolving the certification gate registered by the
+            // recovery path.
+            let _ = marshaled.broadcast(commitment, Plan::Propose { round });
+            let certify_rx = marshaled.certify(round, commitment).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "recovered proposal must certify through the relay handshake"
+                    );
+                },
+                _ = verify_started => {
+                    panic!("certifying a recovered proposal must not run app verification");
+                },
+            }
         });
     }
 

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -4478,13 +4478,16 @@ mod tests {
         // - we receive a shard for commitment B (the certifiable one)
         // - commitment A reconstructs first
         // - commitment B must still remain recoverable
+        // - the leader must not be blocked (a leader that crashes after its
+        //   broadcast but before its local persist legitimately re-proposes
+        //   a different block for the same round after restart)
         let fixture: Fixture<C> = Fixture {
             num_peers: 10,
             ..Default::default()
         };
 
         fixture.start(
-            |config, context, _oracle, mut peers, _, coding_config| async move {
+            |config, context, oracle, mut peers, _, coding_config| async move {
                 let receiver_idx = 3usize;
                 let receiver_pk = peers[receiver_idx].public_key.clone();
                 let receiver_shard_idx = peers[receiver_idx].index.get() as u16;
@@ -4572,6 +4575,17 @@ mod tests {
                         panic!("certifiable commitment was not recoverable after same-round equivocation");
                     },
                 }
+
+                // Cross-commitment equivocation within a round is tolerated,
+                // so the leader must not be blocked.
+                let blocked_peers = oracle.blocked().await.unwrap();
+                let is_blocked = blocked_peers
+                    .iter()
+                    .any(|(a, b)| a == &receiver_pk && b == &leader);
+                assert!(
+                    !is_blocked,
+                    "leader must not be blocked for same-round cross-commitment shards"
+                );
             },
         );
     }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -663,7 +663,7 @@ where
                     .cache
                     .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
                     .await;
-                ack.expect("durable ack present").send_lossy(handle);
+                ack.send_lossy(handle);
             }
             Message::Certified {
                 round, block, ack, ..
@@ -696,7 +696,7 @@ where
                     let (notarization, block) = join(notarization_sync, block_sync).await;
                     notarization.and(block)
                 });
-                ack.expect("durable ack present").send_lossy(handle);
+                ack.send_lossy(handle);
             }
             Message::Notarization { notarization, .. } => {
                 let round = notarization.round();

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -632,38 +632,14 @@ where
                 // broadcast a conflicting block for the same round after
                 // restart.
                 buffer.send(round, Arc::clone(&block), recipients);
-                self.ingest(Arc::clone(&block), buffer, application, resolver)
+                self.persist_verified(round, block, ack, buffer, application, resolver)
                     .await;
-
-                // If the round has already been pruned by tip advancement,
-                // `put_verified` is a no-op because the round is below
-                // the retention floor (and no longer is required by consensus
-                // to make progress). A duplicate delivery is also a no-op, with
-                // the handle still covering the original write's durability.
-                let digest = block.digest();
-                let handle = self
-                    .cache
-                    .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
-                    .await;
-                ack.send_lossy(handle);
             }
             Message::Verified {
                 round, block, ack, ..
             } => {
-                self.ingest(Arc::clone(&block), buffer, application, resolver)
+                self.persist_verified(round, block, ack, buffer, application, resolver)
                     .await;
-                let digest = block.digest();
-
-                // If the round has already been pruned by tip advancement,
-                // `put_verified` is a no-op because the round is below
-                // the retention floor (and no longer is required by consensus
-                // to make progress). A duplicate delivery is also a no-op, with
-                // the handle still covering the original write's durability.
-                let handle = self
-                    .cache
-                    .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
-                    .await;
-                ack.send_lossy(handle);
             }
             Message::Certified {
                 round, block, ack, ..
@@ -1191,6 +1167,32 @@ where
                 Request::finalized_block_by_round(commitment, round),
             )
             .ignore();
+    }
+
+    /// Ingests `block` and persists it as a verify-stage candidate for `round`,
+    /// delivering the write's durable-sync handle through `ack`.
+    ///
+    /// If the round has already been pruned by tip advancement, `put_verified`
+    /// is a no-op because the round is below the retention floor (and no longer
+    /// is required by consensus to make progress). A duplicate delivery is also
+    /// a no-op, with the handle still covering the original write's durability.
+    async fn persist_verified<Buf: Buffer<V>>(
+        &mut self,
+        round: Round,
+        block: Arc<V::Block>,
+        ack: oneshot::Sender<Handle<()>>,
+        buffer: &mut Buf,
+        application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
+        resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
+    ) {
+        self.ingest(Arc::clone(&block), buffer, application, resolver)
+            .await;
+        let digest = block.digest();
+        let handle = self
+            .cache
+            .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
+            .await;
+        ack.send_lossy(handle);
     }
 
     /// Notifies subscribers of a validated block and applies it to any

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -128,8 +128,6 @@ where
     strategy: T,
 
     // ---------- State ----------
-    // Last proposed block
-    last_proposed_block: Option<(Round, V::Commitment, Arc<V::Block>)>,
     // Current processed floor and any pending floor update
     floor: Floor<P::Scheme, V::Commitment>,
     // Application delivery cursor
@@ -247,7 +245,6 @@ where
                 max_repair: config.max_repair,
                 block_codec_config: config.block_codec_config,
                 strategy: config.strategy,
-                last_proposed_block: None,
                 floor,
                 stream,
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
@@ -616,42 +613,39 @@ where
                 if matches!(&recipients, Recipients::Some(peers) if peers.is_empty()) {
                     return;
                 }
-                let block = match self.take_proposed(round, commitment) {
-                    Some(block) => block,
-                    None => {
-                        let Some(block) = self.find_block_by_commitment(buffer, commitment).await
-                        else {
-                            debug!(?commitment, "block not found for forwarding");
-                            return;
-                        };
-                        block
-                    }
+                let Some(block) = self.find_block_by_commitment(buffer, commitment).await else {
+                    debug!(?commitment, "block not found for forwarding");
+                    return;
                 };
                 buffer.send(round, block, recipients);
             }
             Message::Proposed {
-                round, block, ack, ..
+                round,
+                block,
+                recipients,
+                ack,
+                ..
             } => {
+                // Hand the block to the network before ingesting and
+                // persisting it, so peers are not kept waiting on the storage
+                // write. Nothing consumes the durability ack before certify,
+                // and no certificate can form until peers receive the block,
+                // so ordering the write after the send is safe.
+                buffer.send(round, Arc::clone(&block), recipients);
                 self.ingest(Arc::clone(&block), buffer, application, resolver)
                     .await;
-                let digest = block.digest();
 
                 // If the round has already been pruned by tip advancement,
                 // `put_verified` is a no-op because the round is below
                 // the retention floor (and no longer is required by consensus
                 // to make progress). A duplicate delivery is also a no-op, with
                 // the handle still covering the original write's durability.
+                let digest = block.digest();
                 let handle = self
                     .cache
-                    .put_verified(round, digest, block.as_ref().clone().into())
+                    .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
                     .await;
-
-                // Retain the block in memory so the subsequent `Forward` can
-                // broadcast it without reloading from storage. An older retained
-                // proposal (if any) is overwritten.
-                let commitment = V::commitment(&block);
-                self.last_proposed_block = Some((round, commitment, block));
-                ack.expect("durable ack present").send_lossy(handle);
+                ack.send_lossy(handle);
             }
             Message::Verified {
                 round, block, ack, ..
@@ -1806,16 +1800,6 @@ where
     }
 
     // -------------------- Prunable Storage --------------------
-
-    /// If a block previously accepted via [`Message::Proposed`] matches the
-    /// supplied `(round, commitment)`, remove and return it.
-    fn take_proposed(&mut self, round: Round, commitment: V::Commitment) -> Option<Arc<V::Block>> {
-        let (cached_round, cached_commitment, _) = self.last_proposed_block.as_ref()?;
-        if *cached_round != round || *cached_commitment != commitment {
-            return None;
-        }
-        self.last_proposed_block.take().map(|(_, _, block)| block)
-    }
 
     /// Sync both finalization archives to durable storage, blocking the actor
     /// until they are durable.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -626,11 +626,11 @@ where
                 ack,
                 ..
             } => {
-                // Hand the block to the network before ingesting and
-                // persisting it, so peers are not kept waiting on the storage
-                // write. Nothing consumes the durability ack before certify,
-                // and no certificate can form until peers receive the block,
-                // so ordering the write after the send is safe.
+                // We broadcast the block before persisting it because
+                // durability is not required until certify. Because the send
+                // precedes vote durability, a leader that crashes here may
+                // broadcast a conflicting block for the same round after
+                // restart.
                 buffer.send(round, Arc::clone(&block), recipients);
                 self.ingest(Arc::clone(&block), buffer, application, resolver)
                     .await;

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -146,9 +146,6 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         recipients: Recipients<S::PublicKey>,
     },
     /// A request to broadcast a locally proposed block and persist it.
-    ///
-    /// The block is handed to the network before it is ingested and persisted,
-    /// so the storage write never delays propagation.
     Proposed {
         /// The span carried with this request.
         span: Span,

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -879,10 +879,9 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// Notifies the actor that a block should be durably persisted at `round`,
     /// delivering its durable-sync handle through `ack` without awaiting it.
     ///
-    /// Used by certification to persist a staged proposal whose broadcast was
-    /// never requested (completing the propose durability handshake), and by the
-    /// blocking [Self::verified]. A dropped `ack` (the mailbox is closed)
-    /// abandons the handshake.
+    /// Takes a sender rather than returning a receiver so certification can
+    /// deliver the handle into a handshake staged at propose time. A dropped
+    /// `ack` (the mailbox is closed) abandons the handshake.
     pub fn verified_deferred(
         &self,
         round: Round,

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -145,7 +145,10 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The recipients to forward the block to.
         recipients: Recipients<S::PublicKey>,
     },
-    /// A notification that a block has been locally proposed by this node.
+    /// A request to broadcast a locally proposed block and persist it.
+    ///
+    /// The block is handed to the network before it is ingested and persisted,
+    /// so the storage write never delays propagation.
     Proposed {
         /// The span carried with this request.
         span: Span,
@@ -153,8 +156,10 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         round: Round,
         /// The proposed block.
         block: Arc<V::Block>,
+        /// The recipients to broadcast the block to.
+        recipients: Recipients<S::PublicKey>,
         /// A channel sent once the block sync has started.
-        ack: Option<oneshot::Sender<Handle<()>>>,
+        ack: oneshot::Sender<Handle<()>>,
     },
     /// A notification that a block has been verified by the application.
     Verified {
@@ -844,80 +849,64 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         receiver.await.ok().flatten()
     }
 
-    /// Notifies the actor that a block has been locally proposed, returning a
-    /// receiver for its durable-sync handle without awaiting it.
+    /// Requests the broadcast of a locally proposed block, persisting it after
+    /// the send.
     ///
-    /// The message is enqueued synchronously (before this returns), so a subsequent
-    /// [Self::forward] for the same block is ordered after it. This lets a leader
-    /// broadcast the proposal digest immediately and await durability later (at
-    /// certification), overlapping the durable sync with consensus voting. Callers
-    /// that simply need durability before proceeding should use the blocking
-    /// [Self::proposed].
-    #[must_use = "the receiver delivers the durable-sync handle and dropping it forfeits sync-failure observation"]
-    pub fn proposed_deferred(
+    /// The actor hands the block to the network before ingesting and persisting
+    /// it, so the storage write never delays propagation. `ack` receives the
+    /// durable-sync handle once the write's sync has started. The propose path
+    /// stages the block (and `ack`) at propose time and calls this when consensus
+    /// requests the broadcast via [`crate::Relay::broadcast`], awaiting durability
+    /// only at certification so the sync overlaps consensus voting.
+    ///
+    /// A dropped `ack` (the mailbox is closed) abandons the handshake.
+    pub fn proposed(
         &self,
         round: Round,
         block: impl Into<Arc<V::Block>>,
-    ) -> oneshot::Receiver<Handle<()>> {
-        let (ack, receiver) = oneshot::channel();
-        let _ = self.sender.enqueue(Message::Proposed {
+        recipients: Recipients<S::PublicKey>,
+        ack: oneshot::Sender<Handle<()>>,
+    ) -> Feedback {
+        self.sender.enqueue(Message::Proposed {
             span: info_span!("marshal.mailbox.proposed", round = %round),
             round,
             block: block.into(),
-            ack: Some(ack),
-        });
-        receiver
+            recipients,
+            ack,
+        })
     }
 
-    /// Notifies the actor that a block has been locally proposed.
+    /// Notifies the actor that a block should be durably persisted at `round`,
+    /// delivering its durable-sync handle through `ack` without awaiting it.
     ///
-    /// Returns after the block is durably persisted. The durable sync is awaited on
-    /// the caller's task (off the actor), so the actor never blocks on fsync. The
-    /// propose path should use [Self::proposed_deferred], which must enqueue before
-    /// broadcasting the digest and await durability only at certify.
-    #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn proposed(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
-        let Ok(handle) = self.proposed_deferred(round, block).await else {
-            return false;
-        };
-        handle.durable(round, "proposed").await
-    }
-
-    /// Notifies the actor that a block has been verified, returning a receiver for
-    /// its durable-sync handle without awaiting it. Enqueued synchronously, as with
-    /// [Self::proposed_deferred].
-    ///
-    /// This is the deferred form for the leader's boundary re-proposal path, which
-    /// must enqueue before broadcasting the digest and await durability only at
-    /// certification (overlapping the sync with consensus voting). Verify/certify
-    /// consumers that simply need durability before proceeding should use the
-    /// blocking [Self::verified].
-    #[must_use = "the receiver delivers the durable-sync handle and dropping it forfeits sync-failure observation"]
+    /// Used by certification to persist a staged proposal whose broadcast was
+    /// never requested (completing the propose durability handshake), and by the
+    /// blocking [Self::verified]. A dropped `ack` (the mailbox is closed)
+    /// abandons the handshake.
     pub fn verified_deferred(
         &self,
         round: Round,
         block: impl Into<Arc<V::Block>>,
-    ) -> oneshot::Receiver<Handle<()>> {
-        let (ack, receiver) = oneshot::channel();
+        ack: oneshot::Sender<Handle<()>>,
+    ) {
         let _ = self.sender.enqueue(Message::Verified {
             span: info_span!("marshal.mailbox.verified", round = %round),
             round,
             block: block.into(),
             ack: Some(ack),
         });
-        receiver
     }
 
     /// Notifies the actor that a block has been verified.
     ///
     /// Returns after the block is durably persisted. Mirrors [Self::certified]: the
     /// durable sync is awaited on the caller's task (off the actor), so the actor
-    /// never blocks on fsync. The boundary re-proposal path should use
-    /// [Self::verified_deferred], which must enqueue before broadcasting and await
-    /// durability only at certify.
+    /// never blocks on fsync.
     #[must_use = "callers must consider block durability before proceeding"]
     pub async fn verified(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
-        let Ok(handle) = self.verified_deferred(round, block).await else {
+        let (ack, receiver) = oneshot::channel();
+        self.verified_deferred(round, block, ack);
+        let Ok(handle) = receiver.await else {
             return false;
         };
         handle.durable(round, "verified").await
@@ -968,7 +957,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         });
     }
 
-    /// Forward a block to a set of recipients.
+    /// Forward a locally stored block to a set of recipients.
     pub fn forward(
         &self,
         round: Round,
@@ -1071,7 +1060,8 @@ mod tests {
                 span: Span::none(),
                 round: round(height),
                 block: block(height).into(),
-                ack: Some(ack),
+                recipients: Recipients::All,
+                ack,
             },
             receiver,
         )
@@ -1290,7 +1280,9 @@ mod tests {
             let mailbox = Mailbox::<harness::S, Standard<harness::B>>::new(sender);
             drop(receiver);
 
-            assert!(!mailbox.proposed(round(1), block(1)).await);
+            let (ack, receiver) = oneshot::channel();
+            let _ = mailbox.proposed(round(1), block(1), Recipients::All, ack);
+            assert!(receiver.await.is_err());
             assert!(!mailbox.verified(round(2), block(2)).await);
             assert!(!mailbox.certified(round(3), block(3)).await);
         });

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -170,7 +170,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The verified block.
         block: Arc<V::Block>,
         /// A channel sent once the block sync has started.
-        ack: Option<oneshot::Sender<Handle<()>>>,
+        ack: oneshot::Sender<Handle<()>>,
     },
     /// A notification that a block has been certified by the application.
     Certified {
@@ -182,7 +182,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         block: Arc<V::Block>,
         /// A channel sent once the block and notarization syncs have started; the
         /// handle covers both.
-        ack: Option<oneshot::Sender<Handle<()>>>,
+        ack: oneshot::Sender<Handle<()>>,
     },
     /// Attempts to set the sync starting point from a finalized commitment.
     ///
@@ -892,7 +892,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
             span: info_span!("marshal.mailbox.verified", round = %round),
             round,
             block: block.into(),
-            ack: Some(ack),
+            ack,
         });
     }
 
@@ -921,7 +921,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
             span: info_span!("marshal.mailbox.certified", round = %round),
             round,
             block: block.into(),
-            ack: Some(ack),
+            ack,
         });
         let Ok(handle) = receiver.await else {
             return false;
@@ -1073,7 +1073,7 @@ mod tests {
                 span: Span::none(),
                 round: round(height),
                 block: block(height).into(),
-                ack: Some(ack),
+                ack,
             },
             receiver,
         )
@@ -1086,7 +1086,7 @@ mod tests {
                 span: Span::none(),
                 round: round(height),
                 block: block(height).into(),
-                ack: Some(ack),
+                ack,
             },
             receiver,
         )

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -12,7 +12,7 @@ use crate::{
             Coding,
         },
         config::{Config, Start},
-        core::{Actor, CommitmentFallback, DigestFallback, Mailbox},
+        core::{durability::Durable as _, Actor, CommitmentFallback, DigestFallback, Mailbox},
         mocks::{application::Application, block::Block},
         resolver::p2p as resolver,
         standard::Standard,
@@ -35,7 +35,10 @@ use commonware_cryptography::{
     Committable, Digest as DigestTrait, Digestible, Hasher as _, Signer,
 };
 use commonware_macros::select;
-use commonware_p2p::simulated::{self, Link, Network, Oracle};
+use commonware_p2p::{
+    simulated::{self, Link, Network, Oracle},
+    Recipients,
+};
 use commonware_parallel::Sequential;
 use commonware_runtime::{
     buffer::paged::CacheRef,
@@ -50,7 +53,9 @@ use commonware_storage::{
     archive::{immutable, prunable},
     translator::EightCap,
 };
-use commonware_utils::{test_rng, vec::NonEmptyVec, NZUsize, TestRng, NZU16, NZU64};
+use commonware_utils::{
+    channel::oneshot, test_rng, vec::NonEmptyVec, NZUsize, TestRng, NZU16, NZU64,
+};
 use futures::StreamExt;
 use rand::{
     seq::{IteratorRandom, SliceRandom},
@@ -211,6 +216,7 @@ pub trait TestHarness: 'static + Sized {
     type TestBlock: Heightable
         + Clone
         + Send
+        + Sync
         + Into<<Self::Variant as crate::marshal::core::Variant>::Block>;
 
     /// Additional per-validator state (e.g., shards mailbox for coding).
@@ -269,12 +275,24 @@ pub trait TestHarness: 'static + Sized {
     /// Get the height from a test block.
     fn height(block: &Self::TestBlock) -> Height;
 
-    /// Propose a block (broadcast to network).
+    /// Drive the leader's full proposal flow as consensus would: request the
+    /// broadcast of the proposed block (mirroring [`crate::Relay::broadcast`]
+    /// with a propose plan) and await the durable-sync handle like the
+    /// certification gate does, asserting the block is durable.
     fn propose(
         handle: &mut ValidatorHandle<Self>,
         round: Round,
         block: &Self::TestBlock,
-    ) -> impl Future<Output = ()> + Send;
+    ) -> impl Future<Output = ()> + Send {
+        async move {
+            let (ack, persist) = oneshot::channel();
+            let block: <Self::Variant as crate::marshal::core::Variant>::Block =
+                block.clone().into();
+            let _ = handle.mailbox.proposed(round, block, Recipients::All, ack);
+            let sync = persist.await.expect("proposed sync handle missing");
+            assert!(sync.durable(round, "proposed").await);
+        }
+    }
 
     /// Mark a block as verified.
     fn verify(
@@ -898,8 +916,9 @@ pub fn hailstorm<H: TestHarness>(
     })
 }
 
-/// Contract: `marshal.proposed(...)=true` means the block survives an
-/// immediate crash and repeated recoveries.
+/// Contract: a durable propose handshake (the relayed proposal's sync handle
+/// resolving durable) means the block survives an immediate crash and
+/// repeated recoveries.
 pub fn proposed_success_implies_recoverable_after_restart<H: TestHarness>(
     seeds: impl IntoIterator<Item = u64>,
 ) {
@@ -984,7 +1003,7 @@ pub fn proposed_success_implies_recoverable_after_restart<H: TestHarness>(
                                 .await
                                 .unwrap_or_else(|| {
                                     panic!(
-                                        "marshal.proposed() returning true must imply \
+                                        "a durable propose handshake must imply \
                                      get_verified(round) recovers the block after restart \
                                      (seed={seed}, cycle={cycle})"
                                     )
@@ -1972,10 +1991,6 @@ impl TestHarness for StandardHarness {
         block.height()
     }
 
-    async fn propose(handle: &mut ValidatorHandle<Self>, round: Round, block: &B) {
-        assert!(handle.mailbox.proposed(round, block.clone()).await);
-    }
-
     async fn verify(
         handle: &mut ValidatorHandle<Self>,
         round: Round,
@@ -2222,18 +2237,6 @@ impl TestHarness for InlineHarness {
         StandardHarness::height(block)
     }
 
-    async fn propose(handle: &mut ValidatorHandle<Self>, round: Round, block: &Self::TestBlock) {
-        StandardHarness::propose(
-            &mut ValidatorHandle::<StandardHarness> {
-                mailbox: handle.mailbox.clone(),
-                extra: handle.extra.clone(),
-            },
-            round,
-            block,
-        )
-        .await;
-    }
-
     async fn verify(
         handle: &mut ValidatorHandle<Self>,
         round: Round,
@@ -2424,18 +2427,6 @@ impl TestHarness for DeferredHarness {
 
     fn height(block: &Self::TestBlock) -> Height {
         InlineHarness::height(block)
-    }
-
-    async fn propose(handle: &mut ValidatorHandle<Self>, round: Round, block: &Self::TestBlock) {
-        InlineHarness::propose(
-            &mut ValidatorHandle::<InlineHarness> {
-                mailbox: handle.mailbox.clone(),
-                extra: handle.extra.clone(),
-            },
-            round,
-            block,
-        )
-        .await;
     }
 
     async fn verify(
@@ -2815,14 +2806,6 @@ impl TestHarness for CodingHarness {
 
     fn height(block: &CodedBlock<CodingB, ReedSolomon<Sha256>, Sha256>) -> Height {
         block.height()
-    }
-
-    async fn propose(
-        handle: &mut ValidatorHandle<Self>,
-        round: Round,
-        block: &CodedBlock<CodingB, ReedSolomon<Sha256>, Sha256>,
-    ) {
-        assert!(handle.mailbox.proposed(round, block.clone()).await);
     }
 
     async fn verify(

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -996,18 +996,9 @@ pub fn proposed_success_implies_recoverable_after_restart<H: TestHarness>(
                             provider.clone(),
                         )
                         .await;
-                        let recovered =
-                            restarted
-                                .mailbox
-                                .get_verified(round)
-                                .await
-                                .unwrap_or_else(|| {
-                                    panic!(
-                                        "a durable propose handshake must imply \
-                                     get_verified(round) recovers the block after restart \
-                                     (seed={seed}, cycle={cycle})"
-                                    )
-                                });
+                        let recovered = restarted.mailbox.get_verified(round).await.unwrap_or_else(
+                            || panic!("durable proposal lost after restart (seed={seed}, cycle={cycle})"),
+                        );
                         assert_eq!(
                             recovered.digest(),
                             digest,

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -12,7 +12,7 @@ use crate::{
             Coding,
         },
         config::{Config, Start},
-        core::{durability::Durable as _, Actor, CommitmentFallback, DigestFallback, Mailbox},
+        core::{Actor, CommitmentFallback, DigestFallback, Mailbox},
         mocks::{application::Application, block::Block},
         resolver::p2p as resolver,
         standard::Standard,
@@ -35,10 +35,7 @@ use commonware_cryptography::{
     Committable, Digest as DigestTrait, Digestible, Hasher as _, Signer,
 };
 use commonware_macros::select;
-use commonware_p2p::{
-    simulated::{self, Link, Network, Oracle},
-    Recipients,
-};
+use commonware_p2p::simulated::{self, Link, Network, Oracle};
 use commonware_parallel::Sequential;
 use commonware_runtime::{
     buffer::paged::CacheRef,
@@ -53,9 +50,7 @@ use commonware_storage::{
     archive::{immutable, prunable},
     translator::EightCap,
 };
-use commonware_utils::{
-    channel::oneshot, test_rng, vec::NonEmptyVec, NZUsize, TestRng, NZU16, NZU64,
-};
+use commonware_utils::{test_rng, vec::NonEmptyVec, NZUsize, TestRng, NZU16, NZU64};
 use futures::StreamExt;
 use rand::{
     seq::{IteratorRandom, SliceRandom},
@@ -275,22 +270,23 @@ pub trait TestHarness: 'static + Sized {
     /// Get the height from a test block.
     fn height(block: &Self::TestBlock) -> Height;
 
-    /// Drive the leader's full proposal flow as consensus would: request the
-    /// broadcast of the proposed block (mirroring [`crate::Relay::broadcast`]
-    /// with a propose plan) and await the durable-sync handle like the
-    /// certification gate does, asserting the block is durable.
+    /// Drive the leader's propose durability handshake: persist the proposed
+    /// block and assert it is durable, without broadcasting it (mirroring the
+    /// certify-time flush of a staged proposal whose broadcast was never
+    /// requested). Scenarios drive dissemination explicitly, so a proposal
+    /// must not pre-seed peer buffers and mask delivery and backfill paths.
     fn propose(
         handle: &mut ValidatorHandle<Self>,
         round: Round,
         block: &Self::TestBlock,
     ) -> impl Future<Output = ()> + Send {
         async move {
-            let (ack, persist) = oneshot::channel();
             let block: <Self::Variant as crate::marshal::core::Variant>::Block =
                 block.clone().into();
-            let _ = handle.mailbox.proposed(round, block, Recipients::All, ack);
-            let sync = persist.await.expect("proposed sync handle missing");
-            assert!(sync.durable(round, "proposed").await);
+            assert!(
+                handle.mailbox.verified(round, block).await,
+                "proposed block must be durable"
+            );
         }
     }
 
@@ -916,7 +912,7 @@ pub fn hailstorm<H: TestHarness>(
     })
 }
 
-/// Contract: a durable propose handshake (the relayed proposal's sync handle
+/// Contract: a durable propose handshake (the proposal's sync handle
 /// resolving durable) means the block survives an immediate crash and
 /// repeated recoveries.
 pub fn proposed_success_implies_recoverable_after_restart<H: TestHarness>(

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -78,11 +78,12 @@ use crate::{
         },
         core::{CommitmentFallback, DigestFallback, Mailbox},
         standard::{
+            relay,
             validation::{
                 await_and_validate_parent, precheck_epoch_and_reproposal, run_app_verify, Decision,
                 ParentCheck,
             },
-            variant, Standard,
+            Standard,
         },
         Update,
     },
@@ -854,7 +855,7 @@ where
     type Plan = Plan<S::PublicKey>;
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
-        variant::broadcast(&self.gates, &self.marshal, commitment, plan)
+        relay::broadcast(&self.gates, &self.marshal, commitment, plan)
     }
 }
 

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -611,7 +611,6 @@ where
                     .expect("current epoch should exist");
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
-
                     gates
                         .stage_and_defer(
                             consensus_context.round,

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -863,11 +863,6 @@ where
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
         match plan {
-            // The propose plan relays the staged proposal: it is broadcast
-            // before it is persisted, and its ack completes the propose
-            // durability handshake. Every propose path stages its block
-            // (including leader recovery), so a missing entry means the round
-            // was already pruned by finalization and there is nothing to relay.
             Plan::Propose { round } => {
                 let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
                     debug!(%round, %commitment, "no staged proposal to relay");

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -665,7 +665,6 @@ where
                 build_timer.observe(&runtime_context);
 
                 let digest = built_block.digest();
-
                 gates
                     .stage_and_defer(
                         consensus_context.round,

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -909,9 +909,9 @@ mod tests {
             },
             verifying::{GatedVerifyingApp, MockVerifyingApp},
         },
-        simplex::scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
+        simplex::{scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, Plan},
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View},
-        Automaton, CertifiableAutomaton,
+        Automaton, CertifiableAutomaton, Relay,
     };
     use commonware_broadcast::Broadcaster;
     use commonware_cryptography::{
@@ -1432,7 +1432,10 @@ mod tests {
     /// Regression: when marshal holds a verified block for a round from a
     /// pre-crash propose, a restarted leader's `propose` must return that
     /// block's digest instead of asking the application to build afresh.
-    /// See `standard::inline::tests::test_propose_reuses_verified_block_on_restart`.
+    /// The recovered proposal must also be staged for the relay, so the
+    /// broadcast re-sends it and certification resolves through the
+    /// deduplicated re-persist. The inline variant skips the view instead
+    /// (see `inline::tests::test_propose_skips_when_verified_block_exists_on_restart`).
     #[test_traced("WARN")]
     fn test_propose_reuses_verified_block_on_restart() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
@@ -1470,12 +1473,13 @@ mod tests {
             let digest_a = block_a.digest();
             assert!(marshal.verified(round, block_a.clone()).await);
 
-            let block_b = B::new::<Sha256>(ctx.clone(), genesis.digest(), Height::new(1), 200);
-            let digest_b = block_b.digest();
-            assert_ne!(digest_a, digest_b, "test requires distinct digests");
-
-            let mock_app: MockVerifyingApp<B, S> =
-                MockVerifyingApp::new().with_propose_result(block_b);
+            // The app cannot build (`propose` returns None) and its
+            // verification never completes, so the assertions below hold
+            // only if the stored block is reused as-is and certification
+            // resolves through the durability gate registered by the
+            // recovery staging.
+            let (mock_app, verify_started, _release_verify): (GatedVerifyingApp<B, S>, _, _) =
+                GatedVerifyingApp::new();
             let mut marshaled = Deferred::new(
                 context.child("deferred"),
                 mock_app,
@@ -1489,6 +1493,24 @@ mod tests {
                 digest, digest_a,
                 "propose must reuse the block marshal already persisted for this round"
             );
+
+            // The relay broadcast must find the recovered proposal staged and
+            // re-persist it (a dedup no-op whose handle covers the pre-crash
+            // write), resolving the certification gate registered by the
+            // recovery path.
+            let _ = marshaled.broadcast(digest, Plan::Propose { round });
+            let certify_rx = marshaled.certify(round, digest).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "recovered proposal must certify through the relay handshake"
+                    );
+                },
+                _ = verify_started => {
+                    panic!("certifying a recovered proposal must not run app verification");
+                },
+            }
         });
     }
 

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -299,7 +299,7 @@ where
                 // Publish only when the block is both valid and durable. App-invalid
                 // candidates may already be in the cache from the concurrent store above,
                 // so the gate verdict is the authority for consensus progress.
-                if let Some(application_valid) = gates::handle(verdict, durable) {
+                if let Some(application_valid) = gates::resolve(verdict, durable) {
                     tx.send_lossy(application_valid);
                 }
             }
@@ -549,7 +549,7 @@ where
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
-                        .wait(
+                        .stage(
                             consensus_context.round,
                             digest,
                             Arc::new(block),
@@ -605,7 +605,7 @@ where
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
                     gates
-                        .wait(
+                        .stage(
                             consensus_context.round,
                             digest,
                             parent,
@@ -658,7 +658,7 @@ where
 
                 let digest = built_block.digest();
                 gates
-                    .wait(
+                    .stage(
                         consensus_context.round,
                         digest,
                         Arc::new(built_block),
@@ -830,7 +830,7 @@ where
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.deferred.certify", level = "info", skip_all, fields(round = %round, digest = %digest))]
     async fn certify(&mut self, round: Round, digest: Self::Digest) -> oneshot::Receiver<bool> {
-        self.gates.flush(&self.marshal, round, digest);
+        self.gates.flush_unrelayed(&self.marshal, round, digest);
 
         // Attempt to retrieve the existing certification gate task for this round/digest.
         let task = self.gates.take(round, digest);

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -152,7 +152,7 @@ where
     application: A,
     marshal: Mailbox<S, Standard<B>>,
     epocher: ES,
-    gates: Gates<<B as Digestible>::Digest>,
+    gates: Gates<<B as Digestible>::Digest, B>,
 
     build_duration: Timed,
     proposal_parent_fetch_duration: Timed,
@@ -430,6 +430,13 @@ where
         digest: B::Digest,
         task: oneshot::Receiver<bool>,
     ) -> oneshot::Receiver<bool> {
+        // A staged proposal whose broadcast was never requested cannot resolve
+        // its gate. Certification now demands durability, so persist it
+        // (without broadcasting) to complete the handshake.
+        if let Some((block, ack)) = self.gates.take_staged(round, digest) {
+            self.marshal.verified_deferred(round, block, ack);
+        }
+
         // `verify()` waits only on local broadcast delivery, so nudge a
         // round-bound notarized fetch that can unblock the existing waiter
         // if local broadcast never arrives. For the standard variant, the
@@ -478,9 +485,10 @@ where
     /// boundary block to avoid creating blocks that would be invalidated by the epoch transition.
     ///
     /// The proposal operation is spawned in a background task and returns a receiver that will
-    /// contain the proposed block's digest when ready. The block's persistence is enqueued
-    /// before the digest is delivered, and the resulting sync handle is awaited only at
-    /// certification so it overlaps consensus voting. The digest does not imply durability on
+    /// contain the proposed block's digest when ready. The block is staged before the digest is
+    /// delivered and handed to marshal when consensus requests the relay broadcast, which
+    /// persists it after the send. The resulting sync handle is awaited only at certification so
+    /// it overlaps consensus voting. The digest does not imply durability on
     /// its own; [`CertifiableAutomaton::certify`] awaits the registered certification gate before
     /// the finalize vote.
     #[allow(clippy::async_yields_async)]
@@ -513,8 +521,9 @@ where
         context.spawn(move |runtime_context| {
             async move {
                 // On leader recovery, marshal may already hold a verified block
-                // for this round (persisted by a pre-crash propose whose
-                // notarize vote never reached the journal).
+                // for this round (persisted by a pre-crash propose that reached
+                // its relay broadcast while the notarize vote never reached the
+                // journal).
                 //
                 // The pre-crash digest may already have been broadcast, so
                 // building a fresh block would equivocate. The stored block is
@@ -536,14 +545,25 @@ where
                         );
                         return;
                     }
+                    // Stage the recovered block so the relay broadcast re-sends
+                    // it through the same handshake as a fresh proposal. The
+                    // relay-time persist deduplicates against the pre-crash
+                    // write, with the handle covering the original.
                     let digest = block.digest();
-                    let success = tx.send_lossy(digest);
                     debug!(
                         round = ?consensus_context.round,
                         ?digest,
-                        success,
-                        "reused verified block from marshal on leader recovery"
+                        "reusing verified block from marshal on leader recovery"
                     );
+                    gates
+                        .stage_and_defer(
+                            consensus_context.round,
+                            digest,
+                            Arc::new(block),
+                            tx,
+                            "recovered block",
+                        )
+                        .await;
                     return;
                 }
 
@@ -592,13 +612,12 @@ where
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
 
-                    let persist = marshal.verified_deferred(consensus_context.round, parent);
                     gates
-                        .persist_and_defer(
+                        .stage_and_defer(
                             consensus_context.round,
                             digest,
+                            parent,
                             tx,
-                            persist,
                             "re-proposed boundary block",
                         )
                         .await;
@@ -647,13 +666,12 @@ where
 
                 let digest = built_block.digest();
 
-                let persist = marshal.proposed_deferred(consensus_context.round, built_block);
                 gates
-                    .persist_and_defer(
+                    .stage_and_defer(
                         consensus_context.round,
                         digest,
+                        Arc::new(built_block),
                         tx,
-                        persist,
                         "proposed block",
                     )
                     .await;
@@ -844,11 +862,23 @@ where
     type Plan = Plan<S::PublicKey>;
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
-        let (round, recipients) = match plan {
-            Plan::Propose { round } => (round, Recipients::All),
-            Plan::Forward { round, recipients } => (round, recipients),
-        };
-        self.marshal.forward(round, commitment, recipients)
+        match plan {
+            // The propose plan relays the staged proposal: it is broadcast
+            // before it is persisted, and its ack completes the propose
+            // durability handshake. Every propose path stages its block
+            // (including leader recovery), so a missing entry means the round
+            // was already pruned by finalization and there is nothing to relay.
+            Plan::Propose { round } => {
+                let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
+                    debug!(%round, %commitment, "no staged proposal to relay");
+                    return Feedback::Ok;
+                };
+                self.marshal.proposed(round, block, Recipients::All, ack)
+            }
+            Plan::Forward { round, recipients } => {
+                self.marshal.forward(round, commitment, recipients)
+            }
+        }
     }
 }
 
@@ -1278,7 +1308,7 @@ mod tests {
             // block subscription is still pending.
             context.sleep(Duration::from_millis(10)).await;
 
-            assert!(marshal.proposed(round, block).await);
+            assert!(marshal.verified(round, block).await);
             let certify_rx = marshaled.certify(round, digest).await;
             select! {
                 result = certify_rx => {

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -82,7 +82,7 @@ use crate::{
                 await_and_validate_parent, precheck_epoch_and_reproposal, run_app_verify, Decision,
                 ParentCheck,
             },
-            Standard,
+            variant, Standard,
         },
         Update,
     },
@@ -93,7 +93,6 @@ use crate::{
 use commonware_actor::Feedback;
 use commonware_cryptography::{certificate::Scheme, Digestible};
 use commonware_macros::select;
-use commonware_p2p::Recipients;
 use commonware_runtime::{
     telemetry::{
         metrics::{
@@ -430,13 +429,6 @@ where
         digest: B::Digest,
         task: oneshot::Receiver<bool>,
     ) -> oneshot::Receiver<bool> {
-        // A staged proposal whose broadcast was never requested cannot resolve
-        // its gate. Certification now demands durability, so persist it
-        // (without broadcasting) to complete the handshake.
-        if let Some((block, ack)) = self.gates.take_staged(round, digest) {
-            self.marshal.verified_deferred(round, block, ack);
-        }
-
         // `verify()` waits only on local broadcast delivery, so nudge a
         // round-bound notarized fetch that can unblock the existing waiter
         // if local broadcast never arrives. For the standard variant, the
@@ -556,7 +548,7 @@ where
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
-                        .stage_and_defer(
+                        .wait(
                             consensus_context.round,
                             digest,
                             Arc::new(block),
@@ -612,7 +604,7 @@ where
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
                     gates
-                        .stage_and_defer(
+                        .wait(
                             consensus_context.round,
                             digest,
                             parent,
@@ -665,7 +657,7 @@ where
 
                 let digest = built_block.digest();
                 gates
-                    .stage_and_defer(
+                    .wait(
                         consensus_context.round,
                         digest,
                         Arc::new(built_block),
@@ -837,6 +829,8 @@ where
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.deferred.certify", level = "info", skip_all, fields(round = %round, digest = %digest))]
     async fn certify(&mut self, round: Round, digest: Self::Digest) -> oneshot::Receiver<bool> {
+        self.gates.flush(&self.marshal, round, digest);
+
         // Attempt to retrieve the existing certification gate task for this round/digest.
         let task = self.gates.take(round, digest);
         if let Some(task) = task {
@@ -860,18 +854,7 @@ where
     type Plan = Plan<S::PublicKey>;
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
-        match plan {
-            Plan::Propose { round } => {
-                let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
-                    debug!(%round, %commitment, "no staged proposal to relay");
-                    return Feedback::Ok;
-                };
-                self.marshal.proposed(round, block, Recipients::All, ack)
-            }
-            Plan::Forward { round, recipients } => {
-                self.marshal.forward(round, commitment, recipients)
-            }
-        }
+        variant::broadcast(&self.gates, &self.marshal, commitment, plan)
     }
 }
 

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -326,7 +326,6 @@ where
                     .expect("current epoch should exist");
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
-
                     gates
                         .stage_and_defer(
                             consensus_context.round,

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -47,11 +47,12 @@ use crate::{
         application::gates::{self, Gates},
         core::{CommitmentFallback, DigestFallback, Mailbox},
         standard::{
+            relay,
             validation::{
                 await_and_validate_parent, precheck_epoch_and_reproposal, run_app_verify, Decision,
                 ParentCheck,
             },
-            variant, Standard,
+            Standard,
         },
         Update,
     },
@@ -647,7 +648,7 @@ where
     type Plan = Plan<S::PublicKey>;
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
-        variant::broadcast(&self.gates, &self.marshal, commitment, plan)
+        relay::broadcast(&self.gates, &self.marshal, commitment, plan)
     }
 }
 

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -327,7 +327,7 @@ where
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
                     gates
-                        .wait(
+                        .stage(
                             consensus_context.round,
                             digest,
                             parent,
@@ -380,7 +380,7 @@ where
 
                 let digest = built_block.digest();
                 gates
-                    .wait(
+                    .stage(
                         consensus_context.round,
                         digest,
                         Arc::new(built_block),
@@ -543,7 +543,7 @@ where
                     valid
                 };
                 let (verdict, durable) = futures::join!(verify_then_vote, store);
-                if let Some(valid) = gates::handle(verdict, durable) {
+                if let Some(valid) = gates::resolve(verdict, durable) {
                     durable_tx.send_lossy(valid);
                 }
             }
@@ -566,7 +566,7 @@ where
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.inline.certify", level = "info", skip_all, fields(round = %round, digest = %digest))]
     async fn certify(&mut self, round: Round, digest: Self::Digest) -> oneshot::Receiver<bool> {
-        self.gates.flush(&self.marshal, round, digest);
+        self.gates.flush_unrelayed(&self.marshal, round, digest);
 
         // `propose`/`verify` register an in-flight certification gate whose result resolves
         // once the block's sync handle completes. Awaiting it here is the durability barrier

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -380,7 +380,6 @@ where
                 build_timer.observe(&runtime_context);
 
                 let digest = built_block.digest();
-
                 gates
                     .stage_and_defer(
                         consensus_context.round,

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -142,7 +142,7 @@ where
     application: A,
     marshal: Mailbox<S, Standard<B>>,
     epocher: ES,
-    gates: Gates<B::Digest>,
+    gates: Gates<B::Digest, B>,
 
     build_duration: Timed,
     proposal_parent_fetch_duration: Timed,
@@ -229,7 +229,8 @@ where
     /// Proposes a new block or re-proposes an epoch boundary block.
     ///
     /// Proposal runs in a spawned task and returns a receiver for the resulting digest. The
-    /// block's persistence is enqueued before the digest is delivered, and the resulting sync
+    /// block is staged before the digest is delivered and handed to marshal when consensus
+    /// requests the relay broadcast, which persists it after the send. The resulting sync
     /// handle is awaited only at certification so it overlaps consensus voting. The digest does
     /// not imply durability on its own; [`CertifiableAutomaton::certify`] awaits the registered
     /// certification gate before the finalize vote.
@@ -261,8 +262,9 @@ where
         context.spawn(move |runtime_context| {
             async move {
                 // On leader recovery, marshal may already hold a verified block
-                // for this round (persisted by a pre-crash propose whose
-                // notarize vote never reached the journal).
+                // for this round (persisted by a pre-crash propose that reached
+                // its relay broadcast while the notarize vote never reached the
+                // journal).
                 //
                 // The parent context recovered by simplex may differ from the one
                 // the cached block was built against, so the stored block is not
@@ -325,13 +327,12 @@ where
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
 
-                    let persist = marshal.verified_deferred(consensus_context.round, parent);
                     gates
-                        .persist_and_defer(
+                        .stage_and_defer(
                             consensus_context.round,
                             digest,
+                            parent,
                             tx,
-                            persist,
                             "re-proposed boundary block",
                         )
                         .await;
@@ -380,13 +381,12 @@ where
 
                 let digest = built_block.digest();
 
-                let persist = marshal.proposed_deferred(consensus_context.round, built_block);
                 gates
-                    .persist_and_defer(
+                    .stage_and_defer(
                         consensus_context.round,
                         digest,
+                        Arc::new(built_block),
                         tx,
-                        persist,
                         "proposed block",
                     )
                     .await;
@@ -574,6 +574,13 @@ where
         // instead of freezing certify with a fresh fsync.
         let task = self.gates.take(round, digest);
 
+        // A staged proposal whose broadcast was never requested cannot resolve
+        // its gate. Certification now demands durability, so persist it
+        // (without broadcasting) to complete the handshake.
+        if let Some((block, ack)) = self.gates.take_staged(round, digest) {
+            self.marshal.verified_deferred(round, block, ack);
+        }
+
         // `verify()` waits only on local broadcast delivery, so nudge a
         // round-bound notarized fetch that can unblock the existing waiter
         // if local broadcast never arrives. For the standard variant, the
@@ -648,11 +655,23 @@ where
     type Plan = Plan<S::PublicKey>;
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
-        let (round, recipients) = match plan {
-            Plan::Propose { round } => (round, Recipients::All),
-            Plan::Forward { round, recipients } => (round, recipients),
-        };
-        self.marshal.forward(round, commitment, recipients)
+        match plan {
+            // The propose plan relays the staged proposal: it is broadcast
+            // before it is persisted, and its ack completes the propose
+            // durability handshake. Every propose path stages its block, so a
+            // missing entry means the round was already pruned by finalization
+            // and there is nothing to relay.
+            Plan::Propose { round } => {
+                let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
+                    debug!(%round, %commitment, "no staged proposal to relay");
+                    return Feedback::Ok;
+                };
+                self.marshal.proposed(round, block, Recipients::All, ack)
+            }
+            Plan::Forward { round, recipients } => {
+                self.marshal.forward(round, commitment, recipients)
+            }
+        }
     }
 }
 
@@ -1228,7 +1247,7 @@ mod tests {
             // block subscription is still pending.
             context.sleep(Duration::from_millis(10)).await;
 
-            assert!(marshal.proposed(round, block).await);
+            assert!(marshal.verified(round, block).await);
             let certify_rx = inline.certify(round, digest).await;
             select! {
                 result = certify_rx => {

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -656,11 +656,6 @@ where
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
         match plan {
-            // The propose plan relays the staged proposal: it is broadcast
-            // before it is persisted, and its ack completes the propose
-            // durability handshake. Every propose path stages its block, so a
-            // missing entry means the round was already pruned by finalization
-            // and there is nothing to relay.
             Plan::Propose { round } => {
                 let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
                     debug!(%round, %commitment, "no staged proposal to relay");

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -51,7 +51,7 @@ use crate::{
                 await_and_validate_parent, precheck_epoch_and_reproposal, run_app_verify, Decision,
                 ParentCheck,
             },
-            Standard,
+            variant, Standard,
         },
         Update,
     },
@@ -62,7 +62,6 @@ use crate::{
 use commonware_actor::Feedback;
 use commonware_cryptography::certificate::Scheme;
 use commonware_macros::select;
-use commonware_p2p::Recipients;
 use commonware_runtime::{
     telemetry::{
         metrics::{
@@ -232,7 +231,7 @@ where
     /// block is staged before the digest is delivered and handed to marshal when consensus
     /// requests the relay broadcast, which persists it after the send. The resulting sync
     /// handle is awaited only at certification so it overlaps consensus voting. The digest does
-    /// not imply durability on its own; [`CertifiableAutomaton::certify`] awaits the registered
+    /// not imply durability on its own. [`CertifiableAutomaton::certify`] awaits the registered
     /// certification gate before the finalize vote.
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.inline.propose", level = "info", skip_all, fields(round = %consensus_context.round))]
@@ -327,7 +326,7 @@ where
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
                     gates
-                        .stage_and_defer(
+                        .wait(
                             consensus_context.round,
                             digest,
                             parent,
@@ -380,7 +379,7 @@ where
 
                 let digest = built_block.digest();
                 gates
-                    .stage_and_defer(
+                    .wait(
                         consensus_context.round,
                         digest,
                         Arc::new(built_block),
@@ -566,18 +565,13 @@ where
     #[allow(clippy::async_yields_async)]
     #[tracing::instrument(name = "marshal.inline.certify", level = "info", skip_all, fields(round = %round, digest = %digest))]
     async fn certify(&mut self, round: Round, digest: Self::Digest) -> oneshot::Receiver<bool> {
+        self.gates.flush(&self.marshal, round, digest);
+
         // `propose`/`verify` register an in-flight certification gate whose result resolves
         // once the block's sync handle completes. Awaiting it here is the durability barrier
         // for the finalize vote, and it lets the sync overlap consensus voting
         // instead of freezing certify with a fresh fsync.
         let task = self.gates.take(round, digest);
-
-        // A staged proposal whose broadcast was never requested cannot resolve
-        // its gate. Certification now demands durability, so persist it
-        // (without broadcasting) to complete the handshake.
-        if let Some((block, ack)) = self.gates.take_staged(round, digest) {
-            self.marshal.verified_deferred(round, block, ack);
-        }
 
         // `verify()` waits only on local broadcast delivery, so nudge a
         // round-bound notarized fetch that can unblock the existing waiter
@@ -653,18 +647,7 @@ where
     type Plan = Plan<S::PublicKey>;
 
     fn broadcast(&mut self, commitment: Self::Digest, plan: Plan<S::PublicKey>) -> Feedback {
-        match plan {
-            Plan::Propose { round } => {
-                let Some((block, ack)) = self.gates.take_staged(round, commitment) else {
-                    debug!(%round, %commitment, "no staged proposal to relay");
-                    return Feedback::Ok;
-                };
-                self.marshal.proposed(round, block, Recipients::All, ack)
-            }
-            Plan::Forward { round, recipients } => {
-                self.marshal.forward(round, commitment, recipients)
-            }
-        }
+        variant::broadcast(&self.gates, &self.marshal, commitment, plan)
     }
 }
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -32,6 +32,7 @@ commonware_macros::stability_scope!(ALPHA {
     mod inline;
     pub use inline::Inline;
 
+    mod relay;
     mod validation;
 });
 
@@ -40,7 +41,7 @@ pub use variant::Standard;
 
 #[cfg(test)]
 mod tests {
-    use super::{variant, Deferred, Inline, Standard};
+    use super::{relay, Deferred, Inline, Standard};
     use crate::{
         marshal::{
             ancestry::BlockProvider,
@@ -3213,11 +3214,6 @@ mod tests {
         digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         sends: Arc<Mutex<Vec<BufferSend>>>,
-        /// Ack receiver installed by tests that pin send-before-persist
-        /// ordering. Each `send` polls it once synchronously (inside the
-        /// dispatching handler) and records whether the ack had already fired.
-        persist_probe: Arc<Mutex<Option<oneshot::Receiver<commonware_runtime::Handle<()>>>>>,
-        acked_at_send: Arc<Mutex<Vec<bool>>>,
     }
 
     impl RecordingBuffer {
@@ -3274,9 +3270,6 @@ mod tests {
         fn finalized(&self, _commitment: D) {}
 
         fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
-            if let Some(probe) = self.persist_probe.lock().as_mut() {
-                self.acked_at_send.lock().push(probe.try_recv().is_ok());
-            }
             self.sends.lock().push((round, block, recipients));
         }
     }
@@ -7195,11 +7188,10 @@ mod tests {
         });
     }
 
-    /// A block relayed via `Proposed` must be broadcast before it is
-    /// persisted: a probe polled inside the buffer's dispatch asserts the
-    /// persist ack has not yet fired at send time, and the sync handle then
-    /// resolves durable. A subsequent `Forward` for the same
-    /// `(round, commitment)` serves the persisted block from storage.
+    /// A block relayed via `Proposed` must be dispatched to the buffer and
+    /// persisted, with the sync handle resolving durable. A subsequent
+    /// `Forward` for the same `(round, commitment)` serves the persisted
+    /// block from storage.
     #[test_traced("WARN")]
     fn test_standard_proposed_broadcasts_then_persists() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
@@ -7227,7 +7219,6 @@ mod tests {
 
             let targets = vec![participants[1].clone()];
             let (ack, persist) = oneshot::channel();
-            *buffer.persist_probe.lock() = Some(persist);
             mailbox.proposed(round, block.clone(), Recipients::Some(targets.clone()), ack);
             wait_until(&context, Duration::from_secs(5), "proposed send", || {
                 !buffer.sends.lock().is_empty()
@@ -7239,21 +7230,8 @@ mod tests {
             assert_eq!(sends[0].0, round);
             assert_eq!(sends[0].1.digest(), digest);
 
-            // The probe was polled synchronously inside the dispatch, so a
-            // recorded ack would mean the handler persisted before sending.
-            assert_eq!(
-                buffer.acked_at_send.lock().as_slice(),
-                &[false],
-                "persist ack must not fire before the broadcast send"
-            );
-
             // The message persists the block after broadcasting it, so the
             // sync handle must resolve durable.
-            let persist = buffer
-                .persist_probe
-                .lock()
-                .take()
-                .expect("probe must still hold the ack receiver");
             let sync = persist.await.expect("proposed sync handle missing");
             assert!(sync.durable(round, "proposed").await);
 
@@ -7322,7 +7300,7 @@ mod tests {
 
             // The relay finds nothing staged and must forward the persisted
             // block instead of dropping the broadcast.
-            let feedback = variant::broadcast(&gates, &mailbox, digest, Plan::Propose { round });
+            let feedback = relay::broadcast(&gates, &mailbox, digest, Plan::Propose { round });
             assert!(matches!(feedback, Feedback::Ok));
             wait_until(&context, Duration::from_secs(5), "fallback send", || {
                 !buffer.sends.lock().is_empty()
@@ -7380,7 +7358,7 @@ mod tests {
             let gate = gates.take(round, digest).expect("gate registered");
 
             // The relay must take the staged proposal and dispatch it.
-            let feedback = variant::broadcast(&gates, &mailbox, digest, Plan::Propose { round });
+            let feedback = relay::broadcast(&gates, &mailbox, digest, Plan::Propose { round });
             assert!(matches!(feedback, Feedback::Ok));
             wait_until(&context, Duration::from_secs(5), "staged send", || {
                 !buffer.sends.lock().is_empty()

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -45,7 +45,9 @@ mod tests {
         marshal::{
             ancestry::BlockProvider,
             config::{Config, Start},
-            core::{cache, Actor, CommitmentFallback, DigestFallback, Mailbox},
+            core::{
+                cache, durability::Durable as _, Actor, CommitmentFallback, DigestFallback, Mailbox,
+            },
             mocks::{
                 application::Application,
                 harness::{
@@ -7182,14 +7184,14 @@ mod tests {
         });
     }
 
-    /// A block admitted via `Proposed` must be broadcast straight from the
-    /// in-memory cache when `Forward` arrives: the `RecordingBuffer` reports
-    /// no `find_by_commitment` hits, so if the forward dispatches a block it
-    /// must have come from the in-memory slot populated by `Proposed`.
-    /// A subsequent `Forward` for the same `(round, commitment)` falls
-    /// through to storage because the slot is consumed.
+    /// A block relayed via `Proposed` must be broadcast straight from the
+    /// message: the `RecordingBuffer` reports no `find_by_commitment` hits, so
+    /// the dispatched block cannot have come from storage. The message then
+    /// persists the block, resolving the sync handle only after the send. A
+    /// subsequent `Forward` for the same `(round, commitment)` serves the
+    /// persisted block from storage.
     #[test_traced("WARN")]
-    fn test_standard_proposed_is_served_from_in_memory_cache() {
+    fn test_standard_proposed_broadcasts_then_persists() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -7213,25 +7215,28 @@ mod tests {
             .await;
             let buffer = buffer.expect("buffer was provided");
 
-            assert!(mailbox.proposed(round, block.clone()).await);
-
             let targets = vec![participants[1].clone()];
-            mailbox.forward(round, digest, Recipients::Some(targets.clone()));
-            wait_until(&context, Duration::from_secs(5), "first forward", || {
+            let (ack, persist) = oneshot::channel();
+            mailbox.proposed(round, block.clone(), Recipients::Some(targets.clone()), ack);
+            wait_until(&context, Duration::from_secs(5), "proposed send", || {
                 !buffer.sends.lock().is_empty()
             })
             .await;
 
             let sends = buffer.sends();
-            assert_eq!(sends.len(), 1, "cached proposal must dispatch exactly once");
+            assert_eq!(sends.len(), 1, "proposal must dispatch exactly once");
             assert_eq!(sends[0].0, round);
             assert_eq!(sends[0].1.digest(), digest);
 
-            // The in-memory slot was consumed; a second forward for the same
-            // commitment must still succeed by falling back to storage (the
-            // block was persisted by `Proposed`, mirroring `Verified`).
+            // The message persists the block after broadcasting it, so the
+            // sync handle must resolve durable.
+            let sync = persist.await.expect("proposed sync handle missing");
+            assert!(sync.durable(round, "proposed").await);
+
+            // A forward for the same commitment must serve the persisted
+            // block from storage.
             mailbox.forward(round, digest, Recipients::Some(targets));
-            wait_until(&context, Duration::from_secs(5), "second forward", || {
+            wait_until(&context, Duration::from_secs(5), "forward send", || {
                 buffer.sends.lock().len() >= 2
             })
             .await;

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3213,6 +3213,11 @@ mod tests {
         digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         sends: Arc<Mutex<Vec<BufferSend>>>,
+        /// Ack receiver installed by tests that pin send-before-persist
+        /// ordering. Each `send` polls it once synchronously (inside the
+        /// dispatching handler) and records whether the ack had already fired.
+        persist_probe: Arc<Mutex<Option<oneshot::Receiver<commonware_runtime::Handle<()>>>>>,
+        acked_at_send: Arc<Mutex<Vec<bool>>>,
     }
 
     impl RecordingBuffer {
@@ -3269,6 +3274,9 @@ mod tests {
         fn finalized(&self, _commitment: D) {}
 
         fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
+            if let Some(probe) = self.persist_probe.lock().as_mut() {
+                self.acked_at_send.lock().push(probe.try_recv().is_ok());
+            }
             self.sends.lock().push((round, block, recipients));
         }
     }
@@ -7187,12 +7195,11 @@ mod tests {
         });
     }
 
-    /// A block relayed via `Proposed` must be broadcast straight from the
-    /// message: the `RecordingBuffer` reports no `find_by_commitment` hits, so
-    /// the dispatched block cannot have come from storage. The message then
-    /// persists the block, resolving the sync handle only after the send. A
-    /// subsequent `Forward` for the same `(round, commitment)` serves the
-    /// persisted block from storage.
+    /// A block relayed via `Proposed` must be broadcast before it is
+    /// persisted: a probe polled inside the buffer's dispatch asserts the
+    /// persist ack has not yet fired at send time, and the sync handle then
+    /// resolves durable. A subsequent `Forward` for the same
+    /// `(round, commitment)` serves the persisted block from storage.
     #[test_traced("WARN")]
     fn test_standard_proposed_broadcasts_then_persists() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
@@ -7220,6 +7227,7 @@ mod tests {
 
             let targets = vec![participants[1].clone()];
             let (ack, persist) = oneshot::channel();
+            *buffer.persist_probe.lock() = Some(persist);
             mailbox.proposed(round, block.clone(), Recipients::Some(targets.clone()), ack);
             wait_until(&context, Duration::from_secs(5), "proposed send", || {
                 !buffer.sends.lock().is_empty()
@@ -7231,8 +7239,21 @@ mod tests {
             assert_eq!(sends[0].0, round);
             assert_eq!(sends[0].1.digest(), digest);
 
+            // The probe was polled synchronously inside the dispatch, so a
+            // recorded ack would mean the handler persisted before sending.
+            assert_eq!(
+                buffer.acked_at_send.lock().as_slice(),
+                &[false],
+                "persist ack must not fire before the broadcast send"
+            );
+
             // The message persists the block after broadcasting it, so the
             // sync handle must resolve durable.
+            let persist = buffer
+                .persist_probe
+                .lock()
+                .take()
+                .expect("probe must still hold the ack receiver");
             let sync = persist.await.expect("proposed sync handle missing");
             assert!(sync.durable(round, "proposed").await);
 
@@ -7313,6 +7334,126 @@ mod tests {
             assert_eq!(sends[0].0, round);
             assert_eq!(sends[0].1.digest(), digest);
             assert!(matches!(sends[0].2, Recipients::All));
+        });
+    }
+
+    /// A propose relay with a staged proposal must dispatch it through the
+    /// `Proposed` message and complete the durability handshake. The block is
+    /// never persisted beforehand, so the forward fallback has nothing to
+    /// serve: only the staged-hit path can produce the send.
+    #[test_traced("WARN")]
+    fn test_standard_propose_relay_sends_staged_block() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let me = participants[0].clone();
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(Sha256::hash(b""), Height::new(1), 100);
+            let digest = block.digest();
+
+            let (mailbox, buffer, _resolver, _actor_handle) = start_standard_actor(
+                context.child("validator").with_attribute("index", 0),
+                &format!("relay-hit-{me}"),
+                ConstantProvider::new(schemes[0].clone()),
+                Application::<B>::manual_ack(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            )
+            .await;
+            let buffer = buffer.expect("buffer was provided");
+
+            // Stage the proposal as propose would.
+            let gates = Gates::new();
+            let (tx, rx) = oneshot::channel();
+            let staged = gates.clone();
+            let staged_block = block.clone();
+            context.child("stager").spawn(move |_| async move {
+                staged
+                    .wait(round, digest, Arc::new(staged_block), tx, "test")
+                    .await;
+            });
+            assert_eq!(rx.await.expect("id published"), digest);
+            let gate = gates.take(round, digest).expect("gate registered");
+
+            // The relay must take the staged proposal and dispatch it.
+            let feedback = variant::broadcast(&gates, &mailbox, digest, Plan::Propose { round });
+            assert!(matches!(feedback, Feedback::Ok));
+            wait_until(&context, Duration::from_secs(5), "staged send", || {
+                !buffer.sends.lock().is_empty()
+            })
+            .await;
+
+            let sends = buffer.sends();
+            assert_eq!(sends.len(), 1, "staged proposal must dispatch exactly once");
+            assert_eq!(sends[0].0, round);
+            assert_eq!(sends[0].1.digest(), digest);
+            assert!(matches!(sends[0].2, Recipients::All));
+            assert!(
+                gates.take_staged(round, digest).is_none(),
+                "relay must consume the staged proposal"
+            );
+
+            // The relayed proposal is persisted through the staged ack, so
+            // the certification gate resolves durably.
+            assert!(
+                gate.await.expect("gate resolved"),
+                "relay handshake must resolve the gate durably"
+            );
+        });
+    }
+
+    /// A proposer that relays conflicting blocks for the same round must not
+    /// be blocked by its own conflict: a leader that crashes after the send
+    /// may legitimately propose a different block for the round after
+    /// restart. The verified archive stores candidates with multi-put
+    /// semantics, so both `Proposed` handshakes must broadcast and resolve
+    /// durable.
+    #[test_traced("WARN")]
+    fn test_standard_proposed_conflicting_blocks_both_ack() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let me = participants[0].clone();
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block_a = make_raw_block(Sha256::hash(b""), Height::new(1), 100);
+            let block_b = make_raw_block(Sha256::hash(b""), Height::new(1), 200);
+            assert_ne!(block_a.digest(), block_b.digest());
+
+            let (mailbox, buffer, _resolver, _actor_handle) = start_standard_actor(
+                context.child("validator").with_attribute("index", 0),
+                &format!("proposed-conflict-{me}"),
+                ConstantProvider::new(schemes[0].clone()),
+                Application::<B>::manual_ack(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            )
+            .await;
+            let buffer = buffer.expect("buffer was provided");
+
+            let (ack_a, persist_a) = oneshot::channel();
+            mailbox.proposed(round, block_a.clone(), Recipients::All, ack_a);
+            let (ack_b, persist_b) = oneshot::channel();
+            mailbox.proposed(round, block_b.clone(), Recipients::All, ack_b);
+
+            let sync_a = persist_a.await.expect("first proposed sync handle missing");
+            assert!(sync_a.durable(round, "proposed").await);
+            let sync_b = persist_b
+                .await
+                .expect("second proposed sync handle missing");
+            assert!(sync_b.durable(round, "proposed").await);
+
+            let sends = buffer.sends();
+            assert_eq!(sends.len(), 2, "both conflicting proposals must dispatch");
+            assert_eq!(sends[0].1.digest(), block_a.digest());
+            assert_eq!(sends[1].1.digest(), block_b.digest());
         });
     }
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -40,10 +40,11 @@ pub use variant::Standard;
 
 #[cfg(test)]
 mod tests {
-    use super::{Deferred, Inline, Standard};
+    use super::{variant, Deferred, Inline, Standard};
     use crate::{
         marshal::{
             ancestry::BlockProvider,
+            application::gates::Gates,
             config::{Config, Start},
             core::{
                 cache, durability::Durable as _, Actor, CommitmentFallback, DigestFallback, Mailbox,
@@ -65,6 +66,7 @@ mod tests {
         simplex::{
             scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
             types::{Finalization, Proposal},
+            Plan,
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta},
         Automaton, CertifiableAutomaton, Heightable, Reporter,
@@ -87,7 +89,8 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_resolver::{Consumer, Delivery, Fetch, Resolver, TargetedResolver};
     use commonware_runtime::{
-        buffer::paged::CacheRef, deterministic, Clock, Metrics, Quota, Runner, Supervisor as _,
+        buffer::paged::CacheRef, deterministic, Clock, Metrics, Quota, Runner, Spawner,
+        Supervisor as _,
     };
     use commonware_storage::{
         archive::{immutable, prunable, Archive as _},
@@ -7244,6 +7247,72 @@ mod tests {
             let sends = buffer.sends();
             assert_eq!(sends.len(), 2);
             assert_eq!(sends[1].1.digest(), digest);
+        });
+    }
+
+    /// A propose relay that finds no staged proposal must fall back to
+    /// forwarding the persisted block. Staging then flushing at certify (the
+    /// recovered-leader race) persists the block and resolves the
+    /// certification gate through the staged ack, so the subsequent relay
+    /// broadcast re-sends the block from storage instead of dropping it.
+    #[test_traced("WARN")]
+    fn test_standard_propose_relay_miss_forwards_persisted_block() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let me = participants[0].clone();
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(Sha256::hash(b""), Height::new(1), 100);
+            let digest = block.digest();
+
+            let (mailbox, buffer, _resolver, _actor_handle) = start_standard_actor(
+                context.child("validator").with_attribute("index", 0),
+                &format!("relay-miss-{me}"),
+                ConstantProvider::new(schemes[0].clone()),
+                Application::<B>::manual_ack(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            )
+            .await;
+            let buffer = buffer.expect("buffer was provided");
+
+            // Stage the proposal as propose would, then flush it as certify
+            // does when certification wins the race against the relay.
+            let gates = Gates::new();
+            let (tx, rx) = oneshot::channel();
+            let staged = gates.clone();
+            let staged_block = block.clone();
+            context.child("stager").spawn(move |_| async move {
+                staged
+                    .wait(round, digest, Arc::new(staged_block), tx, "test")
+                    .await;
+            });
+            assert_eq!(rx.await.expect("id published"), digest);
+            let gate = gates.take(round, digest).expect("gate registered");
+            gates.flush(&mailbox, round, digest);
+            assert!(
+                gate.await.expect("gate resolved"),
+                "certify flush must resolve the gate durably"
+            );
+
+            // The relay finds nothing staged and must forward the persisted
+            // block instead of dropping the broadcast.
+            let feedback = variant::broadcast(&gates, &mailbox, digest, Plan::Propose { round });
+            assert!(matches!(feedback, Feedback::Ok));
+            wait_until(&context, Duration::from_secs(5), "fallback send", || {
+                !buffer.sends.lock().is_empty()
+            })
+            .await;
+
+            let sends = buffer.sends();
+            assert_eq!(sends.len(), 1, "fallback must dispatch exactly once");
+            assert_eq!(sends[0].0, round);
+            assert_eq!(sends[0].1.digest(), digest);
+            assert!(matches!(sends[0].2, Recipients::All));
         });
     }
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -7283,16 +7283,18 @@ mod tests {
             // does when certification wins the race against the relay.
             let gates = Gates::new();
             let (tx, rx) = oneshot::channel();
-            let staged = gates.clone();
-            let staged_block = block.clone();
-            context.child("stager").spawn(move |_| async move {
-                staged
-                    .wait(round, digest, Arc::new(staged_block), tx, "test")
-                    .await;
+            context.child("stager").spawn({
+                let gates = gates.clone();
+                let block = block.clone();
+                move |_| async move {
+                    gates
+                        .stage(round, digest, Arc::new(block), tx, "test")
+                        .await;
+                }
             });
             assert_eq!(rx.await.expect("id published"), digest);
             let gate = gates.take(round, digest).expect("gate registered");
-            gates.flush(&mailbox, round, digest);
+            gates.flush_unrelayed(&mailbox, round, digest);
             assert!(
                 gate.await.expect("gate resolved"),
                 "certify flush must resolve the gate durably"
@@ -7347,12 +7349,14 @@ mod tests {
             // Stage the proposal as propose would.
             let gates = Gates::new();
             let (tx, rx) = oneshot::channel();
-            let staged = gates.clone();
-            let staged_block = block.clone();
-            context.child("stager").spawn(move |_| async move {
-                staged
-                    .wait(round, digest, Arc::new(staged_block), tx, "test")
-                    .await;
+            context.child("stager").spawn({
+                let gates = gates.clone();
+                let block = block.clone();
+                move |_| async move {
+                    gates
+                        .stage(round, digest, Arc::new(block), tx, "test")
+                        .await;
+                }
             });
             assert_eq!(rx.await.expect("id published"), digest);
             let gate = gates.take(round, digest).expect("gate registered");

--- a/consensus/src/marshal/standard/relay.rs
+++ b/consensus/src/marshal/standard/relay.rs
@@ -1,0 +1,41 @@
+//! Shared consensus-relay plumbing for the standard variant wrappers.
+
+use crate::{
+    marshal::{application::gates::Gates, core::Mailbox, standard::Standard},
+    simplex::Plan,
+    Block,
+};
+use commonware_actor::Feedback;
+use commonware_cryptography::certificate::Scheme;
+use commonware_p2p::Recipients;
+use tracing::debug;
+
+/// Relays a consensus broadcast [`Plan`] through marshal for the standard
+/// variants ([`super::Deferred`] and [`super::Inline`]).
+///
+/// A propose plan sends the staged proposal to all peers, delivering the
+/// durable-sync handle through the staged ack. A forward plan re-sends a
+/// stored block to the requested recipients. A propose plan whose staged
+/// proposal was already consumed falls back to a best-effort forward of the
+/// persisted block.
+pub(super) fn broadcast<S, B>(
+    gates: &Gates<B::Digest, B>,
+    marshal: &Mailbox<S, Standard<B>>,
+    commitment: B::Digest,
+    plan: Plan<S::PublicKey>,
+) -> Feedback
+where
+    S: Scheme,
+    B: Block,
+{
+    match plan {
+        Plan::Propose { round } => {
+            let Some((block, ack)) = gates.take_staged(round, commitment) else {
+                debug!(%round, %commitment, "no staged proposal to relay, attempting forwarding");
+                return marshal.forward(round, commitment, Recipients::All);
+            };
+            marshal.proposed(round, block, Recipients::All, ack)
+        }
+        Plan::Forward { round, recipients } => marshal.forward(round, commitment, recipients),
+    }
+}

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -6,18 +6,21 @@
 use crate::{
     marshal::{
         ancestry::BlockProvider,
+        application::gates::Gates,
         core::{Buffer, CommitmentFallback, Mailbox, Variant},
     },
-    simplex::scheme::Scheme as SimplexScheme,
+    simplex::{scheme::Scheme as SimplexScheme, Plan},
     types::Round,
     Block,
 };
+use commonware_actor::Feedback;
 use commonware_broadcast::buffered;
 use commonware_codec::Read;
 use commonware_cryptography::{certificate::Scheme, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
 use std::{future::Future, sync::Arc};
+use tracing::debug;
 
 /// The standard variant of Marshal, which broadcasts complete blocks.
 ///
@@ -116,6 +119,36 @@ where
 
     fn send(&self, _round: Round, block: Arc<B>, recipients: Recipients<K>) {
         self.broadcast_shared(recipients, block);
+    }
+}
+
+/// Relays a consensus broadcast [`Plan`] through marshal for the standard
+/// variants ([`super::Deferred`] and [`super::Inline`]).
+///
+/// A propose plan sends the staged proposal to all peers, delivering the
+/// durable-sync handle through the staged ack. A forward plan re-sends a
+/// stored block to the requested recipients. A propose plan whose staged
+/// proposal was already consumed falls back to a best-effort forward of the
+/// persisted block.
+pub(super) fn broadcast<S, B>(
+    gates: &Gates<B::Digest, B>,
+    marshal: &Mailbox<S, Standard<B>>,
+    commitment: B::Digest,
+    plan: Plan<S::PublicKey>,
+) -> Feedback
+where
+    S: Scheme,
+    B: Block,
+{
+    match plan {
+        Plan::Propose { round } => {
+            let Some((block, ack)) = gates.take_staged(round, commitment) else {
+                debug!(%round, %commitment, "no staged proposal to relay, attempting forwarding");
+                return marshal.forward(round, commitment, Recipients::All);
+            };
+            marshal.proposed(round, block, Recipients::All, ack)
+        }
+        Plan::Forward { round, recipients } => marshal.forward(round, commitment, recipients),
     }
 }
 

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -6,21 +6,18 @@
 use crate::{
     marshal::{
         ancestry::BlockProvider,
-        application::gates::Gates,
         core::{Buffer, CommitmentFallback, Mailbox, Variant},
     },
-    simplex::{scheme::Scheme as SimplexScheme, Plan},
+    simplex::scheme::Scheme as SimplexScheme,
     types::Round,
     Block,
 };
-use commonware_actor::Feedback;
 use commonware_broadcast::buffered;
 use commonware_codec::Read;
 use commonware_cryptography::{certificate::Scheme, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
 use std::{future::Future, sync::Arc};
-use tracing::debug;
 
 /// The standard variant of Marshal, which broadcasts complete blocks.
 ///
@@ -119,36 +116,6 @@ where
 
     fn send(&self, _round: Round, block: Arc<B>, recipients: Recipients<K>) {
         self.broadcast_shared(recipients, block);
-    }
-}
-
-/// Relays a consensus broadcast [`Plan`] through marshal for the standard
-/// variants ([`super::Deferred`] and [`super::Inline`]).
-///
-/// A propose plan sends the staged proposal to all peers, delivering the
-/// durable-sync handle through the staged ack. A forward plan re-sends a
-/// stored block to the requested recipients. A propose plan whose staged
-/// proposal was already consumed falls back to a best-effort forward of the
-/// persisted block.
-pub(super) fn broadcast<S, B>(
-    gates: &Gates<B::Digest, B>,
-    marshal: &Mailbox<S, Standard<B>>,
-    commitment: B::Digest,
-    plan: Plan<S::PublicKey>,
-) -> Feedback
-where
-    S: Scheme,
-    B: Block,
-{
-    match plan {
-        Plan::Propose { round } => {
-            let Some((block, ack)) = gates.take_staged(round, commitment) else {
-                debug!(%round, %commitment, "no staged proposal to relay, attempting forwarding");
-                return marshal.forward(round, commitment, Recipients::All);
-            };
-            marshal.proposed(round, block, Recipients::All, ack)
-        }
-        Plan::Forward { round, recipients } => marshal.forward(round, commitment, recipients),
     }
 }
 

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -729,7 +729,7 @@ mod test {
         ) {
             let mut marshal = self.nodes[index].marshal.clone();
             let round = finalization.proposal.round;
-            assert!(marshal.proposed(round, block).await);
+            assert!(marshal.verified(round, block).await);
             let _ = marshal.report(Activity::Finalization(finalization));
         }
 


### PR DESCRIPTION
## Overview

The leader's proposal previously entered marshal at propose time (`proposed_deferred`), and the relay broadcast was a separate `Forward` message that had to route through actor state: the block was retained in a `last_proposed_block` slot so the later `Forward` could send it without a storage read. The network send was therefore queued behind the ingest/persist work, and the mailbox needed a propose-time handshake plus cross-message state to connect the two.

This PR moves the propose-time handshake out of the mailbox entirely and puts the network send first. `propose` stages the block (and its durability ack) in the wrapper's `Gates` registry and only publishes the digest, so marshal hears nothing at propose time. When consensus requests the broadcast, the staged block is handed to marshal as one self-contained `Proposed { block, recipients, ack }` message. The actor sends to the network first, then ingests and persists, then delivers the sync handle through the ack. `last_proposed_block`/`take_proposed` are deleted, `Forward` is a pure find-and-send again, and `Relay::broadcast` branches strictly on the plan: `Plan::Propose` relays only a staged proposal and `Plan::Forward` only forwards from storage.

## Flow

Before:

```
 leader wrapper                      marshal actor                      peers
 ──────────────                      ─────────────                      ─────
 propose():
   proposed_deferred(block) ───────► Proposed { block, ack }
   publish digest ──► consensus        1. ingest
                                       2. put_verified (write + sync)
                                       3. last_proposed_block = block ◄─ cross-
                                       4. ack: sync handle               message
                                                                         state
 Relay::broadcast(Plan::Propose):
   forward(commitment) ────────────► Forward { commitment }
                                       take last_proposed_block
                                         (or storage fallback)
                                       buffer.send ──────────────────► block /
                                                                       shards
 certify():
   await gate: handle durable ─────► finalize vote
```

After:

```
 leader wrapper                      marshal actor                      peers
 ──────────────                      ─────────────                      ─────
 propose():
   stage (block, ack) in Gates       (no mailbox message)
   publish digest ──► consensus

 Relay::broadcast(Plan::Propose):
   take_staged ─► proposed(...) ───► Proposed { block, recipients, ack }
                                       1. buffer.send ────────────────► block /
                                       2. ingest                        shards
                                       3. put_verified (write + sync)
                                       4. ack: sync handle

 certify():
   flush: take_staged ─► verified_deferred(block, ack)
                                     (only if broadcast was never requested)
   await gate: handle durable ─────► finalize vote
```

`Plan::Forward` is unchanged: a find-and-send from the buffer or storage, which a prior `Proposed` on the FIFO mailbox has always populated by the time a forward for it can arrive.

## Durability contract (unchanged)

Certification still awaits the staged gate, and the gate resolves only after the sync handle reports durable, so the finalize vote never precedes block durability. If consensus never requests the broadcast (the view moved on before the digest landed), `certify` flushes the staged proposal through `verified_deferred` — persist without broadcast — so the gate resolves through the same handshake. This preserves the pinned leader contract that a certified proposal survives restart even if `Relay::broadcast` never runs. `Gates::retain_after` now prunes staged proposals alongside gate tasks for decided rounds. A pruned or dropped ack abandons the gate, which sends certification to its existing recovery-fetch fallback.

Ordering the write after the send is safe because nothing consumes the durability ack before certify, and no certificate can form until peers receive the block. Restart equivocation is prevented by the voter, not by this write: votes are journal-synced before they are broadcast, and a journaled notarize replays as a built proposal, so `propose` is not re-requested. When the leader recovers a block that a pre-crash relay broadcast already persisted, the reuse path re-stages it and the relay-time `put_verified` deduplicates, with the returned handle covering the original write.

## Also included

The blocking `mailbox.proposed()` is removed and its remaining test users switch to the equivalent `verified()`. The `Proposed`/`Verified`/`Certified` acks are now bare senders (no constructor ever passed `None`). The harness drives the real relay message through a single shared default `propose` impl instead of four per-harness copies. New tests pin the send-before-persist ordering, the staged handshake, and prune-time abandonment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
