### PR TITLE
[storage] Make `async` `mut` able methods consume/produce `Self`

### DIFF
--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -640,8 +640,7 @@ where
             debug!("{}", Mode::SHUTDOWN_MESSAGE);
         },
         _ = context.sleep_until(next_op_time) => {
-            // Add operations to the database. A failed mutation consumes the database,
-            // so treat it as fatal and stop serving.
+            // Add operations to the database. A failed mutation is fatal; stop serving.
             if let Err(err) = maybe_add_operations(&state, &mut context, &config).await {
                 error!(?err, "failed to add additional operations; shutting down");
                 return Err(err);

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -72,8 +72,11 @@ struct Config {
 
 /// Server state containing the database and metrics.
 struct State<DB> {
-    /// The database wrapped in async rwlock.
-    database: Arc<AsyncRwLock<DB>>,
+    /// The database wrapped in an async rwlock. Owned mutations take the
+    /// database out of the slot and put it back on success; a failure, panic,
+    /// or cancellation mid-mutation leaves the slot empty, and handlers then
+    /// return [`Error::DatabaseUnavailable`].
+    database: Arc<AsyncRwLock<Option<DB>>>,
     /// Request counter for metrics.
     request_counter: Counter,
     /// Error counter for metrics.
@@ -90,7 +93,7 @@ impl<DB> State<DB> {
         E: Metrics,
     {
         Self {
-            database: Arc::new(AsyncRwLock::new(database)),
+            database: Arc::new(AsyncRwLock::new(Some(database))),
             request_counter: context.counter("requests", "Number of requests received"),
             error_counter: context.counter("error", "Number of errors"),
             ops_counter: context.counter(
@@ -188,17 +191,22 @@ where
     };
     if should_add {
         let seed = context.next_u64();
-        let mut database = state.database.write().await;
+        let mut guard = state.database.write().await;
+        let database = guard.take().ok_or(Error::DatabaseUnavailable)?;
         let starting_loc = database.current_floor();
         let new_operations =
             DB::create_test_operations(config.ops_per_interval, seed, starting_loc);
         let new_operations_len = new_operations.len();
-        if let Err(err) = database.add_operations(new_operations).await {
-            error!(?err, "failed to add operations to database");
-            return Err(err.into());
-        }
+        let database = match database.add_operations(new_operations).await {
+            Ok(database) => database,
+            Err(err) => {
+                error!(?err, "failed to add operations to database");
+                return Err(err.into());
+            }
+        };
         let root = database.root();
-        drop(database);
+        *guard = Some(database);
+        drop(guard);
         state.ops_counter.inc_by(new_operations_len as u64);
         info!(
             new_operations_len,
@@ -222,7 +230,8 @@ where
 
     // Get the current database state
     let (root, sync_boundary, size) = {
-        let database = state.database.read().await;
+        let guard = state.database.read().await;
+        let database = guard.as_ref().ok_or(Error::DatabaseUnavailable)?;
         (database.root(), database.sync_boundary(), database.size())
     };
     let response = wire::GetSyncTargetResponse::<Key> {
@@ -245,8 +254,8 @@ where
     state.request_counter.inc();
 
     let target = {
-        let database = state.database.read().await;
-        database.target()
+        let guard = state.database.read().await;
+        guard.as_ref().ok_or(Error::DatabaseUnavailable)?.target()
     };
     let response = wire::GetCompactTargetResponse::<Key> {
         request_id: request.request_id,
@@ -268,7 +277,8 @@ where
     state.request_counter.inc();
     request.validate()?;
 
-    let database = state.database.read().await;
+    let guard = state.database.read().await;
+    let database = guard.as_ref().ok_or(Error::DatabaseUnavailable)?;
 
     // Check if we have enough operations
     let db_size = database.size();
@@ -317,7 +327,7 @@ where
         None
     };
 
-    drop(database);
+    drop(guard);
 
     debug!(
         request_id = request.request_id,
@@ -341,7 +351,7 @@ async fn handle_get_compact_state<DB>(
 ) -> Result<wire::GetCompactStateResponse<DB::Operation, Key>, Error>
 where
     DB: CompactSyncable<Family = mmr::Family>,
-    Arc<AsyncRwLock<DB>>: compact::Resolver<
+    Arc<AsyncRwLock<Option<DB>>>: compact::Resolver<
             Family = mmr::Family,
             Op = DB::Operation,
             Digest = Key,
@@ -357,9 +367,8 @@ where
             match err {
                 compact::ServeError::Database(err) => Error::Database(err),
                 compact::ServeError::StaleTarget { .. } => Error::StaleTarget(err.to_string()),
-                compact::ServeError::InvalidTarget(_) | compact::ServeError::MissingSource => {
-                    Error::InvalidRequest(err.to_string())
-                }
+                compact::ServeError::MissingSource => Error::DatabaseUnavailable,
+                compact::ServeError::InvalidTarget(_) => Error::InvalidRequest(err.to_string()),
             }
         })?;
 
@@ -406,7 +415,7 @@ where
     DB: CompactSyncable<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    Arc<AsyncRwLock<DB>>: compact::Resolver<
+    Arc<AsyncRwLock<Option<DB>>>: compact::Resolver<
             Family = mmr::Family,
             Op = DB::Operation,
             Digest = Key,
@@ -537,7 +546,7 @@ where
 
 /// Initialize and display database state with initial operations.
 async fn initialize_database<DB, E>(
-    mut database: DB,
+    database: DB,
     config: &Config,
     context: &mut E,
 ) -> Result<DB, BoxError>
@@ -555,7 +564,7 @@ where
         operations_len = initial_ops.len(),
         "creating initial operations"
     );
-    database.add_operations(initial_ops).await?;
+    let database = database.add_operations(initial_ops).await?;
 
     // Display database state
     let size = database.size();
@@ -568,7 +577,7 @@ where
 
 /// Initialize and display compact-source database state with initial operations.
 async fn initialize_compact_database<DB, E>(
-    mut database: DB,
+    database: DB,
     config: &Config,
     context: &mut E,
 ) -> Result<DB, BoxError>
@@ -585,7 +594,7 @@ where
         operations_len = initial_ops.len(),
         "creating initial operations"
     );
-    database.add_operations(initial_ops).await?;
+    let database = database.add_operations(initial_ops).await?;
 
     let target = database.target();
     let root = target.root;
@@ -631,9 +640,11 @@ where
             debug!("{}", Mode::SHUTDOWN_MESSAGE);
         },
         _ = context.sleep_until(next_op_time) => {
-            // Add operations to the database
+            // Add operations to the database. A failed mutation consumes the database,
+            // so treat it as fatal and stop serving.
             if let Err(err) = maybe_add_operations(&state, &mut context, &config).await {
-                warn!(?err, "failed to add additional operations");
+                error!(?err, "failed to add additional operations; shutting down");
+                return Err(err);
             }
             next_op_time = context.current() + config.op_interval;
         },
@@ -681,7 +692,7 @@ where
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
     E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
-    Arc<AsyncRwLock<DB>>: compact::Resolver<
+    Arc<AsyncRwLock<Option<DB>>>: compact::Resolver<
             Family = mmr::Family,
             Op = DB::Operation,
             Digest = Key,

--- a/examples/sync/src/databases/any.rs
+++ b/examples/sync/src/databases/any.rs
@@ -89,13 +89,13 @@ where
     }
 
     async fn add_operations(
-        &mut self,
+        mut self,
         operations: Vec<Self::Operation>,
-    ) -> Result<(), qmdb::Error<mmr::Family>> {
+    ) -> Result<Self, qmdb::Error<mmr::Family>> {
         if operations.last().is_none() || !operations.last().unwrap().is_commit() {
             // Ignore bad inputs rather than return errors.
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         }
 
         let mut batch = self.new_batch();
@@ -108,14 +108,14 @@ where
                     batch = batch.write(key, None);
                 }
                 Operation::CommitFloor(metadata, _) => {
-                    let merkleized = batch.merkleize(self, metadata).await?;
-                    self.apply_batch(merkleized).await?;
-                    self.commit().await?;
+                    let merkleized = batch.merkleize(&self, metadata).await?;
+                    (self, _) = self.apply_batch(merkleized).await?;
+                    self = self.commit().await?;
                     batch = self.new_batch();
                 }
             }
         }
-        Ok(())
+        Ok(self)
     }
 
     fn current_floor(&self) -> u64 {

--- a/examples/sync/src/databases/current.rs
+++ b/examples/sync/src/databases/current.rs
@@ -112,12 +112,12 @@ where
     }
 
     async fn add_operations(
-        &mut self,
+        mut self,
         operations: Vec<Self::Operation>,
-    ) -> Result<(), qmdb::Error<mmr::Family>> {
+    ) -> Result<Self, qmdb::Error<mmr::Family>> {
         if operations.last().is_none() || !operations.last().unwrap().is_commit() {
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         }
 
         let mut batch = self.new_batch();
@@ -130,14 +130,14 @@ where
                     batch = batch.write(key, None);
                 }
                 Operation::CommitFloor(metadata, _) => {
-                    let merkleized = batch.merkleize(self, metadata).await?;
-                    self.apply_batch(merkleized).await?;
-                    self.commit().await?;
+                    let merkleized = batch.merkleize(&self, metadata).await?;
+                    (self, _) = self.apply_batch(merkleized).await?;
+                    self = self.commit().await?;
                     batch = self.new_batch();
                 }
             }
         }
-        Ok(())
+        Ok(self)
     }
 
     fn current_floor(&self) -> u64 {

--- a/examples/sync/src/databases/immutable.rs
+++ b/examples/sync/src/databases/immutable.rs
@@ -101,13 +101,13 @@ where
     }
 
     async fn add_operations(
-        &mut self,
+        mut self,
         operations: Vec<Self::Operation>,
-    ) -> Result<(), commonware_storage::qmdb::Error<mmr::Family>> {
+    ) -> Result<Self, commonware_storage::qmdb::Error<mmr::Family>> {
         if operations.last().is_none() || !operations.last().unwrap().is_commit() {
             // Ignore bad inputs rather than return errors.
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         }
 
         let mut batch = self.new_batch();
@@ -117,14 +117,14 @@ where
                     batch = batch.set(key, value);
                 }
                 Operation::Commit(metadata, floor) => {
-                    let merkleized = batch.merkleize(self, metadata, floor).await;
-                    self.apply_batch(merkleized).await?;
-                    self.commit().await?;
+                    let merkleized = batch.merkleize(&self, metadata, floor).await;
+                    (self, _) = self.apply_batch(merkleized).await?;
+                    self = self.commit().await?;
                     batch = self.new_batch();
                 }
             }
         }
-        Ok(())
+        Ok(self)
     }
 
     fn current_floor(&self) -> u64 {

--- a/examples/sync/src/databases/immutable_compact.rs
+++ b/examples/sync/src/databases/immutable_compact.rs
@@ -50,16 +50,16 @@ where
     }
 
     async fn add_operations(
-        &mut self,
+        mut self,
         operations: Vec<Self::Operation>,
-    ) -> Result<(), qmdb::Error<mmr::Family>> {
+    ) -> Result<Self, qmdb::Error<mmr::Family>> {
         let Some(last) = operations.last() else {
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         };
         if !matches!(last, Operation::Commit(..)) {
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         }
 
         let mut batch = self.new_batch();
@@ -69,14 +69,14 @@ where
                     batch = batch.set(key, value);
                 }
                 Operation::Commit(metadata, floor) => {
-                    let merkleized = batch.merkleize(self, metadata, floor).await;
-                    self.apply_batch(merkleized)?;
-                    self.sync().await?;
+                    let merkleized = batch.merkleize(&self, metadata, floor).await;
+                    (self, _) = self.apply_batch(merkleized)?;
+                    self = self.sync().await?;
                     batch = self.new_batch();
                 }
             }
         }
-        Ok(())
+        Ok(self)
     }
 
     fn current_floor(&self) -> u64 {

--- a/examples/sync/src/databases/keyless.rs
+++ b/examples/sync/src/databases/keyless.rs
@@ -95,13 +95,13 @@ where
     }
 
     async fn add_operations(
-        &mut self,
+        mut self,
         operations: Vec<Self::Operation>,
-    ) -> Result<(), qmdb::Error<mmr::Family>> {
+    ) -> Result<Self, qmdb::Error<mmr::Family>> {
         if operations.last().is_none() || !operations.last().unwrap().is_commit() {
             // Ignore bad inputs rather than return errors.
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         }
 
         let mut batch = self.new_batch();
@@ -111,14 +111,14 @@ where
                     batch = batch.append(value);
                 }
                 Operation::Commit(metadata, floor) => {
-                    let merkleized = batch.merkleize(self, metadata, floor).await;
-                    self.apply_batch(merkleized).await?;
-                    self.commit().await?;
+                    let merkleized = batch.merkleize(&self, metadata, floor).await;
+                    (self, _) = self.apply_batch(merkleized).await?;
+                    self = self.commit().await?;
                     batch = self.new_batch();
                 }
             }
         }
-        Ok(())
+        Ok(self)
     }
 
     fn current_floor(&self) -> u64 {

--- a/examples/sync/src/databases/keyless_compact.rs
+++ b/examples/sync/src/databases/keyless_compact.rs
@@ -50,16 +50,16 @@ where
     }
 
     async fn add_operations(
-        &mut self,
+        mut self,
         operations: Vec<Self::Operation>,
-    ) -> Result<(), qmdb::Error<mmr::Family>> {
+    ) -> Result<Self, qmdb::Error<mmr::Family>> {
         let Some(last) = operations.last() else {
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         };
         if !matches!(last, Operation::Commit(..)) {
             error!("operations must end with a commit");
-            return Ok(());
+            return Ok(self);
         }
 
         let mut batch = self.new_batch();
@@ -69,14 +69,14 @@ where
                     batch = batch.append(value);
                 }
                 Operation::Commit(metadata, floor) => {
-                    let merkleized = batch.merkleize(self, metadata, floor).await;
-                    self.apply_batch(merkleized)?;
-                    self.sync().await?;
+                    let merkleized = batch.merkleize(&self, metadata, floor).await;
+                    (self, _) = self.apply_batch(merkleized)?;
+                    self = self.sync().await?;
                     batch = self.new_batch();
                 }
             }
         }
-        Ok(())
+        Ok(self)
     }
 
     fn current_floor(&self) -> u64 {

--- a/examples/sync/src/databases/mod.rs
+++ b/examples/sync/src/databases/mod.rs
@@ -150,9 +150,9 @@ pub trait ExampleDatabase: Sized {
     /// Add operations to the database, ignoring any input that doesn't end with a commit
     /// operation.
     fn add_operations(
-        &mut self,
+        self,
         operations: Vec<Self::Operation>,
-    ) -> impl Future<Output = Result<(), qmdb::Error<Self::Family>>> + Send;
+    ) -> impl Future<Output = Result<Self, qmdb::Error<Self::Family>>> + Send;
 
     /// Return the floor anchor a caller should pass as `starting_loc` when generating a stream
     /// to append to this db's current state.
@@ -221,7 +221,18 @@ mod tests {
         DatabaseType, ExampleDatabase, SyncMode, immutable, immutable_compact, keyless,
         keyless_compact,
     };
+    use commonware_macros::boxed;
     use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
+
+    /// [`ExampleDatabase::add_operations`] with a heap-allocated state machine (the future
+    /// embeds the database and the operation stream, exceeding the size lint).
+    #[boxed]
+    async fn add_operations_boxed<D: ExampleDatabase>(
+        db: D,
+        ops: Vec<D::Operation>,
+    ) -> Result<D, commonware_storage::qmdb::Error<D::Family>> {
+        db.add_operations(ops).await
+    }
 
     #[test]
     fn test_supported_client_mode_matrix() {
@@ -269,8 +280,8 @@ mod tests {
 
                 let ops = immutable::create_test_operations(count, seed, starting_loc);
 
-                full.add_operations(ops.clone()).await.unwrap();
-                compact.add_operations(ops).await.unwrap();
+                full = add_operations_boxed(full, ops.clone()).await.unwrap();
+                compact = compact.add_operations(ops).await.unwrap();
 
                 assert_eq!(full.root(), compact.root());
                 assert_eq!(full.current_floor(), compact.current_floor());
@@ -303,8 +314,8 @@ mod tests {
 
                 let ops = keyless::create_test_operations(count, seed, starting_loc);
 
-                full.add_operations(ops.clone()).await.unwrap();
-                compact.add_operations(ops).await.unwrap();
+                full = add_operations_boxed(full, ops.clone()).await.unwrap();
+                compact = compact.add_operations(ops).await.unwrap();
 
                 assert_eq!(full.root(), compact.root());
                 assert_eq!(full.current_floor(), compact.current_floor());

--- a/examples/sync/src/error.rs
+++ b/examples/sync/src/error.rs
@@ -30,6 +30,10 @@ pub enum Error {
     #[error("database operation failed")]
     Database(#[from] commonware_storage::qmdb::Error<commonware_storage::mmr::Family>),
 
+    /// Database slot is empty after a failed or interrupted update
+    #[error("database is not available: a previous update failed or was interrupted")]
+    DatabaseUnavailable,
+
     /// Request channel to I/O task closed unexpectedly
     #[error("request channel closed - I/O task may have terminated")]
     RequestChannelClosed,

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -294,7 +294,7 @@ mod tests {
     use super::{Config, Stateful};
     use crate::stateful::{
         actor::syncer::SyncPlan,
-        db::{AttachableResolver, StateSyncDb, SyncEngineConfig},
+        db::{AttachableResolver, Shared, StateSyncDb, SyncEngineConfig},
         tests::mocks::{TestApp, TestBlock, TestDb, TestScheme, TestVariant},
     };
     use commonware_consensus::{
@@ -316,14 +316,14 @@ mod tests {
         Clock as _, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
     };
     use commonware_storage::archive::immutable;
-    use commonware_utils::{NZU16, NZU64, NZUsize, channel::mpsc, sync::TracedAsyncRwLock};
-    use std::{convert::Infallible, sync::Arc, time::Duration};
+    use commonware_utils::{NZU16, NZU64, NZUsize, channel::mpsc};
+    use std::{convert::Infallible, time::Duration};
 
     #[derive(Clone)]
     struct NoopResolver;
 
     impl AttachableResolver<TestDb> for NoopResolver {
-        async fn attach_database(&self, _db: Arc<TracedAsyncRwLock<TestDb>>) {}
+        async fn attach_database(&self, _db: Shared<TestDb>) {}
     }
 
     impl StateSyncDb<deterministic::Context, NoopResolver> for TestDb {

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -331,7 +331,7 @@ mod tests {
             metrics::Metrics as StatefulMetrics,
             syncer::{self, StateSyncMetadata, SyncResult},
         },
-        db::{Anchor, AttachableResolver},
+        db::{Anchor, AttachableResolver, Shared},
         tests::mocks::{TestApp, TestBlock, TestScheme, TestVariant, anchor, test_databases},
     };
     use commonware_actor::mailbox as actor_mailbox;
@@ -348,10 +348,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, NZU16, NZU64, NZUsize,
-        acknowledgement::Exact,
-        channel::oneshot,
-        sync::{AsyncMutex, TracedAsyncRwLock},
+        Acknowledgement, NZU16, NZU64, NZUsize, acknowledgement::Exact, channel::oneshot,
+        sync::AsyncMutex,
     };
     use futures::{FutureExt, pin_mut, poll};
     use std::sync::Arc;
@@ -360,7 +358,7 @@ mod tests {
     struct NoopResolver;
 
     impl<DB: Send + Sync + 'static> AttachableResolver<DB> for NoopResolver {
-        async fn attach_database(&self, _db: Arc<TracedAsyncRwLock<DB>>) {}
+        async fn attach_database(&self, _db: Shared<DB>) {}
     }
 
     struct TestHarness {

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -926,7 +926,7 @@ mod tests {
     use crate::stateful::{
         Application, Proposed, PruneConfig,
         actor::metrics::Metrics as StatefulMetrics,
-        db::{Anchor, DatabaseSet, Merkleized as _, Unmerkleized as _},
+        db::{Anchor, DatabaseSet, Merkleized as _, Shared, Unmerkleized as _},
     };
     use commonware_codec::{Encode, EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
     use commonware_consensus::{
@@ -938,6 +938,7 @@ mod tests {
     use commonware_cryptography::{
         Digest as _, Digestible, Hasher, Sha256, Signer as _, ed25519, sha256::Digest,
     };
+    use commonware_macros::boxed;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
         ContextCell, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
@@ -949,11 +950,7 @@ mod tests {
         translator::TwoCap,
     };
     use commonware_utils::{
-        NZU16, NZU64, NZUsize,
-        channel::oneshot,
-        non_empty_range,
-        range::NonEmptyRange,
-        sync::{Mutex, TracedAsyncRwLock},
+        NZU16, NZU64, NZUsize, channel::oneshot, non_empty_range, range::NonEmptyRange, sync::Mutex,
     };
     use futures::{Stream, StreamExt};
     use std::{
@@ -974,7 +971,7 @@ mod tests {
 
     type Qmdb<E> =
         any::unordered::fixed::Db<mmr::Family, E, Digest, Digest, Sha256, TwoCap, Sequential>;
-    type DbSet<E> = Arc<TracedAsyncRwLock<Qmdb<E>>>;
+    type DbSet<E> = Shared<Qmdb<E>>;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct Block {
@@ -1489,6 +1486,7 @@ mod tests {
             false
         }
 
+        #[boxed]
         async fn finalize(&mut self, block: Block) -> FinalizeStatus {
             self.processor
                 .finalize(self.context_cell.as_present(), &block)
@@ -1496,6 +1494,7 @@ mod tests {
                 .0
         }
 
+        #[boxed]
         async fn finalize_with_prune(
             &mut self,
             block: Block,

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -2,12 +2,12 @@
 //!
 //! The QMDB batch API passes `&db` to `get()` and `merkleize()` for
 //! read-through to committed state. This module provides wrapper types
-//! that capture `Arc<TracedAsyncRwLock<Db>>` alongside the raw batch so the
+//! that capture a [`Shared`] database handle alongside the raw batch so the
 //! [`Unmerkleized`](super::Unmerkleized) and [`Merkleized`](super::Merkleized)
 //! traits can be implemented without a DB parameter.
 
 use crate::stateful::db::{
-    ManagedDb, Merkleized as MerkleizedTrait, StateSyncDb, SyncEngineConfig,
+    ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{Codec, Read as CodecRead};
@@ -38,7 +38,7 @@ use commonware_storage::{
     },
     translator::Translator,
 };
-use commonware_utils::{Array, channel::mpsc, non_empty_range, sync::TracedAsyncRwLock};
+use commonware_utils::{Array, channel::mpsc, non_empty_range};
 use std::{
     ops::{Deref, Range},
     sync::Arc,
@@ -46,9 +46,6 @@ use std::{
 
 // Matches commonware_storage::qmdb::any::BITMAP_CHUNK_BYTES, which is crate-private.
 const ANY_BITMAP_CHUNK_BYTES: usize = 64;
-
-type AnyDbHandle<F, E, C, I, H, U, S> =
-    Arc<TracedAsyncRwLock<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>>;
 
 /// Wraps a QMDB [`UnmerkleizedBatch`] with a reference to the parent
 /// database, implementing the [`Unmerkleized`](super::Unmerkleized) trait.
@@ -64,7 +61,7 @@ where
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, S>,
-    db: AnyDbHandle<F, E, C, I, H, U, S>,
+    db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
     metadata: Option<U::Value>,
 }
 
@@ -86,7 +83,7 @@ where
     Operation<F, U>: Codec,
 {
     staged: Staged<F, H, U, S>,
-    db: AnyDbHandle<F, E, C, I, H, U, S>,
+    db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
     metadata: Option<U::Value>,
 }
 
@@ -112,7 +109,7 @@ where
     /// Read a value by key, falling back to committed state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get(key, &*db).await
+        self.batch.get(key, &db).await
     }
 
     /// Read multiple values by key, falling back to committed state.
@@ -120,7 +117,7 @@ where
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get_many(keys, &*db).await
+        self.batch.get_many(keys, &db).await
     }
 
     /// Read multiple values and return a staged batch for the same keys.
@@ -137,7 +134,7 @@ where
         } = self;
         let (values, staged) = {
             let guard = db.read().await;
-            batch.stage(keys, &*guard).await?
+            batch.stage(keys, &guard).await?
         };
         Ok((
             values,
@@ -170,7 +167,7 @@ where
     Operation<F, U>: Codec,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, U, S>>,
-    db: AnyDbHandle<F, E, C, I, H, U, S>,
+    db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
 }
 
 impl<F, E, C, I, H, U, S> Deref for AnyUnmerkleized<F, E, C, I, H, U, S>
@@ -245,7 +242,7 @@ where
         } = self;
         let (range, values, staged) = {
             let guard = db.read().await;
-            staged.expand(keys, &*guard).await?
+            staged.expand(keys, &guard).await?
         };
         Ok((
             range,
@@ -297,9 +294,7 @@ where
         } = self;
         let inner = {
             let guard = db.read().await;
-            staged
-                .merkleize(updates, upserts, metadata, &*guard)
-                .await?
+            staged.merkleize(updates, upserts, metadata, &guard).await?
         };
         Ok(AnyMerkleized { inner, db })
     }
@@ -343,9 +338,7 @@ where
         } = self;
         let inner = {
             let guard = db.read().await;
-            staged
-                .merkleize(updates, upserts, metadata, &*guard)
-                .await?
+            staged.merkleize(updates, upserts, metadata, &guard).await?
         };
         Ok(AnyMerkleized { inner, db })
     }
@@ -366,7 +359,7 @@ where
     /// Read a value by key, falling back to committed state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get(key, &*db).await
+        self.inner.get(key, &db).await
     }
 
     /// Read multiple values by key, falling back to committed state.
@@ -374,7 +367,7 @@ where
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get_many(keys, &*db).await
+        self.inner.get_many(keys, &db).await
     }
 }
 
@@ -397,7 +390,7 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
+        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
         Ok(AnyMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -424,7 +417,7 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
+        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
         Ok(AnyMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -463,7 +456,7 @@ where
 
 /// Implement [`ManagedDb`] for unordered QMDB databases with fixed-size values.
 ///
-/// `new_batch` captures the `Arc<TracedAsyncRwLock<Db>>` in the returned
+/// `new_batch` captures the [`Shared`] database handle in the returned
 /// wrapper so that `get()` and `merkleize()` can read through to
 /// committed state.
 ///
@@ -522,10 +515,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         AnyUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
         }
@@ -537,12 +530,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -554,16 +547,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -626,10 +619,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         AnyUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
         }
@@ -641,12 +634,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -658,16 +651,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -837,7 +830,7 @@ mod tests {
             let db = <UnorderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let key = |i: u64| Sha256::hash(&i.to_be_bytes());
             let val = |i: u64| Sha256::hash(&(i + 10_000).to_be_bytes());
@@ -852,10 +845,12 @@ mod tests {
                 .await
                 .unwrap();
             {
-                let mut guard = db.write().await;
-                <UnorderedFixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(
+                    <UnorderedFixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap(),
+                );
             }
 
             // Read set: key(1) updated, key(2) deleted, key(999) missing -> created.

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -2,12 +2,12 @@
 //!
 //! The QMDB batch API passes `&db` to `get()` and `merkleize()` for
 //! read-through to committed state. This module provides wrapper types
-//! that capture `Arc<TracedAsyncRwLock<Db>>` alongside the raw batch so the
+//! that capture a [`Shared`] database handle alongside the raw batch so the
 //! [`Unmerkleized`](super::Unmerkleized) and [`Merkleized`](super::Merkleized)
 //! traits can be implemented without a DB parameter.
 
 use crate::stateful::db::{
-    ManagedDb, Merkleized as MerkleizedTrait, StateSyncDb, SyncEngineConfig,
+    ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{Codec, Read as CodecRead};
@@ -41,14 +41,11 @@ use commonware_storage::{
     },
     translator::Translator,
 };
-use commonware_utils::{Array, channel::mpsc, non_empty_range, sync::TracedAsyncRwLock};
+use commonware_utils::{Array, channel::mpsc, non_empty_range};
 use std::{
     ops::{Deref, Range},
     sync::Arc,
 };
-
-type CurrentDbHandle<F, E, C, I, H, U, const N: usize, S> =
-    Arc<TracedAsyncRwLock<Db<F, E, C, I, H, U, N, S>>>;
 
 /// Wraps a QMDB [`UnmerkleizedBatch`] with a reference to the parent
 /// database, implementing the [`Unmerkleized`](super::Unmerkleized) trait.
@@ -64,7 +61,7 @@ where
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, N, S>,
-    db: CurrentDbHandle<F, E, C, I, H, U, N, S>,
+    db: Shared<Db<F, E, C, I, H, U, N, S>>,
     metadata: Option<U::Value>,
 }
 
@@ -86,7 +83,7 @@ where
     Operation<F, U>: Codec,
 {
     staged: Staged<F, H, U, N, S>,
-    db: CurrentDbHandle<F, E, C, I, H, U, N, S>,
+    db: Shared<Db<F, E, C, I, H, U, N, S>>,
     metadata: Option<U::Value>,
 }
 
@@ -112,7 +109,7 @@ where
     /// Read a value by key, falling back to committed state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get(key, &*db).await
+        self.batch.get(key, &db).await
     }
 
     /// Read multiple values by key, falling back to committed state.
@@ -120,7 +117,7 @@ where
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get_many(keys, &*db).await
+        self.batch.get_many(keys, &db).await
     }
 
     /// Read multiple values and return a staged batch for the same keys.
@@ -137,7 +134,7 @@ where
         } = self;
         let (values, staged) = {
             let guard = db.read().await;
-            batch.stage(keys, &*guard).await?
+            batch.stage(keys, &guard).await?
         };
         Ok((
             values,
@@ -170,7 +167,7 @@ where
     Operation<F, U>: Codec,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, U, N, S>>,
-    db: CurrentDbHandle<F, E, C, I, H, U, N, S>,
+    db: Shared<Db<F, E, C, I, H, U, N, S>>,
 }
 
 impl<F, E, C, I, H, U, const N: usize, S> Deref for CurrentUnmerkleized<F, E, C, I, H, U, N, S>
@@ -245,7 +242,7 @@ where
         } = self;
         let (range, values, staged) = {
             let guard = db.read().await;
-            staged.expand(keys, &*guard).await?
+            staged.expand(keys, &guard).await?
         };
         Ok((
             range,
@@ -298,9 +295,7 @@ where
         } = self;
         let inner = {
             let guard = db.read().await;
-            staged
-                .merkleize(updates, upserts, metadata, &*guard)
-                .await?
+            staged.merkleize(updates, upserts, metadata, &guard).await?
         };
         Ok(CurrentMerkleized { inner, db })
     }
@@ -345,9 +340,7 @@ where
         } = self;
         let inner = {
             let guard = db.read().await;
-            staged
-                .merkleize(updates, upserts, metadata, &*guard)
-                .await?
+            staged.merkleize(updates, upserts, metadata, &guard).await?
         };
         Ok(CurrentMerkleized { inner, db })
     }
@@ -368,7 +361,7 @@ where
     /// Read a value by key, falling back to committed state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get(key, &*db).await
+        self.inner.get(key, &db).await
     }
 
     /// Read multiple values by key, falling back to committed state.
@@ -376,7 +369,7 @@ where
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get_many(keys, &*db).await
+        self.inner.get_many(keys, &db).await
     }
 }
 
@@ -399,7 +392,7 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
+        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
         Ok(CurrentMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -426,7 +419,7 @@ where
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
         let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&*db, self.metadata).await?;
+        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
         Ok(CurrentMerkleized {
             inner: merkleized,
             db: self.db.clone(),
@@ -520,10 +513,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         CurrentUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
         }
@@ -535,12 +528,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -552,16 +545,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -621,10 +614,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         CurrentUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
         }
@@ -636,12 +629,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -653,16 +646,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -799,10 +792,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         CurrentUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
         }
@@ -814,12 +807,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -831,16 +824,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -905,10 +898,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         CurrentUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
         }
@@ -920,12 +913,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -937,16 +930,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -1176,6 +1169,7 @@ where
 mod tests {
     use super::*;
     use commonware_cryptography::{Sha256, sha256::Digest};
+    use commonware_macros::boxed;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
         BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
@@ -1193,6 +1187,13 @@ mod tests {
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, non_empty_range};
     use std::num::{NonZeroU16, NonZeroUsize};
+
+    /// Finalize `batch` into `db`, boxing the future ([`ManagedDb::finalize`] embeds the
+    /// database in its state machine).
+    #[boxed]
+    async fn finalize<D: ManagedDb<deterministic::Context>>(db: D, batch: D::Merkleized) -> D {
+        D::finalize(db, batch).await.unwrap()
+    }
 
     type FixedDb = fixed::Db<
         mmr::Family,
@@ -1295,8 +1296,8 @@ mod tests {
         assert_managed_db::<OrderedVariableDb>();
         assert_state_sync_db::<OrderedFixedDb, Arc<OrderedFixedDb>>();
         assert_state_sync_db::<OrderedVariableDb, Arc<OrderedVariableDb>>();
-        assert_database_set::<Arc<TracedAsyncRwLock<OrderedFixedDb>>>();
-        assert_database_set::<Arc<TracedAsyncRwLock<OrderedVariableDb>>>();
+        assert_database_set::<Shared<OrderedFixedDb>>();
+        assert_database_set::<Shared<OrderedVariableDb>>();
     }
 
     #[test]
@@ -1306,7 +1307,7 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
             let key = Sha256::hash(b"key");
             let value = Sha256::hash(b"value");
             let metadata = Sha256::hash(b"metadata");
@@ -1322,10 +1323,8 @@ mod tests {
             let expected_root = merkleized.root();
 
             {
-                let mut guard = db.write().await;
-                <OrderedFixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(finalize::<OrderedFixedDb>(database, merkleized).await);
             }
 
             let guard = db.read().await;
@@ -1353,7 +1352,7 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let key = |i: u64| Sha256::hash(&i.to_be_bytes());
             let val = |i: u64| Sha256::hash(&(i + 10_000).to_be_bytes());
@@ -1368,10 +1367,8 @@ mod tests {
                 .await
                 .unwrap();
             {
-                let mut guard = db.write().await;
-                <OrderedFixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(finalize::<OrderedFixedDb>(database, merkleized).await);
             }
 
             // Read set: key(1) updated, key(2) deleted, key(999) missing -> created.
@@ -1434,7 +1431,7 @@ mod tests {
             let db = <OrderedVariableDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
             let key = Sha256::hash(b"key");
             let value = Sha256::hash(b"value");
             let metadata = Sha256::hash(b"metadata");
@@ -1450,10 +1447,8 @@ mod tests {
             let expected_root = merkleized.root();
 
             {
-                let mut guard = db.write().await;
-                <OrderedVariableDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(finalize::<OrderedVariableDb>(database, merkleized).await);
             }
 
             let guard = db.read().await;
@@ -1476,7 +1471,7 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config.clone())
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let key = Sha256::hash(b"key");
             let value = Sha256::hash(b"value");
@@ -1490,15 +1485,15 @@ mod tests {
                 .await
                 .unwrap();
 
-            let mut verification_db =
+            let verification_db =
                 <OrderedFixedDb as ManagedDb<_>>::init(context.child("verification_db"), config)
                     .await
                     .unwrap();
-            verification_db
+            let (verification_db, _) = verification_db
                 .apply_batch(merkleized.inner.clone())
                 .await
                 .unwrap();
-            verification_db.sync().await.unwrap();
+            let verification_db = verification_db.sync().await.unwrap();
 
             let valid_target = <OrderedFixedDb as ManagedDb<_>>::sync_target(&verification_db);
             assert!(<OrderedFixedDb as ManagedDb<_>>::matches_sync_target(
@@ -1532,7 +1527,7 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let key1 = Sha256::hash(b"key1");
             let value1 = Sha256::hash(b"value1");
@@ -1545,14 +1540,12 @@ mod tests {
                 .await
                 .unwrap();
             {
-                let mut guard = db.write().await;
-                <OrderedFixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized1)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(finalize::<OrderedFixedDb>(database, merkleized1).await);
             }
             let target_after_first = {
                 let guard = db.read().await;
-                <OrderedFixedDb as ManagedDb<_>>::sync_target(&*guard)
+                <OrderedFixedDb as ManagedDb<_>>::sync_target(&guard)
             };
 
             let key2 = Sha256::hash(b"key2");
@@ -1566,24 +1559,24 @@ mod tests {
                 .await
                 .unwrap();
             {
-                let mut guard = db.write().await;
-                <OrderedFixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized2)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(finalize::<OrderedFixedDb>(database, merkleized2).await);
             }
 
             {
-                let mut guard = db.write().await;
-                <OrderedFixedDb as ManagedDb<_>>::rewind_to_target(
-                    &mut *guard,
-                    target_after_first.clone(),
-                )
-                .await
-                .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(
+                    <OrderedFixedDb as ManagedDb<_>>::rewind_to_target(
+                        database,
+                        target_after_first.clone(),
+                    )
+                    .await
+                    .unwrap(),
+                );
             }
             let target_after_rewind = {
                 let guard = db.read().await;
-                <OrderedFixedDb as ManagedDb<_>>::sync_target(&*guard)
+                <OrderedFixedDb as ManagedDb<_>>::sync_target(&guard)
             };
             assert_eq!(target_after_rewind, target_after_first);
         });
@@ -1596,7 +1589,7 @@ mod tests {
             let db = FixedDb::init(context.child("db"), config.clone())
                 .await
                 .unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let key = Sha256::hash(b"key");
             let value = Sha256::hash(b"value");
@@ -1610,14 +1603,14 @@ mod tests {
                 .await
                 .unwrap();
 
-            let mut verification_db = FixedDb::init(context.child("verification_db"), config)
+            let verification_db = FixedDb::init(context.child("verification_db"), config)
                 .await
                 .unwrap();
-            verification_db
+            let (verification_db, _) = verification_db
                 .apply_batch(merkleized.inner.clone())
                 .await
                 .unwrap();
-            verification_db.sync().await.unwrap();
+            let verification_db = verification_db.sync().await.unwrap();
 
             let valid_target = <FixedDb as ManagedDb<_>>::sync_target(&verification_db);
             assert!(<FixedDb as ManagedDb<_>>::matches_sync_target(

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -5,7 +5,7 @@
 //! adapters expose set and merkleization operations but no historical reads.
 
 use crate::stateful::db::{
-    ManagedDb, Merkleized as MerkleizedTrait, StateSyncDb, SyncEngineConfig,
+    ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
@@ -25,11 +25,8 @@ use commonware_storage::{
         sync::{self},
     },
 };
-use commonware_utils::{Array, channel::mpsc, sync::TracedAsyncRwLock};
+use commonware_utils::{Array, channel::mpsc};
 use std::{ops::Deref, sync::Arc};
-
-type ImmutableUnjournaledDbHandle<F, E, K, V, H, C, S> =
-    Arc<TracedAsyncRwLock<CompactDb<F, E, K, V, H, C, S>>>;
 
 /// Wraps an unjournaled immutable batch before merkleization.
 pub struct ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C = ()>
@@ -45,7 +42,7 @@ where
     S: Strategy,
 {
     batch: CompactUnmerkleizedBatch<F, H, K, V, S>,
-    db: ImmutableUnjournaledDbHandle<F, E, K, V, H, C, S>,
+    db: Shared<CompactDb<F, E, K, V, H, C, S>>,
     metadata: Option<V::Value>,
     inactivity_floor: Option<Location<F>>,
 }
@@ -114,7 +111,7 @@ where
     S: Strategy,
 {
     inner: Arc<CompactMerkleizedBatch<F, H::Digest, K, V, S>>,
-    db: ImmutableUnjournaledDbHandle<F, E, K, V, H, C, S>,
+    db: Shared<CompactDb<F, E, K, V, H, C, S>>,
 }
 
 impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
@@ -157,7 +154,7 @@ where
         let merkleized = self
             .batch
             .merkleize(
-                &*db,
+                &db,
                 self.metadata,
                 self.inactivity_floor.unwrap_or_default(),
             )
@@ -225,10 +222,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         ImmutableUnjournaledUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -239,12 +236,12 @@ where
         batch.root() == target.root && target.leaf_count == Location::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner)?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner)?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         Self::prune(self, target.leaf_count).await
     }
 
@@ -252,15 +249,15 @@ where
         self.target()
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.leaf_count).await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.leaf_count).await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -292,10 +289,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         ImmutableUnjournaledUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -306,12 +303,12 @@ where
         batch.root() == target.root && target.leaf_count == Location::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner)?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner)?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         Self::prune(self, target.leaf_count).await
     }
 
@@ -319,15 +316,15 @@ where
         self.target()
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.leaf_count).await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.leaf_count).await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -543,7 +540,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "managed-db");
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
             let key = Sha256::hash(&[1]);
             let value = Sha256::hash(&[2]);
             let metadata = Sha256::hash(&[3]);
@@ -559,17 +556,19 @@ mod tests {
             let expected_root = merkleized.root();
 
             {
-                let mut guard = db.write().await;
-                <FixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap(),
+                );
             }
 
             let guard = db.read().await;
             assert_eq!(guard.root(), expected_root);
             assert_eq!(guard.get_metadata(), Some(metadata));
 
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&*guard);
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
             assert_eq!(target.root, guard.root());
             assert_eq!(target.leaf_count, mmr::Location::new(3));
         });
@@ -578,10 +577,9 @@ mod tests {
     #[test]
     fn state_sync_fetches_fixed_immutable_compact_state() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source =
-                FixedDb::init(context.child("source"), fixed_config(&context, "source"))
-                    .await
-                    .unwrap();
+            let source = FixedDb::init(context.child("source"), fixed_config(&context, "source"))
+                .await
+                .unwrap();
             let metadata = Sha256::hash(&[3]);
             let floor = source.inactivity_floor_loc();
             let batch = source
@@ -589,8 +587,8 @@ mod tests {
                 .set(Sha256::hash(&[1]), Sha256::hash(&[2]))
                 .merkleize(&source, Some(metadata), floor)
                 .await;
-            source.apply_batch(batch).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).unwrap();
+            let source = source.sync().await.unwrap();
 
             let target = source.target();
             let (_update_tx, update_rx) = mpsc::channel(1);
@@ -617,7 +615,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let source_context = context.child("source");
             let source_config = full_fixed_config(&source_context, "source");
-            let mut source = FullFixedDb::init(source_context, source_config)
+            let source = FullFixedDb::init(source_context, source_config)
                 .await
                 .unwrap();
             let floor = source.inactivity_floor_loc();
@@ -626,8 +624,8 @@ mod tests {
                 .set(Sha256::hash(&[1]), Sha256::hash(&[2]))
                 .merkleize(&source, Some(Sha256::hash(&[3])), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.sync().await.unwrap();
             let target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -704,7 +702,7 @@ mod tests {
     #[test]
     fn state_sync_supersedes_in_flight_stale_compact_target() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source = FullFixedDb::init(
+            let source = FullFixedDb::init(
                 context.child("source"),
                 full_fixed_config(&context, "source"),
             )
@@ -717,8 +715,8 @@ mod tests {
                 .set(Sha256::hash(&[1]), Sha256::hash(&[2]))
                 .merkleize(&source, Some(Sha256::hash(&[9])), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.sync().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -730,8 +728,8 @@ mod tests {
                 .set(Sha256::hash(&[3]), Sha256::hash(&[4]))
                 .merkleize(&source, Some(Sha256::hash(&[10])), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.sync().await.unwrap();
             let latest_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -783,7 +781,7 @@ mod tests {
     fn managed_db_rewinds_fixed_immutable_unjournaled_multiple_commit_ranges() {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "rewind");
-            let mut db = FixedDb::init(context.child("db"), config).await.unwrap();
+            let db = FixedDb::init(context.child("db"), config).await.unwrap();
 
             let floor = db.inactivity_floor_loc();
             let batch = db
@@ -791,8 +789,8 @@ mod tests {
                 .set(Sha256::hash(&[1]), Sha256::hash(&[2]))
                 .merkleize(&db, Some(Sha256::hash(&[11])), floor)
                 .await;
-            db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let mut db = db.sync().await.unwrap();
             let first_target = <FixedDb as ManagedDb<_>>::sync_target(&db);
 
             // Commit two more ranges so the rewind below spans multiple commits.
@@ -803,13 +801,13 @@ mod tests {
                     .set(Sha256::hash(&[i]), Sha256::hash(&[i + 1]))
                     .merkleize(&db, Some(Sha256::hash(&[i * 11])), floor)
                     .await;
-                db.apply_batch(batch).unwrap();
-                db.sync().await.unwrap();
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
             }
             let third_target = <FixedDb as ManagedDb<_>>::sync_target(&db);
             assert_ne!(third_target, first_target);
 
-            <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, first_target.clone())
+            let db = <FixedDb as ManagedDb<_>>::rewind_to_target(db, first_target.clone())
                 .await
                 .unwrap();
 
@@ -836,8 +834,8 @@ mod tests {
                     .set(Sha256::hash(&[i]), Sha256::hash(&[i + 1]))
                     .merkleize(&db, Some(Sha256::hash(&[i * 11])), floor)
                     .await;
-                db.apply_batch(batch).unwrap();
-                db.sync().await.unwrap();
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
                 targets.push(<FixedDb as ManagedDb<_>>::sync_target(&db));
             }
 
@@ -845,19 +843,19 @@ mod tests {
 
             // Prune to the second target: the first is no longer a rewind target, but the
             // second still is.
-            <FixedDb as ManagedDb<_>>::prune(&mut db, &targets[1])
+            let db = <FixedDb as ManagedDb<_>>::prune(db, &targets[1])
                 .await
                 .unwrap();
+            let db = <FixedDb as ManagedDb<_>>::rewind_to_target(db, targets[1].clone())
+                .await
+                .unwrap();
+            assert_eq!(<FixedDb as ManagedDb<_>>::sync_target(&db), targets[1]);
             assert!(matches!(
                 db.rewind(targets[0].leaf_count).await,
                 Err(Error::Merkle(
                     commonware_storage::merkle::Error::RewindBeyondHistory
                 ))
             ));
-            <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, targets[1].clone())
-                .await
-                .unwrap();
-            assert_eq!(<FixedDb as ManagedDb<_>>::sync_target(&db), targets[1]);
         });
     }
 }

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -2,11 +2,11 @@
 //! [`immutable`](commonware_storage::qmdb::immutable) databases.
 //!
 //! Immutable databases support adding new keyed values but not updates or
-//! deletions. The wrapper types here capture `Arc<TracedAsyncRwLock<Immutable>>`
+//! deletions. The wrapper types here capture a [`Shared`] database handle
 //! so the batch API can read through to committed state.
 
 use crate::stateful::db::{
-    ManagedDb, Merkleized as MerkleizedTrait, StateSyncDb, SyncEngineConfig,
+    ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{Codec, EncodeShared, Read as CodecRead};
@@ -31,11 +31,11 @@ use commonware_storage::{
     },
     translator::Translator,
 };
-use commonware_utils::{Array, channel::mpsc, non_empty_range, sync::TracedAsyncRwLock};
+use commonware_utils::{Array, channel::mpsc, non_empty_range};
 use std::{ops::Deref, sync::Arc};
 
-type ImmutableDbHandle<F, E, K, V, C, H, T, S> =
-    Arc<TracedAsyncRwLock<Immutable<F, E, K, V, C, H, T, S>>>;
+/// Shared handle to an immutable database.
+type ImmutableDbHandle<F, E, K, V, C, H, T, S> = Shared<Immutable<F, E, K, V, C, H, T, S>>;
 
 /// Wraps an immutable [`UnmerkleizedBatch`] with a reference to the parent
 /// database, implementing the [`Unmerkleized`](crate::stateful::db::Unmerkleized) trait.
@@ -106,7 +106,7 @@ where
     /// Read a value by key, falling back to committed state.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get(key, &*db).await
+        self.batch.get(key, &db).await
     }
 
     /// Read multiple values by key, falling back to committed state.
@@ -114,7 +114,7 @@ where
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get_many(keys, &*db).await
+        self.batch.get_many(keys, &db).await
     }
 
     /// Set `key` to `value` in the speculative batch.
@@ -176,7 +176,7 @@ where
     /// Read a value by key, falling back to committed state.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get(key, &*db).await
+        self.inner.get(key, &db).await
     }
 
     /// Read multiple values by key, falling back to committed state.
@@ -184,7 +184,7 @@ where
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get_many(keys, &*db).await
+        self.inner.get_many(keys, &db).await
     }
 }
 
@@ -208,7 +208,7 @@ where
         let merkleized = self
             .batch
             .merkleize(
-                &*db,
+                &db,
                 self.metadata,
                 self.inactivity_floor.unwrap_or_default(),
             )
@@ -294,10 +294,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         ImmutableUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -310,12 +310,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -327,16 +327,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -386,10 +386,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         ImmutableUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -402,12 +402,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -419,16 +419,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -5,7 +5,7 @@
 //! adapters expose append and merkleization operations but no historical reads.
 
 use crate::stateful::db::{
-    ManagedDb, Merkleized as MerkleizedTrait, StateSyncDb, SyncEngineConfig,
+    ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
@@ -24,11 +24,8 @@ use commonware_storage::{
         sync::{self},
     },
 };
-use commonware_utils::{channel::mpsc, sync::TracedAsyncRwLock};
+use commonware_utils::channel::mpsc;
 use std::{ops::Deref, sync::Arc};
-
-type KeylessUnjournaledDbHandle<F, E, V, H, C, S> =
-    Arc<TracedAsyncRwLock<CompactDb<F, E, V, H, C, S>>>;
 
 /// Wraps an unjournaled keyless batch before merkleization.
 pub struct KeylessUnjournaledUnmerkleized<F, E, V, H, S, C = ()>
@@ -43,7 +40,7 @@ where
     S: Strategy,
 {
     batch: CompactUnmerkleizedBatch<F, H, V, S>,
-    db: KeylessUnjournaledDbHandle<F, E, V, H, C, S>,
+    db: Shared<CompactDb<F, E, V, H, C, S>>,
     metadata: Option<V::Value>,
     inactivity_floor: Option<Location<F>>,
 }
@@ -109,7 +106,7 @@ where
     S: Strategy,
 {
     inner: Arc<CompactMerkleizedBatch<F, H::Digest, V, S>>,
-    db: KeylessUnjournaledDbHandle<F, E, V, H, C, S>,
+    db: Shared<CompactDb<F, E, V, H, C, S>>,
 }
 
 impl<F, E, V, H, S, C> Deref for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
@@ -149,7 +146,7 @@ where
         let merkleized = self
             .batch
             .merkleize(
-                &*db,
+                &db,
                 self.metadata,
                 self.inactivity_floor.unwrap_or_default(),
             )
@@ -212,10 +209,10 @@ where
         sync::compact::Target::new(initial_root::<F, FixedEncoding<V>, H>(), Location::new(1))
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         KeylessUnjournaledUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -226,12 +223,12 @@ where
         batch.root() == target.root && target.leaf_count == Location::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner)?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner)?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         Self::prune(self, target.leaf_count).await
     }
 
@@ -239,15 +236,15 @@ where
         self.target()
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.leaf_count).await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.leaf_count).await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -278,10 +275,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         KeylessUnjournaledUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -292,12 +289,12 @@ where
         batch.root() == target.root && target.leaf_count == Location::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner)?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner)?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         Self::prune(self, target.leaf_count).await
     }
 
@@ -305,15 +302,15 @@ where
         self.target()
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.leaf_count).await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.leaf_count).await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -519,7 +516,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "managed-db");
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let batch = <FixedDb as ManagedDb<_>>::new_batch(&db)
                 .await
@@ -532,17 +529,19 @@ mod tests {
             let expected_root = merkleized.root();
 
             {
-                let mut guard = db.write().await;
-                <FixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap(),
+                );
             }
 
             let guard = db.read().await;
             assert_eq!(guard.root(), expected_root);
             assert_eq!(guard.get_metadata(), Some(U64::new(9)));
 
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&*guard);
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
             assert_eq!(target.root, guard.root());
             assert_eq!(target.leaf_count, mmr::Location::new(3));
         });
@@ -553,7 +552,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "matches-sync-target");
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let batch = <FixedDb as ManagedDb<_>>::new_batch(&db)
                 .await
@@ -587,18 +586,17 @@ mod tests {
     #[test]
     fn state_sync_fetches_fixed_keyless_compact_state() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source =
-                FixedDb::init(context.child("source"), fixed_config(&context, "source"))
-                    .await
-                    .unwrap();
+            let source = FixedDb::init(context.child("source"), fixed_config(&context, "source"))
+                .await
+                .unwrap();
             let floor = source.inactivity_floor_loc();
             let batch = source
                 .new_batch()
                 .append(U64::new(7))
                 .merkleize(&source, Some(U64::new(9)), floor)
                 .await;
-            source.apply_batch(batch).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).unwrap();
+            let source = source.sync().await.unwrap();
 
             let target = source.target();
             let (_update_tx, update_rx) = mpsc::channel(1);
@@ -623,7 +621,7 @@ mod tests {
     #[test]
     fn state_sync_drains_queued_target_before_reporting_reached() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source = FullFixedDb::init(
+            let source = FullFixedDb::init(
                 context.child("source"),
                 full_fixed_config(&context, "source"),
             )
@@ -636,8 +634,8 @@ mod tests {
                 .append(U64::new(7))
                 .merkleize(&source, Some(U64::new(9)), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.sync().await.unwrap();
             let first_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -649,8 +647,8 @@ mod tests {
                 .append(U64::new(8))
                 .merkleize(&source, Some(U64::new(10)), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.sync().await.unwrap();
             let second_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -683,15 +681,15 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let source_context = context.child("source");
             let source_config = fixed_config(&source_context, "source");
-            let mut source = FixedDb::init(source_context, source_config).await.unwrap();
+            let source = FixedDb::init(source_context, source_config).await.unwrap();
             let floor = source.inactivity_floor_loc();
             let batch = source
                 .new_batch()
                 .append(U64::new(7))
                 .merkleize(&source, Some(U64::new(9)), floor)
                 .await;
-            source.apply_batch(batch).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).unwrap();
+            let source = source.sync().await.unwrap();
             let target = source.target();
 
             // A larger target the resolver never serves. Its sync attempt
@@ -765,7 +763,7 @@ mod tests {
     #[test]
     fn state_sync_supersedes_in_flight_stale_compact_target() {
         deterministic::Runner::default().start(|context| async move {
-            let mut source = FixedDb::init(
+            let source = FixedDb::init(
                 context.child("source"),
                 fixed_config(&context, "supersede-source"),
             )
@@ -778,8 +776,8 @@ mod tests {
                 .append(U64::new(7))
                 .merkleize(&source, Some(U64::new(9)), floor)
                 .await;
-            source.apply_batch(batch).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).unwrap();
+            let source = source.sync().await.unwrap();
             let stale_target = source.target();
 
             let floor = source.inactivity_floor_loc();
@@ -788,8 +786,8 @@ mod tests {
                 .append(U64::new(8))
                 .merkleize(&source, Some(U64::new(10)), floor)
                 .await;
-            source.apply_batch(batch).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch).unwrap();
+            let source = source.sync().await.unwrap();
             let latest_target = source.target();
 
             let (stale_request_tx, mut stale_request_rx) = mpsc::channel(1);
@@ -846,8 +844,8 @@ mod tests {
                 .append(U64::new(1))
                 .merkleize(&db, Some(U64::new(11)), floor)
                 .await;
-            db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            (db, _) = db.apply_batch(batch).unwrap();
+            db = db.sync().await.unwrap();
             let first_target = <FixedDb as ManagedDb<_>>::sync_target(&db);
 
             // Commit two more ranges so the rewind below spans multiple commits.
@@ -858,13 +856,13 @@ mod tests {
                     .append(U64::new(i))
                     .merkleize(&db, Some(U64::new(i * 11)), floor)
                     .await;
-                db.apply_batch(batch).unwrap();
-                db.sync().await.unwrap();
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
             }
             let third_target = <FixedDb as ManagedDb<_>>::sync_target(&db);
             assert_ne!(third_target, first_target);
 
-            <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, first_target.clone())
+            let db = <FixedDb as ManagedDb<_>>::rewind_to_target(db, first_target.clone())
                 .await
                 .unwrap();
 
@@ -891,8 +889,8 @@ mod tests {
                     .append(U64::new(i))
                     .merkleize(&db, Some(U64::new(i * 11)), floor)
                     .await;
-                db.apply_batch(batch).unwrap();
-                db.sync().await.unwrap();
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
                 targets.push(<FixedDb as ManagedDb<_>>::sync_target(&db));
             }
 
@@ -900,19 +898,19 @@ mod tests {
 
             // Prune to the second target: the first is no longer a rewind target, but the
             // second still is.
-            <FixedDb as ManagedDb<_>>::prune(&mut db, &targets[1])
+            let db = <FixedDb as ManagedDb<_>>::prune(db, &targets[1])
                 .await
                 .unwrap();
+            let db = <FixedDb as ManagedDb<_>>::rewind_to_target(db, targets[1].clone())
+                .await
+                .unwrap();
+            assert_eq!(<FixedDb as ManagedDb<_>>::sync_target(&db), targets[1]);
             assert!(matches!(
                 db.rewind(targets[0].leaf_count).await,
                 Err(Error::Merkle(
                     commonware_storage::merkle::Error::RewindBeyondHistory
                 ))
             ));
-            <FixedDb as ManagedDb<_>>::rewind_to_target(&mut db, targets[1].clone())
-                .await
-                .unwrap();
-            assert_eq!(<FixedDb as ManagedDb<_>>::sync_target(&db), targets[1]);
         });
     }
 }

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -3,11 +3,11 @@
 //!
 //! Keyless databases are append-only. Operations are addressed by
 //! [`Location`] rather than by key.
-//! The wrapper types here capture `Arc<TracedAsyncRwLock<Keyless>>` so the batch API
+//! The wrapper types here capture a [`Shared`] database handle so the batch API
 //! can read through to committed state.
 
 use crate::stateful::db::{
-    ManagedDb, Merkleized as MerkleizedTrait, StateSyncDb, SyncEngineConfig,
+    ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
@@ -30,10 +30,8 @@ use commonware_storage::{
         sync::{self, Target as AnySyncTarget, resolver::Resolver},
     },
 };
-use commonware_utils::{channel::mpsc, non_empty_range, sync::TracedAsyncRwLock};
+use commonware_utils::{channel::mpsc, non_empty_range};
 use std::{ops::Deref, sync::Arc};
-
-type KeylessDbHandle<F, E, V, C, H, S> = Arc<TracedAsyncRwLock<Keyless<F, E, V, C, H, S>>>;
 
 /// Wraps a keyless [`UnmerkleizedBatch`] with a reference to the parent
 /// database, implementing the [`Unmerkleized`](crate::stateful::db::Unmerkleized) trait.
@@ -48,7 +46,7 @@ where
     Operation<F, V>: EncodeShared,
 {
     batch: UnmerkleizedBatch<F, H, V, S>,
-    db: KeylessDbHandle<F, E, V, C, H, S>,
+    db: Shared<Keyless<F, E, V, C, H, S>>,
     metadata: Option<V::Value>,
     inactivity_floor: Option<Location<F>>,
 }
@@ -98,7 +96,7 @@ where
     /// Read a value by location, falling back to committed state.
     pub async fn get(&self, location: Location<F>) -> Result<Option<V::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get(location, &*db).await
+        self.batch.get(location, &db).await
     }
 
     /// Read multiple values by location, falling back to committed state.
@@ -110,7 +108,7 @@ where
         locations: &[Location<F>],
     ) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.batch.get_many(locations, &*db).await
+        self.batch.get_many(locations, &db).await
     }
 
     /// Append a value to the speculative batch.
@@ -133,7 +131,7 @@ where
     Operation<F, V>: EncodeShared,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, V, S>>,
-    db: KeylessDbHandle<F, E, V, C, H, S>,
+    db: Shared<Keyless<F, E, V, C, H, S>>,
 }
 
 impl<F, E, V, C, H, S> Deref for KeylessMerkleized<F, E, V, C, H, S>
@@ -166,7 +164,7 @@ where
     /// Read a value by location, falling back to committed state.
     pub async fn get(&self, location: Location<F>) -> Result<Option<V::Value>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get(location, &*db).await
+        self.inner.get(location, &db).await
     }
 
     /// Read multiple values by location, falling back to committed state.
@@ -178,7 +176,7 @@ where
         locations: &[Location<F>],
     ) -> Result<Vec<Option<V::Value>>, Error<F>> {
         let db = self.db.read().await;
-        self.inner.get_many(locations, &*db).await
+        self.inner.get_many(locations, &db).await
     }
 }
 
@@ -200,7 +198,7 @@ where
         let merkleized = self
             .batch
             .merkleize(
-                &*db,
+                &db,
                 self.metadata,
                 self.inactivity_floor.unwrap_or_default(),
             )
@@ -266,10 +264,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         KeylessUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -282,12 +280,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -299,16 +297,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -351,10 +349,10 @@ where
         )
     }
 
-    async fn new_batch(db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
-        let inner = db.read().await;
+    async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+        let guard = db.read().await;
         KeylessUnmerkleized {
-            batch: inner.new_batch(),
+            batch: guard.new_batch(),
             db: db.clone(),
             metadata: None,
             inactivity_floor: None,
@@ -367,12 +365,12 @@ where
             && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
     }
 
-    async fn finalize(&mut self, batch: Self::Merkleized) -> Result<(), Error<F>> {
-        self.apply_batch(batch.inner).await?;
-        self.sync().await
+    async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
+        let (db, _) = self.apply_batch(batch.inner).await?;
+        db.sync().await
     }
 
-    async fn prune(&mut self, target: &Self::SyncTarget) -> Result<(), Error<F>> {
+    async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
         self.prune((*target.range.start()).into()).await
     }
 
@@ -384,16 +382,16 @@ where
         )
     }
 
-    async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Error<F>> {
-        self.rewind(target.range.end()).await?;
-        self.sync().await?;
+    async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
+        let db = self.rewind(target.range.end()).await?;
+        let db = db.sync().await?;
 
-        let rewound_target = self.sync_target();
+        let rewound_target = db.sync_target();
         assert_eq!(
             rewound_target, target,
             "rewound database target mismatch after rewind",
         );
-        Ok(())
+        Ok(db)
     }
 }
 
@@ -536,7 +534,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config("stateful-keyless-managed-db", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let batch = <FixedDb as ManagedDb<_>>::new_batch(&db)
                 .await
@@ -548,10 +546,12 @@ mod tests {
                 .unwrap();
 
             {
-                let mut guard = db.write().await;
-                <FixedDb as ManagedDb<_>>::finalize(&mut *guard, merkleized)
-                    .await
-                    .unwrap();
+                let (slot, database) = db.write().await;
+                slot.put(
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap(),
+                );
             }
 
             let guard = db.read().await;
@@ -561,7 +561,7 @@ mod tests {
             );
             assert_eq!(guard.get_metadata().await.unwrap(), Some(U64::new(9)));
 
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&*guard);
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
             assert_eq!(target.root, guard.root());
             assert_eq!(target.range.start(), mmr::Location::new(1));
             assert_eq!(target.range.end(), mmr::Location::new(3));
@@ -573,7 +573,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config("stateful-keyless-matches-sync-target", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
 
             let batch = <FixedDb as ManagedDb<_>>::new_batch(&db)
                 .await

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -80,9 +80,13 @@ use commonware_consensus::{
 use commonware_cryptography::Digest;
 use commonware_macros::select;
 use commonware_runtime::{Metrics, Spawner, reschedule};
+use commonware_storage::{
+    merkle::Location,
+    qmdb::sync::{compact, resolver},
+};
 use commonware_utils::{
     channel::{fallible::AsyncFallibleExt, mpsc, oneshot, ring},
-    sync::TracedAsyncRwLock,
+    sync::{AsyncRwLockReadGuard, AsyncRwLockWriteGuard, TracedAsyncRwLock},
 };
 use futures::{
     future::{Either, pending},
@@ -93,6 +97,7 @@ use std::{
     fmt::Debug,
     future::Future,
     num::{NonZeroU64, NonZeroUsize},
+    ops::Deref,
     sync::Arc,
 };
 
@@ -104,8 +109,131 @@ pub mod immutable;
 pub mod keyless;
 pub mod p2p;
 
-/// A database wrapped for shared, lock-traced access.
-pub type Shared<DB> = Arc<TracedAsyncRwLock<DB>>;
+/// A database shared across tasks.
+///
+/// Owned mutations (finalize, prune, rewind) take the database out of the cell under the
+/// write lock ([Self::write]) and put it back on success ([WriteSlot::put]); a failure,
+/// panic, or cancellation mid-operation leaves the cell empty permanently, and every
+/// later access panics: a lost database is fatal here by design; restart to recover.
+pub struct Shared<DB>(Inner<DB>);
+
+/// The lock wrapped by [`Shared`]. Storage implements its sync resolver traits on
+/// this shape, so [`Shared`]'s resolver impls delegate to it.
+type Inner<DB> = Arc<TracedAsyncRwLock<Option<DB>>>;
+
+impl<DB> Clone for Shared<DB> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+/// Message used when a [`Shared`] cell is empty.
+const DB_LOST_MSG: &str =
+    "database was lost by an earlier failed or interrupted operation; restart to recover";
+
+impl<DB> Shared<DB> {
+    /// Create a cell holding `db`, identified by `label` in lock traces.
+    pub fn new(label: &'static str, db: DB) -> Self {
+        Self(Arc::new(TracedAsyncRwLock::new(label, Some(db))))
+    }
+
+    /// Acquire shared read access to the database.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the database was lost by an earlier failed or interrupted mutation.
+    pub async fn read(&self) -> ReadGuard<'_, DB> {
+        ReadGuard(AsyncRwLockReadGuard::map(self.0.read().await, |db| {
+            db.as_ref().expect(DB_LOST_MSG)
+        }))
+    }
+
+    /// Take the database out for a by-value mutation.
+    ///
+    /// The returned [`WriteSlot`] holds the cell locked and empty until
+    /// [`WriteSlot::put`] restores the database. Dropping the slot without a put
+    /// leaves the database lost.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the database was lost by an earlier failed or interrupted mutation.
+    pub async fn write(&self) -> (WriteSlot<'_, DB>, DB) {
+        let mut guard = self.0.write().await;
+        let db = guard.take().expect(DB_LOST_MSG);
+        (WriteSlot(guard), db)
+    }
+}
+
+/// Shared read access to a [`Shared`] database.
+pub struct ReadGuard<'a, DB>(AsyncRwLockReadGuard<'a, DB>);
+
+impl<DB> Deref for ReadGuard<'_, DB> {
+    type Target = DB;
+
+    fn deref(&self) -> &DB {
+        &self.0
+    }
+}
+
+/// An exclusively locked [`Shared`] cell whose database has been taken out.
+pub struct WriteSlot<'a, DB>(AsyncRwLockWriteGuard<'a, Option<DB>>);
+
+impl<DB> WriteSlot<'_, DB> {
+    /// Restore the database, making it visible to other tasks again.
+    pub fn put(mut self, db: DB) {
+        *self.0 = Some(db);
+    }
+}
+
+/// Serve full sync fetches by delegating to the storage impl on the inner lock.
+impl<DB> resolver::Resolver for Shared<DB>
+where
+    DB: Send + Sync + 'static,
+    Inner<DB>: resolver::Resolver,
+{
+    type Family = <Inner<DB> as resolver::Resolver>::Family;
+    type Digest = <Inner<DB> as resolver::Resolver>::Digest;
+    type Op = <Inner<DB> as resolver::Resolver>::Op;
+    type Error = <Inner<DB> as resolver::Resolver>::Error;
+
+    async fn get_operations(
+        &self,
+        op_count: Location<Self::Family>,
+        start_loc: Location<Self::Family>,
+        max_ops: NonZeroU64,
+        include_pinned_nodes: bool,
+        cancel_rx: oneshot::Receiver<()>,
+    ) -> Result<resolver::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
+        self.0
+            .get_operations(
+                op_count,
+                start_loc,
+                max_ops,
+                include_pinned_nodes,
+                cancel_rx,
+            )
+            .await
+    }
+}
+
+/// Serve compact sync fetches by delegating to the storage impl on the inner lock.
+impl<DB> compact::Resolver for Shared<DB>
+where
+    DB: Send + Sync + 'static,
+    Inner<DB>: compact::Resolver,
+{
+    type Family = <Inner<DB> as compact::Resolver>::Family;
+    type Digest = <Inner<DB> as compact::Resolver>::Digest;
+    type Op = <Inner<DB> as compact::Resolver>::Op;
+    type Error = <Inner<DB> as compact::Resolver>::Error;
+
+    async fn get_compact_state(
+        &self,
+        target: compact::Target<Self::Family, Self::Digest>,
+    ) -> Result<compact::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
+        self.0.get_compact_state(target).await
+    }
+}
 
 /// Mutable batch state before merkleization.
 ///
@@ -155,6 +283,13 @@ pub trait Merkleized: Sized + Send + Sync {
 ///
 /// `E` is a trait generic (not an associated type), so one database type can
 /// work across runtimes that satisfy the bounds.
+///
+/// # Ownership
+///
+/// Mutating methods take the database by value and return it on success. If a mutating
+/// method returns an error, or its future is dropped before it finishes, the database is
+/// gone: state that was not yet durable is discarded, but everything already on disk stays
+/// recoverable.
 pub trait ManagedDb<E>: Send + Sync + Sized {
     /// An in-progress batch of mutations that has not yet been merkleized.
     type Unmerkleized: Unmerkleized;
@@ -205,9 +340,9 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// a `Changeset`, then `db.apply_batch(changeset)` and the database's
     /// durable finalize step.
     fn finalize(
-        &mut self,
+        self,
         batch: Self::Merkleized,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Prune the database to a previously finalized sync target.
     ///
@@ -215,10 +350,10 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// the default no-op. This call makes changes durable and ensures they
     /// will be present on startup without replay.
     fn prune(
-        &mut self,
+        self,
         _target: &Self::SyncTarget,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send {
-        async { Ok(()) }
+    ) -> impl Future<Output = Result<Self, Self::Error>> + Send {
+        async { Ok(self) }
     }
 
     /// Return the sync target for this database's current committed state.
@@ -227,11 +362,11 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// Rewind committed state to `target`.
     ///
     /// Implementations must ensure rewind effects are durable before returning
-    /// `Ok(())` (for example by committing after rewind).
+    /// the database (for example by committing after rewind).
     fn rewind_to_target(
-        &mut self,
+        self,
         target: Self::SyncTarget,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 }
 
 /// A collection of individually locked [`ManagedDb`] instances.
@@ -282,7 +417,8 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
 
     /// Apply each merkleized batch's changeset to its underlying database.
     ///
-    /// Acquires a write lock on each database.
+    /// Acquires a write lock on each database. Cancelling the future mid-flight loses the
+    /// databases whose mutations were in progress (see [Shared]); every later access panics.
     fn finalize(&self, batches: Self::Merkleized) -> impl Future<Output = ()> + Send;
 
     /// Prune each database to the provided per-database targets.
@@ -290,7 +426,8 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// This call makes changes durable and ensures they will be present on
     /// startup without replay.
     ///
-    /// Acquires a write lock on each database.
+    /// Acquires a write lock on each database. Cancelling the future mid-flight loses the
+    /// databases whose mutations were in progress (see [Shared]); every later access panics.
     fn prune(&self, targets: &Self::SyncTargets) -> impl Future<Output = ()> + Send;
 
     /// Return sync targets for the set's current committed state.
@@ -299,6 +436,9 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// Rewind the set to the provided per-database targets.
     ///
     /// Rewind failures are fatal for startup recovery and therefore panic.
+    ///
+    /// Acquires a write lock on each database. Cancelling the future mid-flight loses the
+    /// databases whose mutations were in progress (see [Shared]); every later access panics.
     fn rewind_to_targets(&self, targets: Self::SyncTargets) -> impl Future<Output = ()> + Send;
 }
 
@@ -445,7 +585,7 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Shared<T> {
         let db = T::init(context, config)
             .await
             .expect("database init failed");
-        Self::new(TracedAsyncRwLock::new("stateful.db", db))
+        Self::new("stateful.db", db)
     }
 
     fn initial_sync_targets() -> Self::SyncTargets {
@@ -465,26 +605,27 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Shared<T> {
     }
 
     async fn finalize(&self, batches: Self::Merkleized) {
-        let mut database = self.write().await;
-        finalize_or_panic(&mut *database, batches, None).await;
+        let (slot, database) = self.write().await;
+        slot.put(finalize_or_panic(database, batches, None).await);
     }
 
     async fn prune(&self, target: &Self::SyncTargets) {
-        let mut database = self.write().await;
-        prune_or_panic(&mut *database, target, None).await;
+        let (slot, database) = self.write().await;
+        slot.put(prune_or_panic(database, target, None).await);
     }
 
     async fn committed_targets(&self) -> Self::SyncTargets {
         let database = self.read().await;
-        T::sync_target(&*database)
+        T::sync_target(&database)
     }
 
     async fn rewind_to_targets(&self, target: Self::SyncTargets) {
-        let mut database = self.write().await;
-        if T::sync_target(&*database) == target {
+        let (slot, database) = self.write().await;
+        if T::sync_target(&database) == target {
+            slot.put(database);
             return;
         }
-        rewind_or_panic(&mut *database, target, None).await;
+        slot.put(rewind_or_panic(database, target, None).await);
     }
 }
 
@@ -590,10 +731,7 @@ where
             T::sync_target(&database) == converged_target,
             "state sync database target does not match the coordinator target",
         );
-        Ok((
-            Self::new(TracedAsyncRwLock::new("stateful.db", database)),
-            converged_anchor,
-        ))
+        Ok((Self::new("stateful.db", database), converged_anchor))
     }
 }
 
@@ -675,7 +813,7 @@ macro_rules! impl_database_set {
                                 stringify!($T),
                                 ")",
                             ));
-                        Arc::new(TracedAsyncRwLock::new(concat!("stateful.db.", stringify!($idx)), db))
+                        Shared::new(concat!("stateful.db.", stringify!($idx)), db)
                     },
                 )+);
                 result
@@ -700,8 +838,8 @@ macro_rules! impl_database_set {
             async fn finalize(&self, batches: Self::Merkleized) {
                 join!($(
                     async {
-                        let mut database = self.$idx.write().await;
-                        finalize_or_panic(&mut *database, batches.$idx, Some($idx)).await;
+                        let (slot, database) = self.$idx.write().await;
+                        slot.put(finalize_or_panic(database, batches.$idx, Some($idx)).await);
                     },
                 )+);
             }
@@ -709,8 +847,8 @@ macro_rules! impl_database_set {
             async fn prune(&self, targets: &Self::SyncTargets) {
                 join!($(
                     async {
-                        let mut database = self.$idx.write().await;
-                        prune_or_panic(&mut *database, &targets.$idx, Some($idx)).await;
+                        let (slot, database) = self.$idx.write().await;
+                        slot.put(prune_or_panic(database, &targets.$idx, Some($idx)).await);
                     },
                 )+);
             }
@@ -719,7 +857,7 @@ macro_rules! impl_database_set {
                 join!($(
                     async {
                         let database = self.$idx.read().await;
-                        $T::sync_target(&*database)
+                        $T::sync_target(&database)
                     },
                 )+)
             }
@@ -727,11 +865,12 @@ macro_rules! impl_database_set {
             async fn rewind_to_targets(&self, targets: Self::SyncTargets) {
                 join!($(
                     async {
-                        let mut database = self.$idx.write().await;
-                        if $T::sync_target(&*database) == targets.$idx {
+                        let (slot, database) = self.$idx.write().await;
+                        if $T::sync_target(&database) == targets.$idx {
+                            slot.put(database);
                             return;
                         }
-                        rewind_or_panic(&mut *database, targets.$idx, Some($idx)).await;
+                        slot.put(rewind_or_panic(database, targets.$idx, Some($idx)).await);
                     },
                 )+);
             }
@@ -1033,10 +1172,10 @@ macro_rules! impl_state_sync_set {
                                 let (sync_result, _) = join!(sync, forward_reached);
                                 let result = sync_result
                                     .map(|database| {
-                                        Arc::new(TracedAsyncRwLock::new(
+                                        Shared::new(
                                             concat!("stateful.db.", stringify!($idx)),
                                             database,
-                                        ))
+                                        )
                                     })
                                     .map_err(|err| {
                                         format!(
@@ -1352,66 +1491,60 @@ impl<D: Digest, T: Clone> CoordinatorState<D, T> {
 
 #[tracing::instrument(name = "stateful.db.finalize_or_panic", level = "info", skip_all, fields(index = index))]
 async fn finalize_or_panic<E, T: ManagedDb<E>>(
-    database: &mut T,
+    database: T,
     batch: T::Merkleized,
     index: Option<usize>,
-) {
+) -> T {
     // Mutable finalize failures are fatal by design because other databases in
     // the same set may already have committed, leaving partially applied state.
-    if let Err(err) = database.finalize(batch).await {
-        match index {
-            Some(index) => panic!(
-                "database finalize failed (index {index}, type {}): {err:?}",
+    match database.finalize(batch).await {
+        Ok(database) => database,
+        Err(err) => {
+            let index = index.map_or(String::new(), |i| format!("index {i}, "));
+            panic!(
+                "database finalize failed ({index}type {}): {err:?}",
                 core::any::type_name::<T>(),
-            ),
-            None => panic!(
-                "database finalize failed (type {}): {err:?}",
-                core::any::type_name::<T>(),
-            ),
+            );
         }
     }
 }
 
 #[tracing::instrument(name = "stateful.db.rewind_or_panic", level = "info", skip_all, fields(index = index))]
 async fn rewind_or_panic<E, T: ManagedDb<E>>(
-    database: &mut T,
+    database: T,
     target: T::SyncTarget,
     index: Option<usize>,
-) {
+) -> T {
     // Mutable rewind failures are fatal by design because the database handle
     // may be internally diverged after a failed rewind.
-    if let Err(err) = database.rewind_to_target(target).await {
-        match index {
-            Some(index) => panic!(
-                "database rewind failed (index {index}, type {}): {err:?}",
+    match database.rewind_to_target(target).await {
+        Ok(database) => database,
+        Err(err) => {
+            let index = index.map_or(String::new(), |i| format!("index {i}, "));
+            panic!(
+                "database rewind failed ({index}type {}): {err:?}",
                 core::any::type_name::<T>(),
-            ),
-            None => panic!(
-                "database rewind failed (type {}): {err:?}",
-                core::any::type_name::<T>(),
-            ),
+            );
         }
     }
 }
 
 #[tracing::instrument(name = "stateful.db.prune_or_panic", level = "info", skip_all, fields(index = index))]
 async fn prune_or_panic<E, T: ManagedDb<E>>(
-    database: &mut T,
+    database: T,
     target: &T::SyncTarget,
     index: Option<usize>,
-) {
+) -> T {
     // Prune failures are fatal because pruning may already have discarded part
     // of the retained history before the error surfaced.
-    if let Err(err) = database.prune(target).await {
-        match index {
-            Some(index) => panic!(
-                "database prune failed (index {index}, type {}): {err:?}",
+    match database.prune(target).await {
+        Ok(database) => database,
+        Err(err) => {
+            let index = index.map_or(String::new(), |i| format!("index {i}, "));
+            panic!(
+                "database prune failed ({index}type {}): {err:?}",
                 core::any::type_name::<T>(),
-            ),
-            None => panic!(
-                "database prune failed (type {}): {err:?}",
-                core::any::type_name::<T>(),
-            ),
+            );
         }
     }
 }
@@ -1504,10 +1637,7 @@ mod tests {
     use commonware_runtime::{
         Clock, Runner as _, Spawner as _, Supervisor as _, deterministic, reschedule,
     };
-    use commonware_utils::{
-        channel::{mpsc, oneshot, ring},
-        sync::TracedAsyncRwLock,
-    };
+    use commonware_utils::channel::{mpsc, oneshot, ring};
     use futures::{FutureExt, SinkExt, pin_mut};
     use std::{
         convert::Infallible,
@@ -1925,14 +2055,14 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {}
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -1959,18 +2089,18 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.current_target
         }
 
-        async fn rewind_to_target(&mut self, target: Self::SyncTarget) -> Result<(), Self::Error> {
+        async fn rewind_to_target(mut self, target: Self::SyncTarget) -> Result<Self, Self::Error> {
             self.current_target = target;
             self.rewind_count += 1;
-            Ok(())
+            Ok(self)
         }
     }
 
@@ -1995,19 +2125,19 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
-        async fn prune(&mut self, _target: &Self::SyncTarget) -> Result<(), Self::Error> {
+        async fn prune(self, _target: &Self::SyncTarget) -> Result<Self, Self::Error> {
             self.prune_count.fetch_add(1, Ordering::SeqCst);
-            Ok(())
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {}
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2102,14 +2232,14 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
             Err(TestFinalizeError)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {}
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2118,20 +2248,20 @@ mod tests {
         deterministic::Runner::default().start(|_context| async move {
             type DbSet = (Shared<CountingRewindDb>, Shared<CountingRewindDb>);
 
-            let left = Arc::new(TracedAsyncRwLock::new(
+            let left = Shared::new(
                 "test",
                 CountingRewindDb {
                     current_target: 2,
                     rewind_count: 0,
                 },
-            ));
-            let right = Arc::new(TracedAsyncRwLock::new(
+            );
+            let right = Shared::new(
                 "test",
                 CountingRewindDb {
                     current_target: 1,
                     rewind_count: 0,
                 },
-            ));
+            );
             let databases: DbSet = (left.clone(), right.clone());
 
             <DbSet as DatabaseSet<deterministic::Context>>::rewind_to_targets(&databases, (1, 1))
@@ -2151,12 +2281,12 @@ mod tests {
     fn database_set_prune_calls_managed_db_prune() {
         deterministic::Runner::default().start(|_context| async move {
             let prune_count = Arc::new(AtomicUsize::new(0));
-            let database = Arc::new(TracedAsyncRwLock::new(
+            let database = Shared::new(
                 "test",
                 PruneCountingDb {
                     prune_count: prune_count.clone(),
                 },
-            ));
+            );
 
             <Shared<PruneCountingDb> as DatabaseSet<deterministic::Context>>::prune(&database, &())
                 .await;
@@ -2186,20 +2316,20 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
+        async fn finalize(mut self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
             if let Some(started) = self.started.take() {
                 let _ = started.send(());
             }
             if let Some(release) = self.release.take() {
                 let _ = release.await;
             }
-            Ok(())
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {}
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2226,16 +2356,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2266,16 +2396,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2302,16 +2432,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2338,16 +2468,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             0
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2374,16 +2504,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2410,16 +2540,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             0
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2446,16 +2576,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2482,16 +2612,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2518,16 +2648,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2558,16 +2688,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -2703,16 +2833,16 @@ mod tests {
             true
         }
 
-        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-            Ok(())
+        async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn sync_target(&self) -> Self::SyncTarget {
             self.final_target
         }
 
-        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-            Ok(())
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
         }
     }
 
@@ -3139,12 +3269,12 @@ mod tests {
     #[test]
     fn tuple_new_batches_queues_reads_concurrently() {
         deterministic::Runner::default().start(|_context| async move {
-            let db1 = Arc::new(TracedAsyncRwLock::new("test", TestDb));
-            let db2 = Arc::new(TracedAsyncRwLock::new("test", TestDb));
+            let db1 = Shared::new("test", TestDb);
+            let db2 = Shared::new("test", TestDb);
             let databases = (db1.clone(), db2.clone());
 
-            let writer1 = db1.write().await;
-            let writer2 = db2.write().await;
+            let (slot1, taken1) = db1.write().await;
+            let (slot2, taken2) = db2.write().await;
 
             let new_batches = <(Shared<TestDb>, Shared<TestDb>) as DatabaseSet<
                 deterministic::Context,
@@ -3152,7 +3282,7 @@ mod tests {
             pin_mut!(new_batches);
             assert!(new_batches.as_mut().now_or_never().is_none());
 
-            drop(writer2);
+            slot2.put(taken2);
             {
                 let writer2_again = db2.write();
                 pin_mut!(writer2_again);
@@ -3162,7 +3292,7 @@ mod tests {
                 );
             }
 
-            drop(writer1);
+            slot1.put(taken1);
             let _ = new_batches.await;
         });
     }
@@ -3176,14 +3306,8 @@ mod tests {
             let (release2_tx, release2_rx) = oneshot::channel();
 
             let databases = (
-                Arc::new(TracedAsyncRwLock::new(
-                    "test",
-                    BlockingFinalizeDb::new(started1_tx, release1_rx),
-                )),
-                Arc::new(TracedAsyncRwLock::new(
-                    "test",
-                    BlockingFinalizeDb::new(started2_tx, release2_rx),
-                )),
+                Shared::new("test", BlockingFinalizeDb::new(started1_tx, release1_rx)),
+                Shared::new("test", BlockingFinalizeDb::new(started2_tx, release2_rx)),
             );
 
             let finalize =
@@ -3216,8 +3340,8 @@ mod tests {
     fn tuple_finalize_panic_identifies_failing_database() {
         deterministic::Runner::default().start(|_context| async move {
             let databases = (
-                Arc::new(TracedAsyncRwLock::new("test", TestDb)),
-                Arc::new(TracedAsyncRwLock::new("test", FailingFinalizeDb)),
+                Shared::new("test", TestDb),
+                Shared::new("test", FailingFinalizeDb),
             );
             <(
                 Shared<TestDb>,
@@ -4125,7 +4249,7 @@ mod tests {
         deterministic::Runner::default().start(|_| async move {
             let log = Arc::new(commonware_utils::sync::Mutex::new(Vec::new()));
             let resolver = RecordingResolver::new("db1", log.clone());
-            let db = Arc::new(TracedAsyncRwLock::new("test", AttachDb1));
+            let db = Shared::new("test", AttachDb1);
 
             resolver.attach_databases(db).await;
             assert_eq!(&*log.lock(), &["db1"]);
@@ -4141,8 +4265,8 @@ mod tests {
                 RecordingResolver::new("resolver_1", log.clone()),
             );
             let databases = (
-                Arc::new(TracedAsyncRwLock::new("test", AttachDb1)),
-                Arc::new(TracedAsyncRwLock::new("test", AttachDb2)),
+                Shared::new("test", AttachDb1),
+                Shared::new("test", AttachDb2),
             );
 
             resolvers.attach_databases(databases).await;
@@ -4159,8 +4283,8 @@ mod tests {
                 RecordingResolver::new("db2", log.clone()),
             );
             let databases = (
-                Arc::new(TracedAsyncRwLock::new("test", AttachDb1)),
-                Arc::new(TracedAsyncRwLock::new("test", AttachDb2)),
+                Shared::new("test", AttachDb1),
+                Shared::new("test", AttachDb2),
             );
 
             resolvers.attach_databases(databases).await;

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -114,7 +114,9 @@ pub mod p2p;
 /// Owned mutations (finalize, prune, rewind) take the database out of the cell under the
 /// write lock ([Self::write]) and put it back on success ([WriteSlot::put]); a failure,
 /// panic, or cancellation mid-operation leaves the cell empty permanently, and every
-/// later access panics: a lost database is fatal here by design; restart to recover.
+/// later [Self::read] or [Self::write] panics: a lost database is fatal here by design;
+/// restart to recover. Resolver access instead reports the source as missing, so serving
+/// degrades without crashing remote sync.
 pub struct Shared<DB>(Inner<DB>);
 
 /// The lock wrapped by [`Shared`]. Storage implements its sync resolver traits on

--- a/glue/src/stateful/db/p2p/compact/actor.rs
+++ b/glue/src/stateful/db/p2p/compact/actor.rs
@@ -1,6 +1,7 @@
 //! Actor for compact QMDB sync over P2P.
 
 use super::{Mailbox, handler, mailbox};
+use crate::stateful::db::Shared;
 use commonware_actor::mailbox as actor_mailbox;
 use commonware_codec::{Codec, Decode as _, Encode};
 use commonware_cryptography::{Hasher, PublicKey};
@@ -12,17 +13,13 @@ use commonware_storage::{
     merkle::{Family, Location, MAX_PINNED_NODES, MAX_PROOF_DIGESTS_PER_ELEMENT},
     qmdb::{self, sync::compact},
 };
-use commonware_utils::{
-    channel::{fallible::OneshotExt, oneshot},
-    sync::TracedAsyncRwLock,
-};
+use commonware_utils::channel::{fallible::OneshotExt, oneshot};
 use futures::future;
 use rand_core::Rng;
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{collections::BTreeMap, num::NonZeroUsize, time::Duration};
 use tracing::info;
 
-type DbResolver<DB> = Arc<TracedAsyncRwLock<DB>>;
-type DbOp<DB> = <DbResolver<DB> as compact::Resolver>::Op;
+type DbOp<DB> = <Shared<DB> as compact::Resolver>::Op;
 type Pending<F, Op, D> =
     oneshot::Sender<Result<compact::FetchResult<F, Op, D>, mailbox::ResponseDropped>>;
 type PendingSubs<F, Op, D> = BTreeMap<handler::Request<F, D>, Vec<Pending<F, Op, D>>>;
@@ -41,7 +38,7 @@ where
     pub blocker: B,
 
     /// Local database used to serve incoming requests when available.
-    pub database: Option<DbResolver<DB>>,
+    pub database: Option<Shared<DB>>,
 
     /// Maximum size of resolver mailbox backlogs.
     pub mailbox_size: NonZeroUsize,
@@ -67,7 +64,7 @@ where
 
 enum State<DB> {
     NoDb,
-    HasDb(DbResolver<DB>),
+    HasDb(Shared<DB>),
 }
 
 enum MailboxAction<F: Family, D: commonware_cryptography::Digest> {
@@ -85,7 +82,7 @@ where
     B: Blocker<PublicKey = P>,
     F: Family,
     H: Hasher,
-    DbResolver<DB>: compact::Resolver<Family = F, Digest = H::Digest>,
+    Shared<DB>: compact::Resolver<Family = F, Digest = H::Digest>,
     DbOp<DB>: Codec<Cfg = ()> + Clone + Send + Sync + 'static,
 {
     context: ContextCell<E>,
@@ -103,7 +100,7 @@ where
     B: Blocker<PublicKey = P>,
     F: Family,
     H: Hasher,
-    DbResolver<DB>: compact::Resolver<Family = F, Digest = H::Digest>,
+    Shared<DB>: compact::Resolver<Family = F, Digest = H::Digest>,
     DbOp<DB>: Codec<Cfg = ()> + Clone + Send + Sync + 'static,
 {
     /// Create a new compact resolver actor and mailbox.
@@ -359,9 +356,8 @@ mod tests {
         NZUsize,
         channel::{mpsc, oneshot},
         sequence::U64,
-        sync::TracedAsyncRwLock,
     };
-    use std::{sync::Arc, time::Duration};
+    use std::time::Duration;
 
     #[derive(Clone, Debug)]
     struct DummyProvider;
@@ -404,7 +400,7 @@ mod tests {
     type TestOp = KeylessOp<mmr::Family, U64>;
 
     fn test_config(
-        database: Option<Arc<TracedAsyncRwLock<TestDb>>>,
+        database: Option<Shared<TestDb>>,
     ) -> Config<ed25519::PublicKey, DummyProvider, DummyBlocker, TestDb> {
         Config {
             peer_provider: DummyProvider,
@@ -451,23 +447,19 @@ mod tests {
         compact::Target<mmr::Family, sha256::Digest>,
         compact::FetchResult<mmr::Family, TestOp, sha256::Digest>,
     ) {
-        let mut db = init_db(context).await;
-        db.apply_batch(
-            db.new_batch()
-                .append(U64::new(7))
-                .merkleize(&db, None, db.inactivity_floor_loc())
-                .await,
-        )
-        .unwrap();
-        db.sync().await.unwrap();
+        let db = init_db(context).await;
+        let batch = db
+            .new_batch()
+            .append(U64::new(7))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (db, _) = db.apply_batch(batch).unwrap();
+        let db = db.sync().await.unwrap();
 
         let target = db.target();
-        let fetch = compact::Resolver::get_compact_state(
-            &Arc::new(TracedAsyncRwLock::new("test", db)),
-            target.clone(),
-        )
-        .await
-        .expect("compact state should be available");
+        let fetch = compact::Resolver::get_compact_state(&Shared::new("test", db), target.clone())
+            .await
+            .expect("compact state should be available");
         (target, fetch)
     }
 
@@ -577,7 +569,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let db = init_db(context.child("db")).await;
             let target = db.target();
-            let db = Arc::new(TracedAsyncRwLock::new("test", db));
+            let db = Shared::new("test", db);
             let (mut actor, _mailbox) = TestActor::new(context, test_config(Some(db)));
             let request = handler::Request::from_target(target.clone());
             let (response_tx, response_rx) = oneshot::channel();

--- a/glue/src/stateful/db/p2p/compact/mailbox.rs
+++ b/glue/src/stateful/db/p2p/compact/mailbox.rs
@@ -1,12 +1,12 @@
 //! Mailbox for the compact QMDB P2P resolver.
 
 use super::handler;
-use crate::stateful::db::AttachableResolver;
+use crate::stateful::db::{AttachableResolver, Shared};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_storage::{merkle::Family, qmdb::sync::compact};
-use commonware_utils::{channel::oneshot, sync::TracedAsyncRwLock};
-use std::{collections::VecDeque, future::Future, sync::Arc};
+use commonware_utils::channel::oneshot;
+use std::{collections::VecDeque, future::Future};
 
 struct CancelGuard<DB, F: Family, Op, D: Digest> {
     sender: Sender<Message<DB, F, Op, D>>,
@@ -41,7 +41,7 @@ impl<DB, F: Family, Op, D: Digest> Drop for CancelGuard<DB, F, Op, D> {
 pub struct ResponseDropped;
 
 pub(super) enum Message<DB, F: Family, Op, D: Digest> {
-    AttachDatabase(Arc<TracedAsyncRwLock<DB>>),
+    AttachDatabase(Shared<DB>),
     GetState {
         request: handler::Request<F, D>,
         response: oneshot::Sender<Result<compact::FetchResult<F, Op, D>, ResponseDropped>>,
@@ -61,7 +61,7 @@ impl<DB, F: Family, Op, D: Digest> Message<DB, F, Op, D> {
 }
 
 pub(super) struct Pending<DB, F: Family, Op, D: Digest> {
-    database: Option<Arc<TracedAsyncRwLock<DB>>>,
+    database: Option<Shared<DB>>,
     messages: VecDeque<Message<DB, F, Op, D>>,
 }
 
@@ -140,7 +140,7 @@ impl<DB, F: Family, Op, H: Hasher> Mailbox<DB, F, Op, H> {
 }
 
 impl<DB: Send + Sync, F: Family, Op: Send, H: Hasher> Mailbox<DB, F, Op, H> {
-    pub fn attach_database(&self, db: Arc<TracedAsyncRwLock<DB>>) {
+    pub fn attach_database(&self, db: Shared<DB>) {
         let _ = self.sender.enqueue(Message::AttachDatabase(db));
     }
 }
@@ -181,7 +181,7 @@ where
     Op: Send + Sync + Clone + 'static,
     H: Hasher,
 {
-    fn attach_database(&self, db: Arc<TracedAsyncRwLock<DB>>) -> impl Future<Output = ()> + Send {
+    fn attach_database(&self, db: Shared<DB>) -> impl Future<Output = ()> + Send {
         Self::attach_database(self, db);
         std::future::ready(())
     }

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -1,6 +1,7 @@
 //! Resolver service actor for QMDB sync over P2P.
 
 use super::{Mailbox, handler, mailbox, metrics::Metrics as ResolverMetrics};
+use crate::stateful::db::Shared;
 use commonware_actor::mailbox as actor_mailbox;
 use commonware_codec::{Codec, Decode, Encode};
 use commonware_cryptography::PublicKey;
@@ -15,22 +16,18 @@ use commonware_storage::{
     merkle::Family,
     qmdb::sync::resolver::{FetchResult, Resolver as SyncResolver},
 };
-use commonware_utils::{
-    channel::{fallible::OneshotExt, oneshot},
-    sync::TracedAsyncRwLock,
-};
+use commonware_utils::channel::{fallible::OneshotExt, oneshot};
 use futures::future;
 use rand_core::Rng;
 use std::{
     collections::BTreeMap,
     num::{NonZeroU64, NonZeroUsize},
-    sync::Arc,
     time::Duration,
 };
 use tracing::{debug, info};
 
-type Op<DB> = <Arc<TracedAsyncRwLock<DB>> as SyncResolver>::Op;
-type DatabaseRoot<DB> = <Arc<TracedAsyncRwLock<DB>> as SyncResolver>::Digest;
+type Op<DB> = <Shared<DB> as SyncResolver>::Op;
+type DatabaseRoot<DB> = <Shared<DB> as SyncResolver>::Digest;
 type SyncMailbox<F, DB> = Mailbox<DB, F, Op<DB>, DatabaseRoot<DB>>;
 type Pending<F, Op, D> = oneshot::Sender<Result<FetchResult<F, Op, D>, mailbox::ResponseDropped>>;
 type PendingSubs<F, DB> = BTreeMap<handler::Request<F>, Vec<Pending<F, Op<DB>, DatabaseRoot<DB>>>>;
@@ -49,7 +46,7 @@ where
     pub blocker: B,
 
     /// Local database used to serve incoming requests when available.
-    pub database: Option<Arc<TracedAsyncRwLock<DB>>>,
+    pub database: Option<Shared<DB>>,
 
     /// Maximum size of resolver mailbox backlogs.
     pub mailbox_size: NonZeroUsize,
@@ -81,7 +78,7 @@ enum State<DB> {
     /// Database is not attached yet.
     NoDb,
     /// Database is attached and can serve incoming requests.
-    HasDb(Arc<TracedAsyncRwLock<DB>>),
+    HasDb(Shared<DB>),
 }
 
 /// An action dispatched by incoming mailbox messages.
@@ -99,7 +96,7 @@ where
     D: Provider<PublicKey = P>,
     B: Blocker<PublicKey = P>,
     F: Family,
-    Arc<TracedAsyncRwLock<DB>>: SyncResolver<Family = F>,
+    Shared<DB>: SyncResolver<Family = F>,
     Op<DB>: Codec<Cfg = ()> + Send + Clone + 'static,
 {
     context: ContextCell<E>,
@@ -117,7 +114,7 @@ where
     D: Provider<PublicKey = P>,
     B: Blocker<PublicKey = P>,
     F: Family,
-    Arc<TracedAsyncRwLock<DB>>: SyncResolver<Family = F>,
+    Shared<DB>: SyncResolver<Family = F>,
     Op<DB>: Codec<Cfg = ()> + Send + Clone + 'static,
 {
     /// Create a new resolver actor and mailbox.
@@ -401,8 +398,8 @@ mod tests {
         qmdb::any::{FixedConfig, unordered::fixed},
         translator::TwoCap,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, channel::oneshot, sync::TracedAsyncRwLock};
-    use std::{num::NonZeroU64, sync::Arc, time::Duration};
+    use commonware_utils::{NZU16, NZU64, NZUsize, channel::oneshot};
+    use std::{num::NonZeroU64, time::Duration};
 
     #[derive(Clone, Debug)]
     struct DummyProvider;
@@ -440,7 +437,7 @@ mod tests {
         TwoCap,
         Sequential,
     >;
-    type TestOp = <Arc<TracedAsyncRwLock<TestDb>> as SyncResolver>::Op;
+    type TestOp = <Shared<TestDb> as SyncResolver>::Op;
 
     type TestActor = Actor<
         deterministic::Context,
@@ -452,7 +449,7 @@ mod tests {
     >;
 
     fn test_config(
-        database: Option<Arc<TracedAsyncRwLock<TestDb>>>,
+        database: Option<Shared<TestDb>>,
     ) -> Config<ed25519::PublicKey, DummyProvider, DummyBlocker, TestDb> {
         Config {
             peer_provider: DummyProvider,
@@ -509,14 +506,11 @@ mod tests {
         }
     }
 
-    async fn init_db(
-        context: deterministic::Context,
-        suffix: &str,
-    ) -> Arc<TracedAsyncRwLock<TestDb>> {
+    async fn init_db(context: deterministic::Context, suffix: &str) -> Shared<TestDb> {
         let db = TestDb::init(context.child("db"), db_config(suffix, &context))
             .await
             .expect("db init should succeed");
-        Arc::new(TracedAsyncRwLock::new("test", db))
+        Shared::new("test", db)
     }
 
     fn encoded_fetch_payload() -> Bytes {

--- a/glue/src/stateful/db/p2p/standard/mailbox.rs
+++ b/glue/src/stateful/db/p2p/standard/mailbox.rs
@@ -1,7 +1,7 @@
 //! Mailbox and wire types for the QMDB sync resolver service.
 
 use super::handler;
-use crate::stateful::db::AttachableResolver;
+use crate::stateful::db::{AttachableResolver, Shared};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_codec::Read;
 use commonware_cryptography::Digest;
@@ -10,9 +10,9 @@ use commonware_storage::{
     merkle::{Family, Location},
     qmdb::sync::resolver::{FetchResult, Resolver as SyncResolver},
 };
-use commonware_utils::{channel::oneshot, sync::TracedAsyncRwLock};
+use commonware_utils::channel::oneshot;
 use futures::FutureExt as _;
-use std::{collections::VecDeque, future::Future, num::NonZeroU64, sync::Arc};
+use std::{collections::VecDeque, future::Future, num::NonZeroU64};
 
 /// The resolver actor dropped the response before completion.
 #[derive(Debug, thiserror::Error)]
@@ -22,7 +22,7 @@ pub struct ResponseDropped;
 /// Messages sent from the [`Mailbox`] to the resolver [`Actor`](super::Actor).
 pub(super) enum Message<DB, F: Family, Op, D: Digest> {
     /// Provide a database handle so the actor can serve incoming requests.
-    AttachDatabase(Arc<TracedAsyncRwLock<DB>>),
+    AttachDatabase(Shared<DB>),
     /// Fetch operations from a remote peer via the P2P resolver engine.
     GetOperations {
         request: handler::Request<F>,
@@ -42,7 +42,7 @@ impl<DB, F: Family, Op, D: Digest> Message<DB, F, Op, D> {
 }
 
 pub(super) struct Pending<DB, F: Family, Op, D: Digest> {
-    database: Option<Arc<TracedAsyncRwLock<DB>>>,
+    database: Option<Shared<DB>>,
     messages: VecDeque<Message<DB, F, Op, D>>,
 }
 
@@ -121,7 +121,7 @@ impl<DB, F: Family, Op, D: Digest> Mailbox<DB, F, Op, D> {
 }
 
 impl<DB: Send + Sync, F: Family, Op: Send, D: Digest> Mailbox<DB, F, Op, D> {
-    pub fn attach_database(&self, db: Arc<TracedAsyncRwLock<DB>>) {
+    pub fn attach_database(&self, db: Shared<DB>) {
         let _ = self.sender.enqueue(Message::AttachDatabase(db));
     }
 }
@@ -181,7 +181,7 @@ where
     D: Digest,
     DB: Send + Sync + 'static,
 {
-    fn attach_database(&self, db: Arc<TracedAsyncRwLock<DB>>) -> impl Future<Output = ()> + Send {
+    fn attach_database(&self, db: Shared<DB>) -> impl Future<Output = ()> + Send {
         Self::attach_database(self, db);
         std::future::ready(())
     }

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -1,6 +1,6 @@
 use crate::stateful::{
     Application, Proposed,
-    db::{DatabaseSet, ManagedDb, Merkleized, Unmerkleized},
+    db::{DatabaseSet, ManagedDb, Merkleized, Shared, Unmerkleized},
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
 use commonware_consensus::{
@@ -13,11 +13,10 @@ use commonware_cryptography::{
     Digest as _, Digestible, Signer as _, ed25519, sha256::Digest as Sha256Digest,
 };
 use commonware_runtime::{Buf, BufMut, deterministic};
-use commonware_utils::sync::TracedAsyncRwLock;
 use futures::Stream;
 use std::{convert::Infallible, sync::Arc};
 
-pub(crate) type TestDatabases = Arc<TracedAsyncRwLock<TestDb>>;
+pub(crate) type TestDatabases = Shared<TestDb>;
 pub(crate) type TestScheme = scheme_mocks::Scheme<ed25519::PublicKey>;
 pub(crate) type TestVariant = Standard<TestBlock>;
 
@@ -67,7 +66,7 @@ impl<E: Send> ManagedDb<E> for TestDb {
         Ok(Self)
     }
 
-    async fn new_batch(_db: &Arc<TracedAsyncRwLock<Self>>) -> Self::Unmerkleized {
+    async fn new_batch(_db: &Shared<Self>) -> Self::Unmerkleized {
         TestUnmerkleized
     }
 
@@ -75,16 +74,16 @@ impl<E: Send> ManagedDb<E> for TestDb {
         true
     }
 
-    async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
-        Ok(())
+    async fn finalize(self, _batch: Self::Merkleized) -> Result<Self, Self::Error> {
+        Ok(self)
     }
 
     fn sync_target(&self) -> Self::SyncTarget {
         0
     }
 
-    async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
-        Ok(())
+    async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+        Ok(self)
     }
 }
 
@@ -217,7 +216,7 @@ impl Application<deterministic::Context> for TestApp {
 }
 
 pub(crate) fn test_databases() -> TestDatabases {
-    Arc::new(TracedAsyncRwLock::new("test", TestDb))
+    Shared::new("test", TestDb)
 }
 
 pub(crate) fn anchor(height: u64, digest_byte: u8) -> crate::stateful::db::Anchor<Sha256Digest> {

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -8,7 +8,7 @@ use crate::{
         Application, Config as StatefulConfig, Proposed, PruneConfig, Stateful as StatefulActor,
         SyncPlan,
         db::{
-            DatabaseSet, Merkleized as _, SyncEngineConfig, Unmerkleized as _,
+            DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
             p2p::{compact as compact_resolver, standard as qmdb_resolver},
         },
         probe::{Config as ProbeConfig, Probe},
@@ -56,10 +56,7 @@ use commonware_storage::{
     translator::TwoCap,
 };
 use commonware_utils::{
-    NZDuration, NZU64, NZUsize, non_empty_range,
-    range::NonEmptyRange,
-    sync::{Mutex, TracedAsyncRwLock},
-    test_rng,
+    NZDuration, NZU64, NZUsize, non_empty_range, range::NonEmptyRange, sync::Mutex, test_rng,
 };
 use futures::{Stream, StreamExt};
 use rand_core::Rng;
@@ -75,8 +72,8 @@ type QmdbB<E> =
     immutable::fixed::CompactDb<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, Sequential>;
 
 /// A single QMDB database behind a lock.
-type DbA<E> = Arc<TracedAsyncRwLock<QmdbA<E>>>;
-type DbB<E> = Arc<TracedAsyncRwLock<QmdbB<E>>>;
+type DbA<E> = Shared<QmdbA<E>>;
+type DbB<E> = Shared<QmdbB<E>>;
 
 /// A full and a compact QMDB as a tuple.
 pub(crate) type MultiDatabaseSet<E> = (DbA<E>, DbB<E>);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -8,7 +8,7 @@ use crate::{
         Application, Config as StatefulConfig, Proposed, PruneConfig, Stateful as StatefulActor,
         SyncPlan,
         db::{
-            DatabaseSet, Merkleized as _, SyncEngineConfig, Unmerkleized as _,
+            DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
             p2p::standard as qmdb_resolver,
         },
         probe::{Config as ProbeConfig, Probe},
@@ -54,10 +54,7 @@ use commonware_storage::{
     translator::TwoCap,
 };
 use commonware_utils::{
-    NZDuration, NZU64, NZUsize, non_empty_range,
-    range::NonEmptyRange,
-    sync::{Mutex, TracedAsyncRwLock},
-    test_rng,
+    NZDuration, NZU64, NZUsize, non_empty_range, range::NonEmptyRange, sync::Mutex, test_rng,
 };
 use futures::{Stream, StreamExt};
 use rand_core::Rng;
@@ -67,7 +64,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 type Qmdb<E> =
     fixed::Db<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, TwoCap, Sequential>;
 
-pub(crate) type SingleDatabaseSet<E> = Arc<TracedAsyncRwLock<Qmdb<E>>>;
+pub(crate) type SingleDatabaseSet<E> = Shared<Qmdb<E>>;
 
 /// A block carrying key-value mutations with embedded consensus context.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -241,7 +241,6 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
             for op in &operations {
-                // Each arm takes the db and evaluates to its successor.
                 db = match op {
                     CurrentOperation::Update { key, value } => {
                         pending_writes.push((Key::new(*key), Some(Value::new(*value))));

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -148,35 +148,41 @@ fn apply_pending(
     }
 }
 
-/// Commit pending writes. Returns `true` on success, `false` on error.
+/// Commit pending writes. Returns the db on success; `None` on error (the db
+/// is dropped, simulating a crash).
 async fn commit_pending<F: Graftable>(
-    db: &mut Db<F>,
+    db: Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     pending: &mut HashMap<RawKey, Option<RawValue>>,
     committed: &mut HashMap<RawKey, RawValue>,
-) -> bool {
+) -> Option<Db<F>> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = match batch.merkleize(db, None).await {
+    let merkleized = match batch.merkleize(&db, None).await {
         Ok(m) => m,
         Err(_) => {
             forget_pending(pending, committed);
-            return false;
+            return None;
         }
     };
-    let result = db.apply_batch(merkleized).await;
-    if result.is_err() {
-        forget_pending(pending, committed);
-        return false;
-    }
-    if db.commit().await.is_err() {
-        forget_pending(pending, committed);
-        return false;
-    }
+    let db = match db.apply_batch(merkleized).await {
+        Ok((db, _)) => db,
+        Err(_) => {
+            forget_pending(pending, committed);
+            return None;
+        }
+    };
+    let db = match db.commit().await {
+        Ok(db) => db,
+        Err(_) => {
+            forget_pending(pending, committed);
+            return None;
+        }
+    };
     apply_pending(pending, committed);
-    true
+    Some(db)
 }
 
 fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
@@ -235,43 +241,41 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
             for op in &operations {
-                match op {
+                // Each arm takes the db and evaluates to its successor.
+                db = match op {
                     CurrentOperation::Update { key, value } => {
                         pending_writes.push((Key::new(*key), Some(Value::new(*value))));
                         pending.insert(*key, Some(*value));
+                        db
                     }
                     CurrentOperation::Delete { key } => {
                         pending_writes.push((Key::new(*key), None));
                         pending.insert(*key, None);
+                        db
                     }
                     CurrentOperation::Commit => {
-                        if !commit_pending(
-                            &mut db,
-                            &mut pending_writes,
-                            &mut pending,
-                            &mut committed,
-                        )
-                        .await
-                        {
+                        let Some(db) =
+                            commit_pending(db, &mut pending_writes, &mut pending, &mut committed)
+                                .await
+                        else {
                             break;
-                        }
+                        };
+                        db
                     }
                     CurrentOperation::Prune => {
-                        if !commit_pending(
-                            &mut db,
-                            &mut pending_writes,
-                            &mut pending,
-                            &mut committed,
-                        )
-                        .await
-                        {
+                        let Some(db) =
+                            commit_pending(db, &mut pending_writes, &mut pending, &mut committed)
+                                .await
+                        else {
                             break;
-                        }
-                        if db.prune(db.sync_boundary()).await.is_err() {
-                            break;
+                        };
+                        let boundary = db.sync_boundary();
+                        match db.prune(boundary).await {
+                            Ok(db) => db,
+                            Err(_) => break,
                         }
                     }
-                }
+                };
             }
 
             committed
@@ -285,7 +289,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
         async move {
             *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
 
-            let mut db: Db<F> = Db::init(
+            let db: Db<F> = Db::init(
                 ctx.child("recovered"),
                 make_config(
                     &ctx,
@@ -347,10 +351,12 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(batch)
+            let (db, _) = db
+                .apply_batch(batch)
                 .await
                 .expect("apply_batch after recovery should succeed");
-            db.commit()
+            let db = db
+                .commit()
                 .await
                 .expect("commit after recovery should succeed");
 

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -406,7 +406,6 @@ fn fuzz(data: FuzzInput) {
         .await;
 
         for op in &data.operations {
-            // Each arm takes the dbs and evaluates to their successors.
             (db, reference_db) = match op {
                 CurrentOperation::Update { key, value } => {
                     if issued_writes >= MAX_ACTUAL_WRITES {

--- a/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/current_mmb_prune_grow.rs
@@ -168,16 +168,17 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
     }
 }
 
-async fn apply_pending(db: &mut Db, writes: &[(Key, Option<Value>)]) {
+async fn apply_pending(db: Db, writes: &[(Key, Option<Value>)]) -> Db {
     let mut batch = db.new_batch();
     for (key, value) in writes.iter().cloned() {
         batch = batch.write(key, value);
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized)
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db
+        .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    db.commit().await.expect("commit fsync should not fail");
+    db.commit().await.expect("commit fsync should not fail")
 }
 
 fn assert_matches_reference(db: &Db, reference_db: &Db, context: &str) {
@@ -199,29 +200,30 @@ fn assert_matches_reference(db: &Db, reference_db: &Db, context: &str) {
 }
 
 async fn commit_pending(
-    db: &mut Db,
-    reference_db: &mut Db,
+    db: Db,
+    reference_db: Db,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
     pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
-) {
+) -> (Db, Db) {
     if pending_writes.is_empty() {
-        assert_matches_reference(db, reference_db, "empty commit");
-        return;
+        assert_matches_reference(&db, &reference_db, "empty commit");
+        return (db, reference_db);
     }
 
     let writes = std::mem::take(pending_writes);
-    apply_pending(db, &writes).await;
-    apply_pending(reference_db, &writes).await;
+    let db = apply_pending(db, &writes).await;
+    let reference_db = apply_pending(reference_db, &writes).await;
     committed_state.extend(pending_expected.drain());
-    assert_matches_reference(db, reference_db, "commit");
+    assert_matches_reference(&db, &reference_db, "commit");
+    (db, reference_db)
 }
 
-async fn prune_to_floor(db: &mut Db, reference_db: &Db, context: &str) {
-    db.prune(db.sync_boundary())
-        .await
-        .expect("prune should not fail");
-    assert_matches_reference(db, reference_db, context);
+async fn prune_to_floor(db: Db, reference_db: &Db, context: &str) -> Db {
+    let boundary = db.sync_boundary();
+    let db = db.prune(boundary).await.expect("prune should not fail");
+    assert_matches_reference(&db, reference_db, context);
+    db
 }
 
 async fn reopen_pruned_db(
@@ -268,12 +270,12 @@ async fn reopen_pruned_db(
 }
 
 async fn bootstrap_pruned_state(
-    db: &mut Db,
-    reference_db: &mut Db,
+    mut db: Db,
+    mut reference_db: Db,
     committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
     pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
     all_keys: &mut HashSet<LogicalKey>,
-) {
+) -> (Db, Db) {
     // `step as u8` intentionally wraps for step >= 256; uniqueness is not required here,
     // we just need to drive the inactivity floor forward.
     for step in 0..BOOTSTRAP_COMMITS {
@@ -285,7 +287,7 @@ async fn bootstrap_pruned_state(
         let mut pending_writes = vec![(encode_key(key), Some(Value::new(value)))];
         pending_expected.insert(key, Some(value));
         all_keys.insert(key);
-        commit_pending(
+        (db, reference_db) = commit_pending(
             db,
             reference_db,
             &mut pending_writes,
@@ -293,9 +295,9 @@ async fn bootstrap_pruned_state(
             pending_expected,
         )
         .await;
-        prune_to_floor(db, reference_db, "bootstrap").await;
+        db = prune_to_floor(db, &reference_db, "bootstrap").await;
         if db.pruned_bits() > 0 {
-            return;
+            return (db, reference_db);
         }
     }
     panic!("bootstrap should create a genuinely pruned state");
@@ -309,12 +311,12 @@ struct ReopenEnv<'a> {
 
 async fn drive_post_prune_window(
     mut db: Db,
-    reference_db: &mut Db,
+    mut reference_db: Db,
     committed_state: &mut HashMap<LogicalKey, Option<RawValue>>,
     pending_expected: &mut HashMap<LogicalKey, Option<RawValue>>,
     all_keys: &mut HashSet<LogicalKey>,
     reopen: &mut ReopenEnv<'_>,
-) -> Db {
+) -> (Db, Db) {
     let midpoint = POST_PRUNE_WINDOW_STEPS / 2;
     for step in 0..POST_PRUNE_WINDOW_STEPS {
         let key = step % LOGICAL_KEY_SPACE;
@@ -335,15 +337,15 @@ async fn drive_post_prune_window(
         all_keys.insert(key);
 
         let mut writes = vec![write];
-        commit_pending(
-            &mut db,
+        (db, reference_db) = commit_pending(
+            db,
             reference_db,
             &mut writes,
             committed_state,
             pending_expected,
         )
         .await;
-        prune_to_floor(&mut db, reference_db, "forced-post-prune-window").await;
+        db = prune_to_floor(db, &reference_db, "forced-post-prune-window").await;
 
         // Reopen midway through the window to exercise the metadata round-trip while
         // delayed merges are still in progress.
@@ -353,13 +355,13 @@ async fn drive_post_prune_window(
                 db,
                 reopen.context,
                 reopen.config,
-                reference_db,
+                &reference_db,
                 *reopen.count,
             )
             .await;
         }
     }
-    db
+    (db, reference_db)
 }
 
 fn fuzz(data: FuzzInput) {
@@ -394,9 +396,9 @@ fn fuzz(data: FuzzInput) {
             count: &mut 0usize,
         };
 
-        bootstrap_pruned_state(
-            &mut db,
-            &mut reference_db,
+        (db, reference_db) = bootstrap_pruned_state(
+            db,
+            reference_db,
             &mut committed_state,
             &mut pending_expected,
             &mut all_keys,
@@ -404,7 +406,8 @@ fn fuzz(data: FuzzInput) {
         .await;
 
         for op in &data.operations {
-            match op {
+            // Each arm takes the dbs and evaluates to their successors.
+            (db, reference_db) = match op {
                 CurrentOperation::Update { key, value } => {
                     if issued_writes >= MAX_ACTUAL_WRITES {
                         continue;
@@ -413,6 +416,7 @@ fn fuzz(data: FuzzInput) {
                     pending_expected.insert(*key, Some(*value));
                     all_keys.insert(*key);
                     issued_writes += 1;
+                    (db, reference_db)
                 }
                 CurrentOperation::UpdateBurst { key, value, count } => {
                     for offset in 0..*count {
@@ -427,6 +431,7 @@ fn fuzz(data: FuzzInput) {
                         all_keys.insert(derived_key);
                         issued_writes += 1;
                     }
+                    (db, reference_db)
                 }
                 CurrentOperation::Delete { key } => {
                     if issued_writes >= MAX_ACTUAL_WRITES {
@@ -440,6 +445,7 @@ fn fuzz(data: FuzzInput) {
                     pending_expected.insert(live_key, None);
                     all_keys.insert(live_key);
                     issued_writes += 1;
+                    (db, reference_db)
                 }
                 CurrentOperation::DeleteBurst { key, count } => {
                     for offset in 0..*count {
@@ -457,42 +463,45 @@ fn fuzz(data: FuzzInput) {
                         all_keys.insert(live_key);
                         issued_writes += 1;
                     }
+                    (db, reference_db)
                 }
                 CurrentOperation::Commit | CurrentOperation::Root => {
-                    commit_pending(
-                        &mut db,
-                        &mut reference_db,
+                    let (db, reference_db) = commit_pending(
+                        db,
+                        reference_db,
                         &mut pending_writes,
                         &mut committed_state,
                         &mut pending_expected,
                     )
                     .await;
-                    prune_to_floor(&mut db, &reference_db, "commit+prune").await;
+                    let db = prune_to_floor(db, &reference_db, "commit+prune").await;
                     if db.pruned_bits() > 0 && !forced_window_ran {
                         forced_window_ran = true;
-                        db = drive_post_prune_window(
+                        drive_post_prune_window(
                             db,
-                            &mut reference_db,
+                            reference_db,
                             &mut committed_state,
                             &mut pending_expected,
                             &mut all_keys,
                             &mut reopen_env,
                         )
-                        .await;
+                        .await
+                    } else {
+                        (db, reference_db)
                     }
                 }
                 CurrentOperation::CloseReopen => {
-                    commit_pending(
-                        &mut db,
-                        &mut reference_db,
+                    let (db, reference_db) = commit_pending(
+                        db,
+                        reference_db,
                         &mut pending_writes,
                         &mut committed_state,
                         &mut pending_expected,
                     )
                     .await;
-                    prune_to_floor(&mut db, &reference_db, "close-reopen-prep").await;
+                    let db = prune_to_floor(db, &reference_db, "close-reopen-prep").await;
                     *reopen_env.count += 1;
-                    db = reopen_pruned_db(
+                    let db = reopen_pruned_db(
                         db,
                         reopen_env.context,
                         reopen_env.config,
@@ -500,14 +509,15 @@ fn fuzz(data: FuzzInput) {
                         *reopen_env.count,
                     )
                     .await;
+                    (db, reference_db)
                 }
-            }
+            };
         }
 
         if !pending_writes.is_empty() {
-            commit_pending(
-                &mut db,
-                &mut reference_db,
+            (db, reference_db) = commit_pending(
+                db,
+                reference_db,
                 &mut pending_writes,
                 &mut committed_state,
                 &mut pending_expected,
@@ -515,7 +525,7 @@ fn fuzz(data: FuzzInput) {
             .await;
         }
 
-        prune_to_floor(&mut db, &reference_db, "final").await;
+        let db = prune_to_floor(db, &reference_db, "final").await;
         assert_eq!(
             db.bounds().end,
             reference_db.bounds().end,

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -104,25 +104,27 @@ fn generate_seed_kv(index: u64) -> (RawKey, RawValue) {
 }
 
 async fn commit_pending<F: Graftable>(
-    db: &mut Db<F>,
+    db: Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, RawValue>,
     pending_inserts: &mut HashMap<RawKey, RawValue>,
     pending_deletes: &mut HashSet<RawKey>,
-) {
+) -> Db<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized)
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db
+        .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    db.commit().await.expect("commit fsync should not fail");
+    let db = db.commit().await.expect("commit fsync should not fail");
     for key in pending_deletes.drain() {
         committed_state.remove(&key);
     }
     committed_state.extend(pending_inserts.drain());
+    db
 }
 
 fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
@@ -177,8 +179,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             all_keys.insert(key);
         }
         if !pending_writes.is_empty() {
-            commit_pending(
-                &mut db,
+            db = commit_pending(
+                db,
                 &mut pending_writes,
                 &mut committed_state,
                 &mut pending_inserts,
@@ -189,7 +191,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         }
 
         for op in &operations {
-            match op {
+            // Each arm takes the db and evaluates to its successor.
+            db = match op {
                 CurrentOperation::Update { key, value } => {
                     let k = Key::new(*key);
                     let v = Value::new(*value);
@@ -198,6 +201,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     pending_deletes.remove(key);
                     pending_inserts.insert(*key, *value);
                     all_keys.insert(*key);
+                    db
                 }
 
                 CurrentOperation::Delete { key } => {
@@ -205,6 +209,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     pending_writes.push((k, None));
                     pending_inserts.remove(key);
                     pending_deletes.insert(*key);
+                    db
                 }
 
                 CurrentOperation::Get { key } => {
@@ -227,12 +232,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     }
 
                     all_keys.insert(*key);
+                    db
                 }
 
                 CurrentOperation::GetSpan { key } => {
                     let k = Key::new(*key);
                     let result = db.get_span(&k).await.expect("get should not fail");
                     assert_eq!(result.is_some(), !db.is_empty(), "span should be empty only if db is empty");
+                    db
                 }
 
                 CurrentOperation::OpCount => {
@@ -241,32 +248,36 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         actual, committed_op_count,
                         "Op count mismatch: expected {committed_op_count}, got {actual}"
                     );
+                    db
                 }
 
                 CurrentOperation::Commit => {
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
+                    db
                 }
 
                 CurrentOperation::Prune => {
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
-                    db.prune(db.sync_boundary()).await.expect("Prune should not fail");
+                    let boundary = db.sync_boundary();
+                    db.prune(boundary).await.expect("Prune should not fail")
                 }
 
                 CurrentOperation::Root => {
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
                     let _root = db.root();
+                    db
                 }
 
                 CurrentOperation::RangeProof { start_loc, max_ops } => {
@@ -275,8 +286,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         continue;
                     }
 
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
@@ -303,6 +314,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             "Range proof verification failed for start_loc={start_loc}, max_ops={max_ops}"
                         );
                     }
+                    db
                 }
 
                 CurrentOperation::ArbitraryProof {
@@ -317,8 +329,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     if current_op_count == 0 {
                         continue;
                     }
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
@@ -390,13 +402,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         }
 
                     }
+                    db
                 }
 
                 CurrentOperation::KeyValueProof { key } => {
                     let k = Key::new(*key);
 
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
@@ -420,13 +433,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             panic!("Unexpected error during key value proof generation: {e:?}");
                         }
                     }
+                    db
                 }
 
                 CurrentOperation::ExclusionProof { key } => {
                     let k = Key::new(*key);
 
-                    commit_pending(
-                        &mut db, &mut pending_writes, &mut committed_state,
+                    let db = commit_pending(
+                        db, &mut pending_writes, &mut committed_state,
                         &mut pending_inserts, &mut pending_deletes,
                     ).await;
                     committed_op_count = db.bounds().end;
@@ -448,14 +462,15 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             panic!("Unexpected error during exclusion proof generation: {e:?}");
                         }
                     }
+                    db
                 }
-            }
+            };
         }
 
         // Final commit to ensure all pending operations are persisted.
         if !pending_writes.is_empty() {
-            commit_pending(
-                &mut db, &mut pending_writes, &mut committed_state,
+            db = commit_pending(
+                db, &mut pending_writes, &mut committed_state,
                 &mut pending_inserts, &mut pending_deletes,
             ).await;
         }

--- a/storage/fuzz/fuzz_targets/current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_operations.rs
@@ -191,7 +191,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         }
 
         for op in &operations {
-            // Each arm takes the db and evaluates to its successor.
             db = match op {
                 CurrentOperation::Update { key, value } => {
                     let k = Key::new(*key);

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -117,7 +117,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
     let test_name = test_name.to_string();
     runner.start(|context| async move {
         let cfg = test_config(&test_name, &context);
-        let mut db: Db<F> = Db::init(context.child("storage"), cfg)
+        let db: Db<F> = Db::init(context.child("storage"), cfg)
             .await
             .expect("init current unordered db");
 
@@ -131,8 +131,8 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
             );
         }
         let initial = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(initial).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(initial).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Build the child while the parent is still pending.
         let mut batch = db.new_batch();
@@ -158,8 +158,8 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
 
         // Commit the parent, then rebuild the same logical child from the
         // committed wrapper state. Both canonical and ops roots must match.
-        db.apply_batch(parent).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let mut batch = db.new_batch();
         for mutation in &input.child {
@@ -184,7 +184,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
         );
 
         // Apply the pending child and verify the DB state matches.
-        db.apply_batch(pending_child).await.unwrap();
+        let (db, _) = db.apply_batch(pending_child).await.unwrap();
         assert_eq!(
             db.root(),
             committed_child.root(),

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -179,7 +179,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         }
 
         for op in &operations {
-            // Each arm takes the db and evaluates to its successor.
             db = match op {
                 CurrentOperation::Update { key, value } => {
                     let k = Key::new(*key);

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -98,21 +98,23 @@ fn generate_seed_kv(index: u64) -> (RawKey, RawValue) {
 }
 
 async fn commit_pending<F: Graftable>(
-    db: &mut Db<F>,
+    db: Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, Option<RawValue>>,
     pending_expected: &mut HashMap<RawKey, Option<RawValue>>,
-) {
+) -> Db<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized)
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db
+        .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    db.commit().await.expect("commit fsync should not fail");
+    let db = db.commit().await.expect("commit fsync should not fail");
     committed_state.extend(pending_expected.drain());
+    db
 }
 
 fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
@@ -166,8 +168,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             all_keys.insert(key);
         }
         if !pending_writes.is_empty() {
-            commit_pending(
-                &mut db,
+            db = commit_pending(
+                db,
                 &mut pending_writes,
                 &mut committed_state,
                 &mut pending_expected,
@@ -177,7 +179,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         }
 
         for op in &operations {
-            match op {
+            // Each arm takes the db and evaluates to its successor.
+            db = match op {
                 CurrentOperation::Update { key, value } => {
                     let k = Key::new(*key);
                     let v = Value::new(*value);
@@ -185,6 +188,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     pending_writes.push((k, Some(v)));
                     pending_expected.insert(*key, Some(*value));
                     all_keys.insert(*key);
+                    db
                 }
 
                 CurrentOperation::Delete { key } => {
@@ -197,6 +201,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         pending_expected.insert(*key, None);
                         all_keys.insert(*key);
                     }
+                    db
                 }
 
                 CurrentOperation::Get { key } => {
@@ -220,6 +225,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     }
 
                     all_keys.insert(*key);
+                    db
                 }
 
                 CurrentOperation::OpCount => {
@@ -228,23 +234,27 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         actual, committed_op_count,
                         "Op count mismatch: expected {committed_op_count}, got {actual}"
                     );
+                    db
                 }
 
                 CurrentOperation::Commit => {
-                    commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().end;
+                    db
                 }
 
                 CurrentOperation::Prune => {
-                    commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().end;
-                    db.prune(db.sync_boundary()).await.expect("Prune should not fail");
+                    let boundary = db.sync_boundary();
+                    db.prune(boundary).await.expect("Prune should not fail")
                 }
 
                 CurrentOperation::Root => {
-                    commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().end;
                     let _root = db.root();
+                    db
                 }
 
                 CurrentOperation::RangeProof { start_loc, max_ops } => {
@@ -253,7 +263,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         continue;
                     }
 
-                    commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
@@ -277,6 +287,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 "Range proof verification failed for start_loc={start_loc}, max_ops={max_ops}"
                             );
                     }
+                    db
                 }
 
                 CurrentOperation::ArbitraryProof {
@@ -291,7 +302,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     if current_op_count == 0 {
                         continue;
                     }
-                    commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().end;
 
                     let current_op_count = db.bounds().end;
@@ -361,12 +372,13 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         }
 
                     }
+                    db
                 }
 
                 CurrentOperation::KeyValueProof { key } => {
                     let k = Key::new(*key);
 
-                    commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
@@ -391,13 +403,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                             panic!("Unexpected error during key value proof generation: {e:?}");
                         }
                     }
+                    db
                 }
-            }
+            };
         }
 
         // Final commit to ensure all pending operations are persisted.
         if !pending_writes.is_empty() {
-            commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+            db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
         }
 
 

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -165,7 +165,6 @@ fn fuzz(input: FuzzInput) {
         let mut restarts = 0usize;
 
         for op in input.ops.iter() {
-            // Each arm takes the journal and evaluates to its successor.
             journal = match op {
                 JournalOperation::Append { value } => {
                     let digest = Sha256::hash(&value.to_be_bytes());

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -118,9 +118,9 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 const PAGE_SIZE: NonZeroU16 = NZU16!(57);
 const PAGE_CACHE_SIZE: usize = 1;
 
-/// Reopen the journal after an operation consumed it, returning the recovered journal with
-/// its size and pruning boundary. The consuming errors this harness exercises reject before
-/// any mutation, so the on-disk state is intact and recovery matches a restart.
+/// Reopen the journal, returning the recovered journal with its size and pruning
+/// boundary. The errors this harness exercises reject before any mutation, so the
+/// on-disk state is intact and recovery matches a restart.
 async fn reopen(
     context: &deterministic::Context,
     cfg: &JournalConfig,
@@ -174,7 +174,6 @@ fn fuzz(input: FuzzInput) {
                             journal_size += 1;
                             journal
                         }
-                        // The error consumed the journal; reopen and continue.
                         Err(Error::SizeOverflow) => {
                             let (journal, size, start) =
                                 reopen(&context, &cfg, &mut restarts).await;
@@ -290,8 +289,7 @@ fn fuzz(input: FuzzInput) {
 
                 JournalOperation::AppendMany { count } => {
                     if *count == 0 {
-                        // Exercise the EmptyAppend error path; the error consumes the
-                        // journal, so reopen to continue.
+                        // Exercise the EmptyAppend error path.
                         let err = journal.append_many(Many::Flat(&[])).await;
                         assert!(matches!(err, Err(Error::EmptyAppend)));
                         let (journal, size, start) = reopen(&context, &cfg, &mut restarts).await;
@@ -331,7 +329,6 @@ fn fuzz(input: FuzzInput) {
 
                 JournalOperation::AppendNested { count_a, count_b } => {
                     if *count_a == 0 && *count_b == 0 {
-                        // The error consumes the journal, so reopen to continue.
                         let err = journal.append_many(Many::Nested(&[&[], &[]])).await;
                         assert!(matches!(err, Err(Error::EmptyAppend)));
                         let (journal, size, start) = reopen(&context, &cfg, &mut restarts).await;

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -118,6 +118,32 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 const PAGE_SIZE: NonZeroU16 = NZU16!(57);
 const PAGE_CACHE_SIZE: usize = 1;
 
+/// Reopen the journal after an operation consumed it, returning the recovered journal with
+/// its size and pruning boundary. The consuming errors this harness exercises reject before
+/// any mutation, so the on-disk state is intact and recovery matches a restart.
+async fn reopen(
+    context: &deterministic::Context,
+    cfg: &JournalConfig,
+    restarts: &mut usize,
+) -> (
+    Journal<deterministic::Context, commonware_cryptography::sha256::Digest>,
+    u64,
+    u64,
+) {
+    let journal = Journal::init(
+        context
+            .child("journal")
+            .with_attribute("instance", *restarts),
+        cfg.clone(),
+    )
+    .await
+    .unwrap();
+    *restarts += 1;
+    let size = journal.size();
+    let start = journal.bounds().start;
+    (journal, size, start)
+}
+
 fn fuzz(input: FuzzInput) {
     let runner = deterministic::Runner::default();
 
@@ -139,12 +165,23 @@ fn fuzz(input: FuzzInput) {
         let mut restarts = 0usize;
 
         for op in input.ops.iter() {
-            match op {
+            // Each arm takes the journal and evaluates to its successor.
+            journal = match op {
                 JournalOperation::Append { value } => {
                     let digest = Sha256::hash(&value.to_be_bytes());
                     match journal.append(&digest).await {
-                        Ok(_pos) => journal_size += 1,
-                        Err(Error::SizeOverflow) => {}
+                        Ok((journal, _pos)) => {
+                            journal_size += 1;
+                            journal
+                        }
+                        // The error consumed the journal; reopen and continue.
+                        Err(Error::SizeOverflow) => {
+                            let (journal, size, start) =
+                                reopen(&context, &cfg, &mut restarts).await;
+                            journal_size = size;
+                            oldest_retained_pos = start;
+                            journal
+                        }
                         Err(e) => panic!("unexpected append error: {e:?}"),
                     }
                 }
@@ -154,6 +191,7 @@ fn fuzz(input: FuzzInput) {
                     if bounds.contains(pos) {
                         journal.read(*pos).await.unwrap();
                     }
+                    journal
                 }
 
                 JournalOperation::ReadMany { positions } => {
@@ -180,43 +218,46 @@ fn fuzz(input: FuzzInput) {
                             assert_eq!(batch[i], single);
                         }
                     }
+                    journal
                 }
 
                 JournalOperation::Size => {
-                    let size = journal.size();
-                    assert_eq!(journal_size, size, "unexpected size");
+                    assert_eq!(journal_size, journal.size(), "unexpected size");
+                    journal
                 }
 
-                JournalOperation::Sync => {
-                    journal.sync().await.unwrap();
-                }
+                JournalOperation::Sync => journal.sync().await.unwrap(),
 
                 JournalOperation::Rewind { size } => {
                     if *size <= journal_size && *size >= oldest_retained_pos {
-                        journal.rewind(*size).await.unwrap();
-                        journal.sync().await.unwrap();
+                        let journal = journal.rewind(*size).await.unwrap().sync().await.unwrap();
                         journal_size = *size;
                         oldest_retained_pos = journal.bounds().start;
+                        journal
+                    } else {
+                        journal
                     }
                 }
 
                 JournalOperation::Bounds => {
                     let _bounds = journal.bounds();
+                    journal
                 }
 
                 JournalOperation::Prune { min_pos } => {
                     if *min_pos <= journal_size {
-                        journal.prune(*min_pos).await.unwrap();
+                        let (journal, _) = journal.prune(*min_pos).await.unwrap();
                         oldest_retained_pos = journal.bounds().start;
+                        journal
+                    } else {
+                        journal
                     }
                 }
 
                 JournalOperation::Replay { buffer, start_pos } => {
                     let bounds = journal.bounds();
                     let start_pos = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
-                    let replay = journal.replay(start_pos, NZUsize!(*buffer)).await;
-
-                    match replay {
+                    match journal.replay(start_pos, NZUsize!(*buffer)).await {
                         Ok(stream) => {
                             pin_mut!(stream);
                             // Consume first few items to test stream - panic on stream errors
@@ -231,22 +272,15 @@ fn fuzz(input: FuzzInput) {
                         }
                         Err(e) => panic!("unexpected replay error: {e:?}"),
                     }
+                    journal
                 }
 
                 JournalOperation::Restart => {
                     drop(journal);
-                    journal = Journal::init(
-                        context
-                            .child("journal")
-                            .with_attribute("instance", restarts),
-                        cfg.clone(),
-                    )
-                    .await
-                    .unwrap();
-                    restarts += 1;
-                    // Reset tracking variables to match recovered state
-                    journal_size = journal.size();
-                    oldest_retained_pos = journal.bounds().start;
+                    let (journal, size, start) = reopen(&context, &cfg, &mut restarts).await;
+                    journal_size = size;
+                    oldest_retained_pos = start;
+                    journal
                 }
 
                 JournalOperation::Destroy => {
@@ -256,9 +290,14 @@ fn fuzz(input: FuzzInput) {
 
                 JournalOperation::AppendMany { count } => {
                     if *count == 0 {
-                        // Exercise the EmptyAppend error path
+                        // Exercise the EmptyAppend error path; the error consumes the
+                        // journal, so reopen to continue.
                         let err = journal.append_many(Many::Flat(&[])).await;
                         assert!(matches!(err, Err(Error::EmptyAppend)));
+                        let (journal, size, start) = reopen(&context, &cfg, &mut restarts).await;
+                        journal_size = size;
+                        oldest_retained_pos = start;
+                        journal
                     } else {
                         let items: Vec<_> = (0..*count)
                             .map(|_| {
@@ -268,23 +307,37 @@ fn fuzz(input: FuzzInput) {
                             })
                             .collect();
                         match journal.append_many(Many::Flat(&items)).await {
-                            Ok(_) => journal_size += *count as u64,
-                            Err(Error::SizeOverflow) => {}
+                            Ok((journal, _)) => {
+                                journal_size += *count as u64;
+                                journal
+                            }
+                            Err(Error::SizeOverflow) => {
+                                let (journal, size, start) =
+                                    reopen(&context, &cfg, &mut restarts).await;
+                                journal_size = size;
+                                oldest_retained_pos = start;
+                                journal
+                            }
                             Err(e) => panic!("unexpected append_many error: {e:?}"),
                         }
                     }
                 }
 
                 JournalOperation::MultipleSync => {
-                    journal.sync().await.unwrap();
-                    journal.sync().await.unwrap();
-                    journal.sync().await.unwrap();
+                    let journal = journal.sync().await.unwrap();
+                    let journal = journal.sync().await.unwrap();
+                    journal.sync().await.unwrap()
                 }
 
                 JournalOperation::AppendNested { count_a, count_b } => {
                     if *count_a == 0 && *count_b == 0 {
+                        // The error consumes the journal, so reopen to continue.
                         let err = journal.append_many(Many::Nested(&[&[], &[]])).await;
                         assert!(matches!(err, Err(Error::EmptyAppend)));
+                        let (journal, size, start) = reopen(&context, &cfg, &mut restarts).await;
+                        journal_size = size;
+                        oldest_retained_pos = start;
+                        journal
                     } else {
                         let items_a: Vec<_> = (0..*count_a)
                             .map(|_| {
@@ -302,8 +355,17 @@ fn fuzz(input: FuzzInput) {
                             .collect();
                         let slices: &[&[_]] = &[&items_a, &items_b];
                         match journal.append_many(Many::Nested(slices)).await {
-                            Ok(_) => journal_size += *count_a as u64 + *count_b as u64,
-                            Err(Error::SizeOverflow) => {}
+                            Ok((journal, _)) => {
+                                journal_size += *count_a as u64 + *count_b as u64;
+                                journal
+                            }
+                            Err(Error::SizeOverflow) => {
+                                let (journal, size, start) =
+                                    reopen(&context, &cfg, &mut restarts).await;
+                                journal_size = size;
+                                oldest_retained_pos = start;
+                                journal
+                            }
                             Err(e) => panic!("unexpected append_many error: {e:?}"),
                         }
                     }
@@ -312,10 +374,14 @@ fn fuzz(input: FuzzInput) {
                 JournalOperation::RewindTo { keep_value } => {
                     if journal_size > oldest_retained_pos {
                         let target = Sha256::hash(&keep_value.to_be_bytes());
-                        let new_size = journal.rewind_to(|item| *item == target).await.unwrap();
-                        journal.sync().await.unwrap();
+                        let (journal, new_size) =
+                            journal.rewind_to(|item| *item == target).await.unwrap();
+                        let journal = journal.sync().await.unwrap();
                         journal_size = new_size;
                         oldest_retained_pos = journal.bounds().start;
+                        journal
+                    } else {
+                        journal
                     }
                 }
 
@@ -328,11 +394,12 @@ fn fuzz(input: FuzzInput) {
                             assert_eq!(sync_val, async_val);
                         }
                     }
+                    journal
                 }
 
                 JournalOperation::PruningBoundary => {
-                    let boundary = journal.pruning_boundary();
-                    assert_eq!(boundary, oldest_retained_pos);
+                    assert_eq!(journal.pruning_boundary(), oldest_retained_pos);
+                    journal
                 }
 
                 JournalOperation::InitAtSize { size } => {
@@ -341,23 +408,21 @@ fn fuzz(input: FuzzInput) {
                         .child("journal")
                         .with_attribute("instance", restarts);
                     restarts += 1;
-                    journal = match Journal::init_at_size(attempt, cfg.clone(), *size).await {
-                        Ok(j) => j,
+                    let journal = match Journal::init_at_size(attempt, cfg.clone(), *size).await {
+                        Ok(journal) => journal,
                         // `u64::MAX` is rejected (no append could ever succeed) before any reset
                         // is staged, so the prior on-disk state is intact. Reopen it to continue.
                         Err(Error::SizeOverflow) => {
-                            let reopen = context
-                                .child("journal")
-                                .with_attribute("instance", restarts);
-                            restarts += 1;
-                            Journal::init(reopen, cfg.clone()).await.unwrap()
+                            let (journal, _, _) = reopen(&context, &cfg, &mut restarts).await;
+                            journal
                         }
                         Err(e) => panic!("unexpected init_at_size error: {e:?}"),
                     };
                     journal_size = journal.size();
                     oldest_retained_pos = journal.bounds().start;
+                    journal
                 }
-            }
+            };
         }
     });
 }

--- a/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
+++ b/storage/fuzz/fuzz_targets/fixed_journal_operations.rs
@@ -288,7 +288,7 @@ fn fuzz(input: FuzzInput) {
 
                 JournalOperation::AppendMany { count } => {
                     if *count == 0 {
-                        // Exercise the EmptyAppend error path.
+                        // Exercise the EmptyAppend error path
                         let err = journal.append_many(Many::Flat(&[])).await;
                         assert!(matches!(err, Err(Error::EmptyAppend)));
                         let (journal, size, start) = reopen(&context, &cfg, &mut restarts).await;

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -618,8 +618,8 @@ async fn run_ops<J: FuzzJournal>(
     params: Params,
 ) {
     for op in ops {
-        // A mutation error consumes the journal, ending the cycle. Each arm takes the journal
-        // and evaluates to its successor.
+        // A mutation error ends the cycle. Each arm takes the journal and evaluates to
+        // its successor.
         journal = match op {
             JournalOperation::Append { value } => {
                 let item = Item::from(*value);
@@ -682,9 +682,9 @@ async fn run_ops<J: FuzzJournal>(
                             expected.values.truncate(target as usize);
                             journal
                         }
-                        // Any error consumes the journal, ending the cycle. Validation
-                        // errors reject before mutating and are only possible for a raw
-                        // target; seeing one for a clamped target is a bug. Any other error
+                        // Any error ends the cycle. Validation errors reject before
+                        // mutating and are only possible for a raw target; seeing one for
+                        // a clamped target is a bug. Any other error
                         // may have interrupted the truncation and lost data above `target`,
                         // so lower durable_len conservatively.
                         Err(e @ (Error::InvalidRewind(_) | Error::ItemPruned(_))) => {

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -289,12 +289,12 @@ trait FuzzJournal: Sized {
     fn size(&self) -> impl Future<Output = u64> + Send;
     fn bounds(&self) -> Range<u64>;
 
-    fn append(&mut self, item: Item) -> impl Future<Output = Result<u64, Error>> + Send;
+    fn append(self, item: Item) -> impl Future<Output = Result<(Self, u64), Error>> + Send;
     fn read(&self, pos: u64) -> impl Future<Output = Result<Item, Error>> + Send;
-    fn sync(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
-    fn commit(&mut self) -> impl Future<Output = Result<(), Error>> + Send;
-    fn rewind(&mut self, size: u64) -> impl Future<Output = Result<(), Error>> + Send;
-    fn prune(&mut self, min_pos: u64) -> impl Future<Output = Result<bool, Error>> + Send;
+    fn sync(self) -> impl Future<Output = Result<Self, Error>> + Send;
+    fn commit(self) -> impl Future<Output = Result<Self, Error>> + Send;
+    fn rewind(self, size: u64) -> impl Future<Output = Result<Self, Error>> + Send;
+    fn prune(self, min_pos: u64) -> impl Future<Output = Result<(Self, bool), Error>> + Send;
 
     fn replay(
         &self,
@@ -348,7 +348,7 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         Contiguous::bounds(self)
     }
 
-    async fn append(&mut self, item: Item) -> Result<u64, Error> {
+    async fn append(self, item: Item) -> Result<(Self, u64), Error> {
         FixedJournal::append(self, &item).await
     }
 
@@ -356,19 +356,19 @@ impl FuzzJournal for FixedJournal<deterministic::Context, Item> {
         Contiguous::read(self, pos).await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
+    async fn sync(self) -> Result<Self, Error> {
         FixedJournal::sync(self).await
     }
 
-    async fn commit(&mut self) -> Result<(), Error> {
+    async fn commit(self) -> Result<Self, Error> {
         FixedJournal::commit(self).await
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    async fn rewind(self, size: u64) -> Result<Self, Error> {
         FixedJournal::rewind(self, size).await
     }
 
-    async fn prune(&mut self, min_pos: u64) -> Result<bool, Error> {
+    async fn prune(self, min_pos: u64) -> Result<(Self, bool), Error> {
         FixedJournal::prune(self, min_pos).await
     }
 
@@ -415,7 +415,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         Contiguous::bounds(self)
     }
 
-    async fn append(&mut self, item: Item) -> Result<u64, Error> {
+    async fn append(self, item: Item) -> Result<(Self, u64), Error> {
         VariableJournal::append(self, &item).await
     }
 
@@ -423,15 +423,15 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         Contiguous::read(self, pos).await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
+    async fn sync(self) -> Result<Self, Error> {
         VariableJournal::sync(self).await
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    async fn rewind(self, size: u64) -> Result<Self, Error> {
         VariableJournal::rewind(self, size).await
     }
 
-    async fn prune(&mut self, min_pos: u64) -> Result<bool, Error> {
+    async fn prune(self, min_pos: u64) -> Result<(Self, bool), Error> {
         VariableJournal::prune(self, min_pos).await
     }
 
@@ -443,7 +443,7 @@ impl FuzzJournal for VariableJournal<deterministic::Context, Item> {
         collect_replay(self, start_pos, buffer).await
     }
 
-    async fn commit(&mut self) -> Result<(), Error> {
+    async fn commit(self) -> Result<Self, Error> {
         VariableJournal::commit(self).await
     }
 
@@ -609,28 +609,30 @@ fn assert_replay_suffix(items: &[(u64, Item)], start: u64, bounds: &Range<u64>) 
 }
 
 /// Run a cycle's ops under faults, updating `expected`. Stops early on any error that may have left
-/// the journal inconsistent (a mutable-method error or a tail-repair I/O fault); the caller then
-/// drops the journal to crash. Reads never fault, so a bad read panics instead of ending the cycle.
+/// the journal inconsistent (a mutable-method error or a tail-repair I/O fault); the journal is
+/// then dropped to crash. Reads never fault, so a bad read panics instead of ending the cycle.
 async fn run_ops<J: FuzzJournal>(
-    journal: &mut J,
+    mut journal: J,
     expected: &mut Expected,
     ops: &[JournalOperation],
     params: Params,
 ) {
     for op in ops {
-        let should_continue = match op {
+        // A mutation error consumes the journal, ending the cycle. Each arm takes the journal
+        // and evaluates to its successor.
+        journal = match op {
             JournalOperation::Append { value } => {
                 let item = Item::from(*value);
                 let size_before = journal.size().await;
                 match journal.append(item.clone()).await {
-                    Ok(pos) => {
+                    Ok((journal, pos)) => {
                         assert_eq!(pos, size_before, "append returned non-contiguous position");
                         expected.appended(item);
-                        true
+                        journal
                     }
                     Err(_) => {
                         expected.append_failed(size_before);
-                        false
+                        return;
                     }
                 }
             }
@@ -642,29 +644,29 @@ async fn run_ops<J: FuzzJournal>(
                     assert_read(journal.read(target).await, target, &bounds);
                 }
                 assert_read(journal.read(*pos).await, *pos, &bounds);
-                true
+                journal
             }
 
             JournalOperation::Sync => match journal.sync().await {
-                Ok(()) => {
+                Ok(journal) => {
                     expected.synced(journal.bounds());
-                    true
+                    journal
                 }
-                Err(_) => false,
+                Err(_) => return,
             },
 
             JournalOperation::Commit => match journal.commit().await {
-                Ok(()) => {
+                Ok(journal) => {
                     expected.committed(journal.size().await);
-                    true
+                    journal
                 }
-                Err(_) => false,
+                Err(_) => return,
             },
 
             JournalOperation::Rewind { size } => {
                 let bounds = journal.bounds();
                 if bounds.is_empty() {
-                    true
+                    journal
                 } else {
                     // Usually clamp to a valid retained target; occasionally pass the raw value to
                     // exercise the validation paths.
@@ -675,13 +677,16 @@ async fn run_ops<J: FuzzJournal>(
                         bounds.start + (*size % (bounds.end - bounds.start + 1))
                     };
                     match journal.rewind(target).await {
-                        Ok(()) => {
+                        Ok(journal) => {
                             expected.rewound(target, bounds.end);
                             expected.values.truncate(target as usize);
-                            true
+                            journal
                         }
-                        // Validation error: rejected before any mutation, so leave the expectation
-                        // put. Only a raw target can be invalid; on a clamped target this is a bug.
+                        // Any error consumes the journal, ending the cycle. Validation
+                        // errors reject before mutating and are only possible for a raw
+                        // target; seeing one for a clamped target is a bug. Any other error
+                        // may have interrupted the truncation and lost data above `target`,
+                        // so lower durable_len conservatively.
                         Err(e @ (Error::InvalidRewind(_) | Error::ItemPruned(_))) => {
                             assert!(
                                 use_raw_target,
@@ -689,13 +694,11 @@ async fn run_ops<J: FuzzJournal>(
                                  returned {e:?}",
                                 bounds.start, bounds.end
                             );
-                            true
+                            return;
                         }
-                        // I/O fault mid-truncation: data above `target` may be lost, so lower
-                        // durable_len conservatively and end the cycle.
                         Err(_) => {
                             expected.rewound(target.min(bounds.end), bounds.end);
-                            false
+                            return;
                         }
                     }
                 }
@@ -705,9 +708,9 @@ async fn run_ops<J: FuzzJournal>(
                 // Raw position: `prune` caps it to size internally, covering prune-past-size.
                 let size = journal.size().await;
                 match journal.prune(*min_pos).await {
-                    Ok(_) => {
+                    Ok((journal, _)) => {
                         expected.pruned(journal.bounds().start);
-                        true
+                        journal
                     }
                     Err(_) => {
                         // A failed prune advances the boundary at most to the section floor.
@@ -715,7 +718,7 @@ async fn run_ops<J: FuzzJournal>(
                         let section_floor =
                             capped / params.items_per_section * params.items_per_section;
                         expected.prune_failed(section_floor);
-                        false
+                        return;
                     }
                 }
             }
@@ -744,21 +747,22 @@ async fn run_ops<J: FuzzJournal>(
                     // Tail-repair I/O fault: end the cycle.
                     Err(_) => false,
                 };
-                clamped_ok
-                    && should_continue_raw_replay(
-                        journal.replay(*start_pos, NZUsize!(*buffer)).await,
-                        *start_pos,
-                        &bounds,
-                    )
+                if !clamped_ok {
+                    return;
+                }
+                if !should_continue_raw_replay(
+                    journal.replay(*start_pos, NZUsize!(*buffer)).await,
+                    *start_pos,
+                    &bounds,
+                ) {
+                    return;
+                }
+                journal
             }
 
             // `split_into_cycles` strips `Crash`; a stray one defensively ends the cycle.
-            JournalOperation::Crash => false,
+            JournalOperation::Crash => return,
         };
-
-        if !should_continue {
-            break;
-        }
     }
 }
 
@@ -778,7 +782,7 @@ where
         // Recover with faults disabled to obtain clean ground truth.
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
         let cfg = J::config(&partition, &ctx, &params);
-        let mut journal = J::init(ctx.child("journal"), cfg)
+        let journal = J::init(ctx.child("journal"), cfg)
             .await
             .expect("recovery should succeed without panic");
         assert_matches_expected(&journal, &expected).await;
@@ -787,7 +791,7 @@ where
 
         // Faults on for the operation phase; returning drops the journal (the crash).
         *ctx.storage_fault_config().write() = params.fault_config();
-        run_ops(&mut journal, &mut expected, &ops, params).await;
+        run_ops(journal, &mut expected, &ops, params).await;
         expected
     })
 }
@@ -852,7 +856,7 @@ where
     // sentinel to prove the synced state survives restart.
     deterministic::Runner::from(checkpoint).start(move |ctx| async move {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
-        let mut journal = J::init(
+        let journal = J::init(
             ctx.child("journal_final"),
             J::config(&partition, &ctx, &params),
         )
@@ -864,13 +868,13 @@ where
         let mut expected = to_expected(&journal).await;
         let size = journal.size().await;
         let sentinel = Item::from([0xEFu8; ITEM_SIZE]);
-        let pos = journal
+        let (journal, pos) = journal
             .append(sentinel.clone())
             .await
             .expect("final append");
         assert_eq!(pos, size);
         expected.appended(sentinel.clone());
-        journal.sync().await.expect("final sync");
+        let journal = journal.sync().await.expect("final sync");
         expected.synced(journal.bounds());
         drop(journal);
 

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -618,8 +618,7 @@ async fn run_ops<J: FuzzJournal>(
     params: Params,
 ) {
     for op in ops {
-        // A mutation error ends the cycle. Each arm takes the journal and evaluates to
-        // its successor.
+        // A mutation error ends the cycle.
         journal = match op {
             JournalOperation::Append { value } => {
                 let item = Item::from(*value);

--- a/storage/fuzz/fuzz_targets/merkle_full.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full.rs
@@ -131,7 +131,6 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let mut restarts = 0usize;
 
             for op in operations {
-                // Each arm takes the merkle and evaluates to its successor.
                 merkle = match op {
                     Operation::Add { data } => {
                         let limited_data = if data.len() > MAX_DATA_SIZE {

--- a/storage/fuzz/fuzz_targets/merkle_full.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full.rs
@@ -131,7 +131,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let mut restarts = 0usize;
 
             for op in operations {
-                match op {
+                // Each arm takes the merkle and evaluates to its successor.
+                merkle = match op {
                     Operation::Add { data } => {
                         let limited_data = if data.len() > MAX_DATA_SIZE {
                             &data[0..MAX_DATA_SIZE]
@@ -149,11 +150,12 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         let batch = merkle.with_mem(|mem| {
                             batch.add(&hasher, limited_data).merkleize(mem, &hasher)
                         });
-                        merkle.apply_batch(&batch).unwrap();
+                        let merkle = merkle.apply_batch(&batch).unwrap();
                         leaves.push(limited_data.to_vec());
                         historical_sizes.push(merkle.leaves());
                         assert!(merkle.size() > size_before);
                         assert_eq!(merkle.leaves() - 1, loc);
+                        merkle
                     }
 
                     Operation::AddBatched { items } => {
@@ -186,7 +188,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                 merkle.with_mem(|mem| batch.merkleize(mem, &hasher)),
                             )
                         };
-                        merkle.apply_batch(&batch).unwrap();
+                        let merkle = merkle.apply_batch(&batch).unwrap();
                         assert!(merkle.size() > size_before);
 
                         for (item, loc) in items.iter().zip(&locations) {
@@ -195,10 +197,12 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             historical_sizes.push(*loc + 1);
                         }
                         assert_eq!(merkle.leaves() - 1, *locations.last().unwrap());
+                        merkle
                     }
 
                     Operation::GetNode { pos } => {
                         let _ = merkle.get_node(Position::<F>::new(pos)).await;
+                        merkle
                     }
 
                     Operation::Proof { location } => {
@@ -217,6 +221,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                 }
                             }
                         }
+                        merkle
                     }
 
                     Operation::RangeProof { start_loc, end_loc } => {
@@ -241,6 +246,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                 ));
                             }
                         }
+                        merkle
                     }
 
                     Operation::HistoricalRangeProof { start_loc, end_loc } => {
@@ -282,40 +288,44 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                                 panic!("unexpected historical_range_proof error: {err:?}")
                             }
                         }
+                        merkle
                     }
 
-                    Operation::Sync => {
-                        merkle.sync().await.unwrap();
-                    }
+                    Operation::Sync => merkle.sync().await.unwrap(),
 
-                    Operation::PruneAll => {
-                        merkle.prune_all().await.unwrap();
-                    }
+                    Operation::PruneAll => merkle.prune_all().await.unwrap(),
 
                     Operation::PruneToPos { pos } => {
                         if merkle.size() > 0 {
                             let safe_loc = Location::<F>::new(pos % (*merkle.leaves() + 1));
-                            merkle.prune(safe_loc).await.unwrap();
+                            let merkle = merkle.prune(safe_loc).await.unwrap();
                             assert!(merkle.bounds().start <= merkle.leaves());
+                            merkle
+                        } else {
+                            merkle
                         }
                     }
 
                     Operation::GetRoot => {
                         let _ = merkle.root(&hasher, 0);
+                        merkle
                     }
 
                     Operation::GetSize => {
                         let _ = merkle.size();
+                        merkle
                     }
 
                     Operation::GetLeaves => {
                         let (leaf_count, size) = (merkle.leaves().as_u64(), merkle.size().as_u64());
                         assert!(leaf_count <= size);
+                        merkle
                     }
 
                     Operation::GetPrunedToPos => {
                         let pruned_loc = merkle.bounds().start;
                         assert!(pruned_loc <= merkle.leaves());
+                        merkle
                     }
 
                     Operation::GetOldestRetainedPos => {
@@ -323,12 +333,13 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         if !bounds.is_empty() {
                             assert!(bounds.start < merkle.leaves());
                         }
+                        merkle
                     }
 
                     Operation::Reinit => {
                         // Init a new merkle structure.
                         drop(merkle);
-                        merkle = Merkle::<F, _, _>::init(
+                        let merkle = Merkle::<F, _, _>::init(
                             context.child("merkle").with_attribute("instance", restarts),
                             &hasher,
                             test_config(suffix, &context),
@@ -341,6 +352,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         let recovered_leaves = merkle.leaves().as_u64() as usize;
                         leaves.truncate(recovered_leaves);
                         historical_sizes.truncate(recovered_leaves);
+                        merkle
                     }
 
                     Operation::InitSync {
@@ -375,8 +387,9 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             sync_merkle.destroy().await.unwrap();
                         }
                         restarts += 1;
+                        merkle
                     }
-                }
+                };
             }
         }
     });

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -127,7 +127,7 @@ async fn run_operations<F: MerkleFamily>(
     let mut min_pruned = 0u64;
     let mut max_pruned = merkle.bounds().start.as_u64();
 
-    // A failed operation consumes the handle, so it breaks out of the loop.
+    // A failed operation breaks out of the loop.
     for op in operations.iter() {
         // Each arm takes the merkle and evaluates to its successor.
         merkle = match op {

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -116,7 +116,7 @@ struct ExpectedBounds {
 }
 
 async fn run_operations<F: MerkleFamily>(
-    merkle: &mut Merkle<F>,
+    mut merkle: Merkle<F>,
     hasher: &StandardHasher<Sha256>,
     operations: &[MerkleOperation],
 ) -> ExpectedBounds {
@@ -127,21 +127,22 @@ async fn run_operations<F: MerkleFamily>(
     let mut min_pruned = 0u64;
     let mut max_pruned = merkle.bounds().start.as_u64();
 
+    // A failed operation consumes the handle, so it breaks out of the loop.
     for op in operations.iter() {
-        let failed = match op {
+        // Each arm takes the merkle and evaluates to its successor.
+        merkle = match op {
             MerkleOperation::Add { data } => {
                 let batch = merkle.new_batch().add(hasher, data);
                 let batch = merkle.with_mem(|mem| batch.merkleize(mem, hasher));
-                merkle.apply_batch(&batch).unwrap();
+                let merkle = merkle.apply_batch(&batch).unwrap();
                 max_size = max_size.max(merkle.size().as_u64());
                 max_leaves = max_leaves.max(merkle.leaves().as_u64());
-                false
+                merkle
             }
 
-            MerkleOperation::Sync => {
-                if merkle.sync().await.is_err() {
-                    true
-                } else {
+            MerkleOperation::Sync => match merkle.sync().await {
+                Err(_) => break,
+                Ok(merkle) => {
                     let size = merkle.size().as_u64();
                     let leaves = merkle.leaves().as_u64();
                     let pruned = merkle.bounds().start.as_u64();
@@ -151,30 +152,30 @@ async fn run_operations<F: MerkleFamily>(
                     max_leaves = max_leaves.max(leaves);
                     min_pruned = pruned;
                     max_pruned = max_pruned.max(pruned);
-                    false
+                    merkle
                 }
-            }
+            },
 
             MerkleOperation::PruneToLoc { loc } => {
                 let leaves = *merkle.leaves();
                 let current_pruned = *merkle.bounds().start;
                 let safe_loc = (*loc).min(leaves);
 
-                if safe_loc <= current_pruned {
-                    false
-                } else {
+                if safe_loc > current_pruned {
                     match merkle.prune(Location::new(safe_loc)).await {
                         Err(_) => {
                             max_pruned = max_pruned.max(safe_loc);
-                            true
+                            break;
                         }
-                        Ok(_) => {
+                        Ok(merkle) => {
                             let pruned = merkle.bounds().start.as_u64();
                             min_pruned = pruned;
                             max_pruned = pruned;
-                            false
+                            merkle
                         }
                     }
+                } else {
+                    merkle
                 }
             }
 
@@ -182,28 +183,24 @@ async fn run_operations<F: MerkleFamily>(
                 let leaves = merkle.leaves().as_u64();
                 let current_pruned = merkle.bounds().start.as_u64();
 
-                if leaves == 0 || current_pruned >= leaves {
-                    false
-                } else {
+                if leaves != 0 && current_pruned < leaves {
                     match merkle.prune_all().await {
                         Err(_) => {
                             max_pruned = max_pruned.max(leaves);
-                            true
+                            break;
                         }
-                        Ok(_) => {
+                        Ok(merkle) => {
                             let pruned = merkle.bounds().start.as_u64();
                             min_pruned = pruned;
                             max_pruned = pruned;
-                            false
+                            merkle
                         }
                     }
+                } else {
+                    merkle
                 }
             }
         };
-
-        if failed {
-            break;
-        }
     }
 
     ExpectedBounds {
@@ -238,7 +235,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         let operations = operations.clone();
         async move {
             let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-            let mut merkle = Merkle::<F>::init(
+            let merkle = Merkle::<F>::init(
                 ctx.child("merkle"),
                 &hasher,
                 merkle_config(
@@ -260,7 +257,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 ..Default::default()
             };
 
-            run_operations(&mut merkle, &hasher, &operations).await
+            run_operations(merkle, &hasher, &operations).await
         }
     });
 
@@ -270,7 +267,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         *ctx.storage_fault_config().write() = deterministic::FaultConfig::default();
 
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-        let mut merkle = Merkle::<F>::init(
+        let merkle = Merkle::<F>::init(
             ctx.child("recovered"),
             &hasher,
             merkle_config(
@@ -331,7 +328,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         let test_data = [0xABu8; DATA_SIZE];
         let batch = merkle.new_batch().add(&hasher, &test_data);
         let batch = merkle.with_mem(|mem| batch.merkleize(mem, &hasher));
-        merkle.apply_batch(&batch).unwrap();
+        let merkle = merkle.apply_batch(&batch).unwrap();
         merkle.destroy().await.expect("should be able to destroy");
     });
 }

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -129,7 +129,6 @@ async fn run_operations<F: MerkleFamily>(
 
     // A failed operation breaks out of the loop.
     for op in operations.iter() {
-        // Each arm takes the merkle and evaluates to its successor.
         merkle = match op {
             MerkleOperation::Add { data } => {
                 let batch = merkle.new_batch().add(hasher, data);

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -178,7 +178,6 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
         for op in &input.ops {
-            // Each arm takes the db and evaluates to its successor.
             db = match op {
                 Operation::Update { key, value } => {
                     pending_writes.push((Key::new(*key), Some(Value::new(*value))));

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -178,13 +178,16 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
         for op in &input.ops {
-            match op {
+            // Each arm takes the db and evaluates to its successor.
+            db = match op {
                 Operation::Update { key, value } => {
                     pending_writes.push((Key::new(*key), Some(Value::new(*value))));
+                    db
                 }
 
                 Operation::Delete { key } => {
                     pending_writes.push((Key::new(*key), None));
+                    db
                 }
 
                 Operation::Commit => {
@@ -208,16 +211,16 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                         .merkleize(&db, Some(FixedBytes::new(commit_id)))
                         .await
                         .unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("Commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    db.commit().await.expect("Commit should not fail")
                 }
 
                 Operation::Prune => {
-                    db.prune(db.sync_boundary())
-                        .await
-                        .expect("Prune should not fail");
+                    let boundary = db.sync_boundary();
+                    db.prune(boundary).await.expect("Prune should not fail")
                 }
 
                 Operation::SyncFull { fetch_batch_size } => {
@@ -235,10 +238,11 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                         .merkleize(&db, Some(FixedBytes::new(commit_id)))
                         .await
                         .unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     let target = sync::Target::new(
                         db.root(),
                         non_empty_range!(db.sync_boundary(), db.bounds().end),
@@ -254,9 +258,10 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                         sync_id,
                     )
                     .await;
-                    db = Arc::try_unwrap(wrapped_src)
+                    let db = Arc::try_unwrap(wrapped_src)
                         .unwrap_or_else(|_| panic!("Failed to unwrap src"));
                     sync_id += 1;
+                    db
                 }
 
                 Operation::SimulateFailure => {
@@ -265,15 +270,16 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
                     drop(db);
 
                     let cfg = test_config(&test_name, &context);
-                    db = Db::init(
+                    let db = Db::init(
                         context.child("db").with_attribute("instance", restarts),
                         cfg,
                     )
                     .await
                     .expect("Failed to init source db");
                     restarts += 1;
+                    db
                 }
-            }
+            };
         }
 
         let mut batch = db.new_batch();
@@ -281,7 +287,8 @@ fn fuzz_family<F: MerkleFamily>(input: &mut FuzzInput, test_name: &str) {
             batch = batch.write(k, v);
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized)
+        let (db, _) = db
+            .apply_batch(merkleized)
             .await
             .expect("commit should not fail");
         db.destroy().await.expect("Destroy should not fail");

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -185,7 +185,6 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
         let mut pending_writes: Vec<(Key, Option<Vec<u8>>)> = Vec::new();
 
         for op in &input.ops {
-            // Each arm takes the db and evaluates to its successor.
             db = match op {
                 Operation::Update { key, value_bytes } => {
                     pending_writes.push((Key::new(*key), Some(value_bytes.to_vec())));

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -185,13 +185,16 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
         let mut pending_writes: Vec<(Key, Option<Vec<u8>>)> = Vec::new();
 
         for op in &input.ops {
-            match op {
+            // Each arm takes the db and evaluates to its successor.
+            db = match op {
                 Operation::Update { key, value_bytes } => {
                     pending_writes.push((Key::new(*key), Some(value_bytes.to_vec())));
+                    db
                 }
 
                 Operation::Delete { key } => {
                     pending_writes.push((Key::new(*key), None));
+                    db
                 }
 
                 Operation::Commit { metadata_bytes } => {
@@ -200,25 +203,28 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, metadata_bytes.clone()).await.unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     historical_roots.insert(db.bounds().end, db.root());
+                    db
                 }
 
                 Operation::Prune => {
-                    db.prune(db.sync_boundary())
-                        .await
-                        .expect("Prune should not fail");
+                    let boundary = db.sync_boundary();
+                    db.prune(boundary).await.expect("Prune should not fail")
                 }
 
                 Operation::Get { key } => {
                     let _ = db.get(&Key::new(*key)).await;
+                    db
                 }
 
                 Operation::GetMetadata => {
                     let _ = db.get_metadata().await;
+                    db
                 }
 
                 Operation::Proof { start_loc, max_ops } => {
@@ -228,10 +234,11 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     historical_roots.insert(db.bounds().end, db.root());
                     let start_loc = Location::<F>::new(*start_loc % (*F::MAX_LEAVES + 1));
                     let op_count = db.bounds().end;
@@ -243,6 +250,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         let root = db.root();
                         assert!(verify_proof::<Sha256, _, _>(&proof, start_loc, &log, &root,));
                     }
+                    db
                 }
 
                 Operation::HistoricalProof {
@@ -256,10 +264,11 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     historical_roots.insert(db.bounds().end, db.root());
                     let op_count = {
                         let idx = (*size as usize) % historical_roots.len();
@@ -270,18 +279,17 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                     };
                     let start_loc = Location::<F>::new(*start_loc % (*F::MAX_LEAVES + 1));
 
-                    if start_loc >= op_count || op_count > max_ops.get() {
-                        continue;
-                    }
-
-                    if let Ok((proof, log)) =
-                        db.historical_proof(op_count, start_loc, *max_ops).await
+                    if start_loc < op_count
+                        && op_count <= max_ops.get()
+                        && let Ok((proof, log)) =
+                            db.historical_proof(op_count, start_loc, *max_ops).await
                     {
                         let root = historical_roots
                             .get(&op_count)
                             .expect("historical root missing for known commit point");
                         assert!(verify_proof::<Sha256, _, _>(&proof, start_loc, &log, root,));
                     }
+                    db
                 }
 
                 Operation::Sync => {
@@ -290,19 +298,22 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
                     historical_roots.insert(db.bounds().end, db.root());
-                    db.sync().await.expect("Sync should not fail");
+                    db.sync().await.expect("Sync should not fail")
                 }
 
                 Operation::InactivityFloorLoc => {
                     let _ = db.sync_boundary();
+                    db
                 }
 
                 Operation::OpCount => {
                     let _ = db.bounds().end;
+                    db
                 }
 
                 Operation::Root => {
@@ -312,12 +323,14 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized)
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     historical_roots.insert(db.bounds().end, db.root());
                     let _ = db.root();
+                    db
                 }
 
                 Operation::SimulateFailure => {
@@ -327,15 +340,16 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                     drop(db);
 
                     let cfg = test_config(&test_name, &context);
-                    db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap, Sequential>::init(
+                    let db = Db::<F, _, Key, Vec<u8>, Sha256, TwoCap, Sequential>::init(
                         context.child("db").with_attribute("instance", restarts),
                         cfg,
                     )
                     .await
                     .expect("Failed to init source db");
                     restarts += 1;
+                    db
                 }
-            }
+            };
         }
 
         let mut batch = db.new_batch();
@@ -343,7 +357,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
             batch = batch.write(k, v);
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized)
+        let (db, _) = db
+            .apply_batch(merkleized)
             .await
             .expect("commit should not fail");
         db.destroy().await.expect("Destroy should not fail");

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -160,7 +160,6 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let mut pending_sets: Vec<(Digest, Vec<u8>)> = Vec::new();
 
             for op in operations {
-                // Each arm takes the db and evaluates to its successor.
                 db = match op {
                     ImmutableOperation::Set {
                         key_seed,

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -160,7 +160,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let mut pending_sets: Vec<(Digest, Vec<u8>)> = Vec::new();
 
             for op in operations {
-                match op {
+                // Each arm takes the db and evaluates to its successor.
+                db = match op {
                     ImmutableOperation::Set {
                         key_seed,
                         value_size,
@@ -173,11 +174,13 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         {
                             pending_sets.push((key, value));
                         }
+                        db
                     }
 
                     ImmutableOperation::Get { key_seed } => {
                         let key = generate_key(&mut rng, key_seed);
                         let _ = db.get(&key).await;
+                        db
                     }
 
                     ImmutableOperation::Commit {
@@ -212,9 +215,10 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             db.inactivity_floor_loc()
                         };
                         let merkleized = batch.merkleize(&db, metadata, floor).await;
-                        db.apply_batch(merkleized).await.unwrap();
-                        db.commit().await.unwrap();
+                        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                        let db = db.commit().await.unwrap();
                         last_commit_loc = Some(db.bounds().end - 1);
+                        db
                     }
 
                     ImmutableOperation::Prune { loc } => {
@@ -235,13 +239,16 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             // but never below the current floor (monotonicity).
                             let floor = safe_loc.max(db.inactivity_floor_loc());
                             let merkleized = batch.merkleize(&db, None, floor).await;
-                            db.apply_batch(merkleized).await.unwrap();
-                            db.commit().await.unwrap();
+                            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                            let db = db.commit().await.unwrap();
                             last_commit_loc = Some(db.bounds().end - 1);
-                            db.prune(safe_loc).await.expect("prune should not fail");
+                            let db = db.prune(safe_loc).await.expect("prune should not fail");
                             let oldest = db.bounds().start;
                             set_locations.retain(|(_, l)| *l >= oldest);
                             keys_set.retain(|(_, l)| *l >= oldest);
+                            db
+                        } else {
+                            db
                         }
                     }
 
@@ -267,14 +274,17 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             }
                             let floor = db.inactivity_floor_loc();
                             let merkleized = batch.merkleize(&db, None, floor).await;
-                            db.apply_batch(merkleized).await.unwrap();
-                            db.commit().await.unwrap();
+                            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                            let db = db.commit().await.unwrap();
                             last_commit_loc = Some(db.bounds().end - 1);
                             if let Ok((proof, ops)) = db.proof(safe_start, safe_max_ops).await {
                                 let root = db.root();
                                 let _ =
                                     verify_proof::<Sha256, _, _>(&proof, safe_start, &ops, &root);
                             }
+                            db
+                        } else {
+                            db
                         }
                     }
 
@@ -294,27 +304,33 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
 
                             let floor = db.inactivity_floor_loc();
                             let batch = db.new_batch().merkleize(&db, None, floor).await;
-                            db.apply_batch(batch).await.unwrap();
-                            db.commit().await.unwrap();
+                            let (db, _) = db.apply_batch(batch).await.unwrap();
+                            let db = db.commit().await.unwrap();
                             last_commit_loc = Some(db.bounds().end - 1);
                             if safe_start >= db.bounds().start {
                                 let _ = db
                                     .historical_proof(safe_size, safe_start, safe_max_ops)
                                     .await;
                             }
+                            db
+                        } else {
+                            db
                         }
                     }
 
                     ImmutableOperation::GetMetadata => {
                         let _ = db.get_metadata().await;
+                        db
                     }
 
                     ImmutableOperation::OpCount => {
                         let _ = db.bounds().end;
+                        db
                     }
 
                     ImmutableOperation::OldestRetainedLoc => {
                         let _ = db.bounds().start;
+                        db
                     }
 
                     ImmutableOperation::Root => {
@@ -330,12 +346,13 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         }
                         let floor = db.inactivity_floor_loc();
                         let merkleized = batch.merkleize(&db, None, floor).await;
-                        db.apply_batch(merkleized).await.unwrap();
-                        db.commit().await.unwrap();
+                        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                        let db = db.commit().await.unwrap();
                         last_commit_loc = Some(db.bounds().end - 1);
                         let _ = db.root();
+                        db
                     }
-                }
+                };
             }
 
             assign_pending_locations(
@@ -350,7 +367,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             }
             let floor = db.inactivity_floor_loc();
             let merkleized = batch.merkleize(&db, None, floor).await;
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             db.destroy().await.unwrap();
         }
     });

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -217,6 +217,24 @@ fn test_config<S: Strategy>(
     }
 }
 
+/// Reopen the database after the previous instance was consumed or dropped.
+async fn reopen<F: Family, S: Strategy>(
+    context: &deterministic::Context,
+    suffix: &str,
+    strategy: &S,
+    restarts: &mut usize,
+) -> Db<F, S> {
+    let cfg = test_config(suffix, context, strategy.clone());
+    let db = Db::init(
+        context.child("db").with_attribute("instance", *restarts),
+        cfg,
+    )
+    .await
+    .expect("Failed to init keyless db");
+    *restarts += 1;
+    db
+}
+
 fn fuzz_family<F: Family, S: Strategy>(
     input: &FuzzInput,
     suffix: &str,
@@ -235,9 +253,11 @@ fn fuzz_family<F: Family, S: Strategy>(
         let mut pending_appends: Vec<Vec<u8>> = Vec::new();
 
         for op in &input.ops {
-            match op {
+            // Each arm takes the db and evaluates to its successor.
+            db = match op {
                 Operation::Append { value_bytes } => {
                     pending_appends.push(value_bytes.clone());
+                    db
                 }
 
                 Operation::Commit { metadata_bytes, floor_kind } => {
@@ -274,22 +294,29 @@ fn fuzz_family<F: Family, S: Strategy>(
 
                     match expect_err {
                         None => {
-                            db.apply_batch(merkleized).await.expect("Commit should not fail");
-                            db.commit().await.expect("Commit should not fail");
+                            let (db, _) = db
+                                .apply_batch(merkleized)
+                                .await
+                                .expect("Commit should not fail");
+                            db.commit().await.expect("Commit should not fail")
                         }
                         Some(kind) => {
-                            // Snapshot state; the reject must not mutate.
+                            // Snapshot state; the reject must not mutate persisted state.
                             let before_last_commit = db.last_commit_loc();
                             let before_floor = db.inactivity_floor_loc();
                             let before_root = db.root();
-                            let err = db
-                                .apply_batch(merkleized)
-                                .await
-                                .expect_err("bad floor must be rejected");
+                            let err = match db.apply_batch(merkleized).await {
+                                Ok(_) => panic!("bad floor must be rejected"),
+                                Err(err) => err,
+                            };
                             assert_bad_floor_error(&err, kind);
+                            // The rejected apply consumed the db; reopen and verify the
+                            // reject persisted nothing.
+                            let db = reopen(&context, suffix, &strategy, &mut restarts).await;
                             assert_eq!(db.last_commit_loc(), before_last_commit);
                             assert_eq!(db.inactivity_floor_loc(), before_floor);
                             assert_eq!(db.root(), before_root);
+                            db
                         }
                     }
                 }
@@ -334,14 +361,18 @@ fn fuzz_family<F: Family, S: Strategy>(
                     let before_last_commit = db.last_commit_loc();
                     let before_floor = db.inactivity_floor_loc();
                     let before_root = db.root();
-                    let err = db
-                        .apply_batch(child)
-                        .await
-                        .expect_err("bad ancestor floor must be rejected");
+                    let err = match db.apply_batch(child).await {
+                        Ok(_) => panic!("bad ancestor floor must be rejected"),
+                        Err(err) => err,
+                    };
                     assert_bad_floor_error(&err, kind);
+                    // The rejected apply consumed the db; reopen and verify the reject
+                    // persisted nothing.
+                    let db = reopen(&context, suffix, &strategy, &mut restarts).await;
                     assert_eq!(db.last_commit_loc(), before_last_commit);
                     assert_eq!(db.inactivity_floor_loc(), before_floor);
                     assert_eq!(db.root(), before_root);
+                    db
                 }
 
                 Operation::Get { loc_offset } => {
@@ -350,10 +381,12 @@ fn fuzz_family<F: Family, S: Strategy>(
                         let loc = (*loc_offset as u64) % op_count.as_u64();
                         let _ = db.get(loc.into()).await;
                     }
+                    db
                 }
 
                 Operation::GetMetadata => {
                     let _ = db.get_metadata().await;
+                    db
                 }
 
                 Operation::Prune => {
@@ -368,11 +401,13 @@ fn fuzz_family<F: Family, S: Strategy>(
                     let end = db.bounds().end;
                     let floor = Location::<F>::new(end.as_u64() + pending_count);
                     let merkleized = batch.merkleize(&db, None, floor).await;
-                    db.apply_batch(merkleized).await.expect("Commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
-                    db.prune(db.inactivity_floor_loc())
+                    let (db, _) = db
+                        .apply_batch(merkleized)
                         .await
-                        .expect("Prune should not fail");
+                        .expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
+                    let floor = db.inactivity_floor_loc();
+                    db.prune(floor).await.expect("Prune should not fail")
                 }
 
                 Operation::Sync => {
@@ -381,20 +416,26 @@ fn fuzz_family<F: Family, S: Strategy>(
                         batch = batch.append(v);
                     }
                     let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-                    db.apply_batch(merkleized).await.expect("Commit should not fail");
-                    db.sync().await.expect("Sync should not fail");
+                    let (db, _) = db
+                        .apply_batch(merkleized)
+                        .await
+                        .expect("Commit should not fail");
+                    db.sync().await.expect("Sync should not fail")
                 }
 
                 Operation::OpCount => {
                     let _ = db.bounds().end;
+                    db
                 }
 
                 Operation::LastCommitLoc => {
                     let _ = db.last_commit_loc();
+                    db
                 }
 
                 Operation::OldestRetainedLoc => {
                     let _ = db.bounds().start;
+                    db
                 }
 
                 Operation::Root => {
@@ -403,9 +444,13 @@ fn fuzz_family<F: Family, S: Strategy>(
                         batch = batch.append(v);
                     }
                     let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-                    db.apply_batch(merkleized).await.expect("Commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let (db, _) = db
+                        .apply_batch(merkleized)
+                        .await
+                        .expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     let _ = db.root();
+                    db
                 }
 
                 Operation::Proof {
@@ -421,8 +466,11 @@ fn fuzz_family<F: Family, S: Strategy>(
                         batch = batch.append(v);
                     }
                     let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-                    db.apply_batch(merkleized).await.expect("Commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let (db, _) = db
+                        .apply_batch(merkleized)
+                        .await
+                        .expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     let start_loc = (*start_offset as u64) % op_count.as_u64();
                     let max_ops_value = ((*max_ops as u64) % MAX_PROOF_OPS) + 1;
                     let start_loc: Location<F> = Location::new(start_loc);
@@ -437,6 +485,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                                 "Failed to verify proof for start loc{start_loc} with ops {max_ops} ops",
                             );
                     }
+                    db
                 }
 
                 Operation::HistoricalProof {
@@ -453,8 +502,11 @@ fn fuzz_family<F: Family, S: Strategy>(
                         batch = batch.append(v);
                     }
                     let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-                    db.apply_batch(merkleized).await.expect("Commit should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    let (db, _) = db
+                        .apply_batch(merkleized)
+                        .await
+                        .expect("Commit should not fail");
+                    let db = db.commit().await.expect("Commit should not fail");
                     // Use post-commit op_count so it's consistent with the root.
                     let op_count = db.bounds().end;
                     let size = ((*size_offset as u64) % op_count.as_u64()) + 1;
@@ -475,22 +527,16 @@ fn fuzz_family<F: Family, S: Strategy>(
                                 "Failed to verify historical proof for start loc{start_loc} with max ops {max_ops}",
                             );
                         }
+                    db
                 }
 
                 Operation::SimulateFailure{} => {
                     pending_appends.clear();
                     drop(db);
 
-                    let cfg = test_config(suffix, &context, strategy.clone());
-                    db = Db::init(
-                        context.child("db").with_attribute("instance", restarts),
-                        cfg,
-                    )
-                    .await
-                    .expect("Failed to init keyless db");
-                    restarts += 1;
+                    reopen(&context, suffix, &strategy, &mut restarts).await
                 }
-            }
+            };
         }
 
         let mut batch = db.new_batch();
@@ -498,7 +544,10 @@ fn fuzz_family<F: Family, S: Strategy>(
             batch = batch.append(v);
         }
         let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-        db.apply_batch(merkleized).await.expect("Commit should not fail");
+        let (db, _) = db
+            .apply_batch(merkleized)
+            .await
+            .expect("Commit should not fail");
         db.destroy().await.expect("Destroy should not fail");
     });
 }

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -217,7 +217,7 @@ fn test_config<S: Strategy>(
     }
 }
 
-/// Reopen the database after the previous instance was consumed or dropped.
+/// Reopen the database.
 async fn reopen<F: Family, S: Strategy>(
     context: &deterministic::Context,
     suffix: &str,
@@ -310,8 +310,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                                 Err(err) => err,
                             };
                             assert_bad_floor_error(&err, kind);
-                            // The rejected apply consumed the db; reopen and verify the
-                            // reject persisted nothing.
+                            // Reopen and verify the reject persisted nothing.
                             let db = reopen(&context, suffix, &strategy, &mut restarts).await;
                             assert_eq!(db.last_commit_loc(), before_last_commit);
                             assert_eq!(db.inactivity_floor_loc(), before_floor);
@@ -366,8 +365,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                         Err(err) => err,
                     };
                     assert_bad_floor_error(&err, kind);
-                    // The rejected apply consumed the db; reopen and verify the reject
-                    // persisted nothing.
+                    // Reopen and verify the reject persisted nothing.
                     let db = reopen(&context, suffix, &strategy, &mut restarts).await;
                     assert_eq!(db.last_commit_loc(), before_last_commit);
                     assert_eq!(db.inactivity_floor_loc(), before_floor);

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -253,7 +253,6 @@ fn fuzz_family<F: Family, S: Strategy>(
         let mut pending_appends: Vec<Vec<u8>> = Vec::new();
 
         for op in &input.ops {
-            // Each arm takes the db and evaluates to its successor.
             db = match op {
                 Operation::Append { value_bytes } => {
                     pending_appends.push(value_bytes.clone());

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -126,7 +126,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut all_keys: HashSet<RawKey> = HashSet::new();
 
             for op in operations.iter().take(MAX_OPS) {
-                // Each arm takes the db and evaluates to its successor.
                 db = match op {
                     QmdbOperation::Update { key, value } => {
                         let k = Key::new(*key);

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -61,26 +61,28 @@ const PAGE_SIZE: NonZeroU16 = NZU16!(111);
 const PAGE_CACHE_SIZE: usize = 100;
 
 async fn commit_pending<F: MerkleFamily>(
-    db: &mut GenericDb<F>,
+    db: GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut BTreeMap<RawKey, RawValue>,
     pending_inserts: &mut HashMap<RawKey, RawValue>,
     pending_deletes: &mut HashSet<RawKey>,
     metadata: Option<Value>,
-) {
+) -> GenericDb<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = batch.merkleize(db, metadata).await.unwrap();
-    db.apply_batch(merkleized)
+    let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+    let (db, _) = db
+        .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    db.commit().await.expect("commit fsync should not fail");
+    let db = db.commit().await.expect("commit fsync should not fail");
     for key in pending_deletes.drain() {
         committed_state.remove(&key);
     }
     committed_state.extend(pending_inserts.drain());
+    db
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
@@ -124,7 +126,8 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut all_keys: HashSet<RawKey> = HashSet::new();
 
             for op in operations.iter().take(MAX_OPS) {
-                match op {
+                // Each arm takes the db and evaluates to its successor.
+                db = match op {
                     QmdbOperation::Update { key, value } => {
                         let k = Key::new(*key);
                         let v = Value::new(*value);
@@ -133,6 +136,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         pending_deletes.remove(key);
                         pending_inserts.insert(*key, *value);
                         all_keys.insert(*key);
+                        db
                     }
 
                     QmdbOperation::Delete { key } => {
@@ -140,12 +144,13 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         pending_writes.push((k, None));
                         pending_inserts.remove(key);
                         pending_deletes.insert(*key);
+                        db
                     }
 
                     QmdbOperation::Commit { value } => {
                         assert_eq!(last_commit, db.get_metadata().await.unwrap());
-                        commit_pending(
-                            &mut db,
+                        let db = commit_pending(
+                            db,
                             &mut pending_writes,
                             &mut committed_state,
                             &mut pending_inserts,
@@ -154,6 +159,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         )
                         .await;
                         last_commit = Some(Value::new(*value));
+                        db
                     }
 
                     QmdbOperation::Get { key } => {
@@ -178,13 +184,14 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             }
                         }
                         all_keys.insert(*key);
+                        db
                     }
-                }
+                };
             }
 
             // Commit any remaining pending operations.
-            commit_pending(
-                &mut db,
+            db = commit_pending(
+                db,
                 &mut pending_writes,
                 &mut committed_state,
                 &mut pending_inserts,

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -152,7 +152,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
             for op in operations.iter().take(MAX_OPS) {
-                // Each arm takes the db and evaluates to its successor.
                 db = match op {
                     QmdbOperation::Update { key, value } => {
                         let k = Key::new(*key);

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -85,25 +85,27 @@ const PAGE_SIZE: NonZeroU16 = NZU16!(555);
 const PAGE_CACHE_SIZE: usize = 100;
 
 async fn commit_pending<F: MerkleFamily>(
-    db: &mut GenericDb<F>,
+    db: GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, RawValue>,
     pending_inserts: &mut HashMap<RawKey, RawValue>,
     pending_deletes: &mut HashSet<RawKey>,
-) {
+) -> GenericDb<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized)
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db
+        .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    db.commit().await.expect("commit fsync should not fail");
+    let db = db.commit().await.expect("commit fsync should not fail");
     for key in pending_deletes.drain() {
         committed_state.remove(&key);
     }
     committed_state.extend(pending_inserts.drain());
+    db
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
@@ -150,7 +152,8 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
             for op in operations.iter().take(MAX_OPS) {
-                match op {
+                // Each arm takes the db and evaluates to its successor.
+                db = match op {
                     QmdbOperation::Update { key, value } => {
                         let k = Key::new(*key);
                         let v = Value::new(*value);
@@ -159,6 +162,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         pending_deletes.remove(key);
                         pending_inserts.insert(*key, *value);
                         all_keys.insert(*key);
+                        db
                     }
 
                     QmdbOperation::Delete { key } => {
@@ -166,30 +170,33 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         pending_writes.push((k, None));
                         pending_inserts.remove(key);
                         pending_deletes.insert(*key);
+                        db
                     }
 
                     QmdbOperation::OpCount => {
                         let _ = db.bounds().end;
+                        db
                     }
 
                     QmdbOperation::Commit => {
                         commit_pending(
-                            &mut db, &mut pending_writes, &mut committed_state,
+                            db, &mut pending_writes, &mut committed_state,
                             &mut pending_inserts, &mut pending_deletes,
-                        ).await;
+                        ).await
                     }
 
                     QmdbOperation::Root => {
-                        commit_pending(
-                            &mut db, &mut pending_writes, &mut committed_state,
+                        let db = commit_pending(
+                            db, &mut pending_writes, &mut committed_state,
                             &mut pending_inserts, &mut pending_deletes,
                         ).await;
                         db.root();
+                        db
                     }
 
                     QmdbOperation::Proof { start_loc, max_ops } => {
-                        commit_pending(
-                            &mut db, &mut pending_writes, &mut committed_state,
+                        let db = commit_pending(
+                            db, &mut pending_writes, &mut committed_state,
                             &mut pending_inserts, &mut pending_deletes,
                         ).await;
                         let actual_op_count = db.bounds().end;
@@ -211,11 +218,12 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                                 "Proof verification failed for start_loc={adjusted_start}, max_ops={max_ops}",
                             );
                         }
+                        db
                     }
 
                     QmdbOperation::ArbitraryProof { start_loc, max_ops , proof_leaves, digests} => {
-                        commit_pending(
-                            &mut db, &mut pending_writes, &mut committed_state,
+                        let db = commit_pending(
+                            db, &mut pending_writes, &mut committed_state,
                             &mut pending_inserts, &mut pending_deletes,
                         ).await;
                         let actual_op_count = db.bounds().end;
@@ -241,6 +249,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
 
                             }
                         }
+                        db
                     }
 
                     QmdbOperation::Get { key } => {
@@ -262,20 +271,22 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             }
                         }
                         all_keys.insert(*key);
+                        db
                     }
 
                     QmdbOperation::GetSpan { key } => {
                         let k = Key::new(*key);
                         let result = db.get_span(&k).await.expect("get should not fail");
                         assert_eq!(result.is_some(), !db.is_empty(), "span should be empty only if db is empty");
+                        db
                     }
-                }
+                };
             }
 
             // Final commit to ensure all operations are persisted.
             if !pending_writes.is_empty() {
-                commit_pending(
-                    &mut db, &mut pending_writes, &mut committed_state,
+                db = commit_pending(
+                    db, &mut pending_writes, &mut committed_state,
                     &mut pending_inserts, &mut pending_deletes,
                 ).await;
             }
@@ -304,10 +315,12 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             }
 
             let batch = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(batch)
+            let (db, _) = db
+                .apply_batch(batch)
                 .await
                 .expect("final commit should not fail");
-            db.commit()
+            let db = db
+                .commit()
                 .await
                 .expect("final commit fsync should not fail");
             db.destroy().await.expect("destroy should not fail");

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -115,7 +115,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
 
     runner.start(|context| async move {
         let cfg = test_config(suffix, &context);
-        let mut db: Db<F> = Db::init(context.child("storage"), cfg)
+        let db: Db<F> = Db::init(context.child("storage"), cfg)
             .await
             .expect("init unordered any db");
 
@@ -129,8 +129,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             );
         }
         let initial = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(initial).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(initial).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Build a parent batch, then build the child while the parent is still
         // pending so the child must resolve through base_diff plus the stale
@@ -158,8 +158,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
 
         // Commit the parent, then rebuild the same logical child from the
         // committed DB state. Both speculative roots must match.
-        db.apply_batch(parent).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let mut batch = db.new_batch();
         for mutation in &input.child {
@@ -179,7 +179,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         );
 
         // Apply the pending child and verify the DB state matches.
-        db.apply_batch(pending_child).await.unwrap();
+        let (db, _) = db.apply_batch(pending_child).await.unwrap();
         assert_eq!(
             db.root(),
             committed_child.root(),

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -126,7 +126,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
             for op in &operations {
-                // Each arm takes the db and evaluates to its successor.
                 db = match op {
                     QmdbOperation::Update { key, value } => {
                         let k = Key::new(*key);

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -64,21 +64,23 @@ const PAGE_SIZE: NonZeroU16 = NZU16!(223);
 const PAGE_CACHE_SIZE: usize = 100;
 
 async fn commit_pending<F: MerkleFamily>(
-    db: &mut GenericDb<F>,
+    db: GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, Option<RawValue>>,
     pending_expected: &mut HashMap<RawKey, Option<RawValue>>,
-) {
+) -> GenericDb<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized)
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db
+        .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    db.commit().await.expect("commit fsync should not fail");
+    let db = db.commit().await.expect("commit fsync should not fail");
     committed_state.extend(pending_expected.drain());
+    db
 }
 
 fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
@@ -124,7 +126,8 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
 
             for op in &operations {
-                match op {
+                // Each arm takes the db and evaluates to its successor.
+                db = match op {
                     QmdbOperation::Update { key, value } => {
                         let k = Key::new(*key);
                         let v = Value::new(*value);
@@ -132,6 +135,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         pending_writes.push((k, Some(v)));
                         pending_expected.insert(*key, Some(*value));
                         all_keys.insert(*key);
+                        db
                     }
 
                     QmdbOperation::Delete { key } => {
@@ -145,19 +149,22 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             pending_writes.push((k, None));
                             pending_expected.insert(*key, None);
                         }
+                        db
                     }
 
                     QmdbOperation::OpCount => {
                         let _ = db.bounds().end;
+                        db
                     }
 
                     QmdbOperation::Commit => {
-                        commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                        commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await
                     }
 
                     QmdbOperation::Root => {
-                        commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                        let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                         db.root();
+                        db
                     }
 
                     QmdbOperation::Proof { start_loc, max_ops } => {
@@ -166,7 +173,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             continue;
                         }
 
-                        commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                        let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
                         let current_root = db.root();
                         let actual_op_count = db.bounds().end;
                         let adjusted_start = Location::<F>::new(*start_loc % *actual_op_count);
@@ -185,6 +192,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                                 &current_root),
                             "Proof verification failed for start_loc={adjusted_start}, max_ops={adjusted_max_ops}",
                         );
+                        db
                     }
 
                     QmdbOperation::Get { key } => {
@@ -214,13 +222,14 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         }
 
                         all_keys.insert(*key);
+                        db
                     }
-                }
+                };
             }
 
             // Final commit to ensure all operations are persisted.
             if !pending_writes.is_empty() {
-                commit_pending(&mut db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
             }
 
             // Comprehensive final verification - check ALL keys ever touched.
@@ -251,7 +260,10 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             }
 
             let batch = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(batch).await.expect("final commit should not fail");
+            let (db, _) = db
+                .apply_batch(batch)
+                .await
+                .expect("final commit should not fail");
             db.destroy().await.expect("destroy should not fail");
         }
     });

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -209,7 +209,7 @@ fn make_item(value: u8) -> Vec<u8> {
 }
 
 /// Run operations on the queue, tracking state for recovery verification. A mutation
-/// error consumes the queue, ending the run (the crash).
+/// error ends the run (the crash).
 async fn run_operations(
     mut queue: Queue<deterministic::Context, Vec<u8>>,
     operations: &[QueueOperation],

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -208,23 +208,26 @@ fn make_item(value: u8) -> Vec<u8> {
     vec![value; ITEM_SIZE]
 }
 
-/// Run operations on the queue, tracking state for recovery verification.
+/// Run operations on the queue, tracking state for recovery verification. A mutation
+/// error consumes the queue, ending the run (the crash).
 async fn run_operations(
-    queue: &mut Queue<deterministic::Context, Vec<u8>>,
+    mut queue: Queue<deterministic::Context, Vec<u8>>,
     operations: &[QueueOperation],
 ) -> RecoveryState {
     let mut state = RecoveryState::new();
 
     for op in operations {
-        match op {
+        // Each arm takes the queue and evaluates to its successor.
+        queue = match op {
             QueueOperation::Enqueue { value } => {
                 let item = make_item(*value);
                 match queue.enqueue(item).await {
-                    Ok(pos) => {
+                    Ok((queue, pos)) => {
                         // enqueue = append + commit, so success means ALL
                         // previously uncommitted items are now durable too.
                         state.commit_succeeded();
                         state.enqueue_succeeded(pos, *value);
+                        queue
                     }
                     Err(_) => {
                         state.enqueue_failed(*value);
@@ -237,8 +240,9 @@ async fn run_operations(
             QueueOperation::Append { value } => {
                 let item = make_item(*value);
                 match queue.append(item).await {
-                    Ok(pos) => {
+                    Ok((queue, pos)) => {
                         state.append_succeeded(pos, *value);
+                        queue
                     }
                     Err(_) => {
                         state.append_failed(*value);
@@ -249,8 +253,9 @@ async fn run_operations(
             }
 
             QueueOperation::Commit => match queue.commit().await {
-                Ok(()) => {
+                Ok(queue) => {
                     state.commit_succeeded();
+                    queue
                 }
                 Err(_) => {
                     state.commit_failed();
@@ -265,11 +270,13 @@ async fn run_operations(
                 {
                     state.update_ack_floor(queue.ack_floor());
                 }
+                queue
             }
 
             QueueOperation::DequeueNoAck => {
                 // Dequeue without acking - item should be re-delivered on recovery
                 let _ = queue.dequeue().await;
+                queue
             }
 
             QueueOperation::AckOffset { offset } => {
@@ -288,6 +295,7 @@ async fn run_operations(
                         }
                     }
                 }
+                queue
             }
 
             QueueOperation::AckUpToOffset { offset } => {
@@ -302,28 +310,29 @@ async fn run_operations(
                         return state;
                     }
                 }
+                queue
             }
 
-            QueueOperation::Sync => {
-                match queue.sync().await {
-                    Ok(()) => {
-                        // sync = commit + prune, so success means ALL
-                        // previously uncommitted items are now durable too.
-                        state.commit_succeeded();
-                        state.update_ack_floor(queue.ack_floor());
-                    }
-                    Err(_) => {
-                        state.commit_failed();
-                        state.mark_mutable_error();
-                        return state;
-                    }
+            QueueOperation::Sync => match queue.sync().await {
+                Ok(queue) => {
+                    // sync = commit + prune, so success means ALL
+                    // previously uncommitted items are now durable too.
+                    state.commit_succeeded();
+                    state.update_ack_floor(queue.ack_floor());
+                    queue
                 }
-            }
+                Err(_) => {
+                    state.commit_failed();
+                    state.mark_mutable_error();
+                    return state;
+                }
+            },
 
             QueueOperation::Reset => {
                 queue.reset();
+                queue
             }
-        }
+        };
     }
 
     state
@@ -333,7 +342,7 @@ async fn run_operations(
 ///
 /// Mutable errors may leave storage temporarily inconsistent, so we only assert
 /// that the queue can be re-initialized and used again for basic operations.
-async fn verify_recovery_after_mutable_error(queue: &mut Queue<deterministic::Context, Vec<u8>>) {
+async fn verify_recovery_after_mutable_error(mut queue: Queue<deterministic::Context, Vec<u8>>) {
     // Basic read-path sanity should not fail.
     let size_before = queue.size();
     queue
@@ -342,7 +351,7 @@ async fn verify_recovery_after_mutable_error(queue: &mut Queue<deterministic::Co
         .expect("dequeue should not error after recovery");
 
     // Queue should remain writable after recovery.
-    let new_pos = queue
+    let (queue, new_pos) = queue
         .enqueue(make_item(0xFF))
         .await
         .expect("enqueue should succeed after recovery");
@@ -359,10 +368,7 @@ async fn verify_recovery_after_mutable_error(queue: &mut Queue<deterministic::Co
 }
 
 /// Verify the queue state after recovery.
-async fn verify_recovery(
-    queue: &mut Queue<deterministic::Context, Vec<u8>>,
-    state: &RecoveryState,
-) {
+async fn verify_recovery(mut queue: Queue<deterministic::Context, Vec<u8>>, state: &RecoveryState) {
     if state.saw_mutable_error() {
         verify_recovery_after_mutable_error(queue).await;
         return;
@@ -444,7 +450,7 @@ async fn verify_recovery(
     );
 
     // Verify we can enqueue new items after recovery
-    let new_pos = queue.enqueue(make_item(0xFF)).await.unwrap();
+    let (_queue, new_pos) = queue.enqueue(make_item(0xFF)).await.unwrap();
     assert_eq!(new_pos, size, "new item should be at position {}", size);
 }
 
@@ -474,7 +480,7 @@ fn fuzz(input: FuzzInput) {
                 write_buffer,
             };
 
-            let mut queue = Queue::<_, Vec<u8>>::init(ctx.child("storage"), queue_cfg)
+            let queue = Queue::<_, Vec<u8>>::init(ctx.child("storage"), queue_cfg)
                 .await
                 .unwrap();
 
@@ -487,7 +493,7 @@ fn fuzz(input: FuzzInput) {
             let faults = ctx.storage_fault_config();
             *faults.write() = fault_config;
 
-            run_operations(&mut queue, &operations).await
+            run_operations(queue, &operations).await
         }
     });
 
@@ -506,11 +512,11 @@ fn fuzz(input: FuzzInput) {
             write_buffer,
         };
 
-        let mut queue = Queue::<_, Vec<u8>>::init(ctx.child("storage"), queue_cfg)
+        let queue = Queue::<_, Vec<u8>>::init(ctx.child("storage"), queue_cfg)
             .await
             .expect("Queue recovery should succeed");
 
-        verify_recovery(&mut queue, &state).await;
+        verify_recovery(queue, &state).await;
     });
 }
 

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -208,8 +208,7 @@ fn make_item(value: u8) -> Vec<u8> {
     vec![value; ITEM_SIZE]
 }
 
-/// Run operations on the queue, tracking state for recovery verification. A mutation
-/// error ends the run (the crash).
+/// Run operations on the queue, tracking state for recovery verification.
 async fn run_operations(
     mut queue: Queue<deterministic::Context, Vec<u8>>,
     operations: &[QueueOperation],
@@ -217,7 +216,6 @@ async fn run_operations(
     let mut state = RecoveryState::new();
 
     for op in operations {
-        // Each arm takes the queue and evaluates to its successor.
         queue = match op {
             QueueOperation::Enqueue { value } => {
                 let item = make_item(*value);

--- a/storage/fuzz/fuzz_targets/queue_operations.rs
+++ b/storage/fuzz/fuzz_targets/queue_operations.rs
@@ -177,22 +177,23 @@ fn fuzz(input: FuzzInput) {
         let mut reference = ReferenceQueue::new();
 
         for op in input.operations.iter() {
-            match op {
+            // Each arm takes the queue and evaluates to its successor.
+            queue = match op {
                 QueueOperation::Enqueue { value } => {
-                    let pos = queue.enqueue(vec![*value]).await.unwrap();
+                    let (queue, pos) = queue.enqueue(vec![*value]).await.unwrap();
                     let ref_pos = reference.enqueue(*value);
                     assert_eq!(pos, ref_pos, "enqueue position mismatch");
+                    queue
                 }
 
                 QueueOperation::Append { value } => {
-                    let pos = queue.append(vec![*value]).await.unwrap();
+                    let (queue, pos) = queue.append(vec![*value]).await.unwrap();
                     let ref_pos = reference.enqueue(*value);
                     assert_eq!(pos, ref_pos, "append position mismatch");
+                    queue
                 }
 
-                QueueOperation::Commit => {
-                    queue.commit().await.unwrap();
-                }
+                QueueOperation::Commit => queue.commit().await.unwrap(),
 
                 QueueOperation::Dequeue => {
                     let result = queue.dequeue().await.unwrap();
@@ -208,6 +209,7 @@ fn fuzz(input: FuzzInput) {
                             panic!("dequeue mismatch: got {actual:?}, expected {expected:?}");
                         }
                     }
+                    queue
                 }
 
                 QueueOperation::Ack { pos_offset } => {
@@ -226,6 +228,7 @@ fn fuzz(input: FuzzInput) {
                         ref_result,
                         "ack result mismatch for pos {pos}"
                     );
+                    queue
                 }
 
                 QueueOperation::AckUpTo { pos_offset } => {
@@ -241,17 +244,17 @@ fn fuzz(input: FuzzInput) {
                         ref_result,
                         "ack_up_to result mismatch for up_to {up_to}"
                     );
+                    queue
                 }
 
                 QueueOperation::Reset => {
                     queue.reset();
                     reference.reset();
+                    queue
                 }
 
-                QueueOperation::Sync => {
-                    queue.sync().await.unwrap();
-                }
-            }
+                QueueOperation::Sync => queue.sync().await.unwrap(),
+            };
 
             // Verify invariants after each operation
             assert_eq!(queue.size(), reference.size(), "size mismatch after {op:?}");

--- a/storage/fuzz/fuzz_targets/queue_operations.rs
+++ b/storage/fuzz/fuzz_targets/queue_operations.rs
@@ -177,7 +177,6 @@ fn fuzz(input: FuzzInput) {
         let mut reference = ReferenceQueue::new();
 
         for op in input.operations.iter() {
-            // Each arm takes the queue and evaluates to its successor.
             queue = match op {
                 QueueOperation::Enqueue { value } => {
                     let (queue, pos) = queue.enqueue(vec![*value]).await.unwrap();

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -123,13 +123,16 @@ fn fuzz(input: FuzzInput) {
         let mut pending: BTreeMap<Digest, Option<Vec<u8>>> = BTreeMap::new();
 
         for op in &input.ops {
-            match op {
+            // Each arm takes the db and evaluates to its successor.
+            db = match op {
                 Operation::Update { key, value_bytes } => {
                     pending.insert(Digest(*key), Some(value_bytes.clone()));
+                    db
                 }
 
                 Operation::Delete { key } => {
                     pending.insert(Digest(*key), None);
+                    db
                 }
 
                 Operation::Commit { metadata_bytes } => {
@@ -140,10 +143,12 @@ fn fuzz(input: FuzzInput) {
                             None => batch.delete(key),
                         };
                     }
-                    db.apply_batch(batch.finalize(metadata_bytes.clone()))
+                    let changeset = batch.finalize(metadata_bytes.clone());
+                    let (db, _) = db
+                        .apply_batch(changeset)
                         .await
                         .expect("Apply batch should not fail");
-                    db.commit().await.expect("Commit should not fail");
+                    db.commit().await.expect("Commit should not fail")
                 }
 
                 Operation::Get { key } => {
@@ -153,28 +158,29 @@ fn fuzz(input: FuzzInput) {
                     } else {
                         let _ = db.get(&digest).await;
                     }
+                    db
                 }
 
                 Operation::GetMetadata => {
                     let _ = db.get_metadata().await;
+                    db
                 }
 
-                Operation::Sync => {
-                    db.sync().await.expect("Sync should not fail");
-                }
+                Operation::Sync => db.sync().await.expect("Sync should not fail"),
 
                 Operation::Prune => {
-                    db.prune(db.inactivity_floor_loc())
-                        .await
-                        .expect("Prune should not fail");
+                    let floor = db.inactivity_floor_loc();
+                    db.prune(floor).await.expect("Prune should not fail")
                 }
 
                 Operation::OpCount => {
                     let _ = db.bounds().end;
+                    db
                 }
 
                 Operation::InactivityFloorLoc => {
                     let _ = db.inactivity_floor_loc();
+                    db
                 }
 
                 Operation::SimulateFailure => {
@@ -182,18 +188,19 @@ fn fuzz(input: FuzzInput) {
                     drop(db);
 
                     let cfg = test_config("store-fuzz-test", &context);
-                    db = StoreDb::init(
+                    let db = StoreDb::init(
                         context.child("db").with_attribute("instance", restarts),
                         cfg,
                     )
                     .await
                     .expect("Failed to init db");
                     restarts += 1;
+                    db
                 }
-            }
+            };
         }
 
-        db.commit().await.expect("Commit should not fail");
+        let db = db.commit().await.expect("Commit should not fail");
         db.destroy().await.expect("Destroy should not fail");
     });
 }

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -123,7 +123,6 @@ fn fuzz(input: FuzzInput) {
         let mut pending: BTreeMap<Digest, Option<Vec<u8>>> = BTreeMap::new();
 
         for op in &input.ops {
-            // Each arm takes the db and evaluates to its successor.
             db = match op {
                 Operation::Update { key, value_bytes } => {
                     pending.insert(Digest(*key), Some(value_bytes.clone()));

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -380,12 +380,10 @@ where
     pub async fn commit(mut self) -> Result<Self, Error<F>> {
         // Though not necessary for recovery, we flush the merkle structure (without syncing it) to
         // limit memory bloat.
-        let (journal, merkle) = try_join!(
+        (self.journal, self.merkle) = try_join!(
             self.journal.commit().map_err(Error::Journal),
             self.merkle.flush().map_err(Error::Merkle)
         )?;
-        self.journal = journal;
-        self.merkle = merkle;
 
         Ok(self)
     }
@@ -480,8 +478,8 @@ where
         let encoded_item = item.encode();
 
         // Append item to the journal, then update the Merkle structure state.
-        let (journal, loc) = self.journal.append(item).await?;
-        self.journal = journal;
+        let loc;
+        (self.journal, loc) = self.journal.append(item).await?;
         let unmerkleized_batch = self.merkle.new_batch().add(&self.hasher, &encoded_item);
         let batch = self
             .merkle
@@ -588,15 +586,13 @@ where
         // replay the items between the structure's last element and the journal's first element.
         // Commit the journal alongside: the prune target may be justified by a buffered append
         // (e.g. a commit operation), and pruning does not guarantee buffered appends are durable.
-        let (journal, merkle) = try_join!(
+        (self.journal, self.merkle) = try_join!(
             self.journal.commit().map_err(Error::Journal),
             self.merkle.sync().map_err(Error::Merkle)
         )?;
-        self.journal = journal;
-        self.merkle = merkle;
 
-        let (journal, journal_pruned) = self.journal.prune(*prune_loc).await?;
-        self.journal = journal;
+        let journal_pruned;
+        (self.journal, journal_pruned) = self.journal.prune(*prune_loc).await?;
         let bounds = self.journal.bounds();
         let boundary = Location::new(bounds.start);
         let merkle_boundary = self.merkle.bounds().start;
@@ -715,12 +711,10 @@ where
 
     /// Durably persist the journal, ensuring no recovery is required on startup.
     pub async fn sync(mut self) -> Result<Self, Error<F>> {
-        let (journal, merkle) = try_join!(
+        (self.journal, self.merkle) = try_join!(
             self.journal.sync().map_err(Error::Journal),
             self.merkle.sync().map_err(Error::Merkle)
         )?;
-        self.journal = journal;
-        self.merkle = merkle;
 
         Ok(self)
     }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -1786,7 +1786,7 @@ mod tests {
             assert_eq!(bounds.start, 98);
             assert!(bounds.is_empty());
 
-            // Rewinding into the pruned region fails, consuming the journal.
+            // Rewinding into the pruned region fails.
             let res = journal.rewind(97).await;
             assert!(matches!(
                 res,
@@ -1794,7 +1794,7 @@ mod tests {
             ));
         }
 
-        // Test 8: Rewind target beyond current size fails, consuming the journal.
+        // Test 8: Rewind target beyond current size fails.
         {
             let merkle_cfg = merkle_config("rewind-invalid", &context);
             let journal_cfg = journal_config("rewind-invalid", &context);
@@ -2829,7 +2829,7 @@ mod tests {
             .unwrap();
         assert_eq!(ops, vec![op_a.clone()]);
 
-        // Apply B -- should fail (stale), consuming the journal.
+        // Apply B -- should fail (stale).
         let result = journal.apply_batch(&merkleized_b).await;
         assert!(
             matches!(

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -4,12 +4,19 @@
 //! structure. The item at index i in the journal corresponds to the leaf at Location i in the
 //! Merkle structure. This structure enables efficient proofs that an item is included in the
 //! journal at a specific location.
+//!
+//! # Ownership
+//!
+//! Mutating methods take the journal by value and return it on success. If a mutating
+//! method returns an error, or its future is dropped before it finishes, the journal is
+//! gone: state that was not yet durable is discarded, but everything already on disk stays
+//! recoverable.
 
 use crate::{
     Context,
     journal::{
         Error as JournalError,
-        contiguous::{Contiguous, Many, Mutable, fixed, variable},
+        contiguous::{Contiguous, Many, Mutable},
     },
     merkle::{
         self, Bagging, Family, Location, Position, Proof, Readable, batch, full::Merkle,
@@ -20,7 +27,7 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use commonware_codec::{CodecFixedShared, CodecShared, Encode, EncodeShared};
+use commonware_codec::{Encode, EncodeShared};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
@@ -252,6 +259,21 @@ where
     pub(crate) hasher: StandardHasher<H>,
 }
 
+impl<F, E, C, H, S> core::fmt::Debug for Journal<F, E, C, H, S>
+where
+    F: Family,
+    E: Context,
+    C: Contiguous<Item: EncodeShared>,
+    H: Hasher,
+    S: Strategy,
+{
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Journal")
+            .field("size", &self.size())
+            .finish_non_exhaustive()
+    }
+}
+
 impl<F, E, C, H, S> Journal<F, E, C, H, S>
 where
     F: Family,
@@ -355,15 +377,17 @@ where
     /// Durably persist the journal. This is faster than `sync()` but does not guarantee that the
     /// Merkle structure is durably persisted, meaning recovery may be required on startup in the
     /// event of a crash.
-    pub async fn commit(&mut self) -> Result<(), Error<F>> {
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
         // Though not necessary for recovery, we flush the merkle structure (without syncing it) to
         // limit memory bloat.
-        try_join!(
+        let (journal, merkle) = try_join!(
             self.journal.commit().map_err(Error::Journal),
             self.merkle.flush().map_err(Error::Merkle)
         )?;
+        self.journal = journal;
+        self.merkle = merkle;
 
-        Ok(())
+        Ok(self)
     }
 }
 
@@ -377,17 +401,18 @@ where
 {
     /// Create a new [Journal] from the given components after aligning the Merkle structure with
     /// the journal.
+    #[boxed]
     pub async fn from_components(
-        mut merkle: Merkle<F, E, H::Digest, S>,
+        merkle: Merkle<F, E, H::Digest, S>,
         journal: C,
         hasher: StandardHasher<H>,
         apply_batch_size: u64,
     ) -> Result<Self, Error<F>> {
-        Self::align(&mut merkle, &journal, &hasher, apply_batch_size).await?;
+        let merkle = Self::align(merkle, &journal, &hasher, apply_batch_size).await?;
 
         // Sync the Merkle structure to disk to avoid having to repeat any recovery that may have
         // been performed on next startup.
-        merkle.sync().await?;
+        let merkle = merkle.sync().await?;
 
         Ok(Self {
             merkle,
@@ -402,11 +427,11 @@ where
     /// memory use: each batch's items are buffered in memory so their leaves can be hashed
     /// across the strategy.
     async fn align(
-        merkle: &mut Merkle<F, E, H::Digest, S>,
+        mut merkle: Merkle<F, E, H::Digest, S>,
         journal: &C,
         hasher: &StandardHasher<H>,
         apply_batch_size: u64,
-    ) -> Result<(), Error<F>> {
+    ) -> Result<Merkle<F, E, H::Digest, S>, Error<F>> {
         // Rewind Merkle structure elements that are ahead of the journal.
         let journal_size = journal.bounds().end;
         let mut merkle_leaves = merkle.leaves();
@@ -417,7 +442,7 @@ where
                 ?rewind_count,
                 "rewinding Merkle structure to match journal"
             );
-            merkle.rewind(*rewind_count as usize).await?;
+            merkle = merkle.rewind(*rewind_count as usize).await?;
             merkle_leaves = Location::new(journal_size);
         }
 
@@ -439,30 +464,31 @@ where
 
                 let batch = merkle.new_batch().add_many(hasher, &items);
                 let batch = merkle.with_mem(|mem| batch.merkleize(mem, hasher));
-                merkle.apply_batch(&batch)?;
+                merkle = merkle.apply_batch(&batch)?;
             }
-            return Ok(());
+            return Ok(merkle);
         }
 
         // At this point the Merkle structure and journal should be consistent.
         assert_eq!(journal.bounds().end, *merkle.leaves());
 
-        Ok(())
+        Ok(merkle)
     }
 
     /// Append an item to the journal and update the Merkle structure.
-    pub async fn append(&mut self, item: &C::Item) -> Result<Location<F>, Error<F>> {
+    pub async fn append(mut self, item: &C::Item) -> Result<(Self, Location<F>), Error<F>> {
         let encoded_item = item.encode();
 
         // Append item to the journal, then update the Merkle structure state.
-        let loc = self.journal.append(item).await?;
+        let (journal, loc) = self.journal.append(item).await?;
+        self.journal = journal;
         let unmerkleized_batch = self.merkle.new_batch().add(&self.hasher, &encoded_item);
         let batch = self
             .merkle
             .with_mem(|mem| unmerkleized_batch.merkleize(mem, &self.hasher));
-        self.merkle.apply_batch(&batch)?;
+        self.merkle = self.merkle.apply_batch(&batch)?;
 
-        Ok(Location::new(loc))
+        Ok((self, Location::new(loc)))
     }
 
     /// Apply a batch to the journal.
@@ -472,9 +498,9 @@ where
     /// Already-committed ancestors are skipped automatically.
     /// Applying a batch from a different fork returns an error.
     pub async fn apply_batch(
-        &mut self,
+        mut self,
         batch: &MerkleizedBatch<F, H::Digest, C::Item, S>,
-    ) -> Result<(), Error<F>> {
+    ) -> Result<Self, Error<F>> {
         let merkle_size = self.merkle.size();
         let base_size = batch.inner.base_size();
 
@@ -516,43 +542,45 @@ where
             batches.push(&batch.items);
         }
         if !batches.is_empty() {
-            self.journal.append_many(Many::Nested(&batches)).await?;
+            (self.journal, _) = self.journal.append_many(Many::Nested(&batches)).await?;
         }
 
-        self.merkle.apply_batch(&batch.inner)?;
+        self.merkle = self.merkle.apply_batch(&batch.inner)?;
         assert_eq!(*self.merkle.leaves(), self.journal.bounds().end);
-        Ok(())
+        Ok(self)
     }
 
     /// Rewind the journal and Merkle structure.
-    pub async fn rewind(&mut self, size: u64) -> Result<(), Error<F>> {
-        self.journal.rewind(size).await?;
+    #[boxed]
+    pub async fn rewind(mut self, size: u64) -> Result<Self, Error<F>> {
+        self.journal = self.journal.rewind(size).await?;
 
         let leaves = *self.merkle.leaves();
         if leaves > size {
-            self.merkle.rewind((leaves - size) as usize).await?;
+            self.merkle = self.merkle.rewind((leaves - size) as usize).await?;
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Prune both the Merkle structure and journal to the given location.
     ///
     /// # Returns
     /// The new pruning boundary, which may be less than the requested `prune_loc`.
-    pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<Location<F>, Error<F>> {
-        self.prune_inner(prune_loc)
-            .await
-            .map(|(boundary, _)| boundary)
+    #[boxed]
+    pub async fn prune(self, prune_loc: Location<F>) -> Result<(Self, Location<F>), Error<F>> {
+        let (journal, boundary, _) = self.prune_inner(prune_loc).await?;
+        Ok((journal, boundary))
     }
 
     async fn prune_inner(
-        &mut self,
+        mut self,
         prune_loc: Location<F>,
-    ) -> Result<(Location<F>, bool), Error<F>> {
+    ) -> Result<(Self, Location<F>, bool), Error<F>> {
         if self.merkle.size() == 0 {
             // DB is empty, nothing to prune.
-            return Ok((Location::new(self.journal.bounds().start), false));
+            let boundary = Location::new(self.journal.bounds().start);
+            return Ok((self, boundary, false));
         }
 
         // Sync the Merkle structure before pruning the journal, otherwise its last element could
@@ -560,22 +588,25 @@ where
         // replay the items between the structure's last element and the journal's first element.
         // Commit the journal alongside: the prune target may be justified by a buffered append
         // (e.g. a commit operation), and pruning does not guarantee buffered appends are durable.
-        try_join!(
+        let (journal, merkle) = try_join!(
             self.journal.commit().map_err(Error::Journal),
             self.merkle.sync().map_err(Error::Merkle)
         )?;
+        self.journal = journal;
+        self.merkle = merkle;
 
-        let journal_pruned = self.journal.prune(*prune_loc).await?;
+        let (journal, journal_pruned) = self.journal.prune(*prune_loc).await?;
+        self.journal = journal;
         let bounds = self.journal.bounds();
         let boundary = Location::new(bounds.start);
         let merkle_boundary = self.merkle.bounds().start;
 
         if boundary > merkle_boundary {
             debug!(size = ?bounds.end, ?prune_loc, boundary = ?bounds.start, "pruned inactive ops");
-            self.merkle.prune(boundary).await?;
+            self.merkle = self.merkle.prune(boundary).await?;
         }
 
-        Ok((boundary, journal_pruned || boundary > merkle_boundary))
+        Ok((self, boundary, journal_pruned || boundary > merkle_boundary))
     }
 }
 
@@ -683,66 +714,58 @@ where
     }
 
     /// Durably persist the journal, ensuring no recovery is required on startup.
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
-        try_join!(
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
+        let (journal, merkle) = try_join!(
             self.journal.sync().map_err(Error::Journal),
             self.merkle.sync().map_err(Error::Merkle)
         )?;
+        self.journal = journal;
+        self.merkle = merkle;
 
-        Ok(())
+        Ok(self)
     }
 }
 
 /// The number of items to apply to the Merkle structure in a single batch.
 const APPLY_BATCH_SIZE: u64 = 1 << 16;
 
-/// Generate a `new()` constructor for an authenticated journal backed by a specific contiguous
-/// journal type.
-macro_rules! impl_journal_new {
-    ($journal_mod:ident, $cfg_ty:ty, $codec_bound:path) => {
-        impl<F, E, O, H, S> Journal<F, E, $journal_mod::Journal<E, O>, H, S>
-        where
-            F: Family,
-            E: Context,
-            O: $codec_bound,
-            H: Hasher,
-            S: Strategy,
-        {
-            /// Create a new authenticated [Journal].
-            ///
-            /// The inner journal will be rewound to the last item matching `rewind_predicate`,
-            /// and the merkle structure will be aligned to match.
-            #[boxed]
-            pub async fn new(
-                context: E,
-                merkle_cfg: merkle::full::Config<S>,
-                journal_cfg: $cfg_ty,
-                rewind_predicate: fn(&O) -> bool,
-                bagging: merkle::Bagging,
-            ) -> Result<Self, Error<F>> {
-                let mut journal =
-                    $journal_mod::Journal::init(context.child("journal"), journal_cfg).await?;
-                journal.rewind_to(rewind_predicate).await?;
+impl<F, E, C, H, S> Journal<F, E, C, H, S>
+where
+    F: Family,
+    E: Context,
+    C: Backing<E, Item: EncodeShared>,
+    H: Hasher,
+    S: Strategy,
+{
+    /// Create a new authenticated [Journal].
+    ///
+    /// The backing journal will be rewound to the last item matching `rewind_predicate`,
+    /// and the merkle structure will be aligned to match.
+    #[boxed]
+    pub async fn new(
+        context: E,
+        merkle_cfg: merkle::full::Config<S>,
+        journal_cfg: C::Config,
+        rewind_predicate: fn(&C::Item) -> bool,
+        bagging: merkle::Bagging,
+    ) -> Result<Self, Error<F>> {
+        let journal = C::init(context.child("journal"), journal_cfg).await?;
+        let (journal, _) = journal.rewind_to(rewind_predicate).await?;
 
-                let hasher = StandardHasher::<H>::new(bagging);
-                let mut merkle = Merkle::init(context.child("merkle"), &hasher, merkle_cfg).await?;
-                Self::align(&mut merkle, &journal, &hasher, APPLY_BATCH_SIZE).await?;
+        let hasher = StandardHasher::<H>::new(bagging);
+        let merkle = Merkle::init(context.child("merkle"), &hasher, merkle_cfg).await?;
+        let merkle = Self::align(merkle, &journal, &hasher, APPLY_BATCH_SIZE).await?;
 
-                journal.sync().await?;
-                merkle.sync().await?;
+        let journal = journal.sync().await?;
+        let merkle = merkle.sync().await?;
 
-                Ok(Self {
-                    merkle,
-                    journal,
-                    hasher,
-                })
-            }
-        }
-    };
+        Ok(Self {
+            merkle,
+            journal,
+            hasher,
+        })
+    }
 }
-
-impl_journal_new!(fixed, fixed::Config, CodecFixedShared);
-impl_journal_new!(variable, variable::Config<O::Cfg>, CodecShared);
 
 impl<F, E, C, H, S> Journal<F, E, C, H, S>
 where
@@ -898,17 +921,17 @@ where
     H: Hasher,
     S: Strategy,
 {
-    async fn append(&mut self, item: &Self::Item) -> Result<u64, JournalError> {
-        let res = self.append(item).await.map_err(Self::map_error)?;
+    async fn append(self, item: &Self::Item) -> Result<(Self, u64), JournalError> {
+        let (journal, loc) = Self::append(self, item).await.map_err(Self::map_error)?;
 
-        Ok(*res)
+        Ok((journal, *loc))
     }
 
-    async fn append_many<'a>(
-        &'a mut self,
-        items: Many<'a, Self::Item>,
-    ) -> Result<u64, JournalError> {
-        // The per-item loop below never reaches the inner journal's shared empty check, so the
+    async fn append_many(
+        mut self,
+        items: Many<'_, Self::Item>,
+    ) -> Result<(Self, u64), JournalError> {
+        // The per-item loop below never reaches the backing journal's shared empty check, so the
         // trait's EmptyAppend contract must be enforced here.
         if items.is_empty() {
             return Err(JournalError::EmptyAppend);
@@ -916,47 +939,52 @@ where
 
         // Every append must also update the Merkle structure, so items append one at a time.
         // Batched appends of already-merkleized items go through `apply_batch`, which batches
-        // the inner journal writes instead.
+        // the backing journal writes instead.
         let mut last_pos = self.journal.bounds().end;
         match items {
             Many::Flat(items) => {
                 for item in items {
-                    last_pos = Mutable::append(self, item).await?;
+                    let (journal, loc) = Self::append(self, item).await.map_err(Self::map_error)?;
+                    self = journal;
+                    last_pos = *loc;
                 }
             }
             Many::Nested(nested_items) => {
                 for items in nested_items {
                     for item in *items {
-                        last_pos = Mutable::append(self, item).await?;
+                        let (journal, loc) =
+                            Self::append(self, item).await.map_err(Self::map_error)?;
+                        self = journal;
+                        last_pos = *loc;
                     }
                 }
             }
         }
-        Ok(last_pos)
+        Ok((self, last_pos))
     }
 
-    async fn prune(&mut self, min_position: u64) -> Result<bool, JournalError> {
+    async fn prune(self, min_position: u64) -> Result<(Self, bool), JournalError> {
         let prune_to = {
             let bounds = self.journal.bounds();
             min_position.min(bounds.end)
         };
 
-        let (_, pruned) = self
+        let (journal, _, pruned) = self
             .prune_inner(Location::new(prune_to))
             .await
             .map_err(Self::map_error)?;
-        Ok(pruned)
+        Ok((journal, pruned))
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), JournalError> {
-        self.rewind(size).await.map_err(Self::map_error)
+    async fn rewind(self, size: u64) -> Result<Self, JournalError> {
+        Self::rewind(self, size).await.map_err(Self::map_error)
     }
 
-    async fn commit(&mut self) -> Result<(), JournalError> {
+    async fn commit(self) -> Result<Self, JournalError> {
         Self::commit(self).await.map_err(Self::map_error)
     }
 
-    async fn sync(&mut self) -> Result<(), JournalError> {
+    async fn sync(self) -> Result<Self, JournalError> {
         Self::sync(self).await.map_err(Self::map_error)
     }
 
@@ -965,22 +993,18 @@ where
     }
 }
 
-/// A [Mutable] journal that can serve as the inner journal of an authenticated [Journal].
-pub trait Inner<E: Context>: Mutable {
+/// A [Mutable] journal that can back an authenticated [Journal].
+pub trait Backing<E: Context>: Mutable {
     /// The configuration needed to initialize this journal.
     type Config: Clone + Send;
 
-    /// Initialize an authenticated [Journal] backed by this journal type.
-    fn init<F: Family, H: Hasher, S: Strategy>(
+    /// Initialize the journal from its configuration.
+    fn init(
         context: E,
-        merkle_cfg: merkle::full::Config<S>,
-        journal_cfg: Self::Config,
-        rewind_predicate: fn(&Self::Item) -> bool,
-        bagging: merkle::Bagging,
-    ) -> impl core::future::Future<Output = Result<Journal<F, E, Self, H, S>, Error<F>>> + Send
+        cfg: Self::Config,
+    ) -> impl core::future::Future<Output = Result<Self, JournalError>> + Send
     where
-        Self: Sized,
-        Self::Item: EncodeShared;
+        Self: Sized;
 }
 
 #[cfg(test)]
@@ -1156,9 +1180,9 @@ mod tests {
             let count = 4200u64;
             for i in 0..count {
                 let op = create_operation::<mmr::Family>((i % 251) as u8);
-                journal.append(&op).await.unwrap();
+                (journal, _) = journal.append(&op).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..count).collect();
             let batch = Contiguous::read_many(&journal, &positions).await.unwrap();
@@ -1186,9 +1210,9 @@ mod tests {
             let mut journal = create_empty_journal::<mmr::Family>(context, "unsorted").await;
             for i in 0..2u8 {
                 let op = create_operation::<mmr::Family>(i);
-                journal.append(&op).await.unwrap();
+                (journal, _) = journal.append(&op).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
 
             let _ = Contiguous::read_many(&journal, &[1, 0]).await;
         });
@@ -1214,11 +1238,12 @@ mod tests {
 
         for i in 0..count {
             let op = create_operation::<F>(i as u8);
-            let loc = journal.append(&op).await.unwrap();
+            let loc;
+            (journal, loc) = journal.append(&op).await.unwrap();
             assert_eq!(loc, Location::<F>::new(i as u64));
         }
 
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
         journal
     }
 
@@ -1287,9 +1312,9 @@ mod tests {
 
     /// Verify that align() correctly handles empty Merkle and journal components.
     async fn test_align_with_empty_mmr_and_journal_inner<F: Family + PartialEq>(context: Context) {
-        let (mut merkle, journal, hasher) = create_components::<F>(context, "align-empty").await;
+        let (merkle, journal, hasher) = create_components::<F>(context, "align-empty").await;
 
-        TestJournal::<F>::align(&mut merkle, &journal, &hasher, APPLY_BATCH_SIZE)
+        let merkle = TestJournal::<F>::align(merkle, &journal, &hasher, APPLY_BATCH_SIZE)
             .await
             .unwrap();
 
@@ -1321,21 +1346,21 @@ mod tests {
                     let op = create_operation::<F>(i as u8);
                     let encoded = op.encode();
                     batch = batch.add(&hasher, &encoded);
-                    journal.append(&op).await.unwrap();
+                    (journal, _) = journal.append(&op).await.unwrap();
                 }
                 batch
             };
             let batch = merkle.with_mem(|mem| batch.merkleize(mem, &hasher));
-            merkle.apply_batch(&batch).unwrap();
+            merkle = merkle.apply_batch(&batch).unwrap();
         }
 
         // Add commit operation to journal only (making journal ahead)
         let commit_op = TestOp::<F>::CommitFloor(None, Location::<F>::new(0));
-        journal.append(&commit_op).await.unwrap();
-        journal.sync().await.unwrap();
+        let (journal, _) = journal.append(&commit_op).await.unwrap();
+        let journal = journal.sync().await.unwrap();
 
         // Merkle has 20 leaves, journal has 21 operations (20 ops + 1 commit)
-        TestJournal::<F>::align(&mut merkle, &journal, &hasher, APPLY_BATCH_SIZE)
+        let merkle = TestJournal::<F>::align(merkle, &journal, &hasher, APPLY_BATCH_SIZE)
             .await
             .unwrap();
 
@@ -1358,22 +1383,21 @@ mod tests {
 
     /// Verify that align() replays journal operations when journal is ahead of Merkle.
     async fn test_align_when_journal_ahead_inner<F: Family + PartialEq>(context: Context) {
-        let (mut merkle, mut journal, hasher) =
-            create_components::<F>(context, "journal-ahead").await;
+        let (merkle, mut journal, hasher) = create_components::<F>(context, "journal-ahead").await;
 
         // Add 20 operations to journal only
         for i in 0..20 {
             let op = create_operation::<F>(i as u8);
-            journal.append(&op).await.unwrap();
+            (journal, _) = journal.append(&op).await.unwrap();
         }
 
         // Add commit
         let commit_op = TestOp::<F>::CommitFloor(None, Location::<F>::new(0));
-        journal.append(&commit_op).await.unwrap();
-        journal.sync().await.unwrap();
+        let (journal, _) = journal.append(&commit_op).await.unwrap();
+        let journal = journal.sync().await.unwrap();
 
         // Journal has 21 operations, Merkle has 0 leaves
-        TestJournal::<F>::align(&mut merkle, &journal, &hasher, APPLY_BATCH_SIZE)
+        let merkle = TestJournal::<F>::align(merkle, &journal, &hasher, APPLY_BATCH_SIZE)
             .await
             .unwrap();
 
@@ -1414,32 +1438,32 @@ mod tests {
         .await
         .unwrap();
         for i in 0..20 {
-            journal
+            (journal, _) = journal
                 .append(&create_operation::<F>(i as u8))
                 .await
                 .unwrap();
         }
         let commit_op = TestOp::<F>::CommitFloor(None, Location::<F>::new(0));
-        journal.append(&commit_op).await.unwrap();
-        journal.sync().await.unwrap();
+        let (journal, _) = journal.append(&commit_op).await.unwrap();
+        let journal = journal.sync().await.unwrap();
 
         // Replay with a batch size that forces multiple batches on each side. `Sequential`
         // hashes each batch serially, and a `Manual`-wrapped strategy runs the batch hashing
         // across its pool without any adaptive policy, so the two replays deterministically
         // exercise both the serial and parallel hashing paths.
         let hasher = StandardHasher::<Sha256>::new(ForwardFold);
-        let mut serial = Merkle::<F, _, Digest, Sequential>::init(
+        let serial = Merkle::<F, _, Digest, Sequential>::init(
             context.child("mmr_serial"),
             &hasher,
             merkle_config("replay-serial", &context),
         )
         .await
         .unwrap();
-        TestJournal::<F>::align(&mut serial, &journal, &hasher, 7)
+        let serial = TestJournal::<F>::align(serial, &journal, &hasher, 7)
             .await
             .unwrap();
 
-        let mut parallel = Merkle::<F, _, Digest, Manual<Rayon>>::init(
+        let parallel = Merkle::<F, _, Digest, Manual<Rayon>>::init(
             context.child("mmr_parallel"),
             &hasher,
             merkle_config_with(
@@ -1450,7 +1474,7 @@ mod tests {
         )
         .await
         .unwrap();
-        ParallelJournal::<F>::align(&mut parallel, &journal, &hasher, 7)
+        let parallel = ParallelJournal::<F>::align(parallel, &journal, &hasher, 7)
             .await
             .unwrap();
 
@@ -1482,7 +1506,8 @@ mod tests {
 
         // Add 20 uncommitted operations
         for i in 0..20 {
-            let loc = journal
+            let loc;
+            (journal, loc) = journal
                 .append(&create_operation::<F>(i as u8))
                 .await
                 .unwrap();
@@ -1496,7 +1521,6 @@ mod tests {
 
         // Drop and recreate to simulate restart (which calls align internally)
         journal.sync().await.unwrap();
-        drop(journal);
         let journal = create_empty_journal::<F>(context.child("second"), "mismatched").await;
 
         // Uncommitted operations should be gone
@@ -1531,18 +1555,19 @@ mod tests {
 
             // Add operations where operation 3 is a commit
             for i in 0..3 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal
+            (journal, _) = journal
                 .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
                 .await
                 .unwrap();
             for i in 4..7 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
 
             // Rewind to last commit
-            let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
+            let final_size;
+            (journal, final_size) = journal.rewind_to(|op| op.is_commit()).await.unwrap();
             assert_eq!(final_size, 4);
             assert_eq!(journal.size(), 4);
 
@@ -1561,20 +1586,21 @@ mod tests {
             .unwrap();
 
             // Add multiple commits
-            journal.append(&create_operation::<F>(0)).await.unwrap();
-            journal
+            (journal, _) = journal.append(&create_operation::<F>(0)).await.unwrap();
+            (journal, _) = journal
                 .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
                 .await
                 .unwrap(); // pos 1
-            journal.append(&create_operation::<F>(2)).await.unwrap();
-            journal
+            (journal, _) = journal.append(&create_operation::<F>(2)).await.unwrap();
+            (journal, _) = journal
                 .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(1)))
                 .await
                 .unwrap(); // pos 3
-            journal.append(&create_operation::<F>(4)).await.unwrap();
+            (journal, _) = journal.append(&create_operation::<F>(4)).await.unwrap();
 
             // Should rewind to last commit (pos 3)
-            let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
+            let final_size;
+            (journal, final_size) = journal.rewind_to(|op| op.is_commit()).await.unwrap();
             assert_eq!(final_size, 4);
 
             // Verify the last commit is still there
@@ -1596,11 +1622,12 @@ mod tests {
 
             // Add operations with no commits
             for i in 0..10 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
 
             // Rewind should go to pruning boundary (0 for unpruned)
-            let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
+            let final_size;
+            (journal, final_size) = journal.rewind_to(|op| op.is_commit()).await.unwrap();
             assert_eq!(final_size, 0, "Should rewind to pruning boundary (0)");
             assert_eq!(journal.size(), 0);
         }
@@ -1616,28 +1643,29 @@ mod tests {
 
             // Add operations and a commit at position 10 (past first section boundary of 7)
             for i in 0..10 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal
+            (journal, _) = journal
                 .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
                 .await
                 .unwrap(); // pos 10
             for i in 11..15 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Prune up to position 8 (this will prune section 0, items 0-6, keeping 7+)
-            journal.prune(8).await.unwrap();
+            (journal, _) = journal.prune(8).await.unwrap();
             assert_eq!(journal.bounds().start, 7);
 
             // Add more uncommitted operations
             for i in 15..20 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
 
             // Rewind should keep the commit at position 10
-            let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
+            let final_size;
+            (journal, final_size) = journal.rewind_to(|op| op.is_commit()).await.unwrap();
             assert_eq!(final_size, 11);
 
             // Verify commit is still there
@@ -1656,30 +1684,30 @@ mod tests {
 
             // Add operations with a commit at position 5 (in section 0: 0-6)
             for i in 0..5 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal
+            (journal, _) = journal
                 .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
                 .await
                 .unwrap(); // pos 5
             for i in 6..10 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Prune up to position 8 (this prunes section 0, including the commit at pos 5)
             // Pruning boundary will be at position 7 (start of section 1)
-            journal.prune(8).await.unwrap();
+            (journal, _) = journal.prune(8).await.unwrap();
             assert_eq!(journal.bounds().start, 7);
 
             // Add uncommitted operations with no commits (in section 1: 7-13)
             for i in 10..14 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
 
             // Rewind with no matching commits after the pruning boundary
             // Should rewind to the pruning boundary at position 7
-            let final_size = journal.rewind_to(|op| op.is_commit()).await.unwrap();
+            let (_, final_size) = journal.rewind_to(|op| op.is_commit()).await.unwrap();
             assert_eq!(final_size, 7);
         }
 
@@ -1693,7 +1721,8 @@ mod tests {
             .unwrap();
 
             // Rewind empty journal should be no-op
-            let final_size = journal
+            let final_size;
+            (journal, final_size) = journal
                 .rewind_to(|op: &TestOp<F>| op.is_commit())
                 .await
                 .unwrap();
@@ -1706,7 +1735,7 @@ mod tests {
             let merkle_cfg = merkle_config("rewind", &context);
             let journal_cfg = journal_config("rewind", &context);
             let mut journal = TestJournal::<F>::new(
-                context,
+                context.child("rewind"),
                 merkle_cfg,
                 journal_cfg,
                 |op| op.is_commit(),
@@ -1717,18 +1746,18 @@ mod tests {
 
             // Add operations with a commit at position 5 (in section 0: 0-6)
             for i in 0..5 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal
+            (journal, _) = journal
                 .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
                 .await
                 .unwrap(); // pos 5
             for i in 6..10 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 10);
 
-            journal.rewind(2).await.unwrap();
+            journal = journal.rewind(2).await.unwrap();
             assert_eq!(journal.size(), 2);
             assert_eq!(journal.merkle.leaves(), 2);
             assert_eq!(journal.merkle.size(), 3);
@@ -1736,12 +1765,7 @@ mod tests {
             assert_eq!(bounds.start, 0);
             assert!(!bounds.is_empty());
 
-            assert!(matches!(
-                journal.rewind(3).await,
-                Err(Error::Journal(JournalError::InvalidRewind(_)))
-            ));
-
-            journal.rewind(0).await.unwrap();
+            journal = journal.rewind(0).await.unwrap();
             assert_eq!(journal.size(), 0);
             assert_eq!(journal.merkle.leaves(), 0);
             assert_eq!(journal.merkle.size(), 0);
@@ -1751,21 +1775,46 @@ mod tests {
 
             // Test rewinding after pruning.
             for i in 0..255 {
-                journal.append(&create_operation::<F>(i)).await.unwrap();
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
             }
-            journal.prune(Location::<F>::new(100)).await.unwrap();
+            (journal, _) = journal.prune(Location::<F>::new(100)).await.unwrap();
             assert_eq!(journal.bounds().start, 98);
-            let res = journal.rewind(97).await;
-            assert!(matches!(
-                res,
-                Err(Error::Journal(JournalError::ItemPruned(97)))
-            ));
-            journal.rewind(98).await.unwrap();
+            journal = journal.rewind(98).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 98);
             assert_eq!(journal.merkle.leaves(), 98);
             assert_eq!(bounds.start, 98);
             assert!(bounds.is_empty());
+
+            // Rewinding into the pruned region fails, consuming the journal.
+            let res = journal.rewind(97).await;
+            assert!(matches!(
+                res,
+                Err(Error::Journal(JournalError::ItemPruned(97)))
+            ));
+        }
+
+        // Test 8: Rewind target beyond current size fails, consuming the journal.
+        {
+            let merkle_cfg = merkle_config("rewind-invalid", &context);
+            let journal_cfg = journal_config("rewind-invalid", &context);
+            let mut journal = TestJournal::<F>::new(
+                context,
+                merkle_cfg,
+                journal_cfg,
+                |op| op.is_commit(),
+                ForwardFold,
+            )
+            .await
+            .unwrap();
+
+            for i in 0..2 {
+                (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
+            }
+            assert!(matches!(
+                journal.rewind(3).await,
+                Err(Error::Journal(JournalError::InvalidRewind(_)))
+            ));
         }
     }
 
@@ -1791,7 +1840,8 @@ mod tests {
         // Add 50 operations
         let expected_ops: Vec<_> = (0..50).map(|i| create_operation::<F>(i as u8)).collect();
         for (i, op) in expected_ops.iter().enumerate() {
-            let loc = journal.append(op).await.unwrap();
+            let loc;
+            (journal, loc) = journal.append(op).await.unwrap();
             assert_eq!(loc, Location::<F>::new(i as u64));
             assert_eq!(journal.size(), (i + 1) as u64);
         }
@@ -1799,7 +1849,7 @@ mod tests {
         assert_eq!(journal.size(), 50);
 
         // Verify all operations can be read back correctly
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
         for (i, expected_op) in expected_ops.iter().enumerate() {
             let read_op = journal.read(*Location::<F>::new(i as u64)).await.unwrap();
             assert_eq!(read_op, *expected_op);
@@ -1866,12 +1916,13 @@ mod tests {
         let mut journal = create_journal_with_ops::<F>(context, "read_pruned", 100).await;
 
         // Add commit and prune
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
-        let pruned_boundary = journal.prune(Location::<F>::new(50)).await.unwrap();
+        journal = journal.sync().await.unwrap();
+        let pruned_boundary;
+        (journal, pruned_boundary) = journal.prune(Location::<F>::new(50)).await.unwrap();
 
         // Try to read an operation before the pruned boundary
         let read_loc = Location::<F>::new(0);
@@ -1955,12 +2006,14 @@ mod tests {
         // Add 20 operations
         let expected_ops: Vec<_> = (0..20).map(|i| create_operation::<F>(i as u8)).collect();
         for (i, op) in expected_ops.iter().enumerate() {
-            let loc = journal.append(op).await.unwrap();
+            let loc;
+            (journal, loc) = journal.append(op).await.unwrap();
             assert_eq!(loc, Location::<F>::new(i as u64),);
         }
 
         // Add commit operation to commit the operations
-        let commit_loc = journal
+        let commit_loc;
+        (journal, commit_loc) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
             .await
             .unwrap();
@@ -1972,7 +2025,6 @@ mod tests {
         journal.sync().await.unwrap();
 
         // Reopen and verify the operations persisted
-        drop(journal);
         let journal = create_empty_journal::<F>(context.child("second"), "close_pending").await;
         assert_eq!(journal.size(), 21);
 
@@ -1997,9 +2049,9 @@ mod tests {
 
     /// Verify that pruning an empty journal returns the boundary.
     async fn test_prune_empty_journal_inner<F: Family + PartialEq>(context: Context) {
-        let mut journal = create_empty_journal::<F>(context, "prune_empty").await;
+        let journal = create_empty_journal::<F>(context, "prune_empty").await;
 
-        let boundary = journal.prune(Location::<F>::new(0)).await.unwrap();
+        let (_, boundary) = journal.prune(Location::<F>::new(0)).await.unwrap();
 
         assert_eq!(boundary, Location::<F>::new(0));
     }
@@ -2021,13 +2073,13 @@ mod tests {
         let mut journal = create_journal_with_ops::<F>(context, "prune_to", 100).await;
 
         // Add commit at position 50
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
-        let boundary = journal.prune(Location::<F>::new(50)).await.unwrap();
+        let (_, boundary) = journal.prune(Location::<F>::new(50)).await.unwrap();
 
         // Boundary should be <= requested location (may align to section boundary)
         assert!(boundary <= Location::<F>::new(50));
@@ -2049,14 +2101,14 @@ mod tests {
     async fn test_prune_returns_actual_boundary_inner<F: Family + PartialEq>(context: Context) {
         let mut journal = create_journal_with_ops::<F>(context, "prune_boundary", 100).await;
 
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
         let requested = Location::<F>::new(50);
-        let actual = journal.prune(requested).await.unwrap();
+        let (journal, actual) = journal.prune(requested).await.unwrap();
 
         // Actual boundary should match bounds.start
         let bounds = journal.bounds();
@@ -2085,13 +2137,13 @@ mod tests {
     ) {
         let mut journal = create_journal_with_ops::<F>(context, "trait_prune", 100).await;
 
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
-        let pruned = <TestJournal<F> as Mutable>::prune(&mut journal, 50)
+        let (journal, pruned) = <TestJournal<F> as Mutable>::prune(journal, 50)
             .await
             .unwrap();
         assert!(pruned);
@@ -2101,7 +2153,7 @@ mod tests {
         assert_eq!(Location::<F>::new(item_boundary), merkle_boundary);
         assert!(merkle_boundary > Location::<F>::new(0));
 
-        let pruned = <TestJournal<F> as Mutable>::prune(&mut journal, 50)
+        let (journal, pruned) = <TestJournal<F> as Mutable>::prune(journal, 50)
             .await
             .unwrap();
         assert!(!pruned);
@@ -2125,14 +2177,14 @@ mod tests {
     async fn test_prune_preserves_operation_count_inner<F: Family + PartialEq>(context: Context) {
         let mut journal = create_journal_with_ops::<F>(context, "prune_count", 100).await;
 
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
         let count_before = journal.size();
-        journal.prune(Location::<F>::new(50)).await.unwrap();
+        let (journal, _) = journal.prune(Location::<F>::new(50)).await.unwrap();
         let count_after = journal.size();
 
         assert_eq!(count_before, count_after);
@@ -2167,13 +2219,13 @@ mod tests {
         // Test after pruning
         let mut journal =
             create_journal_with_ops::<F>(context.child("pruned"), "oldest", 100).await;
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
-        let pruned_boundary = journal.prune(Location::<F>::new(50)).await.unwrap();
+        let (journal, pruned_boundary) = journal.prune(Location::<F>::new(50)).await.unwrap();
 
         // Should match the pruned boundary (may be <= 50 due to section alignment)
         let bounds = journal.bounds();
@@ -2210,13 +2262,13 @@ mod tests {
         // Test after pruning
         let mut journal =
             create_journal_with_ops::<F>(context.child("pruned"), "boundary", 100).await;
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(50)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
-        let pruned_boundary = journal.prune(Location::<F>::new(50)).await.unwrap();
+        let (journal, pruned_boundary) = journal.prune(Location::<F>::new(50)).await.unwrap();
 
         assert_eq!(journal.bounds().start, pruned_boundary);
     }
@@ -2237,13 +2289,13 @@ mod tests {
     async fn test_mmr_prunes_to_journal_boundary_inner<F: Family + PartialEq>(context: Context) {
         let mut journal = create_journal_with_ops::<F>(context, "mmr_boundary", 50).await;
 
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(25)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal = journal.sync().await.unwrap();
 
-        let pruned_boundary = journal.prune(Location::<F>::new(25)).await.unwrap();
+        let (journal, pruned_boundary) = journal.prune(Location::<F>::new(25)).await.unwrap();
 
         // Verify Merkle and journal remain in sync
         let bounds = journal.bounds();
@@ -2473,12 +2525,12 @@ mod tests {
 
         // Add more operations after the historical state
         for i in 50..100 {
-            journal
+            (journal, _) = journal
                 .append(&create_operation::<F>(i as u8))
                 .await
                 .unwrap();
         }
-        journal.sync().await.unwrap();
+        let journal = journal.sync().await.unwrap();
 
         // Generate proof for the historical state
         let (proof, ops) = journal
@@ -2520,12 +2572,13 @@ mod tests {
     ) {
         let mut journal = create_journal_with_ops::<F>(context, "proof_pruned", 50).await;
 
-        journal
+        (journal, _) = journal
             .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(25)))
             .await
             .unwrap();
-        journal.sync().await.unwrap();
-        let pruned_boundary = journal.prune(Location::<F>::new(25)).await.unwrap();
+        journal = journal.sync().await.unwrap();
+        let pruned_boundary;
+        (journal, pruned_boundary) = journal.prune(Location::<F>::new(25)).await.unwrap();
 
         // Try to get proof starting at a location before the pruned boundary
         let size = journal.size();
@@ -2647,7 +2700,7 @@ mod tests {
 
         // Apply batch 1.
         let expected_root = batch_root(&journal, &m1);
-        journal.apply_batch(&m1).await.unwrap();
+        journal = journal.apply_batch(&m1).await.unwrap();
 
         // Journal should now match the applied batch's root.
         assert_eq!(journal_root(&journal), expected_root);
@@ -2684,7 +2737,7 @@ mod tests {
         };
 
         let expected_root = batch_root(&journal, &merkleized_b);
-        journal.apply_batch(&merkleized_b).await.unwrap();
+        journal = journal.apply_batch(&merkleized_b).await.unwrap();
         drop(merkleized_a);
 
         assert_eq!(journal_root(&journal), expected_root);
@@ -2720,14 +2773,14 @@ mod tests {
         // Apply batch A.
         let batch_a = journal.new_batch().add(op_a.clone());
         let merkleized_a = journal.merkle.with_mem(|mem| batch_a.merkleize(mem));
-        journal.apply_batch(&merkleized_a).await.unwrap();
+        journal = journal.apply_batch(&merkleized_a).await.unwrap();
         assert_eq!(*journal.size(), 11);
 
         // Apply batch B (built on top of the committed A).
         let batch_b = journal.new_batch().add(op_b.clone());
         let merkleized_b = journal.merkle.with_mem(|mem| batch_b.merkleize(mem));
         let expected_root = batch_root(&journal, &merkleized_b);
-        journal.apply_batch(&merkleized_b).await.unwrap();
+        journal = journal.apply_batch(&merkleized_b).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
         assert_eq!(*journal.size(), 12);
@@ -2752,7 +2805,7 @@ mod tests {
     }
 
     async fn test_stale_batch_sibling_inner<F: Family + PartialEq>(context: Context) {
-        let mut journal = create_empty_journal::<F>(context, "stale-sibling").await;
+        let mut journal = create_empty_journal::<F>(context.child("open"), "stale-sibling").await;
         let op_a = create_operation::<F>(1);
         let op_b = create_operation::<F>(2);
 
@@ -2762,12 +2815,21 @@ mod tests {
         let batch_b = journal.new_batch().add(op_b);
         let merkleized_b = journal.merkle.with_mem(|mem| batch_b.merkleize(mem));
 
-        // Apply A -- should succeed.
-        journal.apply_batch(&merkleized_a).await.unwrap();
-        let expected_root = journal_root(&journal);
-        let expected_size = journal.size();
+        // Apply A, then commit and sync so the recovered state below includes it (reopen
+        // rewinds to the last commit operation).
+        journal = journal.apply_batch(&merkleized_a).await.unwrap();
+        let commit_op = TestOp::<F>::CommitFloor(None, Location::<F>::new(0));
+        (journal, _) = journal.append(&commit_op).await.unwrap();
+        journal = journal.sync().await.unwrap();
+        let root_a = journal_root(&journal);
+        let size_a = journal.size();
+        let (_, ops) = journal
+            .proof(Location::<F>::new(0), NZU64!(1), 0)
+            .await
+            .unwrap();
+        assert_eq!(ops, vec![op_a.clone()]);
 
-        // Apply B -- should fail (stale).
+        // Apply B -- should fail (stale), consuming the journal.
         let result = journal.apply_batch(&merkleized_b).await;
         assert!(
             matches!(
@@ -2777,14 +2839,16 @@ mod tests {
             "expected StaleBatch, got {result:?}"
         );
 
-        // The stale batch must not mutate the journal or desync it from the Merkle.
-        assert_eq!(journal_root(&journal), expected_root);
-        assert_eq!(journal.size(), expected_size);
+        // The eager reject mutated nothing: reopening recovers exactly A's state.
+        let journal = create_empty_journal::<F>(context.child("reopen"), "stale-sibling").await;
+        assert_eq!(journal_root(&journal), root_a);
+        assert_eq!(journal.size(), size_a);
         let (_, ops) = journal
             .proof(Location::<F>::new(0), NZU64!(1), 0)
             .await
             .unwrap();
         assert_eq!(ops, vec![op_a]);
+        journal.destroy().await.unwrap();
     }
 
     #[test_traced("INFO")]
@@ -2811,7 +2875,7 @@ mod tests {
         let child_b = journal.merkle.with_mem(|mem| batch_b.merkleize(mem));
 
         // Apply child_a, then child_b should be stale.
-        journal.apply_batch(&child_a).await.unwrap();
+        journal = journal.apply_batch(&child_a).await.unwrap();
         let result = journal.apply_batch(&child_b).await;
         drop(parent);
         assert!(
@@ -2847,8 +2911,8 @@ mod tests {
         let expected_root = batch_root(&journal, &child);
 
         // Apply parent, then child (sequential commit).
-        journal.apply_batch(&parent).await.unwrap();
-        journal.apply_batch(&child).await.unwrap();
+        journal = journal.apply_batch(&parent).await.unwrap();
+        journal = journal.apply_batch(&child).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
         assert_eq!(*journal.size(), 2);
@@ -2876,7 +2940,7 @@ mod tests {
         let child = journal.merkle.with_mem(|mem| child_batch.merkleize(mem));
 
         // Apply child first (full chain) -- parent should now be stale.
-        journal.apply_batch(&child).await.unwrap();
+        journal = journal.apply_batch(&child).await.unwrap();
         let result = journal.apply_batch(&parent).await;
         assert!(
             matches!(
@@ -2919,10 +2983,10 @@ mod tests {
         let child = journal.merkle.with_mem(|mem| child_batch.merkleize(mem));
 
         // Apply parent.
-        journal.apply_batch(&parent).await.unwrap();
+        journal = journal.apply_batch(&parent).await.unwrap();
 
         // Apply child (ancestor items already committed, skipped automatically).
-        journal.apply_batch(&child).await.unwrap();
+        journal = journal.apply_batch(&child).await.unwrap();
 
         // Verify all items are present.
         let (_, ops) = journal
@@ -2970,13 +3034,13 @@ mod tests {
         let child = journal.merkle.with_mem(|mem| child_batch.merkleize(mem));
 
         // Apply grandparent, then parent, then child sequentially.
-        journal.apply_batch(&grandparent).await.unwrap();
+        journal = journal.apply_batch(&grandparent).await.unwrap();
 
         // Apply parent (ancestor items already committed, skipped automatically).
-        journal.apply_batch(&parent).await.unwrap();
+        journal = journal.apply_batch(&parent).await.unwrap();
 
         // Apply child (ancestor items already committed, skipped automatically).
-        journal.apply_batch(&child).await.unwrap();
+        journal = journal.apply_batch(&child).await.unwrap();
 
         // All 8 items (2 base + 3 + 2 + 1) should be present.
         assert_eq!(*journal.size(), 8);
@@ -3055,7 +3119,7 @@ mod tests {
             .with_mem(|mem| merkleize_with(batch, mem, ops.clone()));
 
         let expected_root = batch_root(&journal, &merkleized);
-        journal.apply_batch(&merkleized).await.unwrap();
+        journal = journal.apply_batch(&merkleized).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
         assert_eq!(*journal.size(), 7);
@@ -3092,8 +3156,8 @@ mod tests {
         let c = journal.merkle.with_mem(|mem| c_batch.merkleize(mem));
 
         // Apply A, then apply C directly (skipping B's apply_batch).
-        journal.apply_batch(&a).await.unwrap();
-        journal.apply_batch(&c).await.unwrap();
+        journal = journal.apply_batch(&a).await.unwrap();
+        journal = journal.apply_batch(&c).await.unwrap();
 
         // All 3 items should be in the journal.
         assert_eq!(*journal.size(), 3);
@@ -3102,7 +3166,7 @@ mod tests {
         let mut reference =
             create_empty_journal::<F>(context.child("ref"), "skip-partial-ref").await;
         for i in 1..=3u8 {
-            reference.append(&create_operation::<F>(i)).await.unwrap();
+            (reference, _) = reference.append(&create_operation::<F>(i)).await.unwrap();
         }
         assert_eq!(journal_root(&journal), journal_root(&reference));
     }

--- a/storage/src/journal/benches/bench.rs
+++ b/storage/src/journal/benches/bench.rs
@@ -58,7 +58,10 @@ async fn get_fixed_journal<const ITEM_SIZE: usize>(
 }
 
 /// Append `items_to_write` random items to the given fixed journal, syncing the changes before returning.
-async fn append_fixed_random_data<C, const ITEM_SIZE: usize>(journal: &mut C, items_to_write: u64)
+async fn append_fixed_random_data<C, const ITEM_SIZE: usize>(
+    mut journal: C,
+    items_to_write: u64,
+) -> C
 where
     C: Mutable<Item = FixedBytes<ITEM_SIZE>>,
 {
@@ -67,14 +70,14 @@ where
     let mut arr = [0; ITEM_SIZE];
     for _ in 0..items_to_write {
         rng.fill_bytes(&mut arr);
-        journal
+        (journal, _) = journal
             .append(&FixedBytes::new(arr))
             .await
             .expect("failed to append data");
     }
 
     // Sync the journal to ensure all data is written to disk.
-    journal.sync().await.expect("failed to sync journal");
+    journal.sync().await.expect("failed to sync journal")
 }
 
 /// Open and return a temp variable journal with the given config parameters.

--- a/storage/src/journal/benches/fixed_append.rs
+++ b/storage/src/journal/benches/fixed_append.rs
@@ -35,7 +35,7 @@ fn bench_fixed_append(c: &mut Criterion) {
                     let mut duration = Duration::ZERO;
                     for _ in 0..iters {
                         // Create a new journal for each iteration
-                        let mut j = get_fixed_journal::<ITEM_SIZE>(
+                        let j = get_fixed_journal::<ITEM_SIZE>(
                             ctx.child("storage"),
                             PARTITION,
                             ITEMS_PER_BLOB,
@@ -44,7 +44,7 @@ fn bench_fixed_append(c: &mut Criterion) {
 
                         // Append random data to the journal
                         let start = Instant::now();
-                        append_fixed_random_data(&mut j, items_to_write).await;
+                        let j = append_fixed_random_data(j, items_to_write).await;
                         duration += start.elapsed();
 
                         // Destroy the journal after appending to avoid polluting the next iteration

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -30,23 +30,24 @@ const ITEM_SIZE: usize = 32;
 /// Read `items_to_read` random items from the given `journal`, awaiting each
 /// result before continuing.
 async fn bench_run_serial(
-    journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>,
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
-) {
-    let reader = journal.snapshot().await.unwrap();
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let mut rng = test_rng();
     for _ in 0..items_to_read {
         let pos = rng.random_range(0..ITEMS_TO_WRITE);
         black_box(reader.read(pos).await.expect("failed to read data"));
     }
+    journal
 }
 
 /// Concurrently read (via try_join_all) `items_to_read` random items from the given `journal`.
 async fn bench_run_concurrent(
-    journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>,
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
-) {
-    let reader = journal.snapshot().await.unwrap();
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let mut rng = test_rng();
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
@@ -54,14 +55,15 @@ async fn bench_run_concurrent(
         futures.push(reader.read(pos));
     }
     try_join_all(futures).await.expect("failed to read data");
+    journal
 }
 
 /// Batch-read `items_to_read` random items via `read_many`.
 async fn bench_run_read_many(
-    journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>,
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
-) {
-    let reader = journal.snapshot().await.unwrap();
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let mut rng = test_rng();
     let mut positions: Vec<u64> = (0..items_to_read)
         .map(|_| rng.random_range(0..ITEMS_TO_WRITE))
@@ -74,6 +76,7 @@ async fn bench_run_read_many(
             .await
             .expect("failed to read data"),
     );
+    journal
 }
 
 fn bench_fixed_read_random(c: &mut Criterion) {
@@ -94,9 +97,8 @@ fn bench_fixed_read_random(c: &mut Criterion) {
                     // Setup: populate journal (once, on first sample).
                     if !initialized {
                         Runner::new(cfg.clone()).start(|ctx| async move {
-                            let mut j = get_fixed_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
-                            append_fixed_random_data::<_, ITEM_SIZE>(&mut j, ITEMS_TO_WRITE).await;
-                            j.sync().await.unwrap();
+                            let j = get_fixed_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
+                            append_fixed_random_data::<_, ITEM_SIZE>(j, ITEMS_TO_WRITE).await;
                         });
                         initialized = true;
                     }
@@ -110,12 +112,12 @@ fn bench_fixed_read_random(c: &mut Criterion) {
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            match mode {
-                                "serial" => bench_run_serial(&mut j, items_to_read).await,
-                                "concurrent" => bench_run_concurrent(&mut j, items_to_read).await,
-                                "read_many" => bench_run_read_many(&mut j, items_to_read).await,
+                            j = match mode {
+                                "serial" => bench_run_serial(j, items_to_read).await,
+                                "concurrent" => bench_run_concurrent(j, items_to_read).await,
+                                "read_many" => bench_run_read_many(j, items_to_read).await,
                                 _ => unreachable!(),
-                            }
+                            };
                             duration += start.elapsed();
                         }
                         duration

--- a/storage/src/journal/benches/fixed_read_sequential.rs
+++ b/storage/src/journal/benches/fixed_read_sequential.rs
@@ -22,11 +22,15 @@ const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(100_000);
 const ITEM_SIZE: usize = 32;
 
 /// Sequentially read `items_to_read` items in the given `journal` starting from item 0.
-async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, items_to_read: u64) {
-    let reader = journal.snapshot().await.unwrap();
+async fn bench_run(
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
+    items_to_read: u64,
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     for pos in 0..items_to_read {
         black_box(reader.read(pos).await.expect("failed to read data"));
     }
+    journal
 }
 
 /// Benchmark the sequential read of items from a journal containing exactly that
@@ -40,9 +44,8 @@ fn bench_fixed_read_sequential(c: &mut Criterion) {
                 b.to_async(&runner).iter_custom(|iters| async move {
                     // Append random data to the journal
                     let ctx = context::get::<commonware_runtime::tokio::Context>();
-                    let mut j =
-                        get_fixed_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
-                    append_fixed_random_data::<_, ITEM_SIZE>(&mut j, items).await;
+                    let j = get_fixed_journal::<ITEM_SIZE>(ctx, PARTITION, ITEMS_PER_BLOB).await;
+                    let mut j = append_fixed_random_data::<_, ITEM_SIZE>(j, items).await;
                     let sz = j.size();
                     assert_eq!(sz, items);
 
@@ -50,7 +53,7 @@ fn bench_fixed_read_sequential(c: &mut Criterion) {
                     let mut duration = Duration::ZERO;
                     for _ in 0..iters {
                         let start = Instant::now();
-                        bench_run(&mut j, items).await;
+                        j = bench_run(j, items).await;
                         duration += start.elapsed();
                     }
 

--- a/storage/src/journal/benches/fixed_replay.rs
+++ b/storage/src/journal/benches/fixed_replay.rs
@@ -17,8 +17,11 @@ use std::{
 const PARTITION: &str = "test-partition";
 
 /// Replay all items in the given `journal`.
-async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
-    let reader = journal.snapshot().await.unwrap();
+async fn bench_run(
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
+    buffer: usize,
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let stream = reader
         .replay(0, NZUsize!(buffer))
         .await
@@ -32,6 +35,7 @@ async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, buffer
             Err(err) => panic!("Failed to read item: {err}"),
         }
     }
+    journal
 }
 
 /// Benchmark the replaying of items from a journal containing exactly that
@@ -54,9 +58,8 @@ fn bench_fixed_replay(c: &mut Criterion) {
                     // Setup: populate journal (once, on first sample).
                     if !initialized {
                         Runner::new(cfg.clone()).start(|ctx| async move {
-                            let mut j = get_fixed_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
-                            append_fixed_random_data::<_, ITEM_SIZE>(&mut j, items).await;
-                            j.sync().await.unwrap();
+                            let j = get_fixed_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
+                            append_fixed_random_data::<_, ITEM_SIZE>(j, items).await;
                         });
                         initialized = true;
                     }
@@ -70,7 +73,7 @@ fn bench_fixed_replay(c: &mut Criterion) {
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            bench_run(&mut j, buffer).await;
+                            j = bench_run(j, buffer).await;
                             duration += start.elapsed();
                         }
                         duration

--- a/storage/src/journal/benches/variable_read_random.rs
+++ b/storage/src/journal/benches/variable_read_random.rs
@@ -30,23 +30,24 @@ const ITEM_SIZE: usize = 32;
 /// Read `items_to_read` random items from the given `journal`, awaiting each
 /// result before continuing.
 async fn bench_run_serial(
-    journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>,
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
-) {
-    let reader = journal.snapshot().await.unwrap();
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let mut rng = test_rng();
     for _ in 0..items_to_read {
         let pos = rng.random_range(0..ITEMS_TO_WRITE);
         black_box(reader.read(pos).await.expect("failed to read data"));
     }
+    journal
 }
 
 /// Concurrently read (via try_join_all) `items_to_read` random items from the given `journal`.
 async fn bench_run_concurrent(
-    journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>,
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
-) {
-    let reader = journal.snapshot().await.unwrap();
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let mut rng = test_rng();
     let mut futures = Vec::with_capacity(items_to_read);
     for _ in 0..items_to_read {
@@ -54,14 +55,15 @@ async fn bench_run_concurrent(
         futures.push(reader.read(pos));
     }
     try_join_all(futures).await.expect("failed to read data");
+    journal
 }
 
 /// Batch-read `items_to_read` random items via `read_many`.
 async fn bench_run_read_many(
-    journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>,
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
     items_to_read: usize,
-) {
-    let reader = journal.snapshot().await.unwrap();
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let mut rng = test_rng();
     let mut positions: Vec<u64> = (0..items_to_read)
         .map(|_| rng.random_range(0..ITEMS_TO_WRITE))
@@ -74,6 +76,7 @@ async fn bench_run_read_many(
             .await
             .expect("failed to read data"),
     );
+    journal
 }
 
 fn bench_variable_read_random(c: &mut Criterion) {
@@ -94,10 +97,8 @@ fn bench_variable_read_random(c: &mut Criterion) {
                     // Setup: populate journal (once, on first sample).
                     if !initialized {
                         Runner::new(cfg.clone()).start(|ctx| async move {
-                            let mut j =
-                                get_variable_journal(ctx, PARTITION, ITEMS_PER_SECTION).await;
-                            append_fixed_random_data::<_, ITEM_SIZE>(&mut j, ITEMS_TO_WRITE).await;
-                            j.sync().await.unwrap();
+                            let j = get_variable_journal(ctx, PARTITION, ITEMS_PER_SECTION).await;
+                            append_fixed_random_data::<_, ITEM_SIZE>(j, ITEMS_TO_WRITE).await;
                         });
                         initialized = true;
                     }
@@ -114,12 +115,12 @@ fn bench_variable_read_random(c: &mut Criterion) {
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            match mode {
-                                "serial" => bench_run_serial(&mut j, items_to_read).await,
-                                "concurrent" => bench_run_concurrent(&mut j, items_to_read).await,
-                                "read_many" => bench_run_read_many(&mut j, items_to_read).await,
+                            j = match mode {
+                                "serial" => bench_run_serial(j, items_to_read).await,
+                                "concurrent" => bench_run_concurrent(j, items_to_read).await,
+                                "read_many" => bench_run_read_many(j, items_to_read).await,
                                 _ => unreachable!(),
-                            }
+                            };
                             duration += start.elapsed();
                         }
                         duration

--- a/storage/src/journal/benches/variable_replay.rs
+++ b/storage/src/journal/benches/variable_replay.rs
@@ -17,8 +17,11 @@ use std::{
 const PARTITION: &str = "variable-test-partition";
 
 /// Replay all items in the given `journal`.
-async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, buffer: usize) {
-    let reader = journal.snapshot().await.unwrap();
+async fn bench_run(
+    journal: Journal<Context, FixedBytes<ITEM_SIZE>>,
+    buffer: usize,
+) -> Journal<Context, FixedBytes<ITEM_SIZE>> {
+    let (journal, reader) = journal.snapshot().await.unwrap();
     let stream = reader
         .replay(0, NZUsize!(buffer))
         .await
@@ -32,6 +35,7 @@ async fn bench_run(journal: &mut Journal<Context, FixedBytes<ITEM_SIZE>>, buffer
             Err(err) => panic!("Failed to read item: {err}"),
         }
     }
+    journal
 }
 
 /// Benchmark the replaying of items from a variable journal containing exactly that
@@ -54,9 +58,8 @@ fn bench_variable_replay(c: &mut Criterion) {
                     // Setup: populate journal (once, on first sample).
                     if !initialized {
                         Runner::new(cfg.clone()).start(|ctx| async move {
-                            let mut j = get_variable_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
-                            append_fixed_random_data::<_, ITEM_SIZE>(&mut j, items).await;
-                            j.sync().await.unwrap();
+                            let j = get_variable_journal(ctx, PARTITION, ITEMS_PER_BLOB).await;
+                            append_fixed_random_data::<_, ITEM_SIZE>(j, items).await;
                         });
                         initialized = true;
                     }
@@ -70,7 +73,7 @@ fn bench_variable_replay(c: &mut Criterion) {
                         let mut duration = Duration::ZERO;
                         for _ in 0..iters {
                             let start = Instant::now();
-                            bench_run(&mut j, buffer).await;
+                            j = bench_run(j, buffer).await;
                             duration += start.elapsed();
                         }
                         duration

--- a/storage/src/journal/conformance.rs
+++ b/storage/src/journal/conformance.rs
@@ -69,12 +69,12 @@ where
     let items = context.random_range(16..96);
     for i in 0..items {
         let item = seed.wrapping_add(i as u64);
-        journal.append(&item).await?;
+        (journal, _) = journal.append(&item).await?;
     }
-    journal.sync().await?;
+    let journal = journal.sync().await?;
 
     if items > 32 {
-        journal
+        let (journal, _) = journal
             .prune(crate::merkle::Location::new(items as u64 / 3))
             .await?;
         journal.sync().await?;
@@ -105,9 +105,10 @@ impl StorageWorkload for ContiguousFixedWorkload {
         context.fill(&mut data_to_write[..]);
 
         for item in data_to_write.iter() {
-            journal.append(item).await?;
+            (journal, _) = journal.append(item).await?;
         }
-        journal.sync().await
+        journal.sync().await?;
+        Ok(())
     }
 }
 
@@ -140,9 +141,10 @@ impl StorageWorkload for ContiguousVariableWorkload {
         }
 
         for item in data_to_write {
-            journal.append(&item).await?;
+            (journal, _) = journal.append(&item).await?;
         }
-        journal.sync().await
+        journal.sync().await?;
+        Ok(())
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -98,6 +98,8 @@ use super::{
     blobs::{Blob, Blobs, Partition, Replay as BlobReplay, Writable},
     checkpoint::Checkpoint,
 };
+#[commonware_macros::stability(ALPHA)]
+use crate::journal::authenticated;
 use crate::{
     Context,
     journal::{
@@ -105,8 +107,6 @@ use crate::{
         contiguous::{Many, Mutable, metrics::Metrics},
     },
 };
-#[commonware_macros::stability(ALPHA)]
-use crate::{journal::authenticated, merkle};
 use commonware_codec::{CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
     Blob as RBlob, Buf, IoBuf,
@@ -313,17 +313,9 @@ pub struct Config {
     pub write_buffer: NonZeroUsize,
 }
 
-/// Implementation of [super::Mutable] for fixed-size value journals.
-///
-/// # Repair
-///
-/// Like
-/// [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
-/// and
-/// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
-/// the first invalid data read will be considered the new end of the journal (and the
-/// underlying blob will be truncated to the last valid item). Repair is performed during init.
-pub struct Journal<E: Context, A> {
+/// The journal state behind the [Journal] handle, boxed so the handle stays pointer-sized
+/// and mutated in place by the handle's methods.
+pub(super) struct Inner<E: Context, A> {
     /// The blobs that comprise the journal.
     blobs: Writable<E>,
 
@@ -345,7 +337,7 @@ pub struct Journal<E: Context, A> {
     _phantom: PhantomData<A>,
 }
 
-impl<E: Context, A: CodecFixedShared> Journal<E, A> {
+impl<E: Context, A: CodecFixedShared> Inner<E, A> {
     /// Size of each entry in bytes. Evaluating this rejects zero-size item types at compile
     /// time, which would otherwise divide by zero in the chunk math.
     pub const CHUNK_SIZE: NonZeroUsize = match NonZeroUsize::new(A::SIZE) {
@@ -391,11 +383,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         }
     }
 
-    /// Initialize a new `Journal` instance.
-    ///
-    /// All backing blobs are opened but not read during initialization. The `replay` method can be
-    /// used to iterate over all items in the `Journal`.
-    pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
+    /// Initialize the journal state, running recovery.
+    pub(crate) async fn init(context: E, cfg: Config) -> Result<Self, Error> {
         let checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition).await?;
         Self::init_with_checkpoint(context, cfg, checkpoint).await
     }
@@ -715,15 +704,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok((size, None))
     }
 
-    /// Initialize a `Journal` in a fully-pruned state at `size`: existing data is cleared and the
-    /// journal behaves as if `size` items were appended then pruned. It is empty (`bounds` is
-    /// `size..size`) and the next `append` writes at position `size`. Used for state sync.
-    ///
-    /// # Crash Safety
-    /// In the event of a crash during this call, upon restart recovery will ensure the journal is
-    /// either still in its prior state, or has bounds `size..size`.
+    /// See [Journal::init_at_size].
     #[commonware_macros::stability(ALPHA)]
-    pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
+    pub(crate) async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
         // Fail before writing intent if existing blob partitions are already inconsistent.
         Partition::select(&context, &cfg.partition).await?;
         Self::init_at_size_cleared(context, cfg, size, || async { Ok(()) }).await
@@ -790,12 +773,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.blobs.sync_from(start_blob).await
     }
 
-    /// Durably persists the current state of the structure.
-    ///
-    /// Does not advance the recovery watermark, so external consumers may need to replay entries
-    /// beyond the previous `sync()`. Use `sync()` to advance the watermark and to ensure that a
-    /// crash after this call doesn't require any recovery.
-    pub async fn commit(&mut self) -> Result<(), Error> {
+    /// In-place [Journal::commit].
+    pub(crate) async fn commit(&mut self) -> Result<(), Error> {
         let _timer = self.metrics.commit_timer();
         self.metrics.commit_calls.inc();
         self.flush_dirty_blobs().await?;
@@ -803,11 +782,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(())
     }
 
-    /// Durably persist the current state of the structure, ensuring no recovery is required in the
-    /// event of a crash following this call.
-    ///
-    /// Advances the recovery watermark to the current size.
-    pub async fn sync(&mut self) -> Result<(), Error> {
+    /// In-place [Journal::sync].
+    pub(crate) async fn sync(&mut self) -> Result<(), Error> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
         self.flush_dirty_blobs().await?;
@@ -821,12 +797,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
             .await
     }
 
-    /// Capture an owned snapshot ([`Reader`]) over the current journal. Bounds are frozen at
-    /// creation, and the snapshot stays readable across concurrent appends and prunes.
-    ///
-    /// If the journal later rewinds or truncates into the returned reader's range, subsequent reads
-    /// from that range may observe unspecified contents.
-    pub async fn snapshot(&mut self) -> Result<Reader<'static, E, A>, Error> {
+    /// In-place [Journal::snapshot].
+    pub(crate) async fn snapshot(&mut self) -> Result<Reader<'static, E, A>, Error> {
         Ok(Reader {
             blobs: self.blobs.snapshot().await?,
             bounds: self.bounds.clone(),
@@ -860,22 +832,16 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.bounds.end
     }
 
-    /// Append a new item to the journal, returning its position.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the underlying storage operation fails.
-    pub async fn append(&mut self, item: &A) -> Result<u64, Error> {
+    /// In-place [Journal::append].
+    pub(crate) async fn append(&mut self, item: &A) -> Result<u64, Error> {
         let _timer = self.metrics.append_timer();
         self.metrics.append_calls.inc();
         self.append_many_inner(Many::Flat(std::slice::from_ref(item)))
             .await
     }
 
-    /// Append items to the journal, returning the position of the last item appended.
-    ///
-    /// Returns [Error::EmptyAppend] if items is empty.
-    pub async fn append_many<'a>(&'a mut self, items: Many<'a, A>) -> Result<u64, Error> {
+    /// In-place [Journal::append_many].
+    pub(crate) async fn append_many<'a>(&'a mut self, items: Many<'a, A>) -> Result<u64, Error> {
         let _timer = self.metrics.append_many_timer();
         self.metrics.append_many_calls.inc();
         self.append_many_inner(items).await
@@ -887,11 +853,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.write_encoded(prepared).await
     }
 
-    /// Encode `items` into a buffer that can be appended later with [`Self::append_prepared`].
-    ///
-    /// This lets callers serialize borrowed items synchronously, release those borrows, and
-    /// perform the append without holding unrelated locks across journal I/O.
-    pub fn prepare_append(&self, items: Many<'_, A>) -> PreparedAppend<A> {
+    /// In-place [Journal::prepare_append].
+    pub(crate) fn prepare_append(&self, items: Many<'_, A>) -> PreparedAppend<A> {
         // Encode all items into a single contiguous buffer up front.
         // Uses Write::write directly to avoid per-item Bytes allocations from Encode::encode.
         let mut buf = Vec::with_capacity(items.len() * A::SIZE);
@@ -915,11 +878,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         }
     }
 
-    /// Append items encoded by [`Self::prepare_append`], returning the position of the last item
-    /// appended.
-    ///
-    /// Returns [Error::EmptyAppend] if `prepared` contains no items.
-    pub async fn append_prepared(&mut self, prepared: PreparedAppend<A>) -> Result<u64, Error> {
+    /// In-place [Journal::append_prepared].
+    pub(crate) async fn append_prepared(
+        &mut self,
+        prepared: PreparedAppend<A>,
+    ) -> Result<u64, Error> {
         let _timer = self.metrics.append_prepared_timer();
         self.metrics.append_prepared_calls.inc();
         self.write_encoded(prepared).await
@@ -978,19 +941,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(self.bounds.end - 1)
     }
 
-    /// Rewind the journal to the given `size`. Returns [Error::InvalidRewind] if `size` is beyond
-    /// the current size, or [Error::ItemPruned] if it precedes the pruning boundary. The journal
-    /// is not synced after rewinding.
-    ///
-    /// # Warnings
-    ///
-    /// * This operation is not guaranteed to survive restarts until `commit()` or `sync()` is
-    ///   called.
-    /// * This operation is not atomic. Its on-disk updates are ordered (blobs removed
-    ///   newest-to-oldest) so that restart recovery always rebuilds a contiguous retained prefix.
-    /// * Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
-    ///   rewind truncates into their range.
-    pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    /// In-place [Journal::rewind].
+    pub(crate) async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         match size.cmp(&self.bounds.end) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),
             std::cmp::Ordering::Equal => return Ok(()),
@@ -1032,16 +984,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         self.bounds.start
     }
 
-    /// Allow the journal to prune items older than `min_item_pos`. The journal may not prune all
-    /// such items in order to preserve blob boundaries, but the amount of such items will always be
-    /// less than the configured number of items per blob. Returns true if any items were pruned.
-    ///
-    /// Readers holding earlier snapshots keep reading pruned blobs through their own handles;
-    /// later snapshots observe [Error::ItemPruned].
-    ///
-    /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
-    /// event of failure as items are always pruned in order from oldest to newest.
-    pub async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
+    /// In-place [Journal::prune].
+    pub(crate) async fn prune(&mut self, min_item_pos: u64) -> Result<bool, Error> {
         // Calculate the blob that would contain min_item_pos, capped to the tail (which is
         // guaranteed to exist by our invariant).
         let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
@@ -1075,14 +1019,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         Ok(true)
     }
 
-    /// Remove any persisted data created by the journal.
-    ///
-    /// # Crash Safety
-    ///
-    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
-    /// reopening the same partition may observe partially removed state. Use [Self::init_at_size]
-    /// for a recoverable reset.
-    pub async fn destroy(self) -> Result<(), Error> {
+    /// See [Journal::destroy].
+    pub(crate) async fn destroy(self) -> Result<(), Error> {
         self.blobs.destroy().await?;
         self.checkpoint.destroy().await?;
         Ok(())
@@ -1142,6 +1080,178 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     }
 }
 
+/// Implementation of [super::Mutable] for fixed-size value journals.
+///
+/// # Repair
+///
+/// Like
+/// [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
+/// and
+/// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
+/// the first invalid data read will be considered the new end of the journal (and the
+/// underlying blob will be truncated to the last valid item). Repair is performed during init.
+pub struct Journal<E: Context, A>(Box<Inner<E, A>>);
+
+impl<E: Context, A: CodecFixedShared> std::fmt::Debug for Journal<E, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Journal")
+            .field("bounds", &super::Contiguous::bounds(self))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<E: Context, A: CodecFixedShared> Journal<E, A> {
+    /// Initialize a new `Journal` instance.
+    ///
+    /// All backing blobs are opened but not read during initialization. The `replay` method can be
+    /// used to iterate over all items in the `Journal`.
+    pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
+        Ok(Self(Box::new(Inner::init(context, cfg).await?)))
+    }
+
+    /// Initialize a `Journal` in a fully-pruned state at `size`: existing data is cleared and the
+    /// journal behaves as if `size` items were appended then pruned. It is empty (`bounds` is
+    /// `size..size`) and the next `append` writes at position `size`. Used for state sync.
+    ///
+    /// # Crash Safety
+    /// In the event of a crash during this call, upon restart recovery will ensure the journal is
+    /// either still in its prior state, or has bounds `size..size`.
+    #[commonware_macros::stability(ALPHA)]
+    pub async fn init_at_size(context: E, cfg: Config, size: u64) -> Result<Self, Error> {
+        Ok(Self(Box::new(
+            Inner::init_at_size(context, cfg, size).await?,
+        )))
+    }
+
+    /// Discard all items and reposition the journal at `new_size`.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) async fn clear_to_size(&mut self, new_size: u64) -> Result<(), Error> {
+        self.0.clear_to_size(new_size).await
+    }
+
+    /// Durably persists the current state of the structure.
+    ///
+    /// Does not advance the recovery watermark, so external consumers may need to replay entries
+    /// beyond the previous `sync()`. Use `sync()` to advance the watermark and to ensure that a
+    /// crash after this call doesn't require any recovery.
+    pub async fn commit(mut self) -> Result<Self, Error> {
+        self.0.commit().await?;
+        Ok(self)
+    }
+
+    /// Durably persist the current state of the structure, ensuring no recovery is required in the
+    /// event of a crash following this call.
+    ///
+    /// Advances the recovery watermark to the current size.
+    pub async fn sync(mut self) -> Result<Self, Error> {
+        self.0.sync().await?;
+        Ok(self)
+    }
+
+    /// Capture an owned snapshot ([`Reader`]) over the current journal. Bounds are frozen at
+    /// creation, and the snapshot stays readable across concurrent appends and prunes.
+    ///
+    /// If the journal later rewinds or truncates into the returned reader's range, subsequent reads
+    /// from that range may observe unspecified contents.
+    pub async fn snapshot(mut self) -> Result<(Self, Reader<'static, E, A>), Error> {
+        let reader = self.0.snapshot().await?;
+        Ok((self, reader))
+    }
+
+    /// Return the total number of items in the journal, irrespective of pruning. The next value
+    /// appended to the journal will be at this position.
+    pub fn size(&self) -> u64 {
+        self.0.size()
+    }
+
+    /// Append a new item to the journal, returning its position.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying storage operation fails.
+    pub async fn append(mut self, item: &A) -> Result<(Self, u64), Error> {
+        let position = self.0.append(item).await?;
+        Ok((self, position))
+    }
+
+    /// Append items to the journal, returning the position of the last item appended.
+    ///
+    /// Returns [Error::EmptyAppend] if items is empty.
+    pub async fn append_many(mut self, items: Many<'_, A>) -> Result<(Self, u64), Error> {
+        let position = self.0.append_many(items).await?;
+        Ok((self, position))
+    }
+
+    /// Encode `items` into a buffer that can be appended later with [`Self::append_prepared`].
+    ///
+    /// This lets callers serialize borrowed items synchronously, release those borrows, and
+    /// perform the append without holding unrelated locks across journal I/O.
+    pub fn prepare_append(&self, items: Many<'_, A>) -> PreparedAppend<A> {
+        self.0.prepare_append(items)
+    }
+
+    /// Append items encoded by [`Self::prepare_append`], returning the position of the last item
+    /// appended.
+    ///
+    /// Returns [Error::EmptyAppend] if `prepared` contains no items.
+    pub async fn append_prepared(
+        mut self,
+        prepared: PreparedAppend<A>,
+    ) -> Result<(Self, u64), Error> {
+        let position = self.0.append_prepared(prepared).await?;
+        Ok((self, position))
+    }
+
+    /// Rewind the journal to `size` items, discarding items from the end.
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::InvalidRewind] if `size` is larger than current size.
+    /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
+    ///
+    /// # Warnings
+    ///
+    /// * This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
+    /// * This operation is not atomic. Its on-disk updates are ordered (blobs removed
+    ///   newest-to-oldest) so that restart recovery always rebuilds a contiguous retained prefix.
+    /// * Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
+    ///   rewind truncates into their range.
+    pub async fn rewind(mut self, size: u64) -> Result<Self, Error> {
+        self.0.rewind(size).await?;
+        Ok(self)
+    }
+
+    /// Return the location before which all items have been pruned.
+    pub fn pruning_boundary(&self) -> u64 {
+        self.0.pruning_boundary()
+    }
+
+    /// Allow the journal to prune items older than `min_item_pos`. The journal may not prune all
+    /// such items in order to preserve blob boundaries, but the amount of such items will always be
+    /// less than the configured number of items per blob. Returns true if any items were pruned.
+    ///
+    /// Readers holding earlier snapshots keep reading pruned blobs through their own handles;
+    /// later snapshots observe [Error::ItemPruned].
+    ///
+    /// Note that this operation may NOT be atomic, however it's guaranteed not to leave gaps in the
+    /// event of failure as items are always pruned in order from oldest to newest.
+    pub async fn prune(mut self, min_item_pos: u64) -> Result<(Self, bool), Error> {
+        let pruned = self.0.prune(min_item_pos).await?;
+        Ok((self, pruned))
+    }
+
+    /// Remove any persisted data created by the journal.
+    ///
+    /// # Crash Safety
+    ///
+    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
+    /// reopening the same partition may observe partially removed state. Use [Self::init_at_size]
+    /// for a recoverable reset.
+    pub async fn destroy(self) -> Result<(), Error> {
+        (*self.0).destroy().await
+    }
+}
+
 /// A reader over a fixed journal.
 pub struct Reader<'a, E: Context, A> {
     blobs: Blobs<'a, E::Blob>,
@@ -1171,7 +1281,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
         let first_position = first_in_blob(self.bounds.start, blob, items_per_blob)?;
         let offsets = group
             .iter()
-            .map(|&pos| Journal::<E, A>::items_to_bytes(pos - first_position))
+            .map(|&pos| Inner::<E, A>::items_to_bytes(pos - first_position))
             .collect::<Result<Vec<u64>, _>>()?;
         Ok((blob, offsets))
     }
@@ -1216,7 +1326,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             let (buf, rest) = remaining_buf.split_at_mut(group.len() * A::SIZE);
             remaining_buf = rest;
             reads.push(async move {
-                blob.read_many_into(buf, &blob_offsets, Journal::<E, A>::CHUNK_SIZE)
+                blob.read_many_into(buf, &blob_offsets, Inner::<E, A>::CHUNK_SIZE)
                     .await
             });
         }
@@ -1244,7 +1354,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
         let items_per_blob = self.items_per_blob.get();
         let blob = super::position_to_blob(pos, items_per_blob);
         let pos_in_blob = pos - first_in_blob(self.bounds.start, blob, items_per_blob)?;
-        let offset = Journal::<E, A>::items_to_bytes(pos_in_blob)?;
+        let offset = Inner::<E, A>::items_to_bytes(pos_in_blob)?;
         let blob = self
             .blobs
             .get(blob)
@@ -1298,7 +1408,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             };
             let buf = &mut buf[..group.len() * A::SIZE];
             let misses =
-                blob.try_read_many_sync_into(buf, &blob_offsets, Journal::<E, A>::CHUNK_SIZE);
+                blob.try_read_many_sync_into(buf, &blob_offsets, Inner::<E, A>::CHUNK_SIZE);
             let mut misses = misses.into_iter().peekable();
             for (idx, slice) in buf.chunks_exact(A::SIZE).enumerate() {
                 if misses.peek() == Some(&idx) {
@@ -1386,7 +1496,7 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
     }
 }
 
-impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
+impl<E: Context, A: CodecFixedShared> super::Contiguous for Inner<E, A> {
     type Item = A;
 
     fn bounds(&self) -> Range<u64> {
@@ -1425,28 +1535,60 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
     }
 }
 
+impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
+    type Item = A;
+
+    fn bounds(&self) -> Range<u64> {
+        super::Contiguous::bounds(&*self.0)
+    }
+
+    async fn read(&self, pos: u64) -> Result<A, Error> {
+        super::Contiguous::read(&*self.0, pos).await
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<A>, Error> {
+        super::Contiguous::read_many(&*self.0, positions).await
+    }
+
+    fn try_read_sync(&self, pos: u64) -> Option<A> {
+        super::Contiguous::try_read_sync(&*self.0, pos)
+    }
+
+    fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<A>> {
+        super::Contiguous::try_read_many_sync(&*self.0, positions)
+    }
+
+    async fn replay(
+        &self,
+        start_pos: u64,
+        buffer: NonZeroUsize,
+    ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
+        super::Contiguous::replay(&*self.0, start_pos, buffer).await
+    }
+}
+
 impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
-    async fn append(&mut self, item: &Self::Item) -> Result<u64, Error> {
+    async fn append(self, item: &Self::Item) -> Result<(Self, u64), Error> {
         Self::append(self, item).await
     }
 
-    async fn append_many<'a>(&'a mut self, items: Many<'a, Self::Item>) -> Result<u64, Error> {
+    async fn append_many(self, items: Many<'_, Self::Item>) -> Result<(Self, u64), Error> {
         Self::append_many(self, items).await
     }
 
-    async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
+    async fn prune(self, min_position: u64) -> Result<(Self, bool), Error> {
         Self::prune(self, min_position).await
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    async fn rewind(self, size: u64) -> Result<Self, Error> {
         Self::rewind(self, size).await
     }
 
-    async fn commit(&mut self) -> Result<(), Error> {
+    async fn commit(self) -> Result<Self, Error> {
         Self::commit(self).await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
+    async fn sync(self) -> Result<Self, Error> {
         Self::sync(self).await
     }
 
@@ -1456,28 +1598,11 @@ impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<E: Context, A: CodecFixedShared> authenticated::Inner<E> for Journal<E, A> {
+impl<E: Context, A: CodecFixedShared> authenticated::Backing<E> for Journal<E, A> {
     type Config = Config;
 
-    async fn init<
-        F: merkle::Family,
-        H: commonware_cryptography::Hasher,
-        S: commonware_parallel::Strategy,
-    >(
-        context: E,
-        merkle_cfg: merkle::full::Config<S>,
-        journal_cfg: Self::Config,
-        rewind_predicate: fn(&A) -> bool,
-        bagging: merkle::Bagging,
-    ) -> Result<authenticated::Journal<F, E, Self, H, S>, authenticated::Error<F>> {
-        authenticated::Journal::<F, E, Self, H, S>::new(
-            context,
-            merkle_cfg,
-            journal_cfg,
-            rewind_predicate,
-            bagging,
-        )
-        .await
+    async fn init(context: E, cfg: Self::Config) -> Result<Self, Error> {
+        Self::init(context, cfg).await
     }
 }
 
@@ -1529,7 +1654,7 @@ mod tests {
             .expect("counter missing")
     }
 
-    impl<E: crate::Context, A: CodecFixedShared> Journal<E, A> {
+    impl<E: crate::Context, A: CodecFixedShared> Inner<E, A> {
         /// Test helper: Get the oldest blob from the blob store.
         pub(crate) const fn test_oldest_blob(&self) -> Option<u64> {
             Some(self.blobs.oldest_blob_index())
@@ -1565,6 +1690,40 @@ mod tests {
         }
     }
 
+    impl<E: crate::Context, A: CodecFixedShared> Journal<E, A> {
+        /// Test helper: Get the oldest blob from the blob store.
+        pub(crate) fn test_oldest_blob(&self) -> Option<u64> {
+            self.0.test_oldest_blob()
+        }
+
+        /// Test helper: Get the newest blob from the blob store.
+        pub(crate) fn test_newest_blob(&self) -> Option<u64> {
+            self.0.test_newest_blob()
+        }
+
+        /// Test helper: Make one blob durable (sealed history or the tail).
+        pub(crate) async fn test_sync_blob(&mut self, blob: u64) -> Result<(), Error> {
+            self.0.test_sync_blob(blob).await
+        }
+
+        /// Test helper: Set and persist the recovery watermark directly.
+        pub(crate) async fn test_set_recovery_watermark(
+            &mut self,
+            watermark: u64,
+        ) -> Result<(), Error> {
+            self.0.test_set_recovery_watermark(watermark).await
+        }
+
+        /// Test helper: Durably stage a clear intent in the journal's checkpoint.
+        pub(crate) async fn test_stage_clear(
+            context: E,
+            partition: &str,
+            target: u64,
+        ) -> Result<(), Error> {
+            Inner::<E, A>::test_stage_clear(context, partition, target).await
+        }
+    }
+
     #[test_traced]
     fn test_fixed_init_marks_suffix_past_recovery_watermark_dirty() {
         let executor = deterministic::Runner::default();
@@ -1575,15 +1734,15 @@ mod tests {
             let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-            journal.append(&1).await.unwrap();
-            journal.append(&2).await.unwrap();
-            journal.sync().await.unwrap();
+            (journal, _) = journal.append(&1).await.unwrap();
+            (journal, _) = journal.append(&2).await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
             // Simulate the state left by a crash after item 2 became visible to recovery, but
             // before the persisted recovery watermark advanced past item 1.
             journal.test_set_recovery_watermark(1).await.unwrap();
             drop(journal);
 
-            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(journal.size(), 2);
@@ -1663,9 +1822,8 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
-            journal.append(&test_digest(1)).await.unwrap();
+            (journal, _) = journal.append(&test_digest(1)).await.unwrap();
             journal.sync().await.unwrap();
-            drop(journal);
 
             let legacy_blobs = scan_partition(&context, &legacy_partition).await;
             let new_blobs = scan_partition(&context, &blobs_partition).await;
@@ -1685,9 +1843,8 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
-            journal.append(&test_digest(1)).await.unwrap();
+            (journal, _) = journal.append(&test_digest(1)).await.unwrap();
             journal.sync().await.unwrap();
-            drop(journal);
 
             let legacy_blobs = scan_partition(&context, &legacy_partition).await;
             let new_blobs = scan_partition(&context, &blobs_partition).await;
@@ -1710,7 +1867,8 @@ mod tests {
                 .expect("failed to initialize journal");
 
             // Append an item to the journal
-            let mut pos = journal
+            let mut pos;
+            (journal, pos) = journal
                 .append(&test_digest(0))
                 .await
                 .expect("failed to append data 0");
@@ -1718,7 +1876,6 @@ mod tests {
 
             // Drop the journal and re-initialize it to simulate a restart
             journal.sync().await.expect("Failed to sync journal");
-            drop(journal);
 
             let cfg = test_cfg(&context, NZU64!(2));
             let mut journal = Journal::init(context.child("second"), cfg.clone())
@@ -1727,12 +1884,12 @@ mod tests {
             assert_eq!(journal.size(), 1);
 
             // Append two more items to the journal to trigger a new blob creation
-            pos = journal
+            (journal, pos) = journal
                 .append(&test_digest(1))
                 .await
                 .expect("failed to append data 1");
             assert_eq!(pos, 1);
-            pos = journal
+            (journal, pos) = journal
                 .append(&test_digest(2))
                 .await
                 .expect("failed to append data 2");
@@ -1749,13 +1906,13 @@ mod tests {
             assert!(matches!(err, Error::ItemOutOfRange(3)));
 
             // Sync the journal
-            journal.sync().await.expect("failed to sync journal");
+            journal = journal.sync().await.expect("failed to sync journal");
 
             // Pruning to 1 should be a no-op because there's no blob with only older items.
-            journal.prune(1).await.expect("failed to prune journal 1");
+            (journal, _) = journal.prune(1).await.expect("failed to prune journal 1");
 
             // Pruning to 2 should allow the first blob to be pruned.
-            journal.prune(2).await.expect("failed to prune journal 2");
+            (journal, _) = journal.prune(2).await.expect("failed to prune journal 2");
             assert_eq!(journal.bounds().start, 2);
 
             // Reading from the first blob should fail since it's now pruned
@@ -1770,7 +1927,8 @@ mod tests {
 
             // Should be able to continue to append items
             for i in 3..10 {
-                let pos = journal
+                let pos;
+                (journal, pos) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
@@ -1778,13 +1936,13 @@ mod tests {
             }
 
             // Check no-op pruning
-            journal.prune(0).await.expect("no-op pruning failed");
+            (journal, _) = journal.prune(0).await.expect("no-op pruning failed");
             assert_eq!(journal.test_oldest_blob(), Some(1));
             assert_eq!(journal.test_newest_blob(), Some(5));
             assert_eq!(journal.bounds().start, 2);
 
             // Prune first 3 blobs (6 items)
-            journal
+            (journal, _) = journal
                 .prune(3 * cfg.items_per_blob.get())
                 .await
                 .expect("failed to prune journal 2");
@@ -1793,7 +1951,7 @@ mod tests {
             assert_eq!(journal.bounds().start, 6);
 
             // Try pruning (more than) everything in the journal.
-            journal
+            (journal, _) = journal
                 .prune(10000)
                 .await
                 .expect("failed to max-prune journal");
@@ -1810,18 +1968,21 @@ mod tests {
 
             // Replaying from 0 should fail since all items before bounds.start are pruned
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let result = reader.replay(0, NZUsize!(1024)).await;
                 assert!(matches!(result, Err(Error::ItemPruned(0))));
             }
 
             // Replaying from pruning_boundary should return empty stream
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let res = reader.replay(0, NZUsize!(1024)).await;
                 assert!(matches!(res, Err(Error::ItemPruned(_))));
 
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader
                     .replay(journal.bounds().start, NZUsize!(1024))
                     .await
@@ -1857,14 +2018,13 @@ mod tests {
                 .expect("failed to initialize journal");
             // Append 2 blobs worth of items.
             for i in 0u64..ITEMS_PER_BLOB.get() * 2 - 1 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
             // Sync, reopen, then read back.
             journal.sync().await.expect("failed to sync journal");
-            drop(journal);
             let journal = Journal::init(context.child("second"), cfg.clone())
                 .await
                 .expect("failed to re-initialize journal");
@@ -1892,7 +2052,8 @@ mod tests {
 
             // Append many items, filling 100 blobs and part of the 101st
             for i in 0u64..(ITEMS_PER_BLOB.get() * 100 + ITEMS_PER_BLOB.get() / 2) {
-                let pos = journal
+                let pos;
+                (journal, pos) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
@@ -1907,7 +2068,8 @@ mod tests {
 
             // Replay should return all items
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader
                     .replay(0, NZUsize!(1024))
                     .await
@@ -1936,7 +2098,6 @@ mod tests {
             }
 
             journal.sync().await.expect("Failed to sync journal");
-            drop(journal);
 
             // Corrupt one of the bytes and make sure it's detected.
             let (blob, _) = context
@@ -1950,7 +2111,7 @@ mod tests {
                 .expect("Failed to write bad bytes");
 
             // Re-initialize the journal to simulate a restart
-            let mut journal = Journal::init(context.child("second"), cfg.clone())
+            let journal = Journal::init(context.child("second"), cfg.clone())
                 .await
                 .expect("Failed to re-initialize journal");
 
@@ -1964,7 +2125,7 @@ mod tests {
             // Replay all items.
             {
                 let mut error_found = false;
-                let reader = journal.snapshot().await.unwrap();
+                let (_journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader
                     .replay(0, NZUsize!(1024))
                     .await
@@ -2000,10 +2161,9 @@ mod tests {
                 .unwrap();
 
             for i in 0u64..30 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             let (blob, _) = context
                 .open(&blob_partition(&cfg), &1u64.to_be_bytes())
@@ -2016,7 +2176,8 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let stream = reader.replay(0, NZUsize!(1024)).await.unwrap();
             pin_mut!(stream);
 
@@ -2044,10 +2205,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0u64..5 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Delete a middle blob (external corruption). The watermark (5) now exceeds the
             // recoverable contiguous prefix, which is corruption.
@@ -2080,7 +2240,8 @@ mod tests {
 
             // Append many items, filling 100 blobs and part of the 101st
             for i in 0u64..(ITEMS_PER_BLOB.get() * 100 + ITEMS_PER_BLOB.get() / 2) {
-                let pos = journal
+                let pos;
+                (journal, pos) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
@@ -2089,7 +2250,8 @@ mod tests {
 
             // Replay should return all items except the first `START_POS`.
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader
                     .replay(START_POS, NZUsize!(1024))
                     .await
@@ -2136,10 +2298,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..5 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Truncate the tail blob by 1 byte (external corruption). The watermark (5) now
             // exceeds the recoverable size, which is corruption.
@@ -2170,15 +2331,16 @@ mod tests {
 
             // Fill 3 blobs (0..15), sync everything.
             for i in 0..15u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
-            assert_eq!(journal.recovery_watermark(), 15);
+            let mut journal = journal.sync().await.unwrap();
+            assert_eq!(journal.0.recovery_watermark(), 15);
 
             // Persist the recovered metadata (watermark=9) as init_with_checkpoint does before
             // applying the rewind repair. This simulates a crash after metadata sync but before
             // the repair removes stale blobs.
             journal
+                .0
                 .checkpoint
                 .persist(cfg.items_per_blob.get(), 0, 9)
                 .await
@@ -2212,7 +2374,7 @@ mod tests {
                 .await
                 .expect("init should succeed after crash during recovery repair");
             assert_eq!(journal.bounds(), 0..9);
-            assert_eq!(journal.recovery_watermark(), 9);
+            assert_eq!(journal.0.recovery_watermark(), 9);
             assert_eq!(journal.read(8).await.unwrap(), test_digest(8));
             assert!(matches!(
                 journal.read(9).await,
@@ -2240,10 +2402,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..7 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen and verify the size is exactly 7 with no repair (a clean short tail).
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -2270,10 +2431,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..5 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen: blob 0 is full, blob 1 is the empty tail. Size = 5, no repair.
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -2298,9 +2458,8 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
-            journal.append(&test_digest(0)).await.unwrap();
+            (journal, _) = journal.append(&test_digest(0)).await.unwrap();
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Add a far-future blob directly. Recovery should inspect actual blob ids and
             // repair at the first missing boundary instead of walking the entire numeric range.
@@ -2341,22 +2500,18 @@ mod tests {
                     .expect("failed to initialize journal at size");
 
             for i in 0..8u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(100 + i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let mut journal = journal.sync().await.expect("failed to sync journal");
             assert_eq!(journal.bounds(), 7..15);
 
-            {
-                journal.checkpoint.set_watermark(Some(6));
-                journal
-                    .checkpoint
-                    .sync()
-                    .await
-                    .expect("failed to sync lower recovery watermark");
-            }
+            journal
+                .test_set_recovery_watermark(6)
+                .await
+                .expect("failed to sync lower recovery watermark");
             drop(journal);
 
             let (blob, size) = context
@@ -2394,24 +2549,20 @@ mod tests {
                     .expect("failed to initialize journal at size");
 
             for i in 0..10u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let mut journal = journal.sync().await.expect("failed to sync journal");
             assert_eq!(journal.bounds(), 7..17);
 
             // Stage the stale forward-looking watermark while the journal is alive (so we go
             // through the public metadata path), then drop and corrupt the underlying blob.
-            {
-                journal.checkpoint.set_watermark(Some(12));
-                journal
-                    .checkpoint
-                    .sync()
-                    .await
-                    .expect("failed to sync recovery watermark");
-            }
+            journal
+                .test_set_recovery_watermark(12)
+                .await
+                .expect("failed to sync recovery watermark");
             drop(journal);
 
             // Shorten blob 2 to two items via Append::resize so the on-disk logical view
@@ -2443,7 +2594,7 @@ mod tests {
                 .await
                 .expect("failed to recover journal");
             assert_eq!(journal.bounds(), 10..12);
-            assert_eq!(journal.recovery_watermark(), 12);
+            assert_eq!(journal.0.recovery_watermark(), 12);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(3));
             assert_eq!(journal.read(11).await.unwrap(), test_digest(4));
             assert!(matches!(
@@ -2466,17 +2617,18 @@ mod tests {
                     .expect("failed to initialize journal at size");
 
             for i in 0..10u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let mut journal = journal.sync().await.expect("failed to sync journal");
             assert_eq!(journal.bounds(), 7..17);
 
             {
-                journal.checkpoint.set_watermark(None);
+                journal.0.checkpoint.set_watermark(None);
                 journal
+                    .0
                     .checkpoint
                     .sync()
                     .await
@@ -2496,13 +2648,13 @@ mod tests {
                 .expect("failed to recover journal");
             assert_eq!(journal.bounds(), 10..17);
             // No watermark: watermark at the tail blob start, not size.
-            assert_eq!(journal.recovery_watermark(), 15);
+            assert_eq!(journal.0.recovery_watermark(), 15);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(3));
             assert_eq!(journal.read(16).await.unwrap(), test_digest(9));
 
             // After sync, watermark advances to the full recovered size.
-            journal.sync().await.expect("failed to sync");
-            assert_eq!(journal.recovery_watermark(), 17);
+            journal = journal.sync().await.expect("failed to sync");
+            assert_eq!(journal.0.recovery_watermark(), 17);
 
             journal.destroy().await.unwrap();
         });
@@ -2523,9 +2675,9 @@ mod tests {
 
             // Append 12 items (positions 3..15) spanning blobs 0, 1, 2.
             for i in 0..12u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
             assert_eq!(journal.bounds(), 3..15);
 
             // Set the boundary hint to 8 (blob 1) and lower the watermark so it won't
@@ -2533,9 +2685,9 @@ mod tests {
             // blob so blob 0 is the oldest. The boundary hint now references a blob ahead
             // of the oldest blob, which is the corruption we're testing.
             {
-                journal.checkpoint.set_boundary_hint(8);
-                journal.checkpoint.set_watermark(Some(3));
-                journal.checkpoint.sync().await.unwrap();
+                journal.0.checkpoint.set_boundary_hint(8);
+                journal.0.checkpoint.set_watermark(Some(3));
+                journal.0.checkpoint.sync().await.unwrap();
             }
             drop(journal);
 
@@ -2562,10 +2714,9 @@ mod tests {
                     .unwrap();
 
             for i in 0..3u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Remove all blobs but leave the checkpoint (with a boundary hint of 7) intact.
             for name in scan_partition(&context, &blob_partition(&cfg)).await {
@@ -2590,16 +2741,17 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..12u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let mut journal = journal.sync().await.expect("failed to sync journal");
 
             {
-                journal.checkpoint.set_watermark(None);
+                journal.0.checkpoint.set_watermark(None);
                 journal
+                    .0
                     .checkpoint
                     .sync()
                     .await
@@ -2613,14 +2765,14 @@ mod tests {
                 .await
                 .expect("failed to recover legacy journal");
             assert_eq!(journal.bounds(), 0..12);
-            assert_eq!(journal.recovery_watermark(), 10);
+            assert_eq!(journal.0.recovery_watermark(), 10);
 
             // After sync, the watermark advances to the full size.
-            journal
+            journal = journal
                 .sync()
                 .await
                 .expect("failed to sync after legacy recovery");
-            assert_eq!(journal.recovery_watermark(), 12);
+            assert_eq!(journal.0.recovery_watermark(), 12);
 
             journal.destroy().await.unwrap();
         });
@@ -2639,23 +2791,23 @@ mod tests {
                 .unwrap();
 
             for i in 0..7u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // Remove the watermark to simulate a legacy journal.
             {
-                journal.checkpoint.set_watermark(None);
-                journal.checkpoint.sync().await.unwrap();
+                journal.0.checkpoint.set_watermark(None);
+                journal.0.checkpoint.sync().await.unwrap();
             }
             drop(journal);
 
-            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(journal.size(), 7);
             // Watermark at tail blob start (blob 1 = position 5).
-            assert_eq!(journal.recovery_watermark(), 5);
+            assert_eq!(journal.0.recovery_watermark(), 5);
 
             // Inject sync faults. If recovered blobs were not marked dirty, commit would
             // skip the data sync and succeed despite the fault.
@@ -2679,20 +2831,20 @@ mod tests {
                 .await
                 .unwrap();
 
-            journal.append(&test_digest(0)).await.unwrap();
-            journal.sync().await.unwrap();
-            assert_eq!(journal.recovery_watermark(), 1);
+            (journal, _) = journal.append(&test_digest(0)).await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
+            assert_eq!(journal.0.recovery_watermark(), 1);
 
-            journal.append(&test_digest(1)).await.unwrap();
-            journal.commit().await.unwrap();
+            (journal, _) = journal.append(&test_digest(1)).await.unwrap();
+            let mut journal = journal.commit().await.unwrap();
             assert_eq!(
-                journal.recovery_watermark(),
+                journal.0.recovery_watermark(),
                 1,
                 "commit must make dirty blobs durable without advancing the recovery watermark",
             );
 
-            journal.sync().await.unwrap();
-            assert_eq!(journal.recovery_watermark(), 2);
+            journal = journal.sync().await.unwrap();
+            assert_eq!(journal.0.recovery_watermark(), 2);
             journal.destroy().await.unwrap();
         });
     }
@@ -2708,16 +2860,16 @@ mod tests {
                     .expect("failed to initialize journal at size");
 
             for i in 0..8u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let mut journal = journal.sync().await.expect("failed to sync journal");
             assert_eq!(journal.bounds(), 7..15);
 
-            journal.prune(10).await.expect("failed to prune journal");
-            journal.sync().await.expect("failed to sync pruned journal");
+            (journal, _) = journal.prune(10).await.expect("failed to prune journal");
+            let journal = journal.sync().await.expect("failed to sync pruned journal");
             assert_eq!(journal.bounds(), 10..15);
             drop(journal);
 
@@ -2746,13 +2898,12 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..5u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
             journal.sync().await.expect("failed to sync journal");
-            drop(journal);
 
             // Inject an extra item into blob 0 at the blob level so its length exceeds
             // items_per_blob -- this is what `recover_bounds` validates and rejects as Corruption.
@@ -2789,13 +2940,12 @@ mod tests {
                 .expect("failed to initialize journal");
 
             // Add only a single item
-            journal
+            (journal, _) = journal
                 .append(&test_digest(0))
                 .await
                 .expect("failed to append data");
             assert_eq!(journal.size(), 1);
             journal.sync().await.expect("Failed to sync journal");
-            drop(journal);
 
             // Manually extend the blob to simulate a failure where the file was extended, but no
             // bytes were written due to failure.
@@ -2817,7 +2967,7 @@ mod tests {
             assert_eq!(journal.size(), 1);
 
             // Make sure journal still works for appending.
-            journal
+            (journal, _) = journal
                 .append(&test_digest(1))
                 .await
                 .expect("failed to append data");
@@ -2832,28 +2982,34 @@ mod tests {
         executor.start(|context| async move {
             // Initialize the journal, allowing a max of 2 items per blob.
             let cfg = test_cfg(&context, NZU64!(2));
-            let mut journal = Journal::init(context.child("first"), cfg.clone())
+            let journal: Journal<_, Digest> = Journal::init(context.child("first"), cfg.clone())
                 .await
                 .expect("failed to initialize journal");
-            assert!(matches!(journal.rewind(0).await, Ok(())));
+            let journal = journal.rewind(0).await.unwrap();
+            // The failed rewind consumes the journal.
             assert!(matches!(
                 journal.rewind(1).await,
                 Err(Error::InvalidRewind(1))
             ));
+            let mut journal: Journal<_, Digest> =
+                Journal::init(context.child("reopen"), cfg.clone())
+                    .await
+                    .expect("failed to re-initialize journal");
 
             // Append an item to the journal
-            journal
+            (journal, _) = journal
                 .append(&test_digest(0))
                 .await
                 .expect("failed to append data 0");
             assert_eq!(journal.size(), 1);
-            assert!(matches!(journal.rewind(1).await, Ok(()))); // should be no-op
-            assert!(matches!(journal.rewind(0).await, Ok(())));
+            journal = journal.rewind(1).await.unwrap(); // should be no-op
+            journal = journal.rewind(0).await.unwrap();
             assert_eq!(journal.size(), 0);
 
             // append 7 items
             for i in 0..7 {
-                let pos = journal
+                let pos;
+                (journal, pos) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
@@ -2862,28 +3018,28 @@ mod tests {
             assert_eq!(journal.size(), 7);
 
             // rewind back to item #4, which should prune 2 blobs
-            assert!(matches!(journal.rewind(4).await, Ok(())));
+            journal = journal.rewind(4).await.unwrap();
             assert_eq!(journal.size(), 4);
 
             // rewind back to empty and ensure all blobs are rewound over
-            assert!(matches!(journal.rewind(0).await, Ok(())));
+            journal = journal.rewind(0).await.unwrap();
             assert_eq!(journal.size(), 0);
 
             // stress test: add 100 items, rewind 49, repeat x10.
             for _ in 0..10 {
                 for i in 0..100 {
-                    journal
+                    (journal, _) = journal
                         .append(&test_digest(i))
                         .await
                         .expect("failed to append data");
                 }
-                journal.rewind(journal.size() - 49).await.unwrap();
+                let size = journal.size();
+                journal = journal.rewind(size - 49).await.unwrap();
             }
             const ITEMS_REMAINING: u64 = 10 * (100 - 49);
             assert_eq!(journal.size(), ITEMS_REMAINING);
 
             journal.sync().await.expect("Failed to sync journal");
-            drop(journal);
 
             // Repeat with a different blob size (3 items per blob)
             let mut cfg = test_cfg(&context, NZU64!(3));
@@ -2893,17 +3049,17 @@ mod tests {
                 .expect("failed to initialize journal");
             for _ in 0..10 {
                 for i in 0..100 {
-                    journal
+                    (journal, _) = journal
                         .append(&test_digest(i))
                         .await
                         .expect("failed to append data");
                 }
-                journal.rewind(journal.size() - 49).await.unwrap();
+                let size = journal.size();
+                journal = journal.rewind(size - 49).await.unwrap();
             }
             assert_eq!(journal.size(), ITEMS_REMAINING);
 
             journal.sync().await.expect("Failed to sync journal");
-            drop(journal);
 
             // Make sure re-opened journal is as expected
             let mut journal: Journal<_, Digest> =
@@ -2913,20 +3069,24 @@ mod tests {
             assert_eq!(journal.size(), 10 * (100 - 49));
 
             // Make sure rewinding works after pruning
-            journal.prune(300).await.expect("pruning failed");
+            (journal, _) = journal.prune(300).await.expect("pruning failed");
             assert_eq!(journal.size(), ITEMS_REMAINING);
+            // Rewinding to the prune point should work.
+            // always remain in the journal.
+            journal = journal.rewind(300).await.unwrap();
+            let bounds = journal.bounds();
+            assert_eq!(bounds.end, 300);
+            assert!(bounds.is_empty());
+
             // Rewinding prior to our prune point should fail.
             assert!(matches!(
                 journal.rewind(299).await,
                 Err(Error::ItemPruned(299))
             ));
-            // Rewinding to the prune point should work.
-            // always remain in the journal.
-            assert!(matches!(journal.rewind(300).await, Ok(())));
-            let bounds = journal.bounds();
-            assert_eq!(bounds.end, 300);
-            assert!(bounds.is_empty());
 
+            let journal: Journal<_, Digest> = Journal::init(context.child("fourth"), cfg.clone())
+                .await
+                .expect("failed to re-initialize journal");
             journal.destroy().await.unwrap();
         });
     }
@@ -2941,16 +3101,15 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..12u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let journal = journal.sync().await.expect("failed to sync journal");
 
-            journal.rewind(7).await.expect("failed to rewind journal");
+            let journal = journal.rewind(7).await.expect("failed to rewind journal");
             journal.commit().await.expect("failed to commit journal");
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
@@ -2978,14 +3137,13 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..12u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let journal = journal.sync().await.expect("failed to sync journal");
             journal.rewind(7).await.expect("failed to rewind journal");
-            drop(journal);
 
             let checkpoint = Checkpoint::open(context.child("metadata"), &cfg.partition)
                 .await
@@ -3013,28 +3171,24 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..12u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let mut journal = journal.sync().await.expect("failed to sync journal");
 
-            {
-                journal.checkpoint.set_watermark(Some(7));
-                journal
-                    .checkpoint
-                    .sync()
-                    .await
-                    .expect("failed to lower recovery watermark");
-            }
+            journal
+                .test_set_recovery_watermark(7)
+                .await
+                .expect("failed to lower recovery watermark");
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .expect("failed to recover journal");
             assert_eq!(journal.bounds(), 0..12);
-            assert_eq!(journal.recovery_watermark(), 7);
+            assert_eq!(journal.0.recovery_watermark(), 7);
             assert_eq!(journal.read(11).await.unwrap(), test_digest(11));
             journal.destroy().await.unwrap();
         });
@@ -3050,28 +3204,27 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..12u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let journal = journal.sync().await.expect("failed to sync journal");
 
-            journal.rewind(7).await.expect("failed to rewind journal");
+            let mut journal = journal.rewind(7).await.expect("failed to rewind journal");
             for i in 0..3u64 {
-                journal
+                (journal, _) = journal
                     .append(&test_digest(100 + i))
                     .await
                     .expect("failed to append data");
             }
             journal.commit().await.expect("failed to commit journal");
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .expect("failed to re-initialize journal");
             assert_eq!(journal.bounds(), 0..10);
-            assert_eq!(journal.recovery_watermark(), 7);
+            assert_eq!(journal.0.recovery_watermark(), 7);
             for i in 0..7u64 {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
             }
@@ -3098,10 +3251,16 @@ mod tests {
 
             // Persist a prefix, then append across multiple blob boundaries without syncing. The
             // unsynced item bytes are lost on drop, but their blobs remain visible.
-            assert_eq!(journal.append(&test_digest(10)).await.unwrap(), 0);
-            journal.sync().await.unwrap();
-            assert_eq!(journal.append(&test_digest(20)).await.unwrap(), 1);
-            assert_eq!(journal.append(&test_digest(30)).await.unwrap(), 2);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(10)).await.unwrap();
+            assert_eq!(appended, 0);
+            journal = journal.sync().await.unwrap();
+            let appended;
+            (journal, appended) = journal.append(&test_digest(20)).await.unwrap();
+            assert_eq!(appended, 1);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(30)).await.unwrap();
+            assert_eq!(appended, 2);
             drop(journal);
 
             let blobs = scan_partition(&context, &blob_partition(&cfg)).await;
@@ -3126,7 +3285,9 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 1);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(42)).await.unwrap();
+            assert_eq!(appended, 1);
             assert_eq!(journal.read(1).await.unwrap(), test_digest(42));
             journal.destroy().await.unwrap();
         });
@@ -3143,8 +3304,12 @@ mod tests {
 
             // Append across multiple blob boundaries without ever syncing. No item bytes become
             // durable, so recovery sees multiple empty blobs and no durable data.
-            assert_eq!(journal.append(&test_digest(10)).await.unwrap(), 0);
-            assert_eq!(journal.append(&test_digest(20)).await.unwrap(), 1);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(10)).await.unwrap();
+            assert_eq!(appended, 0);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(20)).await.unwrap();
+            assert_eq!(appended, 1);
             drop(journal);
 
             let blobs = scan_partition(&context, &blob_partition(&cfg)).await;
@@ -3167,7 +3332,9 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("recovered"), cfg.clone())
                 .await
                 .unwrap();
-            assert_eq!(journal.append(&test_digest(42)).await.unwrap(), 0);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(42)).await.unwrap();
+            assert_eq!(appended, 0);
             assert_eq!(journal.read(0).await.unwrap(), test_digest(42));
             journal.destroy().await.unwrap();
         });
@@ -3191,7 +3358,7 @@ mod tests {
             // Fill blobs 0 and 1 and partially fill blob 2 (positions 20..25). Nothing is
             // synced yet, so only the created blobs are durable, all still empty.
             for i in 0..25u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
             // Sync blobs 0 and 1 but not blob 2, simulating a crash after part of a
@@ -3229,7 +3396,9 @@ mod tests {
             ));
 
             // Appends resume cleanly from the recovered boundary.
-            assert_eq!(journal.append(&test_digest(999)).await.unwrap(), 20);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(999)).await.unwrap();
+            assert_eq!(appended, 20);
             assert_eq!(journal.read(20).await.unwrap(), test_digest(999));
 
             journal.destroy().await.unwrap();
@@ -3255,14 +3424,14 @@ mod tests {
 
             // Durably commit blob 0 (positions 0..10), advancing the recovery watermark to 10.
             for i in 0..10u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Append blob 1 and part of blob 2 without committing. Manually sync only blob
             // 2 to mimic its writes surviving a crash, while blob 1 stays buffered and is lost.
             for i in 10..28u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             {
                 journal.test_sync_blob(2).await.unwrap();
@@ -3300,7 +3469,9 @@ mod tests {
             assert_eq!(names.len(), 2);
 
             // Appends resume cleanly from the recovered boundary.
-            assert_eq!(journal.append(&test_digest(999)).await.unwrap(), 10);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(999)).await.unwrap();
+            assert_eq!(appended, 10);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(999));
 
             journal.destroy().await.unwrap();
@@ -3323,15 +3494,16 @@ mod tests {
             // Durably persist blob 0 (positions 0..10), then append positions 10..25 across
             // blobs 1 and 2 without syncing.
             for i in 0..10u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
             for i in 10..25u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
             // Prune away blob 0, then crash before any sync.
-            assert!(journal.prune(10).await.unwrap());
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
             drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -3363,10 +3535,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..20u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Empty the oldest blob (external corruption). The watermark (20) now exceeds the
             // recoverable size (0), which is corruption.
@@ -3410,7 +3581,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Append 1 item
-            let pos = journal
+            let pos;
+            (journal, pos) = journal
                 .append(&test_digest(0))
                 .await
                 .expect("failed to append");
@@ -3418,7 +3590,7 @@ mod tests {
             assert_eq!(journal.size(), 1);
 
             // Sync
-            journal.sync().await.expect("failed to sync");
+            journal = journal.sync().await.expect("failed to sync");
 
             // Read from size() - 1
             let value = journal
@@ -3429,7 +3601,8 @@ mod tests {
 
             // === Test 2: Multiple items with single item per blob ===
             for i in 1..10u64 {
-                let pos = journal
+                let pos;
+                (journal, pos) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append");
@@ -3449,11 +3622,11 @@ mod tests {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
             }
 
-            journal.sync().await.expect("failed to sync");
+            journal = journal.sync().await.expect("failed to sync");
 
             // === Test 3: Pruning with single item per blob ===
             // Prune to position 5 (removes positions 0-4)
-            journal.prune(5).await.expect("failed to prune");
+            (journal, _) = journal.prune(5).await.expect("failed to prune");
 
             // Size should still be 10
             assert_eq!(journal.size(), 10);
@@ -3480,7 +3653,8 @@ mod tests {
 
             // Append more items after pruning
             for i in 10..15u64 {
-                let pos = journal
+                let pos;
+                (journal, pos) = journal
                     .append(&test_digest(i))
                     .await
                     .expect("failed to append");
@@ -3495,7 +3669,6 @@ mod tests {
             }
 
             journal.sync().await.expect("failed to sync");
-            drop(journal);
 
             // === Test 4: Restart persistence with single item per blob ===
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
@@ -3530,18 +3703,17 @@ mod tests {
 
             // Append 10 items (positions 0-9)
             for i in 0..10u64 {
-                journal.append(&test_digest(i + 100)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i + 100)).await.unwrap();
             }
 
             // Prune to position 5 (removes positions 0-4)
-            journal.prune(5).await.unwrap();
+            (journal, _) = journal.prune(5).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 10);
             assert_eq!(bounds.start, 5);
 
             // Sync and restart
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Re-open journal
             let journal = Journal::<_, Digest>::init(context.child("fourth"), cfg.clone())
@@ -3570,12 +3742,12 @@ mod tests {
                 .expect("failed to initialize journal");
 
             for i in 0..5u64 {
-                journal.append(&test_digest(i + 200)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i + 200)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Prune all items
-            journal.prune(5).await.unwrap();
+            (journal, _) = journal.prune(5).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 5); // Size unchanged
             assert!(bounds.is_empty()); // All pruned
@@ -3585,7 +3757,7 @@ mod tests {
             assert!(matches!(result, Err(Error::ItemPruned(4))));
 
             // After appending, reading works again
-            journal.append(&test_digest(205)).await.unwrap();
+            (journal, _) = journal.append(&test_digest(205)).await.unwrap();
             assert_eq!(journal.bounds().start, 5);
             assert_eq!(
                 journal.read(journal.size() - 1).await.unwrap(),
@@ -3611,7 +3783,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Next append should get position 0
-            let pos = journal.append(&test_digest(100)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(100)).await.unwrap();
             assert_eq!(pos, 0);
             assert_eq!(journal.size(), 1);
             assert_eq!(journal.read(0).await.unwrap(), test_digest(100));
@@ -3649,17 +3822,17 @@ mod tests {
                     .unwrap();
 
             // The first append fills the last representable position.
-            assert_eq!(journal.append(&test_digest(7)).await.unwrap(), u64::MAX - 1);
+            let appended;
+            (journal, appended) = journal.append(&test_digest(7)).await.unwrap();
+            assert_eq!(appended, u64::MAX - 1);
             assert_eq!(journal.size(), u64::MAX);
 
-            // The next append would overflow the size; it must return a recoverable error
-            // rather than panicking.
+            // The next append would overflow the size; it must return an error rather than
+            // panicking.
             assert!(matches!(
                 journal.append(&test_digest(8)).await,
                 Err(Error::SizeOverflow)
             ));
-
-            journal.destroy().await.unwrap();
         });
     }
 
@@ -3675,10 +3848,13 @@ mod tests {
                     .await
                     .unwrap();
             let expected = test_digest(7);
-            assert_eq!(journal.append(&expected).await.unwrap(), u64::MAX - 1);
+            let appended;
+            (journal, appended) = journal.append(&expected).await.unwrap();
+            assert_eq!(appended, u64::MAX - 1);
 
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(u64::MAX - 1, NZUsize!(1024)).await.unwrap();
                 pin_mut!(stream);
                 let (pos, item) = stream.next().await.unwrap().unwrap();
@@ -3708,13 +3884,15 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Next append should get position 10
-            let pos = journal.append(&test_digest(1000)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(1000)).await.unwrap();
             assert_eq!(pos, 10);
             assert_eq!(journal.size(), 11);
             assert_eq!(journal.read(10).await.unwrap(), test_digest(1000));
 
             // Can continue appending
-            let pos = journal.append(&test_digest(1001)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(1001)).await.unwrap();
             assert_eq!(pos, 11);
             assert_eq!(journal.read(11).await.unwrap(), test_digest(1001));
 
@@ -3744,7 +3922,8 @@ mod tests {
             assert!(matches!(journal.read(6).await, Err(Error::ItemPruned(6))));
 
             // Next append should get position 7
-            let pos = journal.append(&test_digest(700)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(700)).await.unwrap();
             assert_eq!(pos, 7);
             assert_eq!(journal.size(), 8);
             assert_eq!(journal.read(7).await.unwrap(), test_digest(700));
@@ -3766,7 +3945,8 @@ mod tests {
                     .unwrap();
 
             let items: Vec<_> = (0..100u64).map(|i| test_digest(1500 + i)).collect();
-            let last = journal.append_many(Many::Flat(&items)).await.unwrap();
+            let last;
+            (journal, last) = journal.append_many(Many::Flat(&items)).await.unwrap();
             assert_eq!(last, 249);
             assert_eq!(journal.bounds(), 150..250);
 
@@ -3779,7 +3959,6 @@ mod tests {
             }
 
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
@@ -3811,7 +3990,8 @@ mod tests {
 
             // Append some items
             for i in 0..5u64 {
-                let pos = journal.append(&test_digest(1500 + i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&test_digest(1500 + i)).await.unwrap();
                 assert_eq!(pos, 15 + i);
             }
 
@@ -3819,7 +3999,6 @@ mod tests {
 
             // Sync and reopen
             journal.sync().await.unwrap();
-            drop(journal);
 
             let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
@@ -3836,7 +4015,8 @@ mod tests {
             }
 
             // Can continue appending
-            let pos = journal.append(&test_digest(9999)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(9999)).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), test_digest(9999));
 
@@ -3873,7 +4053,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Can append starting at position 15
-            let pos = journal.append(&test_digest(1500)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(1500)).await.unwrap();
             assert_eq!(pos, 15);
             assert_eq!(journal.read(15).await.unwrap(), test_digest(1500));
 
@@ -3898,7 +4079,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Next append should get position 1000
-            let pos = journal.append(&test_digest(100000)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(100000)).await.unwrap();
             assert_eq!(pos, 1000);
             assert_eq!(journal.read(1000).await.unwrap(), test_digest(100000));
 
@@ -3920,13 +4102,13 @@ mod tests {
 
             // Append items 20-29
             for i in 0..10u64 {
-                journal.append(&test_digest(2000 + i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(2000 + i)).await.unwrap();
             }
 
             assert_eq!(journal.size(), 30);
 
             // Prune to position 25
-            journal.prune(25).await.unwrap();
+            (journal, _) = journal.prune(25).await.unwrap();
 
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 30);
@@ -3938,7 +4120,8 @@ mod tests {
             }
 
             // Continue appending
-            let pos = journal.append(&test_digest(3000)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(3000)).await.unwrap();
             assert_eq!(pos, 30);
 
             journal.destroy().await.unwrap();
@@ -3956,13 +4139,13 @@ mod tests {
 
             // Append 25 items (positions 0-24, spanning 3 blobs)
             for i in 0..25u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 25);
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Clear to position 100, effectively resetting the journal
-            journal.clear_to_size(100).await.unwrap();
+            journal.0.clear_to_size(100).await.unwrap();
             assert_eq!(journal.size(), 100);
 
             // Old positions should fail
@@ -3980,7 +4163,8 @@ mod tests {
 
             // Append new data starting at position 100
             for i in 100..105u64 {
-                let pos = journal.append(&test_digest(i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&test_digest(i)).await.unwrap();
                 assert_eq!(pos, i);
             }
             assert_eq!(journal.size(), 105);
@@ -3992,7 +4176,6 @@ mod tests {
 
             // Sync and re-init to verify persistence
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("journal_reopened"), cfg)
                 .await
@@ -4018,11 +4201,11 @@ mod tests {
                 .await
                 .unwrap();
             assert!(matches!(
-                journal.clear_to_size(u64::MAX).await,
+                journal.0.clear_to_size(u64::MAX).await,
                 Err(Error::SizeOverflow)
             ));
             assert!(matches!(
-                journal.stage_clear_intent(u64::MAX).await,
+                journal.0.stage_clear_intent(u64::MAX).await,
                 Err(Error::SizeOverflow)
             ));
             journal.destroy().await.unwrap();
@@ -4040,10 +4223,9 @@ mod tests {
                 .unwrap();
 
             for i in 0..5u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.commit().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
@@ -4067,13 +4249,13 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..3u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // Simulate metadata deletion (corruption).
-            journal.checkpoint.clear();
-            journal.checkpoint.sync().await.unwrap();
+            journal.0.checkpoint.clear();
+            journal.0.checkpoint.sync().await.unwrap();
             drop(journal);
 
             let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
@@ -4092,10 +4274,9 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..3u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.commit().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
@@ -4117,13 +4298,12 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..10u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 17);
-            journal.prune(10).await.unwrap();
+            (journal, _) = journal.prune(10).await.unwrap();
 
             journal.commit().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
@@ -4149,10 +4329,10 @@ mod tests {
                     .unwrap();
             // Append 5 items at positions 7-11, filling blob 1 and part of blob 2
             for i in 0..5u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             // Prune to position 5 (blob 1 start) should NOT move boundary back from 7 to 5
-            journal.prune(5).await.unwrap();
+            let (journal, _) = journal.prune(5).await.unwrap();
             assert_eq!(journal.bounds().start, 7);
             journal.destroy().await.unwrap();
         });
@@ -4170,11 +4350,11 @@ mod tests {
                 .unwrap();
 
             for i in 0..12 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
-            journal.prune(5).await.unwrap();
-            journal
+            let (mut journal, _) = journal.prune(5).await.unwrap();
+            journal = journal
                 .commit()
                 .await
                 .expect("commit should not try to sync pruned blobs");
@@ -4200,15 +4380,17 @@ mod tests {
 
             // Append 13 items (positions 7-19), spanning blobs 1, 2, 3
             for i in 0..13u64 {
-                let pos = journal.append(&test_digest(100 + i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&test_digest(100 + i)).await.unwrap();
                 assert_eq!(pos, 7 + i);
             }
             assert_eq!(journal.size(), 20);
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Replay from pruning_boundary
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader
                     .replay(7, NZUsize!(1024))
                     .await
@@ -4229,7 +4411,8 @@ mod tests {
 
             // Replay from mid-stream (position 12)
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader
                     .replay(12, NZUsize!(1024))
                     .await
@@ -4266,22 +4449,25 @@ mod tests {
 
             // Append a few items (positions 10, 11, 12)
             for i in 0..3u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 13);
 
             // Rewind to position 11 should work
-            journal.rewind(11).await.unwrap();
+            journal = journal.rewind(11).await.unwrap();
             assert_eq!(journal.size(), 11);
 
             // Rewind to position 10 (pruning_boundary) should work
-            journal.rewind(10).await.unwrap();
+            journal = journal.rewind(10).await.unwrap();
             assert_eq!(journal.size(), 10);
 
-            // Rewind to before pruning_boundary should fail
+            // Rewind to before pruning_boundary should fail. The error consumes the journal.
             let result = journal.rewind(9).await;
             assert!(matches!(result, Err(Error::ItemPruned(9))));
 
+            let journal = Journal::<_, Digest>::init(context.child("reopen"), cfg.clone())
+                .await
+                .unwrap();
             journal.destroy().await.unwrap();
         });
     }
@@ -4298,10 +4484,9 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..5u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Crash Scenario 1: after clear intent is synced and blobs are removed, but before
             // the new tail blob is created.
@@ -4364,12 +4549,11 @@ mod tests {
 
             // Setup: Init at 12 (Blob 2, offset 2)
             // Metadata = 12
-            let mut journal =
+            let journal =
                 Journal::<_, Digest>::init_at_size(context.child("first"), cfg.clone(), 12)
                     .await
                     .unwrap();
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Crash Scenario: clear_to_size(2) after the intent is synced and blob 0 is created,
             // but before final metadata replaces the clear intent.
@@ -4407,9 +4591,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..12u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let mut checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition)
                 .await
@@ -4423,7 +4607,8 @@ mod tests {
                 .await
                 .expect("init failed after clear intent crash");
             assert_eq!(journal.bounds(), 100..100);
-            let pos = journal.append(&test_digest(100)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(100)).await.unwrap();
             assert_eq!(pos, 100);
             journal.destroy().await.unwrap();
         });
@@ -4452,7 +4637,7 @@ mod tests {
                 .await
                 .expect("clear intent should discard stale corrupt blobs before blob parsing");
             assert_eq!(journal.bounds(), 12..12);
-            assert_eq!(journal.recovery_watermark(), 12);
+            assert_eq!(journal.0.recovery_watermark(), 12);
             journal.destroy().await.unwrap();
         });
     }
@@ -4468,10 +4653,11 @@ mod tests {
                     .unwrap();
 
             for i in 0..6u64 {
-                let pos = journal.append(&test_digest(i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&test_digest(i)).await.unwrap();
                 assert_eq!(pos, 10 + i);
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let mut checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition)
                 .await
@@ -4492,7 +4678,8 @@ mod tests {
                 .expect("init failed after completing mid-blob clear intent");
             assert_eq!(journal.bounds(), 15..15);
             assert!(matches!(journal.read(14).await, Err(Error::ItemPruned(14))));
-            let pos = journal.append(&test_digest(100)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&test_digest(100)).await.unwrap();
             assert_eq!(pos, 15);
             assert_eq!(journal.read(15).await.unwrap(), test_digest(100));
             journal.destroy().await.unwrap();
@@ -4510,10 +4697,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..10u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Remove all blobs and create a single empty blob 1, leaving
             // recovery_watermark=10 in metadata.
@@ -4538,10 +4724,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..10u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Remove all blobs and create a single empty blob 0, leaving
             // recovery_watermark=10 in metadata.
@@ -4560,17 +4745,12 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(10));
-            let mut journal = Journal::<_, Digest>::init(context.child("j"), cfg)
+            let journal = Journal::<_, Digest>::init(context.child("j"), cfg)
                 .await
                 .unwrap();
 
-            let items = journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[])
-                .await
-                .unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            let items = reader.read_many(&[]).await.unwrap();
             assert!(items.is_empty());
 
             journal.destroy().await.unwrap();
@@ -4586,17 +4766,12 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..5u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 5);
 
-            let items = journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[0, 2, 4])
-                .await
-                .unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            let items = reader.read_many(&[0, 2, 4]).await.unwrap();
             assert_eq!(items, vec![test_digest(0), test_digest(2), test_digest(4)]);
 
             journal.destroy().await.unwrap();
@@ -4611,10 +4786,11 @@ mod tests {
             let cfg = test_cfg(&context, NZU64!(10));
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
             for i in 0..5u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
-            let _ = journal.snapshot().await.unwrap().read_many(&[2, 1]).await;
+            let (_journal, reader) = journal.snapshot().await.unwrap();
+            let _ = reader.read_many(&[2, 1]).await;
         });
     }
 
@@ -4627,10 +4803,11 @@ mod tests {
             let cfg = test_cfg(&context, NZU64!(10));
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
             for i in 0..5u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
-            let _ = journal.snapshot().await.unwrap().read_many(&[1, 1]).await;
+            let (_journal, reader) = journal.snapshot().await.unwrap();
+            let _ = reader.read_many(&[1, 1]).await;
         });
     }
 
@@ -4643,18 +4820,13 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..9u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 9);
             // Blobs: [0,1,2], [3,4,5], [6,7,8]
 
-            let items = journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[1, 4, 7])
-                .await
-                .unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            let items = reader.read_many(&[1, 4, 7]).await.unwrap();
             assert_eq!(items, vec![test_digest(1), test_digest(4), test_digest(7)]);
 
             journal.destroy().await.unwrap();
@@ -4670,32 +4842,22 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..9u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 9);
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Prune first blob [0,1,2].
-            journal.prune(3).await.unwrap();
+            (journal, _) = journal.prune(3).await.unwrap();
             assert_eq!(journal.bounds(), 3..9);
 
-            let items = journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[3, 5, 8])
-                .await
-                .unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            let items = reader.read_many(&[3, 5, 8]).await.unwrap();
             assert_eq!(items, vec![test_digest(3), test_digest(5), test_digest(8)]);
 
             // Pruned position should error.
-            let err = journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[1])
-                .await
-                .unwrap_err();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            let err = reader.read_many(&[1]).await.unwrap_err();
             assert!(matches!(err, Error::ItemPruned(1)));
 
             journal.destroy().await.unwrap();
@@ -4710,17 +4872,12 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..3u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 3);
 
-            let err = journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[0, 5])
-                .await
-                .unwrap_err();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            let err = reader.read_many(&[0, 5]).await.unwrap_err();
             assert!(matches!(err, Error::ItemOutOfRange(5)));
 
             journal.destroy().await.unwrap();
@@ -4736,13 +4893,14 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..20u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(journal.size(), 20);
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..20).collect();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let batch = reader.read_many(&positions).await.unwrap();
 
             for &pos in &positions {
@@ -4765,12 +4923,13 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..20u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..20).collect();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let expected = reader.read_many(&positions).await.unwrap();
 
             // Every synchronously served item must match the async read. Positions the
@@ -4809,8 +4968,9 @@ mod tests {
             // After a rewind the journal's end is not blob-aligned, so an out-of-range
             // position can share a blob with a valid one. Validation trims the batch
             // instead of poisoning the shared group.
-            journal.rewind(18).await.unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            journal = journal.rewind(18).await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             reader.read_many(&[17]).await.unwrap();
             let served = reader.try_read_many_sync(&[17, 18]);
             assert!(served[0].is_some());
@@ -4820,8 +4980,9 @@ mod tests {
 
             // A pruned position is trimmed from the prefix rather than reaching offset
             // derivation, and the valid remainder is still served.
-            journal.prune(8).await.unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            (journal, _) = journal.prune(8).await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             reader.read_many(&[9]).await.unwrap();
             let served = reader.try_read_many_sync(&[3, 9]);
             assert!(served[0].is_none());
@@ -4843,12 +5004,13 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..20u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..20).collect();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let expected: Vec<_> = (0..20).map(test_digest).collect();
             for _ in 0..2 {
                 let mut served = reader.try_read_many_sync(&positions);
@@ -4882,21 +5044,18 @@ mod tests {
                     .unwrap();
 
             let items: Vec<_> = (0..5).map(test_digest).collect();
-            journal.append_many(Many::Flat(&items)).await.unwrap();
-            journal.append(&test_digest(5)).await.unwrap();
-            journal.commit().await.unwrap();
-            journal.sync().await.unwrap();
-            journal.snapshot().await.unwrap().read(0).await.unwrap();
-            journal.snapshot().await.unwrap().try_read_sync(0).unwrap();
-            journal
-                .snapshot()
-                .await
-                .unwrap()
-                .read_many(&[1, 2, 4])
-                .await
-                .unwrap();
-            journal.prune(2).await.unwrap();
-            journal.rewind(4).await.unwrap();
+            (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
+            (journal, _) = journal.append(&test_digest(5)).await.unwrap();
+            journal = journal.commit().await.unwrap();
+            journal = journal.sync().await.unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            reader.read(0).await.unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            reader.try_read_sync(0).unwrap();
+            let (journal, reader) = journal.snapshot().await.unwrap();
+            reader.read_many(&[1, 2, 4]).await.unwrap();
+            let (journal, _) = journal.prune(2).await.unwrap();
+            let journal = journal.rewind(4).await.unwrap();
 
             let buffer = context.encode();
             for expected in [
@@ -4937,16 +5096,17 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..7u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
-            let snapshot = journal.snapshot().await.unwrap();
+            let snapshot;
+            (journal, snapshot) = journal.snapshot().await.unwrap();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Appending past the blob boundary rolls the snapshot's tail blob into
             // history; the snapshot keeps reading it through its own handle.
             for i in 7..23u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             assert_eq!(snapshot.bounds(), 0..7);
             for i in 0..7u64 {
@@ -4957,7 +5117,8 @@ mod tests {
                 Err(Error::ItemOutOfRange(7))
             ));
 
-            let fresh = journal.snapshot().await.unwrap();
+            let fresh;
+            (journal, fresh) = journal.snapshot().await.unwrap();
             assert_eq!(fresh.bounds(), 0..23);
             assert_eq!(fresh.read(22).await.unwrap(), test_digest(22));
 
@@ -4978,12 +5139,15 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..17u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
-            let snapshot = journal.snapshot().await.unwrap();
-            assert!(journal.prune(12).await.unwrap());
+            let snapshot;
+            (journal, snapshot) = journal.snapshot().await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(12).await.unwrap();
+            assert!(pruned);
 
             // The straggler reads the pruned range through its own handles.
             assert_eq!(snapshot.bounds(), 0..17);
@@ -4991,7 +5155,8 @@ mod tests {
                 assert_eq!(snapshot.read(i).await.unwrap(), test_digest(i));
             }
 
-            let fresh = journal.snapshot().await.unwrap();
+            let fresh;
+            (journal, fresh) = journal.snapshot().await.unwrap();
             assert_eq!(fresh.bounds(), 10..17);
             assert!(matches!(fresh.read(3).await, Err(Error::ItemPruned(3))));
 
@@ -5027,9 +5192,10 @@ mod tests {
             });
 
             for i in 0..40u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
                 if i % 7 == 0 {
-                    let snapshot = journal.snapshot().await.unwrap();
+                    let snapshot;
+                    (journal, snapshot) = journal.snapshot().await.unwrap();
                     if tx.try_send(snapshot).is_err() {
                         break;
                     }
@@ -5053,18 +5219,21 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..7u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
 
             // Positions 5..7 live in the snapshot's tail blob.
-            let snapshot = journal.snapshot().await.unwrap();
+            let snapshot;
+            (journal, snapshot) = journal.snapshot().await.unwrap();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Roll the snapshot's tail into history, then prune both of its blobs away.
             for i in 7..23u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            assert!(journal.prune(12).await.unwrap());
+            let pruned;
+            (journal, pruned) = journal.prune(12).await.unwrap();
+            assert!(pruned);
 
             {
                 let stream = snapshot.replay(0, NZUsize!(1024)).await.unwrap();
@@ -5098,13 +5267,14 @@ mod tests {
             let mut journal = Journal::init(context.child("j"), cfg).await.unwrap();
 
             for i in 0..50u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
             // Prune mid-blob so first_in_blob differs from the blob start.
-            journal.prune(11).await.unwrap();
+            (journal, _) = journal.prune(11).await.unwrap();
 
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
 
             // Sparse subset spanning multiple blobs, including the pruning boundary.
             // `try_read_sync` probes do not populate the cache, so the cached subset is
@@ -5161,10 +5331,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..40u64 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen with a fresh page cache so every full page is cold. The positions avoid
             // each blob's trailing bytes, which sealed blobs keep in memory and always serve
@@ -5173,7 +5342,8 @@ mod tests {
             let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg)
                 .await
                 .unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let positions = [1, 5, 10, 14, 17, 22, 25, 30];
             for pos in positions {
                 assert!(reader.try_read_sync(pos).is_none(), "position {pos}");
@@ -5223,12 +5393,13 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..20 {
-                journal.append(&test_digest(i)).await.unwrap();
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // The page cache cannot hold every page, so some position must be cold.
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let pos = (0..20)
                 .find(|&pos| reader.try_read_sync(pos).is_none())
                 .expect("some position should be cold");

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -3082,11 +3082,6 @@ mod tests {
                 journal.rewind(299).await,
                 Err(Error::ItemPruned(299))
             ));
-
-            let journal: Journal<_, Digest> = Journal::init(context.child("fourth"), cfg.clone())
-                .await
-                .expect("failed to re-initialize journal");
-            journal.destroy().await.unwrap();
         });
     }
 
@@ -4460,7 +4455,7 @@ mod tests {
             journal = journal.rewind(10).await.unwrap();
             assert_eq!(journal.size(), 10);
 
-            // Rewind to before pruning_boundary should fail.
+            // Rewind to before pruning_boundary should fail
             let result = journal.rewind(9).await;
             assert!(matches!(result, Err(Error::ItemPruned(9))));
         });

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -2986,7 +2986,6 @@ mod tests {
                 .await
                 .expect("failed to initialize journal");
             let journal = journal.rewind(0).await.unwrap();
-            // The failed rewind consumes the journal.
             assert!(matches!(
                 journal.rewind(1).await,
                 Err(Error::InvalidRewind(1))
@@ -4461,7 +4460,7 @@ mod tests {
             journal = journal.rewind(10).await.unwrap();
             assert_eq!(journal.size(), 10);
 
-            // Rewind to before pruning_boundary should fail. The error consumes the journal.
+            // Rewind to before pruning_boundary should fail.
             let result = journal.rewind(9).await;
             assert!(matches!(result, Err(Error::ItemPruned(9))));
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1823,7 +1823,8 @@ mod tests {
                 .await
                 .expect("failed to initialize journal");
             (journal, _) = journal.append(&test_digest(1)).await.unwrap();
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             let legacy_blobs = scan_partition(&context, &legacy_partition).await;
             let new_blobs = scan_partition(&context, &blobs_partition).await;
@@ -1844,7 +1845,8 @@ mod tests {
                 .await
                 .expect("failed to initialize journal");
             (journal, _) = journal.append(&test_digest(1)).await.unwrap();
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             let legacy_blobs = scan_partition(&context, &legacy_partition).await;
             let new_blobs = scan_partition(&context, &blobs_partition).await;
@@ -1875,7 +1877,8 @@ mod tests {
             assert_eq!(pos, 0);
 
             // Drop the journal and re-initialize it to simulate a restart
-            journal.sync().await.expect("Failed to sync journal");
+            let journal = journal.sync().await.expect("Failed to sync journal");
+            drop(journal);
 
             let cfg = test_cfg(&context, NZU64!(2));
             let mut journal = Journal::init(context.child("second"), cfg.clone())
@@ -2097,7 +2100,8 @@ mod tests {
                 }
             }
 
-            journal.sync().await.expect("Failed to sync journal");
+            let journal = journal.sync().await.expect("Failed to sync journal");
+            drop(journal);
 
             // Corrupt one of the bytes and make sure it's detected.
             let (blob, _) = context
@@ -2163,7 +2167,8 @@ mod tests {
             for i in 0u64..30 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             let (blob, _) = context
                 .open(&blob_partition(&cfg), &1u64.to_be_bytes())
@@ -2207,7 +2212,8 @@ mod tests {
             for i in 0u64..5 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Delete a middle blob (external corruption). The watermark (5) now exceeds the
             // recoverable contiguous prefix, which is corruption.
@@ -2300,7 +2306,8 @@ mod tests {
             for i in 0..5 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Truncate the tail blob by 1 byte (external corruption). The watermark (5) now
             // exceeds the recoverable size, which is corruption.
@@ -2459,7 +2466,8 @@ mod tests {
                 .await
                 .unwrap();
             (journal, _) = journal.append(&test_digest(0)).await.unwrap();
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Add a far-future blob directly. Recovery should inspect actual blob ids and
             // repair at the first missing boundary instead of walking the entire numeric range.
@@ -2716,7 +2724,8 @@ mod tests {
             for i in 0..3u64 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Remove all blobs but leave the checkpoint (with a boundary hint of 7) intact.
             for name in scan_partition(&context, &blob_partition(&cfg)).await {
@@ -2903,7 +2912,8 @@ mod tests {
                     .await
                     .expect("failed to append data");
             }
-            journal.sync().await.expect("failed to sync journal");
+            let journal = journal.sync().await.expect("failed to sync journal");
+            drop(journal);
 
             // Inject an extra item into blob 0 at the blob level so its length exceeds
             // items_per_blob -- this is what `recover_bounds` validates and rejects as Corruption.
@@ -2945,7 +2955,8 @@ mod tests {
                 .await
                 .expect("failed to append data");
             assert_eq!(journal.size(), 1);
-            journal.sync().await.expect("Failed to sync journal");
+            let journal = journal.sync().await.expect("Failed to sync journal");
+            drop(journal);
 
             // Manually extend the blob to simulate a failure where the file was extended, but no
             // bytes were written due to failure.
@@ -3038,7 +3049,8 @@ mod tests {
             const ITEMS_REMAINING: u64 = 10 * (100 - 49);
             assert_eq!(journal.size(), ITEMS_REMAINING);
 
-            journal.sync().await.expect("Failed to sync journal");
+            let journal = journal.sync().await.expect("Failed to sync journal");
+            drop(journal);
 
             // Repeat with a different blob size (3 items per blob)
             let mut cfg = test_cfg(&context, NZU64!(3));
@@ -3531,7 +3543,8 @@ mod tests {
             for i in 0..20u64 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Empty the oldest blob (external corruption). The watermark (20) now exceeds the
             // recoverable size (0), which is corruption.
@@ -4475,7 +4488,8 @@ mod tests {
             for i in 0..5u64 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Crash Scenario 1: after clear intent is synced and blobs are removed, but before
             // the new tail blob is created.
@@ -4542,7 +4556,8 @@ mod tests {
                 Journal::<_, Digest>::init_at_size(context.child("first"), cfg.clone(), 12)
                     .await
                     .unwrap();
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Crash Scenario: clear_to_size(2) after the intent is synced and blob 0 is created,
             // but before final metadata replaces the clear intent.
@@ -4688,7 +4703,8 @@ mod tests {
             for i in 0..10u64 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Remove all blobs and create a single empty blob 1, leaving
             // recovery_watermark=10 in metadata.
@@ -4715,7 +4731,8 @@ mod tests {
             for i in 0..10u64 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Remove all blobs and create a single empty blob 0, leaving
             // recovery_watermark=10 in metadata.
@@ -5322,7 +5339,8 @@ mod tests {
             for i in 0..40u64 {
                 (journal, _) = journal.append(&test_digest(i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Reopen with a fresh page cache so every full page is cold. The positions avoid
             // each blob's trailing bytes, which sealed blobs keep in memory and always serve

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -383,7 +383,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         }
     }
 
-    /// Initialize the journal state, running recovery.
+    /// See [Journal::init].
     pub(crate) async fn init(context: E, cfg: Config) -> Result<Self, Error> {
         let checkpoint = Checkpoint::open(context.child("meta"), &cfg.partition).await?;
         Self::init_with_checkpoint(context, cfg, checkpoint).await
@@ -4463,11 +4463,6 @@ mod tests {
             // Rewind to before pruning_boundary should fail.
             let result = journal.rewind(9).await;
             assert!(matches!(result, Err(Error::ItemPruned(9))));
-
-            let journal = Journal::<_, Digest>::init(context.child("reopen"), cfg.clone())
-                .await
-                .unwrap();
-            journal.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -4,8 +4,12 @@
 //! contiguously and can be accessed by their position (0-indexed). Both [fixed]-size and
 //! [variable]-size item journals are supported.
 //!
-//! Storage errors from mutable operations are considered fatal for the current handle and may
-//! leave its in-memory state inconsistent with the underlying storage.
+//! # Ownership
+//!
+//! Mutating methods take the journal by value and return it on success. If a mutating
+//! method returns an error, or its future is dropped before it finishes, the journal is
+//! gone: state that was not yet durable is discarded, but everything already on disk stays
+//! recoverable.
 
 use super::Error;
 use futures::{Stream, StreamExt as _, stream};
@@ -226,7 +230,7 @@ impl<T> Many<'_, T> {
 }
 
 /// A [Contiguous] journal that supports appending, rewinding, and pruning.
-pub trait Mutable: Contiguous + Send + Sync {
+pub trait Mutable: Contiguous + Sized {
     /// Append a new item to the journal, returning its position.
     ///
     /// Positions are consecutively increasing starting from 0. The position of each item
@@ -238,17 +242,17 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// Returns an error if the underlying storage operation fails or if the item cannot
     /// be encoded.
     fn append(
-        &mut self,
+        self,
         item: &Self::Item,
-    ) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
+    ) -> impl std::future::Future<Output = Result<(Self, u64), Error>> + Send;
 
     /// Append items to the journal, returning the position of the last item appended.
     ///
     /// Returns [Error::EmptyAppend] if items is empty.
-    fn append_many<'a>(
-        &'a mut self,
-        items: Many<'a, Self::Item>,
-    ) -> impl std::future::Future<Output = Result<u64, Error>> + Send + 'a
+    fn append_many(
+        self,
+        items: Many<'_, Self::Item>,
+    ) -> impl std::future::Future<Output = Result<(Self, u64), Error>> + Send
     where
         Self::Item: Sync;
 
@@ -268,9 +272,9 @@ pub trait Mutable: Contiguous + Send + Sync {
     ///
     /// Returns an error if the underlying storage operation fails.
     fn prune(
-        &mut self,
+        self,
         min_position: u64,
-    ) -> impl std::future::Future<Output = Result<bool, Error>> + Send;
+    ) -> impl std::future::Future<Output = Result<(Self, bool), Error>> + Send;
 
     /// Rewind the journal to the given size, discarding items from the end.
     ///
@@ -294,18 +298,18 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// Returns [Error::InvalidRewind] if `size` is beyond the current size, or [Error::ItemPruned]
     /// if it precedes the pruning boundary. Returns an error if the underlying storage operation
     /// fails.
-    fn rewind(&mut self, size: u64) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    fn rewind(self, size: u64) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
     /// Durably persist the journal, guaranteeing the current state will survive a crash.
     ///
     /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
-    fn commit(&mut self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    fn commit(self) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
     /// Durably persist the journal, guaranteeing the current state will survive a crash, and that
     /// no recovery will be needed on startup.
     ///
     /// This provides a stronger guarantee than [Self::commit] but may be slower.
-    fn sync(&mut self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+    fn sync(self) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
     /// Destroy the journal, removing all associated storage.
     ///
@@ -317,44 +321,57 @@ pub trait Mutable: Contiguous + Send + Sync {
     /// This operation is intended for final teardown and is not crash-safe. If interrupted,
     /// reopening the same storage may observe partially removed state. Use a reset operation
     /// provided by the concrete type when the journal must remain recoverable.
-    fn destroy(self) -> impl std::future::Future<Output = Result<(), Error>> + Send
-    where
-        Self: Sized;
+    fn destroy(self) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
-    /// Rewinds the journal to the last item matching `predicate`. If no item matches, the journal
-    /// is rewound to the pruning boundary, discarding all unpruned items.
+    /// Rewinds the journal to the last item matching `predicate`, returning the resulting
+    /// size. If no item matches, the journal is rewound to the pruning boundary, discarding
+    /// all unpruned items.
     ///
     /// # Warnings
     ///
     /// - This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
-    fn rewind_to<'a, P>(
-        &'a mut self,
-        mut predicate: P,
-    ) -> impl std::future::Future<Output = Result<u64, Error>> + Send + 'a
+    fn rewind_to<P>(
+        mut self,
+        predicate: P,
+    ) -> impl std::future::Future<Output = Result<(Self, u64), Error>> + Send
     where
-        P: FnMut(&Self::Item) -> bool + Send + 'a,
+        P: FnMut(&Self::Item) -> bool + Send,
     {
         async move {
-            let bounds = self.bounds();
-            let mut rewind_size = bounds.end;
-            while rewind_size > bounds.start {
-                let item = self.read(rewind_size - 1).await?;
-                if predicate(&item) {
-                    break;
-                }
-                rewind_size -= 1;
+            let rewind_size = scan_rewind_size(&self, predicate).await?;
+            if rewind_size != self.bounds().end {
+                self = self.rewind(rewind_size).await?;
             }
 
-            if rewind_size != bounds.end {
-                let rewound_items = bounds.end - rewind_size;
-                warn!(
-                    journal_size = bounds.end,
-                    rewound_items, "rewinding journal items"
-                );
-                self.rewind(rewind_size).await?;
-            }
-
-            Ok(rewind_size)
+            Ok((self, rewind_size))
         }
     }
+}
+
+/// Scan backwards from the end of `journal` to the last item matching `predicate`, returning
+/// the size the journal must rewind to (and warning if that drops any items).
+async fn scan_rewind_size<C, P>(journal: &C, mut predicate: P) -> Result<u64, Error>
+where
+    C: Contiguous,
+    P: FnMut(&C::Item) -> bool + Send,
+{
+    let bounds = journal.bounds();
+    let mut rewind_size = bounds.end;
+    while rewind_size > bounds.start {
+        let item = journal.read(rewind_size - 1).await?;
+        if predicate(&item) {
+            break;
+        }
+        rewind_size -= 1;
+    }
+
+    if rewind_size != bounds.end {
+        let rewound_items = bounds.end - rewind_size;
+        warn!(
+            journal_size = bounds.end,
+            rewound_items, "rewinding journal items"
+        );
+    }
+
+    Ok(rewind_size)
 }

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -95,7 +95,7 @@ where
 
     // Append some items
     for i in 0..10 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     let bounds = journal.bounds();
@@ -117,7 +117,7 @@ where
 
     // Append items across multiple sections
     for i in 0..30 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     // Initially bounds should be 0..30
@@ -126,7 +126,7 @@ where
     assert_eq!(bounds.end, 30);
 
     // Prune first section - trait only guarantees section-aligned pruning
-    journal.prune(10).await.unwrap();
+    (journal, _) = journal.prune(10).await.unwrap();
 
     // Assumed blob-aligned pruning and items_per_blob = 10.
     let bounds = journal.bounds();
@@ -134,7 +134,7 @@ where
     assert_eq!(bounds.end, 30);
 
     // Prune more
-    journal.prune(25).await.unwrap();
+    (journal, _) = journal.prune(25).await.unwrap();
 
     // bounds.start should have advanced to 20 (section-aligned)
     let bounds = journal.bounds();
@@ -142,7 +142,7 @@ where
     assert_eq!(bounds.end, 30);
 
     // Prune all
-    journal.prune(30).await.unwrap();
+    (journal, _) = journal.prune(30).await.unwrap();
     let bounds = journal.bounds();
     assert_eq!(bounds.start, 30);
     assert_eq!(bounds.end, 30);
@@ -150,7 +150,6 @@ where
 
     // Drop and reopen
     journal.sync().await.unwrap();
-    drop(journal);
     let journal = factory("bounds-after-prune".into()).await.unwrap();
     let bounds = journal.bounds();
     assert!(bounds.is_empty());
@@ -165,9 +164,12 @@ where
 {
     let mut journal = factory("append-and-size".into()).await.unwrap();
 
-    let pos1 = journal.append(&100).await.unwrap();
-    let pos2 = journal.append(&200).await.unwrap();
-    let pos3 = journal.append(&300).await.unwrap();
+    let pos1;
+    (journal, pos1) = journal.append(&100).await.unwrap();
+    let pos2;
+    (journal, pos2) = journal.append(&200).await.unwrap();
+    let pos3;
+    (journal, pos3) = journal.append(&300).await.unwrap();
 
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
@@ -191,7 +193,8 @@ where
     let mut journal = factory("sequential-appends".into()).await.unwrap();
 
     for i in 0..25u64 {
-        let pos = journal.append(&(i * 10)).await.unwrap();
+        let pos;
+        (journal, pos) = journal.append(&(i * 10)).await.unwrap();
         assert_eq!(pos, i);
     }
 
@@ -213,7 +216,7 @@ where
     let mut journal = factory("replay-from-start".into()).await.unwrap();
 
     for i in 0..10u64 {
-        journal.append(&(i * 10)).await.unwrap();
+        (journal, _) = journal.append(&(i * 10)).await.unwrap();
     }
 
     {
@@ -244,7 +247,7 @@ where
     let mut journal = factory("replay-from-middle".into()).await.unwrap();
 
     for i in 0..15u64 {
-        journal.append(&(i * 10)).await.unwrap();
+        (journal, _) = journal.append(&(i * 10)).await.unwrap();
     }
 
     {
@@ -275,7 +278,7 @@ where
     let mut journal = factory("replay-from-unsealed-tail".into()).await.unwrap();
 
     for i in 0..17u64 {
-        journal.append(&(i * 10)).await.unwrap();
+        (journal, _) = journal.append(&(i * 10)).await.unwrap();
     }
 
     {
@@ -307,7 +310,7 @@ where
     let mut journal = factory("replay-with-small-buffer".into()).await.unwrap();
 
     for i in 0..25u64 {
-        journal.append(&(i * 10)).await.unwrap();
+        (journal, _) = journal.append(&(i * 10)).await.unwrap();
     }
 
     {
@@ -338,22 +341,21 @@ where
     let mut journal = factory("prune-retains-size".into()).await.unwrap();
 
     for i in 0..20u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     let size_before = journal.bounds().end;
-    journal.prune(10).await.unwrap();
+    (journal, _) = journal.prune(10).await.unwrap();
     let size_after = journal.bounds().end;
 
     assert_eq!(size_before, size_after);
     assert_eq!(size_after, 20);
 
-    journal.prune(20).await.unwrap();
+    (journal, _) = journal.prune(20).await.unwrap();
     let size_after_all = journal.bounds().end;
     assert_eq!(size_after, size_after_all);
 
     journal.sync().await.unwrap();
-    drop(journal);
 
     let journal = factory("prune-retains-size".into()).await.unwrap();
     let size_after_close = journal.bounds().end;
@@ -368,10 +370,10 @@ where
     F: Fn(String) -> BoxFuture<'static, Result<J, Error>>,
     J: Mutable<Item = u64>,
 {
-    let mut journal = factory("through-trait".into()).await.unwrap();
+    let journal = factory("through-trait".into()).await.unwrap();
 
-    let pos1 = Mutable::append(&mut journal, &42).await.unwrap();
-    let pos2 = Mutable::append(&mut journal, &100).await.unwrap();
+    let (journal, pos1) = Mutable::append(journal, &42).await.unwrap();
+    let (journal, pos2) = Mutable::append(journal, &100).await.unwrap();
 
     assert_eq!(pos1, 0);
     assert_eq!(pos2, 1);
@@ -391,10 +393,10 @@ where
     let mut journal = factory("replay-after-prune".into()).await.unwrap();
 
     for i in 0..20u64 {
-        journal.append(&(i * 10)).await.unwrap();
+        (journal, _) = journal.append(&(i * 10)).await.unwrap();
     }
 
-    journal.prune(10).await.unwrap();
+    let (journal, _) = journal.prune(10).await.unwrap();
 
     {
         // Replay from a position that may or may not be pruned (section-aligned)
@@ -430,15 +432,16 @@ where
 
     // Append exactly one section (10 items)
     for i in 0..10u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     // Prune all items at a blob boundary.
-    journal.prune(10).await.unwrap();
+    (journal, _) = journal.prune(10).await.unwrap();
     assert!(journal.bounds().is_empty());
 
     // Append new items after pruning - position should continue from 10
-    let pos = journal.append(&999).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&999).await.unwrap();
     assert_eq!(pos, 10);
 
     assert_eq!(journal.bounds().end, 11);
@@ -456,15 +459,16 @@ where
 
     // Append initial items
     for i in 0..20u64 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     // Prune first 10
-    journal.prune(10).await.unwrap();
+    (journal, _) = journal.prune(10).await.unwrap();
 
     // Append more items
     for i in 20..25u64 {
-        let pos = journal.append(&(i * 100)).await.unwrap();
+        let pos;
+        (journal, pos) = journal.append(&(i * 100)).await.unwrap();
         assert_eq!(pos, i);
     }
 
@@ -504,14 +508,15 @@ where
     let mut journal = factory("sync-behavior".into()).await.unwrap();
 
     for i in 0..5u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    journal.sync().await.unwrap();
+    journal = journal.sync().await.unwrap();
 
     // Verify operations work after sync
     assert_eq!(journal.read(0).await.unwrap(), 0);
-    let pos = journal.append(&100).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&100).await.unwrap();
     assert_eq!(pos, 5);
     assert_eq!(journal.read(5).await.unwrap(), 100);
 
@@ -552,7 +557,7 @@ where
     let mut journal = factory("replay-at-exact-size".into()).await.unwrap();
 
     for i in 0..10u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     let bounds = journal.bounds();
@@ -581,11 +586,13 @@ where
     let mut journal = factory("multiple-prunes".into()).await.unwrap();
 
     for i in 0..20u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    let pruned1 = journal.prune(10).await.unwrap();
-    let pruned2 = journal.prune(10).await.unwrap();
+    let pruned1;
+    (journal, pruned1) = journal.prune(10).await.unwrap();
+    let pruned2;
+    (journal, pruned2) = journal.prune(10).await.unwrap();
 
     assert!(pruned1);
     assert!(!pruned2); // Second prune should return false (nothing to prune)
@@ -606,16 +613,17 @@ where
     let mut journal = factory("prune-beyond-size".into()).await.unwrap();
 
     for i in 0..10u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     // Prune with min_position > size should be safe
-    journal.prune(100).await.unwrap();
+    (journal, _) = journal.prune(100).await.unwrap();
 
     // Verify journal still works
     assert_eq!(journal.bounds().end, 10);
 
-    let pos = journal.append(&999).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&999).await.unwrap();
     assert_eq!(pos, 10);
     assert_eq!(journal.read(10).await.unwrap(), 999);
 
@@ -635,7 +643,8 @@ where
         let mut journal = factory(test_name.clone()).await.unwrap();
 
         for i in 0..15u64 {
-            let pos = journal.append(&(i * 10)).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&(i * 10)).await.unwrap();
             assert_eq!(pos, i);
         }
 
@@ -689,11 +698,12 @@ where
         let mut journal = factory(test_name.clone()).await.unwrap();
 
         for i in 0..25u64 {
-            journal.append(&(i * 100)).await.unwrap();
+            (journal, _) = journal.append(&(i * 100)).await.unwrap();
         }
 
         // Prune first 10 items
-        let pruned = journal.prune(10).await.unwrap();
+        let pruned;
+        (journal, pruned) = journal.prune(10).await.unwrap();
         assert!(pruned);
 
         assert_eq!(journal.bounds().end, 25);
@@ -737,7 +747,8 @@ where
         }
 
         // Append more items after re-opening
-        let pos = journal.append(&999).await.unwrap();
+        let pos;
+        (journal, pos) = journal.append(&999).await.unwrap();
         assert_eq!(pos, 25);
 
         // Verify the newly appended item can be read
@@ -756,7 +767,7 @@ where
     let mut journal = factory("read-by-position".into()).await.unwrap();
 
     for i in 0..1000u64 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
         assert_eq!(journal.read(i).await.unwrap(), i * 100);
     }
 
@@ -777,7 +788,7 @@ where
     let mut journal = factory("read-many".into()).await.unwrap();
 
     for i in 0..15u64 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     let items = journal.read_many(&[1, 4, 12]).await.unwrap();
@@ -794,7 +805,7 @@ where
 {
     let mut journal = factory("read-out-of-range".into()).await.unwrap();
 
-    journal.append(&42).await.unwrap();
+    (journal, _) = journal.append(&42).await.unwrap();
 
     // Try to read beyond size
     let result = journal.read(10).await;
@@ -812,10 +823,10 @@ where
     let mut journal = factory("read-after-prune".into()).await.unwrap();
 
     for i in 0..20u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    journal.prune(10).await.unwrap();
+    let (journal, _) = journal.prune(10).await.unwrap();
 
     let bounds = journal.bounds();
     let result = journal.read(bounds.start - 1).await;
@@ -834,11 +845,11 @@ where
 
     // Append 20 items
     for i in 0..20u64 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     // Rewind to 12 items
-    journal.rewind(12).await.unwrap();
+    journal = journal.rewind(12).await.unwrap();
 
     assert_eq!(journal.bounds().end, 12);
 
@@ -856,7 +867,8 @@ where
     }
 
     // Next append should get position 12
-    let pos = journal.append(&999).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&999).await.unwrap();
     assert_eq!(pos, 12);
     assert_eq!(journal.read(12).await.unwrap(), 999);
 
@@ -872,17 +884,18 @@ where
     let mut journal = factory("rewind-to-zero".into()).await.unwrap();
 
     for i in 0..10u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    journal.rewind(0).await.unwrap();
+    journal = journal.rewind(0).await.unwrap();
 
     let bounds = journal.bounds();
     assert_eq!(bounds.end, 0);
     assert!(bounds.is_empty());
 
     // Next append should get position 0
-    let pos = journal.append(&42).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&42).await.unwrap();
     assert_eq!(pos, 0);
 
     journal.destroy().await.unwrap();
@@ -897,11 +910,11 @@ where
     let mut journal = factory("rewind-current-size".into()).await.unwrap();
 
     for i in 0..10u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     // Rewind to current size should be no-op
-    journal.rewind(10).await.unwrap();
+    let journal = journal.rewind(10).await.unwrap();
     assert_eq!(journal.bounds().end, 10);
 
     journal.destroy().await.unwrap();
@@ -916,13 +929,14 @@ where
     let mut journal = factory("rewind-invalid-forward".into()).await.unwrap();
 
     for i in 0..10u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    // Try to rewind forward (invalid)
+    // Try to rewind forward (invalid). The error consumes the journal.
     let result = journal.rewind(20).await;
     assert!(matches!(result, Err(Error::InvalidRewind(20))));
 
+    let journal = factory("rewind-invalid-forward".into()).await.unwrap();
     journal.destroy().await.unwrap();
 }
 
@@ -935,16 +949,17 @@ where
     let mut journal = factory("rewind-invalid-pruned".into()).await.unwrap();
 
     for i in 0..20u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     // Prune first 10 items
-    journal.prune(10).await.unwrap();
+    let (journal, _) = journal.prune(10).await.unwrap();
 
-    // Try to rewind to pruned position (invalid)
+    // Try to rewind to pruned position (invalid). The error consumes the journal.
     let result = journal.rewind(5).await;
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
+    let journal = factory("rewind-invalid-pruned".into()).await.unwrap();
     journal.destroy().await.unwrap();
 }
 
@@ -959,15 +974,17 @@ where
 
     // Append across a blob boundary (15 items = 1.5 blobs).
     for i in 0..15u64 {
-        journal.append(&i).await.unwrap();
+        (journal, _) = journal.append(&i).await.unwrap();
     }
 
     // Rewind to position 8 (within first section, not at boundary)
-    journal.rewind(8).await.unwrap();
+    journal = journal.rewind(8).await.unwrap();
 
     // Append should continue from position 8
-    let pos1 = journal.append(&888).await.unwrap();
-    let pos2 = journal.append(&999).await.unwrap();
+    let pos1;
+    (journal, pos1) = journal.append(&888).await.unwrap();
+    let pos2;
+    (journal, pos2) = journal.append(&999).await.unwrap();
 
     assert_eq!(pos1, 8);
     assert_eq!(pos2, 9);
@@ -987,11 +1004,11 @@ where
 
     // Append some items
     for i in 0..10u64 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     // Rewind to 0 (empty journal)
-    journal.rewind(0).await.unwrap();
+    journal = journal.rewind(0).await.unwrap();
 
     // Verify journal is empty
     let bounds = journal.bounds();
@@ -999,7 +1016,8 @@ where
     assert!(bounds.is_empty());
 
     // Append should work
-    let pos = journal.append(&42).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&42).await.unwrap();
     assert_eq!(pos, 0);
     assert_eq!(journal.bounds().end, 1);
     assert_eq!(journal.read(0).await.unwrap(), 42);
@@ -1018,16 +1036,16 @@ where
 
     // Append items across 3 blobs (30 items, assuming items_per_blob = 10).
     for i in 0..30u64 {
-        journal.append(&(i * 100)).await.unwrap();
+        (journal, _) = journal.append(&(i * 100)).await.unwrap();
     }
 
     // Prune first section (items 0-9)
-    journal.prune(10).await.unwrap();
+    (journal, _) = journal.prune(10).await.unwrap();
     let bounds = journal.bounds();
     assert_eq!(bounds.start, 10);
 
     // Rewind to position 20 (still in retained range)
-    journal.rewind(20).await.unwrap();
+    journal = journal.rewind(20).await.unwrap();
     let bounds = journal.bounds();
     assert_eq!(bounds.end, 20);
     assert_eq!(bounds.start, 10);
@@ -1037,21 +1055,18 @@ where
         assert_eq!(journal.read(i).await.unwrap(), i * 100);
     }
 
-    // Attempt to rewind to a pruned position should fail
-    let result = journal.rewind(5).await;
-    assert!(matches!(result, Err(Error::ItemPruned(5))));
-
-    // Verify journal state is unchanged after failed rewind
-    let bounds = journal.bounds();
-    assert_eq!(bounds.end, 20);
-    assert_eq!(bounds.start, 10);
-
     // Append should continue from position 20
-    let pos = journal.append(&999).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&999).await.unwrap();
     assert_eq!(pos, 20);
     assert_eq!(journal.read(20).await.unwrap(), 999);
     assert_eq!(journal.bounds().start, 10);
 
+    // Attempt to rewind to a pruned position should fail. The error consumes the journal.
+    let result = journal.rewind(5).await;
+    assert!(matches!(result, Err(Error::ItemPruned(5))));
+
+    let journal = factory("rewind-after-prune".into()).await.unwrap();
     journal.destroy().await.unwrap();
 }
 
@@ -1066,7 +1081,8 @@ where
 
     // Append exactly one section worth of items (10 items)
     for i in 0..10u64 {
-        let pos = journal.append(&(i * 100)).await.unwrap();
+        let pos;
+        (journal, pos) = journal.append(&(i * 100)).await.unwrap();
         assert_eq!(pos, i);
     }
 
@@ -1074,12 +1090,13 @@ where
     assert_eq!(journal.bounds().end, 10);
 
     // Append one more item to cross the boundary
-    let pos = journal.append(&999).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&999).await.unwrap();
     assert_eq!(pos, 10);
     assert_eq!(journal.bounds().end, 11);
 
     // Prune exactly at the blob boundary.
-    journal.prune(10).await.unwrap();
+    (journal, _) = journal.prune(10).await.unwrap();
     assert_eq!(journal.bounds().start, 10);
 
     // Verify only the item after the boundary is readable
@@ -1087,19 +1104,21 @@ where
     assert_eq!(journal.read(10).await.unwrap(), 999);
 
     // Append another item to move past the boundary
-    let pos = journal.append(&888).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&888).await.unwrap();
     assert_eq!(pos, 11);
     assert_eq!(journal.bounds().end, 12);
 
     // Rewind to exactly the blob boundary (position 10).
     // This leaves bounds.end=10, bounds.start=10, making the journal fully pruned
-    journal.rewind(10).await.unwrap();
+    journal = journal.rewind(10).await.unwrap();
     let bounds = journal.bounds();
     assert_eq!(bounds.end, 10);
     assert!(bounds.is_empty());
 
     // Append after rewinding to boundary should continue from position 10
-    let pos = journal.append(&777).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&777).await.unwrap();
     assert_eq!(pos, 10);
     assert_eq!(journal.bounds().end, 11);
     assert_eq!(journal.read(10).await.unwrap(), 777);
@@ -1124,10 +1143,10 @@ where
         let mut journal = factory(test_name.clone()).await.unwrap();
 
         for i in 0..20u64 {
-            journal.append(&(i * 100)).await.unwrap();
+            (journal, _) = journal.append(&(i * 100)).await.unwrap();
         }
 
-        journal.prune(10).await.unwrap();
+        let (journal, _) = journal.prune(10).await.unwrap();
         assert_eq!(journal.bounds().end, 20);
         assert!(!journal.bounds().is_empty());
 
@@ -1169,16 +1188,18 @@ where
     let mut journal = factory("append-many-empty".into()).await.unwrap();
 
     // Append some items first.
-    journal.append(&10).await.unwrap();
-    journal.append(&20).await.unwrap();
+    (journal, _) = journal.append(&10).await.unwrap();
+    (journal, _) = journal.append(&20).await.unwrap();
 
-    // append_many with empty slice should return an error.
+    assert_eq!(journal.bounds().end, 2);
+
+    // append_many with empty slice should return an error. The error consumes the journal.
     assert!(matches!(
         journal.append_many(Many::Flat(&[])).await,
         Err(Error::EmptyAppend)
     ));
-    assert_eq!(journal.bounds().end, 2);
 
+    let journal = factory("append-many-empty".into()).await.unwrap();
     journal.destroy().await.unwrap();
 }
 
@@ -1190,7 +1211,8 @@ where
 {
     let mut journal = factory("append-many-basic".into()).await.unwrap();
 
-    let pos = journal
+    let pos;
+    (journal, pos) = journal
         .append_many(Many::Flat(&[100, 200, 300]))
         .await
         .unwrap();
@@ -1214,7 +1236,8 @@ where
 
     // Append 25 items in one call, crossing section boundaries at 10 and 20.
     let items: Vec<u64> = (0..25).map(|i| i * 10).collect();
-    let pos = journal.append_many(Many::Flat(&items)).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append_many(Many::Flat(&items)).await.unwrap();
     assert_eq!(pos, 24);
     assert_eq!(journal.bounds().end, 25);
 
@@ -1233,11 +1256,12 @@ where
 {
     let mut journal = factory("append-many-then-single".into()).await.unwrap();
 
-    journal
+    (journal, _) = journal
         .append_many(Many::Flat(&[10, 20, 30]))
         .await
         .unwrap();
-    let pos = journal.append(&40).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append(&40).await.unwrap();
     assert_eq!(pos, 3);
 
     assert_eq!(journal.read(0).await.unwrap(), 10);
@@ -1256,7 +1280,8 @@ where
 {
     let mut journal = factory("append-many-single".into()).await.unwrap();
 
-    let pos = journal.append_many(Many::Flat(&[42])).await.unwrap();
+    let pos;
+    (journal, pos) = journal.append_many(Many::Flat(&[42])).await.unwrap();
     assert_eq!(pos, 0);
     assert_eq!(journal.read(0).await.unwrap(), 42);
 

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -932,7 +932,7 @@ where
         (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    // Try to rewind forward (invalid).
+    // Try to rewind forward (invalid)
     let result = journal.rewind(20).await;
     assert!(matches!(result, Err(Error::InvalidRewind(20))));
 
@@ -955,7 +955,7 @@ where
     // Prune first 10 items
     let (journal, _) = journal.prune(10).await.unwrap();
 
-    // Try to rewind to pruned position (invalid).
+    // Try to rewind to pruned position (invalid)
     let result = journal.rewind(5).await;
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
@@ -1062,7 +1062,7 @@ where
     assert_eq!(journal.read(20).await.unwrap(), 999);
     assert_eq!(journal.bounds().start, 10);
 
-    // Attempt to rewind to a pruned position should fail.
+    // Attempt to rewind to a pruned position should fail
     let result = journal.rewind(5).await;
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -932,7 +932,7 @@ where
         (journal, _) = journal.append(&i).await.unwrap();
     }
 
-    // Try to rewind forward (invalid). The error consumes the journal.
+    // Try to rewind forward (invalid).
     let result = journal.rewind(20).await;
     assert!(matches!(result, Err(Error::InvalidRewind(20))));
 
@@ -955,7 +955,7 @@ where
     // Prune first 10 items
     let (journal, _) = journal.prune(10).await.unwrap();
 
-    // Try to rewind to pruned position (invalid). The error consumes the journal.
+    // Try to rewind to pruned position (invalid).
     let result = journal.rewind(5).await;
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
@@ -1062,7 +1062,7 @@ where
     assert_eq!(journal.read(20).await.unwrap(), 999);
     assert_eq!(journal.bounds().start, 10);
 
-    // Attempt to rewind to a pruned position should fail. The error consumes the journal.
+    // Attempt to rewind to a pruned position should fail.
     let result = journal.rewind(5).await;
     assert!(matches!(result, Err(Error::ItemPruned(5))));
 
@@ -1193,7 +1193,7 @@ where
 
     assert_eq!(journal.bounds().end, 2);
 
-    // append_many with empty slice should return an error. The error consumes the journal.
+    // append_many with empty slice should return an error.
     assert!(matches!(
         journal.append_many(Many::Flat(&[])).await,
         Err(Error::EmptyAppend)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2917,7 +2917,8 @@ mod tests {
             for i in 0..20u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             let cfg = Config {
                 page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
@@ -2968,7 +2969,8 @@ mod tests {
             for item in &items {
                 (journal, _) = journal.append(item).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Reopen with a fresh page cache so sealed-blob full pages are cold.
             let cfg = Config {
@@ -3070,7 +3072,8 @@ mod tests {
             assert_eq!(bounds.start, 20);
             assert_eq!(bounds.end, 40);
 
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // === Phase 2: Simulate complete offsets partition loss ===
             // Remove both the offsets data partition and its metadata partition
@@ -3119,7 +3122,8 @@ mod tests {
                 (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
-            variable.sync().await.unwrap();
+            let variable = variable.sync().await.unwrap();
+            drop(variable);
 
             // === Simulate data loss: Delete data partition but keep offsets ===
             context
@@ -3695,7 +3699,8 @@ mod tests {
             variable.test_prune_offsets(20).await.unwrap(); // Prune to position 20
             variable.test_prune_data(1).await.unwrap(); // Only prune data blobs to blob 1 (position 10)
 
-            variable.sync().await.unwrap();
+            let variable = variable.sync().await.unwrap();
+            drop(variable);
 
             // === Verify corruption detected ===
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
@@ -4210,7 +4215,8 @@ mod tests {
             for i in 0..20u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Empty the oldest data blob in place, leaving blob 1's items orphaned past the
             // gap, then drop the offsets journal so recovery rebuilds from the data alone.
@@ -4284,7 +4290,8 @@ mod tests {
             for i in 0..128u8 {
                 (journal, _) = journal.append(&FixedBytes::new([i; 31])).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             let physical_page_size = LARGE_PAGE_SIZE.get() as u64 + 12;
             let items_in_page = LARGE_PAGE_SIZE.get() as u64 / 32;
@@ -4875,7 +4882,8 @@ mod tests {
                     .unwrap();
                 (journal, _) = journal.append(&10).await.unwrap();
                 (journal, _) = journal.append(&20).await.unwrap();
-                journal.sync().await.unwrap();
+                let journal = journal.sync().await.unwrap();
+                drop(journal);
 
                 let (blob, raw_size) = context
                     .open(&offsets_blob_partition, &0u64.to_be_bytes())
@@ -4940,7 +4948,8 @@ mod tests {
                     .unwrap();
                 (journal, _) = journal.append(&10).await.unwrap();
                 (journal, _) = journal.append(&20).await.unwrap();
-                journal.sync().await.unwrap();
+                let journal = journal.sync().await.unwrap();
+                drop(journal);
 
                 let (blob, raw_size) = context
                     .open(&data_partition, &0u64.to_be_bytes())
@@ -5452,7 +5461,8 @@ mod tests {
                 for i in 0..12u64 {
                     (journal, _) = journal.append(&(100 + i)).await.unwrap();
                 }
-                journal.sync().await.unwrap();
+                let journal = journal.sync().await.unwrap();
+                drop(journal);
 
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
                     sync_rate: Some(1.0),
@@ -5636,7 +5646,8 @@ mod tests {
                 for i in 0..12u64 {
                     (journal, _) = journal.append(&(100 + i)).await.unwrap();
                 }
-                journal.sync().await.unwrap();
+                let journal = journal.sync().await.unwrap();
+                drop(journal);
 
                 let offsets_cfg = fixed::Config {
                     partition: cfg.offsets_partition(),
@@ -5710,7 +5721,8 @@ mod tests {
             for i in 0..12u64 {
                 (journal, _) = journal.append(&(100 + i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Simulate a prior `clear_to_size(5)` that crashed after staging its intent: the offsets
             // checkpoint carries a clear target of 5 while the data blobs still holds all 12 items.
@@ -5773,7 +5785,8 @@ mod tests {
                 (journal, appended) = journal.append(&(500 + i)).await.unwrap();
                 assert_eq!(appended, 5 + i);
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
                 .await
@@ -6248,7 +6261,8 @@ mod tests {
             for i in 0..20u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Initialize with sync boundaries that overlap with existing data
             // lower_bound: 8 (blob 1), upper_bound: 31 (last location 30, blob 6)
@@ -6342,7 +6356,8 @@ mod tests {
             for i in 0..20u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Initialize with sync boundaries that exactly match existing data
             let lower_bound = 5; // blob 1
@@ -6411,7 +6426,8 @@ mod tests {
             for i in 0..30u64 {
                 (journal, _) = journal.append(&(i * 1000)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Initialize with sync boundaries that are exceeded by existing data
             let lower_bound = 8; // blob 1
@@ -6498,7 +6514,8 @@ mod tests {
             )
             .await
             .expect("Failed to create stale empty journal");
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Simulate clear_to_size(7) crashing after clearing data, but before offsets were
             // re-cleared. Recovery will initially see the old empty offsets boundary at 9.
@@ -6551,7 +6568,8 @@ mod tests {
             for i in 0..10u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Initialize with sync boundaries beyond all existing data
             let lower_bound = 15; // blob 3
@@ -6603,7 +6621,8 @@ mod tests {
             for i in 0..25u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Test sync boundaries exactly at blob boundaries
             let lower_bound = 15; // Exactly at blob boundary (15/5 = 3)
@@ -6671,7 +6690,8 @@ mod tests {
             for i in 0..15u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Test sync boundaries within the same blob
             let lower_bound = 10; // operation 10 (blob 2: 10/5 = 2)
@@ -7308,7 +7328,8 @@ mod tests {
             for i in 0..10u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Remove the empty tail blob, leaving only the full blob 0 (the layout written
             // before eager tail creation).
@@ -7395,7 +7416,8 @@ mod tests {
             for i in 0..25u64 {
                 (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Remove blob 1, leaving a gap in the retained data blobs.
             context

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1034,7 +1034,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         );
     }
 
-    /// Initialize the journal state, running recovery.
+    /// See [Journal::init].
     #[boxed]
     pub(crate) async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_section.get();
@@ -5775,10 +5775,9 @@ mod tests {
             }
             journal.sync().await.unwrap();
 
-            let journal = Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
+            Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
                 .await
                 .unwrap();
-            drop(journal);
 
             let mut journal = Journal::<_, u64>::init(context.child("after_reset"), cfg.clone())
                 .await

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -10,6 +10,8 @@ use super::{
     metrics::Metrics,
     position_to_blob,
 };
+#[commonware_macros::stability(ALPHA)]
+use crate::journal::authenticated;
 use crate::{
     Context,
     journal::{
@@ -20,8 +22,6 @@ use crate::{
         },
     },
 };
-#[commonware_macros::stability(ALPHA)]
-use crate::{journal::authenticated, merkle};
 use commonware_codec::{Codec, CodecShared, varint::MAX_U32_VARINT_SIZE};
 use commonware_macros::boxed;
 use commonware_runtime::{
@@ -365,57 +365,15 @@ impl<C> Config<C> {
     }
 }
 
-/// A contiguous journal with variable-size entries.
-///
-/// This journal manages blob assignment automatically, allowing callers to append items
-/// sequentially without manually tracking blob indexes.
-///
-/// # Repair
-///
-/// Like
-/// [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
-/// and
-/// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
-/// the first invalid data read will be considered the new end of the journal (and the underlying
-/// blob will be truncated to the last valid item). Repair is performed during init.
-/// Incomplete trailing frames are repaired as torn writes; complete frames whose payloads fail to
-/// decode are treated as corruption.
-///
-/// # Invariants
-///
-/// ## 1. Data Blobs are the Source of Truth
-///
-/// The data blobs are always the source of truth. The offsets journal is an index that may
-/// temporarily diverge during crashes. Divergences are automatically aligned during init():
-/// * If offsets are behind data after the recovery watermark: rebuild missing offsets by replaying
-///   data from the recovery anchor.
-/// * If offsets are ahead of the retained data prefix but the data still reaches the recovery
-///   watermark: rewind offsets to match the data-backed size. Retained data ending before the
-///   watermark is corruption because acknowledged data is missing.
-/// * If offsets.bounds().start < the oldest data blob's start: prune offsets to match (this can
-///   happen if we crash after pruning the data blobs but before pruning the offsets journal).
-///
-/// Offsets may start after the data's blob-aligned start when both are in the same blob, as in a
-/// mid-blob `init_at_size`. Offsets starting in a later blob imply corruption because we
-/// always prune the data blobs before the offsets journal.
-///
-/// ## 2. Offsets Recovery Watermark
-///
-/// The offsets journal's recovery watermark records a durable lower bound on the journal size and
-/// a preferred point for replaying data to rebuild offset entries after a crash. Fixed-journal
-/// recovery rejects watermarks beyond the recovered offsets size as corruption. A watermark below
-/// the recovered offsets start is stale after a prune, so init falls back to the offsets start. If
-/// retained data exists but ends before the watermark, init returns corruption because acknowledged
-/// data is missing. If no retained data exists, init reconciles both sides to an empty journal.
-/// Replay after a valid anchor stops at the first short data blob and truncates newer blobs so the
-/// recovered journal remains a contiguous prefix.
-pub struct Journal<E: Context, V: Codec> {
+/// The journal state behind the [Journal] handle, boxed so the handle stays pointer-sized
+/// and mutated in place by the handle's methods.
+struct Inner<E: Context, V: Codec> {
     /// The data blobs: sealed history plus the writable tail.
     blobs: Writable<E>,
 
     /// Index mapping positions to byte offsets within their data blob. Its checkpoint is also
     /// this journal's durable recovery record.
-    offsets: fixed::Journal<E, u64>,
+    offsets: fixed::Inner<E, u64>,
 
     /// The readable positions; `bounds.end` is the next append position.
     bounds: Range<u64>,
@@ -1067,7 +1025,7 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
     }
 }
 
-impl<E: Context, V: CodecShared> Journal<E, V> {
+impl<E: Context, V: CodecShared> Inner<E, V> {
     /// Mark all data blobs from `blob` onward as dirty.
     fn mark_dirty_from(&mut self, blob: u64) {
         self.dirty_from_blob = Some(
@@ -1076,14 +1034,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         );
     }
 
-    /// Initialize a contiguous variable journal.
-    ///
-    /// # Crash Recovery
-    ///
-    /// The data blobs are the source of truth. If the offsets journal is inconsistent
-    /// it will be updated to match the data blobs.
+    /// Initialize the journal state, running recovery.
     #[boxed]
-    pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
+    pub(crate) async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_section.get();
         let data_partition = cfg.data_partition();
         let data_context = context.child("data");
@@ -1091,7 +1044,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // If a prior `init_at_size`/`clear_to_size` crashed mid-reset, the offsets journal
         // carries a staged clear. `init_cleared` discards the data partition before finishing
         // that reset so stale data is never replayed past the reset size.
-        let mut offsets = fixed::Journal::<E, u64>::init_cleared(
+        let mut offsets = fixed::Inner::<E, u64>::init_cleared(
             context.child("offsets"),
             fixed::Config {
                 partition: cfg.offsets_partition(),
@@ -1147,16 +1100,13 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         })
     }
 
-    /// Initialize an empty [Journal] at the given logical `size`.
-    ///
-    /// This discards any existing data and offsets. The offsets reset intent is staged before the
-    /// data partition is cleared so recovery can complete the requested reset if a crash
-    /// interrupts the operation.
-    ///
-    /// Returns a journal with journal.bounds() == Range{start: size, end: size}
-    /// and next append at position `size`.
+    /// See [Journal::init_at_size].
     #[commonware_macros::stability(ALPHA)]
-    pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
+    pub(crate) async fn init_at_size(
+        context: E,
+        cfg: Config<V::Cfg>,
+        size: u64,
+    ) -> Result<Self, Error> {
         let items_per_blob = cfg.items_per_section.get();
         let data_partition = cfg.data_partition();
         let data_context = context.child("data");
@@ -1169,7 +1119,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         // `init_at_size_cleared` durably stages the offsets reset, clears the data partition,
         // then completes the reset. A crash at any point leaves a staged clear that the next
         // `init` (via `init_cleared`) finishes, so stale data can never outlive the reset.
-        let offsets = fixed::Journal::<E, u64>::init_at_size_cleared(
+        let offsets = fixed::Inner::<E, u64>::init_at_size_cleared(
             offsets_context,
             fixed::Config {
                 partition: offsets_partition,
@@ -1212,31 +1162,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         })
     }
 
-    /// Initialize a [Journal] for use in state sync.
-    ///
-    /// The bounds are item locations (not blob indexes). This function prepares the
-    /// on-disk journal so that subsequent appends go to the correct physical location for the
-    /// requested range.
-    ///
-    /// Behavior by existing on-disk state:
-    /// - Fresh (no data): returns an empty journal, resetting to `range.start` if needed.
-    /// - Stale (all data strictly before `range.start`): resets to `range.start` using the
-    ///   crash-safe clear path and returns an empty journal.
-    /// - Overlap within [`range.start`, `range.end`]:
-    ///   - Prunes toward `range.start` (blob-aligned, so some items before
-    ///     `range.start` may be retained)
-    /// - Data beyond `range.end`: returns [Error::ItemOutOfRange].
-    ///
-    /// # Arguments
-    /// - `context`: storage context
-    /// - `cfg`: journal configuration
-    /// - `range`: range of item locations to retain
-    ///
-    /// # Returns
-    /// A contiguous journal ready for sync operations. The journal's size will be within the range.
-    ///
-    /// # Errors
-    /// Returns [Error::ItemOutOfRange] if existing data extends beyond `range.end`.
+    /// See [Journal::init_sync].
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn init_sync(
         context: E,
@@ -1307,21 +1233,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(journal)
     }
 
-    /// Rewind the journal to the given size, discarding items from the end.
-    ///
-    /// After rewinding to size N, the journal will contain exactly N items, and the next append
-    /// will receive position N.
-    ///
-    /// # Errors
-    ///
-    /// Returns [Error::InvalidRewind] if `size` is larger than current size.
-    /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
-    /// # Warning
-    ///
-    /// - This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
-    /// - Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
-    ///   rewind truncates into their range.
-    pub async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    /// In-place [Journal::rewind].
+    pub(crate) async fn rewind(&mut self, size: u64) -> Result<(), Error> {
         match size.cmp(&self.bounds.end) {
             std::cmp::Ordering::Greater => return Err(Error::InvalidRewind(size)),
             std::cmp::Ordering::Equal => return Ok(()),
@@ -1364,26 +1277,16 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(())
     }
 
-    /// Append a new item to the journal, returning its position.
-    ///
-    /// The position returned is a stable, consecutively increasing value starting from 0.
-    /// This position remains constant after pruning.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the underlying storage operation fails or if the item cannot
-    /// be encoded.
-    pub async fn append(&mut self, item: &V) -> Result<u64, Error> {
+    /// In-place [Journal::append].
+    pub(crate) async fn append(&mut self, item: &V) -> Result<u64, Error> {
         let _timer = self.metrics.append_timer();
         self.metrics.append_calls.inc();
         self.append_many_inner(Many::Flat(std::slice::from_ref(item)))
             .await
     }
 
-    /// Append items to the journal, returning the position of the last item appended.
-    ///
-    /// Returns [Error::EmptyAppend] if items is empty.
-    pub async fn append_many<'a>(&'a mut self, items: Many<'a, V>) -> Result<u64, Error> {
+    /// In-place [Journal::append_many].
+    pub(crate) async fn append_many<'a>(&'a mut self, items: Many<'a, V>) -> Result<u64, Error> {
         let _timer = self.metrics.append_many_timer();
         self.metrics.append_many_calls.inc();
         self.append_many_inner(items).await
@@ -1393,11 +1296,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         self.write_encoded(self.prepare_append(items)?).await
     }
 
-    /// Encode `items` into a buffer that can be appended later with [`Self::append_prepared`].
-    ///
-    /// This lets callers serialize borrowed items synchronously, release those borrows, and
-    /// perform the append without holding unrelated locks across journal I/O.
-    pub fn prepare_append(&self, items: Many<'_, V>) -> Result<PreparedAppend<V>, Error> {
+    /// In-place [Journal::prepare_append].
+    pub(crate) fn prepare_append(&self, items: Many<'_, V>) -> Result<PreparedAppend<V>, Error> {
         let mut encoded = Vec::new();
         let mut item_starts = Vec::with_capacity(items.len());
         let mut encode = |item: &V| {
@@ -1426,13 +1326,11 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         })
     }
 
-    /// Append items encoded by [`Self::prepare_append`], returning the position of the last item
-    /// appended.
-    ///
-    /// Returns [Error::EmptyAppend] if `prepared` contains no items.
-    /// Returns [Error::InvalidConfiguration] if `prepared` was encoded with different compression
-    /// settings than this journal uses.
-    pub async fn append_prepared(&mut self, prepared: PreparedAppend<V>) -> Result<u64, Error> {
+    /// In-place [Journal::append_prepared].
+    pub(crate) async fn append_prepared(
+        &mut self,
+        prepared: PreparedAppend<V>,
+    ) -> Result<u64, Error> {
         let _timer = self.metrics.append_prepared_timer();
         self.metrics.append_prepared_calls.inc();
         self.write_encoded(prepared).await
@@ -1523,12 +1421,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(self.bounds.end - 1)
     }
 
-    /// Capture an owned snapshot ([`Reader`]) over the current journal. Bounds are frozen at
-    /// creation, and the snapshot stays readable across concurrent appends and prunes.
-    ///
-    /// If the journal later rewinds into the returned reader's range, subsequent reads
-    /// from that range may observe unspecified contents.
-    pub async fn snapshot(&mut self) -> Result<Reader<'static, E, V>, Error> {
+    /// In-place [Journal::snapshot].
+    pub(crate) async fn snapshot(&mut self) -> Result<Reader<'static, E, V>, Error> {
         Ok(Reader {
             data: self.blobs.snapshot().await?,
             bounds: self.bounds.clone(),
@@ -1559,14 +1453,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         self.bounds.end
     }
 
-    /// Prune items at positions strictly less than `min_position`.
-    ///
-    /// Returns `true` if any data was pruned, `false` otherwise.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the underlying storage operation fails.
-    pub async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
+    /// In-place [Journal::prune].
+    pub(crate) async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
         let items_per_blob = self.items_per_blob.get();
 
         // Calculate the blob that would contain min_position, capped to the tail (which is
@@ -1624,11 +1512,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         self.blobs.sync_from(start_blob).await
     }
 
-    /// Persist dirty data blobs so committed data survives a crash.
-    ///
-    /// Does not advance the recovery watermark, so reopen may need to replay entries beyond
-    /// the previous `sync()`.
-    pub async fn commit(&mut self) -> Result<(), Error> {
+    /// In-place [Journal::commit].
+    pub(crate) async fn commit(&mut self) -> Result<(), Error> {
         let _timer = self.metrics.commit_timer();
         self.metrics.commit_calls.inc();
         self.flush_dirty_data().await?;
@@ -1636,8 +1521,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(())
     }
 
-    /// Persist dirty data blobs and all metadata for both the data and offsets journals.
-    pub async fn sync(&mut self) -> Result<(), Error> {
+    /// In-place [Journal::sync].
+    pub(crate) async fn sync(&mut self) -> Result<(), Error> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
         self.flush_dirty_data().await?;
@@ -1646,16 +1531,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok(())
     }
 
-    /// Remove any underlying blobs created by the journal.
-    ///
-    /// This destroys both the data blobs and the offsets journal.
-    ///
-    /// # Crash Safety
-    ///
-    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
-    /// reopening the same partitions may observe partially removed state. Use [Self::init_at_size]
-    /// for a recoverable reset.
-    pub async fn destroy(self) -> Result<(), Error> {
+    /// See [Journal::destroy].
+    pub(crate) async fn destroy(self) -> Result<(), Error> {
         self.blobs.destroy().await?;
         self.offsets.destroy().await
     }
@@ -1723,7 +1600,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     async fn align(
         partition: &Partition<E>,
         pending: &mut BTreeMap<u64, Writer<E::Blob>>,
-        offsets: &mut fixed::Journal<E, u64>,
+        offsets: &mut fixed::Inner<E, u64>,
         items_per_blob: u64,
         codec_config: &V::Cfg,
         compressed: bool,
@@ -1883,7 +1760,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     async fn align_empty(
         partition: &Partition<E>,
         pending: &mut BTreeMap<u64, Writer<E::Blob>>,
-        offsets: &mut fixed::Journal<E, u64>,
+        offsets: &mut fixed::Inner<E, u64>,
         items_per_blob: u64,
     ) -> Result<Range<u64>, Error> {
         let offsets_bounds = offsets.pruning_boundary()..offsets.size();
@@ -1926,7 +1803,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// Choose the position to rebuild offsets from. A watermark below the pruning boundary is
     /// stale after a prune, while a watermark beyond retained data indicates corruption.
     fn recovery_anchor(
-        offsets: &fixed::Journal<E, u64>,
+        offsets: &fixed::Inner<E, u64>,
         offsets_bounds: &Range<u64>,
         retained_data_end_bound: u64,
     ) -> Result<u64, Error> {
@@ -1990,7 +1867,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     async fn rebuild_offsets_from_anchor(
         partition: &Partition<E>,
         pending: &mut BTreeMap<u64, Writer<E::Blob>>,
-        offsets: &mut fixed::Journal<E, u64>,
+        offsets: &mut fixed::Inner<E, u64>,
         items_per_blob: u64,
         anchor: u64,
         codec_config: &V::Cfg,
@@ -2132,7 +2009,247 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     }
 }
 
-impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
+/// A contiguous journal with variable-size entries.
+///
+/// This journal manages blob assignment automatically, allowing callers to append items
+/// sequentially without manually tracking blob indexes.
+///
+/// # Repair
+///
+/// Like
+/// [sqlite](https://github.com/sqlite/sqlite/blob/8658a8df59f00ec8fcfea336a2a6a4b5ef79d2ee/src/wal.c#L1504-L1505)
+/// and
+/// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
+/// the first invalid data read will be considered the new end of the journal (and the underlying
+/// blob will be truncated to the last valid item). Repair is performed during init.
+/// Incomplete trailing frames are repaired as torn writes; complete frames whose payloads fail to
+/// decode are treated as corruption.
+///
+/// # Invariants
+///
+/// ## 1. Data Blobs are the Source of Truth
+///
+/// The data blobs are always the source of truth. The offsets journal is an index that may
+/// temporarily diverge during crashes. Divergences are automatically aligned during init():
+/// * If offsets are behind data after the recovery watermark: rebuild missing offsets by replaying
+///   data from the recovery anchor.
+/// * If offsets are ahead of the retained data prefix but the data still reaches the recovery
+///   watermark: rewind offsets to match the data-backed size. Retained data ending before the
+///   watermark is corruption because acknowledged data is missing.
+/// * If offsets.bounds().start < the oldest data blob's start: prune offsets to match (this can
+///   happen if we crash after pruning the data blobs but before pruning the offsets journal).
+///
+/// Offsets may start after the data's blob-aligned start when both are in the same blob, as in a
+/// mid-blob `init_at_size`. Offsets starting in a later blob imply corruption because we
+/// always prune the data blobs before the offsets journal.
+///
+/// ## 2. Offsets Recovery Watermark
+///
+/// The offsets journal's recovery watermark records a durable lower bound on the journal size and
+/// a preferred point for replaying data to rebuild offset entries after a crash. Fixed-journal
+/// recovery rejects watermarks beyond the recovered offsets size as corruption. A watermark below
+/// the recovered offsets start is stale after a prune, so init falls back to the offsets start. If
+/// retained data exists but ends before the watermark, init returns corruption because acknowledged
+/// data is missing. If no retained data exists, init reconciles both sides to an empty journal.
+/// Replay after a valid anchor stops at the first short data blob and truncates newer blobs so the
+/// recovered journal remains a contiguous prefix.
+pub struct Journal<E: Context, V: Codec>(Box<Inner<E, V>>);
+
+impl<E: Context, V: CodecShared> std::fmt::Debug for Journal<E, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Journal")
+            .field("bounds", &super::Contiguous::bounds(self))
+            .finish_non_exhaustive()
+    }
+}
+
+impl<E: Context, V: CodecShared> Journal<E, V> {
+    /// Initialize a contiguous variable journal.
+    ///
+    /// # Crash Recovery
+    ///
+    /// The data blobs are the source of truth. If the offsets journal is inconsistent
+    /// it will be updated to match the data blobs.
+    pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
+        Ok(Self(Box::new(Inner::init(context, cfg).await?)))
+    }
+
+    /// Initialize an empty [Journal] at the given logical `size`.
+    ///
+    /// This discards any existing data and offsets. The offsets reset intent is staged before the
+    /// data partition is cleared so recovery can complete the requested reset if a crash
+    /// interrupts the operation.
+    ///
+    /// Returns a journal with journal.bounds() == Range{start: size, end: size}
+    /// and next append at position `size`.
+    #[commonware_macros::stability(ALPHA)]
+    pub async fn init_at_size(context: E, cfg: Config<V::Cfg>, size: u64) -> Result<Self, Error> {
+        Ok(Self(Box::new(
+            Inner::init_at_size(context, cfg, size).await?,
+        )))
+    }
+
+    /// Initialize a [Journal] for use in state sync.
+    ///
+    /// The bounds are item locations (not blob indexes). This function prepares the
+    /// on-disk journal so that subsequent appends go to the correct physical location for the
+    /// requested range.
+    ///
+    /// Behavior by existing on-disk state:
+    /// - Fresh (no data): returns an empty journal, resetting to `range.start` if needed.
+    /// - Stale (all data strictly before `range.start`): resets to `range.start` using the
+    ///   crash-safe clear path and returns an empty journal.
+    /// - Overlap within [`range.start`, `range.end`]:
+    ///   - Prunes toward `range.start` (blob-aligned, so some items before
+    ///     `range.start` may be retained)
+    /// - Data beyond `range.end`: returns [Error::ItemOutOfRange].
+    ///
+    /// # Arguments
+    /// - `context`: storage context
+    /// - `cfg`: journal configuration
+    /// - `range`: range of item locations to retain
+    ///
+    /// # Returns
+    /// A contiguous journal ready for sync operations. The journal's size will be within the range.
+    ///
+    /// # Errors
+    /// Returns [Error::ItemOutOfRange] if existing data extends beyond `range.end`.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) async fn init_sync(
+        context: E,
+        cfg: Config<V::Cfg>,
+        range: core::ops::Range<u64>,
+    ) -> Result<Self, Error> {
+        Ok(Self(Box::new(Inner::init_sync(context, cfg, range).await?)))
+    }
+
+    /// Discard all items and reposition the journal at `new_size`.
+    #[commonware_macros::stability(ALPHA)]
+    pub(crate) async fn clear_to_size(&mut self, new_size: u64) -> Result<(), Error> {
+        self.0.clear_to_size(new_size).await
+    }
+
+    /// Rewind the journal to the given size, discarding items from the end.
+    ///
+    /// After rewinding to size N, the journal will contain exactly N items, and the next append
+    /// will receive position N.
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::InvalidRewind] if `size` is larger than current size.
+    /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
+    /// # Warning
+    ///
+    /// - This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
+    /// - Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
+    ///   rewind truncates into their range.
+    pub async fn rewind(mut self, size: u64) -> Result<Self, Error> {
+        self.0.rewind(size).await?;
+        Ok(self)
+    }
+
+    /// Append a new item to the journal, returning its position.
+    ///
+    /// The position returned is a stable, consecutively increasing value starting from 0.
+    /// This position remains constant after pruning.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying storage operation fails or if the item cannot
+    /// be encoded.
+    pub async fn append(mut self, item: &V) -> Result<(Self, u64), Error> {
+        let position = self.0.append(item).await?;
+        Ok((self, position))
+    }
+
+    /// Append items to the journal, returning the position of the last item appended.
+    ///
+    /// Returns [Error::EmptyAppend] if items is empty.
+    pub async fn append_many(mut self, items: Many<'_, V>) -> Result<(Self, u64), Error> {
+        let position = self.0.append_many(items).await?;
+        Ok((self, position))
+    }
+
+    /// Encode `items` into a buffer that can be appended later with [`Self::append_prepared`].
+    ///
+    /// This lets callers serialize borrowed items synchronously, release those borrows, and
+    /// perform the append without holding unrelated locks across journal I/O.
+    pub fn prepare_append(&self, items: Many<'_, V>) -> Result<PreparedAppend<V>, Error> {
+        self.0.prepare_append(items)
+    }
+
+    /// Append items encoded by [`Self::prepare_append`], returning the position of the last item
+    /// appended.
+    ///
+    /// Returns [Error::EmptyAppend] if `prepared` contains no items.
+    /// Returns [Error::InvalidConfiguration] if `prepared` was encoded with different compression
+    /// settings than this journal uses.
+    pub async fn append_prepared(
+        mut self,
+        prepared: PreparedAppend<V>,
+    ) -> Result<(Self, u64), Error> {
+        let position = self.0.append_prepared(prepared).await?;
+        Ok((self, position))
+    }
+
+    /// Capture an owned snapshot ([`Reader`]) over the current journal. Bounds are frozen at
+    /// creation, and the snapshot stays readable across concurrent appends and prunes.
+    ///
+    /// If the journal later rewinds into the returned reader's range, subsequent reads
+    /// from that range may observe unspecified contents.
+    pub async fn snapshot(mut self) -> Result<(Self, Reader<'static, E, V>), Error> {
+        let reader = self.0.snapshot().await?;
+        Ok((self, reader))
+    }
+
+    /// Return the total number of items in the journal, irrespective of pruning. The next value
+    /// appended to the journal will be at this position.
+    pub fn size(&self) -> u64 {
+        self.0.size()
+    }
+
+    /// Prune items at positions strictly less than `min_position`.
+    ///
+    /// Returns `true` if any data was pruned, `false` otherwise.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying storage operation fails.
+    pub async fn prune(mut self, min_position: u64) -> Result<(Self, bool), Error> {
+        let pruned = self.0.prune(min_position).await?;
+        Ok((self, pruned))
+    }
+
+    /// Persist dirty data blobs so committed data survives a crash.
+    ///
+    /// Does not advance the recovery watermark, so reopen may need to replay entries beyond
+    /// the previous `sync()`.
+    pub async fn commit(mut self) -> Result<Self, Error> {
+        self.0.commit().await?;
+        Ok(self)
+    }
+
+    /// Persist dirty data blobs and all metadata for both the data and offsets journals.
+    pub async fn sync(mut self) -> Result<Self, Error> {
+        self.0.sync().await?;
+        Ok(self)
+    }
+
+    /// Remove any underlying blobs created by the journal.
+    ///
+    /// This destroys both the data blobs and the offsets journal.
+    ///
+    /// # Crash Safety
+    ///
+    /// This operation is intended for final teardown and is not crash-safe. If interrupted,
+    /// reopening the same partitions may observe partially removed state. Use [Self::init_at_size]
+    /// for a recoverable reset.
+    pub async fn destroy(self) -> Result<(), Error> {
+        (*self.0).destroy().await
+    }
+}
+
+impl<E: Context, V: CodecShared> Contiguous for Inner<E, V> {
     type Item = V;
 
     fn bounds(&self) -> Range<u64> {
@@ -2167,28 +2284,60 @@ impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
     }
 }
 
+impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
+    type Item = V;
+
+    fn bounds(&self) -> Range<u64> {
+        Contiguous::bounds(&*self.0)
+    }
+
+    async fn read(&self, position: u64) -> Result<V, Error> {
+        Contiguous::read(&*self.0, position).await
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<V>, Error> {
+        Contiguous::read_many(&*self.0, positions).await
+    }
+
+    fn try_read_sync(&self, position: u64) -> Option<V> {
+        Contiguous::try_read_sync(&*self.0, position)
+    }
+
+    fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<V>> {
+        Contiguous::try_read_many_sync(&*self.0, positions)
+    }
+
+    async fn replay(
+        &self,
+        start_pos: u64,
+        buffer: NonZeroUsize,
+    ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
+        Contiguous::replay(&*self.0, start_pos, buffer).await
+    }
+}
+
 impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
-    async fn append(&mut self, item: &Self::Item) -> Result<u64, Error> {
+    async fn append(self, item: &Self::Item) -> Result<(Self, u64), Error> {
         Self::append(self, item).await
     }
 
-    async fn append_many<'a>(&'a mut self, items: Many<'a, Self::Item>) -> Result<u64, Error> {
+    async fn append_many(self, items: Many<'_, Self::Item>) -> Result<(Self, u64), Error> {
         Self::append_many(self, items).await
     }
 
-    async fn prune(&mut self, min_position: u64) -> Result<bool, Error> {
+    async fn prune(self, min_position: u64) -> Result<(Self, bool), Error> {
         Self::prune(self, min_position).await
     }
 
-    async fn rewind(&mut self, size: u64) -> Result<(), Error> {
+    async fn rewind(self, size: u64) -> Result<Self, Error> {
         Self::rewind(self, size).await
     }
 
-    async fn commit(&mut self) -> Result<(), Error> {
+    async fn commit(self) -> Result<Self, Error> {
         Self::commit(self).await
     }
 
-    async fn sync(&mut self) -> Result<(), Error> {
+    async fn sync(self) -> Result<Self, Error> {
         Self::sync(self).await
     }
 
@@ -2198,28 +2347,11 @@ impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
 }
 
 #[commonware_macros::stability(ALPHA)]
-impl<E: Context, V: CodecShared> authenticated::Inner<E> for Journal<E, V> {
+impl<E: Context, V: CodecShared> authenticated::Backing<E> for Journal<E, V> {
     type Config = Config<V::Cfg>;
 
-    async fn init<
-        F: merkle::Family,
-        H: commonware_cryptography::Hasher,
-        S: commonware_parallel::Strategy,
-    >(
-        context: E,
-        merkle_cfg: merkle::full::Config<S>,
-        journal_cfg: Self::Config,
-        rewind_predicate: fn(&V) -> bool,
-        bagging: merkle::Bagging,
-    ) -> Result<authenticated::Journal<F, E, Self, H, S>, authenticated::Error<F>> {
-        authenticated::Journal::<F, E, Self, H, S>::new(
-            context,
-            merkle_cfg,
-            journal_cfg,
-            rewind_predicate,
-            bagging,
-        )
-        .await
+    async fn init(context: E, cfg: Self::Config) -> Result<Self, Error> {
+        Self::init(context, cfg).await
     }
 }
 
@@ -2227,22 +2359,22 @@ impl<E: Context, V: CodecShared> authenticated::Inner<E> for Journal<E, V> {
 impl<E: Context, V: CodecShared> Journal<E, V> {
     /// Test helper: Prune the data blobs directly (simulates crash scenario).
     pub(crate) async fn test_prune_data(&mut self, min_blob: u64) -> Result<bool, Error> {
-        let min_blob = min_blob.min(self.blobs.tail_blob_index());
-        if min_blob <= self.blobs.oldest_blob_index() {
+        let min_blob = min_blob.min(self.0.blobs.tail_blob_index());
+        if min_blob <= self.0.blobs.oldest_blob_index() {
             return Ok(false);
         }
-        self.blobs.prune(min_blob).await?;
+        self.0.blobs.prune(min_blob).await?;
         Ok(true)
     }
 
     /// Test helper: Prune the internal offsets journal directly (simulates crash scenario).
     pub(crate) async fn test_prune_offsets(&mut self, position: u64) -> Result<bool, Error> {
-        self.offsets.prune(position).await
+        self.0.offsets.prune(position).await
     }
 
     /// Test helper: Rewind the internal offsets journal directly (simulates crash scenario).
     pub(crate) async fn test_rewind_offsets(&mut self, position: u64) -> Result<(), Error> {
-        self.offsets.rewind(position).await
+        self.0.offsets.rewind(position).await
     }
 
     /// Test helper: Set and persist the offsets recovery watermark directly.
@@ -2250,12 +2382,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         &mut self,
         watermark: u64,
     ) -> Result<(), Error> {
-        self.offsets.test_set_recovery_watermark(watermark).await
+        self.0.offsets.test_set_recovery_watermark(watermark).await
     }
 
     /// Test helper: Get the size of the internal offsets journal.
     pub(crate) fn test_offsets_size(&self) -> u64 {
-        self.offsets.size()
+        self.0.offsets.size()
     }
 
     /// Test helper: Rewind the data blobs to the item at `position` (simulates crash scenario).
@@ -2263,12 +2395,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         &mut self,
         position: u64,
     ) -> Result<(), Error> {
-        let offset = self.offsets.read(position).await?;
-        let blob = position_to_blob(position, self.items_per_blob.get());
-        if blob == self.blobs.tail_blob_index() {
-            self.blobs.rewind_tail(offset).await
+        let offset = self.0.offsets.read(position).await?;
+        let blob = position_to_blob(position, self.0.items_per_blob.get());
+        if blob == self.0.blobs.tail_blob_index() {
+            self.0.blobs.rewind_tail(offset).await
         } else {
-            self.blobs.rewind_into_sealed(blob, offset).await
+            self.0.blobs.rewind_into_sealed(blob, offset).await
         }
     }
 
@@ -2280,18 +2412,18 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         item: V,
     ) -> Result<(u64, u32), Error> {
         let mut encoded = Vec::new();
-        encode_frame_into(self.compression, &item, &mut encoded)?;
+        encode_frame_into(self.0.compression, &item, &mut encoded)?;
         let item_len = encoded.len() as u32;
 
-        let tail_blob = self.blobs.tail_blob_index();
+        let tail_blob = self.0.blobs.tail_blob_index();
         if blob == tail_blob {
-            let writer = self.blobs.tail_writer();
+            let writer = self.0.blobs.tail_writer();
             let offset = writer.size();
             writer.append(&encoded).await.map_err(Error::Runtime)?;
             return Ok((offset, item_len));
         }
         assert!(blob > tail_blob, "cannot append to a sealed blob");
-        let mut writer = self.blobs.open_blob(blob).await?;
+        let mut writer = self.0.blobs.open_blob(blob).await?;
         let offset = writer.size();
         writer.append(&encoded).await.map_err(Error::Runtime)?;
         writer.sync().await.map_err(Error::Runtime)?;
@@ -2300,12 +2432,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
 
     /// Test helper: Sync the data tail.
     pub(crate) async fn test_sync_data(&mut self) -> Result<(), Error> {
-        self.blobs.sync_from(self.blobs.tail_blob_index()).await
+        self.0.blobs.sync_from(self.0.blobs.tail_blob_index()).await
     }
 
     /// Test helper: Sync one data blob.
     pub(crate) async fn test_sync_data_blob(&mut self, blob: u64) -> Result<(), Error> {
-        self.blobs.sync_blob(blob).await
+        self.0.blobs.sync_blob(blob).await
     }
 }
 
@@ -2357,9 +2489,9 @@ mod tests {
                 Journal::<_, FixedBytes<32>>::init(context.child("first"), cfg.clone())
                     .await
                     .unwrap();
-            journal.append(&FixedBytes::new([1; 32])).await.unwrap();
-            journal.append(&FixedBytes::new([2; 32])).await.unwrap();
-            journal.sync().await.unwrap();
+            (journal, _) = journal.append(&FixedBytes::new([1; 32])).await.unwrap();
+            (journal, _) = journal.append(&FixedBytes::new([2; 32])).await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
             // Simulate the state left by a crash after item 2's data became visible to recovery,
             // but before the offsets journal's recovery watermark advanced past item 1.
             journal
@@ -2409,7 +2541,8 @@ mod tests {
                 FixedBytes::new([4; 32]),
             ];
 
-            let last = journal.append_many(Many::Flat(&items)).await.unwrap();
+            let last;
+            (journal, last) = journal.append_many(Many::Flat(&items)).await.unwrap();
             assert_eq!(last, 4);
             for (pos, item) in items.iter().enumerate() {
                 assert_eq!(journal.read(pos as u64).await.unwrap(), *item);
@@ -2439,9 +2572,10 @@ mod tests {
                 Journal::<_, FixedBytes<300>>::init(context.child("first"), cfg.clone())
                     .await
                     .unwrap();
-            assert_eq!(journal.append_many(Many::Flat(&items)).await.unwrap(), 12);
+            let appended;
+            (journal, appended) = journal.append_many(Many::Flat(&items)).await.unwrap();
+            assert_eq!(appended, 12);
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, FixedBytes<300>>::init(context.child("second"), cfg)
                 .await
@@ -2507,14 +2641,14 @@ mod tests {
                     .unwrap();
 
             // The first append fills the last representable position.
-            assert_eq!(journal.append(&7).await.unwrap(), u64::MAX - 1);
+            let appended;
+            (journal, appended) = journal.append(&7).await.unwrap();
+            assert_eq!(appended, u64::MAX - 1);
             assert_eq!(journal.size(), u64::MAX);
 
             // The next append would overflow the size; it must return a recoverable error
-            // rather than panicking.
+            // rather than panicking. The error consumes the journal.
             assert!(matches!(journal.append(&8).await, Err(Error::SizeOverflow)));
-
-            journal.destroy().await.unwrap();
         });
     }
 
@@ -2535,10 +2669,13 @@ mod tests {
                 Journal::<_, u64>::init_at_size(context.child("near_max"), cfg, u64::MAX - 1)
                     .await
                     .unwrap();
-            assert_eq!(journal.append(&7).await.unwrap(), u64::MAX - 1);
+            let appended;
+            (journal, appended) = journal.append(&7).await.unwrap();
+            assert_eq!(appended, u64::MAX - 1);
 
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(u64::MAX - 1, NZUsize!(20)).await.unwrap();
                 futures::pin_mut!(stream);
                 let (pos, item) = stream.next().await.unwrap().unwrap();
@@ -2571,11 +2708,12 @@ mod tests {
             let mut journal = Journal::<_, FixedBytes<300>>::init(context.child("j"), cfg)
                 .await
                 .unwrap();
-            journal.append_many(Many::Flat(&items)).await.unwrap();
-            journal.sync().await.unwrap();
+            (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..items.len() as u64).collect();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             // Warm both the offsets and data page caches, then expect every position to be
             // served synchronously.
             let expected = reader.read_many(&positions).await.unwrap();
@@ -2615,11 +2753,11 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..5u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
-            let reader = journal.snapshot().await.unwrap();
+            let (_journal, reader) = journal.snapshot().await.unwrap();
             let _ = reader.read_many(&[2, 1]).await;
         });
     }
@@ -2642,11 +2780,11 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..5u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
-            let reader = journal.snapshot().await.unwrap();
+            let (_journal, reader) = journal.snapshot().await.unwrap();
             let _ = reader.read_many(&[1, 1]).await;
         });
     }
@@ -2669,13 +2807,14 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..12u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             let positions: Vec<u64> = (0..12).collect();
             let expected: Vec<u64> = (0..12).map(|i| i * 100).collect();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             for _ in 0..2 {
                 let mut served = reader.try_read_many_sync(&positions);
                 let misses: Vec<u64> = positions
@@ -2720,9 +2859,10 @@ mod tests {
             let mut journal = Journal::<_, FixedBytes<300>>::init(context.child("j"), cfg)
                 .await
                 .unwrap();
-            journal.append_many(Many::Flat(&appended)).await.unwrap();
-            journal.sync().await.unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            (journal, _) = journal.append_many(Many::Flat(&appended)).await.unwrap();
+            journal = journal.sync().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
 
             // Churn the 4-page pool with section-1 frames (five data pages) so every
             // section-0 page is evicted, then warm the offsets page shared by positions
@@ -2775,10 +2915,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..20u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             let cfg = Config {
                 page_cache: CacheRef::from_pooler(&context, SMALL_PAGE_SIZE, NZUsize!(2)),
@@ -2787,7 +2926,8 @@ mod tests {
             let mut journal = Journal::<_, u64>::init(context.child("second"), cfg)
                 .await
                 .unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let positions: Vec<u64> = (3..10).collect();
             let items = reader.read_many(&positions).await.unwrap();
             assert_eq!(items, vec![300, 400, 500, 600, 700, 800, 900]);
@@ -2826,10 +2966,9 @@ mod tests {
                     .await
                     .unwrap();
             for item in &items {
-                journal.append(item).await.unwrap();
+                (journal, _) = journal.append(item).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen with a fresh page cache so sealed-blob full pages are cold.
             let cfg = Config {
@@ -2839,7 +2978,8 @@ mod tests {
             let mut journal = Journal::<_, FixedBytes<300>>::init(context.child("second"), cfg)
                 .await
                 .unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
 
             // Warm blobs 1 (positions 5..10) and 3 (positions 15..20) with one read each. The
             // faulted pages cover the neighboring positions asserted below.
@@ -2921,17 +3061,16 @@ mod tests {
 
             // Append 40 items across 4 blobs (0-3)
             for i in 0..40u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Prune to position 20 (removes blobs 0-1, keeps blobs 2-3)
-            journal.prune(20).await.unwrap();
+            let (journal, _) = journal.prune(20).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.start, 20);
             assert_eq!(bounds.end, 40);
 
             journal.sync().await.unwrap();
-            drop(journal);
 
             // === Phase 2: Simulate complete offsets partition loss ===
             // Remove both the offsets data partition and its metadata partition
@@ -2977,11 +3116,10 @@ mod tests {
 
             // Append 20 items across 2 blobs
             for i in 0..20u64 {
-                variable.append(&(i * 100)).await.unwrap();
+                (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
             variable.sync().await.unwrap();
-            drop(variable);
 
             // === Simulate data loss: Delete data partition but keep offsets ===
             context
@@ -3009,7 +3147,8 @@ mod tests {
             }
 
             // Can append new data starting at position 20
-            let pos = journal.append(&999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), 999);
 
@@ -3036,12 +3175,13 @@ mod tests {
 
             // Append 40 items across 4 blobs (0-3)
             for i in 0..40u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Test 1: Full replay
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(0, NZUsize!(20)).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 0..40u64 {
@@ -3054,7 +3194,8 @@ mod tests {
 
             // Test 2: Partial replay from middle of blob
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(15, NZUsize!(20)).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 15..40u64 {
@@ -3067,7 +3208,8 @@ mod tests {
 
             // Test 3: Partial replay from blob boundary
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(20, NZUsize!(20)).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 20..40u64 {
@@ -3079,21 +3221,24 @@ mod tests {
             }
 
             // Test 4: Prune and verify replay from pruned
-            journal.prune(20).await.unwrap();
+            (journal, _) = journal.prune(20).await.unwrap();
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let res = reader.replay(0, NZUsize!(20)).await;
                 assert!(matches!(res, Err(crate::journal::Error::ItemPruned(_))));
             }
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let res = reader.replay(19, NZUsize!(20)).await;
                 assert!(matches!(res, Err(crate::journal::Error::ItemPruned(_))));
             }
 
             // Test 5: Replay from exactly at pruning boundary after prune
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(20, NZUsize!(20)).await.unwrap();
                 futures::pin_mut!(stream);
                 for i in 20..40u64 {
@@ -3106,7 +3251,8 @@ mod tests {
 
             // Test 6: Replay from the end
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let stream = reader.replay(40, NZUsize!(20)).await.unwrap();
                 futures::pin_mut!(stream);
                 assert!(stream.next().await.is_none());
@@ -3114,7 +3260,8 @@ mod tests {
 
             // Test 7: Replay beyond the end (should error)
             {
-                let reader = journal.snapshot().await.unwrap();
+                let reader;
+                (journal, reader) = journal.snapshot().await.unwrap();
                 let res = reader.replay(41, NZUsize!(20)).await;
                 assert!(matches!(
                     res,
@@ -3143,9 +3290,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..30u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
 
             let (blob, _) = context
                 .open(&cfg.data_partition(), &1u64.to_be_bytes())
@@ -3248,7 +3395,7 @@ mod tests {
 
             // Append items across 4 blobs: [0-9], [10-19], [20-29], [30-39]
             for i in 0..40u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Initial state: all items accessible
@@ -3257,7 +3404,8 @@ mod tests {
             assert_eq!(bounds.end, 40);
 
             // First prune: remove blob 0 (positions 0-9)
-            let pruned = journal.prune(10).await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(10).await.unwrap();
             assert!(pruned);
 
             // Variable-specific guarantee: oldest is EXACTLY at blob boundary
@@ -3272,7 +3420,8 @@ mod tests {
             assert_eq!(journal.read(19).await.unwrap(), 1900);
 
             // Second prune: remove blob 1 (positions 10-19)
-            let pruned = journal.prune(20).await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(20).await.unwrap();
             assert!(pruned);
 
             // Variable-specific guarantee: oldest is EXACTLY at blob boundary
@@ -3291,7 +3440,8 @@ mod tests {
             assert_eq!(journal.read(29).await.unwrap(), 2900);
 
             // Third prune: remove blob 2 (positions 20-29)
-            let pruned = journal.prune(30).await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(30).await.unwrap();
             assert!(pruned);
 
             // Variable-specific guarantee: oldest is EXACTLY at blob boundary
@@ -3336,7 +3486,7 @@ mod tests {
                 .unwrap();
 
             for i in 0..100u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             let bounds = journal.bounds();
@@ -3344,7 +3494,8 @@ mod tests {
             assert_eq!(bounds.start, 0);
 
             // === Phase 2: Prune all data ===
-            let pruned = journal.prune(100).await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(100).await.unwrap();
             assert!(pruned);
 
             // All data is pruned - no items remain
@@ -3361,7 +3512,6 @@ mod tests {
             }
 
             journal.sync().await.unwrap();
-            drop(journal);
 
             // === Phase 3: Re-init and verify position preserved ===
             let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -3383,7 +3533,7 @@ mod tests {
 
             // === Phase 4: Append new data ===
             // Next append should get position 100
-            journal.append(&10000).await.unwrap();
+            (journal, _) = journal.append(&10000).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 101);
             // Now we have one item at position 100
@@ -3423,11 +3573,11 @@ mod tests {
 
             // Append 40 items across 4 blobs to both journals
             for i in 0..40u64 {
-                variable.append(&(i * 100)).await.unwrap();
+                (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
             // Prune to position 10 normally (both data and offsets journals pruned)
-            variable.prune(10).await.unwrap();
+            let (mut variable, _) = variable.prune(10).await.unwrap();
             assert_eq!(variable.bounds().start, 10);
 
             // === Simulate crash: Prune data blobs but not offsets journal ===
@@ -3436,7 +3586,6 @@ mod tests {
             // Offsets journal still has data from position 10-19
 
             variable.sync().await.unwrap();
-            drop(variable);
 
             // === Verify recovery ===
             let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -3484,17 +3633,17 @@ mod tests {
             // Persist offsets only through position 7, then append enough unsynced items for a
             // prune to advance the data boundary beyond that durable offsets end.
             for i in 0..7u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
             for i in 7..12u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Drop the production prune future while it is parked after the data-blob
             // removal, before offsets.prune has made the appended offsets durable: a
-            // genuine cancellation at that await.
-            journal.halt_before_offsets_prune = true;
+            // genuine cancellation at that await. The dropped future consumes the journal.
+            journal.0.halt_before_offsets_prune = true;
             {
                 let fut = journal.prune(10);
                 futures::pin_mut!(fut);
@@ -3503,7 +3652,6 @@ mod tests {
                     "prune must park before offsets.prune"
                 );
             }
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -3540,7 +3688,7 @@ mod tests {
 
             // Append 40 items across 4 blobs to both journals
             for i in 0..40u64 {
-                variable.append(&(i * 100)).await.unwrap();
+                (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
             // Prune offsets journal ahead of data blobs (impossible state)
@@ -3548,7 +3696,6 @@ mod tests {
             variable.test_prune_data(1).await.unwrap(); // Only prune data blobs to blob 1 (position 10)
 
             variable.sync().await.unwrap();
-            drop(variable);
 
             // === Verify corruption detected ===
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
@@ -3576,13 +3723,13 @@ mod tests {
                 .unwrap();
 
             for i in 0..15u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // Clear offsets to blob 2 (position 20) while data starts at blob 0.
             // This puts them in different blobs with offsets empty (bounds 20..20).
-            journal.offsets.clear_to_size(20).await.unwrap();
+            journal.0.offsets.clear_to_size(20).await.unwrap();
             drop(journal);
 
             let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
@@ -3610,9 +3757,9 @@ mod tests {
                 .unwrap();
 
             for i in 0..15u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // Prune data to blob 1 (position 10), but rewind offsets to 5 (so offsets_bounds is 0..5).
             // offsets_bounds.end = 5 < data_oldest_pos = 10.
@@ -3648,10 +3795,9 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..5u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -3683,12 +3829,12 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
 
             // Prune to blob 1 (position 10), then set watermark below the new start.
-            journal.prune(10).await.unwrap();
+            let (mut journal, _) = journal.prune(10).await.unwrap();
             journal
                 .test_set_offsets_recovery_watermark(5)
                 .await
@@ -3727,7 +3873,7 @@ mod tests {
 
             // Append 15 items to both journals (fills blob 0, partial blob 1)
             for i in 0..15u64 {
-                variable.append(&(i * 100)).await.unwrap();
+                (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
             assert_eq!(variable.size(), 15);
@@ -3739,7 +3885,6 @@ mod tests {
             // Offsets journal still has only 15 entries
 
             variable.sync().await.unwrap();
-            drop(variable);
 
             // === Verify recovery ===
             let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -3847,10 +3992,16 @@ mod tests {
             // First persist a prefix, then append across multiple blob
             // boundaries without syncing. The unsynced item bytes are lost when
             // the journal is dropped, but their blob files remain visible.
-            assert_eq!(journal.append(&10).await.unwrap(), 0);
-            journal.sync().await.unwrap();
-            assert_eq!(journal.append(&20).await.unwrap(), 1);
-            assert_eq!(journal.append(&30).await.unwrap(), 2);
+            let appended;
+            (journal, appended) = journal.append(&10).await.unwrap();
+            assert_eq!(appended, 0);
+            journal = journal.sync().await.unwrap();
+            let appended;
+            (journal, appended) = journal.append(&20).await.unwrap();
+            assert_eq!(appended, 1);
+            let appended;
+            (journal, appended) = journal.append(&30).await.unwrap();
+            assert_eq!(appended, 2);
             drop(journal);
 
             let data_partition = cfg.data_partition();
@@ -3872,7 +4023,9 @@ mod tests {
                 .unwrap();
             assert_eq!(journal.bounds(), 0..1);
             assert_eq!(journal.read(0).await.unwrap(), 10);
-            assert_eq!(journal.append(&42).await.unwrap(), 1);
+            let appended;
+            (journal, appended) = journal.append(&42).await.unwrap();
+            assert_eq!(appended, 1);
             assert_eq!(journal.read(1).await.unwrap(), 42);
             drop(journal);
 
@@ -3908,8 +4061,12 @@ mod tests {
             // append opens a fresh blob blob, but no item bytes (and no offsets)
             // become durable, so recovery sees multiple empty blobs and no
             // durable data.
-            assert_eq!(journal.append(&10).await.unwrap(), 0);
-            assert_eq!(journal.append(&20).await.unwrap(), 1);
+            let appended;
+            (journal, appended) = journal.append(&10).await.unwrap();
+            assert_eq!(appended, 0);
+            let appended;
+            (journal, appended) = journal.append(&20).await.unwrap();
+            assert_eq!(appended, 1);
             drop(journal);
 
             let data_partition = cfg.data_partition();
@@ -3928,7 +4085,9 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(journal.bounds(), 0..0);
-            assert_eq!(journal.append(&42).await.unwrap(), 0);
+            let appended;
+            (journal, appended) = journal.append(&42).await.unwrap();
+            assert_eq!(appended, 0);
             assert_eq!(journal.read(0).await.unwrap(), 42);
             journal.destroy().await.unwrap();
         });
@@ -3961,15 +4120,15 @@ mod tests {
 
             // Durably commit blob 0 (positions 0..10), advancing the recovery watermark to 10.
             for i in 0..10u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Append blobs 1 and 2 without committing. Manually sync only blob 2's data blob
             // to mimic its page-cache writes surviving a crash, while blob 1 stays buffered and
             // the offsets journal is never advanced past position 10.
             for i in 10..30u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.test_sync_data_blob(2).await.unwrap();
             drop(journal);
@@ -4013,7 +4172,9 @@ mod tests {
             assert_eq!(data_blobs.len(), 2);
 
             // Appends resume cleanly from the recovered boundary.
-            assert_eq!(journal.append(&1234).await.unwrap(), 10);
+            let appended;
+            (journal, appended) = journal.append(&1234).await.unwrap();
+            assert_eq!(appended, 10);
             assert_eq!(journal.read(10).await.unwrap(), 1234);
 
             journal.destroy().await.unwrap();
@@ -4047,10 +4208,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..20u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Empty the oldest data blob in place, leaving blob 1's items orphaned past the
             // gap, then drop the offsets journal so recovery rebuilds from the data alone.
@@ -4082,7 +4242,9 @@ mod tests {
             ));
 
             // The orphaned newer blob is truncated away and appends resume from position 0.
-            assert_eq!(journal.append(&42).await.unwrap(), 0);
+            let appended;
+            (journal, appended) = journal.append(&42).await.unwrap();
+            assert_eq!(appended, 0);
             assert_eq!(journal.read(0).await.unwrap(), 42);
             let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
             assert_eq!(
@@ -4120,10 +4282,9 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..128u8 {
-                journal.append(&FixedBytes::new([i; 31])).await.unwrap();
+                (journal, _) = journal.append(&FixedBytes::new([i; 31])).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             let physical_page_size = LARGE_PAGE_SIZE.get() as u64 + 12;
             let items_in_page = LARGE_PAGE_SIZE.get() as u64 / 32;
@@ -4176,10 +4337,9 @@ mod tests {
             );
 
             // Appends resume directly after the recovered prefix.
-            assert_eq!(
-                journal.append(&FixedBytes::new([42; 31])).await.unwrap(),
-                items_in_page
-            );
+            let pos;
+            (journal, pos) = journal.append(&FixedBytes::new([42; 31])).await.unwrap();
+            assert_eq!(pos, items_in_page);
             assert_eq!(
                 journal.read(items_in_page).await.unwrap(),
                 FixedBytes::new([42; 31])
@@ -4215,7 +4375,7 @@ mod tests {
             // Fill blobs 0 and 1 and partially fill blob 2 (positions 20..25). Nothing is
             // synced yet, so only the created blob files are durable, all still empty.
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Sync blobs 0 and 1 but not blob 2 (and not offsets), simulating a crash after
@@ -4257,7 +4417,9 @@ mod tests {
             // recovered end.
             let data_blobs = context.scan(&cfg.data_partition()).await.unwrap();
             assert_eq!(data_blobs.len(), 3);
-            assert_eq!(journal.append(&2000).await.unwrap(), 20);
+            let appended;
+            (journal, appended) = journal.append(&2000).await.unwrap();
+            assert_eq!(appended, 20);
             assert_eq!(journal.read(20).await.unwrap(), 2000);
 
             journal.destroy().await.unwrap();
@@ -4285,11 +4447,11 @@ mod tests {
 
             // Append 50 items across 5 blobs to both journals
             for i in 0..50u64 {
-                variable.append(&(i * 100)).await.unwrap();
+                (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
             // Prune to position 10 normally (both data and offsets journals pruned)
-            variable.prune(10).await.unwrap();
+            let (mut variable, _) = variable.prune(10).await.unwrap();
             assert_eq!(variable.bounds().start, 10);
 
             // === Simulate crash: Multiple prunes on data blobs, not on offsets journal ===
@@ -4298,7 +4460,6 @@ mod tests {
             // Offsets journal still thinks oldest is position 10
 
             variable.sync().await.unwrap();
-            drop(variable);
 
             // === Verify recovery ===
             let variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -4353,7 +4514,7 @@ mod tests {
 
             // Append 25 items across 3 blobs (blob 0: 0-9, blob 1: 10-19, blob 2: 20-24)
             for i in 0..25u64 {
-                variable.append(&(i * 100)).await.unwrap();
+                (variable, _) = variable.append(&(i * 100)).await.unwrap();
             }
 
             assert_eq!(variable.size(), 25);
@@ -4362,7 +4523,6 @@ mod tests {
             variable.test_rewind_offsets(5).await.unwrap();
 
             variable.sync().await.unwrap();
-            drop(variable);
 
             // === Verify recovery ===
             let mut variable = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -4383,7 +4543,8 @@ mod tests {
             assert_eq!(variable.test_offsets_size(), 25);
 
             // Verify next append gets position 25
-            let pos = variable.append(&2500).await.unwrap();
+            let pos;
+            (variable, pos) = variable.append(&2500).await.unwrap();
             assert_eq!(pos, 25);
             assert_eq!(variable.read(25).await.unwrap(), 2500);
 
@@ -4410,7 +4571,7 @@ mod tests {
             );
             let mut pending = BTreeMap::new();
             pending.insert(0, partition.open(0).await.unwrap());
-            let mut offsets = fixed::Journal::<_, u64>::init(context.child("offsets"), offsets_cfg)
+            let mut offsets = fixed::Inner::<_, u64>::init(context.child("offsets"), offsets_cfg)
                 .await
                 .unwrap();
 
@@ -4419,7 +4580,7 @@ mod tests {
             pending.get_mut(&0).unwrap().append(&encoded).await.unwrap();
             offsets.append(&0).await.unwrap();
 
-            let result = Journal::<_, u64>::rebuild_offsets_from_anchor(
+            let result = Inner::<_, u64>::rebuild_offsets_from_anchor(
                 &partition,
                 &mut pending,
                 &mut offsets,
@@ -4460,9 +4621,9 @@ mod tests {
                 .unwrap();
 
             for i in 0..20u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // The offsets watermark is in-bounds, but vouches for acknowledged data that no
             // longer exists.
@@ -4507,9 +4668,9 @@ mod tests {
                 .unwrap();
 
             for i in 0..30u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // Keep the offsets watermark in bounds and within the retained data end bound, but make
             // the data blob that contains the watermark too short to reach it.
@@ -4564,13 +4725,12 @@ mod tests {
                 .unwrap();
 
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
 
-            journal.rewind(12).await.unwrap();
+            let journal = journal.rewind(12).await.unwrap();
             journal.commit().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -4606,9 +4766,9 @@ mod tests {
                 .unwrap();
 
             for i in 0..20u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             journal.test_rewind_data_to_position(10).await.unwrap();
             journal.test_sync_data().await.unwrap();
@@ -4648,9 +4808,9 @@ mod tests {
                 .unwrap();
 
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Simulate a crash after the previous recovery checkpoint where blob 1 was only
             // partly durable but blob 2 was present. Recovery should keep the contiguous prefix
@@ -4660,7 +4820,7 @@ mod tests {
                 .await
                 .unwrap();
             let offset = {
-                let offsets = journal.offsets.snapshot().await.unwrap();
+                let offsets = journal.0.offsets.snapshot().await.unwrap();
                 offsets.read(12).await.unwrap()
             };
             drop(journal);
@@ -4713,10 +4873,9 @@ mod tests {
                 let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                     .await
                     .unwrap();
-                journal.append(&10).await.unwrap();
-                journal.append(&20).await.unwrap();
+                (journal, _) = journal.append(&10).await.unwrap();
+                (journal, _) = journal.append(&20).await.unwrap();
                 journal.sync().await.unwrap();
-                drop(journal);
 
                 let (blob, raw_size) = context
                     .open(&offsets_blob_partition, &0u64.to_be_bytes())
@@ -4779,10 +4938,9 @@ mod tests {
                 let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                     .await
                     .unwrap();
-                journal.append(&10).await.unwrap();
-                journal.append(&20).await.unwrap();
+                (journal, _) = journal.append(&10).await.unwrap();
+                (journal, _) = journal.append(&20).await.unwrap();
                 journal.sync().await.unwrap();
-                drop(journal);
 
                 let (blob, raw_size) = context
                     .open(&data_partition, &0u64.to_be_bytes())
@@ -4849,14 +5007,14 @@ mod tests {
 
             // Append 10 items (positions 0-9), fills blob 0
             for i in 0..10u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 10);
             assert_eq!(bounds.start, 0);
 
             // === Phase 2: Prune to create empty journal ===
-            journal.prune(10).await.unwrap();
+            (journal, _) = journal.prune(10).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 10);
             assert!(bounds.is_empty()); // Empty!
@@ -4918,11 +5076,11 @@ mod tests {
 
             // Append items across a blob boundary
             for i in 0..15u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Manually sync only data to simulate crash during concurrent sync
-            journal.commit().await.unwrap();
+            let journal = journal.commit().await.unwrap();
 
             // Simulate a crash (offsets not synced)
             drop(journal);
@@ -4958,14 +5116,17 @@ mod tests {
                 Journal::<_, u64>::init_at_size(context.child("first"), cfg.clone(), 7)
                     .await
                     .unwrap();
-            assert_eq!(journal.append(&700).await.unwrap(), 7);
-            journal.sync().await.unwrap();
+            let appended;
+            (journal, appended) = journal.append(&700).await.unwrap();
+            assert_eq!(appended, 7);
+            journal = journal.sync().await.unwrap();
 
             for i in 1..6u64 {
-                assert_eq!(journal.append(&(700 + i)).await.unwrap(), 7 + i);
+                let appended;
+                (journal, appended) = journal.append(&(700 + i)).await.unwrap();
+                assert_eq!(appended, 7 + i);
             }
             journal.commit().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -5034,7 +5195,8 @@ mod tests {
             assert!(journal.bounds().is_empty());
 
             // Next append should get position 0
-            let pos = journal.append(&100).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&100).await.unwrap();
             assert_eq!(pos, 0);
             assert_eq!(journal.size(), 1);
             assert_eq!(journal.read(0).await.unwrap(), 100);
@@ -5070,13 +5232,15 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Next append should get position 10
-            let pos = journal.append(&1000).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&1000).await.unwrap();
             assert_eq!(pos, 10);
             assert_eq!(journal.size(), 11);
             assert_eq!(journal.read(10).await.unwrap(), 1000);
 
             // Can continue appending
-            let pos = journal.append(&1001).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&1001).await.unwrap();
             assert_eq!(pos, 11);
             assert_eq!(journal.read(11).await.unwrap(), 1001);
 
@@ -5111,7 +5275,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Next append should get position 7
-            let pos = journal.append(&700).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&700).await.unwrap();
             assert_eq!(pos, 7);
             assert_eq!(journal.size(), 8);
             assert_eq!(journal.read(7).await.unwrap(), 700);
@@ -5141,7 +5306,8 @@ mod tests {
 
             // Append some items
             for i in 0..5u64 {
-                let pos = journal.append(&(1500 + i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(1500 + i)).await.unwrap();
                 assert_eq!(pos, 15 + i);
             }
 
@@ -5149,7 +5315,6 @@ mod tests {
 
             // Sync and reopen
             journal.sync().await.unwrap();
-            drop(journal);
 
             let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -5166,7 +5331,8 @@ mod tests {
             }
 
             // Can continue appending
-            let pos = journal.append(&9999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&9999).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), 9999);
 
@@ -5209,7 +5375,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Can append starting at position 15
-            let pos = journal.append(&1500).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&1500).await.unwrap();
             assert_eq!(pos, 15);
             assert_eq!(journal.read(15).await.unwrap(), 1500);
 
@@ -5234,19 +5401,19 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..12u64 {
-                journal.append(&(100 + i)).await.unwrap();
+                (journal, _) = journal.append(&(100 + i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             let mut journal =
                 Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
                     .await
                     .unwrap();
             assert_eq!(journal.bounds(), 7..7);
-            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            let appended;
+            (journal, appended) = journal.append(&700).await.unwrap();
+            assert_eq!(appended, 7);
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
                 .await
@@ -5283,10 +5450,9 @@ mod tests {
                     .await
                     .unwrap();
                 for i in 0..12u64 {
-                    journal.append(&(100 + i)).await.unwrap();
+                    (journal, _) = journal.append(&(100 + i)).await.unwrap();
                 }
                 journal.sync().await.unwrap();
-                drop(journal);
 
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
                     sync_rate: Some(1.0),
@@ -5343,9 +5509,9 @@ mod tests {
                     .await
                     .unwrap();
                 for i in 0..12u64 {
-                    journal.append(&(100 + i)).await.unwrap();
+                    (journal, _) = journal.append(&(100 + i)).await.unwrap();
                 }
-                journal.sync().await.unwrap();
+                let mut journal = journal.sync().await.unwrap();
 
                 // Fail the offsets metadata sync inside `stage_clear_intent` so `clear_to_size`
                 // aborts before any data is cleared. The reset intent never becomes durable.
@@ -5353,7 +5519,7 @@ mod tests {
                     sync_rate: Some(1.0),
                     ..Default::default()
                 };
-                assert!(journal.clear_to_size(7).await.is_err());
+                assert!(journal.0.clear_to_size(7).await.is_err());
             }
         });
 
@@ -5400,9 +5566,9 @@ mod tests {
                     .await
                     .unwrap();
                 for i in 0..12u64 {
-                    journal.append(&(100 + i)).await.unwrap();
+                    (journal, _) = journal.append(&(100 + i)).await.unwrap();
                 }
-                journal.sync().await.unwrap();
+                journal = journal.sync().await.unwrap();
 
                 // Let `stage_clear_intent` (a metadata sync) persist the reset intent, but fail the
                 // subsequent `data.clear()` (a blob remove) so `clear_to_size` aborts after the
@@ -5411,7 +5577,7 @@ mod tests {
                     remove_rate: Some(1.0),
                     ..Default::default()
                 };
-                assert!(journal.clear_to_size(7).await.is_err());
+                assert!(journal.0.clear_to_size(7).await.is_err());
             }
         });
 
@@ -5431,9 +5597,10 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(journal.bounds(), 7..7);
-            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            let appended;
+            (journal, appended) = journal.append(&700).await.unwrap();
+            assert_eq!(appended, 7);
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen: the completed reset persists and no stale data was replayed.
             let journal = Journal::<_, u64>::init(context.child("reopen"), cfg.clone())
@@ -5467,10 +5634,9 @@ mod tests {
                 .await
                 .unwrap();
                 for i in 0..12u64 {
-                    journal.append(&(100 + i)).await.unwrap();
+                    (journal, _) = journal.append(&(100 + i)).await.unwrap();
                 }
                 journal.sync().await.unwrap();
-                drop(journal);
 
                 let offsets_cfg = fixed::Config {
                     partition: cfg.offsets_partition(),
@@ -5506,9 +5672,10 @@ mod tests {
                 .await
                 .unwrap();
                 assert_eq!(journal.bounds(), 7..7);
-                assert_eq!(journal.append(&700).await.unwrap(), 7);
+                let appended;
+                (journal, appended) = journal.append(&700).await.unwrap();
+                assert_eq!(appended, 7);
                 journal.sync().await.unwrap();
-                drop(journal);
 
                 let journal = Journal::<_, u64>::init(
                     context.child("reopen").with_attribute("index", index),
@@ -5541,10 +5708,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..12u64 {
-                journal.append(&(100 + i)).await.unwrap();
+                (journal, _) = journal.append(&(100 + i)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Simulate a prior `clear_to_size(5)` that crashed after staging its intent: the offsets
             // checkpoint carries a clear target of 5 while the data blobs still holds all 12 items.
@@ -5569,9 +5735,10 @@ mod tests {
                     .await
                     .unwrap();
             assert_eq!(journal.bounds(), 10..10);
-            assert_eq!(journal.append(&700).await.unwrap(), 10);
+            let appended;
+            (journal, appended) = journal.append(&700).await.unwrap();
+            assert_eq!(appended, 10);
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen: target 10 (not 5) persisted and no stale data was replayed.
             let journal = Journal::<_, u64>::init(context.child("reopen"), cfg.clone())
@@ -5602,10 +5769,11 @@ mod tests {
                     .await
                     .unwrap();
             for i in 0..4u64 {
-                assert_eq!(journal.append(&(500 + i)).await.unwrap(), 5 + i);
+                let appended;
+                (journal, appended) = journal.append(&(500 + i)).await.unwrap();
+                assert_eq!(appended, 5 + i);
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init_at_size(context.child("reset"), cfg.clone(), 7)
                 .await
@@ -5621,9 +5789,10 @@ mod tests {
                 Err(Error::ItemOutOfRange(7))
             ));
 
-            assert_eq!(journal.append(&700).await.unwrap(), 7);
+            let appended;
+            (journal, appended) = journal.append(&700).await.unwrap();
+            assert_eq!(appended, 7);
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("after_append"), cfg.clone())
                 .await
@@ -5661,7 +5830,8 @@ mod tests {
 
             // Append 3 items at positions 7, 8, 9 (fills rest of blob 1)
             for i in 0..3u64 {
-                let pos = journal.append(&(700 + i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(700 + i)).await.unwrap();
                 assert_eq!(pos, 7 + i);
             }
 
@@ -5671,7 +5841,6 @@ mod tests {
 
             // Sync and reopen
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -5717,7 +5886,8 @@ mod tests {
 
             // Append 8 items: positions 7-14 (blob 1: 3 items, blob 2: 5 items)
             for i in 0..8u64 {
-                let pos = journal.append(&(700 + i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(700 + i)).await.unwrap();
                 assert_eq!(pos, 7 + i);
             }
 
@@ -5727,7 +5897,6 @@ mod tests {
 
             // Sync and reopen
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Reopen
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -5767,9 +5936,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..7u64 {
-                journal.append(&(100 + i)).await.unwrap();
+                (journal, _) = journal.append(&(100 + i)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Simulate crash after data was cleared but before offsets were pruned.
             drop(journal);
@@ -5786,7 +5955,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Append one item at position 7.
-            let pos = journal.append(&777).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&777).await.unwrap();
             assert_eq!(pos, 7);
             assert_eq!(journal.size(), 8);
             assert_eq!(journal.read(7).await.unwrap(), 777);
@@ -5830,7 +6000,7 @@ mod tests {
 
             // Append 3 items
             for i in 0..3u64 {
-                journal.append(&(700 + i)).await.unwrap();
+                (journal, _) = journal.append(&(700 + i)).await.unwrap();
             }
 
             // Sync only the data blobs, not offsets (simulate crash). The appended items
@@ -5878,13 +6048,14 @@ mod tests {
 
             // Append a few items at positions 7..9
             for i in 0..3u64 {
-                let pos = journal.append(&(700 + i)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(700 + i)).await.unwrap();
                 assert_eq!(pos, 7 + i);
             }
             assert_eq!(journal.bounds().start, 7);
 
             // Prune to a position within the same blob should not move bounds.start backwards.
-            journal.prune(8).await.unwrap();
+            (journal, _) = journal.prune(8).await.unwrap();
             assert_eq!(journal.bounds().start, 7);
             assert!(matches!(journal.read(6).await, Err(Error::ItemPruned(6))));
             assert_eq!(journal.read(7).await.unwrap(), 700);
@@ -5910,7 +6081,9 @@ mod tests {
                 Journal::<_, u64>::init_at_size(context.child("first"), cfg.clone(), u64::MAX - 1)
                     .await
                     .unwrap();
-            assert_eq!(journal.append(&7).await.unwrap(), u64::MAX - 1);
+            let appended;
+            (journal, appended) = journal.append(&7).await.unwrap();
+            assert_eq!(appended, u64::MAX - 1);
             journal
                 .test_sync_data_blob(position_to_blob(u64::MAX - 1, cfg.items_per_section.get()))
                 .await
@@ -5952,7 +6125,8 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Next append should get position 1000
-            let pos = journal.append(&100000).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&100000).await.unwrap();
             assert_eq!(pos, 1000);
             assert_eq!(journal.read(1000).await.unwrap(), 100000);
 
@@ -5981,13 +6155,13 @@ mod tests {
 
             // Append items 20-29
             for i in 0..10u64 {
-                journal.append(&(2000 + i)).await.unwrap();
+                (journal, _) = journal.append(&(2000 + i)).await.unwrap();
             }
 
             assert_eq!(journal.size(), 30);
 
             // Prune to position 25
-            journal.prune(25).await.unwrap();
+            (journal, _) = journal.prune(25).await.unwrap();
 
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 30);
@@ -5999,7 +6173,8 @@ mod tests {
             }
 
             // Continue appending
-            let pos = journal.append(&3000).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&3000).await.unwrap();
             assert_eq!(pos, 30);
 
             journal.destroy().await.unwrap();
@@ -6036,11 +6211,13 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Append items using the contiguous API
-            let pos1 = journal.append(&42u64).await.unwrap();
+            let pos1;
+            (journal, pos1) = journal.append(&42u64).await.unwrap();
             assert_eq!(pos1, lower_bound);
             assert_eq!(journal.read(pos1).await.unwrap(), 42u64);
 
-            let pos2 = journal.append(&43u64).await.unwrap();
+            let pos2;
+            (journal, pos2) = journal.append(&43u64).await.unwrap();
             assert_eq!(pos2, lower_bound + 1);
             assert_eq!(journal.read(pos2).await.unwrap(), 43u64);
 
@@ -6070,16 +6247,15 @@ mod tests {
 
             // Add data at positions 0-19 (blobs 0-3 with items_per_section=5)
             for i in 0..20u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Initialize with sync boundaries that overlap with existing data
             // lower_bound: 8 (blob 1), upper_bound: 31 (last location 30, blob 6)
             let lower_bound = 8;
             let upper_bound = 31;
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let mut journal = Journal::<_, u64>::init_sync(
                 context.child("storage"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6108,7 +6284,8 @@ mod tests {
             ));
 
             // Assert journal can accept new items
-            let pos = journal.append(&999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), 999);
 
@@ -6132,7 +6309,7 @@ mod tests {
             };
 
             #[allow(clippy::reversed_empty_ranges)]
-            let _result = Journal::<deterministic::Context, u64>::init_sync(
+            let _result = Journal::<_, u64>::init_sync(
                 context.child("storage"),
                 cfg,
                 10..5, // invalid range: lower > upper
@@ -6164,15 +6341,14 @@ mod tests {
 
             // Add data at positions 0-19 (blobs 0-3 with items_per_section=5)
             for i in 0..20u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Initialize with sync boundaries that exactly match existing data
             let lower_bound = 5; // blob 1
             let upper_bound = 20; // blob 3
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let mut journal = Journal::<_, u64>::init_sync(
                 context.child("storage"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6201,7 +6377,8 @@ mod tests {
             ));
 
             // Assert journal can accept new operations
-            let pos = journal.append(&999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), 999);
 
@@ -6233,15 +6410,14 @@ mod tests {
 
             // Add data at positions 0-29 (blobs 0-5 with items_per_section=5)
             for i in 0..30u64 {
-                journal.append(&(i * 1000)).await.unwrap();
+                (journal, _) = journal.append(&(i * 1000)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Initialize with sync boundaries that are exceeded by existing data
             let lower_bound = 8; // blob 1
             for (i, upper_bound) in (9..29).enumerate() {
-                let result = Journal::<deterministic::Context, u64>::init_sync(
+                let result = Journal::<_, u64>::init_sync(
                     context.child("sync").with_attribute("index", i),
                     cfg.clone(),
                     lower_bound..upper_bound,
@@ -6282,7 +6458,7 @@ mod tests {
 
             let lower_bound = 10;
             let upper_bound = 26;
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let mut journal = Journal::<_, u64>::init_sync(
                 context.child("second"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6293,7 +6469,8 @@ mod tests {
             assert_eq!(journal.size(), lower_bound);
             assert!(journal.bounds().is_empty());
 
-            let pos = journal.append(&999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, lower_bound);
             assert_eq!(journal.read(pos).await.unwrap(), 999);
 
@@ -6315,7 +6492,7 @@ mod tests {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
             };
 
-            let mut journal = Journal::<deterministic::Context, u64>::init_at_size(
+            let journal = Journal::<deterministic::Context, u64>::init_at_size(
                 context.child("first"),
                 cfg.clone(),
                 9,
@@ -6323,7 +6500,6 @@ mod tests {
             .await
             .expect("Failed to create stale empty journal");
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Simulate clear_to_size(7) crashing after clearing data, but before offsets were
             // re-cleared. Recovery will initially see the old empty offsets boundary at 9.
@@ -6334,7 +6510,7 @@ mod tests {
 
             let lower_bound = 7;
             let upper_bound = 20;
-            let journal = Journal::<deterministic::Context, u64>::init_sync(
+            let journal = Journal::<_, u64>::init_sync(
                 context.child("second"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6374,15 +6550,14 @@ mod tests {
 
             // Add data at positions 0-9 (blobs 0-1 with items_per_section=5)
             for i in 0..10u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Initialize with sync boundaries beyond all existing data
             let lower_bound = 15; // blob 3
             let upper_bound = 26; // last element in blob 5
-            let journal = Journal::<deterministic::Context, u64>::init_sync(
+            let journal = Journal::<_, u64>::init_sync(
                 context.child("second"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6427,15 +6602,14 @@ mod tests {
 
             // Add data at positions 0-24 (blobs 0-4 with items_per_section=5)
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Test sync boundaries exactly at blob boundaries
             let lower_bound = 15; // Exactly at blob boundary (15/5 = 3)
             let upper_bound = 25; // Last element exactly at blob boundary (24/5 = 4)
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let mut journal = Journal::<_, u64>::init_sync(
                 context.child("storage"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6464,7 +6638,8 @@ mod tests {
             ));
 
             // Assert journal can accept new operations
-            let pos = journal.append(&999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, 25);
             assert_eq!(journal.read(25).await.unwrap(), 999);
 
@@ -6495,15 +6670,14 @@ mod tests {
 
             // Add data at positions 0-14 (blobs 0-2 with items_per_section=5)
             for i in 0..15u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Test sync boundaries within the same blob
             let lower_bound = 10; // operation 10 (blob 2: 10/5 = 2)
             let upper_bound = 15; // Last operation 14 (blob 2: 14/5 = 2)
-            let mut journal = Journal::<deterministic::Context, u64>::init_sync(
+            let mut journal = Journal::<_, u64>::init_sync(
                 context.child("storage"),
                 cfg.clone(),
                 lower_bound..upper_bound,
@@ -6533,7 +6707,8 @@ mod tests {
             ));
 
             // Assert journal can accept new operations
-            let pos = journal.append(&999).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, 15);
             assert_eq!(journal.read(15).await.unwrap(), 999);
 
@@ -6569,12 +6744,13 @@ mod tests {
             assert!(bounds.is_empty());
 
             // Append 1 item (value = position * 100, so position 0 has value 0)
-            let pos = journal.append(&0).await.unwrap();
+            let pos;
+            (journal, pos) = journal.append(&0).await.unwrap();
             assert_eq!(pos, 0);
             assert_eq!(journal.size(), 1);
 
             // Sync
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Read from size() - 1
             let value = journal.read(journal.size() - 1).await.unwrap();
@@ -6582,7 +6758,8 @@ mod tests {
 
             // === Test 2: Multiple items with single item per blob ===
             for i in 1..10u64 {
-                let pos = journal.append(&(i * 100)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(i * 100)).await.unwrap();
                 assert_eq!(pos, i);
                 assert_eq!(journal.size(), i + 1);
 
@@ -6596,11 +6773,12 @@ mod tests {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
             }
 
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // === Test 3: Pruning with single item per blob ===
             // Prune to position 5 (removes positions 0-4)
-            let pruned = journal.prune(5).await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(5).await.unwrap();
             assert!(pruned);
 
             // Size should still be 10
@@ -6628,7 +6806,8 @@ mod tests {
 
             // Append more items after pruning
             for i in 10..15u64 {
-                let pos = journal.append(&(i * 100)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(i * 100)).await.unwrap();
                 assert_eq!(pos, i);
 
                 // Verify we can read from size() - 1
@@ -6637,7 +6816,6 @@ mod tests {
             }
 
             journal.sync().await.unwrap();
-            drop(journal);
 
             // === Test 4: Restart persistence with single item per blob ===
             let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
@@ -6669,18 +6847,17 @@ mod tests {
 
             // Append 10 items (positions 0-9)
             for i in 0..10u64 {
-                journal.append(&(i * 1000)).await.unwrap();
+                (journal, _) = journal.append(&(i * 1000)).await.unwrap();
             }
 
             // Prune to position 5 (removes positions 0-4)
-            journal.prune(5).await.unwrap();
+            (journal, _) = journal.prune(5).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 10);
             assert_eq!(bounds.start, 5);
 
             // Sync and restart
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Re-open journal
             let journal = Journal::<_, u64>::init(context.child("fourth"), cfg.clone())
@@ -6711,12 +6888,12 @@ mod tests {
                 .unwrap();
 
             for i in 0..5u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Prune all items
-            journal.prune(5).await.unwrap();
+            (journal, _) = journal.prune(5).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 5); // Size unchanged
             assert!(bounds.is_empty()); // All pruned
@@ -6726,7 +6903,7 @@ mod tests {
             assert!(matches!(result, Err(crate::journal::Error::ItemPruned(4))));
 
             // After appending, reading works again
-            journal.append(&500).await.unwrap();
+            (journal, _) = journal.append(&500).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.start, 5);
             assert_eq!(journal.read(bounds.end - 1).await.unwrap(), 500);
@@ -6754,15 +6931,15 @@ mod tests {
 
             // Append 25 items (spanning multiple blobs)
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 25);
             assert_eq!(bounds.start, 0);
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // Clear to position 100, effectively resetting the journal
-            journal.clear_to_size(100).await.unwrap();
+            journal.0.clear_to_size(100).await.unwrap();
             let bounds = journal.bounds();
             assert_eq!(bounds.end, 100);
             assert!(bounds.is_empty());
@@ -6787,7 +6964,8 @@ mod tests {
 
             // Append new data starting at position 100
             for i in 100..105u64 {
-                let pos = journal.append(&(i * 100)).await.unwrap();
+                let pos;
+                (journal, pos) = journal.append(&(i * 100)).await.unwrap();
                 assert_eq!(pos, i);
             }
             let bounds = journal.bounds();
@@ -6801,7 +6979,6 @@ mod tests {
 
             // Sync and re-init to verify persistence
             journal.sync().await.unwrap();
-            drop(journal);
 
             let journal = Journal::<_, u64>::init(context.child("journal_reopened"), cfg)
                 .await
@@ -6835,17 +7012,18 @@ mod tests {
                 .unwrap();
 
             let items = [0, 1, 2, 3, 4];
-            journal.append_many(Many::Flat(&items)).await.unwrap();
-            journal.append(&5).await.unwrap();
-            let reader = journal.snapshot().await.unwrap();
+            (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
+            (journal, _) = journal.append(&5).await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             reader.read(0).await.unwrap();
             reader.read_many(&[1, 2]).await.unwrap();
             reader.try_read_sync(3).unwrap();
             drop(reader);
-            journal.commit().await.unwrap();
-            journal.sync().await.unwrap();
-            journal.prune(2).await.unwrap();
-            journal.rewind(4).await.unwrap();
+            journal = journal.commit().await.unwrap();
+            journal = journal.sync().await.unwrap();
+            (journal, _) = journal.prune(2).await.unwrap();
+            journal = journal.rewind(4).await.unwrap();
 
             let buffer = context.encode();
             for expected in [
@@ -6898,12 +7076,13 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..200u64 {
-                journal.append(&i).await.unwrap();
+                (journal, _) = journal.append(&i).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
             // The page cache cannot hold every page, so some position must be cold.
-            let reader = journal.snapshot().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
             let pos = (0..200)
                 .find(|&pos| reader.try_read_sync(pos).is_none())
                 .expect("some position should be cold");
@@ -6933,16 +7112,17 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..7u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
-            let snapshot = journal.snapshot().await.unwrap();
+            let snapshot;
+            (journal, snapshot) = journal.snapshot().await.unwrap();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Appending past the blob boundary rolls the snapshot's tail blob into
             // history; the snapshot keeps reading it through its own handle.
             for i in 7..23u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             assert_eq!(snapshot.bounds(), 0..7);
             for i in 0..7u64 {
@@ -6953,7 +7133,8 @@ mod tests {
                 Err(Error::ItemOutOfRange(7))
             ));
 
-            let fresh = journal.snapshot().await.unwrap();
+            let fresh;
+            (journal, fresh) = journal.snapshot().await.unwrap();
             assert_eq!(fresh.bounds(), 0..23);
             assert_eq!(fresh.read(22).await.unwrap(), 2200);
 
@@ -6979,12 +7160,15 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..17u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            journal = journal.sync().await.unwrap();
 
-            let snapshot = journal.snapshot().await.unwrap();
-            assert!(journal.prune(12).await.unwrap());
+            let snapshot;
+            (journal, snapshot) = journal.snapshot().await.unwrap();
+            let pruned;
+            (journal, pruned) = journal.prune(12).await.unwrap();
+            assert!(pruned);
 
             // The straggler reads the pruned range through its own handles.
             assert_eq!(snapshot.bounds(), 0..17);
@@ -6996,7 +7180,8 @@ mod tests {
                 vec![100, 200, 300, 1100, 1600]
             );
 
-            let fresh = journal.snapshot().await.unwrap();
+            let fresh;
+            (journal, fresh) = journal.snapshot().await.unwrap();
             assert_eq!(fresh.bounds(), 10..17);
             assert!(matches!(fresh.read(3).await, Err(Error::ItemPruned(3))));
 
@@ -7037,9 +7222,10 @@ mod tests {
             });
 
             for i in 0..40u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
                 if i % 7 == 0 {
-                    let snapshot = journal.snapshot().await.unwrap();
+                    let snapshot;
+                    (journal, snapshot) = journal.snapshot().await.unwrap();
                     if tx.try_send(snapshot).is_err() {
                         break;
                     }
@@ -7068,18 +7254,21 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..7u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
 
             // Positions 5..7 live in the snapshot's tail blob.
-            let snapshot = journal.snapshot().await.unwrap();
+            let snapshot;
+            (journal, snapshot) = journal.snapshot().await.unwrap();
             assert_eq!(snapshot.bounds(), 0..7);
 
             // Roll the snapshot's tail into history, then prune both of its blobs away.
             for i in 7..23u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            assert!(journal.prune(12).await.unwrap());
+            let pruned;
+            (journal, pruned) = journal.prune(12).await.unwrap();
+            assert!(pruned);
 
             {
                 let stream = snapshot.replay(0, NZUsize!(1024)).await.unwrap();
@@ -7118,10 +7307,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..10u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Remove the empty tail blob, leaving only the full blob 0 (the layout written
             // before eager tail creation).
@@ -7138,7 +7326,9 @@ mod tests {
             for i in 0..10u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i * 100);
             }
-            assert_eq!(journal.append(&1000).await.unwrap(), 10);
+            let appended;
+            (journal, appended) = journal.append(&1000).await.unwrap();
+            assert_eq!(appended, 10);
             assert_eq!(journal.read(10).await.unwrap(), 1000);
 
             journal.destroy().await.unwrap();
@@ -7165,9 +7355,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
-            journal.sync().await.unwrap();
+            let mut journal = journal.sync().await.unwrap();
 
             // `rewind` truncates offsets (lowering the watermark) before the data; simulate a
             // crash in between.
@@ -7204,10 +7394,9 @@ mod tests {
                 .await
                 .unwrap();
             for i in 0..25u64 {
-                journal.append(&(i * 100)).await.unwrap();
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
             }
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Remove blob 1, leaving a gap in the retained data blobs.
             context

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2647,7 +2647,7 @@ mod tests {
             assert_eq!(journal.size(), u64::MAX);
 
             // The next append would overflow the size; it must return a recoverable error
-            // rather than panicking. The error consumes the journal.
+            // rather than panicking.
             assert!(matches!(journal.append(&8).await, Err(Error::SizeOverflow)));
         });
     }
@@ -3642,7 +3642,7 @@ mod tests {
 
             // Drop the production prune future while it is parked after the data-blob
             // removal, before offsets.prune has made the appended offsets durable: a
-            // genuine cancellation at that await. The dropped future consumes the journal.
+            // genuine cancellation at that await.
             journal.0.halt_before_offsets_prune = true;
             {
                 let fut = journal.prune(10);

--- a/storage/src/merkle/benches/flush.rs
+++ b/storage/src/merkle/benches/flush.rs
@@ -85,11 +85,11 @@ fn bench_flush_family<F: Family>(c: &mut Criterion, family: &'static str) {
                             batch = batch.add(&hasher, &sha256::Digest::random(&mut rng));
                         }
                         let batch = merkle.with_mem(|mem| batch.merkleize(mem, &hasher));
-                        merkle.apply_batch(&batch).unwrap();
+                        merkle = merkle.apply_batch(&batch).unwrap();
 
                         // Timed: flush the freshly applied nodes to the journal.
                         let start = Instant::now();
-                        merkle.flush().await.unwrap();
+                        merkle = merkle.flush().await.unwrap();
                         total += start.elapsed();
                     }
 

--- a/storage/src/merkle/conformance.rs
+++ b/storage/src/merkle/conformance.rs
@@ -112,7 +112,7 @@ mod tests {
     {
         let hasher = Standard::new(ForwardFold);
         let cfg = storage_config(&format!("{prefix}-{seed}"), &context);
-        let mut merkle = full::Merkle::<F, _, sha256::Digest, Sequential>::init(
+        let merkle = full::Merkle::<F, _, sha256::Digest, Sequential>::init(
             context.child("merkle"),
             &hasher,
             cfg,
@@ -126,11 +126,11 @@ mod tests {
             batch = batch.add(&hasher, &element);
         }
         let batch = merkle.with_mem(|mem| batch.merkleize(mem, &hasher));
-        merkle.apply_batch(&batch)?;
-        merkle.sync().await?;
+        let merkle = merkle.apply_batch(&batch)?;
+        let merkle = merkle.sync().await?;
 
         if items > 32 {
-            merkle
+            let merkle = merkle
                 .prune(crate::merkle::Location::new(items as u64 / 3))
                 .await?;
             merkle.sync().await?;

--- a/storage/src/merkle/mmr/full.rs
+++ b/storage/src/merkle/mmr/full.rs
@@ -66,7 +66,7 @@ mod tests {
             let test_mmr = build_test_mmr(&hasher, test_mmr, NUM_ELEMENTS);
             let expected_root = test_mmr.root(&hasher, 0).unwrap();
 
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.child("storage"),
                 &Standard::<Sha256>::new(ForwardFold),
                 test_config(&context),
@@ -80,7 +80,7 @@ mod tests {
                 batch = batch.add(&hasher, &element);
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
+            let mmr = mmr.apply_batch(&batch).unwrap();
             assert_eq!(mmr.root(&hasher, 0).unwrap(), expected_root);
 
             mmr.destroy().await.unwrap();
@@ -95,7 +95,9 @@ mod tests {
 
             let hasher: Standard<Sha256> = Standard::new(ForwardFold);
             let cfg = test_config(&context);
-            let mut mmr = Mmr::init(context, &hasher, cfg).await.unwrap();
+            let mut mmr = Mmr::init(context.child("init"), &hasher, cfg)
+                .await
+                .unwrap();
 
             let mut c_hasher = Sha256::new();
             let mut batch = mmr.new_batch();
@@ -105,11 +107,11 @@ mod tests {
                 batch = batch.add(&hasher, &element);
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
+            mmr = mmr.apply_batch(&batch).unwrap();
 
             // Rewind one node at a time without syncing until empty, confirming the root matches.
             for i in (0..NUM_ELEMENTS).rev() {
-                assert!(mmr.rewind(1).await.is_ok());
+                mmr = mmr.rewind(1).await.unwrap();
                 let root = mmr.root(&hasher, 0).unwrap();
                 let mut reference_mmr = mem::Mmr::new();
                 let batch = {
@@ -128,8 +130,11 @@ mod tests {
                     "root mismatch after rewind at {i}"
                 );
             }
+            mmr = mmr.rewind(0).await.unwrap();
             assert!(matches!(mmr.rewind(1).await, Err(Error::Empty)));
-            assert!(mmr.rewind(0).await.is_ok());
+            let mut mmr = Mmr::init(context.child("reopen1"), &hasher, test_config(&context))
+                .await
+                .unwrap();
 
             // Repeat the test though sync part of the way to tip to test crossing the boundary from
             // cached to uncached leaves, and rewind 2 at a time instead of just 1.
@@ -146,8 +151,8 @@ mod tests {
                     }
                 }
                 let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                mmr.apply_batch(&batch).unwrap();
-                mmr.sync().await.unwrap();
+                mmr = mmr.apply_batch(&batch).unwrap();
+                mmr = mmr.sync().await.unwrap();
                 let mut batch = mmr.new_batch();
                 for i in 102u64..NUM_ELEMENTS {
                     c_hasher.update(&i.to_be_bytes());
@@ -155,11 +160,11 @@ mod tests {
                     batch = batch.add(&hasher, &element);
                 }
                 let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                mmr.apply_batch(&batch).unwrap();
+                mmr = mmr.apply_batch(&batch).unwrap();
             }
 
             for i in (0..NUM_ELEMENTS - 1).rev().step_by(2) {
-                assert!(mmr.rewind(2).await.is_ok(), "at position {i:?}");
+                mmr = mmr.rewind(2).await.unwrap();
                 let root = mmr.root(&hasher, 0).unwrap();
                 let reference_mmr = mem::Mmr::new();
                 let reference_mmr = build_test_mmr(&hasher, reference_mmr, i);
@@ -169,7 +174,12 @@ mod tests {
                     "root mismatch at position {i:?}"
                 );
             }
+            // Persist the empty state so re-initialization below starts from it.
+            mmr = mmr.sync().await.unwrap();
             assert!(matches!(mmr.rewind(99).await, Err(Error::Empty)));
+            let mut mmr = Mmr::init(context.child("reopen2"), &hasher, test_config(&context))
+                .await
+                .unwrap();
 
             // Repeat one more time only after pruning the MMR first.
             {
@@ -180,8 +190,8 @@ mod tests {
                     batch = batch.add(&hasher, &element);
                 }
                 let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                mmr.apply_batch(&batch).unwrap();
-                mmr.sync().await.unwrap();
+                mmr = mmr.apply_batch(&batch).unwrap();
+                mmr = mmr.sync().await.unwrap();
                 let mut batch = mmr.new_batch();
                 for i in 102u64..NUM_ELEMENTS {
                     c_hasher.update(&i.to_be_bytes());
@@ -189,26 +199,25 @@ mod tests {
                     batch = batch.add(&hasher, &element);
                 }
                 let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                mmr.apply_batch(&batch).unwrap();
+                mmr = mmr.apply_batch(&batch).unwrap();
             }
             let prune_loc = Location::new(50);
             let prune_pos = Position::try_from(prune_loc).unwrap();
-            mmr.prune(prune_loc).await.unwrap();
+            mmr = mmr.prune(prune_loc).await.unwrap();
             // Rewind enough nodes to cause the mem-mmr to be completely emptied, and then some.
-            mmr.rewind(80).await.unwrap();
+            mmr = mmr.rewind(80).await.unwrap();
             // Make sure the pinned node boundary is valid by generating a proof for the oldest item.
             mmr.proof(&hasher, prune_loc, 0).await.unwrap();
             // prune all remaining leaves 1 at a time.
             while mmr.size() > prune_pos {
-                assert!(mmr.rewind(1).await.is_ok());
+                mmr = mmr.rewind(1).await.unwrap();
             }
-            assert!(matches!(mmr.rewind(1).await, Err(Error::ElementPruned(_))));
 
             // Make sure pruning to an older location is a no-op.
-            assert!(mmr.prune(prune_loc - 1).await.is_ok());
+            mmr = mmr.prune(prune_loc - 1).await.unwrap();
             assert_eq!(mmr.bounds().start, prune_loc);
 
-            mmr.destroy().await.unwrap();
+            assert!(matches!(mmr.rewind(1).await, Err(Error::ElementPruned(_))));
         });
     }
 
@@ -221,7 +230,7 @@ mod tests {
             let hasher: Standard<Sha256> = Standard::new(ForwardFold);
 
             // Build base full MMR with 10 elements.
-            let mut mmr = Mmr::init(
+            let mmr = Mmr::init(
                 context.child("storage"),
                 &Standard::<Sha256>::new(ForwardFold),
                 test_config(&context),
@@ -235,8 +244,8 @@ mod tests {
                 batch = batch.add(&hasher, &element);
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
-            mmr.sync().await.unwrap();
+            let mmr = mmr.apply_batch(&batch).unwrap();
+            let mmr = mmr.sync().await.unwrap();
 
             // Batch A: add 5 elements.
             let mut batch_a = mmr.new_batch();
@@ -258,7 +267,7 @@ mod tests {
                 .unwrap();
 
             // Apply.
-            mmr.apply_batch(&merkleized_b).unwrap();
+            let mmr = mmr.apply_batch(&merkleized_b).unwrap();
             assert_eq!(mmr.root(&hasher, 0).unwrap(), expected_root);
 
             // Build a reference in-memory MMR with 20 elements to verify.
@@ -284,7 +293,7 @@ mod tests {
             let hasher = Standard::<Sha256>::new(ForwardFold);
 
             // Build an MMR with 5 leaves (size 8), sync, drop.
-            let mut mmr = Mmr::<_, Digest, Sequential>::init(
+            let mmr = Mmr::<_, Digest, Sequential>::init(
                 context.child("init"),
                 &hasher,
                 test_config(&context),
@@ -296,9 +305,8 @@ mod tests {
                 batch = batch.add(&hasher, &test_digest(i));
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
+            let mmr = mmr.apply_batch(&batch).unwrap();
             mmr.sync().await.unwrap();
-            drop(mmr);
 
             // Build a reference MMR to 100 leaves to get valid pinned nodes for the
             // sync boundary.
@@ -310,7 +318,7 @@ mod tests {
                 strategy: Sequential,
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
-            let mut ref_mmr =
+            let ref_mmr =
                 Mmr::<_, Digest, Sequential>::init(context.child("ref"), &hasher, ref_cfg)
                     .await
                     .unwrap();
@@ -319,7 +327,7 @@ mod tests {
                 batch = batch.add(&hasher, &test_digest(i));
             }
             let batch = ref_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            ref_mmr.apply_batch(&batch).unwrap();
+            let ref_mmr = ref_mmr.apply_batch(&batch).unwrap();
             let expected_size = ref_mmr.size();
             let prune_loc = Location::new(100);
             let mut pinned = Vec::new();
@@ -335,7 +343,7 @@ mod tests {
                 range: non_empty_range!(Location::new(100), Location::new(200)),
                 pinned_nodes: Some(pinned),
             };
-            let mut sync_mmr = Mmr::init_sync(context.child("sync"), sync_cfg)
+            let sync_mmr = Mmr::init_sync(context.child("sync"), sync_cfg)
                 .await
                 .unwrap();
 
@@ -345,7 +353,7 @@ mod tests {
             // Should be able to add new elements without panic.
             let batch = sync_mmr.new_batch().add(&hasher, &test_digest(999));
             let batch = sync_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            sync_mmr.apply_batch(&batch).unwrap();
+            let sync_mmr = sync_mmr.apply_batch(&batch).unwrap();
 
             sync_mmr.destroy().await.unwrap();
         });

--- a/storage/src/merkle/mmr/full.rs
+++ b/storage/src/merkle/mmr/full.rs
@@ -306,7 +306,8 @@ mod tests {
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
             let mmr = mmr.apply_batch(&batch).unwrap();
-            mmr.sync().await.unwrap();
+            let mmr = mmr.sync().await.unwrap();
+            drop(mmr);
 
             // Build a reference MMR to 100 leaves to get valid pinned nodes for the
             // sync boundary.

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -5,6 +5,13 @@
 //! pruned.
 //!
 //! This module is generic over [`Family`], so it works for both MMR and MMB.
+//!
+//! # Ownership
+//!
+//! Mutating methods take the structure by value and return it on success. If a mutating
+//! method returns an error, or its future is dropped before it finishes, the structure is
+//! gone: state that was not yet durable is discarded, but everything already on disk stays
+//! recoverable.
 
 use crate::{
     Context,
@@ -167,6 +174,15 @@ pub struct Merkle<F: Family, E: Context, D: Digest, S: Strategy> {
     pub(crate) strategy: S,
 }
 
+impl<F: Family, E: Context, D: Digest, S: Strategy> std::fmt::Debug for Merkle<F, E, D, S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Merkle")
+            .field("size", &self.size())
+            .field("leaves", &self.leaves())
+            .finish_non_exhaustive()
+    }
+}
+
 /// Prefix used for nodes in the metadata prefixed U8 key.
 const NODE_PREFIX: u8 = 0;
 
@@ -303,7 +319,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         if *metadata_prune_pos > journal_bounds_start {
             // Metadata is ahead of journal (crashed before completing journal prune).
             // Prune the journal to match metadata.
-            journal.prune(*metadata_prune_pos).await?;
+            (journal, _) = journal.prune(*metadata_prune_pos).await?;
             if journal.bounds().start != journal_bounds_start {
                 // This should only happen in the event of some failure during the last attempt to
                 // prune the journal.
@@ -354,8 +370,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             if let Ok(item) = recovered_item {
                 orphaned_leaf = Some(item);
             }
-            journal.rewind(*last_valid_size).await?;
-            journal.sync().await?;
+            journal = journal.rewind(*last_valid_size).await?.sync().await?;
             journal_size = last_valid_size
         }
 
@@ -388,9 +403,9 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             for p in journal.size()..*mem.size() {
                 let p = Position::new(p);
                 let node = *mem.get_node_unchecked(p);
-                journal.append(&node).await?;
+                (journal, _) = journal.append(&node).await?;
             }
-            journal.sync().await?;
+            journal = journal.sync().await?;
             assert_eq!(mem.size(), journal.size());
 
             // Prune mem and reinstate pinned nodes.
@@ -452,8 +467,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
                 ?last_valid_size,
                 "init_sync: encountered invalid structure, recovering from last valid size"
             );
-            journal.rewind(*last_valid_size).await?;
-            journal.sync().await?;
+            journal = journal.rewind(*last_valid_size).await?.sync().await?;
             journal_size = last_valid_size;
         }
 
@@ -521,7 +535,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         metadata.sync().await?;
 
         // Prune the journal to range.start.
-        journal.prune(*prune_pos).await?;
+        (journal, _) = journal.prune(*prune_pos).await?;
 
         Ok(Self {
             mem: Arc::new(mem),
@@ -593,28 +607,28 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Flush all nodes cached in the in-memory structure to the journal without forcing them to
     /// disk. Flushed nodes are pruned from the in-memory structure and remain readable through the
     /// journal, but they are not guaranteed to survive a crash until [Self::sync] is called.
-    pub async fn flush(&mut self) -> Result<(), Error<F>> {
+    pub async fn flush(self) -> Result<Self, Error<F>> {
         self.flush_internal().await
     }
 
     /// Flush all nodes cached in the in-memory structure to the journal and make them durable.
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
-        self.flush_internal().await?;
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
+        self = self.flush_internal().await?;
 
         // Sync the journal to ensure durability before returning. This covers nodes appended by
         // the flush above as well as nodes left non-durable by earlier [Self::flush] calls.
         if self.journal_dirty {
-            self.journal.sync().await?;
+            self.journal = self.journal.sync().await?;
             self.journal_dirty = false;
         }
 
-        Ok(())
+        Ok(self)
     }
 
     /// Append nodes cached in the in-memory structure that are missing from the journal, then
     /// prune them from the in-memory structure. Sets [Self::journal_dirty] when nodes are
     /// appended.
-    async fn flush_internal(&mut self) -> Result<(), Error<F>> {
+    async fn flush_internal(mut self) -> Result<Self, Error<F>> {
         let journal_size = Position::<F>::new(self.journal.size());
 
         // Encode the nodes missing from the journal directly to bytes and snapshot the pinned
@@ -628,7 +642,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
                 "journal size should never exceed in-memory structure size"
             );
             if journal_size == size {
-                return Ok(());
+                return Ok(self);
             }
 
             // Encode the un-journaled tail to an owned buffer before the journal I/O below.
@@ -648,7 +662,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         };
 
         // Append missing nodes to the journal.
-        self.journal.append_prepared(encoded).await?;
+        (self.journal, _) = self.journal.append_prepared(encoded).await?;
         self.journal_dirty = true;
 
         // Now that the missing nodes are readable from the journal, it's safe to prune them from
@@ -658,7 +672,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             .expect("captured leaves is in bounds");
         mem.add_pinned_nodes(pinned_nodes);
 
-        Ok(())
+        Ok(self)
     }
 
     /// Prune all nodes up to but not including the given leaf location and update the pinned nodes.
@@ -668,27 +682,27 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     ///
     /// Returns [Error::LocationOverflow] if `loc` exceeds [Family::MAX_LEAVES].
     /// Returns [Error::LeafOutOfBounds] if `loc` exceeds the current leaf count.
-    pub async fn prune(&mut self, loc: Location<F>) -> Result<(), Error<F>> {
+    pub async fn prune(mut self, loc: Location<F>) -> Result<Self, Error<F>> {
         let pos = Position::try_from(loc)?;
         if loc > self.mem.leaves() {
             return Err(Error::LeafOutOfBounds(loc));
         }
         if pos <= self.pruned_to_pos {
-            return Ok(());
+            return Ok(self);
         }
 
         // Flush items cached in the mem to disk to ensure the current state is recoverable.
-        self.sync().await?;
+        self = self.sync().await?;
 
         // Update metadata to reflect the desired pruning boundary, allowing for recovery in the
         // event of a pruning failure.
         let pinned_nodes = self.update_metadata(pos).await?;
 
-        self.journal.prune(*pos).await?;
+        (self.journal, _) = self.journal.prune(*pos).await?;
         Arc::make_mut(&mut self.mem).add_pinned_nodes(pinned_nodes);
         self.pruned_to_pos = pos;
 
-        Ok(())
+        Ok(self)
     }
 
     /// Compute the root of the structure using `inactive_peaks` and the bagging carried by `hasher`.
@@ -702,12 +716,12 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
 
     /// Prune as many nodes as possible, leaving behind at most items_per_blob nodes in the current
     /// blob.
-    pub async fn prune_all(&mut self) -> Result<(), Error<F>> {
+    pub async fn prune_all(mut self) -> Result<Self, Error<F>> {
         let leaves = self.mem.leaves();
         if leaves != 0 {
-            self.prune(leaves).await?;
+            self = self.prune(leaves).await?;
         }
-        Ok(())
+        Ok(self)
     }
 
     /// Close and permanently remove any disk resources.
@@ -721,7 +735,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     #[cfg(any(test, feature = "fuzzing"))]
     /// Sync elements to disk until `write_limit` elements have been written, then abort to simulate
     /// a partial write for testing failure scenarios.
-    pub async fn simulate_partial_sync(&mut self, write_limit: usize) -> Result<(), Error<F>> {
+    pub async fn simulate_partial_sync(mut self, write_limit: usize) -> Result<(), Error<F>> {
         if write_limit == 0 {
             return Ok(());
         }
@@ -733,7 +747,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         let mut written_count = 0usize;
         for i in *journal_size..*self.mem.size() {
             let node = *self.mem.get_node_unchecked(Position::new(i));
-            self.journal.append(&node).await?;
+            (self.journal, _) = self.journal.append(&node).await?;
             written_count += 1;
             if written_count >= write_limit {
                 break;
@@ -757,7 +771,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         assert!(prune_to_pos <= self.mem.size());
 
         // Flush items cached in the mem to disk to ensure the current state is recoverable.
-        self.sync().await?;
+        self = self.sync().await?;
 
         // Update metadata to reflect the desired pruning boundary, allowing for recovery in the
         // event of a pruning failure.
@@ -773,9 +787,12 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// chain was created, or if only ancestors of this batch have been applied.
     /// Already-committed ancestors are skipped automatically.
     /// Applying a batch from a different fork returns [`Error::StaleBatch`].
-    pub fn apply_batch(&mut self, batch: &batch::MerkleizedBatch<F, D, S>) -> Result<(), Error<F>> {
+    pub fn apply_batch(
+        mut self,
+        batch: &batch::MerkleizedBatch<F, D, S>,
+    ) -> Result<Self, Error<F>> {
         Arc::make_mut(&mut self.mem).apply_batch(batch)?;
-        Ok(())
+        Ok(self)
     }
 
     /// Create an owned [`batch::MerkleizedBatch`] representing the current committed state.
@@ -819,9 +836,9 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// n) pinned nodes. A batch pop would expose new peaks that are not in memory, and `merkleize`
     /// cannot load them because [`Readable::get_node`] is synchronous. `rewind` performs async
     /// journal I/O to rebuild state at the target position.
-    pub(crate) async fn rewind(&mut self, leaves_to_remove: usize) -> Result<(), Error<F>> {
+    pub(crate) async fn rewind(mut self, leaves_to_remove: usize) -> Result<Self, Error<F>> {
         if leaves_to_remove == 0 {
-            return Ok(());
+            return Ok(self);
         }
 
         let current_leaves = *self.leaves();
@@ -847,8 +864,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         // Rewind the journal if needed.
         let journal_size = Position::<F>::new(self.journal.size());
         if new_size < journal_size {
-            self.journal.rewind(*new_size).await?;
-            self.journal.sync().await?;
+            self.journal = self.journal.rewind(*new_size).await?.sync().await?;
         }
 
         // Truncate the in-memory structure to the target size.
@@ -879,7 +895,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             self.mem = Arc::new(mem);
         }
 
-        Ok(())
+        Ok(self)
     }
 }
 
@@ -1091,19 +1107,27 @@ mod tests {
         assert!(mmr.get_node(Position::<F>::new(0)).await.is_err());
         let bounds = mmr.bounds();
         assert!(bounds.is_empty());
-        assert!(mmr.prune_all().await.is_ok());
+        mmr = mmr.prune_all().await.unwrap();
         assert_eq!(bounds.start, 0);
-        assert!(mmr.prune(Location::<F>::new(0)).await.is_ok());
-        assert!(mmr.sync().await.is_ok());
+        mmr = mmr.prune(Location::<F>::new(0)).await.unwrap();
+        mmr = mmr.sync().await.unwrap();
         assert!(matches!(mmr.rewind(1).await, Err(Error::Empty)));
 
+        // The failed rewind consumed the mmr; reopen the same partitions.
+        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
+            context.child("reopen"),
+            &hasher,
+            test_config(&context),
+        )
+        .await
+        .unwrap();
         let batch = mmr.new_batch().add(&hasher, &test_digest(0));
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         assert_eq!(mmr.size(), 1);
-        mmr.sync().await.unwrap();
+        mmr = mmr.sync().await.unwrap();
         assert!(mmr.get_node(Position::<F>::new(0)).await.is_ok());
-        assert!(mmr.rewind(1).await.is_ok());
+        mmr = mmr.rewind(1).await.unwrap();
         assert_eq!(mmr.size(), 0);
         mmr.sync().await.unwrap();
 
@@ -1134,7 +1158,7 @@ mod tests {
         // Confirm empty proof no longer verifies after adding an element.
         let batch = mmr.new_batch().add(&hasher, &test_digest(0));
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let root = mmr.root(&hasher, 0).unwrap();
         assert!(!empty_proof.verify_range_inclusion(
             &hasher,
@@ -1177,14 +1201,12 @@ mod tests {
 
         let batch = mmr.new_batch().add(&hasher, &test_digest(0));
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         assert!(matches!(
             mmr.prune(Location::<F>::new(2)).await,
             Err(Error::LeafOutOfBounds(loc)) if loc == Location::<F>::new(2)
         ));
-
-        mmr.destroy().await.unwrap();
     }
 
     #[test_traced]
@@ -1218,33 +1240,57 @@ mod tests {
             batch = batch.add(&hasher, &i.to_be_bytes());
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.prune(Location::<F>::new(8)).await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.prune(Location::<F>::new(8)).await.unwrap();
         let leaves_before = mmr.leaves();
         assert!(matches!(
             mmr.rewind(128).await,
             Err(Error::ElementPruned(_))
         ));
-        // After error, leaves should reflect any partial rewinds that occurred.
-        assert!(mmr.leaves() <= leaves_before);
+
+        // The failed rewind consumed the mmr before mutating anything durable; reopening
+        // recovers the synced state.
+        let mmr = Merkle::<F, _, Digest, Sequential>::init(
+            element_pruned_context.child("element_pruned_reopen"),
+            &hasher,
+            test_config(&element_pruned_context),
+        )
+        .await
+        .unwrap();
+        assert_eq!(mmr.leaves(), leaves_before);
         mmr.destroy().await.unwrap();
 
-        // Case 2: rewind partially succeeds, then returns Empty.
+        // Case 2: rewind underflows and returns Empty without removing any leaves.
         let empty_context = context.child("empty_case");
-        let cfg = test_config(&empty_context);
-        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(empty_context, &hasher, cfg)
-            .await
-            .unwrap();
+        let cfg = Config {
+            journal_partition: "empty-journal-partition".into(),
+            metadata_partition: "empty-metadata-partition".into(),
+            ..test_config(&empty_context)
+        };
+        let mut mmr =
+            Merkle::<F, _, Digest, Sequential>::init(empty_context.child("open"), &hasher, cfg)
+                .await
+                .unwrap();
         let mut batch = mmr.new_batch();
         for i in 0u64..8 {
             batch = batch.add(&hasher, &i.to_be_bytes());
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        let leaves_before = mmr.leaves();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.sync().await.unwrap();
         assert!(matches!(mmr.rewind(9).await, Err(Error::Empty)));
-        // Rewind returns error without partial modification.
-        assert_eq!(mmr.leaves(), leaves_before);
+
+        // Reopen: the underflowing rewind persisted nothing.
+        let cfg = Config {
+            journal_partition: "empty-journal-partition".into(),
+            metadata_partition: "empty-metadata-partition".into(),
+            ..test_config(&empty_context)
+        };
+        let mmr =
+            Merkle::<F, _, Digest, Sequential>::init(empty_context.child("reopen"), &hasher, cfg)
+                .await
+                .unwrap();
+        assert_eq!(mmr.leaves(), Location::<F>::new(8));
         mmr.destroy().await.unwrap();
     }
 
@@ -1277,7 +1323,7 @@ mod tests {
             batch = batch.add(&hasher, leaf);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         assert_eq!(mmr.size(), expected_size);
 
@@ -1295,7 +1341,7 @@ mod tests {
         ));
 
         // Sync the structure, make sure it flushes the in-mem structure as expected.
-        mmr.sync().await.unwrap();
+        mmr = mmr.sync().await.unwrap();
 
         // Now that the element is flushed from the in-mem structure, confirm its proof is still
         // generated correctly.
@@ -1349,12 +1395,12 @@ mod tests {
             batch = batch.add(&hasher, leaf);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         let root = mmr.root(&hasher, 0).unwrap();
 
         // Flush writes all cached nodes to the journal and prunes them from the mem.
-        mmr.flush().await.unwrap();
+        mmr = mmr.flush().await.unwrap();
         assert_eq!(Position::<F>::new(mmr.journal.size()), expected_size);
         assert_eq!(mmr.size(), expected_size);
         assert_eq!(
@@ -1363,7 +1409,7 @@ mod tests {
         );
 
         // Flushing again is a no-op.
-        mmr.flush().await.unwrap();
+        mmr = mmr.flush().await.unwrap();
         assert_eq!(Position::<F>::new(mmr.journal.size()), expected_size);
 
         // Flushed nodes remain readable and provable, and the root is unchanged.
@@ -1375,7 +1421,7 @@ mod tests {
 
         // Sync after flush succeeds (and must fsync the journal even though there is nothing
         // left to flush).
-        mmr.sync().await.unwrap();
+        mmr = mmr.sync().await.unwrap();
 
         mmr.destroy().await.unwrap();
     }
@@ -1415,8 +1461,8 @@ mod tests {
                 batch = batch.add(&hasher, &test_digest(i));
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
-            mmr.sync().await.unwrap();
+            mmr = mmr.apply_batch(&batch).unwrap();
+            let mut mmr = mmr.sync().await.unwrap();
             let synced_size = mmr.size();
 
             let mut batch = mmr.new_batch();
@@ -1424,8 +1470,8 @@ mod tests {
                 batch = batch.add(&hasher, &test_digest(i));
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
-            mmr.flush().await.unwrap();
+            mmr = mmr.apply_batch(&batch).unwrap();
+            mmr = mmr.flush().await.unwrap();
             assert_eq!(Position::<F>::new(mmr.journal.size()), mmr.size());
 
             synced_size
@@ -1478,9 +1524,9 @@ mod tests {
                 batch = batch.add(&hasher, &test_digest(i));
             }
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
-            mmr.flush().await.unwrap();
-            mmr.sync().await.unwrap();
+            mmr = mmr.apply_batch(&batch).unwrap();
+            mmr = mmr.flush().await.unwrap();
+            let mmr = mmr.sync().await.unwrap();
 
             mmr.size()
         });
@@ -1535,16 +1581,15 @@ mod tests {
             batch = batch.add(&hasher, leaf);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         assert_eq!(mmr.size(), expected_size);
         mmr.sync().await.unwrap();
-        drop(mmr);
 
         // Simulate a crash that wrote a leaf but not its parent nodes by appending one
         // extra digest to the journal. This creates an invalid structure size.
         {
-            let mut journal: Journal<_, Digest> = Journal::init(
+            let journal: Journal<_, Digest> = Journal::init(
                 context.child("corrupt"),
                 JConfig {
                     partition: "journal-partition".into(),
@@ -1556,8 +1601,8 @@ mod tests {
             .await
             .unwrap();
             assert_eq!(journal.size(), expected_size);
-            journal.append(&Sha256::hash(b"orphan")).await.unwrap();
-            journal.sync().await.unwrap();
+            let (journal, _) = journal.append(&Sha256::hash(b"orphan")).await.unwrap();
+            let journal = journal.sync().await.unwrap();
             assert_eq!(journal.size(), expected_size + 1);
         }
 
@@ -1636,13 +1681,13 @@ mod tests {
             batch = batch.add(&hasher, leaf);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let mut batch = pruned_mmr.new_batch();
         for leaf in &leaves {
             batch = batch.add(&hasher, leaf);
         }
         let batch = pruned_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        pruned_mmr.apply_batch(&batch).unwrap();
+        pruned_mmr = pruned_mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         assert_eq!(mmr.size(), expected_size);
         assert_eq!(pruned_mmr.size(), expected_size);
@@ -1651,7 +1696,7 @@ mod tests {
         // roots and accept new elements.
         for i in 0usize..300 {
             let prune_loc = Location::<F>::new(std::cmp::min(i as u64 * 10, *pruned_mmr.leaves()));
-            pruned_mmr.prune(prune_loc).await.unwrap();
+            pruned_mmr = pruned_mmr.prune(prune_loc).await.unwrap();
             assert_eq!(prune_loc, pruned_mmr.bounds().start);
 
             let digest = test_digest(LEAF_COUNT + i);
@@ -1659,10 +1704,10 @@ mod tests {
             let last_leaf = leaves.last().unwrap();
             let batch = pruned_mmr.new_batch().add(&hasher, last_leaf);
             let batch = pruned_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            pruned_mmr.apply_batch(&batch).unwrap();
+            pruned_mmr = pruned_mmr.apply_batch(&batch).unwrap();
             let batch = mmr.new_batch().add(&hasher, last_leaf);
             let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            mmr.apply_batch(&batch).unwrap();
+            mmr = mmr.apply_batch(&batch).unwrap();
             assert_eq!(
                 pruned_mmr.root(&hasher, 0).unwrap(),
                 mmr.root(&hasher, 0).unwrap()
@@ -1670,7 +1715,7 @@ mod tests {
         }
 
         // Sync the structures.
-        pruned_mmr.sync().await.unwrap();
+        pruned_mmr = pruned_mmr.sync().await.unwrap();
         assert_eq!(
             pruned_mmr.root(&hasher, 0).unwrap(),
             mmr.root(&hasher, 0).unwrap()
@@ -1678,7 +1723,6 @@ mod tests {
 
         // Sync the structure & reopen.
         pruned_mmr.sync().await.unwrap();
-        drop(pruned_mmr);
         let mut pruned_mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("pruned_reopen"),
             &hasher,
@@ -1693,7 +1737,7 @@ mod tests {
 
         // Prune everything.
         let size = pruned_mmr.size();
-        pruned_mmr.prune_all().await.unwrap();
+        pruned_mmr = pruned_mmr.prune_all().await.unwrap();
         assert_eq!(
             pruned_mmr.root(&hasher, 0).unwrap(),
             mmr.root(&hasher, 0).unwrap()
@@ -1706,15 +1750,14 @@ mod tests {
         // expected on reopening.
         let batch = mmr.new_batch().add(&hasher, &test_digest(LEAF_COUNT));
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let batch = pruned_mmr
             .new_batch()
             .add(&hasher, &test_digest(LEAF_COUNT));
         let batch = pruned_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        pruned_mmr.apply_batch(&batch).unwrap();
+        pruned_mmr = pruned_mmr.apply_batch(&batch).unwrap();
         assert!(*pruned_mmr.size() % cfg_pruned.items_per_blob != 0);
         pruned_mmr.sync().await.unwrap();
-        drop(pruned_mmr);
         let mut pruned_mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("pruned_reopen").with_attribute("index", 2),
             &hasher,
@@ -1731,12 +1774,10 @@ mod tests {
         assert_eq!(bounds.start, Location::<F>::try_from(size).unwrap());
 
         // Make sure pruning to older location is a no-op.
-        assert!(
-            pruned_mmr
-                .prune(Location::<F>::try_from(size).unwrap() - 1)
-                .await
-                .is_ok()
-        );
+        pruned_mmr = pruned_mmr
+            .prune(Location::<F>::try_from(size).unwrap() - 1)
+            .await
+            .unwrap();
         assert_eq!(
             pruned_mmr.bounds().start,
             Location::<F>::try_from(size).unwrap()
@@ -1749,9 +1790,9 @@ mod tests {
                 .new_batch()
                 .add(&hasher, &test_digest(LEAF_COUNT));
             let batch = pruned_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-            pruned_mmr.apply_batch(&batch).unwrap();
+            pruned_mmr = pruned_mmr.apply_batch(&batch).unwrap();
         }
-        pruned_mmr.prune_all().await.unwrap();
+        pruned_mmr = pruned_mmr.prune_all().await.unwrap();
         assert!(pruned_mmr.bounds().is_empty());
 
         pruned_mmr.destroy().await.unwrap();
@@ -1791,11 +1832,10 @@ mod tests {
             batch = batch.add(&hasher, leaf);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         assert_eq!(mmr.size(), expected_size);
         mmr.sync().await.unwrap();
-        drop(mmr);
 
         // Prune the structure in increments of 50, simulating a partial write after each prune.
         for i in 0usize..200 {
@@ -1813,7 +1853,7 @@ mod tests {
                 mmr.simulate_pruning_failure(prune_loc).await.unwrap();
                 continue;
             }
-            mmr.prune(prune_loc).await.unwrap();
+            mmr = mmr.prune(prune_loc).await.unwrap();
 
             // add new elements, simulating a partial write after each.
             for j in 0..10 {
@@ -1824,7 +1864,7 @@ mod tests {
                     .add(&hasher, leaves.last().unwrap())
                     .add(&hasher, leaves.last().unwrap());
                 let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                mmr.apply_batch(&batch).unwrap();
+                mmr = mmr.apply_batch(&batch).unwrap();
                 let digest = test_digest(LEAF_COUNT + i);
                 leaves.push(digest);
                 let batch = mmr
@@ -1832,7 +1872,7 @@ mod tests {
                     .add(&hasher, leaves.last().unwrap())
                     .add(&hasher, leaves.last().unwrap());
                 let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-                mmr.apply_batch(&batch).unwrap();
+                mmr = mmr.apply_batch(&batch).unwrap();
             }
             let end_size = mmr.size();
             let total_to_write = (*end_size - *start_size) as usize;
@@ -1880,7 +1920,7 @@ mod tests {
             batch = batch.add(&hasher, elt);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let original_leaves = mmr.leaves();
 
         // Historical proof should match "regular" proof when historical size == current database size
@@ -1917,7 +1957,7 @@ mod tests {
             batch = batch.add(&hasher, elt);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let new_historical_proof = mmr
             .historical_range_proof(
                 &hasher,
@@ -1965,11 +2005,11 @@ mod tests {
             batch = batch.add(&hasher, elt);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         // Prune to leaf 16 (position 30)
         let prune_loc = Location::<F>::new(16);
-        mmr.prune(prune_loc).await.unwrap();
+        let mmr = mmr.prune(prune_loc).await.unwrap();
 
         // Create reference structure for verification to get correct size
         let mut ref_mmr = Merkle::<F, _, Digest, Sequential>::init(
@@ -1992,7 +2032,7 @@ mod tests {
             batch = batch.add(&hasher, elt);
         }
         let batch = ref_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        ref_mmr.apply_batch(&batch).unwrap();
+        ref_mmr = ref_mmr.apply_batch(&batch).unwrap();
         let historical_leaves = ref_mmr.leaves();
         let historical_root = ref_mmr.root(&hasher, 0).unwrap();
 
@@ -2060,7 +2100,7 @@ mod tests {
             batch = batch.add(&hasher, elt);
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let range = Location::<F>::new(30)..Location::<F>::new(61);
 
@@ -2086,7 +2126,7 @@ mod tests {
             batch = batch.add(&hasher, elt);
         }
         let batch = ref_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        ref_mmr.apply_batch(&batch).unwrap();
+        ref_mmr = ref_mmr.apply_batch(&batch).unwrap();
         let historical_leaves = ref_mmr.leaves();
         let expected_root = ref_mmr.root(&hasher, 0).unwrap();
 
@@ -2129,7 +2169,7 @@ mod tests {
         let element = test_digest(0);
         let batch = mmr.new_batch().add(&hasher, &element);
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         // Test single element proof at historical position
         let single_proof = mmr
@@ -2191,7 +2231,7 @@ mod tests {
         let new_element = test_digest(999);
         let batch = sync_mmr.new_batch().add(&hasher, &new_element);
         let batch = sync_mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        sync_mmr.apply_batch(&batch).unwrap();
+        sync_mmr = sync_mmr.apply_batch(&batch).unwrap();
 
         // Root should be computable
         let _root = sync_mmr.root(&hasher, 0).unwrap();
@@ -2228,8 +2268,8 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
         let original_size = mmr.size();
         let original_leaves = mmr.leaves();
         let original_root = mmr.root(&hasher, 0).unwrap();
@@ -2253,7 +2293,6 @@ mod tests {
         };
 
         mmr.sync().await.unwrap();
-        drop(mmr);
 
         let sync_mmr =
             Merkle::<F, _, Digest, Sequential>::init_sync(context.child("sync"), sync_cfg)
@@ -2308,9 +2347,9 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
-        mmr.prune(Location::<F>::new(6)).await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
+        let mmr = mmr.prune(Location::<F>::new(6)).await.unwrap();
 
         let original_size = mmr.size();
         let original_leaves = mmr.leaves();
@@ -2335,7 +2374,6 @@ mod tests {
         };
 
         mmr.sync().await.unwrap();
-        drop(mmr);
 
         let sync_mmr =
             Merkle::<F, _, Digest, Sequential>::init_sync(context.child("sync"), sync_cfg)
@@ -2422,13 +2460,12 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
 
         // Prune enough that the journal boundary's pinned nodes span pruned blobs.
         let prune_loc = Location::<F>::new(25);
         mmr.prune(prune_loc).await.unwrap();
-        drop(mmr);
 
         // Simulate a crash after journal prune but before metadata was updated:
         // clear all metadata and write only a stale pruning boundary of 0 (no pinned nodes).
@@ -2499,12 +2536,12 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
 
         // Prune to position 30 (this stores pinned nodes and updates metadata)
         let prune_loc = Location::<F>::new(16);
-        mmr.prune(prune_loc).await.unwrap();
+        let mmr = mmr.prune(prune_loc).await.unwrap();
         let expected_root = mmr.root(&hasher, 0).unwrap();
         let expected_size = mmr.size();
         drop(mmr);
@@ -2569,8 +2606,8 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
 
         // Don't prune - this ensures metadata has no pinned nodes. init_sync will need to
         // read pinned nodes from the journal.
@@ -2630,10 +2667,10 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let prune_loc = Location::<F>::new(16);
-        mmr.prune(prune_loc).await.unwrap();
+        let mmr = mmr.prune(prune_loc).await.unwrap();
 
         let historical_leaves = mmr.leaves();
         let mut pruned_loc = None;
@@ -2655,7 +2692,7 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(10_000 + i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.apply_batch(&batch).unwrap();
 
         let requested = mmr.leaves();
         let result = mmr
@@ -2695,7 +2732,7 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let historical_leaves = Location::<F>::new(10);
         let range = Location::<F>::new(2)..Location::<F>::new(8);
@@ -2706,7 +2743,7 @@ mod tests {
             .add(&hasher, &test_digest(100))
             .add(&hasher, &test_digest(101));
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let proof = mmr
             .historical_range_proof(&hasher, historical_leaves, range.clone(), 0)
@@ -2751,8 +2788,8 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
 
         let historical_leaves = Location::<F>::new(20);
         let range = Location::<F>::new(5)..Location::<F>::new(15);
@@ -2797,10 +2834,10 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let prune_loc = Location::<F>::new(10);
-        mmr.prune(prune_loc).await.unwrap();
+        let mmr = mmr.prune(prune_loc).await.unwrap();
 
         let requested = Location::<F>::new(20);
         let range = prune_loc..requested;
@@ -2863,9 +2900,9 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let end = mmr.leaves();
-        mmr.prune_all().await.unwrap();
+        mmr = mmr.prune_all().await.unwrap();
         assert!(mmr.bounds().is_empty());
         let pruned_result = mmr
             .historical_range_proof(&hasher, end, end - 1..end, 0)
@@ -2893,10 +2930,10 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let end = mmr.leaves();
         let keep_loc = end - 1;
-        mmr.prune(keep_loc).await.unwrap();
+        mmr = mmr.prune(keep_loc).await.unwrap();
         let ok_result = mmr
             .historical_range_proof(&hasher, end, keep_loc..end, 0)
             .await;
@@ -2942,7 +2979,7 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let requested = mmr.leaves() + 1;
 
         let result = mmr
@@ -2985,7 +3022,7 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let valid_range = Location::<F>::new(0)..Location::<F>::new(1);
 
@@ -3074,13 +3111,13 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
 
         let end = mmr.leaves();
         let mut failures = Vec::new();
         for prune_leaf in 1..*end {
             let prune_loc = Location::<F>::new(prune_leaf);
-            mmr.prune(prune_loc).await.unwrap();
+            mmr = mmr.prune(prune_loc).await.unwrap();
             for loc_u64 in 0..*end {
                 let loc = Location::<F>::new(loc_u64);
                 let range_includes_pruned_leaf = loc < prune_loc;
@@ -3140,17 +3177,16 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
         let valid_size = mmr.size();
         let valid_root = mmr.root(&hasher, 0).unwrap();
         mmr.sync().await.unwrap();
-        drop(mmr);
 
         // Append one extra digest to the journal, simulating a crash that wrote a
         // leaf (for the 4th element) but not its parent nodes. This makes the
         // journal size invalid.
         {
-            let mut journal: Journal<_, Digest> = Journal::init(
+            let journal: Journal<_, Digest> = Journal::init(
                 context.child("corrupt"),
                 JConfig {
                     partition: "journal-partition".into(),
@@ -3162,8 +3198,8 @@ mod tests {
             .await
             .unwrap();
             assert_eq!(journal.size(), valid_size);
-            journal.append(&Sha256::hash(b"orphan")).await.unwrap();
-            journal.sync().await.unwrap();
+            let (journal, _) = journal.append(&Sha256::hash(b"orphan")).await.unwrap();
+            let journal = journal.sync().await.unwrap();
             assert_eq!(journal.size(), valid_size + 1);
         }
 
@@ -3213,16 +3249,13 @@ mod tests {
         let batch_b = mmr.with_mem(|mem| batch_b.merkleize(mem, &hasher));
 
         // Apply A -- should succeed.
-        mmr.apply_batch(&batch_a).unwrap();
+        mmr = mmr.apply_batch(&batch_a).unwrap();
 
         // Apply B -- should fail (stale).
-        let result = mmr.apply_batch(&batch_b);
-        assert!(
-            matches!(result, Err(Error::StaleBatch { .. })),
-            "expected StaleBatch, got {result:?}"
-        );
-
-        mmr.destroy().await.unwrap();
+        assert!(matches!(
+            mmr.apply_batch(&batch_b),
+            Err(Error::StaleBatch { .. })
+        ));
     }
 
     #[test]
@@ -3289,8 +3322,8 @@ mod tests {
             batch = batch.add(&hasher, &test_digest(i));
         }
         let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
-        mmr.apply_batch(&batch).unwrap();
-        mmr.sync().await.unwrap();
+        mmr = mmr.apply_batch(&batch).unwrap();
+        let mmr = mmr.sync().await.unwrap();
 
         // Attempt to update leaf 0 which has been synced out of memory.
         // Use the inner batch type directly since the full wrapper

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -1583,7 +1583,8 @@ mod tests {
         mmr = mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         assert_eq!(mmr.size(), expected_size);
-        mmr.sync().await.unwrap();
+        let mmr = mmr.sync().await.unwrap();
+        drop(mmr);
 
         // Simulate a crash that wrote a leaf but not its parent nodes by appending one
         // extra digest to the journal. This creates an invalid structure size.
@@ -1834,7 +1835,8 @@ mod tests {
         mmr = mmr.apply_batch(&batch).unwrap();
         let expected_size = Position::<F>::try_from(Location::<F>::new(LEAF_COUNT as u64)).unwrap();
         assert_eq!(mmr.size(), expected_size);
-        mmr.sync().await.unwrap();
+        let mmr = mmr.sync().await.unwrap();
+        drop(mmr);
 
         // Prune the structure in increments of 50, simulating a partial write after each prune.
         for i in 0usize..200 {
@@ -2291,7 +2293,8 @@ mod tests {
             pinned_nodes: None,
         };
 
-        mmr.sync().await.unwrap();
+        let mmr = mmr.sync().await.unwrap();
+        drop(mmr);
 
         let sync_mmr =
             Merkle::<F, _, Digest, Sequential>::init_sync(context.child("sync"), sync_cfg)
@@ -2372,7 +2375,8 @@ mod tests {
             pinned_nodes: None,
         };
 
-        mmr.sync().await.unwrap();
+        let mmr = mmr.sync().await.unwrap();
+        drop(mmr);
 
         let sync_mmr =
             Merkle::<F, _, Digest, Sequential>::init_sync(context.child("sync"), sync_cfg)
@@ -3179,7 +3183,8 @@ mod tests {
         mmr = mmr.apply_batch(&batch).unwrap();
         let valid_size = mmr.size();
         let valid_root = mmr.root(&hasher, 0).unwrap();
-        mmr.sync().await.unwrap();
+        let mmr = mmr.sync().await.unwrap();
+        drop(mmr);
 
         // Append one extra digest to the journal, simulating a crash that wrote a
         // leaf (for the 4th element) but not its parent nodes. This makes the

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -1113,7 +1113,7 @@ mod tests {
         mmr = mmr.sync().await.unwrap();
         assert!(matches!(mmr.rewind(1).await, Err(Error::Empty)));
 
-        // The failed rewind consumed the mmr; reopen the same partitions.
+        // Reopen the same partitions.
         let mut mmr = Merkle::<F, _, Digest, Sequential>::init(
             context.child("reopen"),
             &hasher,
@@ -1248,8 +1248,7 @@ mod tests {
             Err(Error::ElementPruned(_))
         ));
 
-        // The failed rewind consumed the mmr before mutating anything durable; reopening
-        // recovers the synced state.
+        // The failed rewind mutated nothing durable; reopening recovers the synced state.
         let mmr = Merkle::<F, _, Digest, Sequential>::init(
             element_pruned_context.child("element_pruned_reopen"),
             &hasher,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2776,6 +2776,20 @@ where
     S: Strategy,
     Operation<F, U>: Codec,
 {
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &MerkleizedBatch<F, H::Digest, U, S>,
+    ) -> Result<(), crate::qmdb::Error<F>> {
+        batch
+            .bounds
+            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+    }
+
     /// Apply a batch to the database, returning the range of written operations.
     ///
     /// A batch is valid only if every batch applied to the database since this batch's
@@ -2798,19 +2812,17 @@ where
         ),
     )]
     pub async fn apply_batch(
-        &mut self,
+        mut self,
         batch: Arc<MerkleizedBatch<F, H::Digest, U, S>>,
-    ) -> Result<Range<Location<F>>, crate::qmdb::Error<F>> {
+    ) -> Result<(Self, Range<Location<F>>), crate::qmdb::Error<F>> {
         let _timer = self.metrics.apply_batch_timer();
         self.metrics.apply_batch_calls.inc();
+        self.validate_batch(&batch)?;
         let db_size = *self.last_commit_loc + 1;
-        batch
-            .bounds
-            .validate_apply_to(db_size, self.inactivity_floor_loc)?;
         let start_loc = Location::new(db_size);
 
         // Apply journal (handles its own partial ancestor skipping).
-        self.log.apply_batch(&batch.journal_batch).await?;
+        self.log = self.log.apply_batch(&batch.journal_batch).await?;
 
         // Scoped so the bitmap guard drops before later `.await`s (guard is `!Send`).
         {
@@ -2873,7 +2885,7 @@ where
         self.metrics
             .operations_applied
             .inc_by(*range.end - *range.start);
-        Ok(range)
+        Ok((self, range))
     }
 }
 
@@ -2933,7 +2945,7 @@ fn extract_update_value<F: Family, U: update::Update>(op: &Operation<F, U>) -> U
 mod trait_impls {
     use super::*;
     use crate::qmdb::any::traits::{
-        BatchableDb, MerkleizedBatch as MerkleizedBatchTrait,
+        ApplyBatchResult, BatchableDb, MerkleizedBatch as MerkleizedBatchTrait,
         UnmerkleizedBatch as UnmerkleizedBatchTrait,
     };
     use std::future::Future;
@@ -3040,9 +3052,9 @@ mod trait_impls {
         }
 
         fn apply_batch(
-            &mut self,
+            self,
             batch: Self::Merkleized,
-        ) -> impl Future<Output = Result<Range<Location<F>>, crate::qmdb::Error<F>>> {
+        ) -> impl Future<Output = ApplyBatchResult<Self>> {
             self.apply_batch(batch)
         }
     }
@@ -3071,9 +3083,9 @@ mod trait_impls {
         }
 
         fn apply_batch(
-            &mut self,
+            self,
             batch: Self::Merkleized,
-        ) -> impl Future<Output = Result<Range<Location<F>>, crate::qmdb::Error<F>>> {
+        ) -> impl Future<Output = ApplyBatchResult<Self>> {
             self.apply_batch(batch)
         }
     }
@@ -3633,7 +3645,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("mixed-ancestor-overlaps", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             let key_update = Sha256::hash(b"update-through-all-layers");
             let key_recreate_then_delete = Sha256::hash(b"recreate-then-delete");
@@ -3654,7 +3666,7 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
 
             let applied = db
                 .new_batch()
@@ -3696,8 +3708,8 @@ mod tests {
 
             // Apply only the first ancestor. Applying the child must combine applied
             // fixups from that ancestor with the still-pending parent diff.
-            db.apply_batch(applied).await.unwrap();
-            db.apply_batch(child).await.unwrap();
+            let (db, _) = db.apply_batch(applied).await.unwrap();
+            let (db, _) = db.apply_batch(child).await.unwrap();
 
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.get(&key_update).await.unwrap(), Some(final_update));
@@ -3736,7 +3748,7 @@ mod tests {
                     >;
 
                     let config = fixed_db_config::<OneCap>($partition, &context);
-                    let mut db = TestDb::init(context, config).await.unwrap();
+                    let db = TestDb::init(context, config).await.unwrap();
 
                     let k0 = colliding_digest(0x40 + $shift, 0);
                     let k1 = colliding_digest(0x40 + $shift, 1);
@@ -3767,8 +3779,8 @@ mod tests {
                         .merkleize(&db, None)
                         .await
                         .unwrap();
-                    db.apply_batch(seed).await.unwrap();
-                    db.commit().await.unwrap();
+                    let (db, _) = db.apply_batch(seed).await.unwrap();
+                    let db = db.commit().await.unwrap();
 
                     // Read set with duplicate slots for k0 (0,4) and missing (2,5), plus del_read at 7.
                     let read_keys = [k0, read_only, missing, k1, k0, missing, k2, del_read];
@@ -3844,7 +3856,7 @@ mod tests {
                     assert_eq!(explicit.root(), staged_merkleized.root());
                     assert_eq!(explicit.root(), expanded.root());
 
-                    db.apply_batch(expanded).await.unwrap();
+                    let (db, _) = db.apply_batch(expanded).await.unwrap();
                     assert_eq!(db.get(&k0).await.unwrap(), upserts[2].1);
                     assert_eq!(db.get(&missing).await.unwrap(), indexed_updates[4].1);
                     assert_eq!(db.get(&k1).await.unwrap(), indexed_updates[2].1);
@@ -4075,7 +4087,7 @@ mod tests {
             type TestUpdate = update::Unordered<sha256::Digest, FixedEncoding<sha256::Digest>>;
 
             let config = fixed_db_config::<OneCap>("unordered-staged-prior-mutation", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             let key = colliding_digest(0x95, 0);
             let old = colliding_digest(0x95, 1);
@@ -4091,8 +4103,8 @@ mod tests {
             let old_loc = lookup_sorted(seed.diff.as_slice(), &key)
                 .and_then(DiffEntry::loc)
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let explicit = db
                 .new_batch()
@@ -4259,15 +4271,15 @@ mod tests {
                         };
                         let context = context.child(label);
                         let config = fixed_db_config::<OneCap>(label, &context);
-                        let mut db = TestDb::init(context, config).await.unwrap();
+                        let db = TestDb::init(context, config).await.unwrap();
 
                         let mut seed = db.new_batch();
                         for i in 0..100u64 {
                             seed = seed.write(key(i), Some(val(i)));
                         }
                         let seed = seed.merkleize(&db, None).await.unwrap();
-                        db.apply_batch(seed).await.unwrap();
-                        db.commit().await.unwrap();
+                        let (db, _) = db.apply_batch(seed).await.unwrap();
+                        let mut db = db.commit().await.unwrap();
 
                         let mut grandparent = db.new_batch();
                         for i in 0..10u64 {
@@ -4293,8 +4305,8 @@ mod tests {
                             let (mut values, staged) =
                                 child.stage(&keys[..split], &db).await.unwrap();
 
-                            db.apply_batch(grandparent).await.unwrap();
-                            db.commit().await.unwrap();
+                            (db, _) = db.apply_batch(grandparent).await.unwrap();
+                            db = db.commit().await.unwrap();
 
                             let (range, suffix_values, staged) =
                                 staged.expand(&keys[split..], &db).await.unwrap();
@@ -4314,17 +4326,17 @@ mod tests {
                                 .unwrap()
                         } else {
                             let mut child = parent.new_batch::<Sha256>();
-                            db.apply_batch(grandparent).await.unwrap();
-                            db.commit().await.unwrap();
+                            (db, _) = db.apply_batch(grandparent).await.unwrap();
+                            db = db.commit().await.unwrap();
                             for suffix in &suffixes {
                                 child = child.write(key(*suffix), Some(val(suffix + 3_000)));
                             }
                             child.merkleize(&db, None).await.unwrap()
                         };
 
-                        db.apply_batch(parent).await.unwrap();
-                        db.apply_batch(child).await.unwrap();
-                        db.commit().await.unwrap();
+                        let (db, _) = db.apply_batch(parent).await.unwrap();
+                        let (db, _) = db.apply_batch(child).await.unwrap();
+                        let db = db.commit().await.unwrap();
 
                         for suffix in &suffixes {
                             assert_eq!(
@@ -4375,7 +4387,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("read-locations-all-sources", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             let key_db = colliding_digest(0x30, 0);
             let value_db = colliding_digest(0x30, 1);
@@ -4391,8 +4403,8 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let committed_loc = db.snapshot.get(&key_db).next().copied().unwrap();
 
@@ -4460,7 +4472,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("batch-collision-regression", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
             let key_a = colliding_digest(0xAA, 1);
             let key_b = colliding_digest(0xAA, 0);
 
@@ -4473,8 +4485,8 @@ mod tests {
                 initial = initial.write(colliding_digest(0xAA, i), Some(colliding_digest(0xBB, i)));
             }
             let initial = initial.merkleize(&db, None).await.unwrap();
-            db.apply_batch(initial).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Update only key_a so the colliding sibling key_b remains outside
             // parent.diff and must still be resolved through the committed
@@ -4505,8 +4517,8 @@ mod tests {
 
             let pending_root = pending_child.root();
 
-            db.apply_batch(parent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let committed_child = db
                 .new_batch()
@@ -4520,7 +4532,7 @@ mod tests {
 
             // Apply pending child. The resulting root should match a
             // child built directly from the committed DB.
-            db.apply_batch(pending_child).await.unwrap();
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
             assert_eq!(db.root(), committed_child.root());
 
             db.destroy().await.unwrap();
@@ -4542,7 +4554,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("ordered-batch-collision-regression", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
             let key_a = colliding_digest(0xAA, 1);
             let key_b = colliding_digest(0xAA, 0);
 
@@ -4553,8 +4565,8 @@ mod tests {
                 initial = initial.write(colliding_digest(0xAA, i), Some(colliding_digest(0xBB, i)));
             }
             let initial = initial.merkleize(&db, None).await.unwrap();
-            db.apply_batch(initial).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Update only key_a so the colliding sibling key_b remains outside
             // parent.diff and must still be resolved through the committed
@@ -4582,8 +4594,8 @@ mod tests {
 
             let pending_root = pending_child.root();
 
-            db.apply_batch(parent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let committed_child = db
                 .new_batch()
@@ -4597,7 +4609,7 @@ mod tests {
 
             // Apply pending child. The resulting root should match a
             // child built directly from the committed DB.
-            db.apply_batch(pending_child).await.unwrap();
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
             assert_eq!(db.root(), committed_child.root());
 
             db.destroy().await.unwrap();
@@ -4621,7 +4633,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("seq-commit-basic", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             // Seed an initial key.
             let seed = db
@@ -4630,8 +4642,8 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build batch A.
             let key_a = colliding_digest(0x02, 0);
@@ -4653,8 +4665,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            db.apply_batch(batch_a).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(batch_a).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build the same logical B from committed DB for comparison.
             let committed_b = db
@@ -4666,7 +4678,7 @@ mod tests {
             assert_eq!(batch_b.root(), committed_b.root());
 
             // Apply B.
-            db.apply_batch(batch_b).await.unwrap();
+            let (db, _) = db.apply_batch(batch_b).await.unwrap();
             assert_eq!(db.root(), committed_b.root());
 
             db.destroy().await.unwrap();
@@ -4690,7 +4702,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("seq-commit-base-old-loc", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             // Seed an initial key so we have an existing entry.
             let key = colliding_digest(0x10, 0);
@@ -4700,8 +4712,8 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build batch A that updates the key.
             let val_a = colliding_digest(0x10, 2);
@@ -4728,8 +4740,8 @@ mod tests {
 
             // Commit A. The base_old_loc fixup is deferred to apply_batch,
             // which reads A's diff by reference.
-            db.apply_batch(batch_a).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(batch_a).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Verify B produces the same root as a fresh build.
             let committed_b = db
@@ -4740,7 +4752,7 @@ mod tests {
                 .unwrap();
             assert_eq!(batch_b.root(), committed_b.root());
 
-            db.apply_batch(batch_b).await.unwrap();
+            let (db, _) = db.apply_batch(batch_b).await.unwrap();
             assert_eq!(db.root(), committed_b.root());
 
             db.destroy().await.unwrap();
@@ -4764,7 +4776,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("fork-after-commit", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             // Seed.
             let seed = db
@@ -4773,8 +4785,8 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build batch A.
             let key_a = colliding_digest(0x21, 0);
@@ -4804,8 +4816,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            db.apply_batch(batch_a).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(batch_a).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Verify both produce correct roots.
             let committed_b = db
@@ -4845,7 +4857,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("ff-cross", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             // Grandparent: 2 keys.
             let grandparent = db
@@ -4873,15 +4885,15 @@ mod tests {
                 .unwrap();
 
             // Commit grandparent.
-            db.apply_batch(grandparent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(grandparent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Commit parent.
-            db.apply_batch(parent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Commit child.
-            db.apply_batch(child).await.unwrap();
+            let (db, _) = db.apply_batch(child).await.unwrap();
 
             // All 4 keys should be present.
             for i in 1..=4 {
@@ -4914,7 +4926,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("recreate-deleted-collision", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             // Two colliding keys: K0 (suffix 0) and K6 (suffix 6).
             let k0 = colliding_digest(0xAA, 0);
@@ -4928,8 +4940,8 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(initial).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Parent: delete K0. K6 remains untouched.
             let parent = db
@@ -4950,8 +4962,8 @@ mod tests {
                 .unwrap();
 
             // Commit the parent, then rebuild the same child.
-            db.apply_batch(parent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let committed_child = db
                 .new_batch()
@@ -4987,7 +4999,7 @@ mod tests {
             >;
 
             let config = fixed_db_config::<OneCap>("get-many-basic", &context);
-            let mut db = TestDb::init(context, config).await.unwrap();
+            let db = TestDb::init(context, config).await.unwrap();
 
             let key_db = colliding_digest(0x40, 0);
             let val_db = colliding_digest(0x40, 1);
@@ -5004,8 +5016,8 @@ mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // DB-level get_many.
             let results = db.get_many(&[&key_db, &key_missing]).await.unwrap();

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -637,8 +637,8 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
-        // Journal rewind happens before in-memory undo application. An error at any step
-        // consumes the handle. This step is not restart-stable until a later commit/sync.
+        // Journal rewind happens before in-memory undo application. This step is not
+        // restart-stable until a later commit/sync.
         self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -118,6 +118,25 @@ pub struct Db<
     pub(crate) _update: core::marker::PhantomData<U>,
 }
 
+impl<F, E, U, C, I, H, const N: usize, S> std::fmt::Debug for Db<F, E, C, I, H, U, N, S>
+where
+    F: Family,
+    E: Context,
+    U: Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Db")
+            .field("bounds", &self.bounds())
+            .field("inactivity_floor_loc", &self.inactivity_floor_loc)
+            .finish_non_exhaustive()
+    }
+}
+
 // Shared read-only functionality.
 impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
@@ -408,10 +427,11 @@ where
     ///
     /// - Returns [crate::qmdb::Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
     /// - Returns [`crate::merkle::Error::LocationOverflow`] if `prune_loc` > [`crate::merkle::Family::MAX_LEAVES`].
+    #[boxed]
     pub(crate) async fn prune_log(
-        &mut self,
+        mut self,
         prune_loc: Location<F>,
-    ) -> Result<Location<F>, crate::qmdb::Error<F>> {
+    ) -> Result<(Self, Location<F>), crate::qmdb::Error<F>> {
         if prune_loc > self.inactivity_floor_loc {
             return Err(crate::qmdb::Error::PruneBeyondMinRequired(
                 prune_loc,
@@ -419,7 +439,9 @@ where
             ));
         }
 
-        Ok(self.log.prune(prune_loc).await?)
+        let (log, boundary) = self.log.prune(prune_loc).await?;
+        self.log = log;
+        Ok((self, boundary))
     }
 
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
@@ -436,13 +458,14 @@ where
             inactivity_floor = *self.inactivity_floor_loc,
         ),
     )]
-    pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), crate::qmdb::Error<F>> {
+    #[boxed]
+    pub async fn prune(self, prune_loc: Location<F>) -> Result<Self, crate::qmdb::Error<F>> {
         let _timer = self.metrics.prune_timer();
         self.metrics.prune_calls.inc();
-        let actual_pruned = self.prune_log(prune_loc).await?;
-        self.prune_bitmap(actual_pruned);
-        self.update_metrics();
-        Ok(())
+        let (mut db, actual_pruned) = self.prune_log(prune_loc).await?;
+        db.prune_bitmap(actual_pruned);
+        db.update_metrics();
+        Ok(db)
     }
 
     /// Returns a historical proof for `historical_size` operations, anchored at `start_loc`
@@ -529,12 +552,13 @@ where
             prev_size = *self.last_commit_loc + 1,
         ),
     )]
-    pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
 
         if rewind_size == current_size {
-            return Ok(());
+            return Ok(self);
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(JournalError::InvalidRewind(rewind_size)));
@@ -613,10 +637,9 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
-        // Journal rewind happens before in-memory undo application. If any later step fails, this
-        // handle may be internally diverged and must be dropped by the caller. This step is not
-        // restart-stable until a later commit/sync boundary.
-        self.log.rewind(rewind_size).await?;
+        // Journal rewind happens before in-memory undo application. An error at any step
+        // consumes the handle. This step is not restart-stable until a later commit/sync.
+        self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below
         // rewind_size flip back to active in the loop below. `rewind_size >= bitmap.pruned_bits()`
@@ -675,7 +698,7 @@ where
             .root(self.inactive_peaks(Location::new(rewind_size), rewind_floor))?;
         self.update_metrics();
 
-        Ok(())
+        Ok(self)
     }
 }
 
@@ -814,11 +837,12 @@ where
             active_keys = self.active_keys as u64,
         ),
     )]
-    pub async fn sync(&mut self) -> Result<(), crate::qmdb::Error<F>> {
+    #[boxed]
+    pub async fn sync(mut self) -> Result<Self, crate::qmdb::Error<F>> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
-        self.log.sync().await?;
-        Ok(())
+        self.log = self.log.sync().await?;
+        Ok(self)
     }
 
     /// Durably commit the journal state published by prior [`Db::apply_batch`]
@@ -833,11 +857,12 @@ where
             active_keys = self.active_keys as u64,
         ),
     )]
-    pub async fn commit(&mut self) -> Result<(), crate::qmdb::Error<F>> {
+    #[boxed]
+    pub async fn commit(mut self) -> Result<Self, crate::qmdb::Error<F>> {
         let _timer = self.metrics.commit_timer();
         self.metrics.commit_calls.inc();
-        self.log.commit().await?;
-        Ok(())
+        self.log = self.log.commit().await?;
+        Ok(self)
     }
 
     /// Destroy the db, removing all data from disk.

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -439,8 +439,8 @@ where
             ));
         }
 
-        let (log, boundary) = self.log.prune(prune_loc).await?;
-        self.log = log;
+        let boundary;
+        (self.log, boundary) = self.log.prune(prune_loc).await?;
         Ok((self, boundary))
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -18,8 +18,8 @@
 //!     .write(other_key, None)     // delete
 //!     .merkleize(&db, None).await?;
 //! let root = batch.root();        // speculative root
-//! db.apply_batch(batch).await?;
-//! db.commit().await?;             // flush to disk
+//! let (db, _) = db.apply_batch(batch).await?;
+//! let db = db.commit().await?;    // flush to disk
 //! ```
 //!
 //! ```ignore
@@ -28,8 +28,8 @@
 //! let fork_a = parent.new_batch::<Sha256>().write(k2, Some(v2)).merkleize(&db, None).await?;
 //! let fork_b = parent.new_batch::<Sha256>().write(k3, Some(v3)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(fork_a).await?;                 // OK -- includes parent
-//! assert!(db.apply_batch(fork_b).await.is_err()); // StaleBatch
+//! let (db, _) = db.apply_batch(fork_a).await?;   // OK -- includes parent
+//! assert!(db.validate_batch(&fork_b).is_err());  // StaleBatch; applying would consume the db
 //! ```
 //!
 //! ```ignore
@@ -37,9 +37,9 @@
 //! let parent = db.new_batch().write(k1, Some(v1)).merkleize(&db, None).await?;
 //! let child = parent.new_batch::<Sha256>().write(k2, Some(v2)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(parent).await?;           // apply parent
-//! db.apply_batch(child).await?;            // ancestors skipped automatically
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(parent).await?;   // apply parent
+//! let (db, _) = db.apply_batch(child).await?;    // ancestors skipped automatically
+//! let db = db.commit().await?;
 //! ```
 //!
 //! ```ignore
@@ -47,27 +47,27 @@
 //! let parent = db.new_batch().write(k1, Some(v1)).merkleize(&db, None).await?;
 //! let child = parent.new_batch::<Sha256>().write(k2, Some(v2)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(child).await?;                  // OK -- includes parent
-//! assert!(db.apply_batch(parent).await.is_err()); // StaleBatch
+//! let (db, _) = db.apply_batch(child).await?;    // OK -- includes parent
+//! assert!(db.validate_batch(&parent).is_err());  // StaleBatch
 //! ```
 //!
 //! ```ignore
-//! // 5. Two independent chains. Commit the tail of one; the other chain is stale.
+//! // 5. Two independent chains. Apply the tail of one; the other chain is stale.
 //! let a1 = db.new_batch().write(k1, Some(v1)).merkleize(&db, None).await?;
 //! let a2 = a1.new_batch::<Sha256>().write(k2, Some(v2)).merkleize(&db, None).await?;
 //!
 //! let b1 = db.new_batch().write(k3, Some(v3)).merkleize(&db, None).await?;
 //! let b2 = b1.new_batch::<Sha256>().write(k4, Some(v4)).merkleize(&db, None).await?;
 //!
-//! db.apply_batch(a2).await?;                 // OK -- includes a1
-//! assert!(db.apply_batch(b2).await.is_err()); // StaleBatch
+//! let (db, _) = db.apply_batch(a2).await?;   // OK -- includes a1
+//! assert!(db.validate_batch(&b2).is_err());  // StaleBatch
 //! ```
 
 use crate::{
     Context,
     index::Factory as IndexFactory,
     journal::{
-        authenticated::Inner,
+        authenticated,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
     merkle::{Family, Location, full::Config as MerkleConfig},
@@ -151,7 +151,7 @@ where
     H: Hasher,
     T: Translator,
     I: IndexFactory<T, Value = Location<F>>,
-    J: Inner<E, Item = Operation<F, U>>,
+    J: authenticated::Backing<E, Item = Operation<F, U>>,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
@@ -173,11 +173,11 @@ where
     H: Hasher,
     T: Translator,
     I: IndexFactory<T, Value = Location<F>>,
-    J: Inner<E, Item = Operation<F, U>>,
+    J: authenticated::Backing<E, Item = Operation<F, U>>,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
-    let mut log = J::init::<F, H, S>(
+    let mut log = authenticated::Journal::<F, E, J, H, S>::new(
         context.child("log"),
         cfg.merkle_config,
         cfg.journal_config,
@@ -189,8 +189,8 @@ where
     if log.size() == 0 {
         warn!("Authenticated log is empty, initializing new db");
         let commit_floor = Operation::CommitFloor(None, Location::new(0));
-        log.append(&commit_floor).await?;
-        log.sync().await?;
+        let (appended, _) = log.append(&commit_floor).await?;
+        log = appended.sync().await?;
     }
 
     let index = I::new(context.child("index"), cfg.translator);
@@ -307,11 +307,9 @@ pub(crate) mod test {
     type Error = crate::qmdb::Error<mmr::Family>;
     type Location = mmr::Location;
 
-    pub(crate) trait RewindableDb {
-        fn rewind_to_size(
-            &mut self,
-            size: Location,
-        ) -> impl Future<Output = Result<(), Error>> + Send;
+    pub(crate) trait RewindableDb: Sized {
+        fn rewind_to_size(self, size: Location)
+        -> impl Future<Output = Result<Self, Error>> + Send;
     }
 
     impl<E, U, C, I, H, const N: usize, S> RewindableDb for AnyDb<mmr::Family, E, C, I, H, U, N, S>
@@ -324,9 +322,8 @@ pub(crate) mod test {
         AnyOperation<mmr::Family, U>: Codec,
         S: Strategy,
     {
-        async fn rewind_to_size(&mut self, size: Location) -> Result<(), Error> {
-            self.rewind(size).await?;
-            Ok(())
+        async fn rewind_to_size(self, size: Location) -> Result<Self, Error> {
+            self.rewind(size).await
         }
     }
 
@@ -350,10 +347,11 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
-        db.prune(db.sync_boundary()).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
         let root = db.root();
         let op_count = db.size();
         let inactivity_floor_loc = db.inactivity_floor_loc();
@@ -415,7 +413,7 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         db.commit().await.unwrap();
         let db = reopen_db(context.child("reopen").with_attribute("index", 5)).await;
@@ -494,10 +492,9 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         db.commit().await.unwrap();
-        drop(db);
         let db = reopen_db(context.child("reopen").with_attribute("index", 5)).await;
         assert!(db.size() > 1);
         assert_ne!(db.root(), root);
@@ -508,7 +505,7 @@ pub(crate) mod test {
     /// Test that a commit after an older sync boundary is recovered without another sync.
     pub(crate) async fn test_any_db_commit_after_sync_recovery<F: Family, D, V>(
         context: Context,
-        mut db: D,
+        db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
         make_value: impl Fn(u64) -> V,
     ) where
@@ -527,9 +524,9 @@ pub(crate) mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db.sync().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let db = db.sync().await.unwrap();
 
         // Commit a second batch without syncing; reopen must replay it from the journal.
         let merkleized = db
@@ -538,8 +535,8 @@ pub(crate) mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let committed_root = db.root();
         let committed_size = db.size();
         drop(db);
@@ -562,7 +559,7 @@ pub(crate) mod test {
         V: Clone + CodecShared,
     >(
         context: Context,
-        mut db: D,
+        db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
         make_value: impl Fn(u64) -> V,
     ) where
@@ -571,34 +568,31 @@ pub(crate) mod test {
         const ELEMENTS: u64 = 1000;
 
         // Establish a durable state whose last commit declares an early inactivity floor.
-        {
-            let mut batch = db.new_batch();
-            for i in 0u64..ELEMENTS {
-                let k = Sha256::hash(&i.to_be_bytes());
-                batch = batch.write(k, Some(make_value(i)));
-            }
-            let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+        let mut batch = db.new_batch();
+        for i in 0u64..ELEMENTS {
+            let k = Sha256::hash(&i.to_be_bytes());
+            batch = batch.write(k, Some(make_value(i)));
         }
-        db.commit().await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let durable_floor = db.inactivity_floor_loc();
 
         // Apply (but do not commit) a batch that advances the in-memory floor well past the
         // durable commit's floor.
-        {
-            let mut batch = db.new_batch();
-            for i in 0u64..ELEMENTS {
-                let k = Sha256::hash(&i.to_be_bytes());
-                batch = batch.write(k, Some(make_value(i + 1)));
-            }
-            let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+        let mut batch = db.new_batch();
+        for i in 0u64..ELEMENTS {
+            let k = Sha256::hash(&i.to_be_bytes());
+            batch = batch.write(k, Some(make_value(i + 1)));
         }
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let unsynced_floor = db.inactivity_floor_loc();
         assert!(unsynced_floor > durable_floor);
 
         // Prune to the in-memory floor, then crash before any further commit.
-        db.prune(db.sync_boundary()).await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
         let root = db.root();
         let op_count = db.size();
         drop(db);
@@ -616,7 +610,7 @@ pub(crate) mod test {
     /// Test rewinding to a prior committed state and recovering that state after reopen.
     pub(crate) async fn test_any_db_rewind_recovery<D, V>(
         context: Context,
-        mut db: D,
+        db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
         make_value: impl Fn(u64) -> V,
     ) where
@@ -632,11 +626,11 @@ pub(crate) mod test {
 
         // Empty-batch rewind on an otherwise empty DB should apply no snapshot undos.
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let empty_range = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, empty_range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(empty_range.start, initial_size);
         assert_eq!(db.size(), empty_range.end);
-        db.rewind_to_size(initial_size).await.unwrap();
+        let db = db.rewind_to_size(initial_size).await.unwrap();
         assert_eq!(db.root(), initial_root);
         assert_eq!(db.size(), initial_size);
         assert_eq!(db.inactivity_floor_loc(), initial_floor);
@@ -653,8 +647,8 @@ pub(crate) mod test {
             .merkleize(&db, Some(metadata_a.clone()))
             .await
             .unwrap();
-        let range_a = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, range_a) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let root_a = db.root();
         let size_a = db.size();
@@ -673,8 +667,8 @@ pub(crate) mod test {
             .merkleize(&db, Some(metadata_b))
             .await
             .unwrap();
-        let range_b = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, range_b) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(range_b.start, size_a);
         assert_ne!(db.root(), root_a);
 
@@ -689,13 +683,13 @@ pub(crate) mod test {
             .merkleize(&db, Some(metadata_c))
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Rewind across a tail where:
         // - the same key (`key0`) was updated multiple times
         // - `key1` was deleted then recreated (exercises net-zero active_keys_delta path)
-        db.rewind_to_size(size_a).await.unwrap();
+        let db = db.rewind_to_size(size_a).await.unwrap();
         assert_eq!(db.root(), root_a);
         assert_eq!(db.size(), size_a);
         assert_eq!(db.inactivity_floor_loc(), floor_a);
@@ -705,8 +699,7 @@ pub(crate) mod test {
         assert_eq!(db.get(&key2).await.unwrap(), None);
 
         db.commit().await.unwrap();
-        drop(db);
-        let mut db = reopen_db(context.child("reopen_after_rewind")).await;
+        let db = reopen_db(context.child("reopen_after_rewind")).await;
         assert_eq!(db.root(), root_a);
         assert_eq!(db.size(), size_a);
         assert_eq!(db.inactivity_floor_loc(), floor_a);
@@ -725,22 +718,22 @@ pub(crate) mod test {
             .merkleize(&db, Some(metadata_d.clone()))
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_d.clone()));
         assert_eq!(db.get(&key0).await.unwrap(), Some(make_value(10)));
         assert_eq!(db.get(&key1).await.unwrap(), Some(make_value(11)));
         assert_eq!(db.get(&key2).await.unwrap(), Some(value2_d.clone()));
 
         drop(db);
-        let mut db = reopen_db(context.child("reopen_after_rewind_new_writes")).await;
+        let db = reopen_db(context.child("reopen_after_rewind_new_writes")).await;
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_d));
         assert_eq!(db.get(&key0).await.unwrap(), Some(make_value(10)));
         assert_eq!(db.get(&key1).await.unwrap(), Some(make_value(11)));
         assert_eq!(db.get(&key2).await.unwrap(), Some(value2_d));
 
         // Rewind all the way to the initial commit boundary (`first_commit_loc + 1`).
-        db.rewind_to_size(initial_size).await.unwrap();
+        let db = db.rewind_to_size(initial_size).await.unwrap();
         assert_eq!(db.root(), initial_root);
         assert_eq!(db.size(), initial_size);
         assert_eq!(db.inactivity_floor_loc(), initial_floor);
@@ -750,7 +743,6 @@ pub(crate) mod test {
         assert_eq!(db.get(&key2).await.unwrap(), None);
 
         db.commit().await.unwrap();
-        drop(db);
         let db = reopen_db(context.child("reopen_initial_boundary")).await;
         assert_eq!(db.root(), initial_root);
         assert_eq!(db.size(), initial_size);
@@ -811,16 +803,16 @@ pub(crate) mod test {
             }
 
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         // Commit + sync with pruning raises inactivity floor.
-        db.sync().await.unwrap();
-        db.prune(db.sync_boundary()).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
 
         // Drop & reopen and ensure state matches.
         let root = db.root();
         db.sync().await.unwrap();
-        drop(db);
         let db = reopen_db(context.child("reopened")).await;
         assert_eq!(root, db.root());
 
@@ -872,9 +864,9 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         let root = db.root();
 
         // Reopen and verify the state is preserved correctly.
@@ -908,7 +900,7 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         let root_hash = db.root();
         let original_op_count = db.size();
@@ -941,7 +933,7 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         // Historical proof should remain the same even though database has grown
@@ -987,7 +979,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
             if i == 0 {
                 historical_op_count = db.bounds().end;
             }
@@ -1121,7 +1113,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
             boundaries.push(db.bounds().end);
         }
 
@@ -1188,8 +1180,8 @@ pub(crate) mod test {
                 .merkleize(&db, Some(metadata_value.clone()))
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db = db.commit().await.unwrap();
         }
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_value));
         let k = key_at(ELEMENTS - 1, ELEMENTS - 1);
@@ -1200,8 +1192,8 @@ pub(crate) mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), None);
         assert!(db.get(&k).await.unwrap().is_none());
 
@@ -1523,20 +1515,20 @@ pub(crate) mod test {
         Sha256::hash(&(i + 10000).to_be_bytes())
     }
 
-    /// Helper: commit a batch of key-value writes and return the applied range.
+    /// Helper: commit a batch of key-value writes and return the db and applied range.
     async fn commit_writes(
-        db: &mut UnorderedVariable,
+        db: UnorderedVariable,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
-    ) -> std::ops::Range<crate::mmr::Location> {
+    ) -> (UnorderedVariable, std::ops::Range<crate::mmr::Location>) {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
         }
-        let merkleized = batch.merkleize(&*db, metadata).await.unwrap();
-        let range = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        range
+        let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        (db, range)
     }
 
     /// An empty batch (no mutations) still produces a valid commit.
@@ -1545,7 +1537,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("e", &ctx),
             )
@@ -1555,13 +1547,13 @@ pub(crate) mod test {
             let root_before = db.root();
             let batch = db.new_batch();
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // A CommitFloor op was appended, so root must change.
             assert_ne!(db.root(), root_before);
 
             // DB should still be functional.
-            commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
+            let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
             db.destroy().await.unwrap();
@@ -1574,7 +1566,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("m", &ctx),
             )
@@ -1584,13 +1576,13 @@ pub(crate) mod test {
             let metadata = val(42);
 
             // Batch with metadata.
-            commit_writes(&mut db, [(key(0), Some(val(0)))], Some(metadata)).await;
+            let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], Some(metadata)).await;
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
             // Batch without metadata clears it.
             let batch = db.new_batch();
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), None);
 
             db.destroy().await.unwrap();
@@ -1604,7 +1596,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("g", &ctx),
             )
@@ -1614,7 +1606,7 @@ pub(crate) mod test {
             // Pre-populate with key A.
             let ka = key(0);
             let va = val(0);
-            commit_writes(&mut db, [(ka, Some(va))], None).await;
+            let (db, _) = commit_writes(db, [(ka, Some(va))], None).await;
 
             let kb = key(1);
             let vb = val(1);
@@ -1651,7 +1643,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("mg", &ctx),
             )
@@ -1664,7 +1656,7 @@ pub(crate) mod test {
             let kd = key(3);
 
             // Pre-populate A and B.
-            commit_writes(&mut db, [(ka, Some(val(0))), (kb, Some(val(1)))], None).await;
+            let (db, _) = commit_writes(db, [(ka, Some(val(0))), (kb, Some(val(1)))], None).await;
 
             // Batch: update A, delete B, create C.
             let va2 = val(100);
@@ -1731,7 +1723,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("dr", &ctx),
             )
@@ -1741,7 +1733,7 @@ pub(crate) mod test {
             let ka = key(0);
 
             // Pre-populate with key A.
-            commit_writes(&mut db, [(ka, Some(val(0)))], None).await;
+            let (db, _) = commit_writes(db, [(ka, Some(val(0)))], None).await;
 
             // Parent batch deletes A.
             let mut parent = db.new_batch();
@@ -1756,7 +1748,7 @@ pub(crate) mod test {
             assert_eq!(child_m.get(&ka, &db).await.unwrap(), Some(val(200)));
 
             // Apply and verify DB state.
-            db.apply_batch(child_m).await.unwrap();
+            let (db, _) = db.apply_batch(child_m).await.unwrap();
             assert_eq!(db.get(&ka).await.unwrap(), Some(val(200)));
 
             db.destroy().await.unwrap();
@@ -1770,7 +1762,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("fr", &ctx),
             )
@@ -1779,13 +1771,13 @@ pub(crate) mod test {
 
             // Pre-populate with 100 keys.
             let init: Vec<_> = (0..100).map(|i| (key(i), Some(val(i)))).collect();
-            commit_writes(&mut db, init, None).await;
+            let (db, _) = commit_writes(db, init, None).await;
 
             let floor_before = db.inactivity_floor_loc();
 
             // Update 30 keys.
             let updates: Vec<_> = (0..30).map(|i| (key(i), Some(val(i + 500)))).collect();
-            commit_writes(&mut db, updates, None).await;
+            let (db, _) = commit_writes(db, updates, None).await;
 
             // Floor should have advanced.
             assert!(db.inactivity_floor_loc() > floor_before);
@@ -1816,7 +1808,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("ar", &ctx),
             )
@@ -1825,7 +1817,7 @@ pub(crate) mod test {
 
             // First batch: 5 keys.
             let writes: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
-            let range1 = commit_writes(&mut db, writes, None).await;
+            let (db, range1) = commit_writes(db, writes, None).await;
 
             // Range should start after the initial CommitFloor (location 0).
             assert_eq!(range1.start, crate::mmr::Location::new(1));
@@ -1834,7 +1826,7 @@ pub(crate) mod test {
 
             // Second batch: ranges must be contiguous.
             let writes: Vec<_> = (5..10).map(|i| (key(i), Some(val(i)))).collect();
-            let range2 = commit_writes(&mut db, writes, None).await;
+            let (db, range2) = commit_writes(db, writes, None).await;
             assert_eq!(range2.start, range1.end);
 
             db.destroy().await.unwrap();
@@ -1847,7 +1839,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("dc", &ctx),
             )
@@ -1856,7 +1848,7 @@ pub(crate) mod test {
 
             // Pre-populate with keys 0..5.
             let init: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
-            commit_writes(&mut db, init, None).await;
+            let (db, _) = commit_writes(db, init, None).await;
 
             // Parent: overwrite key 0, add key 5.
             let mut parent = db.new_batch();
@@ -1889,7 +1881,7 @@ pub(crate) mod test {
             assert_eq!(grandchild_m.get(&key(7), &db).await.unwrap(), Some(val(7)));
 
             // Apply.
-            db.apply_batch(grandchild_m).await.unwrap();
+            let (db, _) = db.apply_batch(grandchild_m).await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(100)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(101)));
@@ -1913,7 +1905,7 @@ pub(crate) mod test {
 
             // DB A: sequential apply.
             let ctx_a = ctx.child("a");
-            let mut db_a: UnorderedVariable = UnorderedVariableDb::init(
+            let db_a: UnorderedVariable = UnorderedVariableDb::init(
                 ctx_a.child("db"),
                 variable_db_config::<OneCap>("cms-a", &ctx_a),
             )
@@ -1922,7 +1914,7 @@ pub(crate) mod test {
 
             // DB B: chained batch.
             let ctx_b = ctx.child("b");
-            let mut db_b: UnorderedVariable = UnorderedVariableDb::init(
+            let db_b: UnorderedVariable = UnorderedVariableDb::init(
                 ctx_b.child("db"),
                 variable_db_config::<OneCap>("cms-b", &ctx_b),
             )
@@ -1940,8 +1932,8 @@ pub(crate) mod test {
             ];
 
             // DB A: apply sequentially.
-            commit_writes(&mut db_a, writes1.clone(), None).await;
-            commit_writes(&mut db_a, writes2.clone(), None).await;
+            let (db_a, _) = commit_writes(db_a, writes1.clone(), None).await;
+            let (db_a, _) = commit_writes(db_a, writes2.clone(), None).await;
 
             // DB B: apply as chain.
             let mut parent = db_b.new_batch();
@@ -1955,7 +1947,7 @@ pub(crate) mod test {
                 child = child.write(*k, *v);
             }
             let child_m = child.merkleize(&db_b, None).await.unwrap();
-            db_b.apply_batch(child_m).await.unwrap();
+            let (db_b, _) = db_b.apply_batch(child_m).await.unwrap();
 
             // Both DBs must have the same state.
             assert_eq!(db_a.root(), db_b.root());
@@ -1978,7 +1970,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("cd", &ctx),
             )
@@ -1986,7 +1978,7 @@ pub(crate) mod test {
             .unwrap();
 
             // Pre-populate key A.
-            commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
+            let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
 
             // In one batch: create B then delete B, also create C and delete A.
             let mut batch = db.new_batch();
@@ -1995,7 +1987,7 @@ pub(crate) mod test {
             batch = batch.write(key(2), Some(val(2))); // create C
             batch = batch.write(key(0), None); // delete A
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), None);
             assert_eq!(db.get(&key(1)).await.unwrap(), None);
@@ -2011,7 +2003,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("da", &ctx),
             )
@@ -2020,18 +2012,18 @@ pub(crate) mod test {
 
             // Pre-populate 5 keys.
             let init: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
-            commit_writes(&mut db, init, None).await;
+            let (db, _) = commit_writes(db, init, None).await;
 
             // Delete all 5.
             let deletes: Vec<_> = (0..5).map(|i| (key(i), None)).collect();
-            commit_writes(&mut db, deletes, None).await;
+            let (db, _) = commit_writes(db, deletes, None).await;
 
             for i in 0..5 {
                 assert_eq!(db.get(&key(i)).await.unwrap(), None, "key {i} not deleted");
             }
 
             // DB should still be functional after deleting everything.
-            commit_writes(&mut db, [(key(10), Some(val(10)))], None).await;
+            let (db, _) = commit_writes(db, [(key(10), Some(val(10)))], None).await;
             assert_eq!(db.get(&key(10)).await.unwrap(), Some(val(10)));
 
             db.destroy().await.unwrap();
@@ -2044,7 +2036,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("pf", &ctx),
             )
@@ -2052,7 +2044,7 @@ pub(crate) mod test {
             .unwrap();
 
             // Pre-populate.
-            commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
+            let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
             let root_before = db.root();
 
             // Fork A: update key 0 and create key 1.
@@ -2082,7 +2074,7 @@ pub(crate) mod test {
             assert_eq!(db.get(&key(1)).await.unwrap(), None);
 
             // Apply fork A only.
-            db.apply_batch(fork_a_m).await.unwrap();
+            let (db, _) = db.apply_batch(fork_a_m).await.unwrap();
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(100)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
             assert_eq!(db.get(&key(2)).await.unwrap(), None);
@@ -2097,7 +2089,7 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("frc", &ctx),
             )
@@ -2106,7 +2098,7 @@ pub(crate) mod test {
 
             // Pre-populate with 50 keys.
             let init: Vec<_> = (0..50).map(|i| (key(i), Some(val(i)))).collect();
-            commit_writes(&mut db, init, None).await;
+            let (db, _) = commit_writes(db, init, None).await;
             let floor_before = db.inactivity_floor_loc();
 
             // Parent: update keys 0..20.
@@ -2122,7 +2114,7 @@ pub(crate) mod test {
                 child = child.write(key(i), Some(val(i + 500)));
             }
             let child_m = child.merkleize(&db, None).await.unwrap();
-            db.apply_batch(child_m).await.unwrap();
+            let (db, _) = db.apply_batch(child_m).await.unwrap();
 
             // Floor must have advanced.
             assert!(db.inactivity_floor_loc() > floor_before);
@@ -2153,14 +2145,14 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("ab", &ctx),
             )
             .await
             .unwrap();
 
-            commit_writes(&mut db, [(key(0), Some(val(0)))], None).await;
+            let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
             let root_before = db.root();
 
             // Create, populate, merkleize, then drop without apply.
@@ -2188,7 +2180,7 @@ pub(crate) mod test {
         executor.start(|context| async move {
             let partition = "apply_requires_commit";
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>(partition, &ctx),
             )
@@ -2203,7 +2195,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
@@ -2230,7 +2222,7 @@ pub(crate) mod test {
             const KEYS: u64 = 64;
 
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("rp", &ctx),
             )
@@ -2238,7 +2230,7 @@ pub(crate) mod test {
             .unwrap();
 
             let initial: Vec<_> = (0..KEYS).map(|i| (key(i), Some(val(i)))).collect();
-            let first_range = commit_writes(&mut db, initial, None).await;
+            let (mut db, first_range) = commit_writes(db, initial, None).await;
 
             let mut round = 0u64;
             loop {
@@ -2251,9 +2243,10 @@ pub(crate) mod test {
                 let updates: Vec<_> = (0..KEYS)
                     .map(|i| (key(i), Some(val(1000 + round * KEYS + i))))
                     .collect();
-                commit_writes(&mut db, updates, None).await;
+                (db, _) = commit_writes(db, updates, None).await;
 
-                db.prune(db.sync_boundary()).await.unwrap();
+                let boundary = db.sync_boundary();
+                db = db.prune(boundary).await.unwrap();
                 let bounds = db.bounds();
                 if bounds.start > first_range.start {
                     break;
@@ -2261,7 +2254,9 @@ pub(crate) mod test {
             }
 
             let oldest_retained = db.bounds().start;
-            let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
+            let Err(boundary_err) = db.rewind(oldest_retained).await else {
+                panic!("expected rewind at retained boundary to fail");
+            };
             assert!(
                 matches!(
                     boundary_err,
@@ -2270,7 +2265,15 @@ pub(crate) mod test {
                 "unexpected rewind error at retained boundary: {boundary_err:?}"
             );
 
-            let err = db.rewind(first_range.start).await.unwrap_err();
+            let db: UnorderedVariable = UnorderedVariableDb::init(
+                ctx.child("reopen"),
+                variable_db_config::<OneCap>("rp", &ctx),
+            )
+            .await
+            .unwrap();
+            let Err(err) = db.rewind(first_range.start).await else {
+                panic!("expected rewind to pruned target to fail");
+            };
             assert!(
                 matches!(
                     err,
@@ -2279,6 +2282,12 @@ pub(crate) mod test {
                 "unexpected rewind error: {err:?}"
             );
 
+            let db: UnorderedVariable = UnorderedVariableDb::init(
+                ctx.child("reopen2"),
+                variable_db_config::<OneCap>("rp", &ctx),
+            )
+            .await
+            .unwrap();
             db.destroy().await.unwrap();
         });
     }
@@ -2289,20 +2298,25 @@ pub(crate) mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariable = UnorderedVariableDb::init(
+            let db: UnorderedVariable = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_db_config::<OneCap>("ri", &ctx),
             )
             .await
             .unwrap();
 
+            // Commit one key so the reopen checks below verify real state.
+            let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
+
             let root_before = db.root();
             let size_before = db.size();
-            db.rewind(size_before).await.unwrap();
+            let db = db.rewind(size_before).await.unwrap();
             assert_eq!(db.root(), root_before);
             assert_eq!(db.size(), size_before);
 
-            let zero_err = db.rewind(Location::new(0)).await.unwrap_err();
+            let Err(zero_err) = db.rewind(Location::new(0)).await else {
+                panic!("expected rewind to zero to fail");
+            };
             assert!(
                 matches!(
                     zero_err,
@@ -2310,11 +2324,20 @@ pub(crate) mod test {
                 ),
                 "unexpected rewind error: {zero_err:?}"
             );
+
+            let db: UnorderedVariable = UnorderedVariableDb::init(
+                ctx.child("reopen"),
+                variable_db_config::<OneCap>("ri", &ctx),
+            )
+            .await
+            .unwrap();
             assert_eq!(db.root(), root_before);
             assert_eq!(db.size(), size_before);
 
             let too_large_target = Location::new(*size_before + 1);
-            let too_large_err = db.rewind(too_large_target).await.unwrap_err();
+            let Err(too_large_err) = db.rewind(too_large_target).await else {
+                panic!("expected rewind past size to fail");
+            };
             assert!(
                 matches!(
                     too_large_err,
@@ -2323,6 +2346,13 @@ pub(crate) mod test {
                 ),
                 "unexpected rewind error: {too_large_err:?}"
             );
+
+            let db: UnorderedVariable = UnorderedVariableDb::init(
+                ctx.child("reopen2"),
+                variable_db_config::<OneCap>("ri", &ctx),
+            )
+            .await
+            .unwrap();
             assert_eq!(db.root(), root_before);
             assert_eq!(db.size(), size_before);
 
@@ -2339,14 +2369,14 @@ pub(crate) mod test {
             const KEYS: u64 = 64;
 
             let ctx = context.child("db");
-            let mut db: UnorderedVariable =
+            let db: UnorderedVariable =
                 UnorderedVariableDb::init(ctx.child("storage"), variable_db_config::<OneCap>("rf", &ctx))
                     .await
                     .unwrap();
 
-            commit_writes(&mut db, (0..KEYS).map(|i| (key(i), Some(val(i)))), None).await;
-            commit_writes(
-                &mut db,
+            let (db, _) = commit_writes(db, (0..KEYS).map(|i| (key(i), Some(val(i)))), None).await;
+            let (mut db, _) = commit_writes(
+                db,
                 (0..KEYS).map(|i| (key(i), Some(val(1_000 + i)))),
                 None,
             )
@@ -2367,15 +2397,15 @@ pub(crate) mod test {
                     round <= 8,
                     "failed to advance inactivity floor enough for floor-pruned rewind test"
                 );
-                commit_writes(
-                    &mut db,
+                (db, _) = commit_writes(
+                    db,
                     (0..KEYS).map(|i| (key(i), Some(val(10_000 + round * KEYS + i)))),
                     None,
                 )
                 .await;
             }
 
-            db.prune(prune_loc).await.unwrap();
+            let db = db.prune(prune_loc).await.unwrap();
             let bounds = db.bounds();
             assert!(
                 bounds.start > *target_floor,
@@ -2386,7 +2416,9 @@ pub(crate) mod test {
                 "test setup expected target commit retained; target={rewind_target:?}, bounds={bounds:?}"
             );
 
-            let err = db.rewind(rewind_target).await.unwrap_err();
+            let Err(err) = db.rewind(rewind_target).await else {
+                panic!("expected rewind to floor-pruned target to fail");
+            };
             assert!(
                 matches!(
                     err,
@@ -2395,6 +2427,12 @@ pub(crate) mod test {
                 "unexpected rewind error: {err:?}"
             );
 
+            let db: UnorderedVariable = UnorderedVariableDb::init(
+                ctx.child("reopen"),
+                variable_db_config::<OneCap>("rf", &ctx),
+            )
+            .await
+            .unwrap();
             db.destroy().await.unwrap();
         });
     }
@@ -2422,10 +2460,10 @@ pub(crate) mod test {
             let mut cfg = variable_db_config::<OneCap>("rg", &ctx);
             cfg.journal_config.items_per_section = NZU64!(ITEMS_PER_SECTION);
 
-            let mut db: UnorderedVariable =
+            let db: UnorderedVariable =
                 UnorderedVariableDb::init(ctx.child("storage"), cfg).await.unwrap();
 
-            commit_writes(&mut db, (0..100).map(|i| (key(i), Some(val(i)))), None).await;
+            let (db, _) = commit_writes(db, (0..100).map(|i| (key(i), Some(val(i)))), None).await;
             let rewind_target = db.size();
             // Rewind target must lie below the chunk boundary the buggy prune would advance
             // to; otherwise the unfixed code would not panic on truncate.
@@ -2435,14 +2473,14 @@ pub(crate) mod test {
             );
             let root_at_target = db.root();
 
-            commit_writes(
-                &mut db,
+            let (db, _) = commit_writes(
+                db,
                 (0..700).map(|i| (key(i), Some(val(1_000 + i)))),
                 None,
             )
             .await;
-            commit_writes(
-                &mut db,
+            let (db, _) = commit_writes(
+                db,
                 (0..700).map(|i| (key(i), Some(val(10_000 + i)))),
                 None,
             )
@@ -2468,7 +2506,7 @@ pub(crate) mod test {
             );
             assert!(db.inactivity_floor_loc() >= prune_loc);
 
-            db.prune(prune_loc).await.unwrap();
+            let db = db.prune(prune_loc).await.unwrap();
 
             // Journal could not prune any section, so it still retains from 0. The bitmap
             // must therefore also remain at 0.
@@ -2482,7 +2520,7 @@ pub(crate) mod test {
 
             // Rewind to the still-retained early commit must succeed and restore visible
             // state (root match implies the snapshot was rebuilt correctly).
-            db.rewind(rewind_target).await.unwrap();
+            let db = db.rewind(rewind_target).await.unwrap();
             assert_eq!(db.size(), rewind_target);
             assert_eq!(db.root(), root_at_target);
 
@@ -2519,44 +2557,40 @@ pub(crate) mod test {
     }
 
     async fn commit_writes_mmb(
-        db: &mut MmbVariable,
+        db: MmbVariable,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
-    ) {
+    ) -> MmbVariable {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
         }
-        let merkleized = batch.merkleize(db, metadata).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
     #[test_traced("INFO")]
     fn test_mmb_batch_crud() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_mmb_db(context.child("db"), "crud").await;
+            let db = open_mmb_db(context.child("db"), "crud").await;
 
             // Insert and read back.
-            commit_writes_mmb(&mut db, [(key(0), Some(val(0)))], None).await;
+            let db = commit_writes_mmb(db, [(key(0), Some(val(0)))], None).await;
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
             // Update existing key.
-            commit_writes_mmb(&mut db, [(key(0), Some(val(1)))], None).await;
+            let db = commit_writes_mmb(db, [(key(0), Some(val(1)))], None).await;
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(1)));
 
             // Delete key.
-            commit_writes_mmb(&mut db, [(key(0), None)], None).await;
+            let db = commit_writes_mmb(db, [(key(0), None)], None).await;
             assert!(db.get(&key(0)).await.unwrap().is_none());
 
             // Multiple keys.
-            commit_writes_mmb(
-                &mut db,
-                [(key(1), Some(val(1))), (key(2), Some(val(2)))],
-                None,
-            )
-            .await;
+            let db =
+                commit_writes_mmb(db, [(key(1), Some(val(1))), (key(2), Some(val(2)))], None).await;
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
             assert_eq!(db.get(&key(2)).await.unwrap(), Some(val(2)));
 
@@ -2568,14 +2602,14 @@ pub(crate) mod test {
     fn test_mmb_batch_empty() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_mmb_db(context.child("db"), "empty").await;
+            let db = open_mmb_db(context.child("db"), "empty").await;
             let root_before = db.root();
 
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert_ne!(db.root(), root_before);
 
-            commit_writes_mmb(&mut db, [(key(0), Some(val(0)))], None).await;
+            let db = commit_writes_mmb(db, [(key(0), Some(val(0)))], None).await;
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
             db.destroy().await.unwrap();
@@ -2586,14 +2620,14 @@ pub(crate) mod test {
     fn test_mmb_batch_metadata() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_mmb_db(context.child("db"), "meta").await;
+            let db = open_mmb_db(context.child("db"), "meta").await;
 
             let metadata = val(42);
-            commit_writes_mmb(&mut db, [(key(0), Some(val(0)))], Some(metadata)).await;
+            let db = commit_writes_mmb(db, [(key(0), Some(val(0)))], Some(metadata)).await;
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), None);
 
             db.destroy().await.unwrap();
@@ -2604,16 +2638,14 @@ pub(crate) mod test {
     fn test_mmb_recovery() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db =
-                open_mmb_db(context.child("db").with_attribute("index", 0), "recovery").await;
+            let db = open_mmb_db(context.child("db").with_attribute("index", 0), "recovery").await;
 
-            commit_writes_mmb(&mut db, [(key(0), Some(val(0)))], Some(val(99))).await;
-            commit_writes_mmb(&mut db, [(key(1), Some(val(1)))], None).await;
+            let db = commit_writes_mmb(db, [(key(0), Some(val(0)))], Some(val(99))).await;
+            let db = commit_writes_mmb(db, [(key(1), Some(val(1)))], None).await;
 
             let root = db.root();
             let bounds = db.bounds();
             db.sync().await.unwrap();
-            drop(db);
 
             // Reopen and verify state.
             let db = open_mmb_db(context.child("db").with_attribute("index", 1), "recovery").await;
@@ -2634,11 +2666,11 @@ pub(crate) mod test {
             let mut db = open_mmb_db(context.child("db"), "prune").await;
 
             for i in 0u64..20 {
-                commit_writes_mmb(&mut db, [(key(i), Some(val(i)))], None).await;
+                db = commit_writes_mmb(db, [(key(i), Some(val(i)))], None).await;
             }
 
             let floor = db.inactivity_floor_loc();
-            db.prune(floor).await.unwrap();
+            let db = db.prune(floor).await.unwrap();
 
             // All keys still accessible.
             for i in 0u64..20 {
@@ -2666,7 +2698,7 @@ pub(crate) mod test {
                 let mut batch = db.new_batch();
                 batch = batch.write(key(0), Some(val(0)));
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
             }
 
             let child_merkleized = {
@@ -2675,10 +2707,10 @@ pub(crate) mod test {
                 child = child.write(key(1), Some(val(1)));
                 child.merkleize(&db, None).await.unwrap()
             };
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
 
-            db.apply_batch(child_merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
@@ -2721,13 +2753,12 @@ mod bitmap_tests {
 
     /// Commit, drop, reopen, and assert the rebuilt bitmap matches the in-memory bitmap.
     #[boxed]
-    async fn assert_oracle_round_trip(mut db: AnyTest, context: Context, label: &str) -> AnyTest {
+    async fn assert_oracle_round_trip(db: AnyTest, context: Context, label: &str) -> AnyTest {
         let pre_active = bitmap_active_locs(&db);
         let pre_len = db.bitmap.len();
         let pre_pruned = db.bitmap.pruned_bits();
 
         db.commit().await.unwrap();
-        drop(db);
 
         let db = open_db(context.child("reopen").with_attribute("case", label)).await;
 
@@ -2768,9 +2799,9 @@ mod bitmap_tests {
                 commit_locs.push(Location::<crate::merkle::mmr::Family>::new(
                     batch.bounds.total_size - 1,
                 ));
-                db.apply_batch(batch).await.unwrap();
+                (db, _) = db.apply_batch(batch).await.unwrap();
             }
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Setup sanity: three strictly-increasing commit locations, all within the bitmap.
             assert_eq!(commit_locs.len(), 3);
@@ -2802,7 +2833,7 @@ mod bitmap_tests {
     #[test_traced]
     fn rewind_restores_bitmap_to_target_commit() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db(context.child("db")).await;
+            let db = open_db(context.child("db")).await;
             let k1 = Sha256::hash(&[1]);
             let k2 = Sha256::hash(&[2]);
 
@@ -2813,8 +2844,8 @@ mod bitmap_tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(b1).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(b1).await.unwrap();
+            let db = db.commit().await.unwrap();
             let size_after_first = Location::new(*db.last_commit_loc + 1);
 
             let b2 = db
@@ -2823,7 +2854,7 @@ mod bitmap_tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(b2).await.unwrap();
+            let (db, _) = db.apply_batch(b2).await.unwrap();
 
             // Setup sanity: both keys present, db has advanced past size_after_first.
             assert_eq!(db.get(&k1).await.unwrap(), Some(vec![10]));
@@ -2831,7 +2862,7 @@ mod bitmap_tests {
             assert!(*db.last_commit_loc + 1 > *size_after_first);
 
             // Rewind to the state after the first commit.
-            db.rewind(size_after_first).await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
 
             // Post-rewind: k2 gone, k1 remains.
             assert_eq!(db.get(&k1).await.unwrap(), Some(vec![10]));
@@ -2864,7 +2895,7 @@ mod bitmap_tests {
     #[test_traced]
     fn floor_scan_falls_through_to_uncommitted_tail() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db(context.child("db")).await;
+            let db = open_db(context.child("db")).await;
             let anchor = Sha256::hash(&[0xAA]);
 
             // Commit one key.
@@ -2874,7 +2905,7 @@ mod bitmap_tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(b).await.unwrap();
+            let (db, _) = db.apply_batch(b).await.unwrap();
 
             // Setup sanity: anchor in committed snapshot.
             assert_eq!(db.get(&anchor).await.unwrap(), Some(vec![1]));
@@ -2910,7 +2941,7 @@ mod bitmap_tests {
 
             // Apply. If tail-fallthrough or revalidation were wrong, the produced root would
             // diverge from the merkleize-time root.
-            db.apply_batch(child).await.unwrap();
+            let (db, _) = db.apply_batch(child).await.unwrap();
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.get(&anchor).await.unwrap(), Some(vec![3]));
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -189,8 +189,8 @@ where
     if log.size() == 0 {
         warn!("Authenticated log is empty, initializing new db");
         let commit_floor = Operation::CommitFloor(None, Location::new(0));
-        let (appended, _) = log.append(&commit_floor).await?;
-        log = appended.sync().await?;
+        (log, _) = log.append(&commit_floor).await?;
+        log = log.sync().await?;
     }
 
     let index = I::new(context.child("index"), cfg.translator);

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2281,14 +2281,6 @@ pub(crate) mod test {
                 ),
                 "unexpected rewind error: {err:?}"
             );
-
-            let db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.child("reopen2"),
-                variable_db_config::<OneCap>("rp", &ctx),
-            )
-            .await
-            .unwrap();
-            db.destroy().await.unwrap();
         });
     }
 
@@ -2426,14 +2418,6 @@ pub(crate) mod test {
                 ),
                 "unexpected rewind error: {err:?}"
             );
-
-            let db: UnorderedVariable = UnorderedVariableDb::init(
-                ctx.child("reopen"),
-                variable_db_config::<OneCap>("rf", &ctx),
-            )
-            .await
-            .unwrap();
-            db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -233,9 +233,9 @@ pub(crate) mod test {
 
     /// Applies the given operations to the database.
     pub(crate) async fn apply_ops(
-        db: &mut AnyTest,
+        db: AnyTest,
         ops: Vec<Operation<mmr::Family, Digest, Digest>>,
-    ) {
+    ) -> AnyTest {
         let mut batch = db.new_batch();
         for op in ops {
             match op {
@@ -252,8 +252,9 @@ pub(crate) mod test {
                 }
             }
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db
     }
 
     /// Reads on a batch must not perturb `merkleize`: the root must be byte-identical to a
@@ -280,7 +281,7 @@ pub(crate) mod test {
         }
 
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = create_test_db(ctx.child("db")).await;
+            let db = create_test_db(ctx.child("db")).await;
 
             // Seed 500 keys and commit so they live in the committed snapshot. TwoCap makes
             // translated-bucket collisions common, stressing the sibling-read paths.
@@ -289,8 +290,8 @@ pub(crate) mod test {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build a mixed mutation set: updates of existing keys, deletes of existing keys,
             // and creates of fresh keys. `make` re-derives the set from a seed so both paths
@@ -391,7 +392,7 @@ pub(crate) mod test {
         executor.start(|mut context| async move {
             let seed = context.next_u64();
             let config = fixed_db_config::<OneCap>(&seed.to_string(), &context);
-            let mut db =
+            let db =
                 Db::<mmr::Family, Context, FixedBytes<2>, i32, Sha256, OneCap, Sequential>::init(
                     context, config,
                 )
@@ -411,7 +412,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert_eq!(db.get_all(&key1).await.unwrap().unwrap(), (1, key2.clone()));
             assert_eq!(db.get_all(&key2).await.unwrap().unwrap(), (2, key1.clone()));
             assert!(db.get_span(&key1).await.unwrap().unwrap().1.next_key == key2.clone());
@@ -426,7 +427,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert!(db.get_span(&key1).await.unwrap().unwrap().1.next_key == key2.clone());
             assert!(db.get_span(&key2).await.unwrap().unwrap().1.next_key == key2.clone());
             assert!(db.get_span(&early_key).await.unwrap().unwrap().1.next_key == key2.clone());
@@ -439,7 +440,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert!(db.get_span(&key1).await.unwrap().is_none());
             assert!(db.get_span(&key2).await.unwrap().is_none());
 
@@ -454,7 +455,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert_eq!(db.get_all(&key1).await.unwrap().unwrap(), (1, key2.clone()));
             assert_eq!(db.get_all(&key2).await.unwrap().unwrap(), (2, key1.clone()));
             assert!(db.get_span(&key1).await.unwrap().unwrap().1.next_key == key2.clone());
@@ -471,7 +472,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert!(db.get_span(&key1).await.unwrap().unwrap().1.next_key == key1.clone());
             assert!(db.get_span(&key2).await.unwrap().unwrap().1.next_key == key1.clone());
             assert!(db.get_span(&early_key).await.unwrap().unwrap().1.next_key == key1.clone());
@@ -484,7 +485,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             assert!(db.get_span(&key1).await.unwrap().is_none());
             assert!(db.get_span(&key2).await.unwrap().is_none());
 
@@ -533,21 +534,21 @@ pub(crate) mod test {
                 }
 
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
             }
 
             assert_eq!(db.snapshot.items(), 857);
 
             // Test that apply_batch + sync w/ pruning will raise the activity floor.
-            db.sync().await.unwrap();
-            db.prune(db.sync_boundary()).await.unwrap();
+            let db = db.sync().await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
             assert_eq!(db.snapshot.items(), 857);
 
             // Drop & reopen the db, making sure it has exactly the same state.
             let root = db.root();
             db.sync().await.unwrap();
-            drop(db);
-            let mut db = open_db(context.child("second")).await;
+            let db = open_db(context.child("second")).await;
             assert_eq!(root, db.root());
             assert_eq!(db.snapshot.items(), 857);
 
@@ -572,7 +573,7 @@ pub(crate) mod test {
             // Raise the inactivity floor via an empty batch and make sure historical inactive
             // operations are still provable.
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
             assert!(start_loc < db.inactivity_floor_loc());
 
@@ -604,10 +605,11 @@ pub(crate) mod test {
                     batch = batch.write(k, Some(v));
                 }
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
             }
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
             let root = db.root();
             let op_count = db.bounds().end;
             let inactivity_floor_loc = db.inactivity_floor_loc();
@@ -664,9 +666,10 @@ pub(crate) mod test {
                     batch = batch.write(k, Some(v));
                 }
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
             }
+            drop(db);
             let db = open_db(context.child("sixth")).await;
             assert!(db.bounds().end > op_count);
             assert_ne!(db.inactivity_floor_loc(), inactivity_floor_loc);
@@ -736,9 +739,10 @@ pub(crate) mod test {
                     batch = batch.write(k, Some(v));
                 }
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
             }
+            drop(db);
             let db = open_db(context.child("sixth")).await;
             assert!(db.bounds().end > 1);
             assert_ne!(db.root(), root);
@@ -766,8 +770,8 @@ pub(crate) mod test {
                     map.insert(k, v);
                 }
                 let merkleized = batch.merkleize(&db, Some(metadata)).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
             }
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
             let k = Sha256::hash(&((ELEMENTS - 1) * 1000 + (ELEMENTS - 1)).to_be_bytes());
@@ -780,15 +784,15 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), None);
             assert!(db.get(&k).await.unwrap().is_none());
 
             // Drop & reopen the db, making sure the re-opened db has exactly the same state.
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
             let root = db.root();
             drop(db);
             let db = open_db(context.child("second")).await;
@@ -804,9 +808,9 @@ pub(crate) mod test {
     fn test_ordered_any_fixed_db_historical_proof_basic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context.child("storage")).await;
+            let db = create_test_db(context.child("storage")).await;
             let ops = create_test_ops(20);
-            apply_ops(&mut db, ops.clone()).await;
+            let db = apply_ops(db, ops.clone()).await;
             let root_hash = db.root();
             let original_op_count = db.bounds().end;
 
@@ -832,7 +836,7 @@ pub(crate) mod test {
             // (use different seed to avoid key collisions)
             let more_ops = create_test_ops_seeded(5, 1);
 
-            apply_ops(&mut db, more_ops.clone()).await;
+            let db = apply_ops(db, more_ops.clone()).await;
 
             // Historical proof should remain the same even though database has grown
             let (historical_proof, historical_ops) = db
@@ -863,7 +867,7 @@ pub(crate) mod test {
             // after each batch is a commit-boundary historical size.
             let mut commit_boundary_sizes: Vec<Location> = Vec::new();
             for _ in 0..5 {
-                apply_ops(&mut db, create_test_ops(10)).await;
+                db = apply_ops(db, create_test_ops(10)).await;
                 commit_boundary_sizes.push(db.bounds().end);
             }
 
@@ -923,9 +927,9 @@ pub(crate) mod test {
     fn test_ordered_any_fixed_db_historical_proof_different_historical_sizes() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context.child("storage")).await;
+            let db = create_test_db(context.child("storage")).await;
             let ops = create_test_ops(100);
-            apply_ops(&mut db, ops.clone()).await;
+            let mut db = apply_ops(db, ops.clone()).await;
             let root = db.root();
 
             let start_loc = Location::new(20);
@@ -938,7 +942,7 @@ pub(crate) mod test {
             for i in 1..10 {
                 // Use different seed per iteration to avoid key collisions
                 let more_ops = create_test_ops_seeded(100, i);
-                apply_ops(&mut db, more_ops).await;
+                db = apply_ops(db, more_ops).await;
 
                 let (historical_proof, historical_ops) = db
                     .historical_proof(historical_size, start_loc, max_ops)
@@ -980,7 +984,7 @@ pub(crate) mod test {
                         batch = batch.write(key, Some(i));
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized).await.unwrap();
+                    (db, _) = db.apply_batch(merkleized).await.unwrap();
                 }
 
                 // Make sure the db and ordered map agree on contents & key order.
@@ -1004,7 +1008,7 @@ pub(crate) mod test {
                         batch = batch.write(key, None);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized).await.unwrap();
+                    (db, _) = db.apply_batch(merkleized).await.unwrap();
                 }
 
                 let mut iter = keys.iter();
@@ -1027,7 +1031,7 @@ pub(crate) mod test {
                         batch = batch.write(key, None);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(merkleized).await.unwrap();
+                    (db, _) = db.apply_batch(merkleized).await.unwrap();
                 }
                 assert_eq!(keys.len(), 0);
                 assert!(db.is_empty());
@@ -1107,7 +1111,7 @@ pub(crate) mod test {
     fn test_ordered_any_batch_create_with_cycling_next_key() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_fixed_db(context.child("storage")).await;
+            let db = open_fixed_db(context.child("storage")).await;
 
             let mid_key = FixedBytes::from([0xAAu8; 4]);
             let val = Sha256::fill(1u8);
@@ -1117,7 +1121,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // Batch-insert a preceeding non-translated-colliding key.
             let preceeding_key = FixedBytes::from([0x55u8; 4]);
@@ -1128,7 +1132,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&preceeding_key).await.unwrap().unwrap(), val);
             assert_eq!(db.get(&mid_key).await.unwrap().unwrap(), val);
@@ -1148,7 +1152,7 @@ pub(crate) mod test {
     fn test_ordered_any_batch_delete_middle_key() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_fixed_db(context.child("storage")).await;
+            let db = open_fixed_db(context.child("storage")).await;
 
             let key_a = FixedBytes::from([0x11u8; 4]);
             let key_b = FixedBytes::from([0x22u8; 4]);
@@ -1164,7 +1168,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // Verify initial spans
             let span_a = db.get_span(&key_a).await.unwrap().unwrap();
@@ -1181,7 +1185,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // Verify B is deleted
             assert!(db.get(&key_b).await.unwrap().is_none());
@@ -1202,7 +1206,7 @@ pub(crate) mod test {
     fn test_ordered_any_stream_range() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_fixed_db(context.child("storage")).await;
+            let db = open_fixed_db(context.child("storage")).await;
 
             let key1 = FixedBytes::from([0x10u8, 0x00, 0x00, 0x05]);
             let val = Sha256::fill(1u8);
@@ -1214,7 +1218,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // Start key is in the DB.
             {
@@ -1266,7 +1270,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // Start key is in the DB.
             {
@@ -1334,58 +1338,58 @@ pub(crate) mod test {
         Sha256::hash(&(i + 10000).to_be_bytes())
     }
 
-    /// Helper: commit a batch of key-value writes and return the applied range (generic).
+    /// Helper: commit a batch of key-value writes and return the db and applied range (generic).
     async fn commit_writes_generic<F: Family>(
-        db: &mut AnyTestGeneric<F>,
+        db: AnyTestGeneric<F>,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
-    ) -> std::ops::Range<GenericLocation<F>> {
+    ) -> (AnyTestGeneric<F>, std::ops::Range<GenericLocation<F>>) {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
         }
-        let merkleized = batch.merkleize(db, metadata).await.unwrap();
-        let range = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        range
+        let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        (db, range)
     }
 
     // -- Generic inner functions for parameterized batch tests --
 
     async fn batch_empty_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
         let root_before = db.root();
 
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_ne!(db.root(), root_before);
 
-        commit_writes_generic(&mut db, [(key(0), Some(val(0)))], None).await;
+        let (db, _) = commit_writes_generic(db, [(key(0), Some(val(0)))], None).await;
         assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_metadata_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
         let metadata = val(42);
 
-        commit_writes_generic(&mut db, [(key(0), Some(val(0)))], Some(metadata)).await;
+        let (db, _) = commit_writes_generic(db, [(key(0), Some(val(0)))], Some(metadata)).await;
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_get_read_through_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let ka = key(0);
         let va = val(0);
-        commit_writes_generic(&mut db, [(ka, Some(va))], None).await;
+        let (db, _) = commit_writes_generic(db, [(ka, Some(va))], None).await;
 
         let kb = key(1);
         let vb = val(1);
@@ -1409,14 +1413,15 @@ pub(crate) mod test {
     }
 
     async fn batch_get_on_merkleized_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let ka = key(0);
         let kb = key(1);
         let kc = key(2);
         let kd = key(3);
 
-        commit_writes_generic(&mut db, [(ka, Some(val(0))), (kb, Some(val(1)))], None).await;
+        let (db, _) =
+            commit_writes_generic(db, [(ka, Some(val(0))), (kb, Some(val(1)))], None).await;
 
         let va2 = val(100);
         let vc = val(2);
@@ -1462,10 +1467,10 @@ pub(crate) mod test {
     }
 
     async fn batch_stacked_delete_recreate_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
         let ka = key(0);
 
-        commit_writes_generic(&mut db, [(ka, Some(val(0)))], None).await;
+        let (db, _) = commit_writes_generic(db, [(ka, Some(val(0)))], None).await;
 
         let parent_m = db
             .new_batch()
@@ -1483,30 +1488,30 @@ pub(crate) mod test {
             .unwrap();
         assert_eq!(child_m.get(&ka, &db).await.unwrap(), Some(val(200)));
 
-        db.apply_batch(child_m).await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
         assert_eq!(db.get(&ka).await.unwrap(), Some(val(200)));
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_apply_returns_range_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let writes: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
-        let range1 = commit_writes_generic(&mut db, writes, None).await;
+        let (db, range1) = commit_writes_generic(db, writes, None).await;
 
         assert_eq!(range1.start, GenericLocation::<F>::new(1));
         assert!(range1.end.saturating_sub(*range1.start) >= 6);
 
         let writes: Vec<_> = (5..10).map(|i| (key(i), Some(val(i)))).collect();
-        let range2 = commit_writes_generic(&mut db, writes, None).await;
+        let (db, range2) = commit_writes_generic(db, writes, None).await;
         assert_eq!(range2.start, range1.end);
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_speculative_root_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let mut batch = db.new_batch();
         for i in 0..10 {
@@ -1515,7 +1520,7 @@ pub(crate) mod test {
         let merkleized = batch.merkleize(&db, None).await.unwrap();
         let speculative_root = merkleized.root();
 
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.root(), speculative_root);
 
         db.destroy().await.unwrap();
@@ -1535,9 +1540,9 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         let root = db.root();
 
         drop(db);
@@ -1555,7 +1560,7 @@ pub(crate) mod test {
     fn test_ordered_child_delete_colliding_key_corrupts_next_key() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("db")).await;
+            let db = open_db(context.child("db")).await;
 
             // B and K collide under TwoCap (same first 2 bytes 0xAABB).
             let key_b = Digest::from({
@@ -1581,8 +1586,8 @@ pub(crate) mod test {
             });
 
             // Commit A, B, K.
-            commit_writes_generic(
-                &mut db,
+            let (mut db, _) = commit_writes_generic(
+                db,
                 [
                     (key_a, Some(val(1))),
                     (key_b, Some(val(2))),
@@ -1603,7 +1608,7 @@ pub(crate) mod test {
                     p
                 });
                 padding_keys.push(pk);
-                commit_writes_generic(&mut db, [(pk, Some(val(100 + i)))], None).await;
+                (db, _) = commit_writes_generic(db, [(pk, Some(val(100 + i)))], None).await;
             }
 
             // Sanity: B.next_key == K before the speculative batches.
@@ -1621,8 +1626,8 @@ pub(crate) mod test {
             let child_m = child.merkleize(&db, None).await.unwrap();
 
             // Apply and commit.
-            db.apply_batch(child_m).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_m).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // K should be deleted.
             assert!(db.get(&key_k).await.unwrap().is_none());

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -371,11 +371,12 @@ mod test {
         D: DbAny<F, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
     >(
         context: Context,
-        mut db: D,
+        db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
     ) {
         assert!(db.get_metadata().await.unwrap().is_none());
-        assert!(matches!(db.prune(db.sync_boundary()).await, Ok(())));
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
 
         // Make sure closing/reopening gets us back to the same state, even after adding an
         // uncommitted op, and even without a clean shutdown.
@@ -387,18 +388,19 @@ mod test {
             let _batch = db.new_batch().write(d1, Some(d2));
             // Don't merkleize/apply -- simulates uncommitted write
         }
-        let mut db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
+        let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
         assert_eq!(db.root(), root);
 
         // Test applying an empty batch on an empty db.
         let metadata = Sha256::fill(3u8);
         let merkleized = db.new_batch().merkleize(&db, Some(metadata)).await.unwrap();
-        let range = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(range.start, Location::new(1));
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
         let root = db.root();
-        assert!(matches!(db.prune(db.sync_boundary()).await, Ok(())));
+        let boundary = db.sync_boundary();
+        db.prune(boundary).await.unwrap();
 
         // Re-opening the DB without a clean shutdown should still recover the correct state.
         let mut db = reopen_db(context.child("reopen").with_attribute("index", 2)).await;
@@ -408,12 +410,12 @@ mod test {
         // Confirm the inactivity floor doesn't fall endlessly behind with multiple commits.
         for _ in 1..100 {
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            let _ = db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db = db.commit().await.unwrap();
         }
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         db.destroy().await.unwrap();
     }
 
@@ -423,7 +425,7 @@ mod test {
         D: DbAny<F, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
     >(
         context: Context,
-        mut db: D,
+        db: D,
         reopen_db: impl Fn(Context) -> Pin<Box<dyn Future<Output = D> + Send>>,
     ) {
         // Build a db with 2 keys and make sure updates and deletions of those keys work as
@@ -443,8 +445,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&key1).await.unwrap().unwrap(), val1);
         assert!(db.get(&key2).await.unwrap().is_none());
 
@@ -455,8 +457,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&key1).await.unwrap().unwrap(), val1);
         assert_eq!(db.get(&key2).await.unwrap().unwrap(), val2);
 
@@ -466,8 +468,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert!(db.get(&key1).await.unwrap().is_none());
         assert_eq!(db.get(&key2).await.unwrap().unwrap(), val2);
 
@@ -478,8 +480,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&key1).await.unwrap().unwrap(), new_val);
 
         let merkleized = db
@@ -488,14 +490,14 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&key2).await.unwrap().unwrap(), new_val);
 
         // Empty commit batch (no preceding uncommitted writes).
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Make sure key1 is already active.
         assert!(db.get(&key1).await.unwrap().is_some());
@@ -508,8 +510,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert!(db.get(&key2).await.unwrap().is_some());
         let merkleized = db
             .new_batch()
@@ -517,15 +519,15 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert!(db.get(&key1).await.unwrap().is_none());
         assert!(db.get(&key2).await.unwrap().is_none());
 
         // Empty commit batch.
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Multiple deletions of the same key should be a no-op.
         assert!(db.get(&key1).await.unwrap().is_none());
@@ -536,11 +538,11 @@ mod test {
 
         // Make sure closing/reopening gets us back to the same state.
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let op_count = db.bounds().end;
         let root = db.root();
-        let mut db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
+        let db = reopen_db(context.child("reopen").with_attribute("index", 1)).await;
         assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
 
@@ -551,8 +553,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let merkleized = db
             .new_batch()
@@ -560,8 +562,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let merkleized = db
             .new_batch()
@@ -569,8 +571,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let merkleized = db
             .new_batch()
@@ -578,8 +580,8 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let merkleized = db
             .new_batch()
@@ -587,18 +589,18 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Empty commit batch.
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // Confirm close/reopen gets us back to the same state.
         let op_count = db.bounds().end;
         let root = db.root();
-        let mut db = reopen_db(context.child("reopen").with_attribute("index", 2)).await;
+        let db = reopen_db(context.child("reopen").with_attribute("index", 2)).await;
 
         assert_eq!(db.root(), root);
         assert_eq!(db.bounds().end, op_count);
@@ -606,14 +608,15 @@ mod test {
         // Commit will raise the inactivity floor, which won't affect state but will affect the
         // root.
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         assert!(db.root() != root);
 
         // Pruning inactive ops should not affect current state or root.
         let root = db.root();
-        db.prune(db.sync_boundary()).await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
         assert_eq!(db.root(), root);
 
         db.destroy().await.unwrap();
@@ -626,7 +629,7 @@ mod test {
         F: Family,
         D: DbAny<F, Key = FixedBytes<4>, Value = Digest, Digest = Digest>,
     >(
-        mut db: D,
+        db: D,
     ) {
         // This DB uses a TwoCap so we use equivalent two byte prefixes for each key to ensure
         // collisions.
@@ -644,15 +647,15 @@ mod test {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         assert_eq!(db.get(&key1).await.unwrap().unwrap(), val);
         assert_eq!(db.get(&key2).await.unwrap().unwrap(), val);
         assert_eq!(db.get(&key3).await.unwrap().unwrap(), val);
 
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        let _ = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         db.destroy().await.unwrap();
     }
 }

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -245,9 +245,9 @@ pub(crate) mod test {
 
     /// Applies the given operations to the database.
     pub(crate) async fn apply_ops(
-        db: &mut AnyTest,
+        db: AnyTest,
         ops: Vec<Operation<mmr::Family, Digest, Vec<u8>>>,
-    ) {
+    ) -> AnyTest {
         let mut batch = db.new_batch();
         for op in ops {
             match op {
@@ -264,8 +264,9 @@ pub(crate) mod test {
                 }
             }
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db
     }
 
     // Tests using FixedBytes<4> keys (for edge cases that require specific key patterns)
@@ -312,7 +313,7 @@ pub(crate) mod test {
     fn test_ordered_any_update_batch_create_between_collisions() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_variable_db(context.child("storage")).await;
+            let db = open_variable_db(context.child("storage")).await;
 
             // This DB uses a TwoCap so we use equivalent two byte prefixes for each key to ensure
             // collisions.
@@ -328,7 +329,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&key1).await.unwrap().unwrap(), val);
             assert!(db.get(&key2).await.unwrap().is_none());
@@ -341,7 +342,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&key1).await.unwrap().unwrap(), val);
             assert_eq!(db.get(&key2).await.unwrap().unwrap(), val);
@@ -372,7 +373,7 @@ pub(crate) mod test {
             let val3 = Sha256::fill(3u8);
 
             // Delete the previous key of a newly created key.
-            let mut db = open_variable_db(context.child("first")).await;
+            let db = open_variable_db(context.child("first")).await;
             let merkleized = db
                 .new_batch()
                 .write(key1.clone(), Some(val1))
@@ -380,7 +381,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             let merkleized = db
                 .new_batch()
@@ -389,7 +390,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert!(db.get(&key1).await.unwrap().is_none());
             assert_eq!(db.get(&key2).await.unwrap(), Some(val2));
@@ -401,7 +402,7 @@ pub(crate) mod test {
             db.destroy().await.unwrap();
 
             // Create a key that becomes the previous key of a concurrently deleted key.
-            let mut db = open_variable_db(context.child("second")).await;
+            let db = open_variable_db(context.child("second")).await;
             let merkleized = db
                 .new_batch()
                 .write(key1.clone(), Some(val1))
@@ -409,7 +410,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             let merkleized = db
                 .new_batch()
@@ -418,7 +419,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&key1).await.unwrap(), Some(val1));
             assert_eq!(db.get(&key2).await.unwrap(), Some(val2));
@@ -447,11 +448,11 @@ pub(crate) mod test {
     fn test_ordered_sequential_commit_basic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
             // Seed with initial data so the ordered index is non-trivial.
-            apply_ops(&mut db, create_test_ops(10)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(10)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -475,12 +476,12 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Both keys should be readable.
             assert_eq!(db.get(&key_a).await.unwrap().unwrap(), val_a);
@@ -497,10 +498,10 @@ pub(crate) mod test {
     fn test_ordered_sequential_commit_delete_after_insert() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -520,13 +521,13 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_x);
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // key_x should be deleted.
             assert!(db.get(&key_x).await.unwrap().is_none());
@@ -541,10 +542,10 @@ pub(crate) mod test {
     fn test_ordered_sequential_commit_overlapping_keys() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -565,13 +566,13 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_a);
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_b);
 

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -479,7 +479,8 @@ where
         let boundary = sync_db.sync_boundary();
         let sync_db = sync_db.prune(boundary).await.unwrap();
 
-        sync_db.sync().await.unwrap();
+        let sync_db = sync_db.sync().await.unwrap();
+        drop(sync_db);
 
         // Capture target state
         let sync_root = H::sync_target_root(&target_db);
@@ -1615,7 +1616,8 @@ where
         // commit already done in apply_ops
         let boundary = sync_db.sync_boundary();
         let sync_db = sync_db.prune(boundary).await.unwrap();
-        sync_db.sync().await.unwrap();
+        let sync_db = sync_db.sync().await.unwrap();
+        drop(sync_db);
 
         // Add more operations to the target db
         // (use different seed to avoid key collisions)

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -226,11 +226,12 @@ where
     let executor = deterministic::Runner::default();
     executor.start(|mut context| async move {
         // Create and populate target database
-        let mut target_db = H::init_db(context.child("target")).await;
+        let target_db = H::init_db(context.child("target")).await;
         let target_ops = H::create_ops(target_db_ops);
-        target_db = H::apply_ops(target_db, target_ops).await;
+        let target_db = H::apply_ops(target_db, target_ops).await;
         // commit already done in apply_ops
-        target_db.prune(target_db.sync_boundary()).await.unwrap();
+        let boundary = target_db.sync_boundary();
+        let target_db = target_db.prune(boundary).await.unwrap();
 
         let target_op_count = target_db.bounds().end;
         let target_inactivity_floor = target_db.inactivity_floor_loc();
@@ -462,22 +463,23 @@ where
 
         // Create two databases with their own configs
         let target_config = H::config(&context.next_u64().to_string(), &context);
-        let mut target_db = H::init_db_with_config(context.child("target"), target_config).await;
+        let target_db = H::init_db_with_config(context.child("target"), target_config).await;
         let sync_config = H::config(&context.next_u64().to_string(), &context);
         let client_context = context.child("client");
-        let mut sync_db =
+        let sync_db =
             H::init_db_with_config(client_context.child("client"), sync_config.clone()).await;
 
         // Apply the same operations to both databases
-        target_db = H::apply_ops(target_db, target_ops.clone()).await;
-        sync_db = H::apply_ops(sync_db, target_ops.clone()).await;
+        let target_db = H::apply_ops(target_db, target_ops.clone()).await;
+        let sync_db = H::apply_ops(sync_db, target_ops.clone()).await;
         // commit already done in apply_ops
 
-        target_db.prune(target_db.sync_boundary()).await.unwrap();
-        sync_db.prune(sync_db.sync_boundary()).await.unwrap();
+        let boundary = target_db.sync_boundary();
+        let target_db = target_db.prune(boundary).await.unwrap();
+        let boundary = sync_db.sync_boundary();
+        let sync_db = sync_db.prune(boundary).await.unwrap();
 
         sync_db.sync().await.unwrap();
-        drop(sync_db);
 
         // Capture target state
         let sync_root = H::sync_target_root(&target_db);
@@ -1599,25 +1601,26 @@ where
     let executor = deterministic::Runner::default();
     executor.start(|mut context| async move {
         // Create and populate two databases.
-        let mut target_db = H::init_db(context.child("target")).await;
+        let target_db = H::init_db(context.child("target")).await;
         let sync_db_config = H::config(&context.next_u64().to_string(), &context);
         let client_context = context.child("client");
-        let mut sync_db =
+        let sync_db =
             H::init_db_with_config(client_context.child("client"), sync_db_config.clone()).await;
         let original_ops = H::create_ops(NUM_OPS);
-        target_db = H::apply_ops(target_db, original_ops.clone()).await;
+        let target_db = H::apply_ops(target_db, original_ops.clone()).await;
         // commit already done in apply_ops
-        target_db.prune(target_db.sync_boundary()).await.unwrap();
-        sync_db = H::apply_ops(sync_db, original_ops.clone()).await;
+        let boundary = target_db.sync_boundary();
+        let target_db = target_db.prune(boundary).await.unwrap();
+        let sync_db = H::apply_ops(sync_db, original_ops.clone()).await;
         // commit already done in apply_ops
-        sync_db.prune(sync_db.sync_boundary()).await.unwrap();
+        let boundary = sync_db.sync_boundary();
+        let sync_db = sync_db.prune(boundary).await.unwrap();
         sync_db.sync().await.unwrap();
-        drop(sync_db);
 
         // Add more operations to the target db
         // (use different seed to avoid key collisions)
         let more_ops = H::create_ops_seeded(NUM_ADDITIONAL_OPS, 1);
-        target_db = H::apply_ops(target_db, more_ops).await;
+        let target_db = H::apply_ops(target_db, more_ops).await;
         // commit already done in apply_ops
 
         // Capture target db state for comparison
@@ -1673,11 +1676,12 @@ where
     let executor = deterministic::Runner::default();
     executor.start(|mut context| async move {
         // Create and populate a source database
-        let mut source_db = H::init_db(context.child("source")).await;
+        let source_db = H::init_db(context.child("source")).await;
         let ops = H::create_ops(NUM_OPS);
-        source_db = H::apply_ops(source_db, ops).await;
+        let source_db = H::apply_ops(source_db, ops).await;
         // commit already done in apply_ops
-        source_db.prune(source_db.sync_boundary()).await.unwrap();
+        let boundary = source_db.sync_boundary();
+        let source_db = source_db.prune(boundary).await.unwrap();
 
         let lower_bound = source_db.sync_boundary();
         let upper_bound = source_db.bounds().end;
@@ -1826,10 +1830,11 @@ where
     let executor = deterministic::Runner::default();
     executor.start(|mut context| async move {
         // Build a target database with some operations and prune so that pinned nodes are needed.
-        let mut target_db = H::init_db(context.child("target")).await;
+        let target_db = H::init_db(context.child("target")).await;
         let ops = H::create_ops(20);
-        target_db = H::apply_ops(target_db, ops).await;
-        target_db.prune(target_db.sync_boundary()).await.unwrap();
+        let target_db = H::apply_ops(target_db, ops).await;
+        let boundary = target_db.sync_boundary();
+        let target_db = target_db.prune(boundary).await.unwrap();
 
         let sync_root = H::sync_target_root(&target_db);
         let lower_bound = target_db.sync_boundary();
@@ -1964,10 +1969,8 @@ where
         let mut seed = 0;
         loop {
             target_db = H::apply_ops(target_db, H::create_ops_seeded(32, seed)).await;
-            target_db
-                .prune(target_db.sync_boundary())
-                .await
-                .unwrap();
+            let boundary = target_db.sync_boundary();
+            target_db = target_db.prune(boundary).await.unwrap();
 
             if target_db.inactivity_floor_loc() > Location::new(0) {
                 break;
@@ -2248,16 +2251,15 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<
                 crate::qmdb::any::ordered::fixed::Operation<crate::mmr::Family, Digest, Digest>,
             >,
         ) -> Self::Db {
-            crate::qmdb::any::ordered::fixed::test::apply_ops(&mut db, ops).await;
+            let db = crate::qmdb::any::ordered::fixed::test::apply_ops(db, ops).await;
             let merkleized = db.new_batch().merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2310,20 +2312,19 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<
                 crate::qmdb::any::ordered::variable::Operation<crate::mmr::Family, Digest, Vec<u8>>,
             >,
         ) -> Self::Db {
-            crate::qmdb::any::ordered::variable::test::apply_ops(&mut db, ops).await;
+            let db = crate::qmdb::any::ordered::variable::test::apply_ops(db, ops).await;
             let merkleized = db
                 .new_batch()
                 .merkleize(&db, None::<Vec<u8>>)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2373,16 +2374,15 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<
                 crate::qmdb::any::unordered::fixed::Operation<crate::mmr::Family, Digest, Digest>,
             >,
         ) -> Self::Db {
-            crate::qmdb::any::unordered::fixed::test::apply_ops(&mut db, ops).await;
+            let db = crate::qmdb::any::unordered::fixed::test::apply_ops(db, ops).await;
             let merkleized = db.new_batch().merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2436,7 +2436,7 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<
                 crate::qmdb::any::unordered::Operation<
                     crate::mmr::Family,
@@ -2445,15 +2445,14 @@ mod harnesses {
                 >,
             >,
         ) -> Self::Db {
-            crate::qmdb::any::unordered::variable::test::apply_ops(&mut db, ops).await;
+            let db = crate::qmdb::any::unordered::variable::test::apply_ops(db, ops).await;
             let merkleized = db
                 .new_batch()
                 .merkleize(&db, None::<Vec<u8>>)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2513,7 +2512,7 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::ordered::fixed::Operation<mmb::Family, Digest, Digest>>,
         ) -> Self::Db {
             use crate::qmdb::any::operation::Operation;
@@ -2530,11 +2529,10 @@ mod harnesses {
                 }
             }
             let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let merkleized = db.new_batch().merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2597,7 +2595,7 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::ordered::variable::Operation<mmb::Family, Digest, Vec<u8>>>,
         ) -> Self::Db {
             use crate::qmdb::any::operation::Operation;
@@ -2614,15 +2612,14 @@ mod harnesses {
                 }
             }
             let merkleized = batch.merkleize(&db, None::<Vec<u8>>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let merkleized = db
                 .new_batch()
                 .merkleize(&db, None::<Vec<u8>>)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2682,7 +2679,7 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<crate::qmdb::any::unordered::fixed::Operation<mmb::Family, Digest, Digest>>,
         ) -> Self::Db {
             use crate::qmdb::any::operation::Operation;
@@ -2699,11 +2696,10 @@ mod harnesses {
                 }
             }
             let merkleized = batch.merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let merkleized = db.new_batch().merkleize(&db, None::<Digest>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 
@@ -2767,7 +2763,7 @@ mod harnesses {
         }
 
         async fn apply_ops(
-            mut db: Self::Db,
+            db: Self::Db,
             ops: Vec<
                 crate::qmdb::any::unordered::variable::Operation<mmb::Family, Digest, Vec<u8>>,
             >,
@@ -2786,15 +2782,14 @@ mod harnesses {
                 }
             }
             let merkleized = batch.merkleize(&db, None::<Vec<u8>>).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let merkleized = db
                 .new_batch()
                 .merkleize(&db, None::<Vec<u8>>)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db.commit().await.unwrap()
         }
     }
 }

--- a/storage/src/qmdb/any/traits.rs
+++ b/storage/src/qmdb/any/traits.rs
@@ -36,8 +36,12 @@ pub trait MerkleizedBatch: Sized {
     fn root(&self) -> Self::Digest;
 }
 
+/// The result of applying a batch: the database and the range of written operations.
+pub type ApplyBatchResult<D> =
+    Result<(D, Range<Location<<D as BatchableDb>::Family>>), Error<<D as BatchableDb>::Family>>;
+
 /// Db that supports updates through a batch API.
-pub trait BatchableDb {
+pub trait BatchableDb: Sized {
     type Family: Family;
     type K;
     type V;
@@ -54,11 +58,8 @@ pub trait BatchableDb {
     /// Create a new speculative batch of operations with this database as its parent.
     fn new_batch(&self) -> Self::Batch;
 
-    /// Apply a merkleized batch.
-    fn apply_batch(
-        &mut self,
-        batch: Self::Merkleized,
-    ) -> impl Future<Output = Result<Range<Location<Self::Family>>, Error<Self::Family>>>;
+    /// Apply a merkleized batch, returning the range of written operations.
+    fn apply_batch(self, batch: Self::Merkleized) -> impl Future<Output = ApplyBatchResult<Self>>;
 }
 
 /// Unified trait for an authenticated database.
@@ -101,18 +102,18 @@ pub trait DbAny<F: Family>:
     ) -> impl Future<Output = Result<Option<<Self as DbAny<F>>::Value>, Error<F>>> + Send;
 
     /// Prune historical operations prior to `loc`.
-    fn prune(&mut self, loc: Location<F>) -> impl Future<Output = Result<(), Error<F>>> + Send;
+    fn prune(self, loc: Location<F>) -> impl Future<Output = Result<Self, Error<F>>> + Send;
 
     /// Durably persist the database, guaranteeing the current state will survive a crash.
     ///
     /// For a stronger guarantee that eliminates potential recovery, use [Self::sync] instead.
-    fn commit(&mut self) -> impl Future<Output = Result<(), Error<F>>> + Send;
+    fn commit(self) -> impl Future<Output = Result<Self, Error<F>>> + Send;
 
     /// Durably persist the database, guaranteeing the current state will survive a crash, and that
     /// no recovery will be needed on startup.
     ///
     /// This provides a stronger guarantee than [Self::commit] but may be slower.
-    fn sync(&mut self) -> impl Future<Output = Result<(), Error<F>>> + Send;
+    fn sync(self) -> impl Future<Output = Result<Self, Error<F>>> + Send;
 
     /// Destroy the database, removing all data from disk.
     fn destroy(self) -> impl Future<Output = Result<(), Error<F>>> + Send
@@ -203,17 +204,17 @@ macro_rules! impl_db_any {
             }
 
             async fn prune(
-                &mut self,
+                self,
                 loc: $crate::merkle::Location<$fam>,
-            ) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
+            ) -> ::core::result::Result<Self, $crate::qmdb::Error<$fam>> {
                 <$ty>::prune(self, loc).await
             }
 
-            async fn commit(&mut self) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
+            async fn commit(self) -> ::core::result::Result<Self, $crate::qmdb::Error<$fam>> {
                 <$ty>::commit(self).await
             }
 
-            async fn sync(&mut self) -> ::core::result::Result<(), $crate::qmdb::Error<$fam>> {
+            async fn sync(self) -> ::core::result::Result<Self, $crate::qmdb::Error<$fam>> {
                 <$ty>::sync(self).await
             }
 

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -190,7 +190,7 @@ pub(crate) mod test {
             type ParTest = Db<mmr::Family, Context, Digest, Digest, Sha256, TwoCap, Rayon>;
             let strategy = context.strategy(NZUsize!(2));
             let cfg = fixed_db_config_with_strategy::<TwoCap, Rayon>("fused", &context, strategy);
-            let mut db = ParTest::init(context, cfg).await.unwrap();
+            let db = ParTest::init(context, cfg).await.unwrap();
 
             let mut rng = TestRng::new(7);
             let mut keys = Vec::with_capacity(4300);
@@ -202,8 +202,8 @@ pub(crate) mod test {
                 batch = batch.write(key, Some(value));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Mix in absent keys so some probes resolve to nothing.
             for _ in 0..100 {
@@ -242,7 +242,7 @@ pub(crate) mod test {
             >;
             let strategy = context.strategy(NZUsize!(2));
             let cfg = fixed_db_config_with_strategy::<TwoCap, Rayon>("cancel", &context, strategy);
-            let mut db = ParTest::init(context.child("db"), cfg).await.unwrap();
+            let db = ParTest::init(context.child("db"), cfg).await.unwrap();
 
             // Populate and commit so later snapshots carry committed nodes.
             let mut rng = TestRng::new(11);
@@ -255,8 +255,8 @@ pub(crate) mod test {
                 batch = batch.write(key, Some(value));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let mut db = db.commit().await.unwrap();
 
             // Drop one merkleize after a single poll and race another against a timer, so the
             // future is abandoned at whatever stage it reached (possibly mid-hashing-job).
@@ -306,8 +306,8 @@ pub(crate) mod test {
                     .merkleize(&db, None)
                     .await
                     .unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
                 assert_eq!(db.get(&key).await.unwrap(), Some(value));
                 keys[0].1 = value;
                 for (key, value) in &keys[1..] {
@@ -350,9 +350,9 @@ pub(crate) mod test {
 
     /// Applies the given operations to the database.
     pub(crate) async fn apply_ops(
-        db: &mut AnyTest,
+        db: AnyTest,
         ops: Vec<Operation<mmr::Family, Digest, Digest>>,
-    ) {
+    ) -> AnyTest {
         let mut batch = db.new_batch();
         for op in ops {
             match op {
@@ -367,24 +367,25 @@ pub(crate) mod test {
                 }
             }
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db
     }
 
-    /// Helper: commit a batch of key-value writes and return the applied range (generic).
+    /// Helper: commit a batch of key-value writes and return the db and applied range (generic).
     async fn commit_writes_generic<F: Family>(
-        db: &mut AnyTestGeneric<F>,
+        db: AnyTestGeneric<F>,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
-    ) -> std::ops::Range<GenericLocation<F>> {
+    ) -> (AnyTestGeneric<F>, std::ops::Range<GenericLocation<F>>) {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
         }
-        let merkleized = batch.merkleize(db, metadata).await.unwrap();
-        let range = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        range
+        let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        (db, range)
     }
 
     fn key(i: u64) -> Digest {
@@ -403,10 +404,10 @@ pub(crate) mod test {
             // Populate a database with churny operations (repeated updates and deletes drive the
             // collision resolution that the cache accelerates), then commit and drop it.
             let cfg = fixed_db_config::<TwoCap>("cache_equiv", &context);
-            let mut db = AnyTest::init(context.child("populate"), cfg).await.unwrap();
-            apply_ops(&mut db, create_test_ops(10_000)).await;
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
+            let db = AnyTest::init(context.child("populate"), cfg).await.unwrap();
+            let db = apply_ops(db, create_test_ops(10_000)).await;
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
             let root = db.root();
             drop(db);
 
@@ -432,7 +433,7 @@ pub(crate) mod test {
     #[test_traced("INFO")]
     fn test_any_unordered_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = open_db_generic::<mmr::Family>(ctx.child("db")).await;
+            let db = open_db_generic::<mmr::Family>(ctx.child("db")).await;
             let k = key(1);
             let v = val(1);
             let batch = db
@@ -441,12 +442,12 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(batch).await.unwrap();
+            let (db, _) = db.apply_batch(batch).await.unwrap();
             assert_eq!(db.get(&k).await.unwrap(), Some(v));
             assert_eq!(db.get_many(&[&k]).await.unwrap(), vec![Some(v)]);
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
-            db.prune(Location::new(0)).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            let _db = db.prune(Location::new(0)).await.unwrap();
 
             let metrics = ctx.encode();
             for expected in [
@@ -492,7 +493,7 @@ pub(crate) mod test {
         >;
 
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = create_test_db(ctx.child("db")).await;
+            let db = create_test_db(ctx.child("db")).await;
 
             // Seed 2000 keys and commit so they live in the committed snapshot.
             let mut seed = db.new_batch();
@@ -500,8 +501,8 @@ pub(crate) mod test {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build a mixed mutation set: updates of existing keys, deletes of existing keys,
             // and creates of fresh keys. `make` re-derives the set from a seed so both paths and
@@ -622,40 +623,40 @@ pub(crate) mod test {
     // -- Generic inner functions for parameterized batch tests --
 
     async fn batch_empty_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
         let root_before = db.root();
 
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_ne!(db.root(), root_before);
 
         // DB should still be functional.
-        commit_writes_generic(&mut db, [(key(0), Some(val(0)))], None).await;
+        let (db, _) = commit_writes_generic(db, [(key(0), Some(val(0)))], None).await;
         assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_metadata_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
         let metadata = val(42);
 
-        commit_writes_generic(&mut db, [(key(0), Some(val(0)))], Some(metadata)).await;
+        let (db, _) = commit_writes_generic(db, [(key(0), Some(val(0)))], Some(metadata)).await;
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_get_read_through_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let ka = key(0);
         let va = val(0);
-        commit_writes_generic(&mut db, [(ka, Some(va))], None).await;
+        let (db, _) = commit_writes_generic(db, [(ka, Some(va))], None).await;
 
         let kb = key(1);
         let vb = val(1);
@@ -679,14 +680,15 @@ pub(crate) mod test {
     }
 
     async fn batch_get_on_merkleized_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let ka = key(0);
         let kb = key(1);
         let kc = key(2);
         let kd = key(3);
 
-        commit_writes_generic(&mut db, [(ka, Some(val(0))), (kb, Some(val(1)))], None).await;
+        let (db, _) =
+            commit_writes_generic(db, [(ka, Some(val(0))), (kb, Some(val(1)))], None).await;
 
         let va2 = val(100);
         let vc = val(2);
@@ -738,10 +740,10 @@ pub(crate) mod test {
     }
 
     async fn batch_stacked_delete_recreate_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
         let ka = key(0);
 
-        commit_writes_generic(&mut db, [(ka, Some(val(0)))], None).await;
+        let (db, _) = commit_writes_generic(db, [(ka, Some(val(0)))], None).await;
 
         let parent_m = db
             .new_batch()
@@ -759,30 +761,30 @@ pub(crate) mod test {
             .unwrap();
         assert_eq!(child_m.get(&ka, &db).await.unwrap(), Some(val(200)));
 
-        db.apply_batch(child_m).await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
         assert_eq!(db.get(&ka).await.unwrap(), Some(val(200)));
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_apply_returns_range_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let writes: Vec<_> = (0..5).map(|i| (key(i), Some(val(i)))).collect();
-        let range1 = commit_writes_generic(&mut db, writes, None).await;
+        let (db, range1) = commit_writes_generic(db, writes, None).await;
 
         assert_eq!(range1.start, GenericLocation::<F>::new(1));
         assert!(range1.end.saturating_sub(*range1.start) >= 6);
 
         let writes: Vec<_> = (5..10).map(|i| (key(i), Some(val(i)))).collect();
-        let range2 = commit_writes_generic(&mut db, writes, None).await;
+        let (db, range2) = commit_writes_generic(db, writes, None).await;
         assert_eq!(range2.start, range1.end);
 
         db.destroy().await.unwrap();
     }
 
     async fn batch_speculative_root_inner<F: Family>(context: deterministic::Context) {
-        let mut db = open_db_generic::<F>(context.child("db")).await;
+        let db = open_db_generic::<F>(context.child("db")).await;
 
         let mut batch = db.new_batch();
         for i in 0..10 {
@@ -791,7 +793,7 @@ pub(crate) mod test {
         let merkleized = batch.merkleize(&db, None).await.unwrap();
         let speculative_root = merkleized.root();
 
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.root(), speculative_root);
 
         db.destroy().await.unwrap();
@@ -799,7 +801,7 @@ pub(crate) mod test {
 
     async fn log_replay_inner<F: Family>(context: deterministic::Context) {
         let db_context = context.child("db");
-        let mut db = open_db_generic::<F>(db_context.child("db")).await;
+        let db = open_db_generic::<F>(db_context.child("db")).await;
 
         // Update the same key many times within a single batch.
         const UPDATES: u64 = 100;
@@ -810,8 +812,8 @@ pub(crate) mod test {
             batch = batch.write(k, Some(v));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let root = db.root();
 
         // Simulate a failed commit and test that the log replay doesn't leave behind old data.
@@ -942,9 +944,9 @@ pub(crate) mod test {
     fn test_any_fixed_db_historical_proof_basic() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context.child("storage")).await;
+            let db = create_test_db(context.child("storage")).await;
             let ops = create_test_ops(20);
-            apply_ops(&mut db, ops.clone()).await;
+            let db = apply_ops(db, ops.clone()).await;
             let root_hash = db.root();
             let original_op_count = db.bounds().end;
 
@@ -969,7 +971,7 @@ pub(crate) mod test {
             // Add more operations to the database
             // (use different seed to avoid key collisions)
             let more_ops = create_test_ops_seeded(5, 1);
-            apply_ops(&mut db, more_ops.clone()).await;
+            let db = apply_ops(db, more_ops.clone()).await;
 
             // Historical proof should remain the same even though database has grown
             let (historical_proof, historical_ops) = db
@@ -1009,7 +1011,7 @@ pub(crate) mod test {
             // after each batch is a commit-boundary historical size.
             let mut commit_boundary_sizes: Vec<Location> = Vec::new();
             for _ in 0..5 {
-                apply_ops(&mut db, create_test_ops(10)).await;
+                db = apply_ops(db, create_test_ops(10)).await;
                 commit_boundary_sizes.push(db.bounds().end);
             }
 
@@ -1078,7 +1080,7 @@ pub(crate) mod test {
             let mut offset = 0usize;
             let mut checkpoints = Vec::new();
             for chunk in [20usize, 15, 25, 30, 10] {
-                apply_ops(&mut db, ops[offset..offset + chunk].to_vec()).await;
+                db = apply_ops(db, ops[offset..offset + chunk].to_vec()).await;
                 offset += chunk;
 
                 let end_loc = db.bounds().end;
@@ -1090,7 +1092,7 @@ pub(crate) mod test {
             // Grow state past the checkpoints with an empty batch and verify all
             // historical proofs from that later state.
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             for (historical_size, root, reference_proof, reference_ops) in checkpoints {
                 let (historical_proof, historical_ops) = db
                     .historical_proof(historical_size, start_loc, max_ops)

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -230,9 +230,9 @@ pub(crate) mod test {
 
     /// Applies the given operations to the database.
     pub(crate) async fn apply_ops(
-        db: &mut AnyTest,
+        db: AnyTest,
         ops: Vec<unordered::Operation<mmr::Family, Digest, VariableEncoding<Vec<u8>>>>,
-    ) {
+    ) -> AnyTest {
         let mut batch = db.new_batch();
         for op in ops {
             match op {
@@ -247,8 +247,9 @@ pub(crate) mod test {
                 }
             }
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db
     }
 
     /// The staged path (`stage` + `Staged::merkleize`) must produce the same values and root as an
@@ -258,7 +259,7 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn unordered_variable_staged_matches_explicit_writes() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = create_test_db(context.child("staged")).await;
+            let db = create_test_db(context.child("staged")).await;
 
             let key = |i: u64| Sha256::hash(&i.to_be_bytes());
 
@@ -267,8 +268,8 @@ pub(crate) mod test {
                 seed = seed.write(key(i), Some(to_bytes(i)));
             }
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Read set: key(5) duplicated at slots 0/3, read-only key(6), missing key(9000),
             // key(20) deleted via index at slot 4.
@@ -322,7 +323,7 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn unordered_variable_staged_ancestor_commit_before_merkleize() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = create_test_db(context.child("staged_ancestor")).await;
+            let db = create_test_db(context.child("staged_ancestor")).await;
 
             let key = |i: u64| Sha256::hash(&i.to_be_bytes());
 
@@ -333,8 +334,8 @@ pub(crate) mod test {
                 seed = seed.write(key(i), Some(to_bytes(i)));
             }
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Grandparent -> parent chain. The parent touches neither staged key, so the
             // staged reads resolve in the grandparent's diff.
@@ -363,7 +364,7 @@ pub(crate) mod test {
 
             // Commit and free the grandparent: the staged resolutions' locations migrate
             // into the committed region, retiring their recorded bases.
-            db.apply_batch(grandparent).await.unwrap();
+            let (db, _) = db.apply_batch(grandparent).await.unwrap();
 
             let updates = vec![(0, Some(to_bytes(2_000))), (1, Some(to_bytes(2_001)))];
             let staged = staged
@@ -382,9 +383,9 @@ pub(crate) mod test {
                 .root();
             assert_eq!(staged.root(), explicit_root);
 
-            db.apply_batch(parent).await.unwrap();
-            db.apply_batch(staged).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let (db, _) = db.apply_batch(staged).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(to_bytes(2_000)));
             assert_eq!(db.get(&key(100)).await.unwrap(), Some(to_bytes(2_001)));
@@ -411,7 +412,7 @@ pub(crate) mod test {
                 } else {
                     "staged_ancestor_alive_combined"
                 };
-                let mut db = create_test_db(context.child(label)).await;
+                let db = create_test_db(context.child(label)).await;
 
                 let key = |i: u64| Sha256::hash(&i.to_be_bytes());
 
@@ -423,8 +424,8 @@ pub(crate) mod test {
                     seed = seed.write(key(i), Some(to_bytes(i)));
                 }
                 let seed = seed.merkleize(&db, None).await.unwrap();
-                db.apply_batch(seed).await.unwrap();
-                db.commit().await.unwrap();
+                let (db, _) = db.apply_batch(seed).await.unwrap();
+                let db = db.commit().await.unwrap();
 
                 let grandparent = db
                     .new_batch()
@@ -485,12 +486,15 @@ pub(crate) mod test {
                     .root();
                 assert_eq!(staged.root(), explicit_root);
 
-                if apply_ancestors_first {
-                    db.apply_batch(grandparent).await.unwrap();
-                    db.apply_batch(parent).await.unwrap();
-                }
-                db.apply_batch(staged).await.unwrap();
-                db.commit().await.unwrap();
+                let db = if apply_ancestors_first {
+                    let (db, _) = db.apply_batch(grandparent).await.unwrap();
+                    let (db, _) = db.apply_batch(parent).await.unwrap();
+                    db
+                } else {
+                    db
+                };
+                let (db, _) = db.apply_batch(staged).await.unwrap();
+                let db = db.commit().await.unwrap();
 
                 assert_eq!(db.get(&key(0)).await.unwrap(), Some(to_bytes(2_000)));
                 assert_eq!(db.get(&key(100)).await.unwrap(), Some(to_bytes(2_001)));
@@ -546,7 +550,7 @@ pub(crate) mod test {
 
             // Simulate a failure and test that we rollback to the previous root.
             drop(db);
-            let mut db = open_db(context.child("open").with_attribute("index", 2)).await;
+            let db = open_db(context.child("open").with_attribute("index", 2)).await;
             assert_eq!(root, db.root());
 
             // Re-apply the updates and commit them this time.
@@ -557,8 +561,8 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
             let root = db.root();
 
             // Update every 3rd key but don't apply (simulate failure).
@@ -577,7 +581,7 @@ pub(crate) mod test {
 
             // Simulate a failure and test that we rollback to the previous root.
             drop(db);
-            let mut db = open_db(context.child("open").with_attribute("index", 3)).await;
+            let db = open_db(context.child("open").with_attribute("index", 3)).await;
             assert_eq!(root, db.root());
 
             // Re-apply updates for every 3rd key and commit them this time.
@@ -591,8 +595,8 @@ pub(crate) mod test {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
             let root = db.root();
 
             // Delete every 7th key but don't apply (simulate failure).
@@ -610,7 +614,7 @@ pub(crate) mod test {
 
             // Simulate a failure and test that we rollback to the previous root.
             drop(db);
-            let mut db = open_db(context.child("open").with_attribute("index", 4)).await;
+            let db = open_db(context.child("open").with_attribute("index", 4)).await;
             assert_eq!(root, db.root());
 
             // Re-delete every 7th key and commit this time.
@@ -623,18 +627,17 @@ pub(crate) mod test {
                 batch = batch.write(k, None);
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let root = db.root();
             let inactivity_floor = db.inactivity_floor_loc();
-            db.sync().await.unwrap(); // test pruning boundary after sync w/ prune
-            db.prune(inactivity_floor).await.unwrap();
+            let db = db.sync().await.unwrap(); // test pruning boundary after sync w/ prune
+            let db = db.prune(inactivity_floor).await.unwrap();
             let bounds = db.bounds();
             let snapshot_items = db.snapshot.items();
 
             db.sync().await.unwrap();
-            drop(db);
 
             // Confirm state is preserved after reopen.
             let db = open_db(context.child("open").with_attribute("index", 5)).await;
@@ -651,7 +654,7 @@ pub(crate) mod test {
     fn test_any_variable_db_prune_beyond_inactivity_floor() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             // Add some operations
             let key1 = Digest::random(&mut context);
@@ -666,19 +669,20 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // inactivity_floor should be at some location < op_count
             let inactivity_floor = db.inactivity_floor_loc();
             let beyond_floor = Location::new(*inactivity_floor + 1);
 
             // Try to prune beyond the inactivity floor
-            let result = db.prune(beyond_floor).await;
-            assert!(
-                matches!(result, Err(Error::PruneBeyondMinRequired(loc, floor))
-                    if loc == beyond_floor && floor == inactivity_floor)
-            );
+            let Err(err) = db.prune(beyond_floor).await else {
+                panic!("expected prune beyond inactivity floor to fail");
+            };
+            assert!(matches!(err, Error::PruneBeyondMinRequired(loc, floor)
+                    if loc == beyond_floor && floor == inactivity_floor));
 
+            let db = open_db(context.child("reopen")).await;
             db.destroy().await.unwrap();
         });
     }
@@ -687,7 +691,7 @@ pub(crate) mod test {
     fn test_stale_batch_rejected() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             let key1 = Sha256::hash(&[1]);
             let key2 = Sha256::hash(&[2]);
@@ -707,18 +711,21 @@ pub(crate) mod test {
                 .unwrap();
 
             // Apply the first -- should succeed.
-            db.apply_batch(batch_a).await.unwrap();
+            let (db, _) = db.apply_batch(batch_a).await.unwrap();
+            let db = db.commit().await.unwrap();
             let expected_root = db.root();
             let expected_bounds = db.bounds();
             assert_eq!(db.get(&key1).await.unwrap(), Some(vec![10]));
             assert_eq!(db.get(&key2).await.unwrap(), None);
 
             // Apply the second -- should fail because the DB was modified.
-            let result = db.apply_batch(batch_b).await;
-            assert!(
-                matches!(result, Err(Error::StaleBatch { .. })),
-                "expected StaleBatch error, got {result:?}"
-            );
+            let Err(err) = db.apply_batch(batch_b).await else {
+                panic!("expected StaleBatch error");
+            };
+            assert!(matches!(err, Error::StaleBatch { .. }));
+
+            // Reopen and confirm the stale batch left the committed state untouched.
+            let db = open_db(context.child("reopen")).await;
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.bounds(), expected_bounds);
             assert_eq!(db.get(&key1).await.unwrap(), Some(vec![10]));
@@ -734,7 +741,7 @@ pub(crate) mod test {
     fn test_stale_batch_rejected_different_sizes() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             // A writes 1 key, B writes 5 keys -- different total_size.
             let batch_a = db
@@ -758,13 +765,13 @@ pub(crate) mod test {
             assert!(batch_b.bounds.total_size > batch_a.bounds.total_size);
 
             // Apply A, then B must be stale.
-            db.apply_batch(batch_a).await.unwrap();
-            let result = db.apply_batch(batch_b).await;
-            assert!(
-                matches!(result, Err(Error::StaleBatch { .. })),
-                "expected StaleBatch for asymmetric sibling, got {result:?}"
-            );
+            let (db, _) = db.apply_batch(batch_a).await.unwrap();
+            let Err(err) = db.apply_batch(batch_b).await else {
+                panic!("expected StaleBatch for asymmetric sibling");
+            };
+            assert!(matches!(err, Error::StaleBatch { .. }));
 
+            let db = open_db(context.child("reopen")).await;
             db.destroy().await.unwrap();
         });
     }
@@ -776,7 +783,7 @@ pub(crate) mod test {
     fn test_partial_ancestor_commit() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             let key1 = Sha256::hash(&[1]);
             let key2 = Sha256::hash(&[2]);
@@ -805,8 +812,8 @@ pub(crate) mod test {
             let expected_root = c.root();
 
             // Apply only A, then apply C directly (B uncommitted).
-            db.apply_batch(a).await.unwrap();
-            db.apply_batch(c).await.unwrap();
+            let (db, _) = db.apply_batch(a).await.unwrap();
+            let (db, _) = db.apply_batch(c).await.unwrap();
 
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.get(&key1).await.unwrap(), Some(vec![10]));
@@ -821,7 +828,7 @@ pub(crate) mod test {
     fn test_stale_batch_chained() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             let key1 = Sha256::hash(&[1]);
             let key2 = Sha256::hash(&[2]);
@@ -834,7 +841,7 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             // Create a parent batch, then fork two children.
             let parent = db
@@ -858,13 +865,13 @@ pub(crate) mod test {
                 .unwrap();
 
             // Apply child_a, then child_b should be stale.
-            db.apply_batch(child_a).await.unwrap();
-            let result = db.apply_batch(child_b).await;
-            assert!(
-                matches!(result, Err(Error::StaleBatch { .. })),
-                "expected StaleBatch error for sibling, got {result:?}"
-            );
+            let (db, _) = db.apply_batch(child_a).await.unwrap();
+            let Err(err) = db.apply_batch(child_b).await else {
+                panic!("expected StaleBatch error for sibling");
+            };
+            assert!(matches!(err, Error::StaleBatch { .. }));
 
+            let db = open_db(context.child("reopen")).await;
             db.destroy().await.unwrap();
         });
     }
@@ -876,7 +883,7 @@ pub(crate) mod test {
     fn test_sequential_commit_parent_then_child() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             let key1 = Sha256::hash(&[1]);
             let key2 = Sha256::hash(&[2]);
@@ -896,8 +903,8 @@ pub(crate) mod test {
                 .unwrap();
 
             // Apply parent first, then child -- sequential commit.
-            db.apply_batch(parent).await.unwrap();
-            db.apply_batch(child).await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let (db, _) = db.apply_batch(child).await.unwrap();
 
             assert_eq!(db.get(&key1).await.unwrap(), Some(vec![10]));
             assert_eq!(db.get(&key2).await.unwrap(), Some(vec![20]));
@@ -910,7 +917,7 @@ pub(crate) mod test {
     fn test_stale_batch_child_applied_before_parent() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = open_db(context.child("storage")).await;
+            let db = open_db(context.child("storage")).await;
 
             let key1 = Sha256::hash(&[1]);
             let key2 = Sha256::hash(&[2]);
@@ -930,13 +937,13 @@ pub(crate) mod test {
                 .unwrap();
 
             // Apply child first -- parent should now be stale.
-            db.apply_batch(child).await.unwrap();
-            let result = db.apply_batch(parent).await;
-            assert!(
-                matches!(result, Err(Error::StaleBatch { .. })),
-                "expected StaleBatch for parent after child applied, got {result:?}"
-            );
+            let (db, _) = db.apply_batch(child).await.unwrap();
+            let Err(err) = db.apply_batch(parent).await else {
+                panic!("expected StaleBatch for parent after child applied");
+            };
+            assert!(matches!(err, Error::StaleBatch { .. }));
 
+            let db = open_db(context.child("reopen")).await;
             db.destroy().await.unwrap();
         });
     }
@@ -1002,11 +1009,11 @@ pub(crate) mod test {
     fn test_owned_batch_root_matches() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
             // Apply some initial data.
-            apply_ops(&mut db, create_test_ops(20)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(20)).await;
+            let db = db.commit().await.unwrap();
 
             // Build an owned batch from committed state.
             let base = db.to_batch();
@@ -1055,11 +1062,11 @@ pub(crate) mod test {
     fn test_owned_batch_apply() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
             // Apply initial data.
-            apply_ops(&mut db, create_test_ops(20)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(20)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1074,8 +1081,8 @@ pub(crate) mod test {
                 .unwrap();
 
             // Apply the batch.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Verify the key was written.
             let fetched = db.get(&key).await.unwrap();
@@ -1090,11 +1097,11 @@ pub(crate) mod test {
     fn test_owned_batch_chain_commit_parent_first() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
             // Build initial data.
-            apply_ops(&mut db, create_test_ops(10)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(10)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1118,12 +1125,12 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Both keys should be readable.
             assert_eq!(db.get(&key_a).await.unwrap().unwrap(), val_a);
@@ -1138,10 +1145,10 @@ pub(crate) mod test {
     fn test_owned_batch_multiple_forks() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(10)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(10)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1167,8 +1174,8 @@ pub(crate) mod test {
             assert_ne!(fork_a.root(), fork_b.root());
 
             // Apply fork A.
-            db.apply_batch(fork_a).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(fork_a).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert_eq!(db.get(&key_a).await.unwrap().unwrap(), vec![10u8; 8]);
             assert!(db.get(&key_b).await.unwrap().is_none());
@@ -1193,10 +1200,10 @@ pub(crate) mod test {
 
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(10)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(10)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1237,10 +1244,10 @@ pub(crate) mod test {
     fn test_owned_batch_chain_delete_after_ancestor_insert() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1262,13 +1269,13 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_a);
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // key_x should be deleted.
             assert!(db.get(&key_x).await.unwrap().is_none());
@@ -1282,11 +1289,11 @@ pub(crate) mod test {
     fn test_owned_batch_chain_overlapping_keys() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
             // Build initial data.
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1309,15 +1316,15 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // key_x should have parent's value.
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_a);
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // key_x should now have child's value.
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_b);
@@ -1332,10 +1339,10 @@ pub(crate) mod test {
     fn test_owned_batch_chain_three_deep() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(10)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(10)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1369,18 +1376,18 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(grandparent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(grandparent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_a).await.unwrap().unwrap(), val_a);
 
             // Commit parent.
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_b).await.unwrap().unwrap(), val_b);
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_c).await.unwrap().unwrap(), val_c);
 
             // All three keys readable.
@@ -1397,10 +1404,10 @@ pub(crate) mod test {
     fn test_owned_batch_chain_three_deep_overlapping_key() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
             let key_x = Digest::random(commonware_utils::TestRng::new(910));
@@ -1431,18 +1438,18 @@ pub(crate) mod test {
                 .await
                 .unwrap();
 
-            db.apply_batch(grandparent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(grandparent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_a);
 
             // Commit parent.
-            db.apply_batch(parent_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&key_x).await.unwrap().unwrap(), val_b);
 
             // Commit child.
-            db.apply_batch(child_batch).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_batch).await.unwrap();
+            let db = db.commit().await.unwrap();
             assert!(db.get(&key_x).await.unwrap().is_none());
 
             db.destroy().await.unwrap();
@@ -1458,10 +1465,10 @@ pub(crate) mod test {
     fn test_new_child_after_ancestor_committed_and_dropped() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             // Chain: DB <-- a <-- b
             let key_a = Digest::random(commonware_utils::TestRng::new(800));
@@ -1483,8 +1490,8 @@ pub(crate) mod test {
                 .unwrap();
 
             // Commit a and drop it. b's Weak<a> becomes invalid.
-            db.apply_batch(a).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(a).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build c from b. This must not panic despite a being freed.
             let key_c = Digest::random(commonware_utils::TestRng::new(802));
@@ -1497,12 +1504,12 @@ pub(crate) mod test {
                 .unwrap();
 
             // Commit b (skip_ancestors path since a is committed).
-            db.apply_batch(b).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(b).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Commit c.
-            db.apply_batch(c).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(c).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // All three keys present with correct values.
             assert_eq!(db.get(&key_a).await.unwrap().unwrap(), val_a);
@@ -1521,10 +1528,10 @@ pub(crate) mod test {
     fn test_apply_batch_after_ancestor_dropped_without_commit() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_db(context).await;
+            let db = create_test_db(context).await;
 
-            apply_ops(&mut db, create_test_ops(5)).await;
-            db.commit().await.unwrap();
+            let db = apply_ops(db, create_test_ops(5)).await;
+            let db = db.commit().await.unwrap();
 
             let base = db.to_batch();
 
@@ -1562,8 +1569,8 @@ pub(crate) mod test {
 
             // Apply only the tip. This is !skip_ancestors (db hasn't changed).
             // Before the fix, a's and b's snapshot diffs would be silently lost.
-            db.apply_batch(c).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(c).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // All three keys must be in the snapshot.
             assert_eq!(db.get(&key_a).await.unwrap().unwrap(), val_a);

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -681,9 +681,6 @@ pub(crate) mod test {
             };
             assert!(matches!(err, Error::PruneBeyondMinRequired(loc, floor)
                     if loc == beyond_floor && floor == inactivity_floor));
-
-            let db = open_db(context.child("reopen")).await;
-            db.destroy().await.unwrap();
         });
     }
 
@@ -770,9 +767,6 @@ pub(crate) mod test {
                 panic!("expected StaleBatch for asymmetric sibling");
             };
             assert!(matches!(err, Error::StaleBatch { .. }));
-
-            let db = open_db(context.child("reopen")).await;
-            db.destroy().await.unwrap();
         });
     }
 
@@ -870,9 +864,6 @@ pub(crate) mod test {
                 panic!("expected StaleBatch error for sibling");
             };
             assert!(matches!(err, Error::StaleBatch { .. }));
-
-            let db = open_db(context.child("reopen")).await;
-            db.destroy().await.unwrap();
         });
     }
 
@@ -942,9 +933,6 @@ pub(crate) mod test {
                 panic!("expected StaleBatch for parent after child applied");
             };
             assert!(matches!(err, Error::StaleBatch { .. }));
-
-            let db = open_db(context.child("reopen")).await;
-            db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -197,6 +197,7 @@ async fn bench_apply_multi_uncommitted(ctx: &Context, updates: u64) -> Duration 
 }
 
 // Immutable databases are insert-only, so every batch writes fresh keys drawn from `counter`.
+#[boxed]
 async fn seed_imm_db(db: ImmDb, keys: u64, counter: &mut u64, rng: &mut TestRng) -> ImmDb {
     let mut batch = db.new_batch();
     for _ in 0..keys {

--- a/storage/src/qmdb/benches/apply_batch.rs
+++ b/storage/src/qmdb/benches/apply_batch.rs
@@ -60,15 +60,15 @@ async fn open_db(ctx: &Context) -> Db {
 
 #[boxed]
 async fn bench_direct_apply(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_db(ctx).await;
-    seed_db(&mut db, NUM_KEYS).await;
+    let db = open_db(ctx).await;
+    let db = seed_db(db, NUM_KEYS).await;
 
     let mut rng = TestRng::new(7);
     let batch = write_updates::<Db>(db.new_batch(), updates, &mut rng);
     let batch = batch.merkleize(&db, None).await.unwrap();
 
     let start = Instant::now();
-    db.apply_batch(batch).await.unwrap();
+    let (db, _) = db.apply_batch(batch).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -86,15 +86,15 @@ async fn open_ord_db(ctx: &Context) -> ODb {
 
 #[boxed]
 async fn bench_ord_direct_apply(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_ord_db(ctx).await;
-    seed_db(&mut db, NUM_KEYS).await;
+    let db = open_ord_db(ctx).await;
+    let db = seed_db(db, NUM_KEYS).await;
 
     let mut rng = TestRng::new(7);
     let batch = write_updates::<ODb>(db.new_batch(), updates, &mut rng);
     let batch = batch.merkleize(&db, None).await.unwrap();
 
     let start = Instant::now();
-    db.apply_batch(batch).await.unwrap();
+    let (db, _) = db.apply_batch(batch).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -103,8 +103,8 @@ async fn bench_ord_direct_apply(ctx: &Context, updates: u64) -> Duration {
 
 #[boxed]
 async fn bench_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_db(ctx).await;
-    seed_db(&mut db, NUM_KEYS).await;
+    let db = open_db(ctx).await;
+    let db = seed_db(db, NUM_KEYS).await;
 
     let mut rng = TestRng::new(7);
     let parent = write_updates::<Db>(db.new_batch(), updates, &mut rng);
@@ -114,7 +114,7 @@ async fn bench_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> D
     let child = child.merkleize(&db, None).await.unwrap();
 
     let start = Instant::now();
-    db.apply_batch(child).await.unwrap();
+    let (db, _) = db.apply_batch(child).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -123,8 +123,8 @@ async fn bench_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> D
 
 #[boxed]
 async fn bench_apply_with_committed_ancestor(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_db(ctx).await;
-    seed_db(&mut db, NUM_KEYS).await;
+    let db = open_db(ctx).await;
+    let db = seed_db(db, NUM_KEYS).await;
 
     let mut rng = TestRng::new(7);
     let parent = write_updates::<Db>(db.new_batch(), updates, &mut rng);
@@ -133,10 +133,10 @@ async fn bench_apply_with_committed_ancestor(ctx: &Context, updates: u64) -> Dur
     let child = write_updates::<Db>(parent.new_batch(), updates, &mut rng);
     let child = child.merkleize(&db, None).await.unwrap();
 
-    db.apply_batch(parent).await.unwrap();
+    let (db, _) = db.apply_batch(parent).await.unwrap();
 
     let start = Instant::now();
-    db.apply_batch(child).await.unwrap();
+    let (db, _) = db.apply_batch(child).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -146,8 +146,8 @@ async fn bench_apply_with_committed_ancestor(ctx: &Context, updates: u64) -> Dur
 // 1 committed + 1 uncommitted ancestor: apply A, then apply C (whose chain is [B, A]).
 #[boxed]
 async fn bench_apply_committed_uncommitted_chain(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_db(ctx).await;
-    seed_db(&mut db, NUM_KEYS).await;
+    let db = open_db(ctx).await;
+    let db = seed_db(db, NUM_KEYS).await;
 
     let mut rng = TestRng::new(7);
     let a = write_updates::<Db>(db.new_batch(), updates, &mut rng);
@@ -159,10 +159,10 @@ async fn bench_apply_committed_uncommitted_chain(ctx: &Context, updates: u64) ->
     let c = write_updates::<Db>(b.new_batch(), updates, &mut rng);
     let c = c.merkleize(&db, None).await.unwrap();
 
-    db.apply_batch(a).await.unwrap();
+    let (db, _) = db.apply_batch(a).await.unwrap();
 
     let start = Instant::now();
-    db.apply_batch(c).await.unwrap();
+    let (db, _) = db.apply_batch(c).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -172,8 +172,8 @@ async fn bench_apply_committed_uncommitted_chain(ctx: &Context, updates: u64) ->
 // 2 uncommitted ancestors: apply C directly without applying A or B.
 #[boxed]
 async fn bench_apply_multi_uncommitted(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_db(ctx).await;
-    seed_db(&mut db, NUM_KEYS).await;
+    let db = open_db(ctx).await;
+    let db = seed_db(db, NUM_KEYS).await;
 
     let mut rng = TestRng::new(7);
     let a = write_updates::<Db>(db.new_batch(), updates, &mut rng);
@@ -189,7 +189,7 @@ async fn bench_apply_multi_uncommitted(ctx: &Context, updates: u64) -> Duration 
     drop(b);
 
     let start = Instant::now();
-    db.apply_batch(c).await.unwrap();
+    let (db, _) = db.apply_batch(c).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -197,7 +197,7 @@ async fn bench_apply_multi_uncommitted(ctx: &Context, updates: u64) -> Duration 
 }
 
 // Immutable databases are insert-only, so every batch writes fresh keys drawn from `counter`.
-async fn seed_imm_db(db: &mut ImmDb, keys: u64, counter: &mut u64, rng: &mut TestRng) {
+async fn seed_imm_db(db: ImmDb, keys: u64, counter: &mut u64, rng: &mut TestRng) -> ImmDb {
     let mut batch = db.new_batch();
     for _ in 0..keys {
         let key = Sha256::hash(&counter.to_be_bytes());
@@ -205,9 +205,9 @@ async fn seed_imm_db(db: &mut ImmDb, keys: u64, counter: &mut u64, rng: &mut Tes
         batch = batch.set(key, make_fixed_value(rng));
     }
     let floor = db.inactivity_floor_loc();
-    let batch = batch.merkleize(db, None, floor).await;
-    db.apply_batch(batch).await.unwrap();
-    db.commit().await.unwrap();
+    let batch = batch.merkleize(&db, None, floor).await;
+    let (db, _) = db.apply_batch(batch).await.unwrap();
+    db.commit().await.unwrap()
 }
 
 async fn open_imm_db(ctx: &Context) -> ImmDb {
@@ -218,10 +218,10 @@ async fn open_imm_db(ctx: &Context) -> ImmDb {
 
 #[boxed]
 async fn bench_imm_direct_apply(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_imm_db(ctx).await;
+    let db = open_imm_db(ctx).await;
     let mut rng = TestRng::new(7);
     let mut counter = 0u64;
-    seed_imm_db(&mut db, NUM_KEYS, &mut counter, &mut rng).await;
+    let db = seed_imm_db(db, NUM_KEYS, &mut counter, &mut rng).await;
 
     let mut batch = db.new_batch();
     for _ in 0..updates {
@@ -233,7 +233,7 @@ async fn bench_imm_direct_apply(ctx: &Context, updates: u64) -> Duration {
     let batch = batch.merkleize(&db, None, floor).await;
 
     let start = Instant::now();
-    db.apply_batch(batch).await.unwrap();
+    let (db, _) = db.apply_batch(batch).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();
@@ -242,10 +242,10 @@ async fn bench_imm_direct_apply(ctx: &Context, updates: u64) -> Duration {
 
 #[boxed]
 async fn bench_imm_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) -> Duration {
-    let mut db = open_imm_db(ctx).await;
+    let db = open_imm_db(ctx).await;
     let mut rng = TestRng::new(7);
     let mut counter = 0u64;
-    seed_imm_db(&mut db, NUM_KEYS, &mut counter, &mut rng).await;
+    let db = seed_imm_db(db, NUM_KEYS, &mut counter, &mut rng).await;
     let floor = db.inactivity_floor_loc();
 
     let mut parent = db.new_batch();
@@ -265,7 +265,7 @@ async fn bench_imm_apply_with_uncommitted_ancestor(ctx: &Context, updates: u64) 
     let child = child.merkleize(&db, None, floor).await;
 
     let start = Instant::now();
-    db.apply_batch(child).await.unwrap();
+    let (db, _) = db.apply_batch(child).await.unwrap();
     let elapsed = start.elapsed();
 
     db.destroy().await.unwrap();

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -159,12 +159,12 @@ async fn run_chained_growth<
     C: DbAny<F, Key = Digest, Value = Digest>,
     Fork: Fn(&C::Merkleized) -> C::Batch,
 >(
-    mut db: C,
+    db: C,
     grow: u64,
     fork_child: Fork,
 ) -> Duration {
-    seed_db(&mut db, NUM_KEYS).await;
-    db.sync().await.unwrap();
+    let db = seed_db(db, NUM_KEYS).await;
+    let mut db = db.sync().await.unwrap();
     let mut rng = TestRng::new(99);
 
     // Pre-build a deep chain (untimed).
@@ -174,13 +174,13 @@ async fn run_chained_growth<
         let child_batch =
             write_random_updates(fork_child(&parent), UPDATES_PER_BATCH, NUM_KEYS, &mut rng);
         let child = child_batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(parent).await.unwrap();
+        (db, _) = db.apply_batch(parent).await.unwrap();
         parent = child;
     }
 
     // Flush buffered data so the timed region doesn't inherit setup fsync cost.
-    db.commit().await.unwrap();
-    db.sync().await.unwrap();
+    db = db.commit().await.unwrap();
+    db = db.sync().await.unwrap();
 
     // Timed: grow more batches on top of the pre-built chain.
     let start = Instant::now();
@@ -189,10 +189,10 @@ async fn run_chained_growth<
             write_random_updates(fork_child(&parent), UPDATES_PER_BATCH, NUM_KEYS, &mut rng);
         let child = child_batch.merkleize(&db, None).await.unwrap();
         black_box(child.root());
-        db.apply_batch(parent).await.unwrap();
+        (db, _) = db.apply_batch(parent).await.unwrap();
         parent = child;
     }
-    db.apply_batch(parent).await.unwrap();
+    let (db, _) = db.apply_batch(parent).await.unwrap();
     let total = start.elapsed();
 
     db.destroy().await.unwrap();

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -580,7 +580,7 @@ pub(crate) use define_vec_variants;
 /// unseeded keys and insert them organically -- a growing keyspace rather than a fixed population.
 #[allow(clippy::too_many_arguments)]
 pub async fn gen_random_kv<F, M>(
-    db: &mut M,
+    mut db: M,
     num_elements: u64,
     num_operations: u64,
     commit_frequency: Option<u32>,
@@ -589,7 +589,8 @@ pub async fn gen_random_kv<F, M>(
     key_zipf_exponent: Option<f64>,
     keyspace: Option<u64>,
     make_value: impl Fn(&mut TestRng) -> M::Value,
-) where
+) -> M
+where
     F: Family,
     M: DbAny<F, Key = Digest>,
 {
@@ -612,22 +613,22 @@ pub async fn gen_random_kv<F, M>(
             batch = batch.write(key, Some(make_value(&mut rng)));
             pending += 1;
             if seed_batch.is_some_and(|n| pending >= n) {
-                let merkleized = batch.merkleize(db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                let merkleized = batch.merkleize(&db, None).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
                 commits += 1;
                 if prune_frequency.is_some_and(|n| commits.is_multiple_of(n)) {
                     let boundary = db.sync_boundary();
-                    db.prune(boundary).await.unwrap();
+                    db = db.prune(boundary).await.unwrap();
                 }
                 batch = db.new_batch();
                 pending = 0;
             }
         }
         if pending > 0 {
-            let merkleized = batch.merkleize(db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db = db.commit().await.unwrap();
         }
     }
 
@@ -654,21 +655,23 @@ pub async fn gen_random_kv<F, M>(
             if let Some(freq) = commit_frequency
                 && rng.next_u32().is_multiple_of(freq)
             {
-                let merkleized = batch.merkleize(db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                let merkleized = batch.merkleize(&db, None).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
                 commits += 1;
                 if prune_frequency.is_some_and(|n| commits.is_multiple_of(n)) {
                     let boundary = db.sync_boundary();
-                    db.prune(boundary).await.unwrap();
+                    db = db.prune(boundary).await.unwrap();
                 }
                 batch = db.new_batch();
             }
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db = db.commit().await.unwrap();
     }
+
+    db
 }
 
 /// Generate a fixed-size digest value.
@@ -678,18 +681,18 @@ pub fn make_fixed_value(rng: &mut TestRng) -> Digest {
 
 /// Pre-populate the database with `num_keys` unique keys, then commit.
 pub async fn seed_db<F: merkle::Family, C: DbAny<F, Key = Digest, Value = Digest>>(
-    db: &mut C,
+    db: C,
     num_keys: u64,
-) {
+) -> C {
     let mut rng = TestRng::new(42);
     let mut batch = db.new_batch();
     for i in 0u64..num_keys {
         let k = Sha256::hash(&i.to_be_bytes());
         batch = batch.write(k, Some(make_fixed_value(&mut rng)));
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized).await.unwrap();
-    db.commit().await.unwrap();
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db.apply_batch(merkleized).await.unwrap();
+    db.commit().await.unwrap()
 }
 
 /// Write `num_updates` random key updates into a batch.

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -188,7 +188,7 @@ fn report(db: &str, args: &Args, mut times_ms: Vec<f64>) {
 macro_rules! run_pipeline {
     ($db:ident, $args:ident, $label:literal, $merkleized:ty) => {{
         let args = $args;
-        let mut db = $db;
+        let db = $db;
 
         // Seed all keys in one committed batch.
         let seed_start = Instant::now();
@@ -198,8 +198,8 @@ macro_rules! run_pipeline {
             batch = batch.write(key(i), Some(Sha256::hash(&rng.next_u32().to_be_bytes())));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let mut db = db.commit().await.unwrap();
 
         // Churn: overwrite batches so inactive ops accumulate above the floor.
         for _ in 0..CHURN_BATCHES {
@@ -208,10 +208,10 @@ macro_rules! run_pipeline {
                 batch = batch.write(k, Some(v));
             }
             let merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
-        db.sync().await.unwrap();
+        let db = db.commit().await.unwrap();
+        let db = db.sync().await.unwrap();
         eprintln!("seed+churn done in {:?}", seed_start.elapsed());
 
         let mut rng = TestRng::new(99);

--- a/storage/src/qmdb/benches/generate.rs
+++ b/storage/src/qmdb/benches/generate.rs
@@ -31,15 +31,15 @@ const CASES: [(u64, u64); 1] = [(NUM_ELEMENTS, NUM_OPERATIONS)];
 /// destroy).
 #[boxed]
 async fn bench_db<F: Family, C: DbAny<F, Key = Digest>>(
-    mut db: C,
+    db: C,
     elements: u64,
     operations: u64,
     commit_frequency: u32,
     make_value: impl Fn(&mut TestRng) -> C::Value,
 ) -> Duration {
     let start = Instant::now();
-    gen_random_kv::<F, _>(
-        &mut db,
+    let db = gen_random_kv::<F, _>(
+        db,
         elements,
         operations,
         Some(commit_frequency),
@@ -50,8 +50,9 @@ async fn bench_db<F: Family, C: DbAny<F, Key = Digest>>(
         make_value,
     )
     .await;
-    db.prune(db.sync_boundary()).await.unwrap();
-    db.sync().await.unwrap();
+    let boundary = db.sync_boundary();
+    let db = db.prune(boundary).await.unwrap();
+    let db = db.sync().await.unwrap();
     let elapsed = start.elapsed();
     db.destroy().await.unwrap();
     elapsed
@@ -215,14 +216,14 @@ fn bench_keyless_generate(c: &mut Criterion) {
                                         let merkleized = batch
                                             .merkleize(&db, None, db.inactivity_floor_loc())
                                             .await;
-                                        db.apply_batch(merkleized).await.unwrap();
+                                        (db, _) = db.apply_batch(merkleized).await.unwrap();
                                         batch = db.new_batch();
                                     }
                                 }
                                 let merkleized =
                                     batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-                                db.apply_batch(merkleized).await.unwrap();
-                                db.sync().await.unwrap();
+                                let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                                let db = db.sync().await.unwrap();
 
                                 total += start.elapsed();
                                 db.destroy().await.unwrap();

--- a/storage/src/qmdb/benches/init.rs
+++ b/storage/src/qmdb/benches/init.rs
@@ -7,6 +7,7 @@ use crate::common::{
     Digest, define_fixed_variants, define_vec_variants, gen_random_kv, make_fixed_value,
     make_var_value,
 };
+use commonware_macros::boxed;
 use commonware_runtime::{
     Runner as _, Supervisor as _,
     benchmarks::{context, tokio},
@@ -37,13 +38,14 @@ cfg_if::cfg_if! {
 }
 
 /// Populate, prune, and sync a database (used in setup phase).
+#[boxed]
 async fn populate_and_sync<F: Family, C: DbAny<F, Key = Digest>>(
-    db: &mut C,
+    db: C,
     elements: u64,
     operations: u64,
     make_value: impl Fn(&mut TestRng) -> C::Value,
-) {
-    gen_random_kv::<F, _>(
+) -> C {
+    let db = gen_random_kv::<F, _>(
         db,
         elements,
         operations,
@@ -55,8 +57,9 @@ async fn populate_and_sync<F: Family, C: DbAny<F, Key = Digest>>(
         make_value,
     )
     .await;
-    db.prune(db.sync_boundary()).await.unwrap();
-    db.sync().await.unwrap();
+    let boundary = db.sync_boundary();
+    let db = db.prune(boundary).await.unwrap();
+    db.sync().await.unwrap()
 }
 
 // -- Fixed-value variants (16 = 8 db shapes x 2 merkle families) --
@@ -91,7 +94,7 @@ fn bench_fixed_value_init(c: &mut Criterion) {
                                 |ctx| async move {
                                     dispatch_fixed!(ctx, variant, |db| {
                                         populate_and_sync(
-                                            &mut db,
+                                            db,
                                             elements,
                                             operations,
                                             make_fixed_value,
@@ -157,13 +160,8 @@ fn bench_var_value_init(c: &mut Criterion) {
                             commonware_runtime::tokio::Runner::new(cfg.clone()).start(
                                 |ctx| async move {
                                     dispatch_var!(ctx, variant, |db| {
-                                        populate_and_sync(
-                                            &mut db,
-                                            elements,
-                                            operations,
-                                            make_var_value,
-                                        )
-                                        .await;
+                                        populate_and_sync(db, elements, operations, make_var_value)
+                                            .await;
                                     });
                                 },
                             );

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -126,7 +126,7 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
     }
     let cfg = Config::default().with_storage_directory(folder);
     let elapsed = Runner::new(cfg).start(|ctx| async move {
-        let mut db = AnyOFixDb::<Mmr>::init(
+        let db = AnyOFixDb::<Mmr>::init(
             ctx.child("storage"),
             any_fix_cfg_with(&ctx, ITEMS_PER_BLOB, PAGE_CACHE_SIZE),
         )
@@ -134,8 +134,8 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
         .unwrap();
         // Time the build itself (updates + prune + sync); opening the empty db above is cheap.
         let start = Instant::now();
-        gen_random_kv::<Mmr, _>(
-            &mut db,
+        let db = gen_random_kv::<Mmr, _>(
+            db,
             0, // num_elements: no seed phase; the keyspace fills organically as updates sample it
             num_updates,
             Some(COMMIT_FREQUENCY),
@@ -146,9 +146,12 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
             make_fixed_value,
         )
         .await;
-        db.prune(db.sync_boundary()).await.unwrap();
-        db.sync().await.unwrap();
-        start.elapsed()
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let elapsed = start.elapsed();
+        drop(db);
+        elapsed
     });
     println!("generated {num_updates} updates over keyspace {keyspace} at {folder} in {elapsed:?}");
 }

--- a/storage/src/qmdb/benches/init_scale.rs
+++ b/storage/src/qmdb/benches/init_scale.rs
@@ -148,10 +148,8 @@ fn generate(folder: &str, keyspace: u64, num_updates: u64, zipf_exponent: Option
         .await;
         let boundary = db.sync_boundary();
         let db = db.prune(boundary).await.unwrap();
-        let db = db.sync().await.unwrap();
-        let elapsed = start.elapsed();
-        drop(db);
-        elapsed
+        let _db = db.sync().await.unwrap();
+        start.elapsed()
     });
     println!("generated {num_updates} updates over keyspace {keyspace} at {folder} in {elapsed:?}");
 }

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -378,22 +378,22 @@ fn cur_var_cfg_with_cache(
 /// the workload optimized by bitmap-backed floor raising.
 #[boxed]
 async fn run_churned_bench<F: merkle::Family, C: DbAny<F, Key = Digest, Value = Digest>>(
-    mut db: C,
+    db: C,
     num_keys: u64,
     churn_batches: u64,
     iters: u64,
 ) -> Duration {
-    seed_db(&mut db, num_keys).await;
+    let mut db = seed_db(db, num_keys).await;
     let num_updates = num_keys / 10;
     let mut rng = TestRng::new(99);
 
     for _ in 0..churn_batches {
         let batch = write_random_updates(db.new_batch(), num_updates, num_keys, &mut rng);
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        (db, _) = db.apply_batch(merkleized).await.unwrap();
     }
-    db.commit().await.unwrap();
-    db.sync().await.unwrap();
+    let db = db.commit().await.unwrap();
+    let db = db.sync().await.unwrap();
 
     let mut total = Duration::ZERO;
     for _ in 0..iters {
@@ -478,13 +478,14 @@ where
     type Output = Digest;
 
     async fn setup(&mut self) {
-        let Some(db) = self.db.as_mut() else {
+        let Some(db) = self.db.take() else {
             panic!("database must be present during setup");
         };
-        seed_db(db, self.options.num_keys).await;
+        let mut db = seed_db(db, self.options.num_keys).await;
         if self.options.seed_sync {
-            db.sync().await.unwrap();
+            db = db.sync().await.unwrap();
         }
+        self.db = Some(db);
         if self.options.clear_cache {
             self.page_cache.clear();
         }

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -130,8 +130,8 @@ pub(crate) struct Store<E: Context, F: Family, D: Digest> {
 
     /// Whether the cached witness came from compact sync and has not been written to the
     /// journal yet. While set, the journal still holds the partition's previous contents; the
-    /// first persist replaces them with the cached witness and clears this flag. Mutated only
-    /// through the db's `&mut`, so `Relaxed` suffices.
+    /// first persist replaces them with the cached witness and clears this flag. Mutations are
+    /// serialized by ownership of the store, so `Relaxed` suffices.
     import_pending: AtomicBool,
 }
 
@@ -177,11 +177,11 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
     /// frontier, and refreshes the cache.
     pub(crate) async fn commit<H, S>(
-        &mut self,
+        self,
         merkle: &compact::Merkle<F, D, S>,
         inactivity_floor_loc: Location<F>,
         last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<(), Error<F>>
+    ) -> Result<Self, Error<F>>
     where
         H: Hasher<Digest = D>,
         S: Strategy,
@@ -202,11 +202,11 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
     /// frontier, and refreshes the cache.
     pub(crate) async fn sync<H, S>(
-        &mut self,
+        self,
         merkle: &compact::Merkle<F, D, S>,
         inactivity_floor_loc: Location<F>,
         last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<(), Error<F>>
+    ) -> Result<Self, Error<F>>
     where
         H: Hasher<Digest = D>,
         S: Strategy,
@@ -226,12 +226,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// A pending import is cleared only after the entry is durable, so an interrupted journal
     /// replacement is retried by the next persist.
     async fn persist<H, S>(
-        &mut self,
+        mut self,
         merkle: &compact::Merkle<F, D, S>,
         inactivity_floor_loc: Location<F>,
         last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
         durability: Durability,
-    ) -> Result<(), Error<F>>
+    ) -> Result<Self, Error<F>>
     where
         H: Hasher<Digest = D>,
         S: Strategy,
@@ -240,17 +240,17 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?
         else {
-            return Ok(());
+            return Ok(self);
         };
-        self.journal.append(&verified.witness).await?;
-        match durability {
+        (self.journal, _) = self.journal.append(&verified.witness).await?;
+        self.journal = match durability {
             Durability::Commit => self.journal.commit().await?,
             Durability::Sync => self.journal.sync().await?,
-        }
+        };
         self.import_pending.store(false, Ordering::Relaxed);
         merkle.prune_to_frontier();
         self.replace(verified);
-        Ok(())
+        Ok(self)
     }
 
     /// Decide what a persist must write, clearing the journal first when an import is pending.
@@ -297,12 +297,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// is truncated, so a corrupt entry fails the rewind with the journal intact. The rewind is
     /// made durable before returning.
     pub(crate) async fn rewind<H, S, Op>(
-        &mut self,
+        mut self,
         merkle: &compact::Merkle<F, D, S>,
         target: Location<F>,
         commit_codec_config: &Op::Cfg,
         last_commit_floor: impl FnOnce(&Op) -> Option<Location<F>>,
-    ) -> Result<Op, Error<F>>
+    ) -> Result<(Self, Op), Error<F>>
     where
         H: Hasher<Digest = D>,
         S: Strategy,
@@ -320,29 +320,28 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             commit_codec_config,
             last_commit_floor,
         )?;
-        self.journal.rewind(pos + 1).await?;
-        self.journal.sync().await?;
+        self.journal = self.journal.rewind(pos + 1).await?.sync().await?;
         self.replace(witness);
-        Ok(op)
+        Ok((self, op))
     }
 
     /// Drop all entries committing fewer than `pruning_boundary` leaves, bounding how far back
     /// [`Self::rewind`] can reach. The tip entry always survives. Some entries
     /// below the boundary may survive.
-    pub(crate) async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
+    pub(crate) async fn prune(mut self, pruning_boundary: Location<F>) -> Result<Self, Error<F>> {
         self.check_import_persisted()?;
 
         let bounds = self.journal.bounds();
         if bounds.is_empty() {
-            return Ok(());
+            return Ok(self);
         }
         // Clamp below the tip so the journal never empties: the tip is the current state.
         let pos = Self::first_at_or_above(&self.journal, pruning_boundary)
             .await?
             .min(bounds.end - 1);
-        self.journal.prune(pos).await?;
-        self.journal.sync().await?;
-        Ok(())
+        (self.journal, _) = self.journal.prune(pos).await?;
+        self.journal = self.journal.sync().await?;
+        Ok(self)
     }
 
     /// Whether a compact-sync import is not yet durable.
@@ -561,7 +560,7 @@ where
     Op: Read,
 {
     if journal.size() == 0 {
-        bootstrap_initial_commit::<E, F, H, S>(&mut journal, merkle, initial_commit_op_bytes)
+        journal = bootstrap_initial_commit::<E, F, H, S>(journal, merkle, initial_commit_op_bytes)
             .await?;
     }
     let (witness, op) =
@@ -572,10 +571,10 @@ where
 
 /// Insert and persist the initial `Commit(None, 0)` for a new compact db.
 async fn bootstrap_initial_commit<E, F, H, S>(
-    journal: &mut Journal<E, F, H::Digest>,
+    journal: Journal<E, F, H::Digest>,
     merkle: &mut compact::Merkle<F, H::Digest, S>,
     last_commit_op_bytes: Vec<u8>,
-) -> Result<(), Error<F>>
+) -> Result<Journal<E, F, H::Digest>, Error<F>>
 where
     E: Context,
     F: Family,
@@ -591,9 +590,9 @@ where
 
     // The initial commit has one leaf and an inactivity floor of 0.
     let verified = build_witness::<F, H, S>(merkle, Location::new(0), last_commit_op_bytes)?;
-    journal.append(&verified.witness).await?;
-    journal.sync().await?;
-    Ok(())
+    let (journal, _) = journal.append(&verified.witness).await?;
+    let journal = journal.sync().await?;
+    Ok(journal)
 }
 
 #[cfg(test)]
@@ -615,10 +614,11 @@ pub(crate) mod tests {
 
     /// Corrupt the entry at `pos` with `f`, preserving the entries above it.
     pub(crate) async fn corrupt_entry<E, F, D>(
-        journal: &mut Journal<E, F, D>,
+        journal: Journal<E, F, D>,
         pos: u64,
         f: impl FnOnce(&mut Witness<F, D>),
-    ) where
+    ) -> Journal<E, F, D>
+    where
         E: Context,
         F: Family,
         D: Digest,
@@ -630,11 +630,11 @@ pub(crate) mod tests {
             }
         }
         f(&mut entries[0]);
-        journal.rewind(pos).await.unwrap();
+        let mut journal = journal.rewind(pos).await.unwrap();
         for entry in &entries {
-            journal.append(entry).await.unwrap();
+            (journal, _) = journal.append(entry).await.unwrap();
         }
-        journal.sync().await.unwrap();
+        journal.sync().await.unwrap()
     }
 
     /// Read the tip witness entry's components.
@@ -651,16 +651,17 @@ pub(crate) mod tests {
 
     /// Append a witness entry without syncing it.
     pub(crate) async fn append_unsynced<E, F, D>(
-        journal: &mut Journal<E, F, D>,
+        journal: Journal<E, F, D>,
         op_bytes: Vec<u8>,
         proof: Proof<F, D>,
         pinned_nodes: Vec<D>,
-    ) where
+    ) -> Journal<E, F, D>
+    where
         E: Context,
         F: Family,
         D: Digest,
     {
-        journal
+        let (journal, _) = journal
             .append(&Witness {
                 op_bytes,
                 proof,
@@ -668,22 +669,24 @@ pub(crate) mod tests {
             })
             .await
             .unwrap();
+        journal
     }
 
     /// Replace the tip witness entry.
     pub(crate) async fn overwrite_tip<E, F, D>(
-        journal: &mut Journal<E, F, D>,
+        journal: Journal<E, F, D>,
         op_bytes: Vec<u8>,
         proof: Proof<F, D>,
         pinned_nodes: Vec<D>,
-    ) where
+    ) -> Journal<E, F, D>
+    where
         E: Context,
         F: Family,
         D: Digest,
     {
         let size = journal.size();
-        journal.rewind(size - 1).await.unwrap();
-        journal
+        let journal = journal.rewind(size - 1).await.unwrap();
+        let (journal, _) = journal
             .append(&Witness {
                 op_bytes,
                 proof,
@@ -691,6 +694,6 @@ pub(crate) mod tests {
             })
             .await
             .unwrap();
-        journal.sync().await.unwrap();
+        journal.sync().await.unwrap()
     }
 }

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -20,6 +20,7 @@ use crate::{
     translator::{OneCap, TwoCap},
 };
 use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
+use commonware_macros::boxed;
 use commonware_parallel::Sequential;
 use commonware_runtime::{
     BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
@@ -286,15 +287,16 @@ fn colliding_digest(prefix: u8, suffix: u64) -> Digest {
 
 /// Apply a batch of keyed writes (creates, updates, or deletes) to the database.
 async fn apply_writes<F: Family, D: DbAny<F, Key = Digest, Value = Digest>>(
-    db: &mut D,
+    db: D,
     writes: Vec<(Digest, Option<Digest>)>,
-) {
+) -> D {
     let mut batch = db.new_batch();
     for (k, v) in writes {
         batch = batch.write(k, v);
     }
-    let merkleized = batch.merkleize(db, None).await.unwrap();
-    db.apply_batch(merkleized).await.unwrap();
+    let merkleized = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db.apply_batch(merkleized).await.unwrap();
+    db
 }
 
 #[cfg(feature = "arbitrary")]
@@ -390,7 +392,7 @@ mod tests {
                 batch = batch.set(k, v);
             }
             let merkleized = batch.merkleize(&$db, None, floor).await;
-            $db.apply_batch(merkleized).await.unwrap();
+            ($db, _) = $db.apply_batch(merkleized).await.unwrap();
         }};
     }
 
@@ -404,7 +406,7 @@ mod tests {
                 batch = batch.set(k, v);
             }
             let merkleized = batch.merkleize(&$db, None, floor).await;
-            $db.apply_batch(merkleized).unwrap();
+            ($db, _) = $db.apply_batch(merkleized).unwrap();
         }};
     }
 
@@ -418,7 +420,7 @@ mod tests {
                 batch = batch.append(v);
             }
             let merkleized = batch.merkleize(&$db, None, floor).await;
-            $db.apply_batch(merkleized).unwrap();
+            ($db, _) = $db.apply_batch(merkleized).unwrap();
         }};
     }
 
@@ -431,7 +433,7 @@ mod tests {
                 batch = batch.append(v);
             }
             let merkleized = batch.merkleize(&$db, None, floor).await;
-            $db.apply_batch(merkleized).await.unwrap();
+            ($db, _) = $db.apply_batch(merkleized).await.unwrap();
         }};
     }
 
@@ -442,9 +444,9 @@ mod tests {
     /// 3. Recreate the deleted keys alongside new keys that collide under the translator.
     /// 4. Update original keys; delete odd-indexed colliding keys, update even-indexed ones.
     async fn keyed_root<F: Family, D: DbAny<F, Key = Digest, Value = Digest>>(
-        db: &mut D,
+        db: D,
         seed: u64,
-    ) -> Vec<u8> {
+    ) -> (D, Vec<u8>) {
         let n = seed % 50 + 5;
 
         // Choose a translator bucket for colliding keys (varies per seed).
@@ -452,7 +454,7 @@ mod tests {
 
         // 1. Create n keys.
         let writes: Vec<_> = (0..n).map(|i| (to_digest(i), Some(to_val(i, 1)))).collect();
-        apply_writes(db, writes).await;
+        let db = apply_writes(db, writes).await;
 
         // 2. Delete ~20% of keys, update the rest with new values.
         let writes: Vec<_> = (0..n)
@@ -465,7 +467,7 @@ mod tests {
                 }
             })
             .collect();
-        apply_writes(db, writes).await;
+        let db = apply_writes(db, writes).await;
 
         // 3. Recreate every deleted key, and introduce new keys that share a translator
         //    bucket (offset by 10000 to avoid overlapping with the original key range).
@@ -478,7 +480,7 @@ mod tests {
         for i in 0..n / 2 {
             writes.push((colliding_digest(prefix, 10000 + i), Some(to_val(i, 4))));
         }
-        apply_writes(db, writes).await;
+        let db = apply_writes(db, writes).await;
 
         // 4. Update original keys; delete odd-indexed colliding keys, update even-indexed.
         let mut writes = Vec::new();
@@ -493,9 +495,10 @@ mod tests {
                 writes.push((key, Some(to_val(i, 6))));
             }
         }
-        apply_writes(db, writes).await;
+        let db = apply_writes(db, writes).await;
 
-        db.root().to_vec()
+        let root = db.root().to_vec();
+        (db, root)
     }
 
     /// 3-batch immutable workload. Each batch inserts a disjoint set of keys (immutable
@@ -634,8 +637,11 @@ mod tests {
 
     macro_rules! keyed_conformance {
         ($name:ident, $db:ty, $cfg_fn:expr) => {
-            db_conformance!($name, $db, $cfg_fn, |db, seed| keyed_root(&mut db, seed)
-                .await);
+            db_conformance!($name, $db, $cfg_fn, |db, seed| {
+                let (d, root) = keyed_root(db, seed).await;
+                db = d;
+                root
+            });
         };
     }
 
@@ -665,7 +671,8 @@ mod tests {
                     let mut $d =
                         <$db>::init(context.child("db"), ($cfg_fn)(&suffix, &context)).await?;
                     let _root = $body;
-                    $d.sync().await
+                    $d.sync().await?;
+                    Ok(())
                 }
             }
         };
@@ -674,7 +681,9 @@ mod tests {
     macro_rules! keyed_storage_audit {
         ($name:ident, $family:ty, $db:ty, $cfg_fn:expr) => {
             storage_audit_conformance!($name, $family, $db, $cfg_fn, |db, seed| {
-                keyed_root(&mut db, seed).await
+                let (d, root) = keyed_root(db, seed).await;
+                db = d;
+                root
             });
         };
     }
@@ -1144,29 +1153,32 @@ mod tests {
 // operations in forward and reverse order, then asserts the roots are equal.
 
 async fn apply_both_orders<F: Family, D: DbAny<F, Key = Digest, Value = Digest>>(
-    fwd: &mut D,
-    rev: &mut D,
+    fwd: D,
+    rev: D,
     ops: Vec<(Digest, Option<Digest>)>,
     msg: &str,
-) {
-    apply_writes(fwd, ops.clone()).await;
+) -> (D, D) {
+    let fwd = apply_writes(fwd, ops.clone()).await;
     let mut reversed = ops;
     reversed.reverse();
-    apply_writes(rev, reversed).await;
+    let rev = apply_writes(rev, reversed).await;
     assert_eq!(fwd.root().to_vec(), rev.root().to_vec(), "{msg}");
+    (fwd, rev)
 }
 
+#[boxed]
 async fn assert_keyed_order_independent<F: Family, D: DbAny<F, Key = Digest, Value = Digest>>(
-    fwd: &mut D,
-    rev: &mut D,
-) {
+    fwd: D,
+    rev: D,
+) -> (D, D) {
     let mut creates: Vec<_> = (0..20)
         .map(|i| (to_digest(i), Some(to_val(i, 0))))
         .collect();
     for i in 0..8u64 {
         creates.push((colliding_digest(0xAB, i), Some(to_val(i, 100))));
     }
-    apply_both_orders(fwd, rev, creates, "create order must not affect root").await;
+    let (fwd, rev) =
+        apply_both_orders(fwd, rev, creates, "create order must not affect root").await;
 
     let mut mixed: Vec<_> = (0..20)
         .map(|i| {
@@ -1180,7 +1192,8 @@ async fn assert_keyed_order_independent<F: Family, D: DbAny<F, Key = Digest, Val
     for i in 0..8u64 {
         mixed.push((colliding_digest(0xAB, i), Some(to_val(i, 300))));
     }
-    apply_both_orders(fwd, rev, mixed, "delete+update order must not affect root").await;
+    let (fwd, rev) =
+        apply_both_orders(fwd, rev, mixed, "delete+update order must not affect root").await;
 
     let mut recreates: Vec<_> = (0..20)
         .filter(|i| i % 2 == 1)
@@ -1189,13 +1202,14 @@ async fn assert_keyed_order_independent<F: Family, D: DbAny<F, Key = Digest, Val
     for i in 8..16u64 {
         recreates.push((colliding_digest(0xAB, i), Some(to_val(i, 500))));
     }
-    apply_both_orders(
+    let (fwd, rev) = apply_both_orders(
         fwd,
         rev,
         recreates,
         "recreate-after-delete order must not affect root",
     )
     .await;
+    (fwd, rev)
 }
 
 // Macro rather than a generic function because compact immutable apply_batch is sync.
@@ -1212,7 +1226,7 @@ macro_rules! assert_immutable_order_independent_compact {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&$fwd, None, fwd_floor).await;
-        $fwd.apply_batch(merkleized).unwrap();
+        ($fwd, _) = $fwd.apply_batch(merkleized).unwrap();
 
         let rev_floor = $rev.inactivity_floor_loc();
         let mut batch = $rev.new_batch();
@@ -1220,7 +1234,7 @@ macro_rules! assert_immutable_order_independent_compact {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&$rev, None, rev_floor).await;
-        $rev.apply_batch(merkleized).unwrap();
+        ($rev, _) = $rev.apply_batch(merkleized).unwrap();
 
         assert_eq!(
             $fwd.root().to_vec(),
@@ -1244,7 +1258,7 @@ macro_rules! assert_immutable_order_independent {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&$fwd, None, fwd_floor).await;
-        $fwd.apply_batch(merkleized).await.unwrap();
+        ($fwd, _) = $fwd.apply_batch(merkleized).await.unwrap();
 
         let rev_floor = $rev.inactivity_floor_loc();
         let mut batch = $rev.new_batch();
@@ -1252,7 +1266,7 @@ macro_rules! assert_immutable_order_independent {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&$rev, None, rev_floor).await;
-        $rev.apply_batch(merkleized).await.unwrap();
+        ($rev, _) = $rev.apply_batch(merkleized).await.unwrap();
 
         assert_eq!(
             $fwd.root().to_vec(),
@@ -1285,97 +1299,129 @@ order_test!(
     test_order_any_mmr_unordered_fixed,
     AnyMmrUnorderedFixed,
     any_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmr_unordered_variable,
     AnyMmrUnorderedVariable,
     any_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmr_ordered_fixed,
     AnyMmrOrderedFixed,
     any_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmr_ordered_variable,
     AnyMmrOrderedVariable,
     any_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmb_unordered_fixed,
     AnyMmbUnorderedFixed,
     any_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmb_unordered_variable,
     AnyMmbUnorderedVariable,
     any_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmb_ordered_fixed,
     AnyMmbOrderedFixed,
     any_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_any_mmb_ordered_variable,
     AnyMmbOrderedVariable,
     any_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmr_unordered_fixed,
     CurrentMmrUnorderedFixed,
     current_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmr_unordered_variable,
     CurrentMmrUnorderedVariable,
     current_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmr_ordered_fixed,
     CurrentMmrOrderedFixed,
     current_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmr_ordered_variable,
     CurrentMmrOrderedVariable,
     current_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmb_unordered_fixed,
     CurrentMmbUnorderedFixed,
     current_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmb_unordered_variable,
     CurrentMmbUnorderedVariable,
     current_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmb_ordered_fixed,
     CurrentMmbOrderedFixed,
     current_fixed_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_cur_mmb_ordered_variable,
     CurrentMmbOrderedVariable,
     current_variable_config,
-    |fwd, rev| assert_keyed_order_independent(&mut fwd, &mut rev).await
+    |fwd, rev| {
+        (fwd, rev) = assert_keyed_order_independent(fwd, rev).await;
+    }
 );
 order_test!(
     test_order_immutable_mmr_fixed,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1157,7 +1157,7 @@ mod trait_impls {
     use crate::{
         journal::contiguous::Mutable,
         qmdb::any::traits::{
-            BatchableDb, MerkleizedBatch as MerkleizedBatchTrait,
+            ApplyBatchResult, BatchableDb, MerkleizedBatch as MerkleizedBatchTrait,
             UnmerkleizedBatch as UnmerkleizedBatchTrait,
         },
     };
@@ -1273,10 +1273,9 @@ mod trait_impls {
         }
 
         fn apply_batch(
-            &mut self,
+            self,
             batch: Self::Merkleized,
-        ) -> impl Future<Output = Result<core::ops::Range<Location<F>>, crate::qmdb::Error<F>>>
-        {
+        ) -> impl Future<Output = ApplyBatchResult<Self>> {
             self.apply_batch(batch)
         }
     }
@@ -1305,10 +1304,9 @@ mod trait_impls {
         }
 
         fn apply_batch(
-            &mut self,
+            self,
             batch: Self::Merkleized,
-        ) -> impl Future<Output = Result<core::ops::Range<Location<F>>, crate::qmdb::Error<F>>>
-        {
+        ) -> impl Future<Output = ApplyBatchResult<Self>> {
             self.apply_batch(batch)
         }
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -861,8 +861,8 @@ where
     ) -> Result<(Self, Range<Location<F>>), Error<F>> {
         let _timer = self.metrics.apply_batch_timer();
         self.metrics.apply_batch_calls.inc();
-        let (any, range) = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
-        self.any = any;
+        let range;
+        (self.any, range) = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
         Arc::make_mut(&mut self.grafted_tree).apply_batch(&batch.grafted)?;
         self.root = batch.canonical_root;
         self.update_metrics();

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -163,6 +163,25 @@ pub struct Db<
     pub(super) halt_before_prune_log: bool,
 }
 
+impl<F, E, C, I, H, U, const N: usize, S> std::fmt::Debug for Db<F, E, C, I, H, U, N, S>
+where
+    F: merkle::Graftable,
+    E: Context,
+    U: Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Db")
+            .field("bounds", &self.bounds())
+            .field("inactivity_floor_loc", &self.any.inactivity_floor_loc)
+            .finish_non_exhaustive()
+    }
+}
+
 // Shared read-only functionality.
 impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
@@ -514,7 +533,8 @@ where
     /// - Returns [Error::DataCorrupted] if internal grafted-tree state is inconsistent (a pinned
     ///   or retained node is missing, or the prune location overflows a [Position]).
     #[tracing::instrument(name = "qmdb.current.db.prune", level = "info", skip_all)]
-    pub async fn prune(&mut self, prune_loc: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn prune(mut self, prune_loc: Location<F>) -> Result<Self, Error<F>> {
         let _timer = self.metrics.prune_timer();
         self.metrics.prune_calls.inc();
         let sync_boundary = self.sync_boundary();
@@ -527,7 +547,7 @@ where
         // recovery can replay to that boundary: otherwise a crash before the log prune
         // recovers the older durable floor alongside newer pruning metadata and fails to
         // initialize the bitmap.
-        self.any.log.commit().await?;
+        self.any.log = self.any.log.commit().await?;
 
         // Prune the bitmap to the sync boundary (most aggressive safe location).
         self.any.prune_bitmap(sync_boundary);
@@ -545,10 +565,10 @@ where
             std::future::pending::<()>().await;
         }
 
-        self.any.prune_log(prune_loc).await?;
+        (self.any, _) = self.any.prune_log(prune_loc).await?;
         self.any.update_metrics();
         self.update_metrics();
-        Ok(())
+        Ok(self)
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.
@@ -572,13 +592,14 @@ where
     /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
     /// [`Db::sync`].
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
-    pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.any.last_commit_loc + 1;
         // No-op short-circuit. Avoids the post-rewind grafted-tree rebuild and the validation
         // and journal-read overhead below. Validation runs after this on the non-no-op path.
         if rewind_size == current_size {
-            return Ok(());
+            return Ok(self);
         }
         // Reject zero / out-of-range up front: lines below compute `rewind_size - 1`, which
         // underflows when `rewind_size == 0`. `any::Db::rewind` would catch these, but it isn't
@@ -634,7 +655,7 @@ where
         // `any.rewind` rewinds the log and patches the shared bitmap (truncate + restore active
         // bits + set the rewound tail's CommitFloor). Live pre-rewind batches must be dropped by
         // the caller; reads through them now return inconsistent data.
-        self.any.rewind(size).await?;
+        self.any = self.any.rewind(size).await?;
 
         let ops_size = self.any.log.merkle.size();
         let ops_leaves = Location::<F>::try_from(ops_size)?;
@@ -667,7 +688,7 @@ where
         self.root = root;
         self.update_metrics();
 
-        Ok(())
+        Ok(self)
     }
 
     /// Sync the metadata to disk.
@@ -768,22 +789,25 @@ where
     /// Durably commit the journal state published by prior [`Db::apply_batch`]
     /// calls.
     #[tracing::instrument(name = "qmdb.current.db.commit", level = "info", skip_all)]
-    pub async fn commit(&mut self) -> Result<(), Error<F>> {
-        self.any.commit().await
+    #[boxed]
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
+        self.any = self.any.commit().await?;
+        Ok(self)
     }
 
     /// Sync all database state to disk.
     #[tracing::instrument(name = "qmdb.current.db.sync", level = "info", skip_all)]
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
-        self.any.sync().await?;
+        self.any = self.any.sync().await?;
 
         // Write the bitmap pruning boundary to disk so that next startup doesn't have to
         // re-Merkleize the inactive portion up to the inactivity floor.
         self.sync_metadata().await?;
         self.update_metrics();
-        Ok(())
+        Ok(self)
     }
 
     /// Destroy the db, removing all data from disk.
@@ -808,6 +832,18 @@ where
     S: Strategy,
     Operation<F, U>: Codec,
 {
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &super::batch::MerkleizedBatch<F, H::Digest, U, N, S>,
+    ) -> Result<(), Error<F>> {
+        self.any.validate_batch(&batch.inner)
+    }
+
     /// Apply a batch to the database, returning the range of written operations.
     ///
     /// A batch is valid only if every batch applied to the database since this batch's
@@ -820,16 +856,17 @@ where
     /// durability.
     #[tracing::instrument(name = "qmdb.current.db.apply_batch", level = "info", skip_all)]
     pub async fn apply_batch(
-        &mut self,
+        mut self,
         batch: Arc<super::batch::MerkleizedBatch<F, H::Digest, U, N, S>>,
-    ) -> Result<Range<Location<F>>, Error<F>> {
+    ) -> Result<(Self, Range<Location<F>>), Error<F>> {
         let _timer = self.metrics.apply_batch_timer();
         self.metrics.apply_batch_calls.inc();
-        let range = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
+        let (any, range) = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
+        self.any = any;
         Arc::make_mut(&mut self.grafted_tree).apply_batch(&batch.grafted)?;
         self.root = batch.canonical_root;
         self.update_metrics();
-        Ok(range)
+        Ok((self, range))
     }
 }
 
@@ -1396,7 +1433,8 @@ mod tests {
         commonware_parallel::Sequential,
     >;
 
-    async fn populate_fixed_db<F, DB>(db: &mut DB, start: u64, count: u64)
+    #[boxed]
+    async fn populate_fixed_db<F, DB>(db: DB, start: u64, count: u64) -> DB
     where
         F: merkle::Graftable,
         DB: DbAny<F, Key = sha256::Digest, Value = sha256::Digest>,
@@ -1407,9 +1445,9 @@ mod tests {
             let value = Sha256::hash(&(idx + count).to_be_bytes());
             batch = batch.write(key, Some(value));
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
     /// A prune dropped between the pruning-metadata sync and the log prune must remain
@@ -1420,7 +1458,7 @@ mod tests {
     fn test_current_prune_dropped_before_log_prune() {
         let executor = deterministic::Runner::default();
         executor.start(|ctx| async move {
-            let mut db = MmrDb::init(
+            let db = MmrDb::init(
                 ctx.child("storage"),
                 fixed_config::<OneCap>("prune-park", &ctx),
             )
@@ -1429,37 +1467,35 @@ mod tests {
 
             // Establish a durable state, then apply (but do not commit) a batch that rewrites
             // every key, advancing the in-memory floor well past the durable commit's floor.
-            populate_fixed_db::<mmr::Family, _>(&mut db, 0, 512).await;
+            let db = populate_fixed_db::<mmr::Family, _>(db, 0, 512).await;
             let durable_floor = db.inactivity_floor_loc();
-            {
-                let mut batch = db.new_batch();
-                for idx in 0..512u64 {
-                    let key = Sha256::hash(&idx.to_be_bytes());
-                    let value = Sha256::hash(&(idx + 1024).to_be_bytes());
-                    batch = batch.write(key, Some(value));
-                }
-                let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+            let mut batch = db.new_batch();
+            for idx in 0..512u64 {
+                let key = Sha256::hash(&idx.to_be_bytes());
+                let value = Sha256::hash(&(idx + 1024).to_be_bytes());
+                batch = batch.write(key, Some(value));
             }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (mut db, _) = db.apply_batch(merkleized).await.unwrap();
             assert!(db.sync_boundary() > durable_floor);
             let bounds = db.bounds();
             let floor = db.inactivity_floor_loc();
             let root = db.root();
 
             // Drop the production prune future while it is parked after the metadata sync,
-            // before the log prune: a genuine cancellation at that await.
+            // before the log prune: a genuine cancellation at that await. The dropped future
+            // consumes the db, so the parked prune's in-flight state is only observable via
+            // reopen.
             db.halt_before_prune_log = true;
+            let boundary = db.sync_boundary();
             {
-                let fut = db.prune(db.sync_boundary());
+                let fut = db.prune(boundary);
                 futures::pin_mut!(fut);
                 assert!(
                     futures::poll!(fut.as_mut()).is_pending(),
                     "prune must park before the log prune"
                 );
             }
-            let pruned_bits = db.any.bitmap.pruned_bits();
-            assert!(pruned_bits > *durable_floor);
-            drop(db);
 
             // Reopening must succeed and recover the post-batch state: prune committed the
             // buffered operations before durably recording the pruning metadata that depends
@@ -1474,7 +1510,7 @@ mod tests {
             assert_eq!(db.bounds(), bounds);
             assert_eq!(db.inactivity_floor_loc(), floor);
             assert_eq!(db.root(), root);
-            assert_eq!(db.any.bitmap.pruned_bits(), pruned_bits);
+            assert!(db.any.bitmap.pruned_bits() > *durable_floor);
             db.destroy().await.unwrap();
         });
     }
@@ -1490,10 +1526,10 @@ mod tests {
             .await
             .unwrap();
             let mut next_idx = 0;
-            populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 256).await;
+            db = populate_fixed_db::<mmr::Family, _>(db, next_idx, 256).await;
             next_idx += 256;
             while partial_chunk::<_, 32>(db.any.bitmap.as_ref()).is_some() {
-                populate_fixed_db::<mmr::Family, _>(&mut db, next_idx, 1).await;
+                db = populate_fixed_db::<mmr::Family, _>(db, next_idx, 1).await;
                 next_idx += 1;
             }
             let witness = db.ops_root_witness().await.unwrap();
@@ -1519,13 +1555,13 @@ mod tests {
     fn test_ops_root_witness_verifies_with_partial_chunk() {
         let executor = deterministic::Runner::default();
         executor.start(|ctx| async move {
-            let mut db = MmbDb::init(
+            let db = MmbDb::init(
                 ctx.child("storage"),
                 fixed_config::<OneCap>("ops-root-witness-partial", &ctx),
             )
             .await
             .unwrap();
-            populate_fixed_db::<mmb::Family, _>(&mut db, 0, 260).await;
+            let db = populate_fixed_db::<mmb::Family, _>(db, 0, 260).await;
             let witness = db.ops_root_witness().await.unwrap();
             let ops_root = db.ops_root();
             let canonical_root = db.root();
@@ -1566,9 +1602,10 @@ mod tests {
 
             // Churn the same keys repeatedly to drive the inactivity floor past chunk boundaries.
             for _ in 0..5 {
-                populate_fixed_db::<mmr::Family, _>(&mut db, 0, 512).await;
+                db = populate_fixed_db::<mmr::Family, _>(db, 0, 512).await;
             }
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
             assert!(
                 db.any.bitmap.pruned_chunks() > 0,
                 "test requires at least one pruned chunk to exercise the zero-chunk path"

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1483,9 +1483,7 @@ mod tests {
             let root = db.root();
 
             // Drop the production prune future while it is parked after the metadata sync,
-            // before the log prune: a genuine cancellation at that await. The dropped future
-            // consumes the db, so the parked prune's in-flight state is only observable via
-            // reopen.
+            // before the log prune: a genuine cancellation at that await.
             db.halt_before_prune_log = true;
             let boundary = db.sync_boundary();
             {

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1933,7 +1933,8 @@ pub mod tests {
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
             assert_eq!(db.get(&key(2)).await.unwrap(), None);
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
+            drop(db);
 
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen"),
@@ -1960,7 +1961,8 @@ pub mod tests {
             assert_eq!(reopened.get(&key(1)).await.unwrap(), None);
             assert_eq!(reopened.get(&key(2)).await.unwrap(), None);
 
-            reopened.commit().await.unwrap();
+            let reopened = reopened.commit().await.unwrap();
+            drop(reopened);
 
             let reopened_initial: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen_initial"),
@@ -2043,7 +2045,8 @@ pub mod tests {
             assert_eq!(db.bounds().end, target_size);
             assert_eq!(db.get(&key0).await.unwrap(), Some(target_value));
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
+            drop(db);
 
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen_pruned_recovery"),
@@ -2805,7 +2808,8 @@ pub mod tests {
             assert_eq!(db.get(&key0).await.unwrap(), Some(target_key0));
             assert_eq!(db.get(&key1).await.unwrap(), target_key1);
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
+            drop(db);
 
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen_small_delta"),

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -328,7 +328,7 @@ use crate::{
     Context,
     index::Factory as IndexFactory,
     journal::{
-        authenticated::Inner,
+        authenticated,
         contiguous::{fixed::Config as FConfig, variable::Config as VConfig},
     },
     merkle::{self, Location, full::Config as MerkleConfig},
@@ -411,7 +411,7 @@ where
     H: Hasher,
     T: Translator,
     I: IndexFactory<T, Value = Location<F>>,
-    J: Inner<E, Item = Operation<F, U>>,
+    J: authenticated::Backing<E, Item = Operation<F, U>>,
     S: Strategy,
     Operation<F, U>: Committable + CodecShared,
 {
@@ -570,15 +570,15 @@ pub mod tests {
                 }
 
                 deterministic::Runner::default().start(|ctx| async move {
-                    let mut db = $open_db(ctx.child("current"), "staged-parity".to_string()).await;
+                    let db = $open_db(ctx.child("current"), "staged-parity".to_string()).await;
 
                     let mut seed = db.new_batch();
                     for i in 0..2000u64 {
                         seed = seed.write(key(i), Some(val(i)));
                     }
                     let seed = seed.merkleize(&db, None).await.unwrap();
-                    db.apply_batch(seed).await.unwrap();
-                    db.commit().await.unwrap();
+                    let (db, _) = db.apply_batch(seed).await.unwrap();
+                    let db = db.commit().await.unwrap();
 
                     for depth in [0u8, 1u8, 2u8] {
                         // Keep every uncommitted ancestor alive until the child is merkleized.
@@ -807,19 +807,18 @@ pub mod tests {
     /// Returns a boxed future so the merkleize/apply/commit chain does not inflate the futures
     /// (and poll frames) of every test composing commits, which overflow the stack on platforms
     /// with small defaults.
-    fn commit_writes<'a, F: merkle::Graftable, C: DbAny<F>>(
-        db: &'a mut C,
+    fn commit_writes<'a, F: merkle::Graftable, C: DbAny<F> + 'a>(
+        db: C,
         writes: impl IntoIterator<Item = (C::Key, Option<<C as DbAny<F>>::Value>)> + 'a,
-    ) -> std::pin::Pin<Box<dyn Future<Output = Result<(), Error<F>>> + 'a>> {
+    ) -> std::pin::Pin<Box<dyn Future<Output = Result<C, Error<F>>> + 'a>> {
         Box::pin(async move {
             let mut batch = db.new_batch();
             for (k, v) in writes {
                 batch = batch.write(k, v);
             }
-            let merkleized = batch.merkleize(db, None).await?;
-            db.apply_batch(merkleized).await?;
-            db.commit().await?;
-            Ok(())
+            let merkleized = batch.merkleize(&db, None).await?;
+            let (db, _) = db.apply_batch(merkleized).await?;
+            db.commit().await
         })
     }
 
@@ -851,7 +850,7 @@ pub mod tests {
             })
             .collect();
         if commit_changes {
-            commit_writes(&mut db, writes).await?;
+            db = commit_writes(db, writes).await?;
         }
 
         // Randomly update / delete them. We use a delete frequency that is 1/7th of the update
@@ -866,11 +865,11 @@ pub mod tests {
             let v = TestValue::from_seed(rng.next_u64());
             pending.push((rand_key, Some(v)));
             if commit_changes && rng.next_u32().is_multiple_of(20) {
-                commit_writes(&mut db, pending.drain(..)).await?;
+                db = commit_writes(db, pending.drain(..)).await?;
             }
         }
         if commit_changes {
-            commit_writes(&mut db, pending).await?;
+            db = commit_writes(db, pending).await?;
         }
         Ok(db)
     }
@@ -893,13 +892,13 @@ pub mod tests {
 
         let partition = "build-random".to_string();
         let rng_seed = context.next_u64();
-        let mut db: C = open_db(context.child("first"), partition.clone()).await;
-        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+        let db: C = open_db(context.child("first"), partition.clone()).await;
+        let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
             .await
             .unwrap();
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.sync().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.sync().await.unwrap();
 
         // Drop and reopen the db
         let root = db.root();
@@ -950,20 +949,20 @@ pub mod tests {
     {
         let mut open_db_clone = open_db.clone();
         let partition = "commit-after-sync".to_string();
-        let mut db: C = Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
+        let db: C = Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
         let key0 = <<C as DbAny<M>>::Key as TestKey>::from_seed(0);
         let key1 = <<C as DbAny<M>>::Key as TestKey>::from_seed(1);
         let value0 = <C as DbAny<M>>::Value::from_seed(100);
         let value1 = <C as DbAny<M>>::Value::from_seed(200);
 
         // Establish a synced baseline so metadata and journal recovery start from it.
-        commit_writes::<M, C>(&mut db, [(key0, Some(value0.clone()))])
+        let db = commit_writes::<M, C>(db, [(key0, Some(value0.clone()))])
             .await
             .unwrap();
-        db.sync().await.unwrap();
+        let db = db.sync().await.unwrap();
 
         // Commit a later batch without syncing metadata; reopen must rebuild it from the log.
-        commit_writes::<M, C>(&mut db, [(key1, Some(value1.clone()))])
+        let db = commit_writes::<M, C>(db, [(key1, Some(value1.clone()))])
             .await
             .unwrap();
         let committed_root = db.root();
@@ -996,14 +995,15 @@ pub mod tests {
 
         let partition = "build-random-fail-commit".to_string();
         let rng_seed = context.next_u64();
-        let mut db: C = Box::pin(open_db(context.child("first"), partition.clone())).await;
-        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+        let db: C = Box::pin(open_db(context.child("first"), partition.clone())).await;
+        let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
             .await
             .unwrap();
-        commit_writes(&mut db, []).await.unwrap();
+        let db = commit_writes(db, []).await.unwrap();
         let committed_root = db.root();
         let committed_op_count = db.bounds().end;
-        db.prune(db.sync_boundary()).await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
 
         // Perform more random operations without committing any of them.
         let db = apply_random_ops::<M, C>(ELEMENTS, false, rng_seed + 1, db)
@@ -1044,15 +1044,16 @@ pub mod tests {
         // To confirm the second committed hash is correct we'll re-build the DB in a new
         // partition, but without any failures. They should have the exact same state.
         let fresh_partition = "build-random-fail-commit-fresh".to_string();
-        let mut db: C = Box::pin(open_db(context.child("fresh"), fresh_partition.clone())).await;
-        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+        let db: C = Box::pin(open_db(context.child("fresh"), fresh_partition.clone())).await;
+        let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
             .await
             .unwrap();
-        commit_writes(&mut db, []).await.unwrap();
-        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
+        let db = commit_writes(db, []).await.unwrap();
+        let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed + 1, db)
             .await
             .unwrap();
-        db.prune(db.sync_boundary()).await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
         // State from scenario #2 should match that of a successful commit.
         assert_eq!(db.bounds().end, committed_op_count);
         assert_eq!(db.root(), scenario_2_root);
@@ -1100,13 +1101,13 @@ pub mod tests {
 
             // Commit periodically
             if i % 50 == 49 {
-                commit_writes(&mut db_no_pruning, pending_no_pruning.drain(..))
+                db_no_pruning = commit_writes(db_no_pruning, pending_no_pruning.drain(..))
                     .await
                     .unwrap();
-                commit_writes(&mut db_pruning, pending_pruning.drain(..))
+                db_pruning = commit_writes(db_pruning, pending_pruning.drain(..))
                     .await
                     .unwrap();
-                db_pruning
+                db_pruning = db_pruning
                     .prune(db_no_pruning.sync_boundary())
                     .await
                     .unwrap();
@@ -1114,12 +1115,10 @@ pub mod tests {
         }
 
         // Final commit for remaining writes.
-        commit_writes(&mut db_no_pruning, pending_no_pruning)
+        let db_no_pruning = commit_writes(db_no_pruning, pending_no_pruning)
             .await
             .unwrap();
-        commit_writes(&mut db_pruning, pending_pruning)
-            .await
-            .unwrap();
+        let db_pruning = commit_writes(db_pruning, pending_pruning).await.unwrap();
 
         // Get roots from both databases - they should match
         let root_no_pruning = db_no_pruning.root();
@@ -1157,17 +1156,18 @@ pub mod tests {
         let mut open_db_clone = open_db.clone();
         let partition = "sync-bitmap-pruning".to_string();
         let rng_seed = context.next_u64();
-        let mut db: C = Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
+        let db: C = Box::pin(open_db_clone(context.child("first"), partition.clone())).await;
 
         // Apply random operations with commits to advance the inactivity floor.
-        db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
+        let db = apply_random_ops::<M, C>(ELEMENTS, true, rng_seed, db)
             .await
             .unwrap();
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Prune to flatten bitmap layers and advance pruned_chunks.
-        db.prune(db.sync_boundary()).await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
 
         let pruned_bits_before = db.pruned_bits();
         warn!(
@@ -1184,7 +1184,7 @@ pub mod tests {
         );
 
         // Call sync() to persist the bitmap pruning boundary.
-        db.sync().await.unwrap();
+        let db = db.sync().await.unwrap();
 
         // Record the root before dropping.
         let root_before = db.root();
@@ -1226,7 +1226,7 @@ pub mod tests {
         const ELEMENTS: u64 = 1000;
 
         let mut open_db_clone = open_db.clone();
-        let mut db: C = Box::pin(open_db_clone(context.child("first"), "build-big".into())).await;
+        let db: C = Box::pin(open_db_clone(context.child("first"), "build-big".into())).await;
 
         let mut map = std::collections::HashMap::<C::Key, <C as DbAny<M>>::Value>::default();
 
@@ -1263,16 +1263,16 @@ pub mod tests {
         }
 
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Sync and prune.
-        db.sync().await.unwrap();
-        db.prune(db.sync_boundary()).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let boundary = db.sync_boundary();
+        let db = db.prune(boundary).await.unwrap();
 
         // Record root before dropping.
         let root = db.root();
         db.sync().await.unwrap();
-        drop(db);
 
         // Reopen the db and verify it has exactly the same state.
         let db: C = Box::pin(open_db(context.child("second"), "build-big".into())).await;
@@ -1304,7 +1304,7 @@ pub mod tests {
         F: FnMut(Context, String) -> Fut,
         Fut: Future<Output = C>,
     {
-        let mut db: C = Box::pin(open_db(
+        let db: C = Box::pin(open_db(
             context.child("db"),
             "stale-side-effect-free".into(),
         ))
@@ -1322,18 +1322,28 @@ pub mod tests {
         batch = batch.write(key2, Some(value2));
         let batch_b = batch.merkleize(&db, None).await.unwrap();
 
-        db.apply_batch(batch_a).await.unwrap();
+        let (db, _) = db.apply_batch(batch_a).await.unwrap();
+        let db = db.commit().await.unwrap();
         let expected_root = db.root();
         let expected_bounds = db.bounds();
         let expected_metadata = db.get_metadata().await.unwrap();
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1.clone()));
         assert_eq!(db.get(&key2).await.unwrap(), None);
 
-        let result = db.apply_batch(batch_b).await;
+        let Err(err) = db.apply_batch(batch_b).await else {
+            panic!("expected StaleBatch error");
+        };
         assert!(
-            matches!(result, Err(Error::StaleBatch { .. })),
-            "expected StaleBatch error, got {result:?}"
+            matches!(err, Error::StaleBatch { .. }),
+            "expected StaleBatch error, got {err:?}"
         );
+
+        // Reopen and confirm the stale batch left the committed state untouched.
+        let db: C = Box::pin(open_db(
+            context.child("reopen"),
+            "stale-side-effect-free".into(),
+        ))
+        .await;
         assert_eq!(db.root(), expected_root);
         assert_eq!(db.bounds(), expected_bounds);
         assert_eq!(db.get_metadata().await.unwrap(), expected_metadata);
@@ -1601,7 +1611,7 @@ pub mod tests {
                 translator: OneCap,
                 init_cache_size: Some(NZUsize!(1024)),
             };
-            let mut db = ForgedExclusionDb::init(context.child("db"), cfg)
+            let db = ForgedExclusionDb::init(context.child("db"), cfg)
                 .await
                 .unwrap();
 
@@ -1621,14 +1631,14 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let merkleized = db
                 .new_batch()
                 .write(c.clone(), Some(vc.clone()))
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // All three keys are live.
@@ -1834,32 +1844,34 @@ pub mod tests {
         Sha256::hash(&(i + 10000).to_be_bytes())
     }
 
+    #[boxed]
     async fn mmb_commit(
-        db: &mut UnorderedVariableMmbDb,
+        db: UnorderedVariableMmbDb,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
-    ) {
+    ) -> UnorderedVariableMmbDb {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
         }
-        let merkleized = batch.merkleize(db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let merkleized = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
+    #[boxed]
     async fn commit_writes_with_metadata(
-        db: &mut UnorderedVariableDb,
+        db: UnorderedVariableDb,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
-    ) -> std::ops::Range<Location<mmr::Family>> {
+    ) -> (UnorderedVariableDb, std::ops::Range<Location<mmr::Family>>) {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
         }
-        let merkleized = batch.merkleize(db, metadata).await.unwrap();
-        let range = db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        range
+        let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        (db, range)
     }
 
     #[test_traced("INFO")]
@@ -1868,7 +1880,7 @@ pub mod tests {
         executor.start(|context| async move {
             let partition = "current-rewind-recovery";
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>(partition, &ctx),
             )
@@ -1880,8 +1892,8 @@ pub mod tests {
             let initial_floor = db.inactivity_floor_loc();
 
             let metadata_a = val(900);
-            let first_range = commit_writes_with_metadata(
-                &mut db,
+            let (db, first_range) = commit_writes_with_metadata(
+                db,
                 [(key(0), Some(val(0))), (key(1), Some(val(1)))],
                 Some(metadata_a),
             )
@@ -1894,8 +1906,8 @@ pub mod tests {
             assert_eq!(size_before, first_range.end);
 
             let metadata_b = val(901);
-            let second_range = commit_writes_with_metadata(
-                &mut db,
+            let (db, second_range) = commit_writes_with_metadata(
+                db,
                 [
                     (key(0), Some(val(100))),
                     (key(1), None),
@@ -1911,7 +1923,7 @@ pub mod tests {
             assert_eq!(db.get(&key(1)).await.unwrap(), None);
             assert_eq!(db.get(&key(2)).await.unwrap(), Some(val(2)));
 
-            db.rewind(size_before).await.unwrap();
+            let db = db.rewind(size_before).await.unwrap();
             assert_eq!(db.bounds().end, size_before);
             assert_eq!(db.root(), root_before);
             assert_eq!(db.ops_root(), ops_root_before);
@@ -1922,7 +1934,6 @@ pub mod tests {
             assert_eq!(db.get(&key(2)).await.unwrap(), None);
 
             db.commit().await.unwrap();
-            drop(db);
 
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen"),
@@ -1939,8 +1950,7 @@ pub mod tests {
             assert_eq!(reopened.get(&key(1)).await.unwrap(), Some(val(1)));
             assert_eq!(reopened.get(&key(2)).await.unwrap(), None);
 
-            let mut reopened = reopened;
-            reopened.rewind(initial_size).await.unwrap();
+            let reopened = reopened.rewind(initial_size).await.unwrap();
             assert_eq!(reopened.bounds().end, initial_size);
             assert_eq!(reopened.root(), initial_root);
             assert_eq!(reopened.ops_root(), initial_ops_root);
@@ -1951,7 +1961,6 @@ pub mod tests {
             assert_eq!(reopened.get(&key(2)).await.unwrap(), None);
 
             reopened.commit().await.unwrap();
-            drop(reopened);
 
             let reopened_initial: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen_initial"),
@@ -1988,8 +1997,8 @@ pub mod tests {
             let key0 = key(0);
             let mut history = Vec::new();
             for round in 0..COMMITS {
-                commit_writes_with_metadata(
-                    &mut db,
+                (db, _) = commit_writes_with_metadata(
+                    db,
                     [(key0, Some(val(20_000 + round)))],
                     None,
                 )
@@ -2005,7 +2014,7 @@ pub mod tests {
 
             // Keep most ops-log history, but force bitmap pruning so rewind uses pinned-node
             // reconstruction (`pruned_chunks > 0` path).
-            db.prune(Location::new(1)).await.unwrap();
+            let db = db.prune(Location::new(1)).await.unwrap();
             let pruned_bits = db.pruned_bits();
             assert!(pruned_bits > 0, "expected bitmap pruning for rewind test");
             let bounds = db.bounds();
@@ -2028,16 +2037,15 @@ pub mod tests {
                     )
                 });
 
-            db.rewind(target_size).await.unwrap();
+            let db = db.rewind(target_size).await.unwrap();
             assert_eq!(db.root(), target_root);
             assert_eq!(db.ops_root(), target_ops_root);
             assert_eq!(db.bounds().end, target_size);
             assert_eq!(db.get(&key0).await.unwrap(), Some(target_value));
 
             db.commit().await.unwrap();
-            drop(db);
 
-            let mut reopened: UnorderedVariableDb = UnorderedVariableDb::init(
+            let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen_pruned_recovery"),
                 variable_config::<OneCap>(partition, &context),
             )
@@ -2051,13 +2059,13 @@ pub mod tests {
             let metadata_after_rewind = val(30_000);
             let new_key = key(1);
             let new_value = val(30_001);
-            let expected_end = commit_writes_with_metadata(
-                &mut reopened,
+            let (reopened, new_write_range) = commit_writes_with_metadata(
+                reopened,
                 [(new_key, Some(new_value))],
                 Some(metadata_after_rewind),
             )
-            .await
-            .end;
+            .await;
+            let expected_end = new_write_range.end;
             let root_after_new_write = reopened.root();
             let ops_root_after_new_write = reopened.ops_root();
             assert_eq!(reopened.bounds().end, expected_end);
@@ -2113,8 +2121,8 @@ pub mod tests {
                 let mut batch = db.new_batch();
                 batch = batch.write(k, expected);
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
             }
 
             let root_before = db.root();
@@ -2129,14 +2137,13 @@ pub mod tests {
             );
 
             // `prune` must reject any non-zero loc because sync_boundary is still 0.
-            let result = db.prune(Location::<mmb::Family>::new(1)).await;
+            let Err(err) = db.prune(Location::<mmb::Family>::new(1)).await else {
+                panic!("expected PruneBeyondMinRequired");
+            };
             assert!(
-                matches!(result, Err(Error::PruneBeyondMinRequired(_, _))),
-                "expected PruneBeyondMinRequired, got {result:?}"
+                matches!(err, Error::PruneBeyondMinRequired(_, _)),
+                "expected PruneBeyondMinRequired, got {err:?}"
             );
-            assert_eq!(db.pruned_bits(), 0);
-            db.sync().await.unwrap();
-            drop(db);
 
             // Reopen: no pruning occurred, state is unchanged.
             let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
@@ -2146,6 +2153,7 @@ pub mod tests {
             .await
             .unwrap();
 
+            assert_eq!(reopened.pruned_bits(), 0);
             assert_eq!(reopened.root(), root_before);
             assert_eq!(reopened.get(&k).await.unwrap(), expected);
 
@@ -2178,15 +2186,16 @@ pub mod tests {
                 let mut batch = db.new_batch();
                 batch = batch.write(key0, Some(val(60_000 + round)));
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
-                db.commit().await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
                 history.push((db.bounds().end, db.inactivity_floor_loc()));
             }
 
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
             let pruned_bits = db.pruned_bits();
             assert!(pruned_bits > 0, "expected MMB bitmap pruning to be active");
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
 
             let chunk_bits = commonware_utils::bitmap::BitMap::<N>::CHUNK_SIZE_BITS;
             let pruned_chunks = (pruned_bits / chunk_bits) as u64;
@@ -2218,16 +2227,18 @@ pub mod tests {
                     )
                 });
 
-            let err = db
+            let Err(err) = db
                 .rewind(merkle::Location::<mmb::Family>::new(unsafe_target))
                 .await
-                .unwrap_err();
+            else {
+                panic!("expected rewind rejection in unsettled delayed-merge window");
+            };
             assert!(
                 matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
                 "unexpected rewind error for unsettled delayed-merge window: {err:?}"
             );
-            drop(db);
 
+            // The failed rewind consumed the db; reopen to continue.
             let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
                 context.child("reopen"),
                 variable_config::<OneCap>(partition, &context),
@@ -2258,10 +2269,11 @@ pub mod tests {
 
             let k = key(0);
             for round in 0..COMMITS {
-                mmb_commit(&mut db, [(k, Some(val(70_000 + round)))]).await;
+                db = mmb_commit(db, [(k, Some(val(70_000 + round)))]).await;
             }
 
-            db.prune(db.sync_boundary()).await.unwrap();
+            let prune_boundary = db.sync_boundary();
+            let db = db.prune(prune_boundary).await.unwrap();
 
             let boundary = db.sync_boundary();
             let floor = db.inactivity_floor_loc();
@@ -2300,15 +2312,16 @@ pub mod tests {
             .unwrap();
 
             for round in 0..COMMITS {
-                commit_writes_with_metadata(
-                    &mut db,
+                (db, _) = commit_writes_with_metadata(
+                    db,
                     [(key(0), Some(val(80_000 + round)))],
                     None,
                 )
                 .await;
             }
 
-            db.prune(db.sync_boundary()).await.unwrap();
+            let prune_boundary = db.sync_boundary();
+            let db = db.prune(prune_boundary).await.unwrap();
 
             let boundary = db.sync_boundary();
             let floor = db.inactivity_floor_loc();
@@ -2344,13 +2357,13 @@ pub mod tests {
             .unwrap();
 
             for round in 0..COMMITS {
-                commit_writes_with_metadata(&mut db, [(key(0), Some(val(90_000 + round)))], None)
+                (db, _) = commit_writes_with_metadata(db, [(key(0), Some(val(90_000 + round)))], None)
                     .await;
             }
 
             assert!(*db.inactivity_floor_loc() > 1);
             let small = Location::new(1);
-            db.prune(small).await.unwrap();
+            let db = db.prune(small).await.unwrap();
 
             assert!(
                 db.bounds().start <= small,
@@ -2379,15 +2392,16 @@ pub mod tests {
             let k = key(0);
 
             for round in 0..200u64 {
-                mmb_commit(&mut db, [(k, Some(val(60_000 + round)))]).await;
+                db = mmb_commit(db, [(k, Some(val(60_000 + round)))]).await;
             }
 
-            db.prune(db.sync_boundary()).await.unwrap();
-            db.sync().await.unwrap();
+            let boundary = db.sync_boundary();
+            db = db.prune(boundary).await.unwrap();
+            db = db.sync().await.unwrap();
 
             // Keep growing without pruning: delayed merges now occur in the pruned region.
             for round in 200..300u64 {
-                mmb_commit(&mut db, [(key(1), Some(val(round)))]).await;
+                db = mmb_commit(db, [(key(1), Some(val(round)))]).await;
             }
 
             let proof = db.key_value_proof(k).await.unwrap();
@@ -2445,9 +2459,10 @@ pub mod tests {
             let mut round = 0u64;
             loop {
                 expected = Some(val(60_000 + round));
-                mmb_commit(&mut db, [(k, expected)]).await;
+                db = mmb_commit(db, [(k, expected)]).await;
                 round += 1;
-                db.prune(db.sync_boundary()).await.unwrap();
+                let boundary = db.sync_boundary();
+                db = db.prune(boundary).await.unwrap();
                 if db.pruned_bits() >= 512 {
                     break;
                 }
@@ -2456,7 +2471,7 @@ pub mod tests {
                     "failed to reach 2 pruned chunks after {round} commits"
                 );
             }
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
 
             let target_root = db.root();
             drop(db);
@@ -2493,11 +2508,12 @@ pub mod tests {
                 let mut expected = None;
                 for i in 0..90 {
                     expected = Some(val(round * 1000 + i));
-                    mmb_commit(&mut db, [(k, expected)]).await;
+                    db = mmb_commit(db, [(k, expected)]).await;
                 }
 
-                db.prune(db.sync_boundary()).await.unwrap();
-                db.sync().await.unwrap();
+                let boundary = db.sync_boundary();
+                db = db.prune(boundary).await.unwrap();
+                db = db.sync().await.unwrap();
 
                 let root_before = db.root();
                 db_ctx = context.child("db").with_attribute("round", round);
@@ -2546,13 +2562,14 @@ pub mod tests {
             // Grow until the inactivity floor reaches 4 chunks.
             while *db.inactivity_floor_loc() < 1024 {
                 let value = Some(val(80_000 + commit_idx));
-                mmb_commit(&mut db, [(k, value)]).await;
-                mmb_commit(&mut ref_db, [(k, value)]).await;
+                db = mmb_commit(db, [(k, value)]).await;
+                ref_db = mmb_commit(ref_db, [(k, value)]).await;
                 commit_idx += 1;
             }
 
-            db.prune(db.sync_boundary()).await.unwrap();
-            db.sync().await.unwrap();
+            let boundary = db.sync_boundary();
+            db = db.prune(boundary).await.unwrap();
+            db = db.sync().await.unwrap();
             assert_eq!(
                 db.root(),
                 ref_db.root(),
@@ -2568,8 +2585,8 @@ pub mod tests {
                 }
 
                 let value = Some(val(80_000 + commit_idx));
-                mmb_commit(&mut db, [(k, value)]).await;
-                mmb_commit(&mut ref_db, [(k, value)]).await;
+                db = mmb_commit(db, [(k, value)]).await;
+                ref_db = mmb_commit(ref_db, [(k, value)]).await;
                 commit_idx += 1;
 
                 let db_leaves =
@@ -2617,8 +2634,8 @@ pub mod tests {
                 for i in 0..COMMITS_PER_ROUND {
                     let value = Some(val(round * 10_000 + i));
                     expected = value;
-                    mmb_commit(&mut db, [(k, value)]).await;
-                    mmb_commit(&mut ref_db, [(k, value)]).await;
+                    db = mmb_commit(db, [(k, value)]).await;
+                    ref_db = mmb_commit(ref_db, [(k, value)]).await;
                 }
 
                 assert_eq!(
@@ -2627,8 +2644,9 @@ pub mod tests {
                     "root mismatch before prune at round {round}"
                 );
 
-                db.prune(db.sync_boundary()).await.unwrap();
-                db.sync().await.unwrap();
+                let boundary = db.sync_boundary();
+                db = db.prune(boundary).await.unwrap();
+                db = db.sync().await.unwrap();
 
                 assert_eq!(
                     db.root(),
@@ -2704,8 +2722,9 @@ pub mod tests {
 
             let key0 = key(0);
             for round in 0..COMMITS {
-                commit_writes_with_metadata(&mut db, [(key0, Some(val(40_000 + round)))], None)
-                    .await;
+                (db, _) =
+                    commit_writes_with_metadata(db, [(key0, Some(val(40_000 + round)))], None)
+                        .await;
             }
 
             let expected_root = db.root();
@@ -2716,20 +2735,16 @@ pub mod tests {
 
             // 32 * 8 = 256 bits per chunk for N=32.
             let invalid_prune_loc = Location::new(*expected_boundary + 256);
-            let result = db.prune(invalid_prune_loc).await;
+            let Err(err) = db.prune(invalid_prune_loc).await else {
+                panic!("expected prune rejection above sync boundary");
+            };
             assert!(
-                matches!(result, Err(Error::PruneBeyondMinRequired(loc, boundary))
+                matches!(err, Error::PruneBeyondMinRequired(loc, boundary)
                     if loc == invalid_prune_loc && boundary == expected_boundary),
-                "expected prune rejection above sync boundary, got {result:?}"
+                "expected prune rejection above sync boundary, got {err:?}"
             );
 
-            assert_eq!(db.root(), expected_root);
-            assert_eq!(db.ops_root(), expected_ops_root);
-            assert_eq!(db.pruned_bits(), expected_pruned_bits);
-            assert_eq!(db.get(&key0).await.unwrap(), expected_value);
-
-            drop(db);
-
+            // The failed prune consumed the db; reopen to continue.
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen"),
                 variable_config::<OneCap>(partition, &context),
@@ -2772,8 +2787,8 @@ pub mod tests {
                     Some(val(50_000 + round))
                 };
 
-                commit_writes_with_metadata(
-                    &mut db,
+                (db, _) = commit_writes_with_metadata(
+                    db,
                     [(key0, Some(key0_value)), (key1, key1_value)],
                     None,
                 )
@@ -2793,7 +2808,7 @@ pub mod tests {
                 .expect("history should contain at least three commits");
             let (target_size, target_root, target_ops_root, target_key0, target_key1) = target;
 
-            db.rewind(target_size).await.unwrap();
+            let db = db.rewind(target_size).await.unwrap();
             assert_eq!(db.bounds().end, target_size);
             assert_eq!(db.root(), target_root);
             assert_eq!(db.ops_root(), target_ops_root);
@@ -2801,7 +2816,6 @@ pub mod tests {
             assert_eq!(db.get(&key1).await.unwrap(), target_key1);
 
             db.commit().await.unwrap();
-            drop(db);
 
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen_small_delta"),
@@ -2827,25 +2841,26 @@ pub mod tests {
 
             let partition = "current-rewind-pruned";
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb =
+            let db: UnorderedVariableDb =
                 UnorderedVariableDb::init(ctx.child("storage"), variable_config::<OneCap>(partition, &ctx))
                     .await
                     .unwrap();
 
-            let first_range = commit_writes_with_metadata(
-                &mut db,
+            let (db, first_range) = commit_writes_with_metadata(
+                db,
                 (0..KEYS).map(|i| (key(i), Some(val(i)))),
                 None,
             )
             .await;
-            commit_writes_with_metadata(
-                &mut db,
+            let (db, _) = commit_writes_with_metadata(
+                db,
                 (0..KEYS).map(|i| (key(i), Some(val(1000 + i)))),
                 None,
             )
             .await;
 
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
             let pruned_bits = db.pruned_bits();
             assert!(
                 pruned_bits > *first_range.start,
@@ -2854,7 +2869,9 @@ pub mod tests {
             );
 
             let oldest_retained = db.bounds().start;
-            let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
+            let Err(boundary_err) = db.rewind(oldest_retained).await else {
+                panic!("expected rewind rejection at retained boundary");
+            };
             assert!(
                 matches!(
                     boundary_err,
@@ -2863,8 +2880,16 @@ pub mod tests {
                 "unexpected rewind error at retained boundary: {boundary_err:?}"
             );
 
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
+                ctx.child("reopen"),
+                variable_config::<OneCap>(partition, &ctx),
+            )
+            .await
+            .unwrap();
             let expected_pruned_loc = *first_range.start - 1;
-            let err = db.rewind(first_range.start).await.unwrap_err();
+            let Err(err) = db.rewind(first_range.start).await else {
+                panic!("expected rewind rejection at pruned target");
+            };
             assert!(
                 matches!(
                     err,
@@ -2874,6 +2899,12 @@ pub mod tests {
                 "unexpected rewind error: {err:?}"
             );
 
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
+                ctx.child("reopen2"),
+                variable_config::<OneCap>(partition, &ctx),
+            )
+            .await
+            .unwrap();
             db.destroy().await.unwrap();
         });
     }
@@ -2893,8 +2924,8 @@ pub mod tests {
 
             let mut history = Vec::new();
             for round in 0..COMMITS {
-                commit_writes_with_metadata(
-                    &mut db,
+                (db, _) = commit_writes_with_metadata(
+                    db,
                     [(key(0), Some(val(10_000 + round)))],
                     None,
                 )
@@ -2906,7 +2937,7 @@ pub mod tests {
             // Intentionally prune less than the inactivity floor: log retains older ops, but the
             // bitmap still prunes to inactivity floor.
             let prune_loc = Location::new(1);
-            db.prune(prune_loc).await.unwrap();
+            let db = db.prune(prune_loc).await.unwrap();
             let pruned_bits = db.pruned_bits();
             assert!(pruned_bits > 0);
             let retained_start = db.bounds().start;
@@ -2933,12 +2964,20 @@ pub mod tests {
                     )
                 });
 
-            let err = db.rewind(rewind_target).await.unwrap_err();
+            let Err(err) = db.rewind(rewind_target).await else {
+                panic!("expected rewind rejection below bitmap floor");
+            };
             assert!(
                 matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
                 "unexpected rewind error: {err:?}"
             );
 
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
+                ctx.child("reopen"),
+                variable_config::<OneCap>(partition, &ctx),
+            )
+            .await
+            .unwrap();
             db.destroy().await.unwrap();
         });
     }
@@ -2966,18 +3005,17 @@ pub mod tests {
         // 260 writes + 1 CommitFloor = 261 operations, completing one chunk with 5 ops in the
         // next partial chunk. This ensures the grafted root computation must handle the
         // newly completed chunk.
-        let mut db: C = Box::pin(open_db_clone(context.child("init"), partition.clone())).await;
+        let db: C = Box::pin(open_db_clone(context.child("init"), partition.clone())).await;
         let mut batch = db.new_batch();
         for i in 0..260 {
             batch = batch.write(TestKey::from_seed(i), Some(TestValue::from_seed(i + 1000)));
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let speculative_root = db.root();
 
         // Sync, close, and reopen to get the root recomputed from committed state.
         db.sync().await.unwrap();
-        drop(db);
 
         let db: C = Box::pin(open_db(context.child("reopen"), partition)).await;
         assert_eq!(db.root(), speculative_root);
@@ -3009,7 +3047,7 @@ pub mod tests {
                 let mut batch = db.new_batch();
                 batch = batch.write(ka, Some(val(0)));
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
             }
 
             // Batch: update A, delete nothing, create B.
@@ -3035,7 +3073,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("ch", &ctx),
             )
@@ -3064,7 +3102,7 @@ pub mod tests {
             assert_eq!(child_m.get(&key(3), &db).await.unwrap(), Some(val(3)));
             assert_eq!(child_m.get(&key(7), &db).await.unwrap(), Some(val(7)));
 
-            db.apply_batch(child_m).await.unwrap();
+            let (db, _) = db.apply_batch(child_m).await.unwrap();
             assert_eq!(db.root(), child_root);
 
             // Verify all keys are correct.
@@ -3082,7 +3120,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedFixedDb =
+            let db: UnorderedFixedDb =
                 UnorderedFixedDb::init(ctx.child("storage"), fixed_config::<OneCap>("ucr", &ctx))
                     .await
                     .unwrap();
@@ -3098,8 +3136,8 @@ pub mod tests {
                 initial = initial.write(colliding_digest(0xAA, i), Some(colliding_digest(0xBB, i)));
             }
             let merkleized = initial.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Update only key_a so the colliding sibling key_b remains outside
             // the parent diff and must still be resolved through the committed
@@ -3125,8 +3163,8 @@ pub mod tests {
             let pending_root = pending_child.root();
             let pending_ops_root = pending_child.ops_root();
 
-            db.apply_batch(parent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let committed_child = db
                 .new_batch()
@@ -3141,7 +3179,7 @@ pub mod tests {
 
             // Apply pending child onto the committed parent
             // and ensure the applied wrapper roots still match.
-            db.apply_batch(pending_child).await.unwrap();
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
             assert_eq!(db.root(), committed_child.root());
             assert_eq!(db.ops_root(), committed_child.ops_root());
 
@@ -3154,7 +3192,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: OrderedFixedDb =
+            let db: OrderedFixedDb =
                 OrderedFixedDb::init(ctx.child("storage"), fixed_config::<OneCap>("ocr", &ctx))
                     .await
                     .unwrap();
@@ -3168,8 +3206,8 @@ pub mod tests {
                 initial = initial.write(colliding_digest(0xAA, i), Some(colliding_digest(0xBB, i)));
             }
             let merkleized = initial.merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Update only key_a so the colliding sibling key_b remains outside
             // the parent diff and must still be resolved through the committed
@@ -3194,8 +3232,8 @@ pub mod tests {
             let pending_root = pending_child.root();
             let pending_ops_root = pending_child.ops_root();
 
-            db.apply_batch(parent).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let committed_child = db
                 .new_batch()
@@ -3210,7 +3248,7 @@ pub mod tests {
 
             // Apply pending child onto the committed parent
             // and compare the applied wrapper roots with the committed-path child roots.
-            db.apply_batch(pending_child).await.unwrap();
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
             assert_eq!(db.root(), committed_child.root());
             assert_eq!(db.ops_root(), committed_child.ops_root());
 
@@ -3225,7 +3263,7 @@ pub mod tests {
         executor.start(|context| async move {
             let partition = "apply_requires_commit";
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>(partition, &ctx),
             )
@@ -3240,7 +3278,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
 
@@ -3265,7 +3303,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("pipe", &ctx),
             )
@@ -3275,7 +3313,7 @@ pub mod tests {
             let mut batch = db.new_batch();
             batch = batch.write(key(0), Some(val(0)));
             let parent_merkleized = batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(parent_merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(parent_merkleized).await.unwrap();
 
             let child_merkleized = {
                 assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
@@ -3283,10 +3321,10 @@ pub mod tests {
                 child = child.write(key(1), Some(val(1)));
                 child.merkleize(&db, None).await.unwrap()
             };
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
 
-            db.apply_batch(child_merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(child_merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
@@ -3302,7 +3340,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("ff", &ctx),
             )
@@ -3325,8 +3363,8 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            db.apply_batch(parent_m).await.unwrap();
-            db.apply_batch(child_m).await.unwrap();
+            let (db, _) = db.apply_batch(parent_m).await.unwrap();
+            let (db, _) = db.apply_batch(child_m).await.unwrap();
 
             // Both keys present.
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
@@ -3335,7 +3373,7 @@ pub mod tests {
             // Build the same result via two sequential plain batches in a fresh DB
             // and verify the roots match.
             let ctx2 = context.child("db").with_attribute("index", 2);
-            let mut db2: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db2: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx2.child("db"),
                 variable_config::<OneCap>("ff2", &ctx2),
             )
@@ -3347,14 +3385,14 @@ pub mod tests {
                 .merkleize(&db2, None)
                 .await
                 .unwrap();
-            db2.apply_batch(m1).await.unwrap();
+            let (db2, _) = db2.apply_batch(m1).await.unwrap();
             let m2 = db2
                 .new_batch()
                 .write(key(1), Some(val(1)))
                 .merkleize(&db2, None)
                 .await
                 .unwrap();
-            db2.apply_batch(m2).await.unwrap();
+            let (db2, _) = db2.apply_batch(m2).await.unwrap();
 
             assert_eq!(db.root(), db2.root());
 
@@ -3370,7 +3408,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("tb", &ctx),
             )
@@ -3384,7 +3422,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(m).await.unwrap();
+            let (db, _) = db.apply_batch(m).await.unwrap();
 
             // Get an owned batch from the committed state.
             let snapshot = db.to_batch();
@@ -3402,7 +3440,7 @@ pub mod tests {
             assert_ne!(child.root(), snapshot.root());
 
             // Apply child.
-            db.apply_batch(child).await.unwrap();
+            let (db, _) = db.apply_batch(child).await.unwrap();
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
 
@@ -3419,7 +3457,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("prune-live", &ctx),
             )
@@ -3432,8 +3470,8 @@ pub mod tests {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed_m = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed_m).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed_m).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Overwrite keys 0..250 so the inactivity floor advances past chunk 0.
             let mut p = db.new_batch();
@@ -3441,8 +3479,8 @@ pub mod tests {
                 p = p.write(key(i), Some(val(i + 10_000)));
             }
             let p_m = p.merkleize(&db, None).await.unwrap();
-            db.apply_batch(Arc::clone(&p_m)).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(Arc::clone(&p_m)).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Build c off p_m; c is live and shares the committed bitmap via its chain.
             let c = p_m
@@ -3453,14 +3491,15 @@ pub mod tests {
                 .unwrap();
 
             // Prune with c still alive. This advances pruned_chunks on the shared bitmap.
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
 
             // Sanity: c's pending write is still readable via the any-layer diff chain.
             assert_eq!(c.get(&key(250), &db).await.unwrap(), Some(val(99_999)));
 
             // The actual prune-interaction test: apply c after prune. apply_batch skips overlay
             // chunks below the current pruned boundary.
-            db.apply_batch(c).await.unwrap();
+            let (db, _) = db.apply_batch(c).await.unwrap();
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(10_000)));
             assert_eq!(db.get(&key(250)).await.unwrap(), Some(val(99_999)));
 
@@ -3481,7 +3520,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("xtend", &ctx),
             )
@@ -3495,7 +3534,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(Arc::clone(&a)).await.unwrap();
+            let (db, _) = db.apply_batch(Arc::clone(&a)).await.unwrap();
 
             // Build B off A after A was applied. B's chain walks through A's layer and falls
             // through to the committed bitmap (now post-A). B's merkleize must read consistent
@@ -3506,7 +3545,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(b).await.unwrap();
+            let (db, _) = db.apply_batch(b).await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
@@ -3518,7 +3557,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(c).await.unwrap();
+            let (db, _) = db.apply_batch(c).await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
             assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
@@ -3539,7 +3578,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("child-after-prune", &ctx),
             )
@@ -3552,8 +3591,8 @@ pub mod tests {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed_m = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed_m).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed_m).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Overwrite keys 0..250 so the inactivity floor advances past chunk 0.
             let mut a_batch = db.new_batch();
@@ -3561,11 +3600,12 @@ pub mod tests {
                 a_batch = a_batch.write(key(i), Some(val(i + 10_000)));
             }
             let a = a_batch.merkleize(&db, None).await.unwrap();
-            db.apply_batch(Arc::clone(&a)).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(Arc::clone(&a)).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Prune while `a` is still live. Mutates the shared bitmap's pruning boundary in place.
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
 
             // Extend `a` into `b` AFTER the prune. Building `b` off `a` triggers
             // `trim_committed` on `a`'s chain, which must correctly see the advanced pruning
@@ -3577,7 +3617,7 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            db.apply_batch(b).await.unwrap();
+            let (db, _) = db.apply_batch(b).await.unwrap();
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(10_000)));
             assert_eq!(db.get(&key(249)).await.unwrap(), Some(val(10_249)));
             assert_eq!(db.get(&key(300)).await.unwrap(), Some(val(300)));
@@ -3594,7 +3634,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("adrop", &ctx),
             )
@@ -3625,8 +3665,8 @@ pub mod tests {
             drop(b_m);
 
             // Apply only the tip. This is !skip_ancestors (DB hasn't changed).
-            db.apply_batch(c_m).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(c_m).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // All nine keys must be accessible.
             for i in 0..9 {
@@ -3655,7 +3695,7 @@ pub mod tests {
         executor.start(|context| async move {
             // -- Path 1: build a 3-deep chain and apply the tip directly. --
             let ctx1 = context.child("db").with_attribute("index", 1);
-            let mut db1: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db1: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx1.child("db"),
                 variable_config::<OneCap>("ord1", &ctx1),
             )
@@ -3663,8 +3703,8 @@ pub mod tests {
             .unwrap();
 
             // Seed some committed data so there's a base bitmap to clear.
-            commit_writes_with_metadata(
-                &mut db1,
+            let (db1, _) = commit_writes_with_metadata(
+                db1,
                 [(key(10), Some(val(10))), (key(11), Some(val(11)))],
                 None,
             )
@@ -3699,8 +3739,8 @@ pub mod tests {
                 .await
                 .unwrap();
 
-            db1.apply_batch(c).await.unwrap();
-            db1.commit().await.unwrap();
+            let (db1, _) = db1.apply_batch(c).await.unwrap();
+            let db1 = db1.commit().await.unwrap();
 
             // Build one more batch on top to exercise the bitmap state.
             let d1 = db1
@@ -3713,15 +3753,15 @@ pub mod tests {
 
             // -- Path 2: apply the same operations sequentially. --
             let ctx2 = context.child("db").with_attribute("index", 2);
-            let mut db2: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db2: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx2.child("db"),
                 variable_config::<OneCap>("ord2", &ctx2),
             )
             .await
             .unwrap();
 
-            commit_writes_with_metadata(
-                &mut db2,
+            let (db2, _) = commit_writes_with_metadata(
+                db2,
                 [(key(10), Some(val(10))), (key(11), Some(val(11)))],
                 None,
             )
@@ -3734,8 +3774,8 @@ pub mod tests {
                 .merkleize(&db2, None)
                 .await
                 .unwrap();
-            db2.apply_batch(a2).await.unwrap();
-            db2.commit().await.unwrap();
+            let (db2, _) = db2.apply_batch(a2).await.unwrap();
+            let db2 = db2.commit().await.unwrap();
 
             let b2 = db2
                 .new_batch()
@@ -3744,8 +3784,8 @@ pub mod tests {
                 .merkleize(&db2, None)
                 .await
                 .unwrap();
-            db2.apply_batch(b2).await.unwrap();
-            db2.commit().await.unwrap();
+            let (db2, _) = db2.apply_batch(b2).await.unwrap();
+            let db2 = db2.commit().await.unwrap();
 
             let c2 = db2
                 .new_batch()
@@ -3753,8 +3793,8 @@ pub mod tests {
                 .merkleize(&db2, None)
                 .await
                 .unwrap();
-            db2.apply_batch(c2).await.unwrap();
-            db2.commit().await.unwrap();
+            let (db2, _) = db2.apply_batch(c2).await.unwrap();
+            let db2 = db2.commit().await.unwrap();
 
             let d2 = db2
                 .new_batch()
@@ -3790,7 +3830,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("stale-clears", &ctx),
             )
@@ -3803,8 +3843,8 @@ pub mod tests {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed_m = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed_m).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed_m).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // P: overwrite keys 1..254. Does NOT touch key(0), but P's floor
             // raise moves key(0) from 255, advancing the floor past chunk 0.
@@ -3823,14 +3863,15 @@ pub mod tests {
                 .unwrap();
 
             // Commit P, prune chunk 0, then apply C.
-            db.apply_batch(p_m).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(p_m).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let floor = *db.inactivity_floor_loc();
             assert!(floor >= 256, "floor must be past chunk 0: floor={floor}",);
 
-            db.prune(db.sync_boundary()).await.unwrap();
-            db.apply_batch(c_m).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
+            let (db, _) = db.apply_batch(c_m).await.unwrap();
 
             db.destroy().await.unwrap();
         });
@@ -3843,7 +3884,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("pac", &ctx),
             )
@@ -3871,8 +3912,8 @@ pub mod tests {
 
             let expected_root = c.root();
 
-            db.apply_batch(a).await.unwrap();
-            db.apply_batch(c).await.unwrap();
+            let (db, _) = db.apply_batch(a).await.unwrap();
+            let (db, _) = db.apply_batch(c).await.unwrap();
 
             assert_eq!(db.root(), expected_root);
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(0)));
@@ -3891,7 +3932,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("bmo", &ctx),
             )
@@ -3927,8 +3968,8 @@ pub mod tests {
             // Apply A only, then apply D (B and C uncommitted).
             // D has 3 ancestors: [C, B, A] (parent-first) with batch_ends [C.total, B.total, A.total].
             // Bitmap ancestors are also parent-first: [C, B, A].
-            db.apply_batch(a).await.unwrap();
-            db.apply_batch(d.clone()).await.unwrap();
+            let (db, _) = db.apply_batch(a).await.unwrap();
+            let (db, _) = db.apply_batch(d.clone()).await.unwrap();
 
             // Build a new batch E on top of the current state. If the bitmap was
             // corrupted by the ordering bug (A's pushes duplicated or B/C's pushes
@@ -3940,7 +3981,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(e).await.unwrap();
+            let (db, _) = db.apply_batch(e).await.unwrap();
 
             // Reference: apply all five sequentially.
             let ref_ctx = context.child("ref");
@@ -3957,7 +3998,7 @@ pub mod tests {
                     .merkleize(&ref_db, None)
                     .await
                     .unwrap();
-                ref_db.apply_batch(batch).await.unwrap();
+                (ref_db, _) = ref_db.apply_batch(batch).await.unwrap();
             }
 
             assert_eq!(
@@ -3991,7 +4032,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb = UnorderedVariableDb::init(
+            let db: UnorderedVariableDb = UnorderedVariableDb::init(
                 ctx.child("storage"),
                 variable_config::<OneCap>("spec_eq", &ctx),
             )
@@ -4001,8 +4042,8 @@ pub mod tests {
             // Seed all keys in one committed batch.
             let seed = (0..SEED_KEYS).fold(db.new_batch(), |b, i| b.write(key(i), Some(val(i))));
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Setup sanity: the committed bitmap spans at least two chunks.
             assert!(
@@ -4050,7 +4091,7 @@ pub mod tests {
             // Apply child (commits parent + child) and re-read every chunk from the committed
             // bitmap. The two views must be byte-identical; otherwise the precomputed
             // `batch.canonical_root` is no longer valid against the post-apply state.
-            db.apply_batch(child).await.unwrap();
+            let (db, _) = db.apply_batch(child).await.unwrap();
             let committed_chunks: Vec<[u8; N]> = {
                 let len = Readable::<N>::len(db.any.bitmap.as_ref());
                 let chunk_count = len.div_ceil(CHUNK_SIZE_BITS) as usize;
@@ -4074,7 +4115,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let ctx = context.child("db");
-            let mut db: UnorderedFixedMmbDb = UnorderedFixedMmbDb::init(
+            let db: UnorderedFixedMmbDb = UnorderedFixedMmbDb::init(
                 ctx.child("storage"),
                 fixed_config::<OneCap>("mmb-ops-proof", &ctx),
             )
@@ -4084,7 +4125,7 @@ pub mod tests {
             // Apply a batch and commit so an ops historical proof exists.
             let writes: Vec<(Digest, Option<Digest>)> =
                 (0u64..16).map(|i| (key(i), Some(val(i)))).collect();
-            commit_writes(&mut db, writes).await.unwrap();
+            let db = commit_writes(db, writes).await.unwrap();
 
             let ops_root = db.ops_root();
             let historical_size = db.bounds().end;

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -2238,7 +2238,6 @@ pub mod tests {
                 "unexpected rewind error for unsettled delayed-merge window: {err:?}"
             );
 
-            // The failed rewind consumed the db; reopen to continue.
             let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
                 context.child("reopen"),
                 variable_config::<OneCap>(partition, &context),
@@ -2744,7 +2743,6 @@ pub mod tests {
                 "expected prune rejection above sync boundary, got {err:?}"
             );
 
-            // The failed prune consumed the db; reopen to continue.
             let reopened: UnorderedVariableDb = UnorderedVariableDb::init(
                 context.child("reopen"),
                 variable_config::<OneCap>(partition, &context),

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -2237,14 +2237,6 @@ pub mod tests {
                 matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
                 "unexpected rewind error for unsettled delayed-merge window: {err:?}"
             );
-
-            let reopened: UnorderedVariableMmbDb = UnorderedVariableMmbDb::init(
-                context.child("reopen"),
-                variable_config::<OneCap>(partition, &context),
-            )
-            .await
-            .unwrap();
-            reopened.destroy().await.unwrap();
         });
     }
 
@@ -2896,14 +2888,6 @@ pub mod tests {
                 ),
                 "unexpected rewind error: {err:?}"
             );
-
-            let db: UnorderedVariableDb = UnorderedVariableDb::init(
-                ctx.child("reopen2"),
-                variable_config::<OneCap>(partition, &ctx),
-            )
-            .await
-            .unwrap();
-            db.destroy().await.unwrap();
         });
     }
 
@@ -2969,14 +2953,6 @@ pub mod tests {
                 matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
                 "unexpected rewind error: {err:?}"
             );
-
-            let db: UnorderedVariableDb = UnorderedVariableDb::init(
-                ctx.child("reopen"),
-                variable_config::<OneCap>(partition, &ctx),
-            )
-            .await
-            .unwrap();
-            db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -168,11 +168,12 @@ pub mod test {
                     .merkleize(&db, None)
                     .await
                     .unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
             }
 
             // Prune the database
-            db.prune(db.sync_boundary()).await.unwrap();
+            let boundary = db.sync_boundary();
+            let db = db.prune(boundary).await.unwrap();
 
             assert!(
                 db.any.bitmap.pruned_chunks() > 0,

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -217,7 +217,7 @@ pub mod tests {
         assert_eq!(db.oldest_retained(), 0);
         let root0 = db.root();
         drop(db);
-        let mut db: C = open_db(context.child("second"), partition.clone()).await;
+        let db: C = open_db(context.child("second"), partition.clone()).await;
         assert!(db.get_metadata().await.unwrap().is_none());
         assert_eq!(db.root(), root0);
 
@@ -231,15 +231,15 @@ pub mod tests {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert!(db.get_metadata().await.unwrap().is_none());
         let root1 = db.root();
         assert_ne!(root1, root0);
 
         drop(db);
-        let mut db: C = open_db(context.child("third"), partition.clone()).await;
+        let db: C = open_db(context.child("third"), partition.clone()).await;
         assert_eq!(db.root(), root1);
 
         // Create of same key should fail (key already exists).
@@ -254,21 +254,21 @@ pub mod tests {
             .merkleize(&db, Some(metadata.clone()))
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
         let root2 = db.root();
 
         drop(db);
-        let mut db: C = open_db(context.child("fourth"), partition.clone()).await;
+        let db: C = open_db(context.child("fourth"), partition.clone()).await;
         assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
         assert_eq!(db.root(), root2);
 
         // Repeated delete of same key should fail (key already deleted).
         assert!(db.get(&k1).await.unwrap().is_none());
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let root3 = db.root();
         assert_ne!(root3, root2);
 
@@ -286,7 +286,7 @@ pub mod tests {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_ne!(db.root(), root3);
 
         db.destroy().await.unwrap();
@@ -310,7 +310,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let partition = "build-small".to_string();
-            let mut db = open_db(context.child("db"), partition.clone()).await;
+            let db = open_db(context.child("db"), partition.clone()).await;
 
             // Add one key.
             let k = Sha256::fill(0x01);
@@ -321,7 +321,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             let (_, op_loc) = db.any.get_with_loc(&k).await.unwrap().unwrap();
             let proof = db.key_value_proof(k).await.unwrap();
@@ -354,7 +354,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // New value should not be verifiable against the old proof.
@@ -485,11 +485,11 @@ pub mod tests {
                 &root,
             ));
 
-            let mut db = apply_random_ops::<F, TestDb<F, C, V>>(200, true, context.next_u64(), db)
+            let db = apply_random_ops::<F, TestDb<F, C, V>>(200, true, context.next_u64(), db)
                 .await
                 .unwrap();
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // Make sure size-constrained batches of operations are provable from the oldest
@@ -539,11 +539,11 @@ pub mod tests {
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
             let db = open_db(context.child("db"), partition.clone()).await;
-            let mut db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
+            let db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
                 .await
                 .unwrap();
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // Confirm bad keys produce the expected error.
@@ -632,7 +632,7 @@ pub mod tests {
                     .merkleize(&db, None)
                     .await
                     .unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
                 assert_eq!(db.get(&k).await.unwrap().unwrap(), v);
                 let root = db.root();
 
@@ -672,7 +672,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let partition = "exclusion-proofs".to_string();
-            let mut db = open_db(context.child("db"), partition.clone()).await;
+            let db = open_db(context.child("db"), partition.clone()).await;
 
             let key_exists_1 = Sha256::fill(0x10);
 
@@ -693,7 +693,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // We shouldn't be able to generate an exclusion proof for a key already in the db.
@@ -737,7 +737,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // Use a lesser/greater key that has a translated-key conflict based
@@ -816,8 +816,8 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.sync().await.unwrap();
             let root = db.root();
             // This root should be different than the empty root from earlier since the DB now has a
             // non-zero number of operations.

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -63,7 +63,9 @@ use crate::{
         },
         metrics::Metrics as AnyMetrics,
         operation::{Committable, Key, Operation as _},
-        sync::{Database, DatabaseConfig as Config, resolver::fetch_operations},
+        sync::{
+            Database, DatabaseConfig as Config, compact::ServeError, resolver::fetch_operations,
+        },
     },
     translator::Translator,
 };
@@ -469,7 +471,7 @@ macro_rules! impl_current_resolver {
             type Family = F;
             type Digest = H::Digest;
             type Op = $op<F, K, V>;
-            type Error = qmdb::Error<F>;
+            type Error = ServeError<F, H::Digest>;
 
             async fn get_operations(
                 &self,
@@ -478,10 +480,10 @@ macro_rules! impl_current_resolver {
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
                 _cancel_rx: oneshot::Receiver<()>,
-            ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, qmdb::Error<F>> {
+            ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
-                let db = guard.as_ref().ok_or(qmdb::Error::<F>::KeyNotFound)?;
-                fetch_operations(
+                let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
+                Ok(fetch_operations(
                     op_count,
                     start_loc,
                     max_ops,
@@ -491,7 +493,7 @@ macro_rules! impl_current_resolver {
                     },
                     |start_loc| db.any.pinned_nodes_at(start_loc),
                 )
-                .await
+                .await?)
             }
         }
     };

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -172,7 +172,7 @@ mod harnesses {
     }
 
     async fn apply_unordered_fixed_ops<F: merkle::Graftable>(
-        mut db: UnorderedFixedDb<F>,
+        db: UnorderedFixedDb<F>,
         ops: Vec<crate::qmdb::any::unordered::fixed::Operation<F, Digest, Digest>>,
     ) -> UnorderedFixedDb<F> {
         use crate::qmdb::any::operation::{Operation, update::Unordered as Update};
@@ -192,13 +192,12 @@ mod harnesses {
             }
             batch.merkleize(&db, None::<Digest>).await.unwrap()
         };
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
     async fn apply_unordered_variable_ops<F: merkle::Graftable>(
-        mut db: UnorderedVariableDb<F>,
+        db: UnorderedVariableDb<F>,
         ops: Vec<crate::qmdb::any::unordered::variable::Operation<F, Digest, Digest>>,
     ) -> UnorderedVariableDb<F> {
         use crate::qmdb::any::operation::{Operation, update::Unordered as Update};
@@ -218,13 +217,12 @@ mod harnesses {
             }
             batch.merkleize(&db, None::<Digest>).await.unwrap()
         };
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
     async fn apply_ordered_fixed_ops<F: merkle::Graftable>(
-        mut db: OrderedFixedDb<F>,
+        db: OrderedFixedDb<F>,
         ops: Vec<crate::qmdb::any::ordered::fixed::Operation<F, Digest, Digest>>,
     ) -> OrderedFixedDb<F> {
         use crate::qmdb::any::operation::{Operation, update::Ordered as Update};
@@ -244,13 +242,12 @@ mod harnesses {
             }
             batch.merkleize(&db, None::<Digest>).await.unwrap()
         };
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
     async fn apply_ordered_variable_ops<F: merkle::Graftable>(
-        mut db: OrderedVariableDb<F>,
+        db: OrderedVariableDb<F>,
         ops: Vec<crate::qmdb::any::ordered::variable::Operation<F, Digest, Digest>>,
     ) -> OrderedVariableDb<F> {
         use crate::qmdb::any::operation::{Operation, update::Ordered as Update};
@@ -270,9 +267,8 @@ mod harnesses {
             }
             batch.merkleize(&db, None::<Digest>).await.unwrap()
         };
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        db.commit().await.unwrap()
     }
 
     pub struct UnorderedFixedHarness<F>(std::marker::PhantomData<F>);
@@ -507,8 +503,8 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
                 .merkleize(&target_db, None)
                 .await
                 .unwrap();
-            target_db.apply_batch(merkleized).await.unwrap();
-            target_db.commit().await.unwrap();
+            (target_db, _) = target_db.apply_batch(merkleized).await.unwrap();
+            target_db = target_db.commit().await.unwrap();
         }
 
         assert!(
@@ -516,7 +512,8 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
             "expected inactivity floor past chunk 0"
         );
 
-        target_db.prune(target_db.sync_boundary()).await.unwrap();
+        let boundary = target_db.sync_boundary();
+        let target_db = target_db.prune(boundary).await.unwrap();
 
         let sync_root = SyncDatabase::root(&target_db);
         let verification_root = target_db.root();
@@ -599,12 +596,12 @@ fn test_current_local_boundary_nodes_rejects_target_before_local_lower_bound() {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db = db.commit().await.unwrap();
         }
         let prune_loc = crate::merkle::Location::new(256);
         assert!(db.sync_boundary() >= prune_loc);
-        db.prune(prune_loc).await.unwrap();
+        let db = db.prune(prune_loc).await.unwrap();
 
         let bounds = db.bounds();
         let local_start = bounds.start;

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -138,7 +138,7 @@ pub mod test {
     #[test_traced("INFO")]
     pub fn test_current_unordered_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = open_db(ctx.child("current"), "metrics".to_string()).await;
+            let db = open_db(ctx.child("current"), "metrics".to_string()).await;
             let key = Sha256::fill(1u8);
             let value = Sha256::fill(2u8);
             let batch = db
@@ -147,10 +147,11 @@ pub mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(batch).await.unwrap();
+            let (db, _) = db.apply_batch(batch).await.unwrap();
             assert_eq!(db.get(&key).await.unwrap(), Some(value));
-            db.sync().await.unwrap();
-            db.prune(db.sync_boundary()).await.unwrap();
+            let db = db.sync().await.unwrap();
+            let boundary = db.sync_boundary();
+            let _db = db.prune(boundary).await.unwrap();
 
             let metrics = ctx.encode();
             for expected in [
@@ -183,15 +184,15 @@ pub mod test {
         }
 
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = open_db(ctx.child("current"), "fused-parity".to_string()).await;
+            let db = open_db(ctx.child("current"), "fused-parity".to_string()).await;
 
             let mut seed = db.new_batch();
             for i in 0..2000u64 {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             let make = |salt: u64| -> Vec<(Digest, Option<Digest>)> {
                 let mut rng = TestRng::new(salt);
@@ -272,7 +273,7 @@ pub mod test {
         }
 
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = open_db(ctx.child("current"), "staged-ancestor".to_string()).await;
+            let db = open_db(ctx.child("current"), "staged-ancestor".to_string()).await;
 
             // Committed base state, so the grandparent's write of key(0) supersedes a
             // committed location. Its create of key(100) supersedes none.
@@ -281,8 +282,8 @@ pub mod test {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let seed = seed.merkleize(&db, None).await.unwrap();
-            db.apply_batch(seed).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(seed).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             // Grandparent -> parent chain. The parent touches neither staged key, so the
             // staged reads resolve in the grandparent's diff.
@@ -311,7 +312,7 @@ pub mod test {
 
             // Commit and free the grandparent: the staged resolutions' locations migrate
             // into the committed region, retiring their recorded bases.
-            db.apply_batch(grandparent).await.unwrap();
+            let (db, _) = db.apply_batch(grandparent).await.unwrap();
 
             let updates = vec![(0, Some(val(2_000))), (1, Some(val(2_001)))];
             let staged = staged
@@ -330,9 +331,9 @@ pub mod test {
                 .root();
             assert_eq!(staged.root(), explicit_root);
 
-            db.apply_batch(parent).await.unwrap();
-            db.apply_batch(staged).await.unwrap();
-            db.commit().await.unwrap();
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let (db, _) = db.apply_batch(staged).await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert_eq!(db.get(&key(0)).await.unwrap(), Some(val(2_000)));
             assert_eq!(db.get(&key(100)).await.unwrap(), Some(val(2_001)));
@@ -362,9 +363,9 @@ pub mod test {
                     .await
                     .unwrap();
                 last_batch_boundary = batch.sync_boundary();
-                db.apply_batch(batch).await.unwrap();
+                (db, _) = db.apply_batch(batch).await.unwrap();
             }
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
 
             // The boundary must have advanced, otherwise the inactivity floor never crossed a chunk
             // and the equality below would hold trivially.

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -81,7 +81,7 @@ pub mod tests {
         assert_eq!(db.oldest_retained(), 0);
         let root0 = db.root();
         drop(db);
-        let mut db: C = open_db(context.child("second"), partition.clone()).await;
+        let db: C = open_db(context.child("second"), partition.clone()).await;
         assert!(db.get_metadata().await.unwrap().is_none());
         assert_eq!(db.root(), root0);
 
@@ -95,14 +95,14 @@ pub mod tests {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert!(db.get_metadata().await.unwrap().is_none());
         let root1 = db.root();
         assert_ne!(root1, root0);
         drop(db);
-        let mut db: C = open_db(context.child("third"), partition.clone()).await;
+        let db: C = open_db(context.child("third"), partition.clone()).await;
         assert!(db.get_metadata().await.unwrap().is_none());
         assert_eq!(db.root(), root1);
 
@@ -118,22 +118,22 @@ pub mod tests {
             .merkleize(&db, Some(metadata.clone()))
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap().unwrap(), metadata);
         let root2 = db.root();
 
         // Repeated delete of same key should fail (key already deleted).
         assert!(db.get(&k1).await.unwrap().is_none());
         let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-        db.apply_batch(merkleized).await.unwrap();
-        db.sync().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.sync().await.unwrap();
         let root3 = db.root();
         assert_ne!(root3, root2);
 
         // Confirm re-open preserves state.
         drop(db);
-        let mut db: C = open_db(context.child("fourth"), partition.clone()).await;
+        let db: C = open_db(context.child("fourth"), partition.clone()).await;
         // Last commit had no metadata (passed None to merkleize).
         assert!(db.get_metadata().await.unwrap().is_none());
         assert_eq!(db.root(), root3);
@@ -152,7 +152,7 @@ pub mod tests {
             .merkleize(&db, None)
             .await
             .unwrap();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_ne!(db.root(), root3);
 
         db.destroy().await.unwrap();
@@ -176,7 +176,7 @@ pub mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let partition = "build-small".to_string();
-            let mut db = open_db(context.child("db"), partition.clone()).await;
+            let db = open_db(context.child("db"), partition.clone()).await;
 
             // Add one key.
             let k = Sha256::fill(0x01);
@@ -187,7 +187,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
             let (_, op_loc) = db.any.get_with_loc(&k).await.unwrap().unwrap();
             let proof = db.key_value_proof(k).await.unwrap();
@@ -211,7 +211,7 @@ pub mod tests {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // New value should not be verifiable against the old proof.
@@ -336,11 +336,11 @@ pub mod tests {
                 &root,
             ));
 
-            let mut db = apply_random_ops::<F, TestDb<F, C, V>>(200, true, context.next_u64(), db)
+            let db = apply_random_ops::<F, TestDb<F, C, V>>(200, true, context.next_u64(), db)
                 .await
                 .unwrap();
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // Make sure size-constrained batches of operations are provable from the oldest
@@ -390,11 +390,11 @@ pub mod tests {
         executor.start(|mut context| async move {
             let partition = "range-proofs".to_string();
             let db = open_db(context.child("db"), partition.clone()).await;
-            let mut db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
+            let db = apply_random_ops::<F, TestDb<F, C, V>>(500, true, context.next_u64(), db)
                 .await
                 .unwrap();
             let merkleized = db.new_batch().merkleize(&db, None).await.unwrap();
-            db.apply_batch(merkleized).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
             let root = db.root();
 
             // Confirm bad keys produce the expected error.
@@ -478,7 +478,7 @@ pub mod tests {
                     .merkleize(&db, None)
                     .await
                     .unwrap();
-                db.apply_batch(merkleized).await.unwrap();
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
                 assert_eq!(db.get(&k).await.unwrap().unwrap(), v);
                 let root = db.root();
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -84,6 +84,25 @@ where
     _key: PhantomData<K>,
 }
 
+impl<F, E, K, V, H, C, S: Strategy> std::fmt::Debug for Db<F, E, K, V, H, C, S>
+where
+    F: Family,
+    E: Context,
+    K: Key,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, K, V>: EncodeShared,
+    Operation<F, K, V>: Read<Cfg = C>,
+    C: Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Db")
+            .field("size", &self.size())
+            .field("inactivity_floor_loc", &self.inactivity_floor_loc())
+            .finish_non_exhaustive()
+    }
+}
+
 type CompactStateResult<F, K, V, D> =
     Result<compact_sync::State<F, Operation<F, K, V>, D>, compact_sync::ServeError<F, D>>;
 
@@ -477,6 +496,20 @@ where
         })
     }
 
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &MerkleizedBatch<F, H::Digest, K, V, S>,
+    ) -> Result<(), Error<F>> {
+        batch
+            .bounds
+            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+    }
+
     /// Apply a merkleized batch to the database.
     ///
     /// Returns the range of locations written. The state is updated in memory only; call
@@ -496,42 +529,47 @@ where
         skip_all
     )]
     pub fn apply_batch(
-        &mut self,
+        mut self,
         batch: Arc<MerkleizedBatch<F, H::Digest, K, V, S>>,
-    ) -> Result<core::ops::Range<Location<F>>, Error<F>> {
-        let db_size = *self.last_commit_loc + 1;
-        batch
-            .bounds
-            .validate_apply_to(db_size, self.inactivity_floor_loc)?;
+    ) -> Result<(Self, core::ops::Range<Location<F>>), Error<F>> {
+        self.validate_batch(&batch)?;
 
         let start_loc = self.last_commit_loc + 1;
         self.merkle.apply_batch(&batch.merkle_batch)?;
         self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        Ok(start_loc..Location::new(batch.bounds.total_size))
+        Ok((self, start_loc..Location::new(batch.bounds.total_size)))
     }
 
     /// Durably persist the current db state to disk. This is faster than [`Self::sync`] but
     /// reopen may need to replay the witness journal's tail to recover.
     #[tracing::instrument(name = "qmdb.immutable.compact.db.commit", level = "info", skip_all)]
-    pub async fn commit(&mut self) -> Result<(), Error<F>> {
-        self.witness
-            .commit::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
-                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
+        let last_commit_metadata = self.last_commit_metadata.clone();
+        let inactivity_floor_loc = self.inactivity_floor_loc;
+        self.witness = self
+            .witness
+            .commit::<H, S>(&self.merkle, inactivity_floor_loc, || {
+                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
             })
-            .await
+            .await?;
+        Ok(self)
     }
 
     /// Durably persist the current db state to disk, also persisting journal metadata to
     /// minimize recovery work on reopen.
     #[tracing::instrument(name = "qmdb.immutable.compact.db.sync", level = "info", skip_all)]
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
-        self.witness
-            .sync::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
-                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
+        let last_commit_metadata = self.last_commit_metadata.clone();
+        let inactivity_floor_loc = self.inactivity_floor_loc;
+        self.witness = self
+            .witness
+            .sync::<H, S>(&self.merkle, inactivity_floor_loc, || {
+                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
             })
-            .await
+            .await?;
+        Ok(self)
     }
 
     /// Rewind the db to the synced commit with exactly `target` operations, discarding any
@@ -543,7 +581,7 @@ where
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
     /// no retained commit has exactly `target` operations (never synced, or pruned).
     #[tracing::instrument(name = "qmdb.immutable.compact.db.rewind", level = "info", skip_all)]
-    pub async fn rewind(&mut self, target: Location<F>) -> Result<(), Error<F>>
+    pub async fn rewind(mut self, target: Location<F>) -> Result<Self, Error<F>>
     where
         F: Family,
     {
@@ -552,10 +590,11 @@ where
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
         {
-            return Ok(());
+            return Ok(self);
         }
 
-        let last_commit_op = self
+        let last_commit_op;
+        (self.witness, last_commit_op) = self
             .witness
             .rewind::<H, S, Operation<F, K, V>>(
                 &self.merkle,
@@ -570,7 +609,7 @@ where
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
         self.last_commit_loc = Location::new(*target - 1);
-        Ok(())
+        Ok(self)
     }
 
     /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness below
@@ -583,8 +622,9 @@ where
     ///
     /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
     /// [`Self::sync`].
-    pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
-        self.witness.prune(pruning_boundary).await
+    pub async fn prune(mut self, pruning_boundary: Location<F>) -> Result<Self, Error<F>> {
+        self.witness = self.witness.prune(pruning_boundary).await?;
+        Ok(self)
     }
 
     /// Destroy all persisted state associated with this database.
@@ -617,8 +657,8 @@ mod tests {
     const WITNESS_PAGE_SIZE: NonZeroU16 = NZU16!(77);
     const WITNESS_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 
-    fn witness_config(partition: &str, pooler: &impl BufferPooler) -> variable::Config<()> {
-        variable::Config {
+    fn witness_config(partition: &str, pooler: &impl BufferPooler) -> JournalConfig<()> {
+        JournalConfig {
             partition: format!("{partition}-witness"),
             items_per_section: NZU64!(64),
             compression: None,
@@ -642,13 +682,13 @@ mod tests {
         partition: &str,
     ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
         let cfg = witness_config(partition, &context);
-        variable::Journal::init(context, cfg).await.unwrap()
+        witness::Journal::init(context, cfg).await.unwrap()
     }
 
     #[test_traced("INFO")]
     fn test_compact_stale_batch_rejected() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "immutable-stale").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-stale").await;
 
             let key1 = Sha256::hash(&[1]);
             let key2 = Sha256::hash(&[2]);
@@ -667,14 +707,12 @@ mod tests {
                 .await;
 
             let expected_root = batch_a.root();
-            db.apply_batch(batch_a).unwrap();
+            let (db, _) = db.apply_batch(batch_a).unwrap();
             assert_eq!(db.root(), expected_root);
             assert!(matches!(
                 db.apply_batch(batch_b),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
@@ -683,8 +721,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_to_batch_reflects_live_state() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-to-batch-live").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-to-batch-live").await;
 
             let pre_apply_root = db.root();
             let pre_snapshot = db.to_batch();
@@ -696,13 +733,12 @@ mod tests {
 
             let key = Sha256::hash(&[1]);
             let value = Sha256::fill(10u8);
-            db.apply_batch(
-                db.new_batch()
-                    .set(key, value)
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
+            let batch = db
+                .new_batch()
+                .set(key, value)
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
 
             // Leave the witness cache behind the live Merkle state.
             let live_root = db.root();
@@ -725,8 +761,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_stale_batch_chained() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-chained-stale").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-chained-stale").await;
 
             let parent = db
                 .new_batch()
@@ -744,20 +779,18 @@ mod tests {
                 .merkleize(&db, None, Location::new(0))
                 .await;
 
-            db.apply_batch(child_a).unwrap();
+            let (db, _) = db.apply_batch(child_a).unwrap();
             assert!(matches!(
                 db.apply_batch(child_b),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_stale_parent_after_child_applied() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-child-before-parent").await;
 
             let parent = db
@@ -771,21 +804,18 @@ mod tests {
                 .merkleize(&db, None, Location::new(0))
                 .await;
 
-            db.apply_batch(child).unwrap();
+            let (db, _) = db.apply_batch(child).unwrap();
             assert!(matches!(
                 db.apply_batch(parent),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_sequential_commit_parent_then_child() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-parent-child").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-parent-child").await;
 
             let parent = db
                 .new_batch()
@@ -799,9 +829,9 @@ mod tests {
                 .await;
             let expected_root = child.root();
 
-            db.apply_batch(parent).unwrap();
-            db.apply_batch(child).unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = db.apply_batch(parent).unwrap();
+            let (db, _) = db.apply_batch(child).unwrap();
+            let db = db.sync().await.unwrap();
 
             assert_eq!(db.root(), expected_root);
 
@@ -812,12 +842,11 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_floor_regressed() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-floor-regressed").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-floor-regressed").await;
 
             let advance_floor = db.new_batch().set(Sha256::hash(&[1]), Sha256::fill(1u8));
             let advance_floor = advance_floor.merkleize(&db, None, Location::new(1)).await;
-            db.apply_batch(advance_floor).unwrap();
+            let (db, _) = db.apply_batch(advance_floor).unwrap();
 
             let regressed = db
                 .new_batch()
@@ -830,8 +859,6 @@ mod tests {
                 Err(Error::FloorRegressed(new, current))
                     if new == Location::new(0) && current == Location::new(1)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
@@ -841,7 +868,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_ancestor_floor_regressed() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-regressed-ancestor-floor")
                     .await;
 
@@ -861,28 +888,25 @@ mod tests {
                 Err(Error::FloorRegressed(new, prev))
                     if new == Location::new(0) && prev == Location::new(1)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_rewind_restores_commit_metadata_and_floor() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-meta").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-meta").await;
 
             let k1 = Sha256::hash(&[1]);
             let v1 = Sha256::fill(11u8);
             let meta1 = Sha256::fill(0xaa);
             let floor1 = Location::new(0);
-            db.apply_batch(
-                db.new_batch()
-                    .set(k1, v1)
-                    .merkleize(&db, Some(meta1), floor1)
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(k1, v1)
+                .merkleize(&db, Some(meta1), floor1)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_after_first = db.root();
             let size_after_first = db.size();
 
@@ -891,18 +915,17 @@ mod tests {
             let meta2 = Sha256::fill(0xbb);
             // Advance the floor to the commit of the first batch (loc 1).
             let floor2 = Location::new(1);
-            db.apply_batch(
-                db.new_batch()
-                    .set(k2, v2)
-                    .merkleize(&db, Some(meta2), floor2)
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(k2, v2)
+                .merkleize(&db, Some(meta2), floor2)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.get_metadata(), Some(meta2));
             assert_eq!(db.inactivity_floor_loc(), floor2);
 
-            db.rewind(size_after_first).await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.get_metadata(), Some(meta1));
             assert_eq!(db.inactivity_floor_loc(), floor1);
@@ -921,28 +944,26 @@ mod tests {
             let floor2 = Location::new(1);
 
             let root_after_first = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
-                        .merkleize(&db, Some(meta1), floor1)
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                    .merkleize(&db, Some(meta1), floor1)
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.sync().await.unwrap();
                 let root = db.root();
                 let size_after_first = db.size();
 
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[2]), Sha256::fill(22u8))
-                        .merkleize(&db, Some(meta2), floor2)
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[2]), Sha256::fill(22u8))
+                    .merkleize(&db, Some(meta2), floor2)
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.sync().await.unwrap();
 
-                db.rewind(size_after_first).await.unwrap();
+                let _db = db.rewind(size_after_first).await.unwrap();
                 root
             };
 
@@ -963,24 +984,22 @@ mod tests {
             let meta2 = Sha256::fill(0xbb);
 
             let root_after_second = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
-                        .merkleize(&db, Some(meta1), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                    .merkleize(&db, Some(meta1), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
 
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[2]), Sha256::fill(22u8))
-                        .merkleize(&db, Some(meta2), Location::new(1))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[2]), Sha256::fill(22u8))
+                    .merkleize(&db, Some(meta2), Location::new(1))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
                 db.root()
             };
 
@@ -1001,33 +1020,31 @@ mod tests {
             let meta2 = Sha256::fill(0xbb);
 
             let (root_a, size_a) = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
-                        .merkleize(&db, Some(meta1), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                    .merkleize(&db, Some(meta1), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
                 let root_a = db.root();
                 let size_a = db.size();
 
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[2]), Sha256::fill(22u8))
-                        .merkleize(&db, Some(meta2), Location::new(1))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[2]), Sha256::fill(22u8))
+                    .merkleize(&db, Some(meta2), Location::new(1))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let _db = db.commit().await.unwrap();
                 (root_a, size_a)
             };
 
             // Both committed witnesses survive the crash: reopen recovers the tip, and the
             // earlier commit remains a valid rewind target.
-            let mut db = open_db::<mmr::Family>(context.child("second"), partition).await;
-            db.rewind(size_a).await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            let db = db.rewind(size_a).await.unwrap();
             assert_eq!(db.root(), root_a);
             assert_eq!(db.get_metadata(), Some(meta1));
             db.destroy().await.unwrap();
@@ -1041,17 +1058,16 @@ mod tests {
             let meta = Sha256::fill(0xaa);
 
             let root = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[1]), Sha256::fill(11u8))
-                        .merkleize(&db, Some(meta), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[1]), Sha256::fill(11u8))
+                    .merkleize(&db, Some(meta), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
                 // The commit already made the state durable, so this is a no-op.
-                db.sync().await.unwrap();
+                let db = db.sync().await.unwrap();
                 db.root()
             };
 
@@ -1066,16 +1082,14 @@ mod tests {
     fn test_compact_reopen_rejects_tampered_witness() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-witness-tamper";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[7]), Sha256::fill(7u8))
-                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[7]), Sha256::fill(7u8))
+                .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Corrupt the persisted proof so it no longer verifies against the stored root.
             let mut journal = open_witness_journal(context.child("tamper"), partition).await;
@@ -1085,7 +1099,7 @@ mod tests {
             } else {
                 proof.leaves = Location::new(*proof.leaves + 1);
             }
-            witness::tests::overwrite_tip(&mut journal, op_bytes, proof, pinned_nodes).await;
+            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
             drop(journal);
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1104,30 +1118,28 @@ mod tests {
     fn test_compact_rewind_rejects_corrupt_target_entry() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-corrupt-rewind-target";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, None, Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, None, Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let rewind_target = db.target().leaf_count;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[2]), Sha256::fill(2u8))
-                    .merkleize(&db, None, Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[2]), Sha256::fill(2u8))
+                .merkleize(&db, None, Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let tip_target = db.target();
             drop(db);
 
             // Corrupt the rewind target's entry (the journal holds bootstrap, target, tip).
             let mut journal = open_witness_journal(context.child("corrupt"), partition).await;
-            witness::tests::corrupt_entry(&mut journal, 1, |entry| {
+            journal = witness::tests::corrupt_entry(journal, 1, |entry| {
                 entry.pinned_nodes[0] = Sha256::fill(0xff);
             })
             .await;
@@ -1135,7 +1147,7 @@ mod tests {
 
             // The tip entry is intact, so reopen succeeds.
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let mut reopened = TestDb::<mmr::Family>::init_from_merkle(
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
                 merkle,
                 context.child("reopen"),
                 witness_config(partition, &context),
@@ -1145,12 +1157,11 @@ mod tests {
             .unwrap();
             assert_eq!(reopened.target(), tip_target);
 
-            // The corrupt entry fails the rewind before any truncation.
+            // The corrupt entry fails the rewind before any truncation, consuming the handle.
             assert!(matches!(
                 reopened.rewind(rewind_target).await,
                 Err(Error::DataCorrupted(_))
             ));
-            drop(reopened);
 
             // The newer history survives: reopen still lands on the original tip.
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1171,16 +1182,14 @@ mod tests {
     fn test_compact_reopen_rejects_interrupted_import() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-interrupted-import";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[7]), Sha256::fill(7u8))
-                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[7]), Sha256::fill(7u8))
+                .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Simulate a crash between an import's journal clear and its entry append: the
             // journal is empty but its size is nonzero.
@@ -1206,16 +1215,14 @@ mod tests {
     fn test_compact_reopen_rejects_commit_floor_beyond_tip() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-invalid-persisted-floor";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[7]), Sha256::fill(7u8))
-                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[7]), Sha256::fill(7u8))
+                .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
             let oversized_floor = Location::new(10);
 
             // Overwrite the persisted commit op with a floor beyond its own commit location.
@@ -1227,7 +1234,7 @@ mod tests {
             )
             .encode()
             .to_vec();
-            witness::tests::overwrite_tip(&mut journal, bad_op, proof, pinned_nodes).await;
+            journal = witness::tests::overwrite_tip(journal, bad_op, proof, pinned_nodes).await;
             drop(journal);
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1249,23 +1256,21 @@ mod tests {
     fn test_compact_reopen_rejects_tampered_pinned_nodes() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-pins-tamper";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[7]), Sha256::fill(7u8))
-                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[7]), Sha256::fill(7u8))
+                .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
             // longer matches the proof stored in the same entry.
             let mut journal = open_witness_journal(context.child("tamper"), partition).await;
             let (op_bytes, proof, mut pinned_nodes) = witness::tests::tip(&journal).await;
             pinned_nodes[0] = Sha256::fill(0xff);
-            witness::tests::overwrite_tip(&mut journal, op_bytes, proof, pinned_nodes).await;
+            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
             drop(journal);
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1286,17 +1291,16 @@ mod tests {
     fn test_compact_reopen_drops_unsynced_witness() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-witness-unsynced";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
 
             // Commit state A.
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let target_a = db.target();
             drop(db);
 
@@ -1305,7 +1309,7 @@ mod tests {
             let mut journal = open_witness_journal(context.child("crash"), partition).await;
             let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
             proof.leaves = Location::new(*proof.leaves + 2);
-            witness::tests::append_unsynced(&mut journal, op_bytes, proof, pinned_nodes).await;
+            journal = witness::tests::append_unsynced(journal, op_bytes, proof, pinned_nodes).await;
             drop(journal);
 
             // Reopen must drop the unsynced entry and recover state A.
@@ -1318,19 +1322,26 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_beyond_history() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-rewind-beyond").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-beyond").await;
             // The bootstrap commit is the oldest retained state (one leaf); no commit with zero
             // operations exists to rewind to.
             assert!(matches!(
                 db.rewind(Location::new(0)).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+
+            // The failed rewind consumed the db; reopen to continue.
+            let db =
+                open_db::<mmr::Family>(context.child("reopen"), "immutable-rewind-beyond").await;
             // A target past the tip is not a commit either.
+            let beyond_tip = Location::new(*db.size() + 100);
             assert!(matches!(
-                db.rewind(Location::new(*db.size() + 100)).await,
+                db.rewind(beyond_tip).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+
+            let db =
+                open_db::<mmr::Family>(context.child("destroy"), "immutable-rewind-beyond").await;
             db.destroy().await.unwrap();
         });
     }
@@ -1338,46 +1349,49 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_between_commits() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-rewind-between").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-between").await;
 
             // A multi-op commit jumps the committed size from 1 (bootstrap) to 4.
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .set(Sha256::hash(&[2]), Sha256::fill(2u8))
-                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .set(Sha256::hash(&[2]), Sha256::fill(2u8))
+                .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_a = db.root();
             let size_a = db.size();
             assert_eq!(size_a, Location::new(4));
 
             // A second commit moves the size to 6.
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[3]), Sha256::fill(3u8))
-                    .merkleize(&db, Some(Sha256::fill(0xb1)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[3]), Sha256::fill(3u8))
+                .merkleize(&db, Some(Sha256::fill(0xb1)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_b = db.root();
 
             // Targets inside a commit's span match no entry, even though entries exist on
-            // both sides.
+            // both sides. Each failed rewind consumes the db, so reopen to continue.
+            let mut db = db;
             for target in [2u64, 3, 5] {
                 assert!(matches!(
                     db.rewind(Location::new(target)).await,
                     Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
                 ));
+                db = open_db::<mmr::Family>(
+                    context.child("reopen").with_attribute("target", target),
+                    "immutable-rewind-between",
+                )
+                .await;
             }
             assert_eq!(db.root(), root_b);
 
             // The exact commit boundary remains a valid target.
-            db.rewind(size_a).await.unwrap();
+            let db = db.rewind(size_a).await.unwrap();
             assert_eq!(db.root(), root_a);
             assert_eq!(db.get_metadata(), Some(Sha256::fill(0xa1)));
             db.destroy().await.unwrap();
@@ -1388,35 +1402,34 @@ mod tests {
     fn test_compact_rewind_multiple_commits() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-rewind-multi";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
 
             // Commit A, B, C, recording the state after A.
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_a = db.root();
             let size_a = db.size();
             let target_a = db.target();
 
+            let mut db = db;
             for i in [2u8, 3] {
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[i]), Sha256::fill(i))
-                        .merkleize(&db, Some(Sha256::fill(i)), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[i]), Sha256::fill(i))
+                    .merkleize(&db, Some(Sha256::fill(i)), Location::new(0))
+                    .await;
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
             }
             assert_ne!(db.root(), root_a);
 
             // Rewind two commits in one call.
-            db.rewind(size_a).await.unwrap();
+            let db = db.rewind(size_a).await.unwrap();
             assert_eq!(db.root(), root_a);
             assert_eq!(db.size(), size_a);
             assert_eq!(db.get_metadata(), Some(Sha256::fill(0xa1)));
@@ -1434,19 +1447,18 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_to_current_is_noop() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-noop").await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-rewind-noop").await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root = db.root();
             let size = db.size();
 
-            db.rewind(size).await.unwrap();
+            let db = db.rewind(size).await.unwrap();
             assert_eq!(db.root(), root);
             assert_eq!(db.size(), size);
             db.destroy().await.unwrap();
@@ -1462,31 +1474,42 @@ mod tests {
             witness_cfg.items_per_section = NZU64!(1);
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let mut db: TestDb<mmr::Family> =
-                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg.clone(), ())
                     .await
                     .unwrap();
 
             // Commit A, B, C.
             let mut sizes = Vec::new();
             for i in [1u8, 2, 3] {
-                db.apply_batch(
-                    db.new_batch()
-                        .set(Sha256::hash(&[i]), Sha256::fill(i))
-                        .merkleize(&db, Some(Sha256::fill(i)), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .set(Sha256::hash(&[i]), Sha256::fill(i))
+                    .merkleize(&db, Some(Sha256::fill(i)), Location::new(0))
+                    .await;
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
                 sizes.push(db.size());
             }
 
             // Prune history below B: rewinding to B still works, rewinding to A does not.
-            db.prune(sizes[1]).await.unwrap();
+            let db = db.prune(sizes[1]).await.unwrap();
             assert!(matches!(
                 db.rewind(sizes[0]).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
-            db.rewind(sizes[1]).await.unwrap();
+
+            // The failed rewind consumed the db; the prune was durable, so reopen and
+            // rewind to B.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let db: TestDb<mmr::Family> = Db::init_from_merkle(
+                merkle,
+                context.child("witness").with_attribute("index", 2),
+                witness_cfg,
+                (),
+            )
+            .await
+            .unwrap();
+            let db = db.rewind(sizes[1]).await.unwrap();
             assert_eq!(db.size(), sizes[1]);
             assert_eq!(db.get_metadata(), Some(Sha256::fill(2)));
 
@@ -1498,19 +1521,19 @@ mod tests {
     fn test_compact_prune_past_tip_keeps_tip() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "immutable-prune-past-tip";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, Some(Sha256::fill(0xa1)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let target = db.target();
 
             // Prune with a boundary beyond the tip: the tip entry must survive.
-            db.prune(Location::new(*db.size() + 100)).await.unwrap();
+            let boundary = Location::new(*db.size() + 100);
+            let db = db.prune(boundary).await.unwrap();
             assert_eq!(db.target(), target);
             drop(db);
 
@@ -1523,20 +1546,19 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_preserves_pre_advance_batch() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(
+            let db = open_db::<mmr::Family>(
                 context.child("db"),
                 "immutable-rewind-preserves-pre-advance",
             )
             .await;
 
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let size_after_first = db.size();
 
             // Merkleize a batch against the post-commit-A state.
@@ -1547,19 +1569,18 @@ mod tests {
                 .await;
 
             // Advance past that state and commit, then rewind back to it.
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[3]), Sha256::fill(3u8))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
-            db.rewind(size_after_first).await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[3]), Sha256::fill(3u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
 
             // The rewind restored the state that `held` was merkleized against, so it still
             // matches the Merkle size and applies cleanly.
-            db.apply_batch(held).unwrap();
+            let (db, _) = db.apply_batch(held).unwrap();
 
             db.destroy().await.unwrap();
         });
@@ -1568,26 +1589,25 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_noop_commit_after_commit() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-noop-after-commit").await;
 
             let k1 = Sha256::hash(&[1]);
             let v1 = Sha256::fill(11u8);
             let k2 = Sha256::hash(&[2]);
             let v2 = Sha256::fill(22u8);
-            db.apply_batch(
-                db.new_batch()
-                    .set(k1, v1)
-                    .set(k2, v2)
-                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(k1, v1)
+                .set(k2, v2)
+                .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_after_first = db.root();
             let size_after_first = db.size();
 
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.target().root, db.root());
@@ -1602,28 +1622,27 @@ mod tests {
             let partition = "immutable-noop-after-reopen";
 
             let (root_before_drop, size_before_drop) = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
                 let k1 = Sha256::hash(&[1]);
                 let v1 = Sha256::fill(11u8);
                 let k2 = Sha256::hash(&[2]);
                 let v2 = Sha256::fill(22u8);
-                db.apply_batch(
-                    db.new_batch()
-                        .set(k1, v1)
-                        .set(k2, v2)
-                        .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .set(k1, v1)
+                    .set(k2, v2)
+                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.sync().await.unwrap();
                 (db.root(), db.size())
             };
 
-            let mut db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
             assert_eq!(db.root(), root_before_drop);
             assert_eq!(db.size(), size_before_drop);
 
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.size(), size_before_drop);
             assert_eq!(db.root(), root_before_drop);
             assert_eq!(db.target().root, db.root());
@@ -1635,41 +1654,39 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_noop_commit_after_rewind() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-noop-after-rewind").await;
 
             let k1 = Sha256::hash(&[1]);
             let v1 = Sha256::fill(11u8);
             let k2 = Sha256::hash(&[2]);
             let v2 = Sha256::fill(22u8);
-            db.apply_batch(
-                db.new_batch()
-                    .set(k1, v1)
-                    .set(k2, v2)
-                    .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(k1, v1)
+                .set(k2, v2)
+                .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_after_first = db.root();
             let size_after_first = db.size();
 
             let k3 = Sha256::hash(&[3]);
             let v3 = Sha256::fill(33u8);
-            db.apply_batch(
-                db.new_batch()
-                    .set(k3, v3)
-                    .merkleize(&db, Some(Sha256::fill(0xbb)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(k3, v3)
+                .merkleize(&db, Some(Sha256::fill(0xbb)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
 
-            db.rewind(size_after_first).await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
 
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.target().root, db.root());
@@ -1681,27 +1698,25 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_makes_post_advance_batch_stale() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "immutable-rewind-makes-stale").await;
 
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[1]), Sha256::fill(1u8))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[1]), Sha256::fill(1u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let size_after_first = db.size();
 
-            db.apply_batch(
-                db.new_batch()
-                    .set(Sha256::hash(&[2]), Sha256::fill(2u8))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .set(Sha256::hash(&[2]), Sha256::fill(2u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
 
             // Merkleize a batch against the post-commit-B state, which the rewind will discard.
             let held = db
@@ -1710,7 +1725,7 @@ mod tests {
                 .merkleize(&db, None, Location::new(0))
                 .await;
 
-            db.rewind(size_after_first).await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
 
             // After rewind, mem.size reflects post-commit-A, but the held batch starts after
             // post-commit-B. Apply must be rejected with StaleBatch.
@@ -1718,16 +1733,13 @@ mod tests {
                 db.apply_batch(held),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_floor_beyond_size() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-floor-beyond").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-floor-beyond").await;
 
             let batch = db.new_batch().merkleize(&db, None, Location::new(2)).await;
 
@@ -1736,8 +1748,6 @@ mod tests {
                 Err(Error::FloorBeyondSize(floor, tip))
                     if floor == Location::new(2) && tip == Location::new(1)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
@@ -1746,9 +1756,8 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_ancestor_floor_beyond_size() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "immutable-ancestor-floor-beyond")
-                    .await;
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-ancestor-floor-beyond")
+                .await;
 
             // parent: set + commit at loc 2, floor=3 (one past parent's commit).
             let parent = db
@@ -1768,8 +1777,6 @@ mod tests {
                 Err(Error::FloorBeyondSize(floor, commit))
                     if floor == Location::new(3) && commit == Location::new(2)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -847,6 +847,8 @@ mod tests {
             let advance_floor = db.new_batch().set(Sha256::hash(&[1]), Sha256::fill(1u8));
             let advance_floor = advance_floor.merkleize(&db, None, Location::new(1)).await;
             let (db, _) = db.apply_batch(advance_floor).unwrap();
+            let db = db.sync().await.unwrap();
+            let target = db.target();
 
             let regressed = db
                 .new_batch()
@@ -859,6 +861,11 @@ mod tests {
                 Err(Error::FloorRegressed(new, current))
                     if new == Location::new(0) && current == Location::new(1)
             ));
+
+            // Reopen and verify the rejected batch persisted nothing.
+            let db =
+                open_db::<mmr::Family>(context.child("reopen"), "immutable-floor-regressed").await;
+            assert_eq!(db.target(), target);
         });
     }
 
@@ -883,11 +890,20 @@ mod tests {
                 .merkleize(&db, None, Location::new(0))
                 .await;
 
+            let target = db.target();
             assert!(matches!(
                 db.apply_batch(child),
                 Err(Error::FloorRegressed(new, prev))
                     if new == Location::new(0) && prev == Location::new(1)
             ));
+
+            // Reopen and verify the rejected chain persisted nothing.
+            let db = open_db::<mmr::Family>(
+                context.child("reopen"),
+                "immutable-regressed-ancestor-floor",
+            )
+            .await;
+            assert_eq!(db.target(), target);
         });
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -1157,7 +1157,7 @@ mod tests {
             .unwrap();
             assert_eq!(reopened.target(), tip_target);
 
-            // The corrupt entry fails the rewind before any truncation, consuming the handle.
+            // The corrupt entry fails the rewind before any truncation.
             assert!(matches!(
                 reopened.rewind(rewind_target).await,
                 Err(Error::DataCorrupted(_))
@@ -1330,7 +1330,6 @@ mod tests {
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
 
-            // The failed rewind consumed the db; reopen to continue.
             let db =
                 open_db::<mmr::Family>(context.child("reopen"), "immutable-rewind-beyond").await;
             // A target past the tip is not a commit either.
@@ -1375,7 +1374,7 @@ mod tests {
             let root_b = db.root();
 
             // Targets inside a commit's span match no entry, even though entries exist on
-            // both sides. Each failed rewind consumes the db, so reopen to continue.
+            // both sides.
             let mut db = db;
             for target in [2u64, 3, 5] {
                 assert!(matches!(
@@ -1498,8 +1497,7 @@ mod tests {
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
 
-            // The failed rewind consumed the db; the prune was durable, so reopen and
-            // rewind to B.
+            // The prune was durable, so reopen and rewind to B.
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let db: TestDb<mmr::Family> = Db::init_from_merkle(
                 merkle,

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -1092,15 +1092,14 @@ mod tests {
             db.sync().await.unwrap();
 
             // Corrupt the persisted proof so it no longer verifies against the stored root.
-            let mut journal = open_witness_journal(context.child("tamper"), partition).await;
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
             let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
             if let Some(digest) = proof.digests.first_mut() {
                 *digest = Sha256::fill(0xff);
             } else {
                 proof.leaves = Location::new(*proof.leaves + 1);
             }
-            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let reopened = TestDb::<mmr::Family>::init_from_merkle(
@@ -1226,7 +1225,7 @@ mod tests {
             let oversized_floor = Location::new(10);
 
             // Overwrite the persisted commit op with a floor beyond its own commit location.
-            let mut journal = open_witness_journal(context.child("tamper"), partition).await;
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
             let (_, proof, pinned_nodes) = witness::tests::tip(&journal).await;
             let bad_op = Operation::<mmr::Family, Digest, FixedEncoding<Digest>>::Commit(
                 Some(Sha256::fill(0xaa)),
@@ -1234,8 +1233,7 @@ mod tests {
             )
             .encode()
             .to_vec();
-            journal = witness::tests::overwrite_tip(journal, bad_op, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::overwrite_tip(journal, bad_op, proof, pinned_nodes).await;
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let reopened = TestDb::<mmr::Family>::init_from_merkle(
@@ -1267,11 +1265,10 @@ mod tests {
 
             // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
             // longer matches the proof stored in the same entry.
-            let mut journal = open_witness_journal(context.child("tamper"), partition).await;
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
             let (op_bytes, proof, mut pinned_nodes) = witness::tests::tip(&journal).await;
             pinned_nodes[0] = Sha256::fill(0xff);
-            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let reopened = TestDb::<mmr::Family>::init_from_merkle(
@@ -1306,11 +1303,10 @@ mod tests {
 
             // Simulate the crash window: append an entry ahead of the tip without syncing it,
             // then drop the journal. The unsynced tail must not survive reopen.
-            let mut journal = open_witness_journal(context.child("crash"), partition).await;
+            let journal = open_witness_journal(context.child("crash"), partition).await;
             let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
             proof.leaves = Location::new(*proof.leaves + 2);
-            journal = witness::tests::append_unsynced(journal, op_bytes, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::append_unsynced(journal, op_bytes, proof, pinned_nodes).await;
 
             // Reopen must drop the unsynced entry and recover state A.
             let reopened = open_db::<mmr::Family>(context.child("reopen"), partition).await;
@@ -1338,10 +1334,6 @@ mod tests {
                 db.rewind(beyond_tip).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
-
-            let db =
-                open_db::<mmr::Family>(context.child("destroy"), "immutable-rewind-beyond").await;
-            db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -1089,7 +1089,8 @@ mod tests {
                 .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
 
             // Corrupt the persisted proof so it no longer verifies against the stored root.
             let journal = open_witness_journal(context.child("tamper"), partition).await;
@@ -1188,7 +1189,8 @@ mod tests {
                 .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
 
             // Simulate a crash between an import's journal clear and its entry append: the
             // journal is empty but its size is nonzero.
@@ -1221,7 +1223,8 @@ mod tests {
                 .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
             let oversized_floor = Location::new(10);
 
             // Overwrite the persisted commit op with a floor beyond its own commit location.
@@ -1261,7 +1264,8 @@ mod tests {
                 .merkleize(&db, Some(Sha256::fill(0xaa)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
 
             // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
             // longer matches the proof stored in the same entry.

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -138,7 +138,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_immutable_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = open_db::<mmr::Family>(ctx.child("db")).await;
+            let db = open_db::<mmr::Family>(ctx.child("db")).await;
             let key = Sha256::fill(1u8);
             let value = Sha256::fill(2u8);
             let floor = db.inactivity_floor_loc();
@@ -147,12 +147,12 @@ mod tests {
                 .set(key, value)
                 .merkleize(&db, None, floor)
                 .await;
-            db.apply_batch(batch).await.unwrap();
+            let (db, _) = db.apply_batch(batch).await.unwrap();
             assert_eq!(db.get(&key).await.unwrap(), Some(value));
             assert_eq!(db.get_many(&[&key]).await.unwrap(), vec![Some(value)]);
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
-            db.prune(crate::merkle::Location::new(0)).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            let _db = db.prune(crate::merkle::Location::new(0)).await.unwrap();
 
             let metrics = ctx.encode();
             for expected in [
@@ -206,23 +206,18 @@ mod tests {
 
     #[allow(dead_code)]
     fn assert_db_futures_are_send(
-        db: &mut Db<
-            mmr::Family,
-            deterministic::Context,
-            Digest,
-            Digest,
-            Sha256,
-            TwoCap,
-            Sequential,
-        >,
+        db: Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>,
         key: Digest,
         loc: crate::merkle::mmr::Location,
+        which: u8,
     ) {
         is_send(db.get(&key));
         is_send(db.get_metadata());
         is_send(db.proof(loc, NZU64!(1)));
-        is_send(db.sync());
-        is_send(db.rewind(loc));
+        match which {
+            0 => is_send(db.sync()),
+            _ => is_send(db.rewind(loc)),
+        }
     }
 
     fn small_sections_config(
@@ -396,8 +391,8 @@ mod tests {
 
     #[boxed]
     async fn assert_compact_root_compatibility<F: Family>(ctx: deterministic::Context) {
-        let mut db = open_db::<F>(ctx.child("db")).await;
-        let mut compact = open_compact::<F>(ctx.child("compact")).await;
+        let db = open_db::<F>(ctx.child("db")).await;
+        let compact = open_compact::<F>(ctx.child("compact")).await;
         assert_eq!(db.root(), compact.root());
 
         let k1 = Sha256::fill(1u8);
@@ -422,10 +417,10 @@ mod tests {
 
         assert_eq!(retained.root(), compact_batch.root());
 
-        db.apply_batch(retained).await.unwrap();
-        compact.apply_batch(compact_batch).unwrap();
-        db.commit().await.unwrap();
-        compact.sync().await.unwrap();
+        let (db, _) = db.apply_batch(retained).await.unwrap();
+        let (compact, _) = compact.apply_batch(compact_batch).unwrap();
+        let db = db.commit().await.unwrap();
+        let compact = compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata));

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -209,15 +209,19 @@ mod tests {
         db: Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>,
         key: Digest,
         loc: crate::merkle::mmr::Location,
-        which: u8,
     ) {
         is_send(db.get(&key));
         is_send(db.get_metadata());
         is_send(db.proof(loc, NZU64!(1)));
-        match which {
-            0 => is_send(db.sync()),
-            _ => is_send(db.rewind(loc)),
-        }
+        is_send(db.sync());
+    }
+
+    #[allow(dead_code)]
+    fn assert_rewind_is_send(
+        db: Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>,
+        loc: crate::merkle::mmr::Location,
+    ) {
+        is_send(db.rewind(loc));
     }
 
     fn small_sections_config(

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -1248,8 +1248,7 @@ pub(super) mod test {
         }
         let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
         let (db, _) = db.apply_batch(merkleized).await.unwrap();
-        let db = db.commit().await.unwrap();
-        drop(db); // Drop before syncing
+        db.commit().await.unwrap(); // Drop before syncing
 
         // Recovery should replay the log to regenerate the merkle structure.
         // op_count = 1002 (first batch + commit) + 1000 (second batch) + 1 (second commit) = 2003
@@ -1689,9 +1688,6 @@ pub(super) mod test {
             matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
             "unexpected rewind error: {err:?}"
         );
-
-        let db = open_small_sections_db(context.child("db")).await;
-        db.destroy().await.unwrap();
     }
 
     /// batch.get() reads pending mutations and falls through to base DB.

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -31,8 +31,8 @@
 //! let merkleized = db.new_batch()
 //!     .set(key, value)
 //!     .merkleize(&db, None, floor).await;
-//! db.apply_batch(merkleized).await?;
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(merkleized).await?;
+//! let db = db.commit().await?;
 //! ```
 //!
 //! ```ignore
@@ -50,31 +50,25 @@
 //!     .set(key_c, value_c)
 //!     .merkleize(&db, None, floor).await;
 //!
-//! db.apply_batch(child_a).await?;
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(child_a).await?;
+//! let db = db.commit().await?;
 //! ```
 //!
 //! ```ignore
-//! // Advanced mode: while the previous batch is being committed, build exactly
-//! // one child batch from the newly published state.
+//! // Apply a parent batch, commit, then build a child batch from the newly
+//! // published state and apply it.
 //! let floor = db.inactivity_floor_loc();
 //! let parent = db.new_batch()
 //!     .set(key_a, value_a)
 //!     .merkleize(&db, None, floor).await;
-//! db.apply_batch(parent).await?;
+//! let (db, _) = db.apply_batch(parent).await?;
+//! let db = db.commit().await?;
 //!
-//! let (child, commit_result) = futures::join!(
-//!     async {
-//!         db.new_batch()
-//!             .set(key_b, value_b)
-//!             .merkleize(&db, None, floor).await
-//!     },
-//!     db.commit(),
-//! );
-//! commit_result?;
-//!
-//! db.apply_batch(child).await?;
-//! db.commit().await?;
+//! let child = db.new_batch()
+//!     .set(key_b, value_b)
+//!     .merkleize(&db, None, floor).await;
+//! let (db, _) = db.apply_batch(child).await?;
+//! let db = db.commit().await?;
 //! ```
 
 use crate::{
@@ -189,6 +183,26 @@ pub struct Immutable<
     metrics: Metrics<E>,
 }
 
+impl<F, E, K, V, C, H, T, S> std::fmt::Debug for Immutable<F, E, K, V, C, H, T, S>
+where
+    F: Family,
+    E: Context,
+    K: Key,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<F, K, V>>,
+    C::Item: EncodeShared,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Immutable")
+            .field("bounds", &self.bounds())
+            .field("inactivity_floor_loc", &self.inactivity_floor_loc())
+            .finish_non_exhaustive()
+    }
+}
+
 // Shared read-only functionality.
 impl<F, E, K, V, C, H, T, S> Immutable<F, E, K, V, C, H, T, S>
 where
@@ -215,10 +229,10 @@ where
     ) -> Result<Self, Error<F>> {
         if journal.size() == 0 {
             warn!("Authenticated log is empty, initialized new db.");
-            journal
+            let (appended, _) = journal
                 .append(&Operation::Commit(None, Location::new(0)))
                 .await?;
-            journal.sync().await?;
+            journal = appended.sync().await?;
         }
 
         let mut snapshot = Index::new(context.child("snapshot"), translator);
@@ -489,7 +503,8 @@ where
     /// - Returns [Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
     /// - Returns [crate::merkle::Error::LocationOverflow] if `prune_loc` > [crate::merkle::Family::MAX_LEAVES].
     #[tracing::instrument(name = "qmdb.immutable.db.prune", level = "info", skip_all)]
-    pub async fn prune(&mut self, loc: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn prune(mut self, loc: Location<F>) -> Result<Self, Error<F>> {
         let _timer = self.metrics.prune_timer();
         self.metrics.prune_calls.inc();
         if loc > self.inactivity_floor_loc {
@@ -498,9 +513,9 @@ where
                 self.inactivity_floor_loc,
             ));
         }
-        self.journal.prune(loc).await?;
+        (self.journal, _) = self.journal.prune(loc).await?;
         self.update_metrics();
-        Ok(())
+        Ok(self)
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.
@@ -523,11 +538,12 @@ where
     /// A successful rewind is not restart-stable until a subsequent [`Immutable::commit`] or
     /// [`Immutable::sync`].
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
-    pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
         if rewind_size == current_size {
-            return Ok(());
+            return Ok(self);
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(crate::journal::Error::InvalidRewind(
@@ -568,7 +584,7 @@ where
 
         // Journal rewind happens before in-memory snapshot updates. If a later step fails, this
         // handle may be internally diverged and must be dropped by the caller.
-        self.journal.rewind(rewind_size).await?;
+        self.journal = self.journal.rewind(rewind_size).await?;
 
         // Remove keys that were set in the range [rewind_size, current_size) from the snapshot.
         let rewind_loc = Location::<F>::new(rewind_size);
@@ -597,7 +613,7 @@ where
         self.root = self.journal.root(inactive_peaks)?;
         self.update_metrics();
 
-        Ok(())
+        Ok(self)
     }
 
     /// Return the canonical QMDB root of the db.
@@ -623,20 +639,20 @@ where
     /// committed operations, periodic invocation may reduce memory usage and the time required to
     /// recover the database on restart.
     #[tracing::instrument(name = "qmdb.immutable.db.sync", level = "info", skip_all)]
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
-        self.journal.sync().await?;
-        Ok(())
+        self.journal = self.journal.sync().await?;
+        Ok(self)
     }
 
     /// Durably commit the journal state published by prior [`Immutable::apply_batch`] calls.
     #[tracing::instrument(name = "qmdb.immutable.db.commit", level = "info", skip_all)]
-    pub async fn commit(&mut self) -> Result<(), Error<F>> {
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
         let _timer = self.metrics.commit_timer();
         self.metrics.commit_calls.inc();
-        self.journal.commit().await?;
-        Ok(())
+        self.journal = self.journal.commit().await?;
+        Ok(self)
     }
 
     /// Destroy the db, removing all data from disk.
@@ -652,14 +668,26 @@ where
         batch::UnmerkleizedBatch::new(self, journal_size)
     }
 
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &batch::MerkleizedBatch<F, H::Digest, K, V, S>,
+    ) -> Result<(), Error<F>> {
+        batch
+            .bounds
+            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+    }
+
     /// Apply a [`batch::MerkleizedBatch`] to the database.
     ///
     /// A batch is valid only if every batch applied to the database since this batch's
     /// ancestor chain was created is an ancestor of this batch. Applying a batch from a
     /// different fork returns [`Error::StaleBatch`] (see [`crate::qmdb::batch_chain`] for
     /// more details).
-    ///
-    /// Returns the range of locations written.
     ///
     /// # Errors
     ///
@@ -675,26 +703,27 @@ where
     ///   commit is its own location; a floor past the commit would permit
     ///   pruning the commit itself.
     ///
-    /// On any floor error, the database state is unchanged.
+    /// Floor validation happens before any journal mutation, so on floor errors the on-disk
+    /// state is unchanged and reopening recovers the database as it was.
+    ///
+    /// Returns the range of locations written.
     ///
     /// This publishes the batch to the in-memory database state and appends it to the
     /// journal, but does not durably commit it. Call [`Immutable::commit`] or
     /// [`Immutable::sync`] to guarantee durability.
     #[tracing::instrument(name = "qmdb.immutable.db.apply_batch", level = "info", skip_all)]
     pub async fn apply_batch(
-        &mut self,
+        mut self,
         batch: Arc<batch::MerkleizedBatch<F, H::Digest, K, V, S>>,
-    ) -> Result<Range<Location<F>>, Error<F>> {
+    ) -> Result<(Self, Range<Location<F>>), Error<F>> {
         let _timer = self.metrics.apply_batch_timer();
         self.metrics.apply_batch_calls.inc();
+        self.validate_batch(&batch)?;
         let db_size = *self.last_commit_loc + 1;
-        batch
-            .bounds
-            .validate_apply_to(db_size, self.inactivity_floor_loc)?;
         let start_loc = Location::new(db_size);
 
         // Apply journal.
-        self.journal.apply_batch(&batch.journal_batch).await?;
+        self.journal = self.journal.apply_batch(&batch.journal_batch).await?;
 
         // Apply snapshot inserts. Child first (child wins via `seen`), then
         // uncommitted ancestor batches.
@@ -745,7 +774,7 @@ where
         self.metrics
             .operations_applied
             .inc_by(*range.end - *range.start);
-        Ok(range)
+        Ok((self, range))
     }
 }
 
@@ -804,15 +833,14 @@ pub(super) mod test {
             // Don't merkleize/apply -- simulate failed commit
         }
         drop(db);
-        let mut db = open_db(context.child("second")).await;
+        let db = open_db(context.child("second")).await;
         assert_eq!(db.root(), root);
         assert_eq!(db.bounds().end, 1);
 
         // Test calling commit on an empty db which should make it (durably) non-empty.
-        db.apply_batch(db.new_batch().merkleize(&db, None, Location::new(0)).await)
-            .await
-            .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db.new_batch().merkleize(&db, None, Location::new(0)).await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.bounds().end, 2); // commit op added
         let root = db.root();
         drop(db);
@@ -834,18 +862,18 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
         let k1 = Sha256::fill(1u8);
         let k2 = Sha256::fill(2u8);
         let v1 = Sha256::fill(3u8);
         let v2 = Sha256::fill(4u8);
 
         // Commit and sync the first key so recovery has an older persisted boundary.
-        commit_sets(&mut db, [(k1, v1)], None).await;
-        db.sync().await.unwrap();
+        let (db, _) = commit_sets(db, [(k1, v1)], None).await;
+        let db = db.sync().await.unwrap();
 
         // Commit a second key without syncing; reopen must replay it from journal data.
-        commit_sets(&mut db, [(k2, v2)], None).await;
+        let (db, _) = commit_sets(db, [(k2, v2)], None).await;
         let committed_bounds = db.bounds();
         let committed_root = db.root();
         drop(db);
@@ -871,7 +899,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         // Build a db with 2 keys.
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let k1 = Sha256::fill(1u8);
         let k2 = Sha256::fill(2u8);
@@ -883,30 +911,26 @@ pub(super) mod test {
 
         // Set and commit the first key.
         let metadata = Some(Sha256::fill(99u8));
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, metadata, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, metadata, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert!(db.get(&k2).await.unwrap().is_none());
         assert_eq!(db.bounds().end, 3);
         assert_eq!(db.get_metadata().await.unwrap(), Some(Sha256::fill(99u8)));
 
         // Set and commit the second key.
-        db.apply_batch(
-            db.new_batch()
-                .set(k2, v2)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
         assert_eq!(db.get(&k2).await.unwrap().unwrap(), v2);
         assert_eq!(db.bounds().end, 5);
@@ -948,19 +972,17 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(10u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let (proof, ops) = db.proof(Location::new(0), NZU64!(100)).await.unwrap();
         let root = db.root();
@@ -991,22 +1013,20 @@ pub(super) mod test {
             let key = Sha256::fill(i);
             let value = Sha256::fill(i.wrapping_add(100));
             let floor = db.bounds().end;
-            db.apply_batch(
-                db.new_batch()
-                    .set(key, value)
-                    .merkleize(&db, None, floor)
-                    .await,
-            )
-            .await
-            .unwrap();
-            db.commit().await.unwrap();
+            let merkleized = db
+                .new_batch()
+                .set(key, value)
+                .merkleize(&db, None, floor)
+                .await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
+            db = db.commit().await.unwrap();
         }
 
         let root_before = db.root();
         let bounds_before = db.bounds();
 
         let prune_loc = Location::new(*bounds_before.end - 5);
-        db.prune(prune_loc).await.unwrap();
+        let db = db.prune(prune_loc).await.unwrap();
 
         assert_eq!(db.root(), root_before);
 
@@ -1040,7 +1060,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         // Fill more than one journal blob and establish a durable baseline whose floor still
         // requires the oldest blob.
@@ -1048,10 +1068,9 @@ pub(super) mod test {
         for i in 0..6u8 {
             batch = batch.set(Sha256::fill(i), Sha256::fill(i.wrapping_add(10)));
         }
-        db.apply_batch(batch.merkleize(&db, None, Location::new(0)).await)
-            .await
-            .unwrap();
-        db.sync().await.unwrap();
+        let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.sync().await.unwrap();
         let durable_state = (db.root(), db.inactivity_floor_loc(), db.bounds().end);
 
         // Apply, but do not commit, a batch that advances the floor far enough for prune to
@@ -1059,18 +1078,16 @@ pub(super) mod test {
         let buffered_floor = db.bounds().end;
         let key = Sha256::fill(100);
         let value = Sha256::fill(101);
-        db.apply_batch(
-            db.new_batch()
-                .set(key, value)
-                .merkleize(&db, None, buffered_floor)
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key, value)
+            .merkleize(&db, None, buffered_floor)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let buffered_state = (db.root(), db.inactivity_floor_loc(), db.bounds().end);
         assert_ne!(buffered_state, durable_state);
 
-        db.prune(buffered_floor).await.unwrap();
+        let db = db.prune(buffered_floor).await.unwrap();
         assert!(db.bounds().start > Location::new(0));
         drop(db);
 
@@ -1098,7 +1115,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let k1 = Sha256::fill(1u8);
         let k2 = Sha256::fill(2u8);
@@ -1122,21 +1139,19 @@ pub(super) mod test {
         assert_eq!(child.get(&k2, &db).await.unwrap(), Some(v2));
         assert!(child.get(&k3, &db).await.unwrap().is_none());
 
-        db.apply_batch(child).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(child).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         assert_eq!(db.get(&k1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&k2).await.unwrap(), Some(v2));
 
-        db.apply_batch(
-            db.new_batch()
-                .set(k3, v3)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k3, v3)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.get(&k3).await.unwrap(), Some(v3));
 
         db.destroy().await.unwrap();
@@ -1154,7 +1169,7 @@ pub(super) mod test {
         C::Item: EncodeShared,
     {
         // Build a db with `ELEMENTS` key/value pairs and prove ranges over them.
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let mut batch = db.new_batch();
         for i in 0u64..2_000 {
@@ -1163,8 +1178,8 @@ pub(super) mod test {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.bounds().end, 2_000 + 2);
 
         // Drop & reopen the db, making sure it has exactly the same state.
@@ -1209,7 +1224,7 @@ pub(super) mod test {
     {
         // Insert 1000 keys then sync.
         const ELEMENTS: u64 = 1000;
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let mut batch = db.new_batch();
         for i in 0u64..ELEMENTS {
@@ -1218,10 +1233,10 @@ pub(super) mod test {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.bounds().end, ELEMENTS + 2);
-        db.sync().await.unwrap();
+        let db = db.sync().await.unwrap();
         let halfway_root = db.root();
 
         // Insert another 1000 keys (different from the first batch) then commit.
@@ -1232,8 +1247,8 @@ pub(super) mod test {
             batch = batch.set(k, v);
         }
         let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         drop(db); // Drop before syncing
 
         // Recovery should replay the log to regenerate the merkle structure.
@@ -1263,20 +1278,18 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         // Insert a single key and then commit to create a first commit point.
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(3u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let first_commit_root = db.root();
 
         // Simulate failure. Sets that are never merkleized/applied are lost.
@@ -1305,7 +1318,7 @@ pub(super) mod test {
     {
         // Build a db with `ELEMENTS` key/value pairs then prune some of them.
         const ELEMENTS: u64 = 2_000;
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         // Batch writes keys in BTreeMap-sorted order, so build the sorted key
         // list to map between journal locations and keys.
@@ -1327,11 +1340,11 @@ pub(super) mod test {
         // Second prune request is at ELEMENTS / 2 + ITEMS_PER_SECTION * 2 - 1.
         let inactivity_floor = Location::new(ELEMENTS / 2 + ITEMS_PER_SECTION * 2 - 1);
         let merkleized = batch.merkleize(&db, None, inactivity_floor).await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.bounds().end, ELEMENTS + 2);
 
         // Prune the db to the first half of the operations.
-        db.prune(Location::new((ELEMENTS + 2) / 2)).await.unwrap();
+        let db = db.prune(Location::new((ELEMENTS + 2) / 2)).await.unwrap();
         let bounds = db.bounds();
         assert_eq!(bounds.end, ELEMENTS + 2);
 
@@ -1351,9 +1364,8 @@ pub(super) mod test {
         // Drop & reopen the db, making sure it has exactly the same state.
         let root = db.root();
         db.sync().await.unwrap();
-        drop(db);
 
-        let mut db = open_db(context.child("second")).await;
+        let db = open_db(context.child("second")).await;
         assert_eq!(root, db.root());
         let bounds = db.bounds();
         assert_eq!(bounds.end, ELEMENTS + 2);
@@ -1362,7 +1374,7 @@ pub(super) mod test {
 
         // Prune to a non-blob boundary.
         let loc = Location::new(ELEMENTS / 2 + (ITEMS_PER_SECTION * 2 - 1));
-        db.prune(loc).await.unwrap();
+        let db = db.prune(loc).await.unwrap();
         // Actual boundary should be a multiple of 5.
         let oldest_retained_loc = db.bounds().start;
         assert_eq!(
@@ -1372,7 +1384,6 @@ pub(super) mod test {
 
         // Confirm boundary persists across restart.
         db.sync().await.unwrap();
-        drop(db);
         let db = open_db(context.child("third")).await;
         let oldest_retained_loc = db.bounds().start;
         assert_eq!(
@@ -1412,7 +1423,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // Test pruning empty database (floor=0, so prune(1) fails)
         let result = db.prune(Location::new(1)).await;
@@ -1420,6 +1431,9 @@ pub(super) mod test {
             matches!(result, Err(Error::PruneBeyondMinRequired(prune_loc, floor))
                 if prune_loc == Location::new(1) && floor == Location::new(0))
         );
+
+        // The failed prune consumed the db; reopen the partition to continue.
+        let db = open_db(context.child("test")).await;
 
         // Add key-value pairs and commit
         let k1 = Digest::from(*b"12345678901234567890123456789012");
@@ -1430,31 +1444,27 @@ pub(super) mod test {
         let v3 = Sha256::fill(3u8);
 
         // First batch with floor=3 (the commit location).
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .set(k2, v2)
-                .merkleize(&db, None, Location::new(3))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(3))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // op_count is 4 (initial_commit, k1, k2, commit), last_commit is at location 3
         assert_eq!(*db.last_commit_loc, 3);
 
         // Second batch with floor=5 (the new commit location).
-        db.apply_batch(
-            db.new_batch()
-                .set(k3, v3)
-                .merkleize(&db, None, Location::new(5))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k3, v3)
+            .merkleize(&db, None, Location::new(5))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Test valid prune (3 <= floor of 5)
-        assert!(db.prune(Location::new(3)).await.is_ok());
+        let db = db.prune(Location::new(3)).await.unwrap();
 
         // Test pruning beyond inactivity floor
         let floor = db.inactivity_floor_loc();
@@ -1464,15 +1474,13 @@ pub(super) mod test {
             matches!(result, Err(Error::PruneBeyondMinRequired(prune_loc, f))
                 if prune_loc == beyond && f == floor)
         );
-
-        db.destroy().await.unwrap();
     }
 
     async fn commit_sets<F: Family, V, C>(
-        db: &mut TestDb<F, V, C>,
+        db: TestDb<F, V, C>,
         sets: impl IntoIterator<Item = (Digest, V::Value)>,
         metadata: Option<V::Value>,
-    ) -> Range<Location<F>>
+    ) -> (TestDb<F, V, C>, Range<Location<F>>)
     where
         V: ValueEncoding<Value = Digest>,
         C: Mutable<Item = Operation<F, Digest, V>>,
@@ -1482,11 +1490,11 @@ pub(super) mod test {
     }
 
     async fn commit_sets_with_floor<F: Family, V, C>(
-        db: &mut TestDb<F, V, C>,
+        db: TestDb<F, V, C>,
         sets: impl IntoIterator<Item = (Digest, V::Value)>,
         metadata: Option<V::Value>,
         floor: Location<F>,
-    ) -> Range<Location<F>>
+    ) -> (TestDb<F, V, C>, Range<Location<F>>)
     where
         V: ValueEncoding<Value = Digest>,
         C: Mutable<Item = Operation<F, Digest, V>>,
@@ -1496,12 +1504,10 @@ pub(super) mod test {
         for (key, value) in sets {
             batch = batch.set(key, value);
         }
-        let range = db
-            .apply_batch(batch.merkleize(db, metadata, floor).await)
-            .await
-            .unwrap();
-        db.commit().await.unwrap();
-        range
+        let merkleized = batch.merkleize(&db, metadata, floor).await;
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        (db, range)
     }
 
     #[boxed]
@@ -1515,7 +1521,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&1u64.to_be_bytes());
         let key2 = Sha256::hash(&2u64.to_be_bytes());
@@ -1528,23 +1534,23 @@ pub(super) mod test {
         let value4 = Sha256::fill(66u8);
 
         let metadata_a = Sha256::fill(44u8);
-        let first_range =
-            commit_sets(&mut db, [(key1, value1), (key2, value2)], Some(metadata_a)).await;
+        let (db, first_range) =
+            commit_sets(db, [(key1, value1), (key2, value2)], Some(metadata_a)).await;
         let size_before = db.bounds().end;
         let root_before = db.root();
         let last_commit_before = db.last_commit_loc;
         assert_eq!(size_before, first_range.end);
 
         let metadata_b = Sha256::fill(55u8);
-        let second_range =
-            commit_sets(&mut db, [(key3, value3), (key4, value4)], Some(metadata_b)).await;
+        let (db, second_range) =
+            commit_sets(db, [(key3, value3), (key4, value4)], Some(metadata_b)).await;
         assert_eq!(second_range.start, size_before);
         assert_ne!(db.root(), root_before);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_b));
         assert_eq!(db.get(&key3).await.unwrap(), Some(value3));
         assert_eq!(db.get(&key4).await.unwrap(), Some(value4));
 
-        db.rewind(size_before).await.unwrap();
+        let db = db.rewind(size_before).await.unwrap();
         assert_eq!(db.root(), root_before);
         assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
@@ -1555,7 +1561,6 @@ pub(super) mod test {
         assert_eq!(db.get(&key4).await.unwrap(), None);
 
         db.commit().await.unwrap();
-        drop(db);
         let db = open_db(context.child("reopen")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.bounds().end, size_before);
@@ -1583,7 +1588,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Two keys sharing the first two bytes collide under TwoCap.
         let mut k1_bytes = [0u8; 32];
@@ -1599,13 +1604,13 @@ pub(super) mod test {
         let value1 = Sha256::fill(11u8);
         let value2 = Sha256::fill(22u8);
 
-        commit_sets(&mut db, [(key1, value1)], None).await;
+        let (db, _) = commit_sets(db, [(key1, value1)], None).await;
         let size_after_first = db.bounds().end;
-        commit_sets(&mut db, [(key2, value2)], None).await;
+        let (db, _) = commit_sets(db, [(key2, value2)], None).await;
         assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
         assert_eq!(db.get(&key2).await.unwrap(), Some(value2));
 
-        db.rewind(size_after_first).await.unwrap();
+        let db = db.rewind(size_after_first).await.unwrap();
 
         // The retained key must still be readable; pre-fix this returned None because the
         // translator bucket was wiped by the suffix-key remove.
@@ -1627,10 +1632,10 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_small_sections_db(context.child("db")).await;
+        let db = open_small_sections_db(context.child("db")).await;
 
-        let first_range = commit_sets(
-            &mut db,
+        let (mut db, first_range) = commit_sets(
+            db,
             (0u64..16).map(|i| (Sha256::hash(&i.to_be_bytes()), Sha256::fill(i as u8))),
             None,
         )
@@ -1647,8 +1652,8 @@ pub(super) mod test {
             // Floor must be >= last_commit_loc for prune to succeed.
             // With 16 sets, commit is at current end + 16.
             let floor = Location::new(*db.bounds().end + 16);
-            commit_sets_with_floor(
-                &mut db,
+            (db, _) = commit_sets_with_floor(
+                db,
                 (0u64..16).map(|i| {
                     let seed = round * 100 + i;
                     (Sha256::hash(&seed.to_be_bytes()), Sha256::fill(seed as u8))
@@ -1657,7 +1662,8 @@ pub(super) mod test {
                 floor,
             )
             .await;
-            db.prune(db.last_commit_loc).await.unwrap();
+            let last_commit = db.last_commit_loc;
+            db = db.prune(last_commit).await.unwrap();
 
             if db.bounds().start > first_range.start {
                 break;
@@ -1665,7 +1671,9 @@ pub(super) mod test {
         }
 
         let oldest_retained = db.bounds().start;
-        let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
+        let Err(boundary_err) = db.rewind(oldest_retained).await else {
+            panic!("expected rewind to fail");
+        };
         assert!(
             matches!(
                 boundary_err,
@@ -1674,12 +1682,17 @@ pub(super) mod test {
             "unexpected rewind error at retained boundary: {boundary_err:?}"
         );
 
-        let err = db.rewind(first_range.start).await.unwrap_err();
+        // The failed rewind consumed the db; reopen the partition to continue.
+        let db = open_small_sections_db(context.child("db")).await;
+        let Err(err) = db.rewind(first_range.start).await else {
+            panic!("expected rewind to fail");
+        };
         assert!(
             matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
             "unexpected rewind error: {err:?}"
         );
 
+        let db = open_small_sections_db(context.child("db")).await;
         db.destroy().await.unwrap();
     }
 
@@ -1695,19 +1708,17 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Pre-populate with key A.
         let key_a = Sha256::hash(&0u64.to_be_bytes());
         let val_a = Sha256::fill(1u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(key_a, val_a)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key_a, val_a)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // batch.get(&A) should return DB value.
         let mut batch = db.new_batch();
@@ -1775,7 +1786,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Sort keys so operations are in BTreeMap order (same as merkleize writes).
         let mut kvs_first: Vec<(Digest, Digest)> = (0u64..5)
@@ -1802,7 +1813,7 @@ pub(super) mod test {
         }
         let child_m = child.merkleize(&db, None, Location::new(0)).await;
         let expected_root = child_m.root();
-        db.apply_batch(child_m).await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
 
         assert_eq!(db.root(), expected_root);
 
@@ -1826,7 +1837,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let mut batch = db.new_batch();
         for i in 0u8..10 {
@@ -1836,7 +1847,7 @@ pub(super) mod test {
         let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
 
         let speculative = merkleized.root();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.root(), speculative);
 
         // Second batch with metadata.
@@ -1846,7 +1857,7 @@ pub(super) mod test {
         batch = batch.set(k, Sha256::fill(0xAA));
         let merkleized = batch.merkleize(&db, metadata, Location::new(0)).await;
         let speculative = merkleized.root();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.root(), speculative);
 
         db.destroy().await.unwrap();
@@ -1864,19 +1875,17 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Pre-populate base DB.
         let key_a = Sha256::hash(&0u64.to_be_bytes());
         let val_a = Sha256::fill(10u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(key_a, val_a)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key_a, val_a)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Create a merkleized batch with a new key.
         let key_b = Sha256::hash(&1u64.to_be_bytes());
@@ -1912,7 +1921,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key_a = Sha256::hash(&0u64.to_be_bytes());
         let val_a = Sha256::fill(1u8);
@@ -1924,7 +1933,7 @@ pub(super) mod test {
             .merkleize(&db, None, Location::new(0))
             .await;
         let root1 = m.root();
-        db.apply_batch(m).await.unwrap();
+        let (db, _) = db.apply_batch(m).await.unwrap();
         assert_eq!(db.root(), root1);
         assert_eq!(db.get(&key_a).await.unwrap(), Some(val_a));
 
@@ -1937,7 +1946,7 @@ pub(super) mod test {
             .merkleize(&db, None, Location::new(0))
             .await;
         let root2 = m.root();
-        db.apply_batch(m).await.unwrap();
+        let (db, _) = db.apply_batch(m).await.unwrap();
         assert_eq!(db.root(), root2);
         assert_eq!(db.get(&key_b).await.unwrap(), Some(val_b));
 
@@ -1973,7 +1982,7 @@ pub(super) mod test {
                 all_kvs.push((k, v));
             }
             let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         // Verify all key-values are readable.
@@ -2010,25 +2019,23 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Apply a non-empty batch first.
         let k = Sha256::hash(&[1u8]);
-        db.apply_batch(
-            db.new_batch()
-                .set(k, Sha256::fill(1u8))
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k, Sha256::fill(1u8))
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let root_before = db.root();
         let size_before = db.bounds().end;
 
         // Empty batch with no mutations.
         let merkleized = db.new_batch().merkleize(&db, None, Location::new(0)).await;
         let speculative = merkleized.root();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Root changed (a new Commit op was appended).
         assert_ne!(db.root(), root_before);
@@ -2051,19 +2058,17 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Pre-populate base DB.
         let key_a = Sha256::hash(&0u64.to_be_bytes());
         let val_a = Sha256::fill(10u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(key_a, val_a)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key_a, val_a)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Parent batch sets key B.
         let key_b = Sha256::hash(&1u64.to_be_bytes());
@@ -2109,7 +2114,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         const N: u64 = 500;
         let mut kvs: Vec<(Digest, Digest)> = Vec::new();
@@ -2122,7 +2127,7 @@ pub(super) mod test {
             kvs.push((k, v));
         }
         let merkleized = batch.merkleize(&db, None, Location::new(0)).await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Verify every value.
         for (k, v) in &kvs {
@@ -2157,7 +2162,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key = Sha256::hash(&0u64.to_be_bytes());
         let val_parent = Sha256::fill(1u8);
@@ -2183,7 +2188,7 @@ pub(super) mod test {
         assert_eq!(child_m.get(&key, &db).await.unwrap(), Some(val_child));
 
         // Apply and verify.
-        db.apply_batch(child_m).await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(val_child));
 
         db.destroy().await.unwrap();
@@ -2209,7 +2214,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db_small_sections(context.child("db")).await;
+        let db = open_db_small_sections(context.child("db")).await;
 
         let key = Sha256::hash(&0u64.to_be_bytes());
         let v1 = Sha256::fill(1u8);
@@ -2217,26 +2222,22 @@ pub(super) mod test {
 
         // First batch sets key.
         // Layout: 0=initial commit, 1=Set(key,v1), 2=Commit
-        db.apply_batch(
-            db.new_batch()
-                .set(key, v1)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         // Second batch sets same key to different value.
         // Layout continues: 3=Set(key,v2), 4=Commit
-        db.apply_batch(
-            db.new_batch()
-                .set(key, v2)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key, v2)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Either written value may be served for the repeated key.
         let live = db.get(&key).await.unwrap().unwrap();
@@ -2244,7 +2245,6 @@ pub(super) mod test {
 
         // A restart must also serve one of the written values.
         db.commit().await.unwrap();
-        drop(db);
         let db = open_db_small_sections(context.child("reopen")).await;
         let reopened = db.get(&key).await.unwrap().unwrap();
         assert!(reopened == v1 || reopened == v2);
@@ -2254,28 +2254,24 @@ pub(super) mod test {
         // snapshot bucket holds both locations. Floor=4 permits prune(2).
         // Layout: 0=initial commit, 1=Set(key,v1), 2=Commit, 3=Set(key,v2),
         // 4=Commit(floor=4)
-        let mut db = open_db_small_sections(context.child("prune")).await;
-        db.apply_batch(
-            db.new_batch()
-                .set(key, v1)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.apply_batch(
-            db.new_batch()
-                .set(key, v2)
-                .merkleize(&db, None, Location::new(4))
-                .await,
-        )
-        .await
-        .unwrap();
+        let db = open_db_small_sections(context.child("prune")).await;
+        let merkleized = db
+            .new_batch()
+            .set(key, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key, v2)
+            .merkleize(&db, None, Location::new(4))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Prune past the first Set (loc 1). With items_per_section=1, pruning
         // to loc 2 removes the blob containing loc 1. get() must skip the
         // pruned location within the bucket and serve the survivor.
-        db.prune(Location::new(2)).await.unwrap();
+        let db = db.prune(Location::new(2)).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v2));
 
         db.destroy().await.unwrap();
@@ -2293,25 +2289,22 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Batch with metadata.
         let metadata = Sha256::fill(42u8);
         let k = Sha256::hash(&[1u8]);
-        db.apply_batch(
-            db.new_batch()
-                .set(k, Sha256::fill(1u8))
-                .merkleize(&db, Some(metadata), Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k, Sha256::fill(1u8))
+            .merkleize(&db, Some(metadata), Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
         // Second batch clears metadata.
-        db.apply_batch(db.new_batch().merkleize(&db, None, Location::new(0)).await)
-            .await
-            .unwrap();
+        let merkleized = db.new_batch().merkleize(&db, None, Location::new(0)).await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         db.destroy().await.unwrap();
@@ -2328,7 +2321,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2347,26 +2340,25 @@ pub(super) mod test {
             .merkleize(&db, None, Location::new(0))
             .await;
 
-        // Apply the first -- should succeed.
-        db.apply_batch(batch_a).await.unwrap();
-        let expected_root = db.root();
-        let expected_bounds = db.bounds();
+        // Apply the first and commit it -- should succeed.
+        let (db, _) = db.apply_batch(batch_a).await.unwrap();
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&key2).await.unwrap(), None);
         assert_eq!(db.get_metadata().await.unwrap(), None);
+        let db = db.commit().await.unwrap();
+        let root = db.root();
+        let size = db.size();
 
         // Apply the second -- should fail because the DB was modified.
         let result = db.apply_batch(batch_b).await;
-        assert!(
-            matches!(result, Err(Error::StaleBatch { .. })),
-            "expected StaleBatch error, got {result:?}"
-        );
-        assert_eq!(db.root(), expected_root);
-        assert_eq!(db.bounds(), expected_bounds);
+        assert!(matches!(result, Err(Error::StaleBatch { .. })));
+
+        // The rejection mutated nothing: reopening recovers the committed state.
+        let db = open_db(context.child("reopen")).await;
+        assert_eq!(db.root(), root);
+        assert_eq!(db.size(), size);
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&key2).await.unwrap(), None);
-        assert_eq!(db.get_metadata().await.unwrap(), None);
-
         db.destroy().await.unwrap();
     }
 
@@ -2381,7 +2373,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2407,16 +2399,11 @@ pub(super) mod test {
             .await;
 
         // Apply child A.
-        db.apply_batch(child_a).await.unwrap();
+        let (db, _) = db.apply_batch(child_a).await.unwrap();
 
         // Child B is stale.
         let result = db.apply_batch(child_b).await;
-        assert!(
-            matches!(result, Err(Error::StaleBatch { .. })),
-            "expected StaleBatch error, got {result:?}"
-        );
-
-        db.destroy().await.unwrap();
+        assert!(matches!(result, Err(Error::StaleBatch { .. })));
     }
 
     #[boxed]
@@ -2430,7 +2417,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2459,8 +2446,8 @@ pub(super) mod test {
         let expected_root = c.root();
 
         // Apply only A, then apply C directly (B uncommitted).
-        db.apply_batch(a).await.unwrap();
-        db.apply_batch(c).await.unwrap();
+        let (db, _) = db.apply_batch(a).await.unwrap();
+        let (db, _) = db.apply_batch(c).await.unwrap();
 
         assert_eq!(db.root(), expected_root);
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
@@ -2481,7 +2468,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2503,8 +2490,8 @@ pub(super) mod test {
             .await;
 
         // Apply parent first, then child. This is a valid sequential commit.
-        db.apply_batch(parent_m).await.unwrap();
-        db.apply_batch(child_m).await.unwrap();
+        let (db, _) = db.apply_batch(parent_m).await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
 
         // Both keys present.
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
@@ -2524,7 +2511,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2543,8 +2530,8 @@ pub(super) mod test {
 
         // Commit the parent, then rebuild the same logical child from the
         // committed DB state and compare roots.
-        db.apply_batch(parent).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let committed_child = db
             .new_batch()
@@ -2568,7 +2555,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2588,16 +2575,11 @@ pub(super) mod test {
             .await;
 
         // Apply child first (it carries all parent ops too).
-        db.apply_batch(child_m).await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
 
         // Parent is stale.
         let result = db.apply_batch(parent_m).await;
-        assert!(
-            matches!(result, Err(Error::StaleBatch { .. })),
-            "expected StaleBatch error, got {result:?}"
-        );
-
-        db.destroy().await.unwrap();
+        assert!(matches!(result, Err(Error::StaleBatch { .. })));
     }
 
     /// to_batch() creates an owned snapshot whose root matches the committed DB.
@@ -2613,19 +2595,17 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         // Populate.
         let key1 = Sha256::hash(&[1]);
         let v1 = Sha256::fill(10u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(key1, v1)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key1, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // to_batch root matches committed root.
         let snapshot = db.to_batch();
@@ -2639,7 +2619,7 @@ pub(super) mod test {
             .set(key2, v2)
             .merkleize(&db, None, Location::new(0))
             .await;
-        db.apply_batch(child).await.unwrap();
+        let (db, _) = db.apply_batch(child).await.unwrap();
 
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
         assert_eq!(db.get(&key2).await.unwrap(), Some(v2));
@@ -2660,7 +2640,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key1 = Sha256::hash(&[1]);
         let key2 = Sha256::hash(&[2]);
@@ -2691,7 +2671,7 @@ pub(super) mod test {
         drop(b);
 
         // Apply only the tip. This is !skip_ancestors (DB hasn't changed).
-        db.apply_batch(c).await.unwrap();
+        let (db, _) = db.apply_batch(c).await.unwrap();
 
         // All three keys must be in the snapshot.
         assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
@@ -2714,7 +2694,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // Empty DB has floor=0.
         assert_eq!(db.inactivity_floor_loc(), Location::new(0));
@@ -2722,33 +2702,28 @@ pub(super) mod test {
         // Apply batch with floor=0, floor stays 0.
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(2u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, None, Location::new(0))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(0));
 
         // Apply batch with floor=3, floor advances.
         let k2 = Sha256::fill(3u8);
         let v2 = Sha256::fill(4u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k2, v2)
-                .merkleize(&db, None, Location::new(3))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(3))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(3));
 
         // Floor persists across restart.
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         db.sync().await.unwrap();
-        drop(db);
         let db = open_db(context.child("reopen")).await;
         assert_eq!(db.inactivity_floor_loc(), Location::new(3));
 
@@ -2768,46 +2743,40 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // DB starts with 1 op (initial commit).
         // First batch: 1 set + 1 commit = total_size 3. Use floor=2 (the commit loc).
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(2u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, None, Location::new(2))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(2))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(2));
 
         // Same floor is OK. Second batch: 1 set + 1 commit = total_size 5. floor=2 < 5.
         let k2 = Sha256::fill(3u8);
         let v2 = Sha256::fill(4u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k2, v2)
-                .merkleize(&db, None, Location::new(2))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(2))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(2));
 
         // Higher floor also succeeds. Third batch: 1 set + 1 commit = total_size 7. floor=5 < 7.
         let k3 = Sha256::fill(5u8);
         let v3 = Sha256::fill(6u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k3, v3)
-                .merkleize(&db, None, Location::new(5))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k3, v3)
+            .merkleize(&db, None, Location::new(5))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(5));
 
         db.destroy().await.unwrap();
@@ -2825,39 +2794,35 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // Apply first batch with floor=2.
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(2u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, None, Location::new(2))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(2))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let first_size = db.bounds().end;
         assert_eq!(db.inactivity_floor_loc(), Location::new(2));
 
         // Apply second batch with floor=4 (the new commit's location).
         let k2 = Sha256::fill(3u8);
         let v2 = Sha256::fill(4u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k2, v2)
-                .merkleize(&db, None, Location::new(4))
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(4))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(4));
 
         // Rewind to the first batch.
-        db.rewind(first_size).await.unwrap();
+        let db = db.rewind(first_size).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(2));
 
         db.destroy().await.unwrap();
@@ -2876,35 +2841,29 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // DB starts with 1 op. First batch: 1 set + 1 commit = total_size 3. floor=2.
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(2u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .merkleize(&db, None, Location::new(2))
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(2))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Apply batch with floor=1 (regression). Should return an error.
         let k2 = Sha256::fill(3u8);
         let v2 = Sha256::fill(4u8);
-        let result = db
-            .apply_batch(
-                db.new_batch()
-                    .set(k2, v2)
-                    .merkleize(&db, None, Location::new(1))
-                    .await,
-            )
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(1))
             .await;
+        let result = db.apply_batch(merkleized).await;
         assert!(matches!(result, Err(Error::FloorRegressed(new, current))
                 if new == Location::new(1) && current == Location::new(2)));
-
-        db.destroy().await.unwrap();
     }
 
     /// Verify that applying a batch with a floor beyond the total operation
@@ -2920,48 +2879,46 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // DB has 1 op (initial commit). A batch with 1 set + 1 commit = total_size 3.
         // Setting floor=100 exceeds total_size.
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(2u8);
-        let result = db
-            .apply_batch(
-                db.new_batch()
-                    .set(k1, v1)
-                    .merkleize(&db, None, Location::new(100))
-                    .await,
-            )
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .merkleize(&db, None, Location::new(100))
             .await;
+        let result = db.apply_batch(merkleized).await;
         assert!(matches!(result, Err(Error::FloorBeyondSize(floor, commit))
                 if floor == Location::new(100) && commit == Location::new(2)));
+
+        // The failed apply_batch consumed the db; reopen the partition to continue.
+        let db = open_db(context.child("test")).await;
 
         // Boundary: floor == total_size must also be rejected. The commit op is
         // at total_size - 1, so a floor equal to total_size would allow a later
         // prune to remove the commit and leave the db unrecoverable.
         let k2 = Sha256::fill(3u8);
         let v2 = Sha256::fill(4u8);
-        let result = db
-            .apply_batch(
-                db.new_batch()
-                    .set(k2, v2)
-                    .merkleize(&db, None, Location::new(3))
-                    .await,
-            )
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(3))
             .await;
+        let result = db.apply_batch(merkleized).await;
         assert!(matches!(result, Err(Error::FloorBeyondSize(floor, commit))
                 if floor == Location::new(3) && commit == Location::new(2)));
 
         // Floor == total_size - 1 (the commit location) is the maximum valid.
-        db.apply_batch(
-            db.new_batch()
-                .set(k2, v2)
-                .merkleize(&db, None, Location::new(2))
-                .await,
-        )
-        .await
-        .unwrap();
+        let db = open_db(context.child("test")).await;
+        let merkleized = db
+            .new_batch()
+            .set(k2, v2)
+            .merkleize(&db, None, Location::new(2))
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         db.destroy().await.unwrap();
     }
@@ -2982,7 +2939,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // Live floor is 0 (from the seeded initial commit).
         // a: 1 set + commit at loc 2, floor=2 (valid: >= 0, == commit_loc).
@@ -3010,14 +2967,18 @@ pub(super) mod test {
         let last_commit_before = db.last_commit_loc;
         let floor_before = db.inactivity_floor_loc();
 
-        let err = db.apply_batch(c).await.unwrap_err();
+        let Err(err) = db.apply_batch(c).await else {
+            panic!("expected apply_batch to fail");
+        };
         assert!(
             matches!(err, Error::FloorRegressed(new, prev)
                 if new == Location::new(1) && prev == Location::new(2)),
             "unexpected error: {err:?}"
         );
 
-        // Database state must be unchanged on a rejected chain.
+        // The failed apply_batch consumed the db; reopen the partition and
+        // verify the rejected chain persisted nothing.
+        let db = open_db(context.child("test")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
         assert_eq!(db.inactivity_floor_loc(), floor_before);
@@ -3040,7 +3001,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // a: 1 set + commit at loc 2; declare floor=3 (one past the commit -- invalid).
         // b: tip valid on its own (floor=0 <= b's commit_loc), but a's floor is bad.
@@ -3059,7 +3020,9 @@ pub(super) mod test {
         let last_commit_before = db.last_commit_loc;
         let floor_before = db.inactivity_floor_loc();
 
-        let err = db.apply_batch(b).await.unwrap_err();
+        let Err(err) = db.apply_batch(b).await else {
+            panic!("expected apply_batch to fail");
+        };
         // The error must identify the ancestor's commit_loc (2), not the tip's (4).
         assert!(
             matches!(err, Error::FloorBeyondSize(floor, commit)
@@ -3067,7 +3030,9 @@ pub(super) mod test {
             "unexpected error: {err:?}"
         );
 
-        // Database state must be unchanged on a rejected chain.
+        // The failed apply_batch consumed the db; reopen the partition and
+        // verify the rejected chain persisted nothing.
+        let db = open_db(context.child("test")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
         assert_eq!(db.inactivity_floor_loc(), floor_before);
@@ -3092,7 +3057,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let k1 = Sha256::fill(1u8);
         let k2 = Sha256::fill(2u8);
@@ -3102,7 +3067,7 @@ pub(super) mod test {
         let v3 = Sha256::fill(13u8);
 
         // Commit A: 3 keys with floor=0.
-        commit_sets(&mut db, [(k1, v1), (k2, v2), (k3, v3)], None).await;
+        let (db, _) = commit_sets(db, [(k1, v1), (k2, v2), (k3, v3)], None).await;
         let first_size = db.bounds().end;
         let first_root = db.root();
 
@@ -3113,18 +3078,18 @@ pub(super) mod test {
         let v4 = Sha256::fill(14u8);
         let v5 = Sha256::fill(15u8);
         let v6 = Sha256::fill(16u8);
-        commit_sets_with_floor(&mut db, [(k4, v4), (k5, v5), (k6, v6)], None, first_size).await;
+        let (db, _) =
+            commit_sets_with_floor(db, [(k4, v4), (k5, v5), (k6, v6)], None, first_size).await;
         db.sync().await.unwrap();
 
         // Reopen: snapshot rebuilt from floor=first_size, batch A keys excluded.
-        drop(db);
-        let mut db = open_db(context.child("second")).await;
+        let db = open_db(context.child("second")).await;
 
         // Verify batch A keys are NOT in the reopened snapshot (expected).
         assert!(db.get(&k1).await.unwrap().is_none());
 
         // Rewind to commit A.
-        db.rewind(first_size).await.unwrap();
+        let db = db.rewind(first_size).await.unwrap();
 
         // All batch A keys must be accessible after rewind.
         assert_eq!(db.get(&k1).await.unwrap(), Some(v1));
@@ -3153,32 +3118,31 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let k1 = Sha256::fill(1u8);
         let v1 = Sha256::fill(11u8);
 
         // Commit A: 1 key, floor=0.
-        commit_sets(&mut db, [(k1, v1)], None).await;
+        let (db, _) = commit_sets(db, [(k1, v1)], None).await;
         let first_size = db.bounds().end;
         let first_root = db.root();
 
         // Commit B: 1 key, floor=first_size.
         let k2 = Sha256::fill(2u8);
         let v2 = Sha256::fill(12u8);
-        commit_sets_with_floor(&mut db, [(k2, v2)], None, first_size).await;
+        let (db, _) = commit_sets_with_floor(db, [(k2, v2)], None, first_size).await;
         let second_size = db.bounds().end;
 
         // Commit C: 1 key, floor=second_size. This raises the floor
         // above commit B's keys, so reopen excludes both A and B keys.
         let k3 = Sha256::fill(3u8);
         let v3 = Sha256::fill(13u8);
-        commit_sets_with_floor(&mut db, [(k3, v3)], None, second_size).await;
+        let (db, _) = commit_sets_with_floor(db, [(k3, v3)], None, second_size).await;
         db.sync().await.unwrap();
 
         // Reopen: snapshot rebuilt from floor=second_size. Only k3 is in snapshot.
-        drop(db);
-        let mut db = open_db(context.child("second")).await;
+        let db = open_db(context.child("second")).await;
         assert!(db.get(&k1).await.unwrap().is_none());
         assert!(db.get(&k2).await.unwrap().is_none());
         assert_eq!(db.get(&k3).await.unwrap(), Some(v3));
@@ -3186,13 +3150,13 @@ pub(super) mod test {
         // Rewind to commit B (not A). The gap fill should add keys from
         // [first_size, second_size) -- which includes k2 but not k1.
         // k3 is in the suffix and gets removed. k2 from the gap gets inserted.
-        db.rewind(second_size).await.unwrap();
+        let db = db.rewind(second_size).await.unwrap();
         assert!(db.get(&k1).await.unwrap().is_none()); // below B's floor
         assert_eq!(db.get(&k2).await.unwrap(), Some(v2));
         assert!(db.get(&k3).await.unwrap().is_none()); // in suffix, removed
 
         // Now rewind further to commit A.
-        db.rewind(first_size).await.unwrap();
+        let db = db.rewind(first_size).await.unwrap();
         assert_eq!(db.get(&k1).await.unwrap(), Some(v1));
         assert!(db.get(&k2).await.unwrap().is_none()); // above first_size, truncated
         assert_eq!(db.root(), first_root);
@@ -3214,7 +3178,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let key = Sha256::fill(7u8);
         let v1 = Sha256::fill(17u8);
@@ -3223,33 +3187,32 @@ pub(super) mod test {
         let v3 = Sha256::fill(19u8);
 
         // Commit A: Set(key, v1) with floor=0.
-        commit_sets(&mut db, [(key, v1)], None).await;
+        let (db, _) = commit_sets(db, [(key, v1)], None).await;
         let first_size = db.bounds().end;
 
         // Commit B: Set(key, v2) with floor=0. Either written value may be served.
-        commit_sets(&mut db, [(key, v2)], None).await;
+        let (db, _) = commit_sets(db, [(key, v2)], None).await;
         let second_size = db.bounds().end;
         let live = db.get(&key).await.unwrap().unwrap();
         assert!(live == v1 || live == v2);
 
         // Commit C: raises floor above both earlier writes.
-        commit_sets_with_floor(&mut db, [(k3, v3)], None, second_size).await;
+        let (db, _) = commit_sets_with_floor(db, [(k3, v3)], None, second_size).await;
         db.sync().await.unwrap();
 
         // Reopen: snapshot rebuilt from floor=second_size, key excluded.
-        drop(db);
-        let mut db = open_db(context.child("second")).await;
+        let db = open_db(context.child("second")).await;
         assert!(db.get(&key).await.unwrap().is_none());
         assert_eq!(db.get(&k3).await.unwrap(), Some(v3));
 
         // Rewind to commit B: gap fill re-inserts both Set(key,...) entries.
-        db.rewind(second_size).await.unwrap();
+        let db = db.rewind(second_size).await.unwrap();
         let rewound = db.get(&key).await.unwrap().unwrap();
         assert!(rewound == v1 || rewound == v2);
 
         // Rewind further to commit A: the v2 entry is dropped and get() must
         // serve v1, proving the gap fill restored the v1 location.
-        db.rewind(first_size).await.unwrap();
+        let db = db.rewind(first_size).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         db.destroy().await.unwrap();
@@ -3269,7 +3232,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("first")).await;
+        let db = open_db(context.child("first")).await;
 
         let key = Sha256::fill(7u8);
         let v1 = Sha256::fill(17u8);
@@ -3278,35 +3241,34 @@ pub(super) mod test {
         let v3 = Sha256::fill(19u8);
 
         // Commit A: Set(key, v1) at loc=0, floor=0.
-        commit_sets(&mut db, [(key, v1)], None).await;
+        let (db, _) = commit_sets(db, [(key, v1)], None).await;
         let first_size = db.bounds().end;
 
         // Commit B: Set(key, v2), floor=0. Either written value may be served.
-        commit_sets(&mut db, [(key, v2)], None).await;
+        let (db, _) = commit_sets(db, [(key, v2)], None).await;
         let second_size = db.bounds().end;
         let live = db.get(&key).await.unwrap().unwrap();
         assert!(live == v1 || live == v2);
 
         // Commit C: raises floor to first_size, so loc=0 is below floor but
         // loc for v2 is retained.
-        commit_sets_with_floor(&mut db, [(k3, v3)], None, first_size).await;
+        let (db, _) = commit_sets_with_floor(db, [(k3, v3)], None, first_size).await;
         db.sync().await.unwrap();
 
         // Reopen: snapshot rebuilt from floor=first_size. The v2 write for key
         // is retained; the v1 write is excluded.
-        drop(db);
-        let mut db = open_db(context.child("second")).await;
+        let db = open_db(context.child("second")).await;
         assert_eq!(db.get(&key).await.unwrap(), Some(v2));
 
         // Rewind to commit B: gap fill re-inserts the v1 write alongside the
         // retained v2 entry, and get() serves one of the two.
-        db.rewind(second_size).await.unwrap();
+        let db = db.rewind(second_size).await.unwrap();
         let rewound = db.get(&key).await.unwrap().unwrap();
         assert!(rewound == v1 || rewound == v2);
 
         // Rewind further to commit A: the v2 entry is dropped and get() must
         // serve v1, proving the gap fill restored the v1 location.
-        db.rewind(first_size).await.unwrap();
+        let db = db.rewind(first_size).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         db.destroy().await.unwrap();
@@ -3332,7 +3294,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("test")).await;
+        let db = open_db(context.child("test")).await;
 
         // Initial commit is at loc 0. 3 sets + 1 commit → commit lands at loc 4.
         // Declare floor = 4 (= commit_loc), the tight maximum.
@@ -3344,17 +3306,15 @@ pub(super) mod test {
         let v1 = Sha256::fill(11u8);
         let v2 = Sha256::fill(12u8);
         let v3 = Sha256::fill(13u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .set(k2, v2)
-                .set(k3, v3)
-                .merkleize(&db, Some(metadata), commit_loc)
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .set(k2, v2)
+            .set(k3, v3)
+            .merkleize(&db, Some(metadata), commit_loc)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.last_commit_loc, commit_loc);
         assert_eq!(db.inactivity_floor_loc(), commit_loc);
         let root_after_commit = db.root();
@@ -3368,7 +3328,7 @@ pub(super) mod test {
         // Pruning is blob-aligned, so `bounds.start` may not physically advance all the way
         // to `commit_loc`; what matters semantically is that the floor authorizes pruning
         // of everything below the commit and that any further prune is rejected.
-        db.prune(commit_loc).await.unwrap();
+        let db = db.prune(commit_loc).await.unwrap();
         let bounds = db.bounds();
         assert!(
             bounds.start <= commit_loc,
@@ -3376,23 +3336,25 @@ pub(super) mod test {
         );
         assert_eq!(bounds.end, Location::new(*commit_loc + 1));
 
-        // Pruning one past the floor must be rejected — the floor is the hard ceiling.
-        let err = db.prune(Location::new(*commit_loc + 1)).await.unwrap_err();
-        assert!(matches!(err, Error::PruneBeyondMinRequired(p, f)
-                if *p == *commit_loc + 1 && *f == *commit_loc));
-
         // State preserved across the prune; root unchanged; commit metadata still readable.
         assert_eq!(db.last_commit_loc, commit_loc);
         assert_eq!(db.inactivity_floor_loc(), commit_loc);
         assert_eq!(db.root(), root_after_commit);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
-        // Persist and reopen. `init_from_journal` rebuilds the snapshot by replaying from
+        // Persist, then verify pruning one past the floor is rejected — the floor is
+        // the hard ceiling. The failing prune consumes the db in place of a drop.
+        let db = db.sync().await.unwrap();
+        let Err(err) = db.prune(Location::new(*commit_loc + 1)).await else {
+            panic!("expected prune to fail");
+        };
+        assert!(matches!(err, Error::PruneBeyondMinRequired(p, f)
+                if *p == *commit_loc + 1 && *f == *commit_loc));
+
+        // Reopen. `init_from_journal` rebuilds the snapshot by replaying from
         // the floor (= commit_loc). The only op at/above the floor is the commit, which
         // contributes no keys — so the rebuilt snapshot is empty.
-        db.sync().await.unwrap();
-        drop(db);
-        let mut db = open_db(context.child("reopened")).await;
+        let db = open_db(context.child("reopened")).await;
         assert_eq!(db.last_commit_loc, commit_loc);
         assert_eq!(db.inactivity_floor_loc(), commit_loc);
         assert_eq!(db.root(), root_after_commit);
@@ -3411,15 +3373,13 @@ pub(super) mod test {
         let k4 = Sha256::fill(4u8);
         let v4 = Sha256::fill(14u8);
         let next_commit_loc = Location::<F>::new(6);
-        db.apply_batch(
-            db.new_batch()
-                .set(k4, v4)
-                .merkleize(&db, None, next_commit_loc)
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k4, v4)
+            .merkleize(&db, None, next_commit_loc)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.last_commit_loc, next_commit_loc);
         assert_eq!(db.inactivity_floor_loc(), next_commit_loc);
 
@@ -3446,7 +3406,7 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let k1 = Sha256::fill(1u8);
         let k2 = Sha256::fill(2u8);
@@ -3458,16 +3418,14 @@ pub(super) mod test {
         let v3 = Sha256::fill(13u8);
 
         // Commit k1 and k2 to disk.
-        db.apply_batch(
-            db.new_batch()
-                .set(k1, v1)
-                .set(k2, v2)
-                .merkleize(&db, None, db.inactivity_floor_loc())
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(k1, v1)
+            .set(k2, v2)
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // DB-level get_many.
         let results = db.get_many(&[&k1, &k2, &k_missing]).await.unwrap();
@@ -3512,19 +3470,17 @@ pub(super) mod test {
         C: Mutable<Item = Operation<F, Digest, V>>,
         C::Item: EncodeShared,
     {
-        let mut db = open_db(context.child("db")).await;
+        let db = open_db(context.child("db")).await;
 
         let key = Sha256::fill(1u8);
         let value = Sha256::fill(11u8);
-        db.apply_batch(
-            db.new_batch()
-                .set(key, value)
-                .merkleize(&db, None, db.inactivity_floor_loc())
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .set(key, value)
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let mut db = db.commit().await.unwrap();
 
         let bad_key = Sha256::fill(99u8);
         let bad_loc = db.last_commit_loc;

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -229,10 +229,10 @@ where
     ) -> Result<Self, Error<F>> {
         if journal.size() == 0 {
             warn!("Authenticated log is empty, initialized new db.");
-            let (appended, _) = journal
+            (journal, _) = journal
                 .append(&Operation::Commit(None, Location::new(0)))
                 .await?;
-            journal = appended.sync().await?;
+            journal = journal.sync().await?;
         }
 
         let mut snapshot = Index::new(context.child("snapshot"), translator);

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -1432,7 +1432,6 @@ pub(super) mod test {
                 if prune_loc == Location::new(1) && floor == Location::new(0))
         );
 
-        // The failed prune consumed the db; reopen the partition to continue.
         let db = open_db(context.child("test")).await;
 
         // Add key-value pairs and commit
@@ -1682,7 +1681,6 @@ pub(super) mod test {
             "unexpected rewind error at retained boundary: {boundary_err:?}"
         );
 
-        // The failed rewind consumed the db; reopen the partition to continue.
         let db = open_small_sections_db(context.child("db")).await;
         let Err(err) = db.rewind(first_range.start).await else {
             panic!("expected rewind to fail");
@@ -2894,7 +2892,6 @@ pub(super) mod test {
         assert!(matches!(result, Err(Error::FloorBeyondSize(floor, commit))
                 if floor == Location::new(100) && commit == Location::new(2)));
 
-        // The failed apply_batch consumed the db; reopen the partition to continue.
         let db = open_db(context.child("test")).await;
 
         // Boundary: floor == total_size must also be rejected. The commit op is
@@ -2976,8 +2973,7 @@ pub(super) mod test {
             "unexpected error: {err:?}"
         );
 
-        // The failed apply_batch consumed the db; reopen the partition and
-        // verify the rejected chain persisted nothing.
+        // Reopen the partition and verify the rejected chain persisted nothing.
         let db = open_db(context.child("test")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
@@ -3030,8 +3026,7 @@ pub(super) mod test {
             "unexpected error: {err:?}"
         );
 
-        // The failed apply_batch consumed the db; reopen the partition and
-        // verify the rejected chain persisted nothing.
+        // Reopen the partition and verify the rejected chain persisted nothing.
         let db = open_db(context.child("test")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.last_commit_loc, last_commit_before);
@@ -3343,7 +3338,7 @@ pub(super) mod test {
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
         // Persist, then verify pruning one past the floor is rejected — the floor is
-        // the hard ceiling. The failing prune consumes the db in place of a drop.
+        // the hard ceiling.
         let db = db.sync().await.unwrap();
         let Err(err) = db.prune(Location::new(*commit_loc + 1)).await else {
             panic!("expected prune to fail");

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -124,7 +124,7 @@ where
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);
-        let mut db = Self {
+        let db = Self {
             journal,
             root,
             snapshot,
@@ -134,8 +134,7 @@ where
         };
         db.update_metrics();
 
-        db.sync().await?;
-        Ok(db)
+        db.sync().await
     }
 
     async fn local_boundary_nodes(
@@ -213,7 +212,7 @@ where
         self.root()
     }
 
-    async fn persist_compact_state(&mut self) -> Result<(), Error<F>> {
+    async fn persist_compact_state(self) -> Result<Self, Error<F>> {
         self.sync().await
     }
 }

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -266,8 +266,7 @@ where
         let expected_op_count = bounds.end;
         let expected_oldest_retained_loc = bounds.start;
 
-        let synced_db = H::db_sync(synced_db).await;
-        drop(synced_db);
+        H::db_sync(synced_db).await;
         let reopened_db = H::init_db_with_config(context.child("reopened"), db_config).await;
 
         assert_eq!(H::db_root(&reopened_db), expected_root);
@@ -441,8 +440,7 @@ where
             H::init_db_with_config(client_context.child("client"), sync_db_config.clone()).await;
 
         let target_db = H::apply_ops(target_db, original_ops.clone(), None).await;
-        let sync_db = H::apply_ops(sync_db, original_ops, None).await;
-        drop(sync_db);
+        H::apply_ops(sync_db, original_ops, None).await;
 
         let last_op = H::create_ops_seeded(1, 1);
         let target_db = H::apply_ops(target_db, last_op, None).await;
@@ -496,8 +494,7 @@ where
             H::init_db_with_config(client_context.child("client"), sync_config.clone()).await;
 
         let target_db = H::apply_ops(target_db, target_ops.clone(), None).await;
-        let sync_db = H::apply_ops(sync_db, target_ops, None).await;
-        drop(sync_db);
+        H::apply_ops(sync_db, target_ops, None).await;
 
         let root = H::db_root(&target_db);
         let bounds = H::bounds(&target_db);

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -46,6 +46,13 @@ const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 
 /// Harness that abstracts per-family details so the generic tests below can operate on
 /// any immutable database.
+/// [`SyncTestHarness::prune`] with a heap-allocated state machine (the future embeds the
+/// database twice and exceeds the size lint in the deepest test).
+#[boxed]
+async fn prune_boxed<H: SyncTestHarness>(db: H::Db, loc: Location<H::Family>) -> H::Db {
+    H::prune(db, loc).await
+}
+
 pub(crate) trait SyncTestHarness: Sized + 'static {
     type Family: merkle::Family;
     type Db: qmdb::sync::Database<
@@ -70,7 +77,7 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
         config: ConfigOf<Self>,
     ) -> impl Future<Output = Self::Db> + Send;
     fn destroy(db: Self::Db) -> impl Future<Output = ()> + Send;
-    fn db_sync(db: &mut Self::Db) -> impl Future<Output = ()> + Send;
+    fn db_sync(db: Self::Db) -> impl Future<Output = Self::Db> + Send;
 
     fn apply_ops(
         db: Self::Db,
@@ -83,9 +90,9 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
         metadata: Option<Self::Metadata>,
         floor: Location<Self::Family>,
     ) -> impl Future<Output = Self::Db> + Send;
-    fn commit(db: &mut Self::Db) -> impl Future<Output = ()> + Send;
+    fn commit(db: Self::Db) -> impl Future<Output = Self::Db> + Send;
     fn inactivity_floor_loc(db: &Self::Db) -> Location<Self::Family>;
-    fn prune(db: &mut Self::Db, loc: Location<Self::Family>) -> impl Future<Output = ()> + Send;
+    fn prune(db: Self::Db, loc: Location<Self::Family>) -> impl Future<Output = Self::Db> + Send;
 
     fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>>;
     fn db_root(db: &Self::Db) -> sha256::Digest;
@@ -251,7 +258,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let mut synced_db: DbOf<H> = sync::sync(config).await.unwrap();
+        let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         assert_eq!(H::db_root(&synced_db), target_root);
         let expected_root = H::db_root(&synced_db);
@@ -259,7 +266,7 @@ where
         let expected_op_count = bounds.end;
         let expected_oldest_retained_loc = bounds.start;
 
-        H::db_sync(&mut synced_db).await;
+        let synced_db = H::db_sync(synced_db).await;
         drop(synced_db);
         let reopened_db = H::init_db_with_config(context.child("reopened"), db_config).await;
 
@@ -535,9 +542,9 @@ where
     executor.start(|mut context| async move {
         let target_db = H::init_db(context.child("target")).await;
         let target_ops = H::create_ops(100);
-        let mut target_db = H::apply_ops(target_db, target_ops, None).await;
+        let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        H::prune(&mut target_db, Location::new(10)).await;
+        let target_db = H::prune(target_db, Location::new(10)).await;
 
         let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
@@ -664,9 +671,9 @@ where
         let initial_root = H::db_root(&target_db);
 
         let more_ops = H::create_ops_seeded(5, 1);
-        let mut target_db = H::apply_ops(target_db, more_ops, None).await;
+        let target_db = H::apply_ops(target_db, more_ops, None).await;
 
-        H::prune(&mut target_db, Location::new(10)).await;
+        let target_db = H::prune(target_db, Location::new(10)).await;
         let target_db = H::apply_ops(target_db, vec![], None).await;
 
         let bounds = H::bounds(&target_db);
@@ -729,20 +736,20 @@ where
 
         // First batch with floor=0.
         let early_ops = H::create_ops(50);
-        let mut target_db = H::apply_ops(target_db, early_ops.clone(), None).await;
-        H::commit(&mut target_db).await;
+        let target_db = H::apply_ops(target_db, early_ops.clone(), None).await;
+        let target_db = H::commit(target_db).await;
         let first_commit_end = H::bounds(&target_db).end;
 
         // Second batch with floor = first_commit_end, declaring the first batch inactive.
         let late_ops = H::create_ops_seeded(50, 1);
-        let mut target_db = H::apply_ops_with_floor(
+        let target_db = H::apply_ops_with_floor(
             target_db,
             late_ops.clone(),
             Some(H::sample_metadata()),
             first_commit_end,
         )
         .await;
-        H::commit(&mut target_db).await;
+        let target_db = H::commit(target_db).await;
 
         assert_eq!(H::inactivity_floor_loc(&target_db), first_commit_end);
 
@@ -925,7 +932,7 @@ pub(crate) mod harnesses {
     }
 
     async fn variable_apply_ops_with_floor<F: Family>(
-        mut db: VariableDb<F>,
+        db: VariableDb<F>,
         ops: Vec<Operation<F, sha256::Digest, sha256::Digest>>,
         metadata: Option<sha256::Digest>,
         floor: Location<F>,
@@ -945,7 +952,7 @@ pub(crate) mod harnesses {
             }
         }
         let merkleized = batch.merkleize(&db, metadata, floor).await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         db
     }
 
@@ -991,8 +998,8 @@ pub(crate) mod harnesses {
             db.destroy().await.unwrap();
         }
 
-        async fn db_sync(db: &mut Self::Db) {
-            db.sync().await.unwrap();
+        async fn db_sync(db: Self::Db) -> Self::Db {
+            db.sync().await.unwrap()
         }
 
         async fn apply_ops(
@@ -1012,21 +1019,21 @@ pub(crate) mod harnesses {
             variable_apply_ops_with_floor::<F>(db, ops, metadata, floor).await
         }
 
-        async fn commit(db: &mut Self::Db) {
-            db.commit().await.unwrap();
+        async fn commit(db: Self::Db) -> Self::Db {
+            db.commit().await.unwrap()
         }
 
         fn inactivity_floor_loc(db: &Self::Db) -> Location<Self::Family> {
             db.inactivity_floor_loc()
         }
 
-        async fn prune(db: &mut Self::Db, loc: Location<Self::Family>) {
+        async fn prune(db: Self::Db, loc: Location<Self::Family>) -> Self::Db {
             // Advance the inactivity floor to `loc` via a commit before pruning,
             // since prune requires the floor to be at or beyond the prune target.
-            let merkleized = db.new_batch().merkleize(db, None, loc).await;
-            db.apply_batch(merkleized).await.unwrap();
-            db.commit().await.unwrap();
-            db.prune(loc).await.unwrap();
+            let merkleized = db.new_batch().merkleize(&db, None, loc).await;
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            db.prune(loc).await.unwrap()
         }
 
         fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>> {
@@ -1157,8 +1164,8 @@ fn test_immutable_local_boundary_nodes_rejects_target_before_local_lower_bound()
         for seed in 0..3u64 {
             db = H::apply_ops(db, H::create_ops_seeded(100, seed), None).await;
         }
-        H::prune(&mut db, Location::new(100)).await;
-        H::db_sync(&mut db).await;
+        let db = prune_boxed::<H>(db, Location::new(100)).await;
+        let db = H::db_sync(db).await;
 
         let bounds = H::bounds(&db);
         let local_start = bounds.start;
@@ -1323,10 +1330,9 @@ mod compact_variable_mmr {
     fn test_compact_sync_roundtrip() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let metadata = vec![8, 8, 8];
             let floor = Location::new(1);
             let key_a = sha256::Digest::from([1; 32]);
@@ -1337,8 +1343,8 @@ mod compact_variable_mmr {
                 .set(key_b, vec![4, 5, 6])
                 .merkleize(&source, Some(metadata.clone()), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1381,17 +1387,16 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_invalid_proof() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-bad-proof-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([3; 32]), vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1434,17 +1439,16 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_tampered_commit_floor() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-bad-floor-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([3; 32]), vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1503,10 +1507,9 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_tampered_pinned_nodes() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-bad-pins-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let key_a = sha256::Digest::from([1; 32]);
             let key_b = sha256::Digest::from([2; 32]);
             let batch = source
@@ -1515,8 +1518,8 @@ mod compact_variable_mmr {
                 .set(key_b, vec![4, 5, 6])
                 .merkleize(&source, Some(vec![7]), Location::new(2))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1568,17 +1571,16 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_leaf_count_mismatch() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-bad-leaf-count-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([3; 32]), vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1621,17 +1623,16 @@ mod compact_variable_mmr {
     fn test_compact_full_source_rejects_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-stale-full-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch1 = source
                 .new_batch()
                 .set(sha256::Digest::from([1; 32]), vec![1, 2, 3])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch1).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).await.unwrap();
+            let source = source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -1642,8 +1643,8 @@ mod compact_variable_mmr {
                 .set(sha256::Digest::from([2; 32]), vec![4, 5, 6])
                 .merkleize(&source, Some(vec![2]), Location::new(2))
                 .await;
-            source.apply_batch(batch2).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).await.unwrap();
+            let source = source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -1669,7 +1670,7 @@ mod compact_variable_mmr {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-unj-source-{}", context.next_u64());
             let source_cfg = client_config(&format!("{suffix}-source"), &context);
-            let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
 
@@ -1680,8 +1681,8 @@ mod compact_variable_mmr {
                 .set(sha256::Digest::from([10; 32]), vec![10, 11])
                 .merkleize(&source, Some(metadata1.clone()), floor1)
                 .await;
-            source.apply_batch(batch1).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).unwrap();
+            let source = source.sync().await.unwrap();
             let target1 = source.target();
             drop(source);
 
@@ -1706,7 +1707,7 @@ mod compact_variable_mmr {
             assert_eq!(served1.inactivity_floor_loc(), floor1);
             served1.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
                 .await
                 .unwrap();
             let metadata2 = vec![2, 2, 2];
@@ -1716,12 +1717,12 @@ mod compact_variable_mmr {
                 .set(sha256::Digest::from([20; 32]), vec![20, 21])
                 .merkleize(&source, Some(metadata2.clone()), floor2)
                 .await;
-            source.apply_batch(batch2).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).unwrap();
+            let source = source.sync().await.unwrap();
             let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind(target1.leaf_count).await.unwrap();
+            let source = source.rewind(target1.leaf_count).await.unwrap();
             assert_eq!(source.target(), target1);
 
             let served2: ClientDb = sync::compact::sync(sync::compact::Config {
@@ -1740,7 +1741,7 @@ mod compact_variable_mmr {
             assert_eq!(served2.inactivity_floor_loc(), floor1);
             served2.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(source.target(), target1);
@@ -1751,8 +1752,8 @@ mod compact_variable_mmr {
                 .set(sha256::Digest::from([30; 32]), vec![30, 31, 32])
                 .merkleize(&source, Some(metadata3.clone()), floor3)
                 .await;
-            source.apply_batch(batch3).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch3).unwrap();
+            let source = source.sync().await.unwrap();
             let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);
@@ -1822,33 +1823,33 @@ mod compact_variable_mmr {
                     .set(sha256::Digest::from([i; 32]), vec![i])
                     .merkleize(&seeded, Some(vec![i]), floor)
                     .await;
-                seeded.apply_batch(batch).unwrap();
-                seeded.sync().await.unwrap();
+                (seeded, _) = seeded.apply_batch(batch).unwrap();
+                seeded = seeded.sync().await.unwrap();
                 first_size.get_or_insert(seeded.size());
             }
-            seeded.prune(seeded.size()).await.unwrap();
+            let boundary = seeded.size();
+            let seeded = seeded.prune(boundary).await.unwrap();
             // The prune moved the journal's pruning boundary: the first commit is unreachable.
+            // The failed rewind consumes the import.
             assert!(matches!(
                 seeded.rewind(first_size.unwrap()).await,
                 Err(crate::qmdb::Error::Merkle(
                     crate::merkle::Error::RewindBeyondHistory
                 ))
             ));
-            drop(seeded);
 
             // Sync different state into the same partition.
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let metadata = vec![9, 9, 9];
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([9; 32]), vec![9])
                 .merkleize(&source, Some(metadata.clone()), Location::new(0))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
             let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
@@ -1886,7 +1887,7 @@ mod compact_variable_mmr {
 
             // Seed the client partition with committed state A.
             let client_cfg = client_config(&suffix, &context);
-            let mut seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
+            let seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
                 .await
                 .unwrap();
             let batch = seeded
@@ -1894,24 +1895,23 @@ mod compact_variable_mmr {
                 .set(sha256::Digest::from([1; 32]), vec![1])
                 .merkleize(&seeded, Some(vec![1]), Location::new(0))
                 .await;
-            seeded.apply_batch(batch).unwrap();
-            seeded.sync().await.unwrap();
+            let (seeded, _) = seeded.apply_batch(batch).unwrap();
+            let seeded = seeded.sync().await.unwrap();
             let target_a = seeded.target();
             drop(seeded);
 
             // Reconstruct state B into the same partition, then drop it before the first
             // persist (as a cancelled sync would).
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([9; 32]), vec![9])
                 .merkleize(&source, Some(vec![9]), Location::new(0))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
             let bounds = source.bounds();
             let target_b = sync::compact::Target {
                 root: source.root(),
@@ -1926,7 +1926,7 @@ mod compact_variable_mmr {
                 state: fetched.state,
                 root: target_b.root,
             };
-            let mut imported = <ClientDb as sync::compact::Database>::from_validated_state(
+            let imported = <ClientDb as sync::compact::Database>::from_validated_state(
                 context.child("import"),
                 client_cfg.clone(),
                 validated,
@@ -1936,14 +1936,29 @@ mod compact_variable_mmr {
             assert_eq!(imported.target(), target_b);
 
             // Rewind is rejected until the import is persisted, even to the imported leaf
-            // count itself: the fast path must not report unpersisted state as durable.
+            // count itself: the fast path must not report unpersisted state as durable. The
+            // failed rewind consumes the import.
             assert!(imported.rewind(target_b.leaf_count).await.is_err());
 
-            // Prune is likewise rejected while the import is pending.
+            // Prune is likewise rejected while the import is pending; rebuild the import,
+            // since the failed rewind consumed the first one.
+            let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
+                .await
+                .unwrap();
+            let validated = sync::compact::ValidatedState {
+                state: fetched.state,
+                root: target_b.root,
+            };
+            let imported = <ClientDb as sync::compact::Database>::from_validated_state(
+                context.child("import").with_attribute("index", 2),
+                client_cfg.clone(),
+                validated,
+            )
+            .await
+            .unwrap();
             assert!(imported.prune(target_b.leaf_count).await.is_err());
-            drop(imported);
 
-            // The dropped import never touched the journal: state A is still there.
+            // The dropped imports never touched the journal: state A is still there.
             let reopened = ClientDb::init(context.child("reopen"), client_cfg)
                 .await
                 .unwrap();
@@ -2074,10 +2089,9 @@ mod compact_variable_mmb {
     fn test_compact_sync_roundtrip() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let metadata = vec![4, 4, 4];
             let floor = Location::new(1);
             let key_a = sha256::Digest::from([1; 32]);
@@ -2088,8 +2102,8 @@ mod compact_variable_mmb {
                 .set(key_b, vec![4, 5, 6])
                 .merkleize(&source, Some(metadata.clone()), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2132,17 +2146,16 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_invalid_proof() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-bad-proof-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([3; 32]), vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2185,17 +2198,16 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_tampered_commit_floor() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-bad-floor-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([3; 32]), vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2254,10 +2266,9 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_tampered_pinned_nodes() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-bad-pins-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let key_a = sha256::Digest::from([1; 32]);
             let key_b = sha256::Digest::from([2; 32]);
             let batch = source
@@ -2266,8 +2277,8 @@ mod compact_variable_mmb {
                 .set(key_b, vec![4, 5, 6])
                 .merkleize(&source, Some(vec![7]), Location::new(2))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2322,17 +2333,16 @@ mod compact_variable_mmb {
                 "compact-immutable-mmb-bad-leaf-count-{}",
                 context.next_u64()
             );
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .set(sha256::Digest::from([3; 32]), vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2375,17 +2385,16 @@ mod compact_variable_mmb {
     fn test_compact_full_source_rejects_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-stale-full-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch1 = source
                 .new_batch()
                 .set(sha256::Digest::from([1; 32]), vec![1, 2, 3])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch1).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).await.unwrap();
+            let source = source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -2396,8 +2405,8 @@ mod compact_variable_mmb {
                 .set(sha256::Digest::from([2; 32]), vec![4, 5, 6])
                 .merkleize(&source, Some(vec![2]), Location::new(2))
                 .await;
-            source.apply_batch(batch2).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).await.unwrap();
+            let source = source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -2423,7 +2432,7 @@ mod compact_variable_mmb {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-immutable-mmb-unj-source-{}", context.next_u64());
             let source_cfg = client_config(&format!("{suffix}-source"), &context);
-            let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
 
@@ -2434,8 +2443,8 @@ mod compact_variable_mmb {
                 .set(sha256::Digest::from([10; 32]), vec![10, 11])
                 .merkleize(&source, Some(metadata1.clone()), floor1)
                 .await;
-            source.apply_batch(batch1).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).unwrap();
+            let source = source.sync().await.unwrap();
             let target1 = source.target();
             drop(source);
 
@@ -2460,7 +2469,7 @@ mod compact_variable_mmb {
             assert_eq!(served1.inactivity_floor_loc(), floor1);
             served1.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
                 .await
                 .unwrap();
             let metadata2 = vec![2, 2, 2];
@@ -2470,12 +2479,12 @@ mod compact_variable_mmb {
                 .set(sha256::Digest::from([20; 32]), vec![20, 21])
                 .merkleize(&source, Some(metadata2.clone()), floor2)
                 .await;
-            source.apply_batch(batch2).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).unwrap();
+            let source = source.sync().await.unwrap();
             let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind(target1.leaf_count).await.unwrap();
+            let source = source.rewind(target1.leaf_count).await.unwrap();
             assert_eq!(source.target(), target1);
 
             let served2: ClientDb = sync::compact::sync(sync::compact::Config {
@@ -2494,7 +2503,7 @@ mod compact_variable_mmb {
             assert_eq!(served2.inactivity_floor_loc(), floor1);
             served2.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(source.target(), target1);
@@ -2505,8 +2514,8 @@ mod compact_variable_mmb {
                 .set(sha256::Digest::from([30; 32]), vec![30, 31, 32])
                 .merkleize(&source, Some(metadata3.clone()), floor3)
                 .await;
-            source.apply_batch(batch3).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch3).unwrap();
+            let source = source.sync().await.unwrap();
             let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -44,15 +44,15 @@ pub(crate) type JournalOf<H> = <DbOf<H> as qmdb::sync::Database>::Journal;
 const PAGE_SIZE: NonZeroU16 = NZU16!(77);
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 
-/// Harness that abstracts per-family details so the generic tests below can operate on
-/// any immutable database.
-/// [`SyncTestHarness::prune`] with a heap-allocated state machine (the future embeds the
-/// database twice and exceeds the size lint in the deepest test).
+/// Wraps [`SyncTestHarness::prune`] with a heap-allocated state machine (the future embeds
+/// the database twice and exceeds the size lint in the deepest test).
 #[boxed]
 async fn prune_boxed<H: SyncTestHarness>(db: H::Db, loc: Location<H::Family>) -> H::Db {
     H::prune(db, loc).await
 }
 
+/// Harness that abstracts per-family details so the generic tests below can operate on
+/// any immutable database.
 pub(crate) trait SyncTestHarness: Sized + 'static {
     type Family: merkle::Family;
     type Db: qmdb::sync::Database<
@@ -1830,7 +1830,6 @@ mod compact_variable_mmr {
             let boundary = seeded.size();
             let seeded = seeded.prune(boundary).await.unwrap();
             // The prune moved the journal's pruning boundary: the first commit is unreachable.
-            // The failed rewind consumes the import.
             assert!(matches!(
                 seeded.rewind(first_size.unwrap()).await,
                 Err(crate::qmdb::Error::Merkle(
@@ -1936,12 +1935,10 @@ mod compact_variable_mmr {
             assert_eq!(imported.target(), target_b);
 
             // Rewind is rejected until the import is persisted, even to the imported leaf
-            // count itself: the fast path must not report unpersisted state as durable. The
-            // failed rewind consumes the import.
+            // count itself: the fast path must not report unpersisted state as durable.
             assert!(imported.rewind(target_b.leaf_count).await.is_err());
 
-            // Prune is likewise rejected while the import is pending; rebuild the import,
-            // since the failed rewind consumed the first one.
+            // Prune is likewise rejected while the import is pending; rebuild the import.
             let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
                 .await
                 .unwrap();

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -185,15 +185,19 @@ mod tests {
         db: Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>,
         key: Digest,
         loc: crate::merkle::mmr::Location,
-        which: u8,
     ) {
         is_send(db.get(&key));
         is_send(db.get_metadata());
         is_send(db.proof(loc, NZU64!(1)));
-        match which {
-            0 => is_send(db.sync()),
-            _ => is_send(db.rewind(loc)),
-        }
+        is_send(db.sync());
+    }
+
+    #[allow(dead_code)]
+    fn assert_rewind_is_send(
+        db: Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>,
+        loc: crate::merkle::mmr::Location,
+    ) {
+        is_send(db.rewind(loc));
     }
 
     fn small_sections_config(

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -182,23 +182,18 @@ mod tests {
 
     #[allow(dead_code)]
     fn assert_db_futures_are_send(
-        db: &mut Db<
-            mmr::Family,
-            deterministic::Context,
-            Digest,
-            Digest,
-            Sha256,
-            TwoCap,
-            Sequential,
-        >,
+        db: Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>,
         key: Digest,
         loc: crate::merkle::mmr::Location,
+        which: u8,
     ) {
         is_send(db.get(&key));
         is_send(db.get_metadata());
         is_send(db.proof(loc, NZU64!(1)));
-        is_send(db.sync());
-        is_send(db.rewind(loc));
+        match which {
+            0 => is_send(db.sync()),
+            _ => is_send(db.rewind(loc)),
+        }
     }
 
     fn small_sections_config(
@@ -328,8 +323,8 @@ mod tests {
 
     #[boxed]
     async fn assert_compact_root_compatibility<F: Family>(ctx: deterministic::Context) {
-        let mut db = open_db::<F>(ctx.child("db")).await;
-        let mut compact = open_compact::<F>(ctx.child("compact")).await;
+        let db = open_db::<F>(ctx.child("db")).await;
+        let compact = open_compact::<F>(ctx.child("compact")).await;
         assert_eq!(db.root(), compact.root());
 
         let k1 = Sha256::fill(1u8);
@@ -354,10 +349,10 @@ mod tests {
 
         assert_eq!(retained.root(), compact_batch.root());
 
-        db.apply_batch(retained).await.unwrap();
-        compact.apply_batch(compact_batch).unwrap();
-        db.commit().await.unwrap();
-        compact.sync().await.unwrap();
+        let (db, _) = db.apply_batch(retained).await.unwrap();
+        let (compact, _) = compact.apply_batch(compact_batch).unwrap();
+        let db = db.commit().await.unwrap();
+        let compact = compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata));

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -1204,7 +1204,7 @@ mod tests {
             .unwrap();
             assert_eq!(reopened.target(), tip_target);
 
-            // The corrupt entry fails the rewind before any truncation, consuming the handle.
+            // The corrupt entry fails the rewind before any truncation.
             assert!(matches!(
                 reopened.rewind(rewind_target).await,
                 Err(Error::DataCorrupted(_))
@@ -1390,7 +1390,6 @@ mod tests {
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
 
-            // The failed rewind consumed the db; reopen to continue.
             let db = open_db::<mmr::Family>(context.child("reopen"), "keyless-rewind-beyond").await;
             // A target past the tip is not a commit either.
             let beyond_tip = Location::new(*db.size() + 100);
@@ -1435,7 +1434,7 @@ mod tests {
             let root_b = db.root();
 
             // Targets inside a commit's span match no entry, even though entries exist on
-            // both sides. Each failed rewind consumes the db, so reopen to continue.
+            // both sides.
             let mut db = db;
             for target in [2u64, 3, 5] {
                 assert!(matches!(
@@ -1571,8 +1570,7 @@ mod tests {
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
 
-            // The failed rewind consumed the db; the prune was durable, so reopen and
-            // rewind to B.
+            // The prune was durable, so reopen and rewind to B.
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let db: TestDb<mmr::Family> = Db::init_from_merkle(
                 merkle,

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -1136,7 +1136,8 @@ mod tests {
                 .merkleize(&db, Some(U64::new(11)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
 
             // Corrupt the persisted proof so it no longer verifies against the stored root.
             let journal = open_witness_journal(context.child("tamper"), partition).await;
@@ -1235,7 +1236,8 @@ mod tests {
                 .merkleize(&db, Some(U64::new(11)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
 
             // Simulate a crash between an import's journal clear and its entry append: the
             // journal is empty but its size is nonzero.
@@ -1268,7 +1270,8 @@ mod tests {
                 .merkleize(&db, Some(U64::new(11)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
             let oversized_floor = Location::new(10);
 
             // Overwrite the persisted commit op with a floor beyond its own commit location.
@@ -1308,7 +1311,8 @@ mod tests {
                 .merkleize(&db, Some(U64::new(11)), Location::new(1))
                 .await;
             let (db, _) = db.apply_batch(batch).unwrap();
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
 
             // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
             // longer matches the proof stored in the same entry.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -1139,15 +1139,14 @@ mod tests {
             db.sync().await.unwrap();
 
             // Corrupt the persisted proof so it no longer verifies against the stored root.
-            let mut journal = open_witness_journal(context.child("tamper"), partition).await;
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
             let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
             if let Some(digest) = proof.digests.first_mut() {
                 *digest = Sha256::fill(0xff);
             } else {
                 proof.leaves = Location::new(*proof.leaves + 1);
             }
-            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let reopened = TestDb::<mmr::Family>::init_from_merkle(
@@ -1273,7 +1272,7 @@ mod tests {
             let oversized_floor = Location::new(10);
 
             // Overwrite the persisted commit op with a floor beyond its own commit location.
-            let mut journal = open_witness_journal(context.child("tamper"), partition).await;
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
             let (_, proof, pinned_nodes) = witness::tests::tip(&journal).await;
             let bad_op = Operation::<mmr::Family, FixedEncoding<U64>>::Commit(
                 Some(U64::new(11)),
@@ -1281,8 +1280,7 @@ mod tests {
             )
             .encode()
             .to_vec();
-            journal = witness::tests::overwrite_tip(journal, bad_op, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::overwrite_tip(journal, bad_op, proof, pinned_nodes).await;
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let reopened = TestDb::<mmr::Family>::init_from_merkle(
@@ -1314,11 +1312,10 @@ mod tests {
 
             // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
             // longer matches the proof stored in the same entry.
-            let mut journal = open_witness_journal(context.child("tamper"), partition).await;
+            let journal = open_witness_journal(context.child("tamper"), partition).await;
             let (op_bytes, proof, mut pinned_nodes) = witness::tests::tip(&journal).await;
             pinned_nodes[0] = Sha256::fill(0xff);
-            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let reopened = TestDb::<mmr::Family>::init_from_merkle(
@@ -1397,10 +1394,6 @@ mod tests {
                 db.rewind(beyond_tip).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
-
-            let db =
-                open_db::<mmr::Family>(context.child("destroy"), "keyless-rewind-beyond").await;
-            db.destroy().await.unwrap();
         });
     }
 
@@ -1478,11 +1471,10 @@ mod tests {
 
             // Simulate the crash window: append an entry ahead of the tip without syncing it,
             // then drop the journal. The unsynced tail must not survive reopen.
-            let mut journal = open_witness_journal(context.child("crash"), partition).await;
+            let journal = open_witness_journal(context.child("crash"), partition).await;
             let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
             proof.leaves = Location::new(*proof.leaves + 2);
-            journal = witness::tests::append_unsynced(journal, op_bytes, proof, pinned_nodes).await;
-            drop(journal);
+            witness::tests::append_unsynced(journal, op_bytes, proof, pinned_nodes).await;
 
             // Reopen must drop the unsynced entry and recover state A.
             let reopened = open_db::<mmr::Family>(context.child("reopen"), partition).await;

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -824,6 +824,8 @@ mod tests {
             let advance_floor = db.new_batch().append(U64::new(1));
             let advance_floor = advance_floor.merkleize(&db, None, Location::new(1)).await;
             let (db, _) = db.apply_batch(advance_floor).unwrap();
+            let db = db.sync().await.unwrap();
+            let target = db.target();
 
             let regressed = db
                 .new_batch()
@@ -836,6 +838,11 @@ mod tests {
                 Err(Error::FloorRegressed(new, current))
                     if new == Location::new(0) && current == Location::new(1)
             ));
+
+            // Reopen and verify the rejected batch persisted nothing.
+            let db =
+                open_db::<mmr::Family>(context.child("reopen"), "keyless-floor-regressed").await;
+            assert_eq!(db.target(), target);
         });
     }
 
@@ -862,11 +869,18 @@ mod tests {
                 .merkleize(&db, None, Location::new(1))
                 .await;
 
+            let target = db.target();
             assert!(matches!(
                 db.apply_batch(child),
                 Err(Error::FloorRegressed(new, prev))
                     if new == Location::new(1) && prev == Location::new(2)
             ));
+
+            // Reopen and verify the rejected chain persisted nothing.
+            let db =
+                open_db::<mmr::Family>(context.child("reopen"), "keyless-ancestor-floor-regressed")
+                    .await;
+            assert_eq!(db.target(), target);
         });
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -77,6 +77,24 @@ where
     witness: witness::Store<E, F, H::Digest>,
 }
 
+impl<F, E, V, H, C, S: Strategy> std::fmt::Debug for Db<F, E, V, H, C, S>
+where
+    F: Family,
+    E: Context,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, V>: EncodeShared,
+    Operation<F, V>: Read<Cfg = C>,
+    C: Clone + Send + Sync + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Db")
+            .field("size", &self.size())
+            .field("inactivity_floor_loc", &self.inactivity_floor_loc())
+            .finish_non_exhaustive()
+    }
+}
+
 type CompactStateResult<F, V, D> =
     Result<compact_sync::State<F, Operation<F, V>, D>, compact_sync::ServeError<F, D>>;
 
@@ -462,6 +480,20 @@ where
         })
     }
 
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &MerkleizedBatch<F, H::Digest, V, S>,
+    ) -> Result<(), Error<F>> {
+        batch
+            .bounds
+            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+    }
+
     /// Apply a merkleized batch to the database.
     ///
     /// Returns the range of locations written. The state is updated in memory only; call
@@ -477,42 +509,47 @@ where
     ///   commit location.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.apply_batch", level = "info", skip_all)]
     pub fn apply_batch(
-        &mut self,
+        mut self,
         batch: Arc<MerkleizedBatch<F, H::Digest, V, S>>,
-    ) -> Result<core::ops::Range<Location<F>>, Error<F>> {
-        let db_size = *self.last_commit_loc + 1;
-        batch
-            .bounds
-            .validate_apply_to(db_size, self.inactivity_floor_loc)?;
+    ) -> Result<(Self, core::ops::Range<Location<F>>), Error<F>> {
+        self.validate_batch(&batch)?;
 
         let start_loc = self.last_commit_loc + 1;
         self.merkle.apply_batch(&batch.merkle_batch)?;
         self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        Ok(start_loc..Location::new(batch.bounds.total_size))
+        Ok((self, start_loc..Location::new(batch.bounds.total_size)))
     }
 
     /// Durably persist the current db state to disk. This is faster than [`Self::sync`] but
     /// reopen may need to replay the witness journal's tail to recover.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.commit", level = "info", skip_all)]
-    pub async fn commit(&mut self) -> Result<(), Error<F>> {
-        self.witness
-            .commit::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
-                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
+        let last_commit_metadata = self.last_commit_metadata.clone();
+        let inactivity_floor_loc = self.inactivity_floor_loc;
+        self.witness = self
+            .witness
+            .commit::<H, S>(&self.merkle, inactivity_floor_loc, || {
+                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
             })
-            .await
+            .await?;
+        Ok(self)
     }
 
     /// Durably persist the current db state to disk, also persisting journal metadata to
     /// minimize recovery work on reopen.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.sync", level = "info", skip_all)]
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
-        self.witness
-            .sync::<H, S>(&self.merkle, self.inactivity_floor_loc, || {
-                Self::encode_commit_op(self.last_commit_metadata.clone(), self.inactivity_floor_loc)
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
+        let last_commit_metadata = self.last_commit_metadata.clone();
+        let inactivity_floor_loc = self.inactivity_floor_loc;
+        self.witness = self
+            .witness
+            .sync::<H, S>(&self.merkle, inactivity_floor_loc, || {
+                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
             })
-            .await
+            .await?;
+        Ok(self)
     }
 
     /// Rewind the db to the synced commit with exactly `target` operations, discarding any
@@ -524,7 +561,7 @@ where
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
     /// no retained commit has exactly `target` operations (never synced, or pruned).
     #[tracing::instrument(name = "qmdb.keyless.compact.db.rewind", level = "info", skip_all)]
-    pub async fn rewind(&mut self, target: Location<F>) -> Result<(), Error<F>>
+    pub async fn rewind(mut self, target: Location<F>) -> Result<Self, Error<F>>
     where
         F: Family,
     {
@@ -533,10 +570,11 @@ where
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
         {
-            return Ok(());
+            return Ok(self);
         }
 
-        let last_commit_op = self
+        let last_commit_op;
+        (self.witness, last_commit_op) = self
             .witness
             .rewind::<H, S, Operation<F, V>>(
                 &self.merkle,
@@ -551,7 +589,7 @@ where
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
         self.last_commit_loc = Location::new(*target - 1);
-        Ok(())
+        Ok(self)
     }
 
     /// Drop witnesses for commits with fewer than `pruning_boundary` operations. Some witness
@@ -564,8 +602,9 @@ where
     ///
     /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
     /// [`Self::sync`].
-    pub async fn prune(&mut self, pruning_boundary: Location<F>) -> Result<(), Error<F>> {
-        self.witness.prune(pruning_boundary).await
+    pub async fn prune(mut self, pruning_boundary: Location<F>) -> Result<Self, Error<F>> {
+        self.witness = self.witness.prune(pruning_boundary).await?;
+        Ok(self)
     }
 
     /// Destroy all persisted state associated with this database.
@@ -597,8 +636,8 @@ mod tests {
     const WITNESS_PAGE_SIZE: NonZeroU16 = NZU16!(77);
     const WITNESS_PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(9);
 
-    fn witness_config(partition: &str, pooler: &impl BufferPooler) -> variable::Config<()> {
-        variable::Config {
+    fn witness_config(partition: &str, pooler: &impl BufferPooler) -> JournalConfig<()> {
+        JournalConfig {
             partition: format!("{partition}-witness"),
             items_per_section: NZU64!(64),
             compression: None,
@@ -622,13 +661,13 @@ mod tests {
         partition: &str,
     ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
         let cfg = witness_config(partition, &context);
-        variable::Journal::init(context, cfg).await.unwrap()
+        witness::Journal::init(context, cfg).await.unwrap()
     }
 
     #[test_traced("INFO")]
     fn test_compact_stale_batch_rejected() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-stale").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-stale").await;
             let floor = db.inactivity_floor_loc();
 
             let batch_a = db
@@ -643,14 +682,12 @@ mod tests {
                 .await;
 
             let expected_root = batch_a.root();
-            db.apply_batch(batch_a).unwrap();
+            let (db, _) = db.apply_batch(batch_a).unwrap();
             assert_eq!(db.root(), expected_root);
             assert!(matches!(
                 db.apply_batch(batch_b),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
@@ -659,7 +696,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_to_batch_reflects_live_state() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-to-batch-live").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-to-batch-live").await;
             let floor = db.inactivity_floor_loc();
 
             let pre_apply_root = db.root();
@@ -670,13 +707,12 @@ mod tests {
                 "snapshot before any mutation should match the live root"
             );
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, Some(U64::new(11)), floor)
-                    .await,
-            )
-            .unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, Some(U64::new(11)), floor)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
 
             // Leave the witness cache behind the live Merkle state.
             let live_root = db.root();
@@ -699,7 +735,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_stale_batch_chained() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-chained-stale").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-chained-stale").await;
             let floor = db.inactivity_floor_loc();
 
             let parent = db
@@ -718,20 +754,18 @@ mod tests {
                 .merkleize(&db, Some(U64::new(33)), floor)
                 .await;
 
-            db.apply_batch(child_a).unwrap();
+            let (db, _) = db.apply_batch(child_a).unwrap();
             assert!(matches!(
                 db.apply_batch(child_b),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_stale_parent_after_child_applied() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-child-before-parent").await;
             let floor = db.inactivity_floor_loc();
 
@@ -746,20 +780,18 @@ mod tests {
                 .merkleize(&db, Some(U64::new(22)), floor)
                 .await;
 
-            db.apply_batch(child).unwrap();
+            let (db, _) = db.apply_batch(child).unwrap();
             assert!(matches!(
                 db.apply_batch(parent),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_sequential_commit_parent_then_child() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-parent-child").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-parent-child").await;
             let floor = db.inactivity_floor_loc();
 
             let parent = db
@@ -774,9 +806,9 @@ mod tests {
                 .await;
             let expected_root = child.root();
 
-            db.apply_batch(parent).unwrap();
-            db.apply_batch(child).unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = db.apply_batch(parent).unwrap();
+            let (db, _) = db.apply_batch(child).unwrap();
+            let db = db.sync().await.unwrap();
 
             assert_eq!(db.root(), expected_root);
 
@@ -787,12 +819,11 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_floor_regressed() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "keyless-floor-regressed").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-floor-regressed").await;
 
             let advance_floor = db.new_batch().append(U64::new(1));
             let advance_floor = advance_floor.merkleize(&db, None, Location::new(1)).await;
-            db.apply_batch(advance_floor).unwrap();
+            let (db, _) = db.apply_batch(advance_floor).unwrap();
 
             let regressed = db
                 .new_batch()
@@ -805,8 +836,6 @@ mod tests {
                 Err(Error::FloorRegressed(new, current))
                     if new == Location::new(0) && current == Location::new(1)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
@@ -816,7 +845,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_ancestor_floor_regressed() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-ancestor-floor-regressed")
                     .await;
 
@@ -838,45 +867,41 @@ mod tests {
                 Err(Error::FloorRegressed(new, prev))
                     if new == Location::new(1) && prev == Location::new(2)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_rewind_restores_commit_metadata_and_floor() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-meta").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-meta").await;
 
             let v1 = U64::new(1);
             let meta1 = U64::new(11);
             let floor1 = Location::new(0);
-            db.apply_batch(
-                db.new_batch()
-                    .append(v1)
-                    .merkleize(&db, Some(meta1.clone()), floor1)
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(v1)
+                .merkleize(&db, Some(meta1.clone()), floor1)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_after_first = db.root();
             let size_after_first = db.size();
 
             let v2 = U64::new(2);
             let meta2 = U64::new(22);
             let floor2 = Location::new(1);
-            db.apply_batch(
-                db.new_batch()
-                    .append(v2)
-                    .merkleize(&db, Some(meta2.clone()), floor2)
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(v2)
+                .merkleize(&db, Some(meta2.clone()), floor2)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.get_metadata(), Some(meta2));
             assert_eq!(db.inactivity_floor_loc(), floor2);
 
-            db.rewind(size_after_first).await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.get_metadata(), Some(meta1));
             assert_eq!(db.inactivity_floor_loc(), floor1);
@@ -895,28 +920,26 @@ mod tests {
             let floor2 = Location::new(1);
 
             let root_after_first = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(1))
-                        .merkleize(&db, Some(meta1.clone()), floor1)
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(1))
+                    .merkleize(&db, Some(meta1.clone()), floor1)
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.sync().await.unwrap();
                 let root = db.root();
                 let size_after_first = db.size();
 
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(2))
-                        .merkleize(&db, Some(meta2), floor2)
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(2))
+                    .merkleize(&db, Some(meta2), floor2)
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.sync().await.unwrap();
 
-                db.rewind(size_after_first).await.unwrap();
+                let _db = db.rewind(size_after_first).await.unwrap();
                 root
             };
 
@@ -937,24 +960,22 @@ mod tests {
             let meta2 = U64::new(22);
 
             let root_after_second = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(1))
-                        .merkleize(&db, Some(meta1), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(1))
+                    .merkleize(&db, Some(meta1), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
 
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(2))
-                        .merkleize(&db, Some(meta2.clone()), Location::new(1))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(2))
+                    .merkleize(&db, Some(meta2.clone()), Location::new(1))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
                 db.root()
             };
 
@@ -975,33 +996,31 @@ mod tests {
             let meta2 = U64::new(22);
 
             let (root_a, size_a) = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(1))
-                        .merkleize(&db, Some(meta1.clone()), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(1))
+                    .merkleize(&db, Some(meta1.clone()), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
                 let root_a = db.root();
                 let size_a = db.size();
 
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(2))
-                        .merkleize(&db, Some(meta2), Location::new(1))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(2))
+                    .merkleize(&db, Some(meta2), Location::new(1))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let _db = db.commit().await.unwrap();
                 (root_a, size_a)
             };
 
             // Both committed witnesses survive the crash: reopen recovers the tip, and the
             // earlier commit remains a valid rewind target.
-            let mut db = open_db::<mmr::Family>(context.child("second"), partition).await;
-            db.rewind(size_a).await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            let db = db.rewind(size_a).await.unwrap();
             assert_eq!(db.root(), root_a);
             assert_eq!(db.get_metadata(), Some(meta1));
             db.destroy().await.unwrap();
@@ -1015,17 +1034,16 @@ mod tests {
             let meta = U64::new(11);
 
             let root = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(1))
-                        .merkleize(&db, Some(meta.clone()), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.commit().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(1))
+                    .merkleize(&db, Some(meta.clone()), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.commit().await.unwrap();
                 // The commit already made the state durable, so this is a no-op.
-                db.sync().await.unwrap();
+                let db = db.sync().await.unwrap();
                 db.root()
             };
 
@@ -1046,17 +1064,14 @@ mod tests {
 
             // Build state B in a separate source partition and capture its validated state.
             let target_b = {
-                let mut source = open_db::<mmr::Family>(context.child("src"), src).await;
-                source
-                    .apply_batch(
-                        source
-                            .new_batch()
-                            .append(U64::new(2))
-                            .merkleize(&source, Some(meta_b.clone()), Location::new(0))
-                            .await,
-                    )
-                    .unwrap();
-                source.sync().await.unwrap();
+                let source = open_db::<mmr::Family>(context.child("src"), src).await;
+                let batch = source
+                    .new_batch()
+                    .append(U64::new(2))
+                    .merkleize(&source, Some(meta_b.clone()), Location::new(0))
+                    .await;
+                let (source, _) = source.apply_batch(batch).unwrap();
+                let source = source.sync().await.unwrap();
                 source.target()
             };
             let (_, proof_b, pinned_b) = {
@@ -1075,24 +1090,21 @@ mod tests {
 
             // Seed the destination partition with a different committed state A.
             {
-                let mut seeded = open_db::<mmr::Family>(context.child("seed"), dst).await;
-                seeded
-                    .apply_batch(
-                        seeded
-                            .new_batch()
-                            .append(U64::new(1))
-                            .merkleize(&seeded, Some(meta_a), Location::new(0))
-                            .await,
-                    )
-                    .unwrap();
-                seeded.sync().await.unwrap();
+                let seeded = open_db::<mmr::Family>(context.child("seed"), dst).await;
+                let batch = seeded
+                    .new_batch()
+                    .append(U64::new(1))
+                    .merkleize(&seeded, Some(meta_a), Location::new(0))
+                    .await;
+                let (seeded, _) = seeded.apply_batch(batch).unwrap();
+                let seeded = seeded.sync().await.unwrap();
                 assert_ne!(seeded.target(), target_b);
             }
 
             // Import state B over the destination and make it durable with commit (not sync).
             {
                 let journal = open_witness_journal(context.child("import"), dst).await;
-                let mut imported = TestDb::<mmr::Family>::init_from_validated_state(
+                let imported = TestDb::<mmr::Family>::init_from_validated_state(
                     Sequential,
                     journal,
                     (),
@@ -1100,7 +1112,7 @@ mod tests {
                 )
                 .unwrap();
                 assert_eq!(imported.target(), target_b);
-                imported.commit().await.unwrap();
+                let _imported = imported.commit().await.unwrap();
             }
 
             // Reopen recovers the committed import, replacing state A even though the journal was
@@ -1117,16 +1129,14 @@ mod tests {
     fn test_compact_reopen_rejects_tampered_witness() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-witness-tamper";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(7))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(7))
+                .merkleize(&db, Some(U64::new(11)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Corrupt the persisted proof so it no longer verifies against the stored root.
             let mut journal = open_witness_journal(context.child("tamper"), partition).await;
@@ -1136,7 +1146,7 @@ mod tests {
             } else {
                 proof.leaves = Location::new(*proof.leaves + 1);
             }
-            witness::tests::overwrite_tip(&mut journal, op_bytes, proof, pinned_nodes).await;
+            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
             drop(journal);
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1155,30 +1165,28 @@ mod tests {
     fn test_compact_rewind_rejects_corrupt_target_entry() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-corrupt-rewind-target";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, None, Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, None, Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let rewind_target = db.target().leaf_count;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(2))
-                    .merkleize(&db, None, Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(2))
+                .merkleize(&db, None, Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let tip_target = db.target();
             drop(db);
 
             // Corrupt the rewind target's entry (the journal holds bootstrap, target, tip).
             let mut journal = open_witness_journal(context.child("corrupt"), partition).await;
-            witness::tests::corrupt_entry(&mut journal, 1, |entry| {
+            journal = witness::tests::corrupt_entry(journal, 1, |entry| {
                 entry.pinned_nodes[0] = Sha256::fill(0xff);
             })
             .await;
@@ -1186,7 +1194,7 @@ mod tests {
 
             // The tip entry is intact, so reopen succeeds.
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let mut reopened = TestDb::<mmr::Family>::init_from_merkle(
+            let reopened = TestDb::<mmr::Family>::init_from_merkle(
                 merkle,
                 context.child("reopen"),
                 witness_config(partition, &context),
@@ -1196,12 +1204,11 @@ mod tests {
             .unwrap();
             assert_eq!(reopened.target(), tip_target);
 
-            // The corrupt entry fails the rewind before any truncation.
+            // The corrupt entry fails the rewind before any truncation, consuming the handle.
             assert!(matches!(
                 reopened.rewind(rewind_target).await,
                 Err(Error::DataCorrupted(_))
             ));
-            drop(reopened);
 
             // The newer history survives: reopen still lands on the original tip.
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1222,16 +1229,14 @@ mod tests {
     fn test_compact_reopen_rejects_interrupted_import() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-interrupted-import";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(7))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(7))
+                .merkleize(&db, Some(U64::new(11)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Simulate a crash between an import's journal clear and its entry append: the
             // journal is empty but its size is nonzero.
@@ -1257,16 +1262,14 @@ mod tests {
     fn test_compact_reopen_rejects_commit_floor_beyond_tip() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-invalid-persisted-floor";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(7))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(7))
+                .merkleize(&db, Some(U64::new(11)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
             let oversized_floor = Location::new(10);
 
             // Overwrite the persisted commit op with a floor beyond its own commit location.
@@ -1278,7 +1281,7 @@ mod tests {
             )
             .encode()
             .to_vec();
-            witness::tests::overwrite_tip(&mut journal, bad_op, proof, pinned_nodes).await;
+            journal = witness::tests::overwrite_tip(journal, bad_op, proof, pinned_nodes).await;
             drop(journal);
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1300,23 +1303,21 @@ mod tests {
     fn test_compact_reopen_rejects_tampered_pinned_nodes() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-pins-tamper";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(7))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(7))
+                .merkleize(&db, Some(U64::new(11)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Corrupt one pinned frontier node: the root recomputed from the rebuilt Merkle no
             // longer matches the proof stored in the same entry.
             let mut journal = open_witness_journal(context.child("tamper"), partition).await;
             let (op_bytes, proof, mut pinned_nodes) = witness::tests::tip(&journal).await;
             pinned_nodes[0] = Sha256::fill(0xff);
-            witness::tests::overwrite_tip(&mut journal, op_bytes, proof, pinned_nodes).await;
+            journal = witness::tests::overwrite_tip(journal, op_bytes, proof, pinned_nodes).await;
             drop(journal);
 
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
@@ -1334,19 +1335,18 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_to_current_is_noop() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-noop").await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-noop").await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, Some(U64::new(11)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root = db.root();
             let size = db.size();
 
-            db.rewind(size).await.unwrap();
+            let db = db.rewind(size).await.unwrap();
             assert_eq!(db.root(), root);
             assert_eq!(db.size(), size);
             db.destroy().await.unwrap();
@@ -1357,19 +1357,19 @@ mod tests {
     fn test_compact_prune_past_tip_keeps_tip() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-prune-past-tip";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, Some(U64::new(11)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let target = db.target();
 
             // Prune with a boundary beyond the tip: the tip entry must survive.
-            db.prune(Location::new(*db.size() + 100)).await.unwrap();
+            let boundary = Location::new(*db.size() + 100);
+            let db = db.prune(boundary).await.unwrap();
             assert_eq!(db.target(), target);
             drop(db);
 
@@ -1382,18 +1382,25 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_beyond_history() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-beyond").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-beyond").await;
             // The bootstrap commit is the oldest retained state (one leaf); no commit with zero
             // operations exists to rewind to.
             assert!(matches!(
                 db.rewind(Location::new(0)).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+
+            // The failed rewind consumed the db; reopen to continue.
+            let db = open_db::<mmr::Family>(context.child("reopen"), "keyless-rewind-beyond").await;
             // A target past the tip is not a commit either.
+            let beyond_tip = Location::new(*db.size() + 100);
             assert!(matches!(
-                db.rewind(Location::new(*db.size() + 100)).await,
+                db.rewind(beyond_tip).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
+
+            let db =
+                open_db::<mmr::Family>(context.child("destroy"), "keyless-rewind-beyond").await;
             db.destroy().await.unwrap();
         });
     }
@@ -1401,47 +1408,50 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_between_commits() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "keyless-rewind-between").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-rewind-between").await;
             let floor = db.inactivity_floor_loc();
 
             // A multi-op commit jumps the committed size from 1 (bootstrap) to 4.
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .append(U64::new(2))
-                    .merkleize(&db, Some(U64::new(11)), floor)
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .append(U64::new(2))
+                .merkleize(&db, Some(U64::new(11)), floor)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_a = db.root();
             let size_a = db.size();
             assert_eq!(size_a, Location::new(4));
 
             // A second commit moves the size to 6.
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(3))
-                    .merkleize(&db, Some(U64::new(22)), floor)
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(3))
+                .merkleize(&db, Some(U64::new(22)), floor)
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_b = db.root();
 
             // Targets inside a commit's span match no entry, even though entries exist on
-            // both sides.
+            // both sides. Each failed rewind consumes the db, so reopen to continue.
+            let mut db = db;
             for target in [2u64, 3, 5] {
                 assert!(matches!(
                     db.rewind(Location::new(target)).await,
                     Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
                 ));
+                db = open_db::<mmr::Family>(
+                    context.child("reopen").with_attribute("target", target),
+                    "keyless-rewind-between",
+                )
+                .await;
             }
             assert_eq!(db.root(), root_b);
 
             // The exact commit boundary remains a valid target.
-            db.rewind(size_a).await.unwrap();
+            let db = db.rewind(size_a).await.unwrap();
             assert_eq!(db.root(), root_a);
             assert_eq!(db.get_metadata(), Some(U64::new(11)));
             db.destroy().await.unwrap();
@@ -1454,17 +1464,16 @@ mod tests {
     fn test_compact_reopen_drops_unsynced_witness() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-witness-unsynced";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
 
             // Commit state A.
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, Some(U64::new(11)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let target_a = db.target();
             drop(db);
 
@@ -1473,7 +1482,7 @@ mod tests {
             let mut journal = open_witness_journal(context.child("crash"), partition).await;
             let (op_bytes, mut proof, pinned_nodes) = witness::tests::tip(&journal).await;
             proof.leaves = Location::new(*proof.leaves + 2);
-            witness::tests::append_unsynced(&mut journal, op_bytes, proof, pinned_nodes).await;
+            journal = witness::tests::append_unsynced(journal, op_bytes, proof, pinned_nodes).await;
             drop(journal);
 
             // Reopen must drop the unsynced entry and recover state A.
@@ -1487,35 +1496,34 @@ mod tests {
     fn test_compact_rewind_multiple_commits() {
         deterministic::Runner::default().start(|context| async move {
             let partition = "keyless-rewind-multi";
-            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
+            let db = open_db::<mmr::Family>(context.child("db"), partition).await;
 
             // Commit A, B, C, recording the state after A.
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, Some(U64::new(11)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_a = db.root();
             let size_a = db.size();
             let target_a = db.target();
 
+            let mut db = db;
             for i in [2u64, 3] {
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(i))
-                        .merkleize(&db, Some(U64::new(i * 11)), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(i))
+                    .merkleize(&db, Some(U64::new(i * 11)), Location::new(0))
+                    .await;
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
             }
             assert_ne!(db.root(), root_a);
 
             // Rewind two commits in one call.
-            db.rewind(size_a).await.unwrap();
+            let db = db.rewind(size_a).await.unwrap();
             assert_eq!(db.root(), root_a);
             assert_eq!(db.size(), size_a);
             assert_eq!(db.get_metadata(), Some(U64::new(11)));
@@ -1539,31 +1547,42 @@ mod tests {
             witness_cfg.items_per_section = NZU64!(1);
             let merkle = crate::merkle::compact::Merkle::new(Sequential);
             let mut db: TestDb<mmr::Family> =
-                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg.clone(), ())
                     .await
                     .unwrap();
 
             // Commit A, B, C.
             let mut sizes = Vec::new();
             for i in [1u64, 2, 3] {
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(i))
-                        .merkleize(&db, Some(U64::new(i * 11)), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(i))
+                    .merkleize(&db, Some(U64::new(i * 11)), Location::new(0))
+                    .await;
+                (db, _) = db.apply_batch(batch).unwrap();
+                db = db.sync().await.unwrap();
                 sizes.push(db.size());
             }
 
             // Prune history below B: rewinding to B still works, rewinding to A does not.
-            db.prune(sizes[1]).await.unwrap();
+            let db = db.prune(sizes[1]).await.unwrap();
             assert!(matches!(
                 db.rewind(sizes[0]).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
             ));
-            db.rewind(sizes[1]).await.unwrap();
+
+            // The failed rewind consumed the db; the prune was durable, so reopen and
+            // rewind to B.
+            let merkle = crate::merkle::compact::Merkle::new(Sequential);
+            let db: TestDb<mmr::Family> = Db::init_from_merkle(
+                merkle,
+                context.child("witness").with_attribute("index", 2),
+                witness_cfg,
+                (),
+            )
+            .await
+            .unwrap();
+            let db = db.rewind(sizes[1]).await.unwrap();
             assert_eq!(db.size(), sizes[1]);
             assert_eq!(db.get_metadata(), Some(U64::new(22)));
 
@@ -1574,18 +1593,17 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_preserves_pre_advance_batch() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-rewind-preserves-pre-advance")
                     .await;
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let size_after_first = db.size();
 
             // Merkleize a batch against the post-commit-A state.
@@ -1596,19 +1614,18 @@ mod tests {
                 .await;
 
             // Advance past that state and commit, then rewind back to it.
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(3))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
-            db.rewind(size_after_first).await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(3))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
 
             // The rewind restored the state that `held` was merkleized against, so it still
             // matches the Merkle size and applies cleanly.
-            db.apply_batch(held).unwrap();
+            let (db, _) = db.apply_batch(held).unwrap();
 
             db.destroy().await.unwrap();
         });
@@ -1617,22 +1634,20 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_noop_commit_after_commit() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "keyless-noop-after-commit").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-noop-after-commit").await;
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .append(U64::new(2))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .append(U64::new(2))
+                .merkleize(&db, Some(U64::new(11)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_after_first = db.root();
             assert_eq!(db.size(), Location::new(4));
 
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.target().root, db.root());
@@ -1647,26 +1662,25 @@ mod tests {
             let partition = "keyless-noop-after-reopen";
 
             let root_before_drop = {
-                let mut db = open_db::<mmr::Family>(context.child("first"), partition).await;
-                db.apply_batch(
-                    db.new_batch()
-                        .append(U64::new(1))
-                        .append(U64::new(2))
-                        .merkleize(&db, Some(U64::new(11)), Location::new(0))
-                        .await,
-                )
-                .unwrap();
-                db.sync().await.unwrap();
+                let db = open_db::<mmr::Family>(context.child("first"), partition).await;
+                let batch = db
+                    .new_batch()
+                    .append(U64::new(1))
+                    .append(U64::new(2))
+                    .merkleize(&db, Some(U64::new(11)), Location::new(0))
+                    .await;
+                let (db, _) = db.apply_batch(batch).unwrap();
+                let db = db.sync().await.unwrap();
                 let root = db.root();
                 assert_eq!(db.size(), Location::new(4));
                 root
             };
 
-            let mut db = open_db::<mmr::Family>(context.child("second"), partition).await;
+            let db = open_db::<mmr::Family>(context.child("second"), partition).await;
             assert_eq!(db.root(), root_before_drop);
             assert_eq!(db.size(), Location::new(4));
 
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_before_drop);
             assert_eq!(db.target().root, db.root());
@@ -1678,34 +1692,31 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_noop_commit_after_rewind() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
-                open_db::<mmr::Family>(context.child("db"), "keyless-noop-after-rewind").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-noop-after-rewind").await;
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .append(U64::new(2))
-                    .merkleize(&db, Some(U64::new(11)), Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .append(U64::new(2))
+                .merkleize(&db, Some(U64::new(11)), Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let root_after_first = db.root();
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(3))
-                    .merkleize(&db, Some(U64::new(22)), Location::new(1))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(3))
+                .merkleize(&db, Some(U64::new(22)), Location::new(1))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
 
-            db.rewind(Location::new(4)).await.unwrap();
+            let db = db.rewind(Location::new(4)).await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
 
-            db.sync().await.unwrap();
+            let db = db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
             assert_eq!(db.target().root, db.root());
@@ -1717,27 +1728,25 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_rewind_makes_post_advance_batch_stale() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-rewind-makes-stale").await;
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(1))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
             let size_after_first = db.size();
 
-            db.apply_batch(
-                db.new_batch()
-                    .append(U64::new(2))
-                    .merkleize(&db, None, Location::new(0))
-                    .await,
-            )
-            .unwrap();
-            db.sync().await.unwrap();
+            let batch = db
+                .new_batch()
+                .append(U64::new(2))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(batch).unwrap();
+            let db = db.sync().await.unwrap();
 
             // Merkleize a batch against the post-commit-B state, which the rewind will discard.
             let held = db
@@ -1746,7 +1755,7 @@ mod tests {
                 .merkleize(&db, None, Location::new(0))
                 .await;
 
-            db.rewind(size_after_first).await.unwrap();
+            let db = db.rewind(size_after_first).await.unwrap();
 
             // After rewind, mem.size reflects post-commit-A, but the held batch starts after
             // post-commit-B. Apply must be rejected with StaleBatch.
@@ -1754,15 +1763,13 @@ mod tests {
                 db.apply_batch(held),
                 Err(Error::StaleBatch { .. })
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
     #[test_traced("INFO")]
     fn test_compact_floor_beyond_size() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db = open_db::<mmr::Family>(context.child("db"), "keyless-floor-beyond").await;
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-floor-beyond").await;
 
             let batch = db.new_batch().merkleize(&db, None, Location::new(2)).await;
 
@@ -1771,8 +1778,6 @@ mod tests {
                 Err(Error::FloorBeyondSize(floor, tip))
                     if floor == Location::new(2) && tip == Location::new(1)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 
@@ -1781,7 +1786,7 @@ mod tests {
     #[test_traced("INFO")]
     fn test_compact_ancestor_floor_beyond_size() {
         deterministic::Runner::default().start(|context| async move {
-            let mut db =
+            let db =
                 open_db::<mmr::Family>(context.child("db"), "keyless-ancestor-floor-beyond").await;
 
             // parent: append + commit at loc 2, floor=3 (one past parent's commit).
@@ -1802,8 +1807,6 @@ mod tests {
                 Err(Error::FloorBeyondSize(floor, commit))
                     if floor == Location::new(3) && commit == Location::new(2)
             ));
-
-            db.destroy().await.unwrap();
         });
     }
 }

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -152,7 +152,7 @@ mod test {
     #[test_traced("INFO")]
     fn test_keyless_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {
-            let mut db = open_db::<mmr::Family>(ctx.child("db")).await;
+            let db = open_db::<mmr::Family>(ctx.child("db")).await;
             let value = commonware_utils::sequence::U64::new(7);
             let floor = db.inactivity_floor_loc();
             let batch = db
@@ -160,15 +160,15 @@ mod test {
                 .append(value.clone())
                 .merkleize(&db, None, floor)
                 .await;
-            let range = db.apply_batch(batch).await.unwrap();
+            let (db, range) = db.apply_batch(batch).await.unwrap();
             assert_eq!(db.get(range.start).await.unwrap(), Some(value.clone()));
             assert_eq!(
                 db.get_many(&[range.start]).await.unwrap(),
                 vec![Some(value)]
             );
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
-            db.prune(crate::merkle::Location::new(0)).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            let _db = db.prune(crate::merkle::Location::new(0)).await.unwrap();
 
             let metrics = ctx.encode();
             for expected in [
@@ -307,8 +307,8 @@ mod test {
     async fn assert_compact_root_compatibility<F: crate::merkle::Family>(
         ctx: deterministic::Context,
     ) {
-        let mut db = open_db::<F>(ctx.child("db")).await;
-        let mut compact = open_compact::<F>(ctx.child("compact")).await;
+        let db = open_db::<F>(ctx.child("db")).await;
+        let compact = open_compact::<F>(ctx.child("compact")).await;
         assert_eq!(db.root(), compact.root());
 
         let v1 = commonware_utils::sequence::U64::new(1);
@@ -331,10 +331,10 @@ mod test {
 
         assert_eq!(retained.root(), compact_batch.root());
 
-        db.apply_batch(retained).await.unwrap();
-        compact.apply_batch(compact_batch).unwrap();
-        db.commit().await.unwrap();
-        compact.sync().await.unwrap();
+        let (db, _) = db.apply_batch(retained).await.unwrap();
+        let (compact, _) = compact.apply_batch(compact_batch).unwrap();
+        let db = db.commit().await.unwrap();
+        let compact = compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata.clone()));
@@ -366,7 +366,7 @@ mod test {
     fn test_keyless_fixed_pruning() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_pruning(db).await;
+            tests::test_keyless_db_pruning(ctx, db, reopen::<mmr::Family>()).await;
         });
     }
 
@@ -462,7 +462,7 @@ mod test {
     fn test_keyless_fixed_stale_batch() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_stale_batch(db).await;
+            tests::test_keyless_stale_batch(ctx, db, reopen::<mmr::Family>()).await;
         });
     }
 
@@ -518,7 +518,8 @@ mod test {
     fn test_keyless_fixed_rewind_pruned_target_errors() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_rewind_pruned_target_errors(db).await;
+            tests::test_keyless_db_rewind_pruned_target_errors(ctx, db, reopen::<mmr::Family>())
+                .await;
         });
     }
 
@@ -534,7 +535,8 @@ mod test {
     fn test_keyless_fixed_floor_regression_rejected() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_regression_rejected(db).await;
+            tests::test_keyless_db_floor_regression_rejected(ctx, db, reopen::<mmr::Family>())
+                .await;
         });
     }
 
@@ -542,7 +544,12 @@ mod test {
     fn test_keyless_fixed_floor_beyond_commit_loc_rejected() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_beyond_commit_loc_rejected(db).await;
+            tests::test_keyless_db_floor_beyond_commit_loc_rejected(
+                ctx,
+                db,
+                reopen::<mmr::Family>(),
+            )
+            .await;
         });
     }
 
@@ -584,7 +591,12 @@ mod test {
     fn test_keyless_fixed_ancestor_floor_regression_rejected() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_ancestor_floor_regression_rejected(db).await;
+            tests::test_keyless_db_ancestor_floor_regression_rejected(
+                ctx,
+                db,
+                reopen::<mmr::Family>(),
+            )
+            .await;
         });
     }
 
@@ -707,7 +719,7 @@ mod test {
     fn test_keyless_fixed_pruning_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_pruning(db).await;
+            tests::test_keyless_db_pruning(ctx, db, reopen::<mmb::Family>()).await;
         });
     }
 
@@ -795,7 +807,7 @@ mod test {
     fn test_keyless_fixed_stale_batch_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_stale_batch(db).await;
+            tests::test_keyless_stale_batch(ctx, db, reopen::<mmb::Family>()).await;
         });
     }
 
@@ -851,7 +863,8 @@ mod test {
     fn test_keyless_fixed_rewind_pruned_target_errors_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_rewind_pruned_target_errors(db).await;
+            tests::test_keyless_db_rewind_pruned_target_errors(ctx, db, reopen::<mmb::Family>())
+                .await;
         });
     }
 
@@ -867,7 +880,8 @@ mod test {
     fn test_keyless_fixed_floor_regression_rejected_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_regression_rejected(db).await;
+            tests::test_keyless_db_floor_regression_rejected(ctx, db, reopen::<mmb::Family>())
+                .await;
         });
     }
 
@@ -875,7 +889,12 @@ mod test {
     fn test_keyless_fixed_floor_beyond_commit_loc_rejected_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_beyond_commit_loc_rejected(db).await;
+            tests::test_keyless_db_floor_beyond_commit_loc_rejected(
+                ctx,
+                db,
+                reopen::<mmb::Family>(),
+            )
+            .await;
         });
     }
 
@@ -917,7 +936,12 @@ mod test {
     fn test_keyless_fixed_ancestor_floor_regression_rejected_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_ancestor_floor_regression_rejected(db).await;
+            tests::test_keyless_db_ancestor_floor_regression_rejected(
+                ctx,
+                db,
+                reopen::<mmb::Family>(),
+            )
+            .await;
         });
     }
 
@@ -959,10 +983,9 @@ mod test {
 
         deterministic::Runner::default().start(|ctx| async move {
             let target_config = db_config("sync-target", &ctx, Sequential);
-            let mut target_db: TestDb<mmr::Family> =
-                TestDb::init(ctx.child("target"), target_config)
-                    .await
-                    .unwrap();
+            let target_db: TestDb<mmr::Family> = TestDb::init(ctx.child("target"), target_config)
+                .await
+                .unwrap();
 
             let mut batch = target_db.new_batch();
             for i in 0..20u64 {
@@ -970,7 +993,7 @@ mod test {
             }
             let floor = target_db.inactivity_floor_loc();
             let merkleized = batch.merkleize(&target_db, None, floor).await;
-            target_db.apply_batch(merkleized).await.unwrap();
+            let (target_db, _) = target_db.apply_batch(merkleized).await.unwrap();
 
             let target_root = target_db.root();
             let bounds = target_db.bounds();

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -2254,9 +2254,6 @@ pub(crate) mod tests {
             matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
             "unexpected rewind error: {err:?}"
         );
-
-        let db = reopen(context.child("reopen_destroy")).await;
-        db.destroy().await.unwrap();
     }
 
     #[boxed]

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -8,8 +8,8 @@
 //! // Simple mode: apply a batch, then durably commit it.
 //! let batch = db.new_batch().append(value);
 //! let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-//! db.apply_batch(merkleized).await?;
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(merkleized).await?;
+//! let db = db.commit().await?;
 //! ```
 //!
 //! ```ignore
@@ -26,8 +26,8 @@
 //! let child_b = child_b.append(value_c);
 //! let child_b = child_b.merkleize(&db, None, floor).await;
 //!
-//! db.apply_batch(child_a).await?;
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(child_a).await?;
+//! let db = db.commit().await?;
 //! ```
 //!
 //! ```ignore
@@ -38,9 +38,9 @@
 //! let child = parent_m.new_batch().append(value_b);
 //! let child_m = child.merkleize(&db, None, floor).await;
 //!
-//! db.apply_batch(parent_m).await?;
-//! db.apply_batch(child_m).await?;
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(parent_m).await?;
+//! let (db, _) = db.apply_batch(child_m).await?;
+//! let db = db.commit().await?;
 //! ```
 
 use crate::{
@@ -124,6 +124,24 @@ where
     metrics: Metrics<E>,
 }
 
+impl<F, E, V, C, H, S> std::fmt::Debug for Keyless<F, E, V, C, H, S>
+where
+    F: Family,
+    E: Context,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<F, V>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, V>: EncodeShared,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Keyless")
+            .field("bounds", &self.bounds())
+            .field("inactivity_floor_loc", &self.inactivity_floor_loc())
+            .finish_non_exhaustive()
+    }
+}
+
 impl<F, E, V, C, H, S> Keyless<F, E, V, C, H, S>
 where
     F: Family,
@@ -142,10 +160,10 @@ where
         let metrics = Metrics::new(context);
         if journal.size() == 0 {
             warn!("no operations found in log, creating initial commit");
-            journal
+            let (appended, _) = journal
                 .append(&Operation::Commit(None, Location::new(0)))
                 .await?;
-            journal.sync().await?;
+            journal = appended.sync().await?;
         }
 
         let (last_commit_loc, inactivity_floor_loc) = {
@@ -370,7 +388,8 @@ where
     ///
     /// - Returns [`Error::PruneBeyondMinRequired`] if `loc` > the inactivity floor.
     #[tracing::instrument(name = "qmdb.keyless.db.prune", level = "info", skip_all)]
-    pub async fn prune(&mut self, loc: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn prune(mut self, loc: Location<F>) -> Result<Self, Error<F>> {
         let _timer = self.metrics.prune_timer();
         self.metrics.prune_calls.inc();
         if loc > self.inactivity_floor_loc {
@@ -379,9 +398,9 @@ where
                 self.inactivity_floor_loc,
             ));
         }
-        self.journal.prune(loc).await?;
+        (self.journal, _) = self.journal.prune(loc).await?;
         self.update_metrics();
-        Ok(())
+        Ok(self)
     }
 
     /// Rewind the database to `size` operations, where `size` is the location of the next append.
@@ -405,11 +424,12 @@ where
     /// A successful rewind is not restart-stable until a subsequent [`Self::commit`] or
     /// [`Self::sync`].
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
-    pub async fn rewind(&mut self, size: Location<F>) -> Result<(), Error<F>> {
+    #[boxed]
+    pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
         if rewind_size == current_size {
-            return Ok(());
+            return Ok(self);
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(crate::journal::Error::InvalidRewind(
@@ -434,33 +454,33 @@ where
 
         // Journal rewind happens before in-memory commit-location updates. If a later step fails,
         // this handle may be internally diverged and must be dropped by the caller.
-        self.journal.rewind(rewind_size).await?;
+        self.journal = self.journal.rewind(rewind_size).await?;
         self.last_commit_loc = rewind_last_loc;
         self.inactivity_floor_loc = rewind_floor;
         let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
         self.root = self.journal.root(inactive_peaks)?;
         self.update_metrics();
-        Ok(())
+        Ok(self)
     }
 
     /// Sync all database state to disk. While this isn't necessary to ensure durability of
     /// committed operations, periodic invocation may reduce memory usage and the time required to
     /// recover the database on restart.
     #[tracing::instrument(name = "qmdb.keyless.db.sync", level = "info", skip_all)]
-    pub async fn sync(&mut self) -> Result<(), Error<F>> {
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
         let _timer = self.metrics.sync_timer();
         self.metrics.sync_calls.inc();
-        self.journal.sync().await?;
-        Ok(())
+        self.journal = self.journal.sync().await?;
+        Ok(self)
     }
 
     /// Durably commit the journal state published by prior [`Keyless::apply_batch`] calls.
     #[tracing::instrument(name = "qmdb.keyless.db.commit", level = "info", skip_all)]
-    pub async fn commit(&mut self) -> Result<(), Error<F>> {
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
         let _timer = self.metrics.commit_timer();
         self.metrics.commit_calls.inc();
-        self.journal.commit().await?;
-        Ok(())
+        self.journal = self.journal.commit().await?;
+        Ok(self)
     }
 
     /// Destroy the db, removing all data from disk.
@@ -492,6 +512,20 @@ where
         })
     }
 
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &batch::MerkleizedBatch<F, H::Digest, V, S>,
+    ) -> Result<(), Error<F>> {
+        batch
+            .bounds
+            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+    }
+
     /// Apply a [`batch::MerkleizedBatch`] to the database.
     ///
     /// A batch is valid only if every batch applied to the database since this batch's
@@ -510,8 +544,8 @@ where
     ///
     /// Violations return [`Error::FloorRegressed`] or [`Error::FloorBeyondSize`] identifying
     /// the offending floor and the bound it crossed (the prior validated floor, or the commit
-    /// location, respectively). Floor validation happens before any journal mutation, so the
-    /// database is untouched on floor errors.
+    /// location, respectively). Floor validation happens before any journal mutation, so on floor
+    /// errors the on-disk state is unchanged and reopening recovers the database as it was.
     ///
     /// Returns the range of locations written.
     ///
@@ -520,18 +554,15 @@ where
     /// [`Keyless::sync`] to guarantee durability.
     #[tracing::instrument(name = "qmdb.keyless.db.apply_batch", level = "info", skip_all)]
     pub async fn apply_batch(
-        &mut self,
+        mut self,
         batch: Arc<batch::MerkleizedBatch<F, H::Digest, V, S>>,
-    ) -> Result<core::ops::Range<Location<F>>, Error<F>> {
+    ) -> Result<(Self, core::ops::Range<Location<F>>), Error<F>> {
         let _timer = self.metrics.apply_batch_timer();
         self.metrics.apply_batch_calls.inc();
-        let db_size = *self.last_commit_loc + 1;
-        batch
-            .bounds
-            .validate_apply_to(db_size, self.inactivity_floor_loc)?;
+        self.validate_batch(&batch)?;
         let start_loc = self.last_commit_loc + 1;
 
-        self.journal.apply_batch(&batch.journal_batch).await?;
+        self.journal = self.journal.apply_batch(&batch.journal_batch).await?;
 
         self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
@@ -543,14 +574,14 @@ where
         self.metrics
             .operations_applied
             .inc_by(*range.end - *range.start);
-        Ok(range)
+        Ok((self, range))
     }
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::{journal::contiguous::Mutable, qmdb::verify_proof};
+    use crate::qmdb::verify_proof;
     use commonware_cryptography::Sha256;
     use commonware_parallel::Strategy;
     use commonware_runtime::{Supervisor as _, deterministic};
@@ -604,7 +635,7 @@ pub(crate) mod tests {
         }
         drop(db);
 
-        let mut db = reopen(context.child("db").with_attribute("index", 2)).await;
+        let db = reopen(context.child("db").with_attribute("index", 2)).await;
         assert_eq!(db.root(), root);
         assert_eq!(db.bounds().end, 1);
         assert_eq!(db.get_metadata().await.unwrap(), None);
@@ -615,8 +646,8 @@ pub(crate) mod tests {
             .new_batch()
             .merkleize(&db, Some(metadata.clone()), db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.bounds().end, 2); // 2 commit ops
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata.clone()));
         assert_eq!(
@@ -644,7 +675,7 @@ pub(crate) mod tests {
         S: Strategy,
     >(
         context: deterministic::Context,
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -662,9 +693,9 @@ pub(crate) mod tests {
             .append(value0.clone())
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
-        db.sync().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let db = db.sync().await.unwrap();
 
         // Commit the next append without syncing; reopen must replay it from the journal.
         let second_loc = db.bounds().end;
@@ -673,8 +704,8 @@ pub(crate) mod tests {
             .append(value1.clone())
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let committed_bounds = db.bounds();
         let committed_root = db.root();
         drop(db);
@@ -711,9 +742,8 @@ pub(crate) mod tests {
             let batch = batch.append(v2.clone());
             assert_eq!(loc1, Location::new(1));
             assert_eq!(loc2, Location::new(2));
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         // Make sure closing/reopening gets us back to the same state.
@@ -722,7 +752,6 @@ pub(crate) mod tests {
         assert_eq!(db.get(Location::new(3)).await.unwrap(), None); // the commit op
         let root = db.root();
         db.sync().await.unwrap();
-        drop(db);
 
         let db = reopen(context.child("db").with_attribute("index", 2)).await;
         assert_eq!(db.bounds().end, 4);
@@ -772,11 +801,10 @@ pub(crate) mod tests {
             for i in 0..ELEMENTS {
                 batch = batch.append(V::Value::make(i + 100));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         let root = db.root();
 
         // Create uncommitted appends then simulate failure.
@@ -798,11 +826,10 @@ pub(crate) mod tests {
             for i in 0..ELEMENTS {
                 batch = batch.append(V::Value::make(i + 300));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         let root = db.root();
 
         // Make sure we can reopen and get back to the same state.
@@ -829,9 +856,8 @@ pub(crate) mod tests {
             for i in 0..ELEMENTS {
                 batch = batch.append(V::Value::make(i));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         let root = db.root();
 
@@ -858,7 +884,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_db_metadata<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -871,14 +897,14 @@ pub(crate) mod tests {
             .append(V::Value::make(1))
             .merkleize(&db, Some(metadata.clone()), db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
         let merkleized = db
             .new_batch()
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.get_metadata().await.unwrap(), None);
 
         db.destroy().await.unwrap();
@@ -886,7 +912,9 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_db_pruning<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        context: deterministic::Context,
+        db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -901,6 +929,9 @@ pub(crate) mod tests {
                 if prune_loc == Location::new(1) && floor == Location::new(0))
         );
 
+        // The failed prune consumed the db; reopen the partition to continue.
+        let db = reopen(context.child("reopen_empty")).await;
+
         // Add values and commit, advancing the floor to the new commit location.
         let first_commit_loc = Location::<F>::new(3);
         let merkleized = db
@@ -909,7 +940,7 @@ pub(crate) mod tests {
             .append(V::Value::make(2))
             .merkleize(&db, None, first_commit_loc)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.last_commit_loc(), first_commit_loc);
         assert_eq!(db.inactivity_floor_loc(), first_commit_loc);
 
@@ -920,11 +951,11 @@ pub(crate) mod tests {
             .append(V::Value::make(3))
             .merkleize(&db, None, second_commit_loc)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         // Valid prune: up to the floor (previous commit location).
         let root = db.root();
-        assert!(db.prune(first_commit_loc).await.is_ok());
+        let db = db.prune(first_commit_loc).await.unwrap();
         assert_eq!(db.root(), root);
 
         // Pruning beyond the current floor fails.
@@ -935,8 +966,6 @@ pub(crate) mod tests {
             matches!(result, Err(Error::PruneBeyondMinRequired(prune_loc, floor))
                 if prune_loc == beyond && floor == new_floor)
         );
-
-        db.destroy().await.unwrap();
     }
 
     #[boxed]
@@ -1004,9 +1033,8 @@ pub(crate) mod tests {
             for i in 0..ELEMENTS {
                 batch = batch.append(V::Value::make(i + 2000));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         db.commit().await.unwrap();
         let db = reopen(context.child("db").with_attribute("index", 6)).await;
@@ -1039,11 +1067,10 @@ pub(crate) mod tests {
             for i in 0..10u64 {
                 batch = batch.append(V::Value::make(i));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         let committed_root = db.root();
         let committed_size = db.bounds().end;
 
@@ -1078,11 +1105,10 @@ pub(crate) mod tests {
                 loc, committed_size,
                 "New append should get the expected location"
             );
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
 
         assert_eq!(db.get(committed_size).await.unwrap(), Some(new_value));
 
@@ -1124,7 +1150,7 @@ pub(crate) mod tests {
     /// results consistent with individual `get` calls.
     #[boxed]
     pub(crate) async fn test_keyless_get_many<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1140,10 +1166,9 @@ pub(crate) mod tests {
         let batch = batch.append(v1.clone());
         let loc2 = batch.size();
         let batch = batch.append(v2.clone());
-        db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-            .await
-            .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         // DB-level get_many.
         let results = db.get_many(&[loc1, loc2]).await.unwrap();
@@ -1175,7 +1200,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_batch_chained<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1198,8 +1223,8 @@ pub(crate) mod tests {
         let child_m = child.merkleize(&db, None, db.inactivity_floor_loc()).await;
         let child_root = child_m.root();
 
-        db.apply_batch(child_m).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(child_m).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         assert_eq!(db.root(), child_root);
         assert_eq!(db.get(loc1).await.unwrap(), Some(v1));
@@ -1211,7 +1236,9 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_stale_batch<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        context: deterministic::Context,
+        db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1229,17 +1256,24 @@ pub(crate) mod tests {
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
 
-        db.apply_batch(batch_a).await.unwrap();
+        let (db, _) = db.apply_batch(batch_a).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let root = db.root();
+        let last_commit_loc = db.last_commit_loc();
 
         let result = db.apply_batch(batch_b).await;
         assert!(matches!(result, Err(Error::StaleBatch { .. })));
 
+        // The rejection mutated nothing: reopening recovers the committed state.
+        let db = reopen(context.child("reopen")).await;
+        assert_eq!(db.root(), root);
+        assert_eq!(db.last_commit_loc(), last_commit_loc);
         db.destroy().await.unwrap();
     }
 
     #[boxed]
     pub(crate) async fn test_keyless_partial_ancestor_commit<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1266,8 +1300,8 @@ pub(crate) mod tests {
         let expected_root = c.root();
 
         // Apply only A, then apply C directly (B's items applied via ancestor batches).
-        db.apply_batch(a).await.unwrap();
-        db.apply_batch(c).await.unwrap();
+        let (db, _) = db.apply_batch(a).await.unwrap();
+        let (db, _) = db.apply_batch(c).await.unwrap();
 
         // Root must match what the full chain produces.
         assert_eq!(db.root(), expected_root);
@@ -1277,7 +1311,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_to_batch<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1286,9 +1320,8 @@ pub(crate) mod tests {
         let batch = db.new_batch();
         let loc1 = batch.size();
         let batch = batch.append(V::Value::make(10));
-        db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-            .await
-            .unwrap();
+        let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         let snapshot = db.to_batch();
         assert_eq!(snapshot.root(), db.root());
@@ -1296,13 +1329,10 @@ pub(crate) mod tests {
         let child_batch = snapshot.new_batch::<Sha256>();
         let loc2 = child_batch.size();
         let child_batch = child_batch.append(V::Value::make(20));
-        db.apply_batch(
-            child_batch
-                .merkleize(&db, None, db.inactivity_floor_loc())
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = child_batch
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         assert_eq!(db.get(loc1).await.unwrap(), Some(V::Value::make(10)));
         assert_eq!(db.get(loc2).await.unwrap(), Some(V::Value::make(20)));
@@ -1330,11 +1360,10 @@ pub(crate) mod tests {
                 batch = batch.append(V::Value::make(i));
             }
             let new_commit = Location::new(*db.last_commit_loc() + 1 + ELEMENTS);
-            db.apply_batch(batch.merkleize(&db, None, new_commit).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, new_commit).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
-        db.commit().await.unwrap();
+        let db = db.commit().await.unwrap();
         let root = db.root();
         let op_count = db.bounds().end;
 
@@ -1361,12 +1390,12 @@ pub(crate) mod tests {
         drop(db);
 
         // Repeat after pruning to the last commit.
-        let mut db = reopen(context.child("db").with_attribute("index", 3)).await;
-        db.prune(db.last_commit_loc()).await.unwrap();
+        let db = reopen(context.child("db").with_attribute("index", 3)).await;
+        let last_commit = db.last_commit_loc();
+        let db = db.prune(last_commit).await.unwrap();
         assert_eq!(db.bounds().end, op_count);
         assert_eq!(db.root(), root);
         db.sync().await.unwrap();
-        drop(db);
 
         let db = reopen(context.child("recovery_c")).await;
         {
@@ -1388,9 +1417,8 @@ pub(crate) mod tests {
             for i in 0..ELEMENTS {
                 batch = batch.append(V::Value::make(i + 3000));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         db.commit().await.unwrap();
         let db = reopen(context.child("db").with_attribute("index", 5)).await;
@@ -1417,9 +1445,8 @@ pub(crate) mod tests {
             for i in 0u64..ELEMENTS {
                 batch = batch.append(V::Value::make(i));
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         // Test that historical proof fails with op_count > number of operations.
@@ -1490,9 +1517,8 @@ pub(crate) mod tests {
                 batch = batch.append(V::Value::make(i));
             }
             let new_commit = Location::new(*db.last_commit_loc() + 1 + ELEMENTS);
-            db.apply_batch(batch.merkleize(&db, None, new_commit).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, new_commit).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         {
@@ -1501,20 +1527,18 @@ pub(crate) mod tests {
                 batch = batch.append(V::Value::make(i));
             }
             let new_commit = Location::new(*db.last_commit_loc() + 1 + ELEMENTS);
-            db.apply_batch(batch.merkleize(&db, None, new_commit).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, new_commit).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
         let root = db.root();
 
         const PRUNE_LOC: u64 = 30;
-        db.prune(Location::new(PRUNE_LOC)).await.unwrap();
+        let db = db.prune(Location::new(PRUNE_LOC)).await.unwrap();
         let oldest_retained = db.bounds().start;
         assert_eq!(db.root(), root);
 
         db.sync().await.unwrap();
-        drop(db);
-        let mut db = reopen(context).await;
+        let db = reopen(context).await;
         assert_eq!(db.root(), root);
 
         for (start_loc, max_ops) in [
@@ -1531,7 +1555,7 @@ pub(crate) mod tests {
         }
 
         let aggressive_prune: Location<F> = Location::new(150);
-        db.prune(aggressive_prune).await.unwrap();
+        let db = db.prune(aggressive_prune).await.unwrap();
 
         let new_oldest = db.bounds().start;
         let (proof, ops) = db.proof(new_oldest, NZU64!(20)).await.unwrap();
@@ -1540,7 +1564,7 @@ pub(crate) mod tests {
         ));
 
         let almost_all = db.bounds().end - 5;
-        db.prune(almost_all).await.unwrap();
+        let db = db.prune(almost_all).await.unwrap();
         let final_oldest = db.bounds().start;
         if final_oldest < db.bounds().end {
             let (final_proof, final_ops) = db.proof(final_oldest, NZU64!(10)).await.unwrap();
@@ -1557,7 +1581,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_db_get_out_of_bounds<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1572,7 +1596,7 @@ pub(crate) mod tests {
             .append(V::Value::make(2))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         assert_eq!(
             db.get(Location::new(1)).await.unwrap(),
@@ -1606,9 +1630,8 @@ pub(crate) mod tests {
                 batch = batch.append(v.clone());
                 base_locs.push(loc);
             }
-            db.apply_batch(batch.merkleize(&db, None, db.inactivity_floor_loc()).await)
-                .await
-                .unwrap();
+            let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         let batch = db.new_batch();
@@ -1660,7 +1683,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_batch_speculative_root<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1673,7 +1696,7 @@ pub(crate) mod tests {
         }
         let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
         let speculative = merkleized.root();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.root(), speculative);
 
         let merkleized = db
@@ -1682,7 +1705,7 @@ pub(crate) mod tests {
             .merkleize(&db, Some(V::Value::make(55)), db.inactivity_floor_loc())
             .await;
         let speculative = merkleized.root();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.root(), speculative);
 
         db.destroy().await.unwrap();
@@ -1690,7 +1713,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_merkleized_batch_get<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1702,7 +1725,7 @@ pub(crate) mod tests {
             .append(base_val.clone())
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         let new_val = V::Value::make(20);
         let merkleized = db
@@ -1732,7 +1755,7 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1748,7 +1771,7 @@ pub(crate) mod tests {
         let parent_m = parent.merkleize(&db, None, db.inactivity_floor_loc()).await;
         let parent_root = parent_m.root();
 
-        db.apply_batch(parent_m).await.unwrap();
+        let (db, _) = db.apply_batch(parent_m).await.unwrap();
         assert_eq!(db.root(), parent_root);
         assert_eq!(db.get(loc1).await.unwrap(), Some(v1));
 
@@ -1757,7 +1780,7 @@ pub(crate) mod tests {
         let batch2 = batch2.append(v2.clone());
         let batch2_m = batch2.merkleize(&db, None, db.inactivity_floor_loc()).await;
         let batch2_root = batch2_m.root();
-        db.apply_batch(batch2_m).await.unwrap();
+        let (db, _) = db.apply_batch(batch2_m).await.unwrap();
         assert_eq!(db.root(), batch2_root);
         assert_eq!(db.get(loc2).await.unwrap(), Some(v2));
 
@@ -1787,7 +1810,7 @@ pub(crate) mod tests {
                 all_locs.push(loc);
             }
             let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-            db.apply_batch(merkleized).await.unwrap();
+            (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
 
         for (i, loc) in all_locs.iter().enumerate() {
@@ -1809,7 +1832,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_batch_empty<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1821,7 +1844,7 @@ pub(crate) mod tests {
             .append(V::Value::make(1))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let root_before = db.root();
         let size_before = db.bounds().end;
 
@@ -1830,7 +1853,7 @@ pub(crate) mod tests {
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
         let speculative = merkleized.root();
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         assert_ne!(db.root(), root_before);
         assert_eq!(db.root(), speculative);
@@ -1841,7 +1864,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_batch_chained_merkleized_get<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1849,14 +1872,12 @@ pub(crate) mod tests {
     {
         let base_val = V::Value::make(10);
         let floor = db.inactivity_floor_loc();
-        db.apply_batch(
-            db.new_batch()
-                .append(base_val.clone())
-                .merkleize(&db, None, floor)
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .append(base_val.clone())
+            .merkleize(&db, None, floor)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         let v1 = V::Value::make(1);
         let parent = db.new_batch();
@@ -1886,7 +1907,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_batch_large<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1904,7 +1925,7 @@ pub(crate) mod tests {
             values.push(v);
         }
         let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
 
         for (i, loc) in locs.iter().enumerate() {
             assert_eq!(db.get(*loc).await.unwrap(), Some(values[i].clone()));
@@ -1925,7 +1946,7 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_stale_batch_chained<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1947,13 +1968,11 @@ pub(crate) mod tests {
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
 
-        db.apply_batch(child_a).await.unwrap();
+        let (db, _) = db.apply_batch(child_a).await.unwrap();
         assert!(matches!(
             db.apply_batch(child_b).await,
             Err(Error::StaleBatch { .. })
         ));
-
-        db.destroy().await.unwrap();
     }
 
     #[boxed]
@@ -1963,7 +1982,7 @@ pub(crate) mod tests {
         C,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -1980,15 +1999,15 @@ pub(crate) mod tests {
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
 
-        db.apply_batch(parent).await.unwrap();
-        db.apply_batch(child).await.unwrap();
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let (db, _) = db.apply_batch(child).await.unwrap();
 
         db.destroy().await.unwrap();
     }
 
     #[boxed]
     pub(crate) async fn test_keyless_stale_batch_child_before_parent<F: Family, V, C, S: Strategy>(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2005,13 +2024,11 @@ pub(crate) mod tests {
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
 
-        db.apply_batch(child).await.unwrap();
+        let (db, _) = db.apply_batch(child).await.unwrap();
         assert!(matches!(
             db.apply_batch(parent).await,
             Err(Error::StaleBatch { .. })
         ));
-
-        db.destroy().await.unwrap();
     }
 
     #[boxed]
@@ -2021,7 +2038,7 @@ pub(crate) mod tests {
         C,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, Sha256, S>,
+        db: TestKeyless<F, V, C, Sha256, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2041,8 +2058,8 @@ pub(crate) mod tests {
 
         // Commit the parent, then rebuild the same logical child from the
         // committed DB state and compare roots.
-        db.apply_batch(parent).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let db = db.commit().await.unwrap();
 
         let committed_child = db
             .new_batch()
@@ -2056,10 +2073,10 @@ pub(crate) mod tests {
     }
 
     async fn commit_appends<F: Family, V, C, H, S: Strategy>(
-        db: &mut TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
         values: impl IntoIterator<Item = V::Value>,
         metadata: Option<V::Value>,
-    ) -> core::ops::Range<Location<F>>
+    ) -> (TestKeyless<F, V, C, H, S>, core::ops::Range<Location<F>>)
     where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2076,18 +2093,16 @@ pub(crate) mod tests {
         for value in appends_iter {
             batch = batch.append(value);
         }
-        let range = db
-            .apply_batch(batch.merkleize(db, metadata, new_commit_loc).await)
-            .await
-            .unwrap();
-        db.commit().await.unwrap();
-        range
+        let merkleized = batch.merkleize(&db, metadata, new_commit_loc).await;
+        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+        (db, range)
     }
 
     #[boxed]
     pub(crate) async fn test_keyless_db_rewind_recovery<F: Family, V, C, H, S: Strategy>(
         context: deterministic::Context,
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2101,8 +2116,8 @@ pub(crate) mod tests {
         let value_a = V::Value::make(1);
         let value_b = V::Value::make(2);
         let metadata_a = V::Value::make(3);
-        let first_range = commit_appends(
-            &mut db,
+        let (db, first_range) = commit_appends(
+            db,
             [value_a.clone(), value_b.clone()],
             Some(metadata_a.clone()),
         )
@@ -2115,13 +2130,13 @@ pub(crate) mod tests {
 
         let value_c = V::Value::make(4);
         let metadata_b = V::Value::make(5);
-        let second_range =
-            commit_appends(&mut db, [value_c.clone()], Some(metadata_b.clone())).await;
+        let (db, second_range) =
+            commit_appends(db, [value_c.clone()], Some(metadata_b.clone())).await;
         assert_eq!(second_range.start, size_before);
         assert_ne!(db.root(), root_before);
         assert_eq!(db.get_metadata().await.unwrap(), Some(metadata_b));
 
-        db.rewind(size_before).await.unwrap();
+        let db = db.rewind(size_before).await.unwrap();
         assert_eq!(db.root(), root_before);
         assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc(), commit_before);
@@ -2143,8 +2158,7 @@ pub(crate) mod tests {
         );
 
         db.commit().await.unwrap();
-        drop(db);
-        let mut db = reopen(context.child("reopen")).await;
+        let db = reopen(context.child("reopen")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.bounds().end, size_before);
         assert_eq!(db.last_commit_loc(), commit_before);
@@ -2162,7 +2176,7 @@ pub(crate) mod tests {
             Err(Error::LocationOutOfBounds(_, size)) if size == size_before
         ));
 
-        db.rewind(initial_size).await.unwrap();
+        let db = db.rewind(initial_size).await.unwrap();
         assert_eq!(db.root(), initial_root);
         assert_eq!(db.bounds().end, initial_size);
         assert_eq!(db.get_metadata().await.unwrap(), None);
@@ -2172,7 +2186,6 @@ pub(crate) mod tests {
         ));
 
         db.commit().await.unwrap();
-        drop(db);
         let db = reopen(context.child("reopen_initial_boundary")).await;
         assert_eq!(db.root(), initial_root);
         assert_eq!(db.bounds().end, initial_size);
@@ -2193,14 +2206,16 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        context: deterministic::Context,
+        db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
-        let first_range = commit_appends(&mut db, (0..16).map(V::Value::make), None).await;
+        let (mut db, first_range) = commit_appends(db, (0..16).map(V::Value::make), None).await;
 
         let mut round = 0u64;
         loop {
@@ -2210,13 +2225,10 @@ pub(crate) mod tests {
                 "failed to prune enough history for rewind test"
             );
 
-            commit_appends(
-                &mut db,
-                (0..16).map(|i| V::Value::make(round * 100 + i)),
-                None,
-            )
-            .await;
-            db.prune(db.last_commit_loc()).await.unwrap();
+            (db, _) =
+                commit_appends(db, (0..16).map(|i| V::Value::make(round * 100 + i)), None).await;
+            let last_commit = db.last_commit_loc();
+            db = db.prune(last_commit).await.unwrap();
 
             if db.bounds().start > first_range.start {
                 break;
@@ -2224,7 +2236,9 @@ pub(crate) mod tests {
         }
 
         let oldest_retained = db.bounds().start;
-        let boundary_err = db.rewind(oldest_retained).await.unwrap_err();
+        let Err(boundary_err) = db.rewind(oldest_retained).await else {
+            panic!("expected rewind to fail");
+        };
         assert!(
             matches!(
                 boundary_err,
@@ -2233,19 +2247,24 @@ pub(crate) mod tests {
             "unexpected rewind error at retained boundary: {boundary_err:?}"
         );
 
-        let err = db.rewind(first_range.start).await.unwrap_err();
+        // The failed rewind consumed the db; reopen the partition to continue.
+        let db = reopen(context.child("reopen_boundary")).await;
+        let Err(err) = db.rewind(first_range.start).await else {
+            panic!("expected rewind to fail");
+        };
         assert!(
             matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),
             "unexpected rewind error: {err:?}"
         );
 
+        let db = reopen(context.child("reopen_destroy")).await;
         db.destroy().await.unwrap();
     }
 
     #[boxed]
     pub(crate) async fn test_keyless_db_floor_tracking<F: Family, V, C, H, S: Strategy>(
         context: deterministic::Context,
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2264,13 +2283,13 @@ pub(crate) mod tests {
             .append(V::Value::make(2))
             .merkleize(&db, None, floor_a)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), floor_a);
 
         // Reopen: floor should survive restart (it's part of the last commit operation).
         drop(db);
-        let mut db = reopen(context.child("reopen")).await;
+        let db = reopen(context.child("reopen")).await;
         assert_eq!(db.inactivity_floor_loc(), floor_a);
 
         // Floor may stay the same across a commit (monotonic non-decreasing).
@@ -2279,7 +2298,7 @@ pub(crate) mod tests {
             .append(V::Value::make(3))
             .merkleize(&db, None, floor_a)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), floor_a);
 
         // Floor may advance further.
@@ -2289,7 +2308,7 @@ pub(crate) mod tests {
             .append(V::Value::make(4))
             .merkleize(&db, None, floor_b)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), floor_b);
 
         db.destroy().await.unwrap();
@@ -2297,21 +2316,24 @@ pub(crate) mod tests {
 
     #[boxed]
     pub(crate) async fn test_keyless_db_floor_regression_rejected<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        context: deterministic::Context,
+        db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
         H: Hasher,
         Operation<F, V>: EncodeShared,
     {
-        // Advance floor to 3.
+        // Advance floor to 3 and commit so the state is durable.
         let merkleized = db
             .new_batch()
             .append(V::Value::make(1))
             .append(V::Value::make(2))
             .merkleize(&db, None, Location::new(3))
             .await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), Location::new(3));
         let root_before = db.root();
         let last_commit_before = db.last_commit_loc();
@@ -2322,13 +2344,17 @@ pub(crate) mod tests {
             .append(V::Value::make(3))
             .merkleize(&db, None, Location::new(1))
             .await;
-        let err = db.apply_batch(merkleized).await.unwrap_err();
+        let Err(err) = db.apply_batch(merkleized).await else {
+            panic!("expected apply_batch to fail");
+        };
         assert!(
             matches!(err, Error::FloorRegressed(new, current) if *new == 1 && *current == 3),
             "unexpected error: {err:?}"
         );
 
-        // DB state must be untouched: floor, last_commit_loc, and root unchanged.
+        // The failed apply_batch consumed the db; reopen the partition and
+        // verify the rejected batch persisted nothing.
+        let db = reopen(context.child("reopen")).await;
         assert_eq!(db.inactivity_floor_loc(), Location::new(3));
         assert_eq!(db.last_commit_loc(), last_commit_before);
         assert_eq!(db.root(), root_before);
@@ -2344,7 +2370,9 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        context: deterministic::Context,
+        db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2354,17 +2382,28 @@ pub(crate) mod tests {
         // Batch of 2 appends + 1 commit lands at locations [1..4); commit at 3, total_size = 4.
         // A floor > 3 (the commit location) is invalid — even floor == 4 (one past the commit)
         // is rejected so a subsequent prune cannot remove the last readable commit.
+        let floor = db.inactivity_floor_loc();
+        let last_commit_loc = db.last_commit_loc();
+        let root = db.root();
         let merkleized = db
             .new_batch()
             .append(V::Value::make(1))
             .append(V::Value::make(2))
             .merkleize(&db, None, Location::new(999))
             .await;
-        let err = db.apply_batch(merkleized).await.unwrap_err();
+        let Err(err) = db.apply_batch(merkleized).await else {
+            panic!("expected apply_batch to fail");
+        };
         assert!(
             matches!(err, Error::FloorBeyondSize(floor, commit) if *floor == 999 && *commit == 3),
             "unexpected error: {err:?}"
         );
+
+        // The failed apply_batch consumed the db; reopen and confirm nothing persisted.
+        let db = reopen(context.child("reopen_boundary")).await;
+        assert_eq!(db.inactivity_floor_loc(), floor);
+        assert_eq!(db.last_commit_loc(), last_commit_loc);
+        assert_eq!(db.root(), root);
 
         // Boundary: floor == total_size (= commit_loc + 1) is also rejected.
         let merkleized = db
@@ -2373,18 +2412,18 @@ pub(crate) mod tests {
             .append(V::Value::make(4))
             .merkleize(&db, None, Location::new(4))
             .await;
-        let err = db.apply_batch(merkleized).await.unwrap_err();
+        let Err(err) = db.apply_batch(merkleized).await else {
+            panic!("expected apply_batch to fail");
+        };
         assert!(
             matches!(err, Error::FloorBeyondSize(floor, commit) if *floor == 4 && *commit == 3),
             "unexpected error: {err:?}"
         );
-
-        db.destroy().await.unwrap();
     }
 
     #[boxed]
     pub(crate) async fn test_keyless_db_rewind_restores_floor<F: Family, V, C, H, S: Strategy>(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2399,8 +2438,8 @@ pub(crate) mod tests {
             .append(V::Value::make(2))
             .merkleize(&db, None, floor_a)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let rewind_target = Location::new(*db.last_commit_loc() + 1);
 
         // Second commit: floor advances to 6.
@@ -2411,31 +2450,31 @@ pub(crate) mod tests {
             .append(V::Value::make(4))
             .merkleize(&db, None, floor_b)
             .await;
-        db.apply_batch(merkleized).await.unwrap();
-        db.commit().await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), floor_b);
 
         // Rewind to the first commit; floor should restore to floor_a.
-        db.rewind(rewind_target).await.unwrap();
+        let db = db.rewind(rewind_target).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), floor_a);
 
-        // Prune is now gated at floor_a. Pruning past it fails.
+        // Prune is now gated at floor_a: pruning up to the floor works.
+        let db = db.prune(floor_a).await.unwrap();
+
+        // Pruning past the floor fails.
         let beyond = Location::new(*floor_a + 1);
-        let err = db.prune(beyond).await.unwrap_err();
+        let Err(err) = db.prune(beyond).await else {
+            panic!("expected prune to fail");
+        };
         assert!(matches!(err, Error::PruneBeyondMinRequired(_, _)));
-
-        // Pruning up to the floor works.
-        db.prune(floor_a).await.unwrap();
-
-        db.destroy().await.unwrap();
     }
 
     /// Floor is embedded in the Commit operation and therefore in the Merkle root: two databases
     /// with identical appends but different floors must produce different roots.
     #[boxed]
     pub(crate) async fn test_keyless_db_floor_changes_root<F: Family, V, C, H, S: Strategy>(
-        mut db_a: TestKeyless<F, V, C, H, S>,
-        mut db_b: TestKeyless<F, V, C, H, S>,
+        db_a: TestKeyless<F, V, C, H, S>,
+        db_b: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2449,18 +2488,16 @@ pub(crate) mod tests {
         for v in appends.iter() {
             batch_a = batch_a.append(v.clone());
         }
-        db_a.apply_batch(batch_a.merkleize(&db_a, None, Location::new(0)).await)
-            .await
-            .unwrap();
+        let merkleized = batch_a.merkleize(&db_a, None, Location::new(0)).await;
+        let (db_a, _) = db_a.apply_batch(merkleized).await.unwrap();
 
         // db_b commits the same appends but with floor=3 (= commit location).
         let mut batch_b = db_b.new_batch();
         for v in appends.iter() {
             batch_b = batch_b.append(v.clone());
         }
-        db_b.apply_batch(batch_b.merkleize(&db_b, None, Location::new(3)).await)
-            .await
-            .unwrap();
+        let merkleized = batch_b.merkleize(&db_b, None, Location::new(3)).await;
+        let (db_b, _) = db_b.apply_batch(merkleized).await.unwrap();
 
         assert_ne!(db_a.root(), db_b.root());
 
@@ -2477,7 +2514,7 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         V: ValueEncoding<Value: TestValue>,
         C: Mutable<Item = Operation<F, V>>,
@@ -2487,15 +2524,13 @@ pub(crate) mod tests {
         // 2 appends + 1 commit on top of the initial commit: commit lands at location 3.
         // floor == 3 (= commit_loc) is the maximum accepted value under the per-commit bound.
         let commit_loc = Location::<F>::new(3);
-        db.apply_batch(
-            db.new_batch()
-                .append(V::Value::make(1))
-                .append(V::Value::make(2))
-                .merkleize(&db, None, commit_loc)
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .append(V::Value::make(1))
+            .append(V::Value::make(2))
+            .merkleize(&db, None, commit_loc)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), commit_loc);
 
         db.destroy().await.unwrap();
@@ -2511,7 +2546,7 @@ pub(crate) mod tests {
         S: Strategy,
     >(
         context: deterministic::Context,
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         V: ValueEncoding<Value: TestValue>,
@@ -2521,44 +2556,38 @@ pub(crate) mod tests {
     {
         // First commit: 2 appends + commit, floor advances to 3.
         let floor_a = Location::<F>::new(3);
-        db.apply_batch(
-            db.new_batch()
-                .append(V::Value::make(1))
-                .append(V::Value::make(2))
-                .merkleize(&db, None, floor_a)
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .append(V::Value::make(1))
+            .append(V::Value::make(2))
+            .merkleize(&db, None, floor_a)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         let rewind_target = Location::new(*db.last_commit_loc() + 1);
 
         // Second commit: 2 appends + commit, floor advances to 6.
         let floor_b = Location::<F>::new(6);
-        db.apply_batch(
-            db.new_batch()
-                .append(V::Value::make(3))
-                .append(V::Value::make(4))
-                .merkleize(&db, None, floor_b)
-                .await,
-        )
-        .await
-        .unwrap();
+        let merkleized = db
+            .new_batch()
+            .append(V::Value::make(3))
+            .append(V::Value::make(4))
+            .merkleize(&db, None, floor_b)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         db.commit().await.unwrap();
 
-        // Drop & reopen to simulate a crash after both commits were durable.
-        drop(db);
-        let mut db = reopen(context.child("reopen")).await;
+        // Reopen to simulate a crash after both commits were durable.
+        let db = reopen(context.child("reopen")).await;
         assert_eq!(db.inactivity_floor_loc(), floor_b);
 
         // Rewind to the first commit; floor should restore to floor_a.
-        db.rewind(rewind_target).await.unwrap();
+        let db = db.rewind(rewind_target).await.unwrap();
         assert_eq!(db.inactivity_floor_loc(), floor_a);
         assert_eq!(db.last_commit_loc(), Location::new(3));
 
         // Commit the rewind so it's durable, then reopen and confirm the floor again.
         db.commit().await.unwrap();
-        drop(db);
         let db = reopen(context.child("reopen").with_attribute("index", 2)).await;
         assert_eq!(db.inactivity_floor_loc(), floor_a);
 
@@ -2577,7 +2606,9 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        context: deterministic::Context,
+        db: TestKeyless<F, V, C, H, S>,
+        reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
@@ -2602,13 +2633,17 @@ pub(crate) mod tests {
         let last_commit_before = db.last_commit_loc();
         let floor_before = db.inactivity_floor_loc();
 
-        let err = db.apply_batch(child).await.unwrap_err();
+        let Err(err) = db.apply_batch(child).await else {
+            panic!("expected apply_batch to fail");
+        };
         assert!(
             matches!(err, Error::FloorRegressed(new, prev) if *new == 1 && *prev == 2),
             "unexpected error: {err:?}"
         );
 
-        // DB state untouched by the rejected chain.
+        // The failed apply_batch consumed the db; reopen the partition and
+        // verify the rejected chain persisted nothing.
+        let db = reopen(context.child("reopen")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.last_commit_loc(), last_commit_before);
         assert_eq!(db.inactivity_floor_loc(), floor_before);
@@ -2626,7 +2661,7 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
@@ -2647,14 +2682,14 @@ pub(crate) mod tests {
             .merkleize(&db, None, Location::new(0))
             .await;
 
-        let err = db.apply_batch(child).await.unwrap_err();
+        let Err(err) = db.apply_batch(child).await else {
+            panic!("expected apply_batch to fail");
+        };
         // Error should identify the ancestor's commit_loc (2), not the tip's.
         assert!(
             matches!(err, Error::FloorBeyondSize(floor, commit) if *floor == 3 && *commit == 2),
             "unexpected error: {err:?}"
         );
-
-        db.destroy().await.unwrap();
     }
 
     /// After committing with `floor = commit_loc` and pruning down to it, the live set is
@@ -2665,7 +2700,7 @@ pub(crate) mod tests {
     #[boxed]
     pub(crate) async fn test_keyless_db_single_commit_live_set<F, V, C, H, S: Strategy>(
         context: deterministic::Context,
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
         reopen: Reopen<TestKeyless<F, V, C, H, S>>,
     ) where
         F: Family,
@@ -2678,17 +2713,15 @@ pub(crate) mod tests {
         // Declare floor = 4 (= commit_loc), the tight maximum.
         let metadata = V::Value::make(42);
         let commit_loc = Location::<F>::new(4);
-        db.apply_batch(
-            db.new_batch()
-                .append(V::Value::make(1))
-                .append(V::Value::make(2))
-                .append(V::Value::make(3))
-                .merkleize(&db, Some(metadata.clone()), commit_loc)
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .append(V::Value::make(1))
+            .append(V::Value::make(2))
+            .append(V::Value::make(3))
+            .merkleize(&db, Some(metadata.clone()), commit_loc)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.last_commit_loc(), commit_loc);
         assert_eq!(db.inactivity_floor_loc(), commit_loc);
         let root_after_commit = db.root();
@@ -2697,18 +2730,13 @@ pub(crate) mod tests {
         // Pruning is blob-aligned, so `bounds.start` may not physically advance all the way
         // to `commit_loc`; what matters semantically is that the floor has authorized pruning
         // of everything below the commit and that any further prune is rejected.
-        db.prune(commit_loc).await.unwrap();
+        let db = db.prune(commit_loc).await.unwrap();
         let bounds = db.bounds();
         assert!(
             bounds.start <= commit_loc,
             "prune must not advance bounds.start past the floor"
         );
         assert_eq!(bounds.end, Location::new(*commit_loc + 1));
-
-        // Pruning one past the floor must be rejected — the floor is the hard ceiling.
-        let err = db.prune(Location::new(*commit_loc + 1)).await.unwrap_err();
-        assert!(matches!(err, Error::PruneBeyondMinRequired(p, f)
-                if *p == *commit_loc + 1 && *f == *commit_loc));
 
         // The commit op remains readable; its metadata is intact.
         assert_eq!(db.get(commit_loc).await.unwrap(), Some(metadata.clone()));
@@ -2718,11 +2746,17 @@ pub(crate) mod tests {
         // Prune does not affect the root (documented invariant on `prune`).
         assert_eq!(db.root(), root_after_commit);
 
-        // Persist the prune, then reopen: `init_from_journal` must recover the floor from
-        // the last commit op.
-        db.sync().await.unwrap();
-        drop(db);
-        let mut db = reopen(context.child("reopened")).await;
+        // Persist the prune, then verify pruning one past the floor is rejected — the
+        // floor is the hard ceiling. The failing prune consumes the db in place of a drop.
+        let db = db.sync().await.unwrap();
+        let Err(err) = db.prune(Location::new(*commit_loc + 1)).await else {
+            panic!("expected prune to fail");
+        };
+        assert!(matches!(err, Error::PruneBeyondMinRequired(p, f)
+                if *p == *commit_loc + 1 && *f == *commit_loc));
+
+        // Reopen: `init_from_journal` must recover the floor from the last commit op.
+        let db = reopen(context.child("reopened")).await;
         let reopened_bounds = db.bounds();
         assert_eq!(reopened_bounds.end, Location::new(*commit_loc + 1));
         assert_eq!(db.last_commit_loc(), commit_loc);
@@ -2736,16 +2770,14 @@ pub(crate) mod tests {
         let next_commit_loc = Location::<F>::new(7);
         let v5 = V::Value::make(5);
         let v6 = V::Value::make(6);
-        db.apply_batch(
-            db.new_batch()
-                .append(v5.clone())
-                .append(v6.clone())
-                .merkleize(&db, None, next_commit_loc)
-                .await,
-        )
-        .await
-        .unwrap();
-        db.commit().await.unwrap();
+        let merkleized = db
+            .new_batch()
+            .append(v5.clone())
+            .append(v6.clone())
+            .merkleize(&db, None, next_commit_loc)
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
         assert_eq!(db.last_commit_loc(), next_commit_loc);
         assert_eq!(db.inactivity_floor_loc(), next_commit_loc);
 
@@ -2767,7 +2799,7 @@ pub(crate) mod tests {
         H,
         S: Strategy,
     >(
-        mut db: TestKeyless<F, V, C, H, S>,
+        db: TestKeyless<F, V, C, H, S>,
     ) where
         F: Family,
         V: ValueEncoding<Value: TestValue>,
@@ -2794,7 +2826,7 @@ pub(crate) mod tests {
             .merkleize(&db, None, Location::new(5))
             .await;
 
-        db.apply_batch(grandchild).await.unwrap();
+        let (db, _) = db.apply_batch(grandchild).await.unwrap();
 
         // Grandchild's commit is the last op; tip's floor is the live floor.
         assert_eq!(db.last_commit_loc(), Location::new(6));

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -160,10 +160,10 @@ where
         let metrics = Metrics::new(context);
         if journal.size() == 0 {
             warn!("no operations found in log, creating initial commit");
-            let (appended, _) = journal
+            (journal, _) = journal
                 .append(&Operation::Commit(None, Location::new(0)))
                 .await?;
-            journal = appended.sync().await?;
+            journal = journal.sync().await?;
         }
 
         let (last_commit_loc, inactivity_floor_loc) = {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -929,7 +929,6 @@ pub(crate) mod tests {
                 if prune_loc == Location::new(1) && floor == Location::new(0))
         );
 
-        // The failed prune consumed the db; reopen the partition to continue.
         let db = reopen(context.child("reopen_empty")).await;
 
         // Add values and commit, advancing the floor to the new commit location.
@@ -2247,7 +2246,6 @@ pub(crate) mod tests {
             "unexpected rewind error at retained boundary: {boundary_err:?}"
         );
 
-        // The failed rewind consumed the db; reopen the partition to continue.
         let db = reopen(context.child("reopen_boundary")).await;
         let Err(err) = db.rewind(first_range.start).await else {
             panic!("expected rewind to fail");
@@ -2352,8 +2350,7 @@ pub(crate) mod tests {
             "unexpected error: {err:?}"
         );
 
-        // The failed apply_batch consumed the db; reopen the partition and
-        // verify the rejected batch persisted nothing.
+        // Reopen the partition and verify the rejected batch persisted nothing.
         let db = reopen(context.child("reopen")).await;
         assert_eq!(db.inactivity_floor_loc(), Location::new(3));
         assert_eq!(db.last_commit_loc(), last_commit_before);
@@ -2399,7 +2396,7 @@ pub(crate) mod tests {
             "unexpected error: {err:?}"
         );
 
-        // The failed apply_batch consumed the db; reopen and confirm nothing persisted.
+        // Reopen and confirm nothing persisted.
         let db = reopen(context.child("reopen_boundary")).await;
         assert_eq!(db.inactivity_floor_loc(), floor);
         assert_eq!(db.last_commit_loc(), last_commit_loc);
@@ -2641,8 +2638,7 @@ pub(crate) mod tests {
             "unexpected error: {err:?}"
         );
 
-        // The failed apply_batch consumed the db; reopen the partition and
-        // verify the rejected chain persisted nothing.
+        // Reopen the partition and verify the rejected chain persisted nothing.
         let db = reopen(context.child("reopen")).await;
         assert_eq!(db.root(), root_before);
         assert_eq!(db.last_commit_loc(), last_commit_before);
@@ -2747,7 +2743,7 @@ pub(crate) mod tests {
         assert_eq!(db.root(), root_after_commit);
 
         // Persist the prune, then verify pruning one past the floor is rejected — the
-        // floor is the hard ceiling. The failing prune consumes the db in place of a drop.
+        // floor is the hard ceiling.
         let db = db.sync().await.unwrap();
         let Err(err) = db.prune(Location::new(*commit_loc + 1)).await else {
             panic!("expected prune to fail");

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -104,7 +104,7 @@ where
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);
-        let mut db = Self {
+        let db = Self {
             journal,
             root,
             last_commit_loc,
@@ -113,8 +113,7 @@ where
         };
         db.update_metrics();
 
-        db.sync().await?;
-        Ok(db)
+        db.sync().await
     }
 
     async fn local_boundary_nodes(
@@ -191,7 +190,7 @@ where
         self.root()
     }
 
-    async fn persist_compact_state(&mut self) -> Result<(), qmdb::Error<F>> {
+    async fn persist_compact_state(self) -> Result<Self, qmdb::Error<F>> {
         self.sync().await
     }
 }

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -65,14 +65,14 @@ pub(crate) trait SyncTestHarness: Sized + 'static {
         config: ConfigOf<Self>,
     ) -> impl Future<Output = Self::Db> + Send;
     fn destroy(db: Self::Db) -> impl Future<Output = ()> + Send;
-    fn db_sync(db: &mut Self::Db) -> impl Future<Output = ()> + Send;
+    fn db_sync(db: Self::Db) -> impl Future<Output = Self::Db> + Send;
 
     fn apply_ops(
         db: Self::Db,
         ops: Vec<OpOf<Self>>,
         metadata: Option<Self::Value>,
     ) -> impl Future<Output = Self::Db> + Send;
-    fn prune(db: &mut Self::Db, loc: Location<Self::Family>) -> impl Future<Output = ()> + Send;
+    fn prune(db: Self::Db, loc: Location<Self::Family>) -> impl Future<Output = Self::Db> + Send;
 
     fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>>;
     fn db_root(db: &Self::Db) -> sha256::Digest;
@@ -263,7 +263,7 @@ where
             reached_target_tx: None,
             max_retained_roots: 8,
         };
-        let mut synced_db: DbOf<H> = sync::sync(config).await.unwrap();
+        let synced_db: DbOf<H> = sync::sync(config).await.unwrap();
 
         assert_eq!(H::db_root(&synced_db), target_root);
         let expected_root = H::db_root(&synced_db);
@@ -271,7 +271,7 @@ where
         let expected_op_count = bounds.end;
         let expected_oldest_retained_loc = bounds.start;
 
-        H::db_sync(&mut synced_db).await;
+        let synced_db = H::db_sync(synced_db).await;
         drop(synced_db);
         let reopened_db = H::init_db_with_config(context.child("reopened"), db_config).await;
 
@@ -539,9 +539,9 @@ where
     executor.start(|mut context| async move {
         let target_db = H::init_db(context.child("target")).await;
         let target_ops = H::create_ops(100);
-        let mut target_db = H::apply_ops(target_db, target_ops, None).await;
+        let target_db = H::apply_ops(target_db, target_ops, None).await;
 
-        H::prune(&mut target_db, Location::new(10)).await;
+        let target_db = H::prune(target_db, Location::new(10)).await;
 
         let bounds = H::bounds(&target_db);
         let initial_lower_bound = bounds.start;
@@ -668,9 +668,9 @@ where
         let initial_root = H::db_root(&target_db);
 
         let more_ops = H::create_ops_seeded(5, 1);
-        let mut target_db = H::apply_ops(target_db, more_ops, None).await;
+        let target_db = H::apply_ops(target_db, more_ops, None).await;
 
-        H::prune(&mut target_db, Location::new(10)).await;
+        let target_db = H::prune(target_db, Location::new(10)).await;
         let target_db = H::apply_ops(target_db, vec![], None).await;
 
         let bounds = H::bounds(&target_db);
@@ -828,7 +828,7 @@ pub(crate) mod harnesses {
     /// Applies the given operations and commits the database, advancing the inactivity floor to
     /// the new commit location so sync tests that exercise pruning can do so freely.
     async fn variable_apply_ops<F: Family>(
-        mut db: VariableDb<F>,
+        db: VariableDb<F>,
         ops: Vec<VariableOp<F>>,
         metadata: Option<Vec<u8>>,
     ) -> VariableDb<F> {
@@ -849,7 +849,7 @@ pub(crate) mod harnesses {
             }
         }
         let merkleized = batch.merkleize(&db, metadata, new_commit).await;
-        db.apply_batch(merkleized).await.unwrap();
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
         db
     }
 
@@ -893,8 +893,8 @@ pub(crate) mod harnesses {
             db.destroy().await.unwrap();
         }
 
-        async fn db_sync(db: &mut Self::Db) {
-            db.sync().await.unwrap();
+        async fn db_sync(db: Self::Db) -> Self::Db {
+            db.sync().await.unwrap()
         }
 
         async fn apply_ops(
@@ -905,8 +905,8 @@ pub(crate) mod harnesses {
             variable_apply_ops::<F>(db, ops, metadata).await
         }
 
-        async fn prune(db: &mut Self::Db, loc: Location<Self::Family>) {
-            db.prune(loc).await.unwrap();
+        async fn prune(db: Self::Db, loc: Location<Self::Family>) -> Self::Db {
+            db.prune(loc).await.unwrap()
         }
 
         fn bounds(db: &Self::Db) -> std::ops::Range<Location<Self::Family>> {
@@ -1037,8 +1037,8 @@ fn test_keyless_local_boundary_nodes_rejects_target_before_local_lower_bound() {
         for seed in 0..3u64 {
             db = Box::pin(H::apply_ops(db, H::create_ops_seeded(100, seed), None)).await;
         }
-        H::prune(&mut db, Location::new(100)).await;
-        H::db_sync(&mut db).await;
+        let db = H::prune(db, Location::new(100)).await;
+        let db = H::db_sync(db).await;
 
         let bounds = H::bounds(&db);
         let local_start = bounds.start;
@@ -1190,10 +1190,9 @@ mod compact_variable_mmr {
     fn test_compact_sync_roundtrip() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let metadata = vec![9, 9, 9];
             let floor = Location::new(2);
             let batch = source
@@ -1202,8 +1201,8 @@ mod compact_variable_mmr {
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(metadata.clone()), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1246,17 +1245,16 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_invalid_proof() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-bad-proof-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1299,17 +1297,16 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_tampered_commit_floor() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-bad-floor-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1366,18 +1363,17 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_tampered_pinned_nodes() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-bad-pins-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![1, 2, 3])
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(vec![7]), Location::new(2))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1428,17 +1424,16 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_leaf_count_mismatch() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-bad-leaf-count-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1481,18 +1476,17 @@ mod compact_variable_mmr {
     fn test_compact_sync_recovers_after_bad_pinned_nodes_with_feedback() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-feedback-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![1, 2, 3])
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(vec![7]), Location::new(2))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -1556,17 +1550,16 @@ mod compact_variable_mmr {
     fn test_compact_full_source_rejects_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-stale-full-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch1 = source
                 .new_batch()
                 .append(vec![1, 2, 3])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch1).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).await.unwrap();
+            let source = source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -1577,8 +1570,8 @@ mod compact_variable_mmr {
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(vec![2]), Location::new(2))
                 .await;
-            source.apply_batch(batch2).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).await.unwrap();
+            let source = source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -1604,7 +1597,7 @@ mod compact_variable_mmr {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-unj-source-{}", context.next_u64());
             let source_cfg = client_config(&format!("{suffix}-source"), &context);
-            let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
 
@@ -1615,8 +1608,8 @@ mod compact_variable_mmr {
                 .append(vec![10, 11])
                 .merkleize(&source, Some(metadata1.clone()), floor1)
                 .await;
-            source.apply_batch(batch1).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).unwrap();
+            let source = source.sync().await.unwrap();
             let target1 = source.target();
             drop(source);
 
@@ -1642,7 +1635,7 @@ mod compact_variable_mmr {
             assert_eq!(served1.inactivity_floor_loc(), floor1);
             served1.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
                 .await
                 .unwrap();
             let metadata2 = vec![2, 2, 2];
@@ -1652,12 +1645,12 @@ mod compact_variable_mmr {
                 .append(vec![20, 21])
                 .merkleize(&source, Some(metadata2.clone()), floor2)
                 .await;
-            source.apply_batch(batch2).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).unwrap();
+            let source = source.sync().await.unwrap();
             let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind(target1.leaf_count).await.unwrap();
+            let source = source.rewind(target1.leaf_count).await.unwrap();
             assert_eq!(source.target(), target1);
 
             let serve2_cfg = client_config(&format!("{suffix}-serve2"), &context);
@@ -1677,7 +1670,7 @@ mod compact_variable_mmr {
             assert_eq!(served2.inactivity_floor_loc(), floor1);
             served2.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(source.target(), target1);
@@ -1688,8 +1681,8 @@ mod compact_variable_mmr {
                 .append(vec![30, 31, 32])
                 .merkleize(&source, Some(metadata3.clone()), floor3)
                 .await;
-            source.apply_batch(batch3).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch3).unwrap();
+            let source = source.sync().await.unwrap();
             let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);
@@ -1760,33 +1753,33 @@ mod compact_variable_mmr {
                     .append(vec![i])
                     .merkleize(&seeded, Some(vec![i]), floor)
                     .await;
-                seeded.apply_batch(batch).unwrap();
-                seeded.sync().await.unwrap();
+                (seeded, _) = seeded.apply_batch(batch).unwrap();
+                seeded = seeded.sync().await.unwrap();
                 first_size.get_or_insert(seeded.size());
             }
-            seeded.prune(seeded.size()).await.unwrap();
+            let boundary = seeded.size();
+            let seeded = seeded.prune(boundary).await.unwrap();
             // The prune moved the journal's pruning boundary: the first commit is unreachable.
+            // The failed rewind consumes the import.
             assert!(matches!(
                 seeded.rewind(first_size.unwrap()).await,
                 Err(crate::qmdb::Error::Merkle(
                     crate::merkle::Error::RewindBeyondHistory
                 ))
             ));
-            drop(seeded);
 
             // Sync different state into the same partition.
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let metadata = vec![9, 9, 9];
             let batch = source
                 .new_batch()
                 .append(vec![1, 2, 3])
                 .merkleize(&source, Some(metadata.clone()), Location::new(0))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
             let bounds = source.bounds();
             let target = sync::compact::Target {
                 root: source.root(),
@@ -1824,7 +1817,7 @@ mod compact_variable_mmr {
 
             // Seed the client partition with committed state A.
             let client_cfg = client_config(&suffix, &context);
-            let mut seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
+            let seeded = ClientDb::init(context.child("seed"), client_cfg.clone())
                 .await
                 .unwrap();
             let batch = seeded
@@ -1832,24 +1825,23 @@ mod compact_variable_mmr {
                 .append(vec![1])
                 .merkleize(&seeded, Some(vec![1]), Location::new(0))
                 .await;
-            seeded.apply_batch(batch).unwrap();
-            seeded.sync().await.unwrap();
+            let (seeded, _) = seeded.apply_batch(batch).unwrap();
+            let seeded = seeded.sync().await.unwrap();
             let target_a = seeded.target();
             drop(seeded);
 
             // Reconstruct state B into the same partition, then drop it before the first
             // persist (as a cancelled sync would).
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![9])
                 .merkleize(&source, Some(vec![9]), Location::new(0))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
             let bounds = source.bounds();
             let target_b = sync::compact::Target {
                 root: source.root(),
@@ -1864,7 +1856,7 @@ mod compact_variable_mmr {
                 state: fetched.state,
                 root: target_b.root,
             };
-            let mut imported = <ClientDb as sync::compact::Database>::from_validated_state(
+            let imported = <ClientDb as sync::compact::Database>::from_validated_state(
                 context.child("import"),
                 client_cfg.clone(),
                 validated,
@@ -1874,14 +1866,29 @@ mod compact_variable_mmr {
             assert_eq!(imported.target(), target_b);
 
             // Rewind is rejected until the import is persisted, even to the imported leaf
-            // count itself: the fast path must not report unpersisted state as durable.
+            // count itself: the fast path must not report unpersisted state as durable. The
+            // failed rewind consumes the import.
             assert!(imported.rewind(target_b.leaf_count).await.is_err());
 
-            // Prune is likewise rejected while the import is pending.
+            // Prune is likewise rejected while the import is pending; rebuild the import,
+            // since the failed rewind consumed the first one.
+            let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
+                .await
+                .unwrap();
+            let validated = sync::compact::ValidatedState {
+                state: fetched.state,
+                root: target_b.root,
+            };
+            let imported = <ClientDb as sync::compact::Database>::from_validated_state(
+                context.child("import").with_attribute("index", 2),
+                client_cfg.clone(),
+                validated,
+            )
+            .await
+            .unwrap();
             assert!(imported.prune(target_b.leaf_count).await.is_err());
-            drop(imported);
 
-            // The dropped import never touched the journal: state A is still there.
+            // The dropped imports never touched the journal: state A is still there.
             let reopened = ClientDb::init(context.child("reopen"), client_cfg)
                 .await
                 .unwrap();
@@ -2000,10 +2007,9 @@ mod compact_variable_mmb {
     fn test_compact_sync_roundtrip() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let metadata = vec![3, 3, 3];
             let floor = Location::new(2);
             let batch = source
@@ -2012,8 +2018,8 @@ mod compact_variable_mmb {
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(metadata.clone()), floor)
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2056,17 +2062,16 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_invalid_proof() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-bad-proof-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2109,17 +2114,16 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_tampered_commit_floor() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-bad-floor-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2176,18 +2180,17 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_tampered_pinned_nodes() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-bad-pins-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![1, 2, 3])
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(vec![7]), Location::new(2))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2238,17 +2241,16 @@ mod compact_variable_mmb {
     fn test_compact_sync_recovers_after_leaf_count_mismatch() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-bad-leaf-count-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch = source
                 .new_batch()
                 .append(vec![7, 8, 9])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch).await.unwrap();
+            let source = source.commit().await.unwrap();
 
             let bounds = source.bounds();
             let target = sync::compact::Target {
@@ -2291,17 +2293,16 @@ mod compact_variable_mmb {
     fn test_compact_full_source_rejects_stale_target() {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-stale-full-{}", context.next_u64());
-            let mut source =
-                SourceDb::init(context.child("source"), source_config(&suffix, &context))
-                    .await
-                    .unwrap();
+            let source = SourceDb::init(context.child("source"), source_config(&suffix, &context))
+                .await
+                .unwrap();
             let batch1 = source
                 .new_batch()
                 .append(vec![1, 2, 3])
                 .merkleize(&source, Some(vec![1]), Location::new(1))
                 .await;
-            source.apply_batch(batch1).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).await.unwrap();
+            let source = source.commit().await.unwrap();
             let stale_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -2312,8 +2313,8 @@ mod compact_variable_mmb {
                 .append(vec![4, 5, 6])
                 .merkleize(&source, Some(vec![2]), Location::new(2))
                 .await;
-            source.apply_batch(batch2).await.unwrap();
-            source.commit().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).await.unwrap();
+            let source = source.commit().await.unwrap();
             let current_target = sync::compact::Target {
                 root: source.root(),
                 leaf_count: source.bounds().end,
@@ -2339,7 +2340,7 @@ mod compact_variable_mmb {
         deterministic::Runner::default().start(|mut context| async move {
             let suffix = format!("compact-keyless-mmb-unj-source-{}", context.next_u64());
             let source_cfg = client_config(&format!("{suffix}-source"), &context);
-            let mut source = ClientDb::init(context.child("source_init"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_init"), source_cfg.clone())
                 .await
                 .unwrap();
 
@@ -2350,8 +2351,8 @@ mod compact_variable_mmb {
                 .append(vec![10, 11])
                 .merkleize(&source, Some(metadata1.clone()), floor1)
                 .await;
-            source.apply_batch(batch1).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch1).unwrap();
+            let source = source.sync().await.unwrap();
             let target1 = source.target();
             drop(source);
 
@@ -2377,7 +2378,7 @@ mod compact_variable_mmb {
             assert_eq!(served1.inactivity_floor_loc(), floor1);
             served1.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_resume"), source_cfg.clone())
                 .await
                 .unwrap();
             let metadata2 = vec![2, 2, 2];
@@ -2387,12 +2388,12 @@ mod compact_variable_mmb {
                 .append(vec![20, 21])
                 .merkleize(&source, Some(metadata2.clone()), floor2)
                 .await;
-            source.apply_batch(batch2).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch2).unwrap();
+            let source = source.sync().await.unwrap();
             let target2 = source.target();
             assert_ne!(target2, target1);
 
-            source.rewind(target1.leaf_count).await.unwrap();
+            let source = source.rewind(target1.leaf_count).await.unwrap();
             assert_eq!(source.target(), target1);
 
             let serve2_cfg = client_config(&format!("{suffix}-serve2"), &context);
@@ -2412,7 +2413,7 @@ mod compact_variable_mmb {
             assert_eq!(served2.inactivity_floor_loc(), floor1);
             served2.destroy().await.unwrap();
 
-            let mut source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
+            let source = ClientDb::init(context.child("source_regrow"), source_cfg.clone())
                 .await
                 .unwrap();
             assert_eq!(source.target(), target1);
@@ -2423,8 +2424,8 @@ mod compact_variable_mmb {
                 .append(vec![30, 31, 32])
                 .merkleize(&source, Some(metadata3.clone()), floor3)
                 .await;
-            source.apply_batch(batch3).unwrap();
-            source.sync().await.unwrap();
+            let (source, _) = source.apply_batch(batch3).unwrap();
+            let source = source.sync().await.unwrap();
             let target3 = source.target();
             assert_ne!(target3, target1);
             assert_ne!(target3, target2);

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -271,8 +271,7 @@ where
         let expected_op_count = bounds.end;
         let expected_oldest_retained_loc = bounds.start;
 
-        let synced_db = H::db_sync(synced_db).await;
-        drop(synced_db);
+        H::db_sync(synced_db).await;
         let reopened_db = H::init_db_with_config(context.child("reopened"), db_config).await;
 
         assert_eq!(H::db_root(&reopened_db), expected_root);
@@ -438,8 +437,7 @@ where
             H::init_db_with_config(client_context.child("client"), sync_db_config.clone()).await;
 
         let target_db = H::apply_ops(target_db, original_ops.clone(), None).await;
-        let sync_db = H::apply_ops(sync_db, original_ops, None).await;
-        drop(sync_db);
+        H::apply_ops(sync_db, original_ops, None).await;
 
         let last_op = H::create_ops_seeded(1, 1);
         let target_db = H::apply_ops(target_db, last_op, None).await;
@@ -493,8 +491,7 @@ where
             H::init_db_with_config(client_context.child("client"), sync_config.clone()).await;
 
         let target_db = H::apply_ops(target_db, target_ops.clone(), None).await;
-        let sync_db = H::apply_ops(sync_db, target_ops, None).await;
-        drop(sync_db);
+        H::apply_ops(sync_db, target_ops, None).await;
 
         let root = H::db_root(&target_db);
         let bounds = H::bounds(&target_db);

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1760,7 +1760,6 @@ mod compact_variable_mmr {
             let boundary = seeded.size();
             let seeded = seeded.prune(boundary).await.unwrap();
             // The prune moved the journal's pruning boundary: the first commit is unreachable.
-            // The failed rewind consumes the import.
             assert!(matches!(
                 seeded.rewind(first_size.unwrap()).await,
                 Err(crate::qmdb::Error::Merkle(
@@ -1866,12 +1865,10 @@ mod compact_variable_mmr {
             assert_eq!(imported.target(), target_b);
 
             // Rewind is rejected until the import is persisted, even to the imported leaf
-            // count itself: the fast path must not report unpersisted state as durable. The
-            // failed rewind consumes the import.
+            // count itself: the fast path must not report unpersisted state as durable.
             assert!(imported.rewind(target_b.leaf_count).await.is_err());
 
-            // Prune is likewise rejected while the import is pending; rebuild the import,
-            // since the failed rewind consumed the first one.
+            // Prune is likewise rejected while the import is pending; rebuild the import.
             let fetched = sync::compact::Resolver::get_compact_state(&source, target_b.clone())
                 .await
                 .unwrap();

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -1011,14 +1011,15 @@ mod test {
     fn assert_db_futures_are_send(
         db: TestDb<mmr::Family>,
         loc: crate::merkle::Location<mmr::Family>,
-        which: u8,
     ) {
         is_send(db.get_metadata());
         is_send(db.proof(loc, NZU64!(1)));
         is_send(db.get(loc));
-        match which {
-            0 => is_send(db.sync()),
-            _ => is_send(db.rewind(loc)),
-        }
+        is_send(db.sync());
+    }
+
+    #[allow(dead_code)]
+    fn assert_rewind_is_send(db: TestDb<mmr::Family>, loc: crate::merkle::Location<mmr::Family>) {
+        is_send(db.rewind(loc));
     }
 }

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -263,14 +263,13 @@ mod test {
                         ));
                 }
                 let new_commit_loc = Location::new(*db.last_commit_loc() + 1 + 3);
-                db.apply_batch(batch.merkleize(&db, None, new_commit_loc).await)
-                    .await
-                    .unwrap();
+                let merkleized = batch.merkleize(&db, None, new_commit_loc).await;
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
             }
 
             // Prune to loc=8: blob 0 ([0,7)) end=7 <= 8 -> pruned. bounds.start = 7, first retained
             // commit is at 8.
-            db.prune(Location::new(8)).await.unwrap();
+            let db = db.prune(Location::new(8)).await.unwrap();
             let bounds = db.bounds();
             assert_eq!(*bounds.start, 7);
 
@@ -336,8 +335,8 @@ mod test {
     async fn assert_compact_root_compatibility<F: crate::merkle::Family>(
         ctx: deterministic::Context,
     ) {
-        let mut db = open_db::<F>(ctx.child("db")).await;
-        let mut compact = open_compact::<F>(ctx.child("compact")).await;
+        let db = open_db::<F>(ctx.child("db")).await;
+        let compact = open_compact::<F>(ctx.child("compact")).await;
         assert_eq!(db.root(), compact.root());
 
         let v1 = b"hello".to_vec();
@@ -360,10 +359,10 @@ mod test {
 
         assert_eq!(retained.root(), compact_batch.root());
 
-        db.apply_batch(retained).await.unwrap();
-        compact.apply_batch(compact_batch).unwrap();
-        db.commit().await.unwrap();
-        compact.sync().await.unwrap();
+        let (db, _) = db.apply_batch(retained).await.unwrap();
+        let (compact, _) = compact.apply_batch(compact_batch).unwrap();
+        let db = db.commit().await.unwrap();
+        let compact = compact.sync().await.unwrap();
 
         assert_eq!(db.root(), compact.root());
         assert_eq!(compact.get_metadata(), Some(metadata.clone()));
@@ -395,7 +394,7 @@ mod test {
     fn test_keyless_db_pruning() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_pruning(db).await;
+            tests::test_keyless_db_pruning(ctx, db, reopen::<mmr::Family>()).await;
         });
     }
 
@@ -491,7 +490,7 @@ mod test {
     fn test_keyless_stale_batch() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_stale_batch(db).await;
+            tests::test_keyless_stale_batch(ctx, db, reopen::<mmr::Family>()).await;
         });
     }
 
@@ -555,7 +554,8 @@ mod test {
     fn test_keyless_rewind_pruned_target_errors() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_rewind_pruned_target_errors(db).await;
+            tests::test_keyless_db_rewind_pruned_target_errors(ctx, db, reopen::<mmr::Family>())
+                .await;
         });
     }
 
@@ -654,7 +654,7 @@ mod test {
     fn test_keyless_db_pruning_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_pruning(db).await;
+            tests::test_keyless_db_pruning(ctx, db, reopen::<mmb::Family>()).await;
         });
     }
 
@@ -742,7 +742,7 @@ mod test {
     fn test_keyless_stale_batch_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_stale_batch(db).await;
+            tests::test_keyless_stale_batch(ctx, db, reopen::<mmb::Family>()).await;
         });
     }
 
@@ -798,7 +798,8 @@ mod test {
     fn test_keyless_rewind_pruned_target_errors_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_rewind_pruned_target_errors(db).await;
+            tests::test_keyless_db_rewind_pruned_target_errors(ctx, db, reopen::<mmb::Family>())
+                .await;
         });
     }
 
@@ -814,7 +815,8 @@ mod test {
     fn test_keyless_variable_floor_regression_rejected_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_regression_rejected(db).await;
+            tests::test_keyless_db_floor_regression_rejected(ctx, db, reopen::<mmb::Family>())
+                .await;
         });
     }
 
@@ -822,7 +824,12 @@ mod test {
     fn test_keyless_variable_floor_beyond_commit_loc_rejected_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_beyond_commit_loc_rejected(db).await;
+            tests::test_keyless_db_floor_beyond_commit_loc_rejected(
+                ctx,
+                db,
+                reopen::<mmb::Family>(),
+            )
+            .await;
         });
     }
 
@@ -864,7 +871,12 @@ mod test {
     fn test_keyless_variable_ancestor_floor_regression_rejected_mmb() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmb::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_ancestor_floor_regression_rejected(db).await;
+            tests::test_keyless_db_ancestor_floor_regression_rejected(
+                ctx,
+                db,
+                reopen::<mmb::Family>(),
+            )
+            .await;
         });
     }
 
@@ -904,7 +916,8 @@ mod test {
     fn test_keyless_variable_floor_regression_rejected() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_regression_rejected(db).await;
+            tests::test_keyless_db_floor_regression_rejected(ctx, db, reopen::<mmr::Family>())
+                .await;
         });
     }
 
@@ -912,7 +925,12 @@ mod test {
     fn test_keyless_variable_floor_beyond_commit_loc_rejected() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_floor_beyond_commit_loc_rejected(db).await;
+            tests::test_keyless_db_floor_beyond_commit_loc_rejected(
+                ctx,
+                db,
+                reopen::<mmr::Family>(),
+            )
+            .await;
         });
     }
 
@@ -954,7 +972,12 @@ mod test {
     fn test_keyless_variable_ancestor_floor_regression_rejected() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;
-            tests::test_keyless_db_ancestor_floor_regression_rejected(db).await;
+            tests::test_keyless_db_ancestor_floor_regression_rejected(
+                ctx,
+                db,
+                reopen::<mmr::Family>(),
+            )
+            .await;
         });
     }
 
@@ -986,13 +1009,16 @@ mod test {
 
     #[allow(dead_code)]
     fn assert_db_futures_are_send(
-        db: &mut TestDb<mmr::Family>,
+        db: TestDb<mmr::Family>,
         loc: crate::merkle::Location<mmr::Family>,
+        which: u8,
     ) {
         is_send(db.get_metadata());
         is_send(db.proof(loc, NZU64!(1)));
-        is_send(db.sync());
         is_send(db.get(loc));
-        is_send(db.rewind(loc));
+        match which {
+            0 => is_send(db.sync()),
+            _ => is_send(db.rewind(loc)),
+        }
     }
 }

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -527,8 +527,8 @@ where
             let old_loc = inactivity_floor_loc;
             inactivity_floor_loc += 1;
             let op = self.log.read(*old_loc).await?;
-            let (helper, moved) = self.move_op_if_active(op, old_loc).await?;
-            self = helper;
+            let moved;
+            (self, moved) = self.move_op_if_active(op, old_loc).await?;
             if moved {
                 return Ok((self, inactivity_floor_loc));
             }

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -29,6 +29,14 @@
 //! Persistence and cleanup are managed directly on the database: `sync()`, `prune()`,
 //! and `destroy()`.
 //!
+//! # Ownership
+//!
+//! Mutating methods take the database by value and return it on success. If a mutating
+//! method returns an error, or its future is dropped before it finishes, the database is
+//! gone: state that was not yet durable is discarded, but everything already on disk stays
+//! recoverable. This applies to validation errors too (e.g. rejecting a stale batch);
+//! use each database's `validate_batch` to pre-check a batch without risking the handle.
+//!
 //! # Traits
 //!
 //! Keyed mutable variants ([any] and [current]) implement `any::traits::DbAny`.
@@ -452,7 +460,7 @@ pub(crate) struct FloorHelper<
     C: Mutable<Item: Operation<F>>,
 > {
     pub snapshot: &'a mut I,
-    pub log: &'a mut C,
+    pub log: C,
 }
 
 impl<F, I, C> FloorHelper<'_, F, I, C>
@@ -462,49 +470,54 @@ where
     C: Mutable<Item: Operation<F>>,
 {
     /// Moves the given operation to the tip of the log if it is active, rendering its old location
-    /// inactive. If the operation was not active, then this is a no-op. Returns whether the
-    /// operation was moved.
+    /// inactive. If the operation was not active, then this is a no-op. Returns the helper and
+    /// whether the operation was moved.
     async fn move_op_if_active(
-        &mut self,
+        mut self,
         op: C::Item,
         old_loc: Location<F>,
-    ) -> Result<bool, Error<F>> {
+    ) -> Result<(Self, bool), Error<F>> {
         let Some(key) = op.key() else {
-            return Ok(false); // operations without keys cannot be active
+            return Ok((self, false)); // operations without keys cannot be active
         };
 
         // If we find a snapshot entry corresponding to the operation, we know it's active.
-        {
+        let active = {
             let Some(mut cursor) = self.snapshot.get_mut(key) else {
-                return Ok(false);
+                return Ok((self, false));
             };
-            if !cursor.find(|&loc| loc == old_loc) {
-                return Ok(false);
+            if cursor.find(|&loc| loc == old_loc) {
+                // Update the operation's snapshot location to point to tip.
+                cursor.update(Location::<F>::new(self.log.bounds().end));
+                true
+            } else {
+                false
             }
-
-            // Update the operation's snapshot location to point to tip.
-            cursor.update(Location::<F>::new(self.log.bounds().end));
+        };
+        if !active {
+            return Ok((self, false));
         }
 
         // Apply the operation at tip.
-        self.log.append(&op).await?;
+        (self.log, _) = self.log.append(&op).await?;
 
-        Ok(true)
+        Ok((self, true))
     }
 
     /// Raise the inactivity floor by taking one _step_, which involves searching for the first
     /// active operation above the inactivity floor, moving it to tip, and then setting the
     /// inactivity floor to the location following the moved operation. This method is therefore
-    /// guaranteed to raise the floor by at least one. Returns the new inactivity floor location.
+    /// guaranteed to raise the floor by at least one. Returns the helper and the new inactivity
+    /// floor location.
     ///
     /// # Panics
     ///
     /// Expects there is at least one active operation above the inactivity floor, and panics
     /// otherwise.
     async fn raise_floor(
-        &mut self,
+        mut self,
         mut inactivity_floor_loc: Location<F>,
-    ) -> Result<Location<F>, Error<F>> {
+    ) -> Result<(Self, Location<F>), Error<F>> {
         let tip_loc: Location<F> = Location::new(self.log.bounds().end);
         loop {
             assert!(
@@ -514,8 +527,10 @@ where
             let old_loc = inactivity_floor_loc;
             inactivity_floor_loc += 1;
             let op = self.log.read(*old_loc).await?;
-            if self.move_op_if_active(op, old_loc).await? {
-                return Ok(inactivity_floor_loc);
+            let (helper, moved) = self.move_op_if_active(op, old_loc).await?;
+            self = helper;
+            if moved {
+                return Ok((self, inactivity_floor_loc));
             }
         }
     }

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -504,9 +504,7 @@ where
             };
             let mut inactivity_floor_loc = self.inactivity_floor_loc;
             for _ in 0..steps_to_take {
-                let (h, floor) = helper.raise_floor(inactivity_floor_loc).await?;
-                helper = h;
-                inactivity_floor_loc = floor;
+                (helper, inactivity_floor_loc) = helper.raise_floor(inactivity_floor_loc).await?;
             }
             self.log = helper.log;
             self.inactivity_floor_loc = inactivity_floor_loc;

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -1157,7 +1157,6 @@ mod test {
         is_send(db.get(&key));
         let batch = db.new_batch();
         is_send(batch.get(&key));
-        drop(batch);
         is_send(db.apply_batch(Changeset::from([(key, Some(value))])));
     }
 

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -594,7 +594,6 @@ mod test {
                 Err(Error::PruneBeyondMinRequired(_, _))
             ));
 
-            // The failed prune consumed the db; reopen the partition to continue.
             let db = create_test_store(context.child("store").with_attribute("index", 3)).await;
 
             // Make sure closing/reopening gets us back to the same state, even after adding an uncommitted op.
@@ -1141,13 +1140,15 @@ mod test {
     fn is_send<T: Send>(_: T) {}
 
     #[allow(dead_code)]
-    fn assert_read_futures_are_send(db: TestStore, key: Digest, loc: Location, which: u8) {
+    fn assert_read_futures_are_send(db: TestStore, key: Digest, loc: Location) {
         is_send(db.get(&key));
         is_send(db.get_metadata());
-        match which {
-            0 => is_send(db.prune(loc)),
-            _ => is_send(db.sync()),
-        }
+        is_send(db.prune(loc));
+    }
+
+    #[allow(dead_code)]
+    fn assert_sync_is_send(db: TestStore) {
+        is_send(db.sync());
     }
 
     #[allow(dead_code)]
@@ -1155,16 +1156,12 @@ mod test {
         db: Db<deterministic::Context, Digest, Vec<u8>, TwoCap>,
         key: Digest,
         value: Vec<u8>,
-        which: u8,
     ) {
         is_send(db.get(&key));
         let batch = db.new_batch();
         is_send(batch.get(&key));
         drop(batch);
-        match which {
-            0 => is_send(db.apply_batch(Changeset::from([(key, Some(value))]))),
-            _ => is_send(db.apply_batch(Changeset::from([(key, None)]))),
-        }
+        is_send(db.apply_batch(Changeset::from([(key, Some(value))])));
     }
 
     #[allow(dead_code)]

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -349,8 +349,8 @@ where
 
         // Prune the log. The log will prune at section boundaries, so the actual oldest retained
         // location may be less than requested.
-        let (log, pruned) = self.log.prune(*prune_loc).await?;
-        self.log = log;
+        let pruned;
+        (self.log, pruned) = self.log.prune(*prune_loc).await?;
         if !pruned {
             return Ok(self);
         }
@@ -471,11 +471,10 @@ where
                 } else {
                     self.active_keys += 1;
                 }
-                let (log, _) = self
+                (self.log, _) = self
                     .log
                     .append(&Operation::Update(Update(key, value)))
                     .await?;
-                self.log = log;
             } else {
                 let deleted = delete_key::<crate::mmr::Family, _, _>(
                     &mut self.snapshot,
@@ -514,11 +513,11 @@ where
         }
 
         // Append the commit operation with the new inactivity floor.
-        let (log, commit_loc) = self
+        let commit_loc;
+        (self.log, commit_loc) = self
             .log
             .append(&Operation::CommitFloor(metadata, self.inactivity_floor_loc))
             .await?;
-        self.log = log;
         self.last_commit_loc = Location::new(commit_loc);
 
         self.steps = 0;

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -33,7 +33,7 @@
 //!         translator: TwoCap,
 //!         init_cache_size: Some(NZUsize!(1 << 16)),
 //!     };
-//!     let mut db =
+//!     let db =
 //!         Db::<_, Digest, Digest, TwoCap>::init(ctx.child("store"), config)
 //!             .await
 //!             .unwrap();
@@ -42,16 +42,18 @@
 //!     let k = Digest::random(&mut ctx);
 //!     let v = Digest::random(&mut ctx);
 //!     let metadata = Some(Digest::random(&mut ctx));
-//!     db.apply_batch(db.new_batch().update(k, v).finalize(metadata)).await.unwrap();
-//!     db.commit().await.unwrap();
+//!     let batch = db.new_batch().update(k, v).finalize(metadata);
+//!     let (db, _) = db.apply_batch(batch).await.unwrap();
+//!     let db = db.commit().await.unwrap();
 //!
 //!     // Fetch the value
 //!     let fetched_value = db.get(&k).await.unwrap();
 //!     assert_eq!(fetched_value.unwrap(), v);
 //!
 //!     // Delete the key's value
-//!     db.apply_batch(db.new_batch().delete(k).finalize(None)).await.unwrap();
-//!     db.commit().await.unwrap();
+//!     let batch = db.new_batch().delete(k).finalize(None);
+//!     let (db, _) = db.apply_batch(batch).await.unwrap();
+//!     let db = db.commit().await.unwrap();
 //!
 //!     // Fetch the value
 //!     let fetched_value = db.get(&k).await.unwrap();
@@ -64,14 +66,15 @@
 //!
 //! ```ignore
 //! // Apply a batch and commit it, then build a child batch from the newly published state
-//! // and apply it. `commit` takes `&mut self`, so committing and building share the same
-//! // exclusive borrow and run in sequence.
-//! db.apply_batch(db.new_batch().update(key_a, value_a).finalize(None)).await?;
-//! db.commit().await?;
+//! // and apply it. Each mutation takes the database and returns it, so committing and
+//! // building run in sequence on the threaded handle.
+//! let batch = db.new_batch().update(key_a, value_a).finalize(None);
+//! let (db, _) = db.apply_batch(batch).await?;
+//! let db = db.commit().await?;
 //!
 //! let child = db.new_batch().update(key_b, value_b).finalize(None);
-//! db.apply_batch(child).await?;
-//! db.commit().await?;
+//! let (db, _) = db.apply_batch(child).await?;
+//! let db = db.commit().await?;
 //! ```
 
 use crate::{
@@ -239,6 +242,21 @@ where
     pub steps: u64,
 }
 
+impl<E, K, V, T> std::fmt::Debug for Db<E, K, V, T>
+where
+    E: Context,
+    K: Array,
+    V: VariableValue,
+    T: Translator,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Db")
+            .field("bounds", &self.bounds())
+            .field("inactivity_floor_loc", &self.inactivity_floor_loc())
+            .finish_non_exhaustive()
+    }
+}
+
 impl<E, K, V, T> Db<E, K, V, T>
 where
     E: Context,
@@ -290,7 +308,7 @@ where
     }
 
     /// Return the Location of the next operation appended to this db.
-    pub const fn size(&self) -> Location {
+    pub fn size(&self) -> Location {
         Location::new(self.log.size())
     }
 
@@ -315,7 +333,8 @@ where
     ///
     /// `prune` requires no prior commit. After a crash, the database remains recoverable;
     /// uncommitted operations are not guaranteed to survive.
-    pub async fn prune(&mut self, prune_loc: Location) -> Result<(), Error> {
+    #[boxed]
+    pub async fn prune(mut self, prune_loc: Location) -> Result<Self, Error> {
         if prune_loc > self.inactivity_floor_loc {
             return Err(Error::PruneBeyondMinRequired(
                 prune_loc,
@@ -326,12 +345,14 @@ where
         // The floor justifying the boundary may exist only in buffered operations (it
         // advances before its batch is durable), and pruning does not guarantee buffered
         // appends are durable. Commit so the justification survives the prune.
-        self.log.commit().await?;
+        self.log = self.log.commit().await?;
 
         // Prune the log. The log will prune at section boundaries, so the actual oldest retained
         // location may be less than requested.
-        if !self.log.prune(*prune_loc).await? {
-            return Ok(());
+        let (log, pruned) = self.log.prune(*prune_loc).await?;
+        self.log = log;
+        if !pruned {
+            return Ok(self);
         }
 
         let bounds = self.log.bounds();
@@ -344,7 +365,7 @@ where
             "pruned inactive ops"
         );
 
-        Ok(())
+        Ok(self)
     }
 
     /// Initializes a new [Db] with the given configuration.
@@ -352,20 +373,22 @@ where
         context: E,
         cfg: Config<T, <Operation<crate::mmr::Family, K, V> as Read>::Cfg>,
     ) -> Result<Self, Error> {
-        let mut log =
+        let log =
             Journal::<E, Operation<crate::mmr::Family, K, V>>::init(context.child("log"), cfg.log)
                 .await?;
 
         // Rewind log to remove uncommitted operations.
-        if log.rewind_to(|op| op.is_commit()).await? == 0 {
+        let (mut log, size) = log.rewind_to(|op| op.is_commit()).await?;
+        if size == 0 {
             warn!("Log is empty, initializing new db");
-            log.append(&Operation::CommitFloor(None, Location::new(0)))
+            (log, _) = log
+                .append(&Operation::CommitFloor(None, Location::new(0)))
                 .await?;
         }
 
         // Sync the log to avoid having to repeat any recovery that may have been performed on next
         // startup.
-        log.sync().await?;
+        let log = log.sync().await?;
 
         let last_commit_loc =
             Location::new(log.size().checked_sub(1).expect("commit should exist"));
@@ -405,8 +428,10 @@ where
     /// Sync all database state to disk. While this isn't necessary to ensure durability of
     /// committed operations, periodic invocation may reduce memory usage and the time required to
     /// recover the database on restart.
-    pub async fn sync(&mut self) -> Result<(), Error> {
-        self.log.sync().await.map_err(Into::into)
+    #[boxed]
+    pub async fn sync(mut self) -> Result<Self, Error> {
+        self.log = self.log.sync().await?;
+        Ok(self)
     }
 
     /// Destroy the db, removing all data from disk.
@@ -415,27 +440,16 @@ where
         self.log.destroy().await.map_err(Into::into)
     }
 
-    #[allow(clippy::type_complexity)]
-    const fn as_floor_helper(
-        &mut self,
-    ) -> FloorHelper<
-        '_,
-        crate::mmr::Family,
-        Index<T, Location>,
-        Journal<E, Operation<crate::mmr::Family, K, V>>,
-    > {
-        FloorHelper {
-            snapshot: &mut self.snapshot,
-            log: &mut self.log,
-        }
-    }
-
     /// Applies a finalized batch to the in-memory database state and appends its operations to the
     /// journal, returning the range of written locations.
     ///
     /// This publishes the batch to the in-memory database state and appends it to the journal, but
     /// does not durably persist it. Call [`Db::commit`] or [`Db::sync`] to guarantee durability.
-    pub async fn apply_batch(&mut self, batch: Changeset<K, V>) -> Result<Range<Location>, Error> {
+    #[boxed]
+    pub async fn apply_batch(
+        mut self,
+        batch: Changeset<K, V>,
+    ) -> Result<(Self, Range<Location>), Error> {
         let start_loc = self.last_commit_loc + 1;
         let (diff, metadata) = batch.into_parts();
 
@@ -457,9 +471,11 @@ where
                 } else {
                     self.active_keys += 1;
                 }
-                self.log
+                let (log, _) = self
+                    .log
                     .append(&Operation::Update(Update(key, value)))
                     .await?;
+                self.log = log;
             } else {
                 let deleted = delete_key::<crate::mmr::Family, _, _>(
                     &mut self.snapshot,
@@ -469,7 +485,7 @@ where
                 )
                 .await?;
                 if deleted.is_some() {
-                    self.log.append(&Operation::Delete(key)).await?;
+                    (self.log, _) = self.log.append(&Operation::Delete(key)).await?;
                     self.steps += 1;
                     self.active_keys -= 1;
                 }
@@ -483,28 +499,39 @@ where
             debug!(tip = ?self.inactivity_floor_loc, "db is empty, raising floor to tip");
         } else {
             let steps_to_take = self.steps + 1;
+            let mut helper = FloorHelper {
+                snapshot: &mut self.snapshot,
+                log: self.log,
+            };
+            let mut inactivity_floor_loc = self.inactivity_floor_loc;
             for _ in 0..steps_to_take {
-                let loc = self.inactivity_floor_loc;
-                self.inactivity_floor_loc = self.as_floor_helper().raise_floor(loc).await?;
+                let (h, floor) = helper.raise_floor(inactivity_floor_loc).await?;
+                helper = h;
+                inactivity_floor_loc = floor;
             }
+            self.log = helper.log;
+            self.inactivity_floor_loc = inactivity_floor_loc;
         }
 
         // Append the commit operation with the new inactivity floor.
-        self.last_commit_loc = Location::new(
-            self.log
-                .append(&Operation::CommitFloor(metadata, self.inactivity_floor_loc))
-                .await?,
-        );
+        let (log, commit_loc) = self
+            .log
+            .append(&Operation::CommitFloor(metadata, self.inactivity_floor_loc))
+            .await?;
+        self.log = log;
+        self.last_commit_loc = Location::new(commit_loc);
 
         self.steps = 0;
 
         let end_loc = self.size();
-        Ok(start_loc..end_loc)
+        Ok((self, start_loc..end_loc))
     }
 
     /// Durably commit the journal state published by prior [`Db::apply_batch`] calls.
-    pub async fn commit(&mut self) -> Result<(), Error> {
-        self.log.commit().await.map_err(Into::into)
+    #[boxed]
+    pub async fn commit(mut self) -> Result<Self, Error> {
+        self.log = self.log.commit().await?;
+        Ok(self)
     }
 }
 
@@ -545,9 +572,9 @@ mod test {
     }
 
     async fn apply_entries(
-        db: &mut TestStore,
+        db: TestStore,
         iter: impl IntoIterator<Item = (Digest, Option<Vec<u8>>)> + Send,
-    ) -> Range<Location> {
+    ) -> (TestStore, Range<Location>) {
         db.apply_batch(iter.into_iter().collect()).await.unwrap()
     }
 
@@ -555,51 +582,54 @@ mod test {
     pub fn test_store_construct_empty() {
         let executor = deterministic::Runner::default();
         executor.start(|mut context| async move {
-            let mut db = create_test_store(context.child("store").with_attribute("index", 0)).await;
+            let db = create_test_store(context.child("store").with_attribute("index", 0)).await;
             assert_eq!(db.bounds().end, 1);
             assert_eq!(db.log.bounds().start, 0);
             assert_eq!(db.inactivity_floor_loc(), 0);
-            assert!(matches!(db.prune(db.inactivity_floor_loc()).await, Ok(())));
+            assert!(db.get_metadata().await.unwrap().is_none());
+            let floor = db.inactivity_floor_loc();
+            let db = db.prune(floor).await.unwrap();
             assert!(matches!(
                 db.prune(Location::new(1)).await,
                 Err(Error::PruneBeyondMinRequired(_, _))
             ));
-            assert!(db.get_metadata().await.unwrap().is_none());
+
+            // The failed prune consumed the db; reopen the partition to continue.
+            let db = create_test_store(context.child("store").with_attribute("index", 3)).await;
 
             // Make sure closing/reopening gets us back to the same state, even after adding an uncommitted op.
             let d1 = Digest::random(&mut context);
             let v1 = vec![1, 2, 3];
-            apply_entries(&mut db, [(d1, Some(v1))]).await;
+            let (db, _) = apply_entries(db, [(d1, Some(v1))]).await;
             drop(db);
 
-            let mut db = create_test_store(context.child("store").with_attribute("index", 1)).await;
+            let db = create_test_store(context.child("store").with_attribute("index", 1)).await;
             assert_eq!(db.bounds().end, 1);
 
             // Test calling commit on an empty db which should make it (durably) non-empty.
             let metadata = vec![1, 2, 3];
             let batch = db.new_batch().finalize(Some(metadata.clone()));
-            let range = db.apply_batch(batch).await.unwrap();
+            let (db, range) = db.apply_batch(batch).await.unwrap();
             assert_eq!(range.start, 1);
             assert_eq!(range.end, 2);
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.bounds().end, 2);
-            assert!(matches!(db.prune(db.inactivity_floor_loc()).await, Ok(())));
+            let floor = db.inactivity_floor_loc();
+            let db = db.prune(floor).await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata.clone()));
 
-            let mut db = create_test_store(context.child("store").with_attribute("index", 2)).await;
+            let db = create_test_store(context.child("store").with_attribute("index", 2)).await;
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata));
 
             // Confirm the inactivity floor doesn't fall endlessly behind with multiple commits on a
             // non-empty db.
-            apply_entries(
-                &mut db,
-                [(Digest::random(&mut context), Some(vec![1, 2, 3]))],
-            )
-            .await;
-            db.commit().await.unwrap();
+            let (db, _) =
+                apply_entries(db, [(Digest::random(&mut context), Some(vec![1, 2, 3]))]).await;
+            let mut db = db.commit().await.unwrap();
             for _ in 1..100 {
-                db.apply_batch(db.new_batch().finalize(None)).await.unwrap();
-                db.commit().await.unwrap();
+                let merkleized = db.new_batch().finalize(None);
+                (db, _) = db.apply_batch(merkleized).await.unwrap();
+                db = db.commit().await.unwrap();
                 // Distance should equal 3 after the second commit, with inactivity_floor
                 // referencing the previous commit operation.
                 assert!(db.bounds().end - db.inactivity_floor_loc <= 3);
@@ -615,7 +645,7 @@ mod test {
         let executor = deterministic::Runner::default();
 
         executor.start(|mut ctx| async move {
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
 
             // Ensure the store is empty
             assert_eq!(db.bounds().end, 1);
@@ -630,7 +660,7 @@ mod test {
 
             // Insert a key-value pair. apply_batch writes the Update, a floor-raise move, and a
             // CommitFloor: 3 new ops on top of the initial commit.
-            apply_entries(&mut db, [(key, Some(value.clone()))]).await;
+            let (db, _) = apply_entries(db, [(key, Some(value.clone()))]).await;
 
             assert_eq!(*db.bounds().end, 4);
             assert_eq!(*db.inactivity_floor_loc, 2);
@@ -643,7 +673,7 @@ mod test {
             drop(db);
 
             // Re-open the store
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
 
             // Ensure the re-opened store removed the uncommitted operations
             assert_eq!(*db.bounds().end, 1);
@@ -652,24 +682,21 @@ mod test {
 
             // Insert a key-value pair and persist with metadata.
             let metadata = vec![99, 100];
-            let range = db
-                .apply_batch(
-                    db.new_batch()
-                        .update(key, value.clone())
-                        .finalize(Some(metadata.clone())),
-                )
-                .await
-                .unwrap();
+            let batch = db
+                .new_batch()
+                .update(key, value.clone())
+                .finalize(Some(metadata.clone()));
+            let (db, range) = db.apply_batch(batch).await.unwrap();
             assert_eq!(*range.start, 1);
             assert_eq!(*range.end, 4);
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata.clone()));
 
             assert_eq!(*db.bounds().end, 4);
             assert_eq!(*db.inactivity_floor_loc, 2);
 
             // Re-open the store
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 2)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 2)).await;
 
             // Ensure the re-opened store retained the committed operations
             assert_eq!(*db.bounds().end, 4);
@@ -682,8 +709,8 @@ mod test {
             // Insert two new k/v pairs to force pruning of the first section.
             let (k1, v1) = (Digest::random(&mut ctx), vec![2, 3, 4, 5, 6]);
             let (k2, v2) = (Digest::random(&mut ctx), vec![6, 7, 8]);
-            apply_entries(&mut db, [(k1, Some(v1.clone()))]).await;
-            apply_entries(&mut db, [(k2, Some(v2.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k1, Some(v1.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k2, Some(v2.clone()))]).await;
 
             assert_eq!(*db.bounds().end, 10);
             assert_eq!(*db.inactivity_floor_loc, 5);
@@ -692,7 +719,7 @@ mod test {
             // the previously committed metadata.
             assert_eq!(db.get_metadata().await.unwrap(), None);
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), None);
 
             // commit() is just an fsync now, so bounds and floor are unchanged.
@@ -707,14 +734,14 @@ mod test {
             // Update existing key with modified value.
             let mut v1_updated = db.get(&k1).await.unwrap().unwrap();
             v1_updated.push(7);
-            apply_entries(&mut db, [(k1, Some(v1_updated))]).await;
-            db.commit().await.unwrap();
+            let (db, _) = apply_entries(db, [(k1, Some(v1_updated))]).await;
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&k1).await.unwrap().unwrap(), vec![2, 3, 4, 5, 6, 7]);
 
             // Create new key.
             let k3 = Digest::random(&mut ctx);
-            apply_entries(&mut db, [(k3, Some(vec![8]))]).await;
-            db.commit().await.unwrap();
+            let (db, _) = apply_entries(db, [(k3, Some(vec![8]))]).await;
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get(&k3).await.unwrap().unwrap(), vec![8]);
 
             // Destroy the store
@@ -734,19 +761,19 @@ mod test {
             let k = Digest::random(&mut ctx);
             for _ in 0..UPDATES {
                 let v = vec![1, 2, 3, 4, 5];
-                apply_entries(&mut db, [(k, Some(v.clone()))]).await;
+                (db, _) = apply_entries(db, [(k, Some(v.clone()))]).await;
             }
 
             let iter = db.snapshot.get(&k);
             assert_eq!(iter.count(), 1);
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Re-open the store, prune it, then ensure it replays the log correctly.
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
-            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            let db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
+            let floor = db.inactivity_floor_loc();
+            let db = db.prune(floor).await.unwrap();
 
             let iter = db.snapshot.get(&k);
             assert_eq!(iter.count(), 1);
@@ -771,7 +798,7 @@ mod test {
         let executor = deterministic::Runner::default();
 
         executor.start(|mut ctx| async move {
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
 
             let (k1, v1) = (Digest::random(&mut ctx), vec![1, 2, 3, 4, 5]);
             let (mut k2, v2) = (Digest::random(&mut ctx), vec![6, 7, 8, 9, 10]);
@@ -779,15 +806,14 @@ mod test {
             // Ensure k2 shares 2 bytes with k1 (test DB uses `TwoCap` translator.)
             k2.0[0..2].copy_from_slice(&k1.0[0..2]);
 
-            apply_entries(&mut db, [(k1, Some(v1.clone()))]).await;
-            apply_entries(&mut db, [(k2, Some(v2.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k1, Some(v1.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k2, Some(v2.clone()))]).await;
 
             assert_eq!(db.get(&k1).await.unwrap().unwrap(), v1);
             assert_eq!(db.get(&k2).await.unwrap().unwrap(), v2);
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             db.sync().await.unwrap();
-            drop(db);
 
             // Re-open the store to ensure it builds the snapshot for the conflicting
             // keys correctly.
@@ -805,13 +831,13 @@ mod test {
         let executor = deterministic::Runner::default();
 
         executor.start(|mut ctx| async move {
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
 
             // Insert a key-value pair
             let k = Digest::random(&mut ctx);
             let v = vec![1, 2, 3, 4, 5];
-            apply_entries(&mut db, [(k, Some(v.clone()))]).await;
-            db.commit().await.unwrap();
+            let (db, _) = apply_entries(db, [(k, Some(v.clone()))]).await;
+            let db = db.commit().await.unwrap();
 
             // Fetch the value
             let fetched_value = db.get(&k).await.unwrap();
@@ -819,7 +845,7 @@ mod test {
 
             // Delete the key
             assert!(db.get(&k).await.unwrap().is_some());
-            apply_entries(&mut db, [(k, None)]).await;
+            let (db, _) = apply_entries(db, [(k, None)]).await;
 
             // Ensure the key is no longer present
             let fetched_value = db.get(&k).await.unwrap();
@@ -830,12 +856,12 @@ mod test {
             db.commit().await.unwrap();
 
             // Re-open the store and ensure the key is still deleted
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
             let fetched_value = db.get(&k).await.unwrap();
             assert!(fetched_value.is_none());
 
             // Re-insert the key
-            apply_entries(&mut db, [(k, Some(v.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k, Some(v.clone()))]).await;
             let fetched_value = db.get(&k).await.unwrap();
             assert_eq!(fetched_value.unwrap(), v);
 
@@ -844,16 +870,16 @@ mod test {
 
             // Re-open the store and ensure the snapshot restores the key, after processing
             // the delete and the subsequent set.
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 2)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 2)).await;
             let fetched_value = db.get(&k).await.unwrap();
             assert_eq!(fetched_value.unwrap(), v);
 
             // Delete a non-existent key (no-op)
             let k_n = Digest::random(&mut ctx);
-            let range = apply_entries(&mut db, [(k_n, None)]).await;
+            let (db, range) = apply_entries(db, [(k_n, None)]).await;
             assert_eq!(range.start, 9);
             assert_eq!(range.end, 11);
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
 
             assert!(db.get(&k_n).await.unwrap().is_none());
             // Make sure k is still there
@@ -869,7 +895,7 @@ mod test {
         let executor = deterministic::Runner::default();
 
         executor.start(|mut ctx| async move {
-            let mut db = create_test_store(ctx.child("store")).await;
+            let db = create_test_store(ctx.child("store")).await;
 
             let k_a = Digest::random(&mut ctx);
             let k_b = Digest::random(&mut ctx);
@@ -878,18 +904,18 @@ mod test {
             let v_b = vec![];
             let v_c = vec![4, 5, 6];
 
-            apply_entries(&mut db, [(k_a, Some(v_a.clone()))]).await;
-            apply_entries(&mut db, [(k_b, Some(v_b.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k_a, Some(v_a.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k_b, Some(v_b.clone()))]).await;
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(*db.bounds().end, 7);
             assert_eq!(*db.inactivity_floor_loc, 3);
             assert_eq!(db.get(&k_a).await.unwrap().unwrap(), v_a);
 
-            apply_entries(&mut db, [(k_b, Some(v_a.clone()))]).await;
-            apply_entries(&mut db, [(k_a, Some(v_c.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k_b, Some(v_a.clone()))]).await;
+            let (db, _) = apply_entries(db, [(k_a, Some(v_c.clone()))]).await;
 
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(*db.bounds().end, 15);
             assert_eq!(*db.inactivity_floor_loc, 12);
             assert_eq!(db.get(&k_a).await.unwrap().unwrap(), v_c);
@@ -913,9 +939,9 @@ mod test {
             for i in 0u64..ELEMENTS {
                 let k = Blake3::hash(&i.to_be_bytes());
                 let v = vec![(i % 255) as u8; ((i % 13) + 7) as usize];
-                apply_entries(&mut db, [(k, Some(v))]).await;
+                (db, _) = apply_entries(db, [(k, Some(v))]).await;
             }
-            db.commit().await.unwrap();
+            let mut db = db.commit().await.unwrap();
             let durable_floor = db.inactivity_floor_loc;
 
             // Apply (but do not commit) entries that advance the in-memory floor past the
@@ -923,13 +949,13 @@ mod test {
             for i in 0u64..ELEMENTS {
                 let k = Blake3::hash(&i.to_be_bytes());
                 let v = vec![((i + 1) % 255) as u8; ((i % 13) + 8) as usize];
-                apply_entries(&mut db, [(k, Some(v))]).await;
+                (db, _) = apply_entries(db, [(k, Some(v))]).await;
             }
             let unsynced_floor = db.inactivity_floor_loc;
             assert!(unsynced_floor > durable_floor);
 
             // Prune to the in-memory floor, then crash before any further commit.
-            db.prune(unsynced_floor).await.unwrap();
+            let db = db.prune(unsynced_floor).await.unwrap();
             let op_count = db.bounds().end;
             drop(db);
 
@@ -968,9 +994,9 @@ mod test {
             for i in 0u64..ELEMENTS {
                 let k = Blake3::hash(&i.to_be_bytes());
                 let v = vec![(i % 255) as u8; ((i % 13) + 7) as usize];
-                apply_entries(&mut db, [(k, Some(v.clone()))]).await;
+                (db, _) = apply_entries(db, [(k, Some(v.clone()))]).await;
             }
-            db.commit().await.unwrap();
+            let mut db = db.commit().await.unwrap();
 
             // Update every 3rd key and commit.
             for i in 0u64..ELEMENTS {
@@ -979,9 +1005,9 @@ mod test {
                 }
                 let k = Blake3::hash(&i.to_be_bytes());
                 let v = vec![((i + 1) % 255) as u8; ((i % 13) + 8) as usize];
-                apply_entries(&mut db, [(k, Some(v.clone()))]).await;
+                (db, _) = apply_entries(db, [(k, Some(v.clone()))]).await;
             }
-            db.commit().await.unwrap();
+            let mut db = db.commit().await.unwrap();
             assert_eq!(db.snapshot.items(), 1000);
 
             // Delete every 7th key and commit.
@@ -990,20 +1016,20 @@ mod test {
                     continue;
                 }
                 let k = Blake3::hash(&i.to_be_bytes());
-                apply_entries(&mut db, [(k, None)]).await;
+                (db, _) = apply_entries(db, [(k, None)]).await;
             }
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             let final_count = db.bounds().end;
             let final_floor = db.inactivity_floor_loc;
 
             // Sync and reopen the store to ensure the state is preserved.
             db.sync().await.unwrap();
-            drop(db);
-            let mut db = create_test_store(context.child("store").with_attribute("index", 2)).await;
+            let db = create_test_store(context.child("store").with_attribute("index", 2)).await;
             assert_eq!(db.bounds().end, final_count);
             assert_eq!(db.inactivity_floor_loc, final_floor);
 
-            db.prune(db.inactivity_floor_loc()).await.unwrap();
+            let floor = db.inactivity_floor_loc();
+            let db = db.prune(floor).await.unwrap();
             assert_eq!(db.log.bounds().start, *final_floor - *final_floor % 7);
             assert_eq!(db.snapshot.items(), 857);
 
@@ -1015,20 +1041,20 @@ mod test {
     pub fn test_store_commit_after_sync_recovers_without_second_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut db = create_test_store(context.child("store").with_attribute("index", 0)).await;
+            let db = create_test_store(context.child("store").with_attribute("index", 0)).await;
             let key0 = Blake3::hash(&0u64.to_be_bytes());
             let key1 = Blake3::hash(&1u64.to_be_bytes());
             let value0 = vec![0, 1, 2];
             let value1 = vec![3, 4, 5, 6];
 
             // Commit and sync an initial update so restart recovery has an older watermark.
-            apply_entries(&mut db, [(key0, Some(value0.clone()))]).await;
-            db.commit().await.unwrap();
-            db.sync().await.unwrap();
+            let (db, _) = apply_entries(db, [(key0, Some(value0.clone()))]).await;
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
 
             // Persist a later commit without syncing; recovery must replay it after reopen.
-            apply_entries(&mut db, [(key1, Some(value1.clone()))]).await;
-            db.commit().await.unwrap();
+            let (db, _) = apply_entries(db, [(key1, Some(value1.clone()))]).await;
+            let db = db.commit().await.unwrap();
             let committed_end = db.bounds().end;
             let committed_floor = db.inactivity_floor_loc();
             drop(db);
@@ -1048,7 +1074,7 @@ mod test {
         let executor = deterministic::Runner::default();
 
         executor.start(|mut ctx| async move {
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 0)).await;
 
             // Ensure the store is empty
             assert_eq!(db.bounds().end, 1);
@@ -1072,11 +1098,11 @@ mod test {
             // Fetch the value
             let fetched_value = batch.get(&key).await.unwrap();
             assert_eq!(fetched_value.unwrap(), value);
-            db.apply_batch(batch.finalize(None)).await.unwrap();
-            drop(db);
+            let changeset = batch.finalize(None);
+            db.apply_batch(changeset).await.unwrap();
 
             // Re-open the store
-            let mut db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
+            let db = create_test_store(ctx.child("store").with_attribute("index", 1)).await;
 
             // Ensure the batch was not applied since we didn't commit.
             assert_eq!(db.bounds().end, 1);
@@ -1085,17 +1111,14 @@ mod test {
 
             // Insert a key-value pair and persist the change.
             let metadata = vec![99, 100];
-            let range = db
-                .apply_batch(
-                    db.new_batch()
-                        .update(key, value.clone())
-                        .finalize(Some(metadata.clone())),
-                )
-                .await
-                .unwrap();
+            let batch = db
+                .new_batch()
+                .update(key, value.clone())
+                .finalize(Some(metadata.clone()));
+            let (db, range) = db.apply_batch(batch).await.unwrap();
             assert_eq!(range.start, 1);
             assert_eq!(range.end, 4);
-            db.commit().await.unwrap();
+            let db = db.commit().await.unwrap();
             assert_eq!(db.get_metadata().await.unwrap(), Some(metadata.clone()));
             drop(db);
 
@@ -1118,28 +1141,34 @@ mod test {
     fn is_send<T: Send>(_: T) {}
 
     #[allow(dead_code)]
-    fn assert_read_futures_are_send(db: &mut TestStore, key: Digest, loc: Location) {
+    fn assert_read_futures_are_send(db: TestStore, key: Digest, loc: Location, which: u8) {
         is_send(db.get(&key));
         is_send(db.get_metadata());
-        is_send(db.prune(loc));
-        is_send(db.sync());
+        match which {
+            0 => is_send(db.prune(loc)),
+            _ => is_send(db.sync()),
+        }
     }
 
     #[allow(dead_code)]
     fn assert_write_futures_are_send(
-        db: &mut Db<deterministic::Context, Digest, Vec<u8>, TwoCap>,
+        db: Db<deterministic::Context, Digest, Vec<u8>, TwoCap>,
         key: Digest,
         value: Vec<u8>,
+        which: u8,
     ) {
         is_send(db.get(&key));
-        is_send(db.apply_batch(Changeset::from([(key, Some(value))])));
-        is_send(db.apply_batch(Changeset::from([(key, None)])));
         let batch = db.new_batch();
         is_send(batch.get(&key));
+        drop(batch);
+        match which {
+            0 => is_send(db.apply_batch(Changeset::from([(key, Some(value))]))),
+            _ => is_send(db.apply_batch(Changeset::from([(key, None)]))),
+        }
     }
 
     #[allow(dead_code)]
-    fn assert_commit_is_send(db: &mut Db<deterministic::Context, Digest, Vec<u8>, TwoCap>) {
+    fn assert_commit_is_send(db: Db<deterministic::Context, Digest, Vec<u8>, TwoCap>) {
         is_send(db.commit());
     }
 }

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -253,17 +253,17 @@ where
     }
 }
 
-/// Resolver-side errors for sync serving.
+/// Resolver-side errors for compact state serving.
 #[derive(Debug, thiserror::Error)]
 pub enum ServeError<F: Family, D: Digest> {
-    /// The source database returned an error while serving.
-    #[error("sync source database error: {0}")]
+    /// The source database returned an error while building compact state.
+    #[error("compact source database error: {0}")]
     Database(#[from] qmdb::Error<F>),
     /// The caller requested a target that compact sync cannot serve.
     #[error("invalid compact target: {0}")]
     InvalidTarget(&'static str),
     /// The resolver wrapper did not currently hold a database.
-    #[error("sync source missing")]
+    #[error("compact source missing")]
     MissingSource,
     /// The caller requested a target different from the source's current witness.
     #[error("stale compact target - requested {requested:?}, current {current:?}")]

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -253,17 +253,17 @@ where
     }
 }
 
-/// Resolver-side errors for compact state serving.
+/// Resolver-side errors for sync serving.
 #[derive(Debug, thiserror::Error)]
 pub enum ServeError<F: Family, D: Digest> {
-    /// The source database returned an error while building compact state.
-    #[error("compact source database error: {0}")]
+    /// The source database returned an error while serving.
+    #[error("sync source database error: {0}")]
     Database(#[from] qmdb::Error<F>),
     /// The caller requested a target that compact sync cannot serve.
     #[error("invalid compact target: {0}")]
     InvalidTarget(&'static str),
     /// The resolver wrapper did not currently hold a database.
-    #[error("compact source missing")]
+    #[error("sync source missing")]
     MissingSource,
     /// The caller requested a target different from the source's current witness.
     #[error("stale compact target - requested {requested:?}, current {current:?}")]
@@ -343,8 +343,8 @@ pub trait Database: Sized + Send {
 
     /// Persist the compact-initialized state once the caller has verified its root.
     fn persist_compact_state(
-        &mut self,
-    ) -> impl Future<Output = Result<(), qmdb::Error<Self::Family>>> + Send;
+        self,
+    ) -> impl Future<Output = Result<Self, qmdb::Error<Self::Family>>> + Send;
 }
 
 /// Configuration for compact synchronization into a compact-storage database.
@@ -531,7 +531,7 @@ where
         // The peer response has already authenticated the final commit and frontier. From here,
         // construction should only fail for local database/storage reasons; a root mismatch is a
         // bug in this path.
-        let mut db = DB::from_validated_state(
+        let db = DB::from_validated_state(
             context.child("compact").with_attribute("attempt", attempt),
             db_config.clone(),
             validated_state,
@@ -547,7 +547,7 @@ where
         if let Some(callback) = callback {
             let _ = callback.send(true);
         }
-        db.persist_compact_state().await?;
+        let db = db.persist_compact_state().await?;
         return Ok(db);
     }
 }
@@ -1155,8 +1155,8 @@ mod tests {
             self.root
         }
 
-        async fn persist_compact_state(&mut self) -> Result<(), qmdb::Error<Self::Family>> {
-            Ok(())
+        async fn persist_compact_state(self) -> Result<Self, qmdb::Error<Self::Family>> {
+            Ok(self)
         }
     }
 

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -40,7 +40,7 @@ impl<J: Clone, S: Strategy> Config for crate::qmdb::keyless::Config<J, S> {
 
 pub trait Database: Sized + Send {
     type Family: Family;
-    type Op: Send;
+    type Op: Send + Sync;
     type Journal: Journal<Self::Family, Context = Self::Context, Op = Self::Op>;
     type Config: Config<JournalConfig = <Self::Journal as Journal<Self::Family>>::Config>;
     type Digest: Digest;

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -406,7 +406,7 @@ where
         mut self,
         new_target: Target<DB::Family, DB::Digest>,
     ) -> Result<Self, Error<DB, R>> {
-        self.journal.resize(new_target.range.start()).await?;
+        self.journal = self.journal.resize(new_target.range.start()).await?;
         // Remove requests at or before the new start. The request at start
         // must be re-issued as a pinned-nodes request with the new target size.
         self.outstanding_requests
@@ -509,7 +509,7 @@ where
     /// This method finds operations that are contiguous with the current journal tip
     /// and applies them in order. It removes stale batches and handles partial
     /// application of batches when needed.
-    pub(crate) async fn apply_operations(&mut self) -> Result<(), Error<DB, R>> {
+    pub(crate) async fn apply_operations(mut self) -> Result<Self, Error<DB, R>> {
         let mut next_loc = self.journal.size();
 
         // Remove any batches of operations with stale data.
@@ -543,28 +543,17 @@ where
             };
 
             // Remove the batch of operations that contains the next operation to apply.
-            let operations = self.fetched_operations.remove(&range_start_loc).unwrap();
+            let mut operations = self.fetched_operations.remove(&range_start_loc).unwrap();
             assert!(!operations.is_empty());
-            // Skip operations that are before the next location.
-            let skip_count = (next_loc - *range_start_loc) as usize;
-            let operations_count = operations.len() - skip_count;
-            let remaining_operations = operations.into_iter().skip(skip_count);
-            next_loc += operations_count as u64;
-            self.apply_operations_batch(remaining_operations).await?;
+            // Skip operations that are before the next location. The containment check when
+            // selecting the range (`next_loc <= range_end`) guarantees at least one operation
+            // at or after it, so the batch is never empty.
+            let operations = operations.split_off((next_loc - *range_start_loc) as usize);
+            next_loc += operations.len() as u64;
+            self.journal = self.journal.append(&operations).await?;
         }
 
-        Ok(())
-    }
-
-    /// Apply a batch of operations to the journal
-    async fn apply_operations_batch<I>(&mut self, operations: I) -> Result<(), Error<DB, R>>
-    where
-        I: IntoIterator<Item = DB::Op>,
-    {
-        for op in operations {
-            self.journal.append(op).await?;
-        }
-        Ok(())
+        Ok(self)
     }
 
     /// Check if sync is complete based on the current journal size and target
@@ -726,9 +715,9 @@ where
             Event::BatchReceived(fetch_result) => {
                 self.handle_fetch_result(fetch_result)?;
                 self.schedule_requests()?;
-                self.apply_operations().await?;
-                self.record_progress();
-                Ok(NextStep::Continue(self))
+                let mut engine = self.apply_operations().await?;
+                engine.record_progress();
+                Ok(NextStep::Continue(engine))
             }
         }
     }
@@ -762,7 +751,7 @@ where
                 return self.handle_event(event).await;
             }
 
-            self.journal.sync().await?;
+            self.journal = self.journal.sync().await?;
 
             // Build the database from the completed sync
             let database = DB::from_sync_result(
@@ -864,22 +853,22 @@ mod tests {
             Ok(Self { size })
         }
 
-        async fn resize(&mut self, start: Location<MmrFamily>) -> Result<(), Self::Error> {
+        async fn resize(mut self, start: Location<MmrFamily>) -> Result<Self, Self::Error> {
             self.size = *start;
-            Ok(())
+            Ok(self)
         }
 
-        async fn sync(&mut self) -> Result<(), Self::Error> {
-            Ok(())
+        async fn sync(self) -> Result<Self, Self::Error> {
+            Ok(self)
         }
 
         fn size(&self) -> u64 {
             self.size
         }
 
-        async fn append(&mut self, _op: Self::Op) -> Result<(), Self::Error> {
-            self.size += 1;
-            Ok(())
+        async fn append(mut self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
+            self.size += ops.len() as u64;
+            Ok(self)
         }
     }
 

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -543,14 +543,14 @@ where
             };
 
             // Remove the batch of operations that contains the next operation to apply.
-            let mut operations = self.fetched_operations.remove(&range_start_loc).unwrap();
+            let operations = self.fetched_operations.remove(&range_start_loc).unwrap();
             assert!(!operations.is_empty());
             // Skip operations that are before the next location. The containment check when
             // selecting the range (`next_loc <= range_end`) guarantees at least one operation
             // at or after it, so the batch is never empty.
-            let operations = operations.split_off((next_loc - *range_start_loc) as usize);
+            let operations = &operations[(next_loc - *range_start_loc) as usize..];
             next_loc += operations.len() as u64;
-            self.journal = self.journal.append(&operations).await?;
+            self.journal = self.journal.append(operations).await?;
         }
 
         Ok(self)

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -194,7 +194,8 @@ mod tests {
             let journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 9)
                 .await
                 .unwrap();
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Simulate clear_to_size(7) crash: blobs cleared, section 1 recreated
             // empty, but metadata still says pruning_boundary=9.
@@ -233,7 +234,8 @@ mod tests {
             let journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 30)
                 .await
                 .unwrap();
-            journal.sync().await.unwrap();
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
 
             // Open via Journal::new with a range whose end < 30. Without the fix this would
             // return ItemOutOfRange because size(30) > range.end(20).

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -1,5 +1,5 @@
 use crate::{
-    journal::contiguous::Contiguous,
+    journal::contiguous::{Contiguous, Many},
     merkle::{Family, Location},
 };
 use commonware_utils::range::NonEmptyRange;
@@ -14,7 +14,7 @@ pub trait Journal<F: Family>: Sized + Send {
     type Config: Sync;
 
     /// The type of operations in the journal
-    type Op: Send;
+    type Op: Send + Sync;
 
     /// The error type returned by the journal
     type Error: std::error::Error + Send + 'static + Into<crate::qmdb::Error<F>>;
@@ -35,19 +35,16 @@ pub trait Journal<F: Family>: Sized + Send {
     ///
     /// If current `size() <= start`, initialize as empty at the given location.
     /// Otherwise prune data before the given location.
-    fn resize(
-        &mut self,
-        start: Location<F>,
-    ) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn resize(self, start: Location<F>) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Persist the journal.
-    fn sync(&mut self) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    fn sync(self) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Get the number of operations in the journal
     fn size(&self) -> u64;
 
-    /// Append an operation to the journal
-    fn append(&mut self, op: Self::Op) -> impl Future<Output = Result<(), Self::Error>> + Send;
+    /// Append a non-empty batch of operations.
+    fn append(self, ops: &[Self::Op]) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 }
 
 impl<F, E, V> Journal<F> for crate::journal::contiguous::variable::Journal<E, V>
@@ -69,15 +66,17 @@ where
         Self::init_sync(context, config.clone(), *range.start()..*range.end()).await
     }
 
-    async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
-        if Contiguous::bounds(self).end <= *start {
-            self.clear_to_size(*start).await
+    async fn resize(mut self, start: Location<F>) -> Result<Self, Self::Error> {
+        if Contiguous::bounds(&self).end <= *start {
+            self.clear_to_size(*start).await?;
+            Ok(self)
         } else {
-            self.prune(*start).await.map(|_| ())
+            let (journal, _) = self.prune(*start).await?;
+            Ok(journal)
         }
     }
 
-    async fn sync(&mut self) -> Result<(), Self::Error> {
+    async fn sync(self) -> Result<Self, Self::Error> {
         Self::sync(self).await
     }
 
@@ -85,8 +84,9 @@ where
         Contiguous::bounds(self).end
     }
 
-    async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {
-        Self::append(self, &op).await.map(|_| ())
+    async fn append(self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
+        let (journal, _) = self.append_many(Many::Flat(ops)).await?;
+        Ok(journal)
     }
 }
 
@@ -130,21 +130,23 @@ where
         if size <= *range.start() {
             journal.clear_to_size(*range.start()).await?;
         } else {
-            journal.prune(*range.start()).await?;
+            (journal, _) = journal.prune(*range.start()).await?;
         }
 
         Ok(journal)
     }
 
-    async fn resize(&mut self, start: Location<F>) -> Result<(), Self::Error> {
-        if Contiguous::bounds(self).end <= *start {
-            self.clear_to_size(*start).await
+    async fn resize(mut self, start: Location<F>) -> Result<Self, Self::Error> {
+        if Contiguous::bounds(&self).end <= *start {
+            self.clear_to_size(*start).await?;
+            Ok(self)
         } else {
-            self.prune(*start).await.map(|_| ())
+            let (journal, _) = self.prune(*start).await?;
+            Ok(journal)
         }
     }
 
-    async fn sync(&mut self) -> Result<(), Self::Error> {
+    async fn sync(self) -> Result<Self, Self::Error> {
         Self::sync(self).await
     }
 
@@ -152,8 +154,9 @@ where
         Contiguous::bounds(self).end
     }
 
-    async fn append(&mut self, op: Self::Op) -> Result<(), Self::Error> {
-        Self::append(self, &op).await.map(|_| ())
+    async fn append(self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
+        let (journal, _) = self.append_many(Many::Flat(ops)).await?;
+        Ok(journal)
     }
 }
 
@@ -188,11 +191,10 @@ mod tests {
             let cfg = test_cfg(&context);
 
             // Create a journal at pruning_boundary=9 (mid-section in section 1).
-            let mut journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 9)
+            let journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 9)
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Simulate clear_to_size(7) crash: blobs cleared, section 1 recreated
             // empty, but metadata still says pruning_boundary=9.
@@ -228,11 +230,10 @@ mod tests {
             let cfg = test_cfg(&context);
 
             // Create a journal at pruning_boundary=30, well beyond our intended range end.
-            let mut journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 30)
+            let journal = FixedJournal::init_at_size(context.child("setup"), cfg.clone(), 30)
                 .await
                 .unwrap();
             journal.sync().await.unwrap();
-            drop(journal);
 
             // Open via Journal::new with a range whose end < 30. Without the fix this would
             // return ItemOutOfRange because size(30) > range.end(20).

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -23,6 +23,7 @@ use crate::{
             variable::{Db as KeylessVariableDb, Operation as KeylessVariableOp},
         },
         operation::Key,
+        sync::compact::ServeError,
     },
     translator::Translator,
 };
@@ -320,7 +321,7 @@ macro_rules! impl_resolver {
             type Family = F;
             type Digest = H::Digest;
             type Op = $op<F, K, V>;
-            type Error = qmdb::Error<F>;
+            type Error = ServeError<F, H::Digest>;
 
             async fn get_operations(
                 &self,
@@ -331,8 +332,8 @@ macro_rules! impl_resolver {
                 _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
-                let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
-                fetch_operations(
+                let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
+                Ok(fetch_operations(
                     op_count,
                     start_loc,
                     max_ops,
@@ -342,7 +343,7 @@ macro_rules! impl_resolver {
                     },
                     |start_loc| db.pinned_nodes_at(start_loc),
                 )
-                .await
+                .await?)
             }
         }
     };
@@ -460,7 +461,7 @@ macro_rules! impl_resolver_immutable {
             type Family = F;
             type Digest = H::Digest;
             type Op = $op<F, K, V>;
-            type Error = qmdb::Error<F>;
+            type Error = ServeError<F, H::Digest>;
 
             async fn get_operations(
                 &self,
@@ -471,8 +472,8 @@ macro_rules! impl_resolver_immutable {
                 _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
-                let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
-                fetch_operations(
+                let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
+                Ok(fetch_operations(
                     op_count,
                     start_loc,
                     max_ops,
@@ -482,7 +483,7 @@ macro_rules! impl_resolver_immutable {
                     },
                     |start_loc| db.pinned_nodes_at(start_loc),
                 )
-                .await
+                .await?)
             }
         }
     };
@@ -583,7 +584,7 @@ macro_rules! impl_resolver_keyless {
             type Family = F;
             type Digest = H::Digest;
             type Op = $op<F, V>;
-            type Error = qmdb::Error<F>;
+            type Error = ServeError<F, H::Digest>;
 
             async fn get_operations(
                 &self,
@@ -594,8 +595,8 @@ macro_rules! impl_resolver_keyless {
                 _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
-                let db = guard.as_ref().ok_or(qmdb::Error::KeyNotFound)?;
-                fetch_operations(
+                let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
+                Ok(fetch_operations(
                     op_count,
                     start_loc,
                     max_ops,
@@ -605,7 +606,7 @@ macro_rules! impl_resolver_keyless {
                     },
                     |start_loc| db.pinned_nodes_at(start_loc),
                 )
-                .await
+                .await?)
             }
         }
     };

--- a/storage/src/queue/conformance.rs
+++ b/storage/src/queue/conformance.rs
@@ -51,7 +51,7 @@ impl StorageWorkload for QueueWorkload {
             context.fill(item.as_mut_slice());
         }
         for item in &data {
-            queue.enqueue(item.clone()).await?;
+            (queue, _) = queue.enqueue(item.clone()).await?;
         }
 
         let dequeue_count = items_count / 2;
@@ -61,7 +61,6 @@ impl StorageWorkload for QueueWorkload {
         }
 
         queue.sync().await?;
-        drop(queue);
 
         let mut queue = Queue::<_, Vec<u8>>::init(
             context.child("queue").with_attribute("index", 1),
@@ -72,7 +71,8 @@ impl StorageWorkload for QueueWorkload {
             assert_eq!(item, data[pos as usize]);
             queue.ack(pos)?;
         }
-        queue.sync().await
+        queue.sync().await?;
+        Ok(())
     }
 }
 

--- a/storage/src/queue/mod.rs
+++ b/storage/src/queue/mod.rs
@@ -5,6 +5,15 @@
 //! explicitly acknowledge each item after processing. On restart, all non-pruned
 //! items are re-delivered (acknowledged or not).
 //!
+//! # Ownership
+//!
+//! Methods that write to storage (`append`, `enqueue`, `commit`, `sync`) take the queue by
+//! value and return it on success. If one returns an error, or its future is dropped before
+//! it finishes, the queue is gone: state that was not yet durable is discarded, but
+//! everything already on disk stays recoverable. Reads and
+//! in-memory bookkeeping (`dequeue`, `ack`, `ack_up_to`, `reset`) borrow the queue; a failed
+//! `dequeue` read does not invalidate it.
+//!
 //! # Concurrent Access
 //!
 //! For concurrent access from separate writer and reader tasks, use the [shared] module.
@@ -60,8 +69,8 @@
 //!     }).await.unwrap();
 //!
 //!     // Enqueue items
-//!     queue.enqueue(b"task1".to_vec()).await.unwrap();
-//!     queue.enqueue(b"task2".to_vec()).await.unwrap();
+//!     (queue, _) = queue.enqueue(b"task1".to_vec()).await.unwrap();
+//!     (queue, _) = queue.enqueue(b"task2".to_vec()).await.unwrap();
 //!
 //!     // Dequeue and process items (can be done out of order)
 //!     while let Some((position, item)) = queue.dequeue().await.unwrap() {
@@ -91,4 +100,8 @@ pub enum Error {
     Journal(#[from] crate::journal::Error),
     #[error("position out of range: {0} (queue size is {1})")]
     PositionOutOfRange(u64, u64),
+    #[error(
+        "queue is no longer usable: a previous operation failed or was interrupted; reopen it to recover"
+    )]
+    Unavailable,
 }

--- a/storage/src/queue/shared.rs
+++ b/storage/src/queue/shared.rs
@@ -9,16 +9,50 @@
 use super::{Config, Error, Queue};
 use crate::Context;
 use commonware_codec::CodecShared;
-use commonware_utils::{channel::mpsc, sync::AsyncMutex};
+use commonware_utils::{
+    channel::mpsc,
+    sync::{AsyncMutex, AsyncMutexGuard},
+};
 use std::{ops::Range, sync::Arc};
 use tracing::debug;
+
+/// The shared queue cell.
+///
+/// Queue mutations take the queue by value, so shared handles keep it in an `Option`:
+/// taken out for each mutation and put back on success. If a mutation fails or its future
+/// is dropped mid-flight, the cell is left empty and every later call returns
+/// [Error::Unavailable]; reopen the queue to recover.
+type Cell<E, V> = Arc<AsyncMutex<Option<Queue<E, V>>>>;
+
+/// Take the queue out of a locked cell, or report it lost.
+fn take<E: Context, V: CodecShared>(
+    guard: &mut AsyncMutexGuard<'_, Option<Queue<E, V>>>,
+) -> Result<Queue<E, V>, Error> {
+    guard.take().ok_or(Error::Unavailable)
+}
+
+/// Borrow the queue in a locked cell, or report it lost.
+fn peek<'a, E: Context, V: CodecShared>(
+    guard: &'a AsyncMutexGuard<'_, Option<Queue<E, V>>>,
+) -> Result<&'a Queue<E, V>, Error> {
+    guard.as_ref().ok_or(Error::Unavailable)
+}
+
+/// Mutably borrow the queue in a locked cell, or report it lost.
+fn peek_mut<'a, E: Context, V: CodecShared>(
+    guard: &'a mut AsyncMutexGuard<'_, Option<Queue<E, V>>>,
+) -> Result<&'a mut Queue<E, V>, Error> {
+    guard.as_mut().ok_or(Error::Unavailable)
+}
 
 /// Writer handle for enqueueing items.
 ///
 /// This handle can be cloned to allow multiple tasks to enqueue items concurrently.
-/// All clones share the same underlying queue and notification channel.
+/// All clones share the same underlying queue and notification channel. Any method
+/// returns [Error::Unavailable] if an earlier mutation failed or was interrupted;
+/// reopen the queue to recover.
 pub struct Writer<E: Context, V: CodecShared> {
-    queue: Arc<AsyncMutex<Queue<E, V>>>,
+    queue: Cell<E, V>,
     notify: mpsc::Sender<()>,
 }
 
@@ -39,7 +73,10 @@ impl<E: Context, V: CodecShared> Writer<E, V> {
     ///
     /// Returns an error if the underlying storage operation fails.
     pub async fn enqueue(&self, item: V) -> Result<u64, Error> {
-        let pos = self.queue.lock().await.enqueue(item).await?;
+        let mut guard = self.queue.lock().await;
+        let (queue, pos) = take(&mut guard)?.enqueue(item).await?;
+        *guard = Some(queue);
+        drop(guard);
 
         // Fire-and-forget so the writer never blocks on reader wake-up.
         // The reader always checks the queue under lock, so a missed
@@ -61,16 +98,18 @@ impl<E: Context, V: CodecShared> Writer<E, V> {
         &self,
         items: impl IntoIterator<Item = V>,
     ) -> Result<Range<u64>, Error> {
-        let mut queue = self.queue.lock().await;
+        let mut guard = self.queue.lock().await;
+        let mut queue = take(&mut guard)?;
         let start = queue.size();
         for item in items {
-            queue.append(item).await?;
+            (queue, _) = queue.append(item).await?;
         }
         let end = queue.size();
         if end > start {
-            queue.commit().await?;
+            queue = queue.commit().await?;
         }
-        drop(queue);
+        *guard = Some(queue);
+        drop(guard);
 
         if start < end {
             let _ = self.notify.try_send(());
@@ -87,7 +126,10 @@ impl<E: Context, V: CodecShared> Writer<E, V> {
     ///
     /// Returns an error if the underlying storage operation fails.
     pub async fn append(&self, item: V) -> Result<u64, Error> {
-        let pos = self.queue.lock().await.append(item).await?;
+        let mut guard = self.queue.lock().await;
+        let (queue, pos) = take(&mut guard)?.append(item).await?;
+        *guard = Some(queue);
+        drop(guard);
         let _ = self.notify.try_send(());
         debug!(position = pos, "writer: appended item");
         Ok(pos)
@@ -95,25 +137,33 @@ impl<E: Context, V: CodecShared> Writer<E, V> {
 
     /// See [Queue::commit](super::Queue::commit).
     pub async fn commit(&self) -> Result<(), Error> {
-        self.queue.lock().await.commit().await
+        let mut guard = self.queue.lock().await;
+        let queue = take(&mut guard)?.commit().await?;
+        *guard = Some(queue);
+        Ok(())
     }
 
     /// See [Queue::sync](super::Queue::sync).
     pub async fn sync(&self) -> Result<(), Error> {
-        self.queue.lock().await.sync().await
+        let mut guard = self.queue.lock().await;
+        let queue = take(&mut guard)?.sync().await?;
+        *guard = Some(queue);
+        Ok(())
     }
 
     /// Returns the total number of items that have been enqueued.
-    pub async fn size(&self) -> u64 {
-        self.queue.lock().await.size()
+    pub async fn size(&self) -> Result<u64, Error> {
+        Ok(peek(&self.queue.lock().await)?.size())
     }
 }
 
 /// Reader handle for dequeuing and acknowledging items.
 ///
-/// There should only be one reader per shared queue.
+/// There should only be one reader per shared queue. Any method returns
+/// [Error::Unavailable] if an earlier mutation failed or was interrupted; reopen the
+/// queue to recover.
 pub struct Reader<E: Context, V: CodecShared> {
-    queue: Arc<AsyncMutex<Queue<E, V>>>,
+    queue: Cell<E, V>,
     notify: mpsc::Receiver<()>,
 }
 
@@ -131,7 +181,7 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
     pub async fn recv(&mut self) -> Result<Option<(u64, V)>, Error> {
         loop {
             // Try to dequeue an item
-            if let Some(item) = self.queue.lock().await.dequeue().await? {
+            if let Some(item) = self.dequeue().await? {
                 return Ok(Some(item));
             }
 
@@ -139,7 +189,7 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
             // Returns None if writer is dropped
             if self.notify.recv().await.is_none() {
                 // Writer dropped, drain any remaining items
-                return self.queue.lock().await.dequeue().await;
+                return self.dequeue().await;
             }
         }
     }
@@ -155,7 +205,12 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
         // Drain pending notification (capacity is 1, so at most 1 buffered).
         let _ = self.notify.try_recv();
 
-        self.queue.lock().await.dequeue().await
+        self.dequeue().await
+    }
+
+    /// Dequeue through the shared cell.
+    async fn dequeue(&self) -> Result<Option<(u64, V)>, Error> {
+        peek_mut(&mut self.queue.lock().await)?.dequeue().await
     }
 
     /// See [Queue::ack].
@@ -164,7 +219,7 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
     ///
     /// Returns [super::Error::PositionOutOfRange] if the position is invalid.
     pub async fn ack(&self, position: u64) -> Result<(), Error> {
-        self.queue.lock().await.ack(position)
+        peek_mut(&mut self.queue.lock().await)?.ack(position)
     }
 
     /// See [Queue::ack_up_to].
@@ -173,27 +228,28 @@ impl<E: Context, V: CodecShared> Reader<E, V> {
     ///
     /// Returns [super::Error::PositionOutOfRange] if `up_to` is invalid.
     pub async fn ack_up_to(&self, up_to: u64) -> Result<(), Error> {
-        self.queue.lock().await.ack_up_to(up_to)
+        peek_mut(&mut self.queue.lock().await)?.ack_up_to(up_to)
     }
 
     /// See [Queue::ack_floor].
-    pub async fn ack_floor(&self) -> u64 {
-        self.queue.lock().await.ack_floor()
+    pub async fn ack_floor(&self) -> Result<u64, Error> {
+        Ok(peek(&self.queue.lock().await)?.ack_floor())
     }
 
     /// See [Queue::read_position].
-    pub async fn read_position(&self) -> u64 {
-        self.queue.lock().await.read_position()
+    pub async fn read_position(&self) -> Result<u64, Error> {
+        Ok(peek(&self.queue.lock().await)?.read_position())
     }
 
     /// See [Queue::is_empty].
-    pub async fn is_empty(&self) -> bool {
-        self.queue.lock().await.is_empty()
+    pub async fn is_empty(&self) -> Result<bool, Error> {
+        Ok(peek(&self.queue.lock().await)?.is_empty())
     }
 
     /// See [Queue::reset].
-    pub async fn reset(&self) {
-        self.queue.lock().await.reset();
+    pub async fn reset(&self) -> Result<(), Error> {
+        peek_mut(&mut self.queue.lock().await)?.reset();
+        Ok(())
     }
 }
 
@@ -225,7 +281,7 @@ pub async fn init<E: Context, V: CodecShared>(
     context: E,
     cfg: Config<V::Cfg>,
 ) -> Result<(Writer<E, V>, Reader<E, V>), Error> {
-    let queue = Arc::new(AsyncMutex::new(Queue::init(context, cfg).await?));
+    let queue = Arc::new(AsyncMutex::new(Some(Queue::init(context, cfg).await?)));
     let (notify_tx, notify_rx) = mpsc::channel(1);
 
     let writer = Writer {
@@ -285,7 +341,7 @@ mod tests {
 
             // Ack the item
             reader.ack(recv_pos).await.unwrap();
-            assert!(reader.is_empty().await);
+            assert!(reader.is_empty().await.unwrap());
         });
     }
 
@@ -319,7 +375,7 @@ mod tests {
             }
 
             reader.ack(0).await.unwrap();
-            assert!(reader.is_empty().await);
+            assert!(reader.is_empty().await.unwrap());
         });
     }
 
@@ -342,7 +398,7 @@ mod tests {
                 assert_eq!(item, vec![i as u8]);
                 reader.ack(pos).await.unwrap();
             }
-            assert!(reader.is_empty().await);
+            assert!(reader.is_empty().await.unwrap());
         });
     }
 

--- a/storage/src/queue/storage.rs
+++ b/storage/src/queue/storage.rs
@@ -157,11 +157,12 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
     /// # Errors
     ///
     /// Returns an error if the underlying storage operation fails.
-    pub async fn append(&mut self, item: V) -> Result<u64, Error> {
-        let pos = self.journal.append(&item).await?;
+    pub async fn append(mut self, item: V) -> Result<(Self, u64), Error> {
+        let pos;
+        (self.journal, pos) = self.journal.append(&item).await?;
         let _ = self.metrics.tip.try_set(pos + 1);
         debug!(pos, "appended item");
-        Ok(pos)
+        Ok((self, pos))
     }
 
     /// Append and commit an item in one step, returning its position.
@@ -170,10 +171,10 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
     /// # Errors
     ///
     /// Returns an error if the underlying storage operation fails.
-    pub async fn enqueue(&mut self, item: V) -> Result<u64, Error> {
-        let pos = self.append(item).await?;
-        self.commit().await?;
-        Ok(pos)
+    pub async fn enqueue(self, item: V) -> Result<(Self, u64), Error> {
+        let (queue, pos) = self.append(item).await?;
+        let queue = queue.commit().await?;
+        Ok((queue, pos))
     }
 
     /// Dequeue the next unacknowledged item, returning its position and value.
@@ -302,12 +303,12 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
     ///
     /// This count is not affected by pruning. It represents the position that the
     /// next enqueued item will receive.
-    pub const fn size(&self) -> u64 {
+    pub fn size(&self) -> u64 {
         self.journal.size()
     }
 
     /// Returns whether all enqueued items have been acknowledged.
-    pub const fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         // If acked_above is non-empty, there's a gap at ack_floor (otherwise floor
         // would have advanced). So all items acked implies ack_floor == size.
         self.ack_floor >= self.journal.size()
@@ -328,7 +329,7 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
 
     /// Returns the number of items not yet read (test-only).
     #[cfg(test)]
-    pub(crate) const fn pending(&self) -> u64 {
+    fn pending(&self) -> u64 {
         self.journal.size().saturating_sub(self.read_pos)
     }
 
@@ -336,26 +337,35 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
     ///
     /// This does not persist acknowledgements. For a stronger guarantee that eliminates potential
     /// recovery and prunes acknowledged items, use [Self::sync] instead.
-    pub async fn commit(&mut self) -> Result<(), Error> {
-        self.journal.commit().await?;
-        Ok(())
+    pub async fn commit(mut self) -> Result<Self, Error> {
+        self.journal = self.journal.commit().await?;
+        Ok(self)
     }
 
     /// Durably persist the queue, guaranteeing the current state will survive a crash, and that
     /// no recovery will be needed on startup.
     ///
     /// This also prunes acknowledged items.
-    pub async fn sync(&mut self) -> Result<(), Error> {
-        self.journal.sync().await?;
-        self.journal.prune(self.ack_floor).await?;
-        Ok(())
+    pub async fn sync(mut self) -> Result<Self, Error> {
+        self.journal = self.journal.sync().await?;
+        (self.journal, _) = self.journal.prune(self.ack_floor).await?;
+        Ok(self)
     }
 
-    /// Destroy the queue, removing all data from disk.
+    /// See [Queue::destroy].
     #[boxed]
     pub async fn destroy(self) -> Result<(), Error> {
         self.journal.destroy().await?;
         Ok(())
+    }
+}
+
+impl<E: Context, V: CodecShared> std::fmt::Debug for Queue<E, V> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Queue")
+            .field("size", &self.size())
+            .field("ack_floor", &self.ack_floor())
+            .finish_non_exhaustive()
     }
 }
 
@@ -407,9 +417,12 @@ mod tests {
             assert_eq!(queue.size(), 0);
 
             // Enqueue items
-            let pos0 = queue.enqueue(b"item0".to_vec()).await.unwrap();
-            let pos1 = queue.enqueue(b"item1".to_vec()).await.unwrap();
-            let pos2 = queue.enqueue(b"item2".to_vec()).await.unwrap();
+            let pos0;
+            (queue, pos0) = queue.enqueue(b"item0".to_vec()).await.unwrap();
+            let pos1;
+            (queue, pos1) = queue.enqueue(b"item1".to_vec()).await.unwrap();
+            let pos2;
+            (queue, pos2) = queue.enqueue(b"item2".to_vec()).await.unwrap();
 
             assert_eq!(pos0, 0);
             assert_eq!(pos1, 1);
@@ -451,9 +464,9 @@ mod tests {
 
             // Append multiple items, then commit once
             for i in 0..5u8 {
-                queue.append(vec![i]).await.unwrap();
+                (queue, _) = queue.append(vec![i]).await.unwrap();
             }
-            queue.commit().await.unwrap();
+            let mut queue = queue.commit().await.unwrap();
             assert_eq!(queue.size(), 5);
 
             // Dequeue and verify order
@@ -465,10 +478,10 @@ mod tests {
 
             // Mix batch and single enqueue
             for i in 5..8u8 {
-                queue.append(vec![i]).await.unwrap();
+                (queue, _) = queue.append(vec![i]).await.unwrap();
             }
-            queue.commit().await.unwrap();
-            queue.enqueue(vec![8]).await.unwrap();
+            let queue = queue.commit().await.unwrap();
+            let (mut queue, _) = queue.enqueue(vec![8]).await.unwrap();
             assert_eq!(queue.size(), 9);
 
             queue.ack_up_to(9).unwrap();
@@ -487,9 +500,9 @@ mod tests {
                     .await
                     .unwrap();
                 for i in 0..4u8 {
-                    queue.append(vec![i]).await.unwrap();
+                    (queue, _) = queue.append(vec![i]).await.unwrap();
                 }
-                queue.commit().await.unwrap();
+                let queue = queue.commit().await.unwrap();
                 queue.sync().await.unwrap();
             }
 
@@ -519,13 +532,13 @@ mod tests {
                     .unwrap();
 
                 // Establish a synced baseline so the recovery watermark is behind the next commit.
-                queue.append(b"synced".to_vec()).await.unwrap();
-                queue.commit().await.unwrap();
-                queue.sync().await.unwrap();
+                (queue, _) = queue.append(b"synced".to_vec()).await.unwrap();
+                queue = queue.commit().await.unwrap();
+                queue = queue.sync().await.unwrap();
 
                 // Commit later data without syncing; reopen must replay it from the old watermark.
-                queue.append(b"committed-a".to_vec()).await.unwrap();
-                queue.append(b"committed-b".to_vec()).await.unwrap();
+                (queue, _) = queue.append(b"committed-a".to_vec()).await.unwrap();
+                (queue, _) = queue.append(b"committed-b".to_vec()).await.unwrap();
                 queue.commit().await.unwrap();
             }
 
@@ -558,7 +571,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..5u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Dequeue and ack sequentially
@@ -586,7 +599,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..5u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Dequeue all
@@ -627,7 +640,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Batch ack items 0-4
@@ -660,7 +673,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Ack some items out of order first
@@ -691,7 +704,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Ack items 5, 6, 7 first
@@ -715,8 +728,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            queue.enqueue(b"item0".to_vec()).await.unwrap();
-            queue.enqueue(b"item1".to_vec()).await.unwrap();
+            (queue, _) = queue.enqueue(b"item0".to_vec()).await.unwrap();
+            let (mut queue, _) = queue.enqueue(b"item1".to_vec()).await.unwrap();
 
             // Can't ack_up_to beyond queue size
             let err = queue.ack_up_to(5).unwrap_err();
@@ -743,7 +756,7 @@ mod tests {
 
             // Enqueue items 0-4
             for i in 0..5u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Ack items 1 and 3 before reading
@@ -776,8 +789,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            queue.enqueue(b"item0".to_vec()).await.unwrap();
-            queue.enqueue(b"item1".to_vec()).await.unwrap();
+            (queue, _) = queue.enqueue(b"item0".to_vec()).await.unwrap();
+            let (mut queue, _) = queue.enqueue(b"item1".to_vec()).await.unwrap();
 
             // Can't ack position beyond queue size
             let err = queue.ack(5).unwrap_err();
@@ -803,9 +816,9 @@ mod tests {
 
             // Enqueue items (more than items_per_section to test pruning)
             for i in 0..25u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
-            queue.sync().await.unwrap();
+            let mut queue = queue.sync().await.unwrap();
 
             // Read and ack some items
             for i in 0..15 {
@@ -832,9 +845,9 @@ mod tests {
 
             // Enqueue many items across multiple sections (items_per_section = 10)
             for i in 0..50u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
-            queue.sync().await.unwrap();
+            let mut queue = queue.sync().await.unwrap();
 
             // First batch: ack items 0-14
             for i in 0..15 {
@@ -889,7 +902,7 @@ mod tests {
                     .unwrap();
 
                 for i in 0..5u8 {
-                    queue.enqueue(vec![i]).await.unwrap();
+                    (queue, _) = queue.enqueue(vec![i]).await.unwrap();
                 }
 
                 // Ack items 0, 1, 2 - but items_per_section=10, so no pruning
@@ -934,7 +947,7 @@ mod tests {
 
                 // Enqueue items across multiple sections (items_per_section = 10)
                 for i in 0..25u8 {
-                    queue.enqueue(vec![i]).await.unwrap();
+                    (queue, _) = queue.enqueue(vec![i]).await.unwrap();
                 }
 
                 // Ack items 0-14 to advance floor past section 0
@@ -944,7 +957,7 @@ mod tests {
                 assert_eq!(queue.ack_floor(), 15);
 
                 // Sync triggers pruning
-                queue.sync().await.unwrap();
+                queue = queue.sync().await.unwrap();
 
                 // Verify pruning occurred
                 let pruning_boundary = queue.journal.bounds().start;
@@ -987,7 +1000,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..5u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Read some
@@ -1018,7 +1031,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Read and ack some
@@ -1057,7 +1070,7 @@ mod tests {
             // Operations on empty queue
             assert!(queue.is_empty());
             assert!(queue.dequeue().await.unwrap().is_none());
-            queue.sync().await.unwrap();
+            queue = queue.sync().await.unwrap();
             queue.reset();
         });
     }
@@ -1074,8 +1087,8 @@ mod tests {
                     .await
                     .unwrap();
 
-                queue.enqueue(b"item0".to_vec()).await.unwrap();
-                queue.enqueue(b"item1".to_vec()).await.unwrap();
+                (queue, _) = queue.enqueue(b"item0".to_vec()).await.unwrap();
+                (queue, _) = queue.enqueue(b"item1".to_vec()).await.unwrap();
                 queue.sync().await.unwrap();
             }
 
@@ -1107,7 +1120,7 @@ mod tests {
 
             // Enqueue many items
             for i in 0..100u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Ack every 3rd item (sparse acking)
@@ -1138,7 +1151,7 @@ mod tests {
 
             // Enqueue items
             for i in 0..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Ack items 1-8 (not 0)
@@ -1167,7 +1180,7 @@ mod tests {
                 .unwrap();
 
             for i in 0..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
 
             // Read only 3 items
@@ -1210,17 +1223,17 @@ mod tests {
             );
 
             // Append updates tip without enqueue
-            queue.append(vec![0]).await.unwrap();
+            (queue, _) = queue.append(vec![0]).await.unwrap();
             let encoded = context.encode();
             assert!(
                 encoded.contains("test_metrics_tip 1"),
                 "expected tip 1: {encoded}"
             );
-            queue.commit().await.unwrap();
+            let mut queue = queue.commit().await.unwrap();
 
             // Enqueue updates tip further
             for i in 1..10u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
             let encoded = context.encode();
             assert!(
@@ -1301,7 +1314,7 @@ mod tests {
 
             // Enqueue 3 items, dequeue and ack only the first
             for i in 0..3u8 {
-                queue.enqueue(vec![i]).await.unwrap();
+                (queue, _) = queue.enqueue(vec![i]).await.unwrap();
             }
             let (pos, _) = queue.dequeue().await.unwrap().unwrap();
             queue.ack(pos).unwrap();

--- a/storage/src/queue/storage.rs
+++ b/storage/src/queue/storage.rs
@@ -352,7 +352,7 @@ impl<E: Context, V: CodecShared> Queue<E, V> {
         Ok(self)
     }
 
-    /// See [Queue::destroy].
+    /// Destroy the queue, removing all data from disk.
     #[boxed]
     pub async fn destroy(self) -> Result<(), Error> {
         self.journal.destroy().await?;


### PR DESCRIPTION
## Motivation

Storage mutators previously took `&mut self`. That shape cannot express two invariants we rely on:

1. **A cancelled mutation must not leave a usable-but-diverged handle.** Dropping an in-flight `commit`/`prune`/`rewind` future could leave in-memory state ahead of, behind, or interleaved with durable state. Callers were expected to reconcile the two (or know not to touch the instance) — nothing enforced it.
2. **Mutable-method errors are fatal.** After a failed mutation, the instance's in-memory state may not match disk. Comments said "do not reuse"; the type system allowed reuse.

This PR makes both invariants structural: every async mutable method takes `self` and returns it **only on success**. An error or a dropped future destroys the handle, so post-failure state is unrepresentable rather than merely discouraged. Recovery is the same as a restart: reopen with `init`, which replays the durable state.

## The contract

```rust
// Success threads the handle; failure (or drop) consumes it.
(self.journal, pos) = self.journal.append(item).await?;
let db = db.commit().await?;
```

- Mutators return `Self` (or `(Self, T)`). `?` on their errors destroys the partially-moved handle.
- Validation errors consume too (`StaleBatch`, bounds checks in `apply_batch`, …). Callers that want to reject a batch and keep the handle use the new borrowed pre-check `validate_batch(&self)`, added at all five qmdb families.
- Read-only methods still borrow.
- Discarding a returned handle (`db.sync().await.unwrap();`) destroys it at the end of the statement; tests use this as the sync-then-teardown idiom.

## Types converted

- **Journals**: `journal::contiguous::{fixed, variable}` and `journal::authenticated`, plus consuming methods on the `Mutable` trait.
- **Merkle**: `merkle::persisted::full` (and the thin `merkle::mmr::full` wrapper).
- **QMDB**: `store`, `any` (ordered/unordered × fixed/variable), `current`, `immutable`, `keyless`, both `compact` variants, and the sync engine's journal handling.
- **Queue**: `Queue`, and the shared `Writer`/`Reader` wrappers.
- Downstream: `glue` (shared-db cells, actors), `examples/sync` (server + databases).

## Mechanical changes

- Mutator bodies own `self` and reassign moved fields with destructuring assignment: `(self.journal, self.merkle) = try_join!(...)?;`. Where the second tuple element is used, `let x; (self.f, x) = ...;`.
- Callers rebind: `let db = db.commit().await?;` outside loops, `(db, x) = ...` inside them.
- The leaf journals (`fixed`, `variable`) gained a private boxed `Inner` so the moved handles stay pointer-sized; the public `Journal` handle carries the docs, `Inner` methods are `See [Journal::x]` stubs. (`Queue` stays a flat struct — its journal field is already a boxed handle.) `authenticated::Inner` (a config-factory trait) was renamed `Backing` to avoid colliding with these structs.
- `#[boxed]` on cold mutators (`init`/`destroy`/`prune`/`rewind`; `commit`/`sync` on the non-benched families) keeps by-value futures small; hot paths (`append`, benched `apply_batch`) are deliberately unboxed.
- Tests and fuzz targets thread handles the same way; fuzz op loops are expression-style (`journal = match op { ... }`) and any consuming error ends the cycle, which the harnesses already treat as the crash under test.

## Non-obvious changes and why

- **Shared handles surface the lost-db state instead of hiding it.** A holder of a shared slot must take the db out to mutate it, and a failure leaves the slot empty:
  - `queue::shared`: subsequent calls return the new `Error::Unavailable`; accessors became fallible.
  - `glue::Shared`: local access panics with "database was lost … restart to recover" (consistent with glue's `*_or_panic` policy); the remote serving path returns an error instead of crashing.
  - `examples/sync` server: returns the new `DatabaseUnavailable`, and a failed periodic `add_operations` now stops the server (main limped on with a warning — meaningless once the db is gone).
- **Resolver empty-slot error is now honest**: `ServeError::MissingSource` replaces the `qmdb::Error::KeyNotFound` stand-in, since an empty slot is a reachable steady state under this contract. Db errors still flow through as `ServeError::Database` via `#[from]`.
- **Sync engine batches appends**: fetched operations are applied with one `append_many` per range instead of per-op appends (same journal state, fewer I/O calls; the range-selection guard makes an empty batch impossible).
- **`persist_compact_state` consumes**, matching the rest of the compact-sync `Database` trait.
- **One test necessarily weakened**: `test_current_prune_dropped_before_log_prune` read in-flight bitmap state off the live handle after cancelling a prune; that state is unobservable once the dropped future owns the db. The reopen-side assertion still proves the metadata sync preceded the crash.
- API fallout: `size()`/`is_empty()` on the boxed journals lost `const` (`Box` deref); `Debug` impls added to the converted types.

## Follow Up Work
#4278