### PR TITLE
[glue/stateful] Pipeline finalized commits off the actor loop

### DIFF
--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -28,7 +28,6 @@ use futures::future::{pending, ready, Either};
 use rand_core::Rng;
 use tracing::{debug, info_span, Instrument as _};
 
-/// Digest of an application block.
 type BlockDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
 type SyncTargets<A, E> = <<A as Application<E>>::Databases as DatabaseSet<E>>::SyncTargets;
 type CommitCompletion<A, E> = (BlockDigest<A, E>, Option<Prune<SyncTargets<A, E>>>);

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -1,8 +1,10 @@
 use crate::stateful::{
     actor::{
         core::mailbox::Message,
-        processor::{FinalizeStatus, Processor},
+        metrics::Metrics as StatefulMetrics,
+        processor::{Commit, FinalizeStatus, Processor, Prune},
     },
+    db::DatabaseSet,
     Application,
 };
 use commonware_actor::mailbox as actor_mailbox;
@@ -12,26 +14,24 @@ use commonware_consensus::{
         core::{Mailbox as MarshalMailbox, Variant},
     },
     types::Height,
-    Heightable,
+    CertifiableBlock, Heightable,
 };
-use commonware_cryptography::certificate::Scheme;
+use commonware_cryptography::{certificate::Scheme, Digestible};
 use commonware_macros::select_loop;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
-use commonware_utils::{channel::fallible::OneshotExt, Acknowledgement};
-use futures::{
-    future::{ready, Either},
-    FutureExt,
+use commonware_utils::{
+    acknowledgement::Exact,
+    channel::{fallible::OneshotExt, mpsc},
+    Acknowledgement,
 };
+use futures::future::{pending, ready, Either};
 use rand_core::Rng;
-use std::sync::mpsc::TryRecvError;
 use tracing::{debug, info_span, Instrument as _};
 
-/// A single unit of work for the processing loop: either a mailbox message to
-/// handle or a deferred prune to run while the mailbox is idle.
-enum Step<M, P> {
-    Message(M),
-    Prune(P),
-}
+/// Digest of an application block.
+type BlockDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
+type SyncTargets<A, E> = <<A as Application<E>>::Databases as DatabaseSet<E>>::SyncTargets;
+type CommitCompletion<A, E> = (BlockDigest<A, E>, Option<Prune<SyncTargets<A, E>>>);
 
 pub(super) struct Processing<E, A, S, V>
 where
@@ -60,6 +60,77 @@ where
     pub(super) skip_finalized_until: Option<Height>,
 }
 
+/// Applies staged commits durably, in finalization order, off the actor loop.
+///
+/// Owning clones of the application and database set lets the committer run
+/// [`DatabaseSet::finalize`] (write lock + durable sync) and the application's
+/// finalized hook without blocking the actor's propose/verify lane. Marshal
+/// acknowledgements are released here, strictly after durability, preserving
+/// the contract that acknowledged blocks are recoverable from disk.
+struct Committer<E, A>
+where
+    E: Rng + Spawner + Metrics + Clock,
+    A: Application<E>,
+{
+    /// Application handle used for post-commit finalized hooks.
+    app: A,
+
+    /// The committed database set.
+    databases: A::Databases,
+
+    /// Actor metrics (records durable commit durations).
+    metrics: StatefulMetrics,
+
+    /// Staged commits from the processing loop, in finalization order.
+    commits: mpsc::UnboundedReceiver<(Commit<E, A>, Exact)>,
+
+    /// Committed digests reported back to the processing loop so it can drop
+    /// the retained pending entries.
+    completions: mpsc::UnboundedSender<CommitCompletion<A, E>>,
+}
+
+impl<E, A> Committer<E, A>
+where
+    E: Rng + Spawner + Metrics + Clock,
+    A: Application<E>,
+{
+    /// Apply staged commits until the processing loop drops the channel.
+    ///
+    /// Failures are fatal by design: [`DatabaseSet::finalize`] and
+    /// [`DatabaseSet::prune`] panic internally on error, and the runtime
+    /// treats a task panic as fatal to the process.
+    async fn run(mut self, context: E) {
+        while let Some((commit, acknowledgement)) = self.commits.recv().await {
+            let Commit {
+                block,
+                batch,
+                prune,
+            } = commit;
+            let timer = self.metrics.finalize_duration.timer(&context);
+            self.databases.finalize(batch).await;
+            self.app
+                .finalized(
+                    (context.child("finalized"), block.context()),
+                    block.as_ref(),
+                    &self.databases,
+                )
+                .await;
+            // The batch is durable: release the marshal acknowledgement.
+            acknowledgement.acknowledge();
+            timer.observe(&context);
+            debug!(
+                height = block.height().get(),
+                "persisted finalized database batch"
+            );
+            // Let the actor drop the pending entry retained for this commit.
+            if self.completions.send((block.digest(), prune)).is_err() {
+                debug!("processing loop stopped, stopping committer");
+                return;
+            }
+        }
+    }
+}
+
 impl<E, A, S, V> Processing<E, A, S, V>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -69,111 +140,168 @@ where
     MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
 {
     pub async fn start(mut self) {
+        // Stage-and-commit pipeline: the actor stages each finalized block in
+        // memory and hands the durable commit (database write lock + sync) to
+        // a single FIFO committer task, so propose/verify are never queued
+        // behind an in-flight commit.
+        //
+        // In-flight commits are bounded by marshal's pending-ack window: every
+        // queued commit holds an unreleased acknowledgement, so marshal stops
+        // delivering finalized blocks long before these channels could grow
+        // without bound.
+        let (commit_tx, commit_rx) = mpsc::unbounded_channel();
+        let (completion_tx, mut completion_rx) = mpsc::unbounded_channel();
+        let committer = Committer {
+            app: self.processor.application(),
+            databases: self.processor.databases().clone(),
+            metrics: self.processor.metrics().clone(),
+            commits: commit_rx,
+            completions: completion_tx,
+        };
+        // Spawned from the actor's long-lived context so the committer lives
+        // exactly as long as the processing loop.
+        let committer = self
+            .context
+            .as_present()
+            .child("committer")
+            .spawn(|context| committer.run(context));
+        let mut commit_tx = Some(commit_tx);
+        let mut committer = Some(committer);
+
         let mut pending_prune = None;
         select_loop! {
             self.context,
             on_start => {
-                // Pruning is non-critical work. We only run it when the mailbox is idle, and
-                // it is never raced against the mailbox due to its internal lock acquisition.
-                // If a message is ready, it is always processed immediately.
-                let next = match self.mailbox.try_recv() {
-                    // A message is ready: handle it now, regardless of any queued prune.
-                    Ok(message) => Either::Left(ready(Some(Step::Message(message)))),
-                    Err(TryRecvError::Empty) => match pending_prune.take() {
-                        // No message, but a prune is queued: run it.
-                        Some(prune) => Either::Left(ready(Some(Step::Prune(prune)))),
-                        // No message and nothing to prune: wait on the mailbox as normal.
-                        None => Either::Right(self.mailbox.recv().map(|m| m.map(Step::Message))),
-                    },
-                    Err(TryRecvError::Disconnected) => {
-                        debug!("mailbox closed, stopping processing");
-                        return;
-                    }
+                // This branch is ordered after the mailbox below, so prune work
+                // only runs when no message is ready.
+                let prune_ready = if pending_prune.is_some() {
+                    Either::Left(ready(()))
+                } else {
+                    Either::Right(pending())
                 };
             },
             on_stopped => {
                 debug!("shutdown signal received, stopping processing");
+                drop(commit_tx.take());
+                committer
+                    .take()
+                    .expect("committer must be running")
+                    .await
+                    .expect("committer terminated unexpectedly");
             },
-            Some(step) = next else {
-                debug!("mailbox closed, stopping processing");
-                break;
-            } => match step {
-                Step::Message(Message::Propose {
-                    span,
-                    context,
-                    ancestry,
-                    response,
-                }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.propose");
-                    self.processor
-                        .propose(
-                            self.context.as_present(),
-                            self.marshal.clone(),
-                            context,
-                            ancestry,
-                            &mut self.input_provider,
-                            response,
-                        )
-                        .instrument(process)
-                        .await;
+            // Biased before the mailbox: completions are cheap map removals
+            // that stop the pending map from retaining committed entries.
+            completion = completion_rx.recv() => {
+                let Some((digest, prune)) = completion else {
+                    panic!("committer terminated unexpectedly");
+                };
+                self.processor.commit_complete(&digest);
+                if let Some(prune) = prune {
+                    pending_prune = Some(prune);
                 }
-                Step::Message(Message::Verify {
-                    span,
-                    context,
-                    ancestry,
-                    response,
-                }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.verify");
-                    self.processor
-                        .verify(
-                            self.context.as_present(),
-                            self.marshal.clone(),
-                            context,
-                            ancestry,
-                            response,
-                        )
-                        .instrument(process)
-                        .await;
-                }
-                Step::Message(Message::Finalized {
-                    span,
-                    block,
-                    acknowledgement,
-                }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.finalized");
-                    let prune = async {
-                        if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
-                            self.processor
-                                .notify_finalized(self.context.as_present(), block.as_ref())
-                                .await;
-                            acknowledgement.acknowledge();
-                            return None;
-                        }
-                        let (status, prune) = self
-                            .processor
-                            .finalize(&self.context, block.as_ref())
+            },
+            message = self.mailbox.recv() => {
+                let Some(message) = message else {
+                    debug!("mailbox closed, stopping processing");
+                    break;
+                };
+                match message {
+                    Message::Propose {
+                        span,
+                        context,
+                        ancestry,
+                        response,
+                    } => {
+                        let process = info_span!(parent: &span, "stateful.actor.propose");
+                        self.processor
+                            .propose(
+                                self.context.as_present(),
+                                self.marshal.clone(),
+                                context,
+                                ancestry,
+                                &mut self.input_provider,
+                                response,
+                            )
+                            .instrument(process)
                             .await;
-                        if let FinalizeStatus::Persisted { height } = status {
-                            debug!(height = height.get(), "persisted finalized database batch");
+                    }
+                    Message::Verify {
+                        span,
+                        context,
+                        ancestry,
+                        response,
+                    } => {
+                        let process = info_span!(parent: &span, "stateful.actor.verify");
+                        self.processor
+                            .verify(
+                                self.context.as_present(),
+                                self.marshal.clone(),
+                                context,
+                                ancestry,
+                                response,
+                            )
+                            .instrument(process)
+                            .await;
+                    }
+                    Message::Finalized {
+                        span,
+                        block,
+                        acknowledgement,
+                    } => {
+                        let process = info_span!(parent: &span, "stateful.actor.finalized");
+                        async {
+                            if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
+                                self.processor
+                                    .notify_finalized(self.context.as_present(), block.as_ref())
+                                    .await;
+                                acknowledgement.acknowledge();
+                                return;
+                            }
+                            let (status, commit) =
+                                self.processor.finalize(&self.context, block).await;
+                            if let FinalizeStatus::Staged { height } = status {
+                                debug!(
+                                    height = height.get(),
+                                    "staged finalized database batch for commit"
+                                );
+                            }
+                            match commit {
+                                // The committer releases the acknowledgement
+                                // only after the batch is durably committed.
+                                Some(commit) => {
+                                    if commit_tx
+                                        .as_ref()
+                                        .expect("committer sender must be open")
+                                        .send((commit, acknowledgement))
+                                        .is_err()
+                                    {
+                                        panic!("committer terminated unexpectedly");
+                                    }
+                                }
+                                None => acknowledgement.acknowledge(),
+                            }
                         }
-                        acknowledgement.acknowledge();
-                        prune
-                    }
-                    .instrument(process)
-                    .await;
-                    if let Some(prune) = prune {
-                        pending_prune = Some(prune);
-                    }
-                }
-                Step::Message(Message::SubscribeDatabases { response }) => {
-                    response.send_lossy(self.processor.databases().clone());
-                }
-                Step::Prune(prune) => {
-                    prune
-                        .run(self.processor.databases_mut(), &self.marshal)
+                        .instrument(process)
                         .await;
+                    }
+                    Message::SubscribeDatabases { response } => {
+                        response.send_lossy(self.processor.databases().clone());
+                    }
                 }
             },
+            _ = prune_ready => {
+                let prune = pending_prune.take().expect("prune must be pending");
+                prune
+                    .run(self.processor.databases_mut(), &self.marshal)
+                    .await;
+            },
+        }
+
+        // Mutable storage operations cannot be cancelled safely. Stop accepting
+        // new work and let the FIFO committer drain before this actor exits.
+        drop(commit_tx.take());
+        if let Some(committer) = committer.take() {
+            committer.await.expect("committer terminated unexpectedly");
         }
     }
 }
@@ -194,8 +322,437 @@ fn skip_finalized_block(skip_until: &mut Option<Height>, height: Height) -> bool
 
 #[cfg(test)]
 mod tests {
-    use super::skip_finalized_block;
-    use commonware_consensus::types::Height;
+    use super::{skip_finalized_block, Processing};
+    use crate::stateful::{
+        actor::{metrics::Metrics as StatefulMetrics, processor::Processor},
+        db::{Anchor, DatabaseSet, ManagedDb, Merkleized, Shared, Unmerkleized},
+        tests::mocks::{TestBlock, TestScheme, TestVariant},
+        Application, Mailbox, Proposed,
+    };
+    use commonware_actor::mailbox as actor_mailbox;
+    use commonware_consensus::{
+        marshal::{self, ancestry, core::Actor as MarshalActor, Update},
+        types::{FixedEpocher, Height, ViewDelta},
+        Application as ConsensusApplication, CertifiableBlock, Heightable as _, Reporter as _,
+    };
+    use commonware_cryptography::{certificate::ConstantProvider, Digestible as _};
+    use commonware_parallel::Sequential;
+    use commonware_runtime::{
+        buffer::paged::CacheRef, deterministic, Clock as _, ContextCell, Runner as _, Spawner as _,
+        Supervisor as _,
+    };
+    use commonware_storage::archive::immutable;
+    use commonware_utils::{
+        acknowledgement::{Acknowledgement as _, Exact},
+        sync::Mutex,
+        NZUsize, NZU16, NZU64,
+    };
+    use futures::{FutureExt as _, Stream, StreamExt as _};
+    use std::{convert::Infallible, sync::Arc, time::Duration};
+
+    /// Simulated latency of one durable database commit (the fsync).
+    const COMMIT_LATENCY: Duration = Duration::from_millis(100);
+
+    /// Where an unmerkleized batch was forked from.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    enum ForkOrigin {
+        /// Forked from committed database state via [`ManagedDb::new_batch`].
+        Committed,
+        /// Forked from a retained pending overlay via [`Merkleized::new_batch`].
+        Overlay,
+    }
+
+    #[derive(Clone, Copy)]
+    struct PacedUnmerkleized {
+        origin: ForkOrigin,
+    }
+
+    #[derive(Clone, Copy)]
+    struct PacedMerkleized;
+
+    #[derive(Default)]
+    struct CommitLog {
+        started: usize,
+        completed: Vec<std::time::SystemTime>,
+    }
+
+    impl Unmerkleized for PacedUnmerkleized {
+        type Merkleized = PacedMerkleized;
+        type Error = Infallible;
+
+        async fn merkleize(self) -> Result<Self::Merkleized, Self::Error> {
+            Ok(PacedMerkleized)
+        }
+    }
+
+    impl Merkleized for PacedMerkleized {
+        type Digest = commonware_cryptography::sha256::Digest;
+        type Unmerkleized = PacedUnmerkleized;
+
+        fn root(&self) -> Self::Digest {
+            commonware_cryptography::sha256::Digest::from([0; 32])
+        }
+
+        fn new_batch(&self) -> Self::Unmerkleized {
+            PacedUnmerkleized {
+                origin: ForkOrigin::Overlay,
+            }
+        }
+    }
+
+    /// A database whose durable commit sleeps for [`COMMIT_LATENCY`] while
+    /// holding the write lock, modeling an fsync under the DB write lock.
+    struct PacedDb {
+        context: deterministic::Context,
+        commits: Arc<Mutex<CommitLog>>,
+    }
+
+    impl ManagedDb<deterministic::Context> for PacedDb {
+        type Unmerkleized = PacedUnmerkleized;
+        type Merkleized = PacedMerkleized;
+        type Error = Infallible;
+        type Config = Arc<Mutex<CommitLog>>;
+        type SyncTarget = ();
+
+        async fn init(
+            context: deterministic::Context,
+            commits: Self::Config,
+        ) -> Result<Self, Self::Error> {
+            Ok(Self { context, commits })
+        }
+
+        fn initial_sync_target() -> Self::SyncTarget {}
+
+        async fn new_batch(db: &Shared<Self>) -> Self::Unmerkleized {
+            // Forking committed state reads through the database, so it must
+            // wait out any in-flight commit's write lock.
+            let _guard = db.read().await;
+            PacedUnmerkleized {
+                origin: ForkOrigin::Committed,
+            }
+        }
+
+        fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
+            true
+        }
+
+        async fn finalize(&mut self, _batch: Self::Merkleized) -> Result<(), Self::Error> {
+            // Model the durable commit fsync while the write lock is held.
+            self.commits.lock().started += 1;
+            self.context.sleep(COMMIT_LATENCY).await;
+            self.commits.lock().completed.push(self.context.current());
+            Ok(())
+        }
+
+        fn sync_target(&self) -> Self::SyncTarget {}
+
+        async fn rewind_to_target(&mut self, _target: Self::SyncTarget) -> Result<(), Self::Error> {
+            Ok(())
+        }
+    }
+
+    /// Application over [`PacedDb`] that records where its propose batches
+    /// were forked from.
+    #[derive(Clone)]
+    struct PacedApp {
+        last_propose_origin: Arc<Mutex<Option<ForkOrigin>>>,
+    }
+
+    impl Application<deterministic::Context> for PacedApp {
+        type SigningScheme = TestScheme;
+        type Context = <TestBlock as CertifiableBlock>::Context;
+        type Block = TestBlock;
+        type Databases = Shared<PacedDb>;
+        type InputProvider = ();
+
+        fn sync_targets(
+            _block: &Self::Block,
+        ) -> <Self::Databases as DatabaseSet<deterministic::Context>>::SyncTargets {
+        }
+
+        async fn genesis(&mut self) -> Self::Block {
+            TestBlock::new(0, 0)
+        }
+
+        async fn propose(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
+            batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
+            _input: &mut Self::InputProvider,
+        ) -> Option<Proposed<Self, deterministic::Context>> {
+            let mut ancestry = Box::pin(ancestry);
+            let parent = ancestry.next().await?;
+            self.last_propose_origin.lock().replace(batches.origin);
+            let height = parent.height().get() + 1;
+            let block = TestBlock::new(height, u8::try_from(height).expect("test height fits u8"));
+            let merkleized = batches.merkleize().await.expect("merkleize is infallible");
+            Some(Proposed { block, merkleized })
+        }
+
+        async fn verify(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            ancestry: impl Stream<Item = Arc<Self::Block>> + Send,
+            batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
+        ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
+            let mut ancestry = Box::pin(ancestry);
+            let _block = ancestry.next().await?;
+            Some(batches.merkleize().await.expect("merkleize is infallible"))
+        }
+
+        async fn apply(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
+        ) -> <Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized {
+            batches.merkleize().await.expect("merkleize is infallible")
+        }
+    }
+
+    fn archive_config(page_cache: CacheRef, partition: &str) -> immutable::Config<()> {
+        immutable::Config {
+            metadata_partition: format!("{partition}-metadata"),
+            freezer_table_partition: format!("{partition}-freezer-table"),
+            freezer_table_initial_size: 4,
+            freezer_table_resize_frequency: 2,
+            freezer_table_resize_chunk_size: 2,
+            freezer_key_partition: format!("{partition}-freezer-key"),
+            freezer_key_page_cache: page_cache,
+            freezer_value_partition: format!("{partition}-freezer-value"),
+            freezer_value_target_size: 128,
+            freezer_value_compression: None,
+            ordinal_partition: format!("{partition}-ordinal"),
+            items_per_section: NZU64!(4),
+            codec_config: (),
+            replay_buffer: NZUsize!(64),
+            freezer_key_write_buffer: NZUsize!(64),
+            freezer_value_write_buffer: NZUsize!(64),
+            ordinal_write_buffer: NZUsize!(64),
+        }
+    }
+
+    /// Benchmark and regression test for pipelined finalization.
+    ///
+    /// A finalized block's durable commit costs [`COMMIT_LATENCY`] under the
+    /// database write lock. A propose request that arrives 1ms later must not
+    /// queue behind that commit: it forks the retained pending overlay of the
+    /// finalizing parent and resolves in ~0 simulated milliseconds. The marshal
+    /// acknowledgement, by contrast, must not fire until the commit is durable,
+    /// and commits must stay in finalization order.
+    #[test]
+    fn finalized_commit_does_not_block_propose() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            // A marshal mailbox is required to construct the processing loop,
+            // but this scenario never performs a marshal lookup: all parents
+            // are either pending or the processed anchor.
+            let mut signing_context = context.child("signing");
+            let fixture = commonware_consensus::simplex::mocks::scheme::fixture(
+                &mut signing_context,
+                b"pipelined-commit",
+                1,
+            );
+            let provider = ConstantProvider::new(fixture.schemes[0].clone());
+            let page_cache = CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(8));
+            let finalizations_by_height = immutable::Archive::init(
+                context.child("finalizations_by_height"),
+                archive_config(page_cache.clone(), "pipelined-commit-finalizations"),
+            )
+            .await
+            .expect("failed to initialize finalizations archive");
+            let finalized_blocks = immutable::Archive::init(
+                context.child("finalized_blocks"),
+                archive_config(page_cache.clone(), "pipelined-commit-blocks"),
+            )
+            .await
+            .expect("failed to initialize blocks archive");
+            let (_marshal_actor, marshal, _height) =
+                MarshalActor::<_, TestVariant, _, _, _, _, _>::init(
+                    context.child("marshal"),
+                    finalizations_by_height,
+                    finalized_blocks,
+                    marshal::Config {
+                        provider,
+                        epocher: FixedEpocher::new(NZU64!(u64::MAX)),
+                        start: marshal::Start::Genesis(TestBlock::new(0, 0)),
+                        partition_prefix: "pipelined-commit-marshal".to_string(),
+                        mailbox_size: NZUsize!(8),
+                        view_retention_timeout: ViewDelta::new(1),
+                        prunable_items_per_section: NZU64!(4),
+                        page_cache,
+                        replay_buffer: NZUsize!(64),
+                        key_write_buffer: NZUsize!(64),
+                        value_write_buffer: NZUsize!(64),
+                        block_codec_config: (),
+                        max_repair: NZUsize!(1),
+                        max_pending_acks: NZUsize!(4),
+                        strategy: Sequential,
+                    },
+                )
+                .await;
+
+            // Assemble the processing loop directly at the genesis anchor.
+            let commits = Arc::new(Mutex::new(CommitLog::default()));
+            let databases = <Shared<PacedDb> as DatabaseSet<deterministic::Context>>::init(
+                context.child("db_set"),
+                commits.clone(),
+            )
+            .await;
+            let app = PacedApp {
+                last_propose_origin: Arc::new(Mutex::new(None)),
+            };
+            let genesis = TestBlock::new(0, 0);
+            let processor = Processor::new(
+                app.clone(),
+                databases,
+                Anchor {
+                    height: Height::zero(),
+                    round: genesis.context().round,
+                    digest: genesis.digest(),
+                },
+                StatefulMetrics::new(&context),
+                None,
+            );
+            let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
+            let mut mailbox = Mailbox::new(sender);
+            let processing = Processing {
+                context: ContextCell::new(context.child("stateful")),
+                mailbox: receiver,
+                input_provider: (),
+                marshal,
+                processor,
+                skip_finalized_until: None,
+            };
+            let processing_handle = context
+                .child("processing")
+                .spawn(move |_| processing.start());
+
+            // Cache pending state for block1 on top of genesis.
+            let block1 = Arc::new(TestBlock::new(1, 1));
+            let genesis = Arc::new(genesis);
+            assert!(
+                mailbox
+                    .verify(
+                        (context.child("verify"), block1.context()),
+                        ancestry::from_iter([Arc::clone(&block1), Arc::clone(&genesis)]),
+                    )
+                    .await,
+                "block1 must verify against the genesis anchor",
+            );
+
+            // Report block1 finalized; its durable commit incurs the paced fsync.
+            let start = context.current();
+            let (ack1, mut waiter1) = Exact::handle();
+            mailbox.report(Update::Block(Arc::clone(&block1), ack1));
+
+            // One millisecond later, ask the actor to propose on top of block1
+            // while the commit is still in flight.
+            context.sleep(Duration::from_millis(1)).await;
+            let propose_started = context.current();
+            let block2 = Arc::new(
+                mailbox
+                    .propose(
+                        (context.child("propose"), TestBlock::new(2, 2).context()),
+                        ancestry::from_iter([Arc::clone(&block1), Arc::clone(&genesis)]),
+                    )
+                    .await
+                    .expect("propose on the finalizing tip must succeed"),
+            );
+            let propose_latency = context
+                .current()
+                .duration_since(propose_started)
+                .expect("time is monotonic");
+            println!("propose latency behind in-flight commit: {propose_latency:?}");
+            assert!(
+                propose_latency < Duration::from_millis(5),
+                "propose must not queue behind the durable commit: {propose_latency:?}",
+            );
+            assert_eq!(
+                *app.last_propose_origin.lock(),
+                Some(ForkOrigin::Overlay),
+                "propose must fork the retained overlay of the committing parent",
+            );
+
+            // The acknowledgement must not fire before the fsync completes.
+            assert!(
+                (&mut waiter1).now_or_never().is_none(),
+                "acknowledgement fired before the durable commit completed",
+            );
+            assert!(
+                commits.lock().completed.is_empty(),
+                "no batch can be durable before the paced fsync elapses",
+            );
+
+            // Finalize the freshly proposed block while block1 is still
+            // committing; commits and acknowledgements must stay in order.
+            let (ack2, mut waiter2) = Exact::handle();
+            mailbox.report(Update::Block(Arc::clone(&block2), ack2));
+
+            waiter1.await.expect("block1 acknowledgement must fire");
+            let ack1_latency = context
+                .current()
+                .duration_since(start)
+                .expect("time is monotonic");
+            println!("block1 acknowledgement latency: {ack1_latency:?}");
+            assert!(
+                ack1_latency >= COMMIT_LATENCY,
+                "acknowledgement must wait for the durable commit: {ack1_latency:?}",
+            );
+            assert!(
+                (&mut waiter2).now_or_never().is_none(),
+                "block2 acknowledged before its own durable commit",
+            );
+
+            waiter2.await.expect("block2 acknowledgement must fire");
+            let ack2_latency = context
+                .current()
+                .duration_since(start)
+                .expect("time is monotonic");
+            println!("block2 acknowledgement latency: {ack2_latency:?}");
+            assert!(
+                ack2_latency >= ack1_latency + COMMIT_LATENCY,
+                "commits must be applied in finalization order: {ack2_latency:?}",
+            );
+            assert_eq!(
+                commits.lock().completed.len(),
+                2,
+                "both batches must be durable"
+            );
+
+            // Global shutdown with a commit in flight must wait for that mutable
+            // storage operation to finish before the processing actor exits.
+            let block3 = mailbox
+                .propose(
+                    (context.child("propose"), TestBlock::new(3, 3).context()),
+                    ancestry::from_iter([Arc::clone(&block2), Arc::clone(&block1)]),
+                )
+                .await
+                .expect("propose on the committed tip must succeed");
+            let (ack3, waiter3) = Exact::handle();
+            mailbox.report(Update::Block(Arc::new(block3), ack3));
+            while commits.lock().started < 3 {
+                context.sleep(Duration::from_millis(1)).await;
+            }
+            assert_eq!(commits.lock().completed.len(), 2, "third commit must still be in flight");
+
+            context
+                .child("stop")
+                .stop(0, None)
+                .await
+                .expect("runtime shutdown must complete");
+
+            processing_handle
+                .await
+                .expect("processing actor must drain the committer");
+            waiter3.await.expect("queued commit must be acknowledged");
+            assert_eq!(
+                commits.lock().completed.len(),
+                3,
+                "queued commit must be durable"
+            );
+        });
+    }
 
     #[test]
     fn skip_finalized_block_skips_through_target_height() {

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -2,7 +2,7 @@ use crate::stateful::{
     actor::{
         core::mailbox::Message,
         metrics::Metrics as StatefulMetrics,
-        processor::{Commit, FinalizeStatus, Processor, Prune},
+        processor::{Commit, Processor, Prune},
     },
     db::DatabaseSet,
     Application,
@@ -14,7 +14,7 @@ use commonware_consensus::{
         core::{Mailbox as MarshalMailbox, Variant},
     },
     types::Height,
-    CertifiableBlock, Heightable,
+    Heightable,
 };
 use commonware_cryptography::{certificate::Scheme, Digestible};
 use commonware_macros::select_loop;
@@ -96,34 +96,21 @@ where
 {
     /// Apply staged commits until the processing loop drops the channel.
     ///
-    /// Failures are fatal by design: [`DatabaseSet::finalize`] and
-    /// [`DatabaseSet::prune`] panic internally on error, and the runtime
-    /// treats a task panic as fatal to the process.
+    /// Failures are fatal by design: database operations panic internally on
+    /// error, and the runtime treats a task panic as fatal to the process.
     async fn run(mut self, context: E) {
         while let Some((commit, acknowledgement)) = self.commits.recv().await {
-            let Commit {
-                block,
-                batch,
-                prune,
-            } = commit;
+            let height = commit.height();
             let timer = self.metrics.finalize_duration.timer(&context);
-            self.databases.finalize(batch).await;
-            self.app
-                .finalized(
-                    (context.child("finalized"), block.context()),
-                    block.as_ref(),
-                    &self.databases,
-                )
+            let (digest, prune) = commit
+                .apply(&context, &mut self.app, &self.databases)
                 .await;
             // The batch is durable: release the marshal acknowledgement.
             acknowledgement.acknowledge();
             timer.observe(&context);
-            debug!(
-                height = block.height().get(),
-                "persisted finalized database batch"
-            );
+            debug!(height = height.get(), "persisted finalized database batch");
             // Let the actor drop the pending entry retained for this commit.
-            if self.completions.send((block.digest(), prune)).is_err() {
+            if self.completions.send((digest, prune)).is_err() {
                 debug!("processing loop stopped, stopping committer");
                 return;
             }
@@ -160,13 +147,17 @@ where
         };
         // Spawned from the actor's long-lived context so the committer lives
         // exactly as long as the processing loop.
+        // Acquire before spawning so shutdown waits even if the committer has
+        // not yet been polled.
+        let shutdown = self.context.as_present().stopped();
         let committer = self
             .context
             .as_present()
             .child("committer")
-            .spawn(|context| committer.run(context));
-        let mut commit_tx = Some(commit_tx);
-        let mut committer = Some(committer);
+            .spawn(move |context| async move {
+                let _shutdown = shutdown;
+                committer.run(context).await;
+            });
 
         let mut pending_prune = None;
         select_loop! {
@@ -182,12 +173,6 @@ where
             },
             on_stopped => {
                 debug!("shutdown signal received, stopping processing");
-                drop(commit_tx.take());
-                committer
-                    .take()
-                    .expect("committer must be running")
-                    .await
-                    .expect("committer terminated unexpectedly");
             },
             // Biased before the mailbox: completions are cheap map removals
             // that stop the pending map from retaining committed entries.
@@ -257,28 +242,19 @@ where
                                 acknowledgement.acknowledge();
                                 return;
                             }
-                            let (status, commit) =
-                                self.processor.finalize(&self.context, block).await;
-                            if let FinalizeStatus::Staged { height } = status {
-                                debug!(
-                                    height = height.get(),
-                                    "staged finalized database batch for commit"
-                                );
-                            }
-                            match commit {
-                                // The committer releases the acknowledgement
-                                // only after the batch is durably committed.
-                                Some(commit) => {
-                                    if commit_tx
-                                        .as_ref()
-                                        .expect("committer sender must be open")
-                                        .send((commit, acknowledgement))
-                                        .is_err()
-                                    {
-                                        panic!("committer terminated unexpectedly");
-                                    }
-                                }
-                                None => acknowledgement.acknowledge(),
+                            let Some(commit) = self.processor.finalize(&self.context, block).await
+                            else {
+                                acknowledgement.acknowledge();
+                                return;
+                            };
+                            debug!(
+                                height = commit.height().get(),
+                                "staged finalized database batch for commit"
+                            );
+                            // The committer releases the acknowledgement only
+                            // after the batch is durably committed.
+                            if commit_tx.send((commit, acknowledgement)).is_err() {
+                                panic!("committer terminated unexpectedly");
                             }
                         }
                         .instrument(process)
@@ -299,10 +275,8 @@ where
 
         // Mutable storage operations cannot be cancelled safely. Stop accepting
         // new work and let the FIFO committer drain before this actor exits.
-        drop(commit_tx.take());
-        if let Some(committer) = committer.take() {
-            committer.await.expect("committer terminated unexpectedly");
-        }
+        drop(commit_tx);
+        committer.await.expect("committer terminated unexpectedly");
     }
 }
 
@@ -310,14 +284,10 @@ fn skip_finalized_block(skip_until: &mut Option<Height>, height: Height) -> bool
     let Some(target) = *skip_until else {
         return false;
     };
-    if height > target {
-        *skip_until = None;
-        return false;
-    }
-    if height == target {
+    if height >= target {
         *skip_until = None;
     }
-    true
+    height <= target
 }
 
 #[cfg(test)]
@@ -362,18 +332,17 @@ mod tests {
         Overlay,
     }
 
-    #[derive(Clone, Copy)]
     struct PacedUnmerkleized {
         origin: ForkOrigin,
     }
 
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     struct PacedMerkleized;
 
     #[derive(Default)]
     struct CommitLog {
         started: usize,
-        completed: Vec<std::time::SystemTime>,
+        completed: usize,
     }
 
     impl Unmerkleized for PacedUnmerkleized {
@@ -440,7 +409,7 @@ mod tests {
             // Model the durable commit fsync while the write lock is held.
             self.commits.lock().started += 1;
             self.context.sleep(COMMIT_LATENCY).await;
-            self.commits.lock().completed.push(self.context.current());
+            self.commits.lock().completed += 1;
             Ok(())
         }
 
@@ -533,7 +502,7 @@ mod tests {
         }
     }
 
-    /// Benchmark and regression test for pipelined finalization.
+    /// Regression test for pipelined finalization.
     ///
     /// A finalized block's durable commit costs [`COMMIT_LATENCY`] under the
     /// database write lock. A propose request that arrives 1ms later must not
@@ -663,7 +632,6 @@ mod tests {
                 .current()
                 .duration_since(propose_started)
                 .expect("time is monotonic");
-            println!("propose latency behind in-flight commit: {propose_latency:?}");
             assert!(
                 propose_latency < Duration::from_millis(5),
                 "propose must not queue behind the durable commit: {propose_latency:?}",
@@ -679,8 +647,9 @@ mod tests {
                 (&mut waiter1).now_or_never().is_none(),
                 "acknowledgement fired before the durable commit completed",
             );
-            assert!(
-                commits.lock().completed.is_empty(),
+            assert_eq!(
+                commits.lock().completed,
+                0,
                 "no batch can be durable before the paced fsync elapses",
             );
 
@@ -694,7 +663,6 @@ mod tests {
                 .current()
                 .duration_since(start)
                 .expect("time is monotonic");
-            println!("block1 acknowledgement latency: {ack1_latency:?}");
             assert!(
                 ack1_latency >= COMMIT_LATENCY,
                 "acknowledgement must wait for the durable commit: {ack1_latency:?}",
@@ -709,13 +677,12 @@ mod tests {
                 .current()
                 .duration_since(start)
                 .expect("time is monotonic");
-            println!("block2 acknowledgement latency: {ack2_latency:?}");
             assert!(
                 ack2_latency >= ack1_latency + COMMIT_LATENCY,
                 "commits must be applied in finalization order: {ack2_latency:?}",
             );
             assert_eq!(
-                commits.lock().completed.len(),
+                commits.lock().completed,
                 2,
                 "both batches must be durable"
             );
@@ -734,7 +701,7 @@ mod tests {
             while commits.lock().started < 3 {
                 context.sleep(Duration::from_millis(1)).await;
             }
-            assert_eq!(commits.lock().completed.len(), 2, "third commit must still be in flight");
+            assert_eq!(commits.lock().completed, 2, "third commit must still be in flight");
 
             context
                 .child("stop")
@@ -747,7 +714,7 @@ mod tests {
                 .expect("processing actor must drain the committer");
             waiter3.await.expect("queued commit must be acknowledged");
             assert_eq!(
-                commits.lock().completed.len(),
+                commits.lock().completed,
                 3,
                 "queued commit must be durable"
             );

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -101,9 +101,7 @@ where
         while let Some((commit, acknowledgement)) = self.commits.recv().await {
             let height = commit.height();
             let timer = self.metrics.finalize_duration.timer(&context);
-            let (digest, prune) = commit
-                .apply(&context, &mut self.app, &self.databases)
-                .await;
+            let (digest, prune) = commit.apply(&context, &mut self.app, &self.databases).await;
             // The batch is durable: release the marshal acknowledgement.
             acknowledgement.acknowledge();
             timer.observe(&context);
@@ -149,14 +147,14 @@ where
         // Acquire before spawning so shutdown waits even if the committer has
         // not yet been polled.
         let shutdown = self.context.as_present().stopped();
-        let committer = self
-            .context
-            .as_present()
-            .child("committer")
-            .spawn(move |context| async move {
-                let _shutdown = shutdown;
-                committer.run(context).await;
-            });
+        let committer =
+            self.context
+                .as_present()
+                .child("committer")
+                .spawn(move |context| async move {
+                    let _shutdown = shutdown;
+                    committer.run(context).await;
+                });
 
         let mut pending_prune = None;
         select_loop! {
@@ -680,11 +678,7 @@ mod tests {
                 ack2_latency >= ack1_latency + COMMIT_LATENCY,
                 "commits must be applied in finalization order: {ack2_latency:?}",
             );
-            assert_eq!(
-                commits.lock().completed,
-                2,
-                "both batches must be durable"
-            );
+            assert_eq!(commits.lock().completed, 2, "both batches must be durable");
 
             // Global shutdown with a commit in flight must wait for that mutable
             // storage operation to finish before the processing actor exits.
@@ -700,7 +694,11 @@ mod tests {
             while commits.lock().started < 3 {
                 context.sleep(Duration::from_millis(1)).await;
             }
-            assert_eq!(commits.lock().completed, 2, "third commit must still be in flight");
+            assert_eq!(
+                commits.lock().completed,
+                2,
+                "third commit must still be in flight"
+            );
 
             context
                 .child("stop")
@@ -712,11 +710,7 @@ mod tests {
                 .await
                 .expect("processing actor must drain the committer");
             waiter3.await.expect("queued commit must be acknowledged");
-            assert_eq!(
-                commits.lock().completed,
-                3,
-                "queued commit must be durable"
-            );
+            assert_eq!(commits.lock().completed, 3, "queued commit must be durable");
         });
     }
 

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -5,7 +5,7 @@ use crate::stateful::{
             processing::Processing,
         },
         metrics::Metrics as StatefulMetrics,
-        processor::{FinalizeStatus, Processor},
+        processor::Processor,
         syncer::{self, StateSyncMetadata, SyncResult},
     },
     db::{Anchor, AttachableResolverSet},
@@ -267,17 +267,12 @@ where
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
-                    let (status, commit) =
-                        processor.finalize(self.context.as_present(), block).await;
-                    if let Some(commit) = commit {
-                        // No committer is running yet: apply the staged commit
-                        // inline before acknowledging.
+                    if let Some(commit) = processor.finalize(self.context.as_present(), block).await {
+                        let height = commit.height();
                         let prune = processor.commit(self.context.as_present(), commit).await;
                         if let Some(prune) = prune {
                             prune.run(processor.databases_mut(), &self.marshal).await;
                         }
-                    }
-                    if let FinalizeStatus::Staged { height } = status {
                         debug!(
                             height = height.get(),
                             "persisted finalized database batch during sync handoff"

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -267,13 +267,17 @@ where
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
-                    let (status, prune) = processor
-                        .finalize(self.context.as_present(), block.as_ref())
-                        .await;
-                    if let Some(prune) = prune {
-                        prune.run(processor.databases_mut(), &self.marshal).await;
+                    let (status, commit) =
+                        processor.finalize(self.context.as_present(), block).await;
+                    if let Some(commit) = commit {
+                        // No committer is running yet: apply the staged commit
+                        // inline before acknowledging.
+                        let prune = processor.commit(self.context.as_present(), commit).await;
+                        if let Some(prune) = prune {
+                            prune.run(processor.databases_mut(), &self.marshal).await;
+                        }
                     }
-                    if let FinalizeStatus::Persisted { height } = status {
+                    if let FinalizeStatus::Staged { height } = status {
                         debug!(
                             height = height.get(),
                             "persisted finalized database batch during sync handoff"

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -267,7 +267,8 @@ where
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
-                    if let Some(commit) = processor.finalize(self.context.as_present(), block).await {
+                    if let Some(commit) = processor.finalize(self.context.as_present(), block).await
+                    {
                         let height = commit.height();
                         let prune = processor.commit(self.context.as_present(), commit).await;
                         if let Some(prune) = prune {

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -715,10 +715,7 @@ where
                 return Err(PrepareBatchesError::Cancelled);
             };
 
-            if !A::Databases::matches_sync_targets(
-                &merkleized,
-                &A::sync_targets(block.as_ref()),
-            ) {
+            if !A::Databases::matches_sync_targets(&merkleized, &A::sync_targets(block.as_ref())) {
                 warn!(
                     ?target_digest,
                     block = ?digest,
@@ -789,7 +786,10 @@ where
         // block commitments previously enforced by `Application::verify`.
         let batch = match self.pending.get_mut(&digest) {
             Some(entry) => {
-                assert!(!entry.committing, "finalized digest already staged for commit");
+                assert!(
+                    !entry.committing,
+                    "finalized digest already staged for commit"
+                );
                 entry.committing = true;
                 entry.merkleized.clone()
             }
@@ -859,9 +859,7 @@ where
         commit: Commit<E, A>,
     ) -> Option<Prune<PendingSyncTargets<A, E>>> {
         let timer = self.metrics.finalize_duration.timer(context);
-        let (digest, prune) = commit
-            .apply(context, &mut self.app, &self.databases)
-            .await;
+        let (digest, prune) = commit.apply(context, &mut self.app, &self.databases).await;
         timer.observe(context);
         self.commit_complete(&digest);
         prune
@@ -874,7 +872,10 @@ where
             .pending
             .remove(digest)
             .expect("commit completion for an unknown digest");
-        assert!(entry.committing, "commit completion for a digest that was not staged");
+        assert!(
+            entry.committing,
+            "commit completion for a digest that was not staged"
+        );
         let _ = self.metrics.pending_blocks.try_set(self.pending.len());
     }
 
@@ -1036,9 +1037,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{
-        await_or_cancel, fetch_ancestor, PrepareBatchesError, Processor, Prune, Pruning,
-    };
+    use super::{await_or_cancel, fetch_ancestor, PrepareBatchesError, Processor, Prune, Pruning};
     use crate::stateful::{
         actor::metrics::Metrics as StatefulMetrics,
         db::{Anchor, DatabaseSet, Merkleized as _, Unmerkleized as _},
@@ -1922,10 +1921,7 @@ mod tests {
 
             let commit1 = harness
                 .processor
-                .finalize(
-                    harness.context_cell.as_present(),
-                    Arc::new(block1.clone()),
-                )
+                .finalize(harness.context_cell.as_present(), Arc::new(block1.clone()))
                 .await
                 .expect("staging must produce commit work");
             assert!(
@@ -1936,10 +1932,7 @@ mod tests {
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             let commit2 = harness
                 .processor
-                .finalize(
-                    harness.context_cell.as_present(),
-                    Arc::new(block2.clone()),
-                )
+                .finalize(harness.context_cell.as_present(), Arc::new(block2.clone()))
                 .await
                 .expect("staging must produce commit work");
             assert!(
@@ -2150,10 +2143,7 @@ mod tests {
 
             let _commit = harness
                 .processor
-                .finalize(
-                    harness.context_cell.as_present(),
-                    Arc::new(block1.clone()),
-                )
+                .finalize(harness.context_cell.as_present(), Arc::new(block1.clone()))
                 .await
                 .expect("first finalization must produce commit work");
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -765,6 +765,14 @@ where
                 digest, self.last_processed.digest,
                 "received conflicting finalized block at processed height",
             );
+            // The processed anchor advances when commit work is staged. Do not
+            // let a duplicate bypass the durability-gated acknowledgement.
+            assert!(
+                self.pending
+                    .get(&digest)
+                    .is_none_or(|entry| !entry.committing),
+                "received duplicate finalized block while commit is in flight",
+            );
             return None;
         }
 
@@ -779,8 +787,12 @@ where
         //
         // Safety contract: replayed `Application::apply` output must match the
         // block commitments previously enforced by `Application::verify`.
-        let batch = match self.pending.get(&digest) {
-            Some(entry) => entry.merkleized.clone(),
+        let batch = match self.pending.get_mut(&digest) {
+            Some(entry) => {
+                assert!(!entry.committing, "finalized digest already staged for commit");
+                entry.committing = true;
+                entry.merkleized.clone()
+            }
             None => {
                 // Fork the parent's retained overlay when its commit is still
                 // in flight; otherwise replay on committed state (which waits
@@ -805,17 +817,19 @@ where
                 );
                 // Retain the replayed state so concurrent propose/verify can
                 // fork it while the commit is in flight.
-                self.cache_pending(digest, parent, round, batch.clone());
+                self.pending.insert(
+                    digest,
+                    PendingEntry {
+                        round,
+                        parent,
+                        merkleized: batch.clone(),
+                        committing: true,
+                    },
+                );
                 batch
             }
         };
 
-        let entry = self
-            .pending
-            .get_mut(&digest)
-            .expect("finalized state must be pending");
-        assert!(!entry.committing, "finalized digest already staged for commit");
-        entry.committing = true;
         let prune = self
             .pruning
             .as_mut()
@@ -2123,6 +2137,30 @@ mod tests {
                 !harness.is_canonical_processed(&conflicting),
                 "conflicting stale block must not be accepted as already processed",
             );
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "received duplicate finalized block while commit is in flight")]
+    fn execution_finalize_panics_on_duplicate_while_commit_in_flight() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut harness = Harness::new(context).await;
+            let genesis = Block::genesis();
+            let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
+
+            let _commit = harness
+                .processor
+                .finalize(
+                    harness.context_cell.as_present(),
+                    Arc::new(block1.clone()),
+                )
+                .await
+                .expect("first finalization must produce commit work");
+
+            let _ = harness
+                .processor
+                .finalize(harness.context_cell.as_present(), Arc::new(block1))
+                .await;
         });
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -14,9 +14,15 @@
 //!   forward via [`Application::apply`], inserting each intermediate result
 //!   into the pending map.
 //!
-//! - Finalization: apply the winning fork's merkleized batches to the
-//!   committed databases, then prune all pending entries at or below the
-//!   finalized round.
+//! - Finalization: stage the winning fork's merkleized batches as a
+//!   [`Commit`], prune all pending entries at or below the finalized round
+//!   (except entries still awaiting a durable commit), and advance the
+//!   processed anchor. The durable commit itself (database write lock +
+//!   sync) is applied by the caller — on a committer task during normal
+//!   processing so it never blocks propose/verify — and the winner's pending
+//!   entry is retained until [`Processor::commit_complete`] so concurrent
+//!   propose/verify keep forking the retained overlay instead of racing the
+//!   in-flight commit.
 //!
 //! All propose/verify paths are cancellation-aware: if the caller drops the
 //! response channel, in-progress work stops at the next await point via
@@ -87,8 +93,31 @@ pub(super) enum FinalizeStatus {
     /// The finalized digest was already processed.
     Duplicate,
 
-    /// The finalized state was persisted and in-memory forks were pruned.
-    Persisted { height: Height },
+    /// The finalized state was staged for durable commit and in-memory forks
+    /// were pruned.
+    Staged { height: Height },
+}
+
+/// Durable-commit work for one finalized block, staged by
+/// [`Processor::finalize`].
+///
+/// The batch is a clone of the retained pending entry: the entry stays in the
+/// pending map so concurrent propose/verify fork the retained overlay instead
+/// of racing the in-flight commit, and is dropped via
+/// [`Processor::commit_complete`] once the durable commit finishes.
+pub(super) struct Commit<E, A>
+where
+    E: Rng + Spawner + Metrics + Clock,
+    A: Application<E>,
+{
+    /// The finalized block being committed.
+    pub(super) block: Arc<A::Block>,
+
+    /// The block's merkleized batches to apply durably.
+    pub(super) batch: PendingBatches<A, E>,
+
+    /// Deferred prune work to run after the commit is durable, if scheduled.
+    pub(super) prune: DeferredPrune<PendingSyncTargets<A, E>>,
 }
 
 /// Marshal and database prune targets selected from finalized history.
@@ -200,6 +229,12 @@ where
     app: A,
     databases: A::Databases,
     pending: PendingMap<A, E>,
+    /// Digests staged for commit whose durable commit has not yet completed.
+    ///
+    /// Their pending entries are retained (even across finalization pruning)
+    /// so concurrent propose/verify can fork them; [`Processor::commit_complete`]
+    /// drops them once durable.
+    committing: HashSet<PendingDigest<A, E>>,
     last_processed: Anchor<PendingDigest<A, E>>,
     metrics: StatefulMetrics,
     pruning: Option<Pruning<PendingSyncTargets<A, E>>>,
@@ -223,6 +258,7 @@ where
             app,
             databases,
             pending: BTreeMap::new(),
+            committing: HashSet::new(),
             last_processed,
             metrics,
             pruning: prune_config.map(Pruning::new),
@@ -237,6 +273,16 @@ where
     /// Returns a mutable reference to the database set.
     pub(super) const fn databases_mut(&mut self) -> &mut A::Databases {
         &mut self.databases
+    }
+
+    /// Returns a clone of the inner application handle.
+    pub(super) fn application(&self) -> A {
+        self.app.clone()
+    }
+
+    /// Returns a reference to the actor metrics.
+    pub(super) const fn metrics(&self) -> &StatefulMetrics {
+        &self.metrics
     }
 
     /// Prepare parent-relative batches and delegate to the application to
@@ -669,7 +715,7 @@ where
                 response,
                 self.app.apply(
                     (context.child("rebuild_pending_apply"), consensus_context),
-                    &block,
+                    block.as_ref(),
                     batches,
                 ),
             )
@@ -678,7 +724,10 @@ where
                 return Err(PrepareBatchesError::Cancelled);
             };
 
-            if !A::Databases::matches_sync_targets(&merkleized, &A::sync_targets(&block)) {
+            if !A::Databases::matches_sync_targets(
+                &merkleized,
+                &A::sync_targets(block.as_ref()),
+            ) {
                 warn!(
                     ?target_digest,
                     block = ?digest,
@@ -696,12 +745,22 @@ where
         Ok(())
     }
 
-    /// Persist finalized state and prune dead in-memory forks.
+    /// Stage finalized state for durable commit and prune dead in-memory forks.
+    ///
+    /// The fast path runs entirely in memory: it locates (or replays) the
+    /// winning fork's merkleized batches, prunes incompatible pending state,
+    /// and advances the processed anchor. The returned [`Commit`] carries
+    /// everything needed to apply the batch durably; callers either enqueue it
+    /// on the committer (normal processing) or apply it inline via
+    /// [`Processor::commit`]. The winner's pending entry is retained until
+    /// [`Processor::commit_complete`] so concurrent propose/verify keep
+    /// forking the retained overlay instead of observing a partially committed
+    /// database.
     pub(super) async fn finalize(
         &mut self,
         context: &E,
-        block: &A::Block,
-    ) -> (FinalizeStatus, DeferredPrune<PendingSyncTargets<A, E>>) {
+        block: Arc<A::Block>,
+    ) -> (FinalizeStatus, Option<Commit<E, A>>) {
         let (height, digest) = (block.height(), block.digest());
         if height < self.last_processed.height {
             panic!(
@@ -718,25 +777,34 @@ where
             return (FinalizeStatus::Duplicate, None);
         }
 
-        let timer = self.metrics.finalize_duration.timer(context);
         let block_context = block.context();
         let round = block_context.round();
-        let sync_targets = A::sync_targets(block);
+        let sync_targets = A::sync_targets(block.as_ref());
 
         // Marshal finalization is ordered. A pending miss means we can replay
-        // this block on top of finalized state.
+        // this block on top of its parent's state (the retained pending entry
+        // if the parent's commit is still in flight, committed state
+        // otherwise).
         //
         // Safety contract: replayed `Application::apply` output must match the
         // block commitments previously enforced by `Application::verify`.
-        let batch = match self.pending.remove(&digest) {
-            Some(entry) => entry.merkleized,
+        let batch = match self.pending.get(&digest) {
+            Some(entry) => entry.merkleized.clone(),
             None => {
-                let batches = self.databases.new_batches().await;
+                // Fork the parent's retained overlay when its commit is still
+                // in flight; otherwise replay on committed state (which waits
+                // out any in-flight commit via the database locks). A replay
+                // from the wrong base is caught by the commitment check below.
+                let parent = block.parent();
+                let batches = match self.fork_batches(&parent).await {
+                    Ok(batches) => batches,
+                    Err(_) => self.databases.new_batches().await,
+                };
                 let batch = self
                     .app
                     .apply(
                         (context.child("finalize_replay"), block_context),
-                        block,
+                        block.as_ref(),
                         batches,
                     )
                     .await;
@@ -744,12 +812,17 @@ where
                     A::Databases::matches_sync_targets(&batch, &sync_targets),
                     "finalize replay state root must match block commitments",
                 );
+                // Retain the replayed state so concurrent propose/verify can
+                // fork it while the commit is in flight.
+                self.cache_pending(digest, parent, round, batch.clone());
                 batch
             }
         };
 
-        self.databases.finalize(batch).await;
-        self.notify_finalized(context, block).await;
+        assert!(
+            self.committing.insert(digest),
+            "finalized digest already staged for commit",
+        );
         let prune = self
             .pruning
             .as_mut()
@@ -760,9 +833,49 @@ where
             round,
             digest,
         };
-        timer.observe(context);
 
-        (FinalizeStatus::Persisted { height }, prune)
+        (
+            FinalizeStatus::Staged { height },
+            Some(Commit {
+                block,
+                batch,
+                prune,
+            }),
+        )
+    }
+
+    /// Apply a staged [`Commit`] inline and drop its retained pending entry,
+    /// returning any deferred prune work.
+    ///
+    /// Normal processing applies commits on the committer task instead; this
+    /// inline path serves callers without a committer (state sync handoff).
+    pub(super) async fn commit(
+        &mut self,
+        context: &E,
+        commit: Commit<E, A>,
+    ) -> DeferredPrune<PendingSyncTargets<A, E>> {
+        let Commit {
+            block,
+            batch,
+            prune,
+        } = commit;
+        let timer = self.metrics.finalize_duration.timer(context);
+        self.databases.finalize(batch).await;
+        self.notify_finalized(context, block.as_ref()).await;
+        timer.observe(context);
+        self.commit_complete(&block.digest());
+        prune
+    }
+
+    /// Drop the pending entry retained for `digest` once its durable commit
+    /// has completed.
+    pub(super) fn commit_complete(&mut self, digest: &PendingDigest<A, E>) {
+        assert!(
+            self.committing.remove(digest),
+            "commit completion for a digest that was not staged",
+        );
+        self.pending.remove(digest);
+        let _ = self.metrics.pending_blocks.try_set(self.pending.len());
     }
 
     /// Notify the application that marshal delivered a finalized block already
@@ -780,8 +893,10 @@ where
     /// Remove pending state that is not compatible with the finalized winner.
     ///
     /// A pending block is kept only when:
-    /// - it is a descendant of `finalized_digest`, and
-    /// - it was created after `finalized_round`.
+    /// - it is a descendant of `finalized_digest` created after
+    ///   `finalized_round`, or
+    /// - it is staged for a durable commit that has not yet completed (the
+    ///   winner itself and any ancestors still in the commit pipeline).
     fn prune_pending_after_finalize(
         &mut self,
         finalized_digest: &<A::Block as Digestible>::Digest,
@@ -813,8 +928,10 @@ where
         }
 
         let before = self.pending.len();
+        let committing = &self.committing;
         self.pending.retain(|candidate_digest, entry| {
-            entry.round > finalized_round && compatible.contains(candidate_digest)
+            committing.contains(candidate_digest)
+                || (entry.round > finalized_round && compatible.contains(candidate_digest))
         });
         let pruned = before - self.pending.len();
         self.metrics.pruned_forks.inc_by(pruned as u64);
@@ -1489,11 +1606,10 @@ mod tests {
             false
         }
 
+        /// Stage a finalized block and apply its durable commit inline,
+        /// mirroring the committer's stage-then-commit sequence.
         async fn finalize(&mut self, block: Block) -> FinalizeStatus {
-            self.processor
-                .finalize(self.context_cell.as_present(), &block)
-                .await
-                .0
+            self.finalize_with_prune(block).await.0
         }
 
         async fn finalize_with_prune(
@@ -1509,9 +1625,18 @@ mod tests {
                 >,
             >,
         ){
-            self.processor
-                .finalize(self.context_cell.as_present(), &block)
-                .await
+            let (status, commit) = self
+                .processor
+                .finalize(self.context_cell.as_present(), Arc::new(block))
+                .await;
+            let mut prune = None;
+            if let Some(commit) = commit {
+                prune = self
+                    .processor
+                    .commit(self.context_cell.as_present(), commit)
+                    .await;
+            }
+            (status, prune)
         }
 
         async fn height_value(&self, height: Height) -> Option<u64> {
@@ -1741,7 +1866,7 @@ mod tests {
             let (status, prune) = harness.finalize_with_prune(block1).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -1767,7 +1892,7 @@ mod tests {
             let status = harness.finalize(winner.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(2)
                 },
                 "finalization should persist winner state",
@@ -1801,7 +1926,7 @@ mod tests {
             let status = harness.finalize(winner.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(2)
                 },
                 "finalization should persist winner state",
@@ -1821,6 +1946,85 @@ mod tests {
     }
 
     #[test]
+    fn execution_finalization_retains_pending_entry_until_commit_completes() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut harness = Harness::new(context).await;
+            let genesis = Block::genesis();
+            let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
+
+            let (status, commit1) = harness
+                .processor
+                .finalize(
+                    harness.context_cell.as_present(),
+                    Arc::new(block1.clone()),
+                )
+                .await;
+            assert_eq!(
+                status,
+                FinalizeStatus::Staged {
+                    height: Height::new(1)
+                }
+            );
+            let commit1 = commit1.expect("staging must produce commit work");
+            assert!(
+                harness.processor.pending.contains_key(&block1.digest()),
+                "staged entry must be retained until its commit completes",
+            );
+            assert!(
+                harness
+                    .processor
+                    .fork_batches(&block1.digest())
+                    .await
+                    .is_ok(),
+                "the retained overlay must remain forkable during the commit",
+            );
+
+            // Build and stage a child while the parent commit is in flight.
+            let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
+            let (status, commit2) = harness
+                .processor
+                .finalize(
+                    harness.context_cell.as_present(),
+                    Arc::new(block2.clone()),
+                )
+                .await;
+            assert_eq!(
+                status,
+                FinalizeStatus::Staged {
+                    height: Height::new(2)
+                }
+            );
+            let commit2 = commit2.expect("staging must produce commit work");
+            assert!(
+                harness.processor.pending.contains_key(&block1.digest()),
+                "committing ancestors must survive finalization pruning",
+            );
+            assert!(harness.processor.pending.contains_key(&block2.digest()));
+            assert_eq!(harness.processor.last_processed.digest, block2.digest());
+
+            // Commit in finalization order; each completion drops its entry.
+            harness
+                .processor
+                .commit(harness.context_cell.as_present(), commit1)
+                .await;
+            assert!(
+                !harness.processor.pending.contains_key(&block1.digest()),
+                "completed commit must drop its retained entry",
+            );
+            assert!(harness.processor.pending.contains_key(&block2.digest()));
+            harness
+                .processor
+                .commit(harness.context_cell.as_present(), commit2)
+                .await;
+            assert!(!harness.processor.pending.contains_key(&block2.digest()));
+
+            assert_eq!(harness.height_value(Height::new(1)).await, Some(1));
+            assert_eq!(harness.height_value(Height::new(2)).await, Some(2));
+            assert_eq!(harness.counter_value().await, Some(2));
+        });
+    }
+
+    #[test]
     fn execution_rebuild_pending_restores_missing_chain() {
         deterministic::Runner::default().start(|context| async move {
             let mut harness = Harness::new(context).await;
@@ -1829,7 +2033,7 @@ mod tests {
             let status = harness.finalize(block1.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -1869,7 +2073,7 @@ mod tests {
                 let status = harness.finalize(block.clone()).await;
                 assert_eq!(
                     status,
-                    FinalizeStatus::Persisted {
+                    FinalizeStatus::Staged {
                         height: Height::new(view),
                     }
                 );
@@ -1908,7 +2112,7 @@ mod tests {
             let status = harness.finalize(block1.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -1945,7 +2149,7 @@ mod tests {
             let status = harness.finalize(block1.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -2007,7 +2211,7 @@ mod tests {
             let status = harness.finalize(canonical).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1),
                 }
             );
@@ -2032,7 +2236,7 @@ mod tests {
             let status = harness.finalize(canonical).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1),
                 }
             );
@@ -2051,7 +2255,7 @@ mod tests {
             let status = harness.finalize(block1).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -2078,14 +2282,14 @@ mod tests {
             let status = harness.finalize(block1).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
             let status = harness.finalize(block2).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(2)
                 }
             );
@@ -2108,7 +2312,7 @@ mod tests {
             let status = harness.finalize(block1.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -2160,7 +2364,7 @@ mod tests {
             let status = harness.finalize(block1.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );
@@ -2195,7 +2399,7 @@ mod tests {
             let status = harness.finalize(block1.clone()).await;
             assert_eq!(
                 status,
-                FinalizeStatus::Persisted {
+                FinalizeStatus::Staged {
                     height: Height::new(1)
                 }
             );

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -14,15 +14,9 @@
 //!   forward via [`Application::apply`], inserting each intermediate result
 //!   into the pending map.
 //!
-//! - Finalization: stage the winning fork's merkleized batches as a
-//!   [`Commit`], prune all pending entries at or below the finalized round
-//!   (except entries still awaiting a durable commit), and advance the
-//!   processed anchor. The durable commit itself (database write lock +
-//!   sync) is applied by the caller — on a committer task during normal
-//!   processing so it never blocks propose/verify — and the winner's pending
-//!   entry is retained until [`Processor::commit_complete`] so concurrent
-//!   propose/verify keep forking the retained overlay instead of racing the
-//!   in-flight commit.
+//! - Finalization: stage the winning fork as a [`Commit`], advance the
+//!   processed anchor, and prune incompatible pending state. The winner remains
+//!   forkable until its durable commit completes.
 //!
 //! All propose/verify paths are cancellation-aware: if the caller drops the
 //! response channel, in-progress work stops at the next await point via
@@ -63,7 +57,6 @@ type PendingDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
 type PendingBatches<A, E> = <<A as Application<E>>::Databases as DatabaseSet<E>>::Merkleized;
 type PendingMap<A, E> = BTreeMap<PendingDigest<A, E>, PendingEntry<A, E>>;
 type PendingSyncTargets<A, E> = <<A as Application<E>>::Databases as DatabaseSet<E>>::SyncTargets;
-type DeferredPrune<T> = Option<Prune<T>>;
 
 /// Cached speculative state for a block digest.
 struct PendingEntry<A, E>
@@ -74,6 +67,7 @@ where
     round: Round,
     parent: PendingDigest<A, E>,
     merkleized: PendingBatches<A, E>,
+    committing: bool,
 }
 
 /// Errors while preparing parent-relative batches for propose/verify.
@@ -87,37 +81,41 @@ pub(super) enum PrepareBatchesError {
     Cancelled,
 }
 
-/// Finalization result for a finalized block report.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum FinalizeStatus {
-    /// The finalized digest was already processed.
-    Duplicate,
-
-    /// The finalized state was staged for durable commit and in-memory forks
-    /// were pruned.
-    Staged { height: Height },
-}
-
-/// Durable-commit work for one finalized block, staged by
-/// [`Processor::finalize`].
-///
-/// The batch is a clone of the retained pending entry: the entry stays in the
-/// pending map so concurrent propose/verify fork the retained overlay instead
-/// of racing the in-flight commit, and is dropped via
-/// [`Processor::commit_complete`] once the durable commit finishes.
+/// Durable work staged by [`Processor::finalize`].
 pub(super) struct Commit<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
 {
-    /// The finalized block being committed.
-    pub(super) block: Arc<A::Block>,
+    block: Arc<A::Block>,
+    batch: PendingBatches<A, E>,
+    prune: Option<Prune<PendingSyncTargets<A, E>>>,
+}
 
-    /// The block's merkleized batches to apply durably.
-    pub(super) batch: PendingBatches<A, E>,
+impl<E, A> Commit<E, A>
+where
+    E: Rng + Spawner + Metrics + Clock,
+    A: Application<E>,
+{
+    pub(super) fn height(&self) -> Height {
+        self.block.height()
+    }
 
-    /// Deferred prune work to run after the commit is durable, if scheduled.
-    pub(super) prune: DeferredPrune<PendingSyncTargets<A, E>>,
+    pub(super) async fn apply(
+        self,
+        context: &E,
+        app: &mut A,
+        databases: &A::Databases,
+    ) -> (PendingDigest<A, E>, Option<Prune<PendingSyncTargets<A, E>>>) {
+        databases.finalize(self.batch).await;
+        app.finalized(
+            (context.child("finalized"), self.block.context()),
+            self.block.as_ref(),
+            databases,
+        )
+        .await;
+        (self.block.digest(), self.prune)
+    }
 }
 
 /// Marshal and database prune targets selected from finalized history.
@@ -178,7 +176,7 @@ impl<T: Clone> Pruning<T> {
     /// plus the configured retained block windows. It then prunes only when the
     /// largest required window is populated and the current finalized height
     /// matches the configured maintenance interval.
-    fn observe_finalized(&mut self, height: Height, targets: T) -> DeferredPrune<T> {
+    fn observe_finalized(&mut self, height: Height, targets: T) -> Option<Prune<T>> {
         self.retained_targets.push_back((height, targets));
         if self.retained_targets.len() > self.marshal_retention_window {
             self.retained_targets.pop_front();
@@ -229,12 +227,6 @@ where
     app: A,
     databases: A::Databases,
     pending: PendingMap<A, E>,
-    /// Digests staged for commit whose durable commit has not yet completed.
-    ///
-    /// Their pending entries are retained (even across finalization pruning)
-    /// so concurrent propose/verify can fork them; [`Processor::commit_complete`]
-    /// drops them once durable.
-    committing: HashSet<PendingDigest<A, E>>,
     last_processed: Anchor<PendingDigest<A, E>>,
     metrics: StatefulMetrics,
     pruning: Option<Pruning<PendingSyncTargets<A, E>>>,
@@ -258,7 +250,6 @@ where
             app,
             databases,
             pending: BTreeMap::new(),
-            committing: HashSet::new(),
             last_processed,
             metrics,
             pruning: prune_config.map(Pruning::new),
@@ -760,7 +751,7 @@ where
         &mut self,
         context: &E,
         block: Arc<A::Block>,
-    ) -> (FinalizeStatus, Option<Commit<E, A>>) {
+    ) -> Option<Commit<E, A>> {
         let (height, digest) = (block.height(), block.digest());
         if height < self.last_processed.height {
             panic!(
@@ -774,7 +765,7 @@ where
                 digest, self.last_processed.digest,
                 "received conflicting finalized block at processed height",
             );
-            return (FinalizeStatus::Duplicate, None);
+            return None;
         }
 
         let block_context = block.context();
@@ -819,10 +810,12 @@ where
             }
         };
 
-        assert!(
-            self.committing.insert(digest),
-            "finalized digest already staged for commit",
-        );
+        let entry = self
+            .pending
+            .get_mut(&digest)
+            .expect("finalized state must be pending");
+        assert!(!entry.committing, "finalized digest already staged for commit");
+        entry.committing = true;
         let prune = self
             .pruning
             .as_mut()
@@ -834,14 +827,11 @@ where
             digest,
         };
 
-        (
-            FinalizeStatus::Staged { height },
-            Some(Commit {
-                block,
-                batch,
-                prune,
-            }),
-        )
+        Some(Commit {
+            block,
+            batch,
+            prune,
+        })
     }
 
     /// Apply a staged [`Commit`] inline and drop its retained pending entry,
@@ -853,28 +843,24 @@ where
         &mut self,
         context: &E,
         commit: Commit<E, A>,
-    ) -> DeferredPrune<PendingSyncTargets<A, E>> {
-        let Commit {
-            block,
-            batch,
-            prune,
-        } = commit;
+    ) -> Option<Prune<PendingSyncTargets<A, E>>> {
         let timer = self.metrics.finalize_duration.timer(context);
-        self.databases.finalize(batch).await;
-        self.notify_finalized(context, block.as_ref()).await;
+        let (digest, prune) = commit
+            .apply(context, &mut self.app, &self.databases)
+            .await;
         timer.observe(context);
-        self.commit_complete(&block.digest());
+        self.commit_complete(&digest);
         prune
     }
 
     /// Drop the pending entry retained for `digest` once its durable commit
     /// has completed.
     pub(super) fn commit_complete(&mut self, digest: &PendingDigest<A, E>) {
-        assert!(
-            self.committing.remove(digest),
-            "commit completion for a digest that was not staged",
-        );
-        self.pending.remove(digest);
+        let entry = self
+            .pending
+            .remove(digest)
+            .expect("commit completion for an unknown digest");
+        assert!(entry.committing, "commit completion for a digest that was not staged");
         let _ = self.metrics.pending_blocks.try_set(self.pending.len());
     }
 
@@ -928,9 +914,8 @@ where
         }
 
         let before = self.pending.len();
-        let committing = &self.committing;
         self.pending.retain(|candidate_digest, entry| {
-            committing.contains(candidate_digest)
+            entry.committing
                 || (entry.round > finalized_round && compatible.contains(candidate_digest))
         });
         let pruned = before - self.pending.len();
@@ -957,6 +942,7 @@ where
                 round,
                 parent,
                 merkleized,
+                committing: false,
             },
         );
     }
@@ -1037,8 +1023,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        await_or_cancel, fetch_ancestor, FinalizeStatus, PrepareBatchesError, Processor, Prune,
-        Pruning,
+        await_or_cancel, fetch_ancestor, PrepareBatchesError, Processor, Prune, Pruning,
     };
     use crate::stateful::{
         actor::metrics::Metrics as StatefulMetrics,
@@ -1606,37 +1591,26 @@ mod tests {
             false
         }
 
-        /// Stage a finalized block and apply its durable commit inline,
-        /// mirroring the committer's stage-then-commit sequence.
-        async fn finalize(&mut self, block: Block) -> FinalizeStatus {
-            self.finalize_with_prune(block).await.0
+        async fn finalize(&mut self, block: Block) {
+            let _ = self.finalize_with_prune(block).await;
         }
 
         async fn finalize_with_prune(
             &mut self,
             block: Block,
-        ) -> (
-            FinalizeStatus,
-            Option<
-                Prune<
-                    <DbSet<deterministic::Context> as DatabaseSet<
-                        deterministic::Context,
-                    >>::SyncTargets,
-                >,
+        ) -> Option<
+            Prune<
+                <DbSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::SyncTargets,
             >,
-        ){
-            let (status, commit) = self
+        > {
+            let commit = self
                 .processor
                 .finalize(self.context_cell.as_present(), Arc::new(block))
-                .await;
-            let mut prune = None;
-            if let Some(commit) = commit {
-                prune = self
-                    .processor
-                    .commit(self.context_cell.as_present(), commit)
-                    .await;
-            }
-            (status, prune)
+                .await
+                .expect("finalization must produce commit work");
+            self.processor
+                .commit(self.context_cell.as_present(), commit)
+                .await
         }
 
         async fn height_value(&self, height: Height) -> Option<u64> {
@@ -1863,13 +1837,7 @@ mod tests {
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            let (status, prune) = harness.finalize_with_prune(block1).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            let prune = harness.finalize_with_prune(block1).await;
             assert_eq!(
                 prune, None,
                 "pruning should wait for the full retention window",
@@ -1889,14 +1857,7 @@ mod tests {
             assert!(harness.processor.pending.contains_key(&winner.digest()));
             assert!(harness.processor.pending.contains_key(&loser.digest()));
 
-            let status = harness.finalize(winner.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(2)
-                },
-                "finalization should persist winner state",
-            );
+            harness.finalize(winner.clone()).await;
             assert!(
                 !harness.processor.pending.contains_key(&loser.digest()),
                 "losing fork at finalized round should be pruned",
@@ -1923,14 +1884,7 @@ mod tests {
                 .pending
                 .contains_key(&loser_child.digest()));
 
-            let status = harness.finalize(winner.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(2)
-                },
-                "finalization should persist winner state",
-            );
+            harness.finalize(winner.clone()).await;
             assert!(
                 !harness.processor.pending.contains_key(&loser.digest()),
                 "losing fork at finalized round should be pruned",
@@ -1952,49 +1906,28 @@ mod tests {
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            let (status, commit1) = harness
+            let commit1 = harness
                 .processor
                 .finalize(
                     harness.context_cell.as_present(),
                     Arc::new(block1.clone()),
                 )
-                .await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
-            let commit1 = commit1.expect("staging must produce commit work");
+                .await
+                .expect("staging must produce commit work");
             assert!(
                 harness.processor.pending.contains_key(&block1.digest()),
                 "staged entry must be retained until its commit completes",
             );
-            assert!(
-                harness
-                    .processor
-                    .fork_batches(&block1.digest())
-                    .await
-                    .is_ok(),
-                "the retained overlay must remain forkable during the commit",
-            );
-
             // Build and stage a child while the parent commit is in flight.
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
-            let (status, commit2) = harness
+            let commit2 = harness
                 .processor
                 .finalize(
                     harness.context_cell.as_present(),
                     Arc::new(block2.clone()),
                 )
-                .await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(2)
-                }
-            );
-            let commit2 = commit2.expect("staging must produce commit work");
+                .await
+                .expect("staging must produce commit work");
             assert!(
                 harness.processor.pending.contains_key(&block1.digest()),
                 "committing ancestors must survive finalization pruning",
@@ -2030,13 +1963,7 @@ mod tests {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let status = harness.finalize(block1.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1.clone()).await;
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             let block3 = harness.stage_pending_child(&block2, View::new(3)).await;
@@ -2070,13 +1997,7 @@ mod tests {
             let mut parent = genesis;
             for view in 1..=5 {
                 let block = harness.stage_pending_child(&parent, View::new(view)).await;
-                let status = harness.finalize(block.clone()).await;
-                assert_eq!(
-                    status,
-                    FinalizeStatus::Staged {
-                        height: Height::new(view),
-                    }
-                );
+                harness.finalize(block.clone()).await;
                 parent = block.clone();
                 chain.push(block);
             }
@@ -2109,13 +2030,7 @@ mod tests {
             let genesis = Block::genesis();
 
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let status = harness.finalize(block1.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1.clone()).await;
 
             let mut block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             harness.processor.pending.clear();
@@ -2146,13 +2061,7 @@ mod tests {
             let genesis = Block::genesis();
 
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let status = harness.finalize(block1.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1.clone()).await;
 
             let gap_height = Height::new(3);
             let gap_view = View::new(3);
@@ -2208,13 +2117,7 @@ mod tests {
             let canonical = harness.stage_pending_child(&genesis, View::new(1)).await;
             let conflicting = harness.stage_pending_child(&genesis, View::new(2)).await;
 
-            let status = harness.finalize(canonical).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1),
-                }
-            );
+            harness.finalize(canonical).await;
 
             assert!(
                 !harness.is_canonical_processed(&conflicting),
@@ -2233,13 +2136,7 @@ mod tests {
             let canonical = harness.stage_pending_child(&genesis, View::new(1)).await;
             let conflicting = harness.stage_pending_child(&genesis, View::new(2)).await;
 
-            let status = harness.finalize(canonical).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1),
-                }
-            );
+            harness.finalize(canonical).await;
 
             let _ = harness.finalize(conflicting).await;
         });
@@ -2252,13 +2149,7 @@ mod tests {
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            let status = harness.finalize(block1).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1).await;
             assert_eq!(harness.counter_value().await, Some(1));
             assert_eq!(
                 harness
@@ -2279,20 +2170,8 @@ mod tests {
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
 
-            let status = harness.finalize(block1).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
-            let status = harness.finalize(block2).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(2)
-                }
-            );
+            harness.finalize(block1).await;
+            harness.finalize(block2).await;
             assert_eq!(
                 finalized_values.lock().clone(),
                 vec![1, 2],
@@ -2309,13 +2188,7 @@ mod tests {
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            let status = harness.finalize(block1.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1.clone()).await;
 
             finalized_values.lock().clear();
             harness
@@ -2361,13 +2234,7 @@ mod tests {
             let mut harness = Harness::new(context.child("harness")).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let status = harness.finalize(block1.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1.clone()).await;
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             harness.processor.pending.clear();
@@ -2396,13 +2263,7 @@ mod tests {
             let mut harness = Harness::new(context.child("harness")).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let status = harness.finalize(block1.clone()).await;
-            assert_eq!(
-                status,
-                FinalizeStatus::Staged {
-                    height: Height::new(1)
-                }
-            );
+            harness.finalize(block1.clone()).await;
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             harness.processor.pending.clear();

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -209,7 +209,6 @@ where
     }
 }
 
-/// Cloning shares the same underlying merkleized batch and database handle.
 impl<F, E, C, I, H, U, S> Clone for AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -209,6 +209,26 @@ where
     }
 }
 
+/// Cloning shares the same underlying merkleized batch and database handle.
+impl<F, E, C, I, H, U, S> Clone for AnyMerkleized<F, E, C, I, H, U, S>
+where
+    F: Family,
+    E: Context,
+    U: Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+        }
+    }
+}
+
 /// Read-expansion operations for the `any` staged batch.
 impl<F, E, C, I, H, U, S> AnyStaged<F, E, C, I, H, U, S>
 where

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -209,7 +209,6 @@ where
     }
 }
 
-/// Cloning shares the same underlying merkleized batch and database handle.
 impl<F, E, C, I, H, U, const N: usize, S> Clone for CurrentMerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -209,6 +209,26 @@ where
     }
 }
 
+/// Cloning shares the same underlying merkleized batch and database handle.
+impl<F, E, C, I, H, U, const N: usize, S> Clone for CurrentMerkleized<F, E, C, I, H, U, N, S>
+where
+    F: Graftable,
+    E: Context,
+    U: Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+        }
+    }
+}
+
 /// Read-expansion operations for the `current` staged batch.
 impl<F, E, C, I, H, U, const N: usize, S> CurrentStaged<F, E, C, I, H, U, N, S>
 where

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -136,7 +136,6 @@ where
     }
 }
 
-/// Cloning shares the same underlying merkleized batch and database handle.
 impl<F, E, K, V, H, S, C> Clone for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
 where
     F: Family,

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -136,6 +136,27 @@ where
     }
 }
 
+/// Cloning shares the same underlying merkleized batch and database handle.
+impl<F, E, K, V, H, S, C> Clone for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
+where
+    F: Family,
+    E: Context,
+    K: Key,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, K, V>: EncodeShared,
+    Operation<F, K, V>: CodecRead<Cfg = C>,
+    C: Clone + Send + Sync + 'static,
+    S: Strategy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, K, V, H, S, C> UnmerkleizedTrait
     for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
 where

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -160,6 +160,27 @@ where
     }
 }
 
+/// Cloning shares the same underlying merkleized batch and database handle.
+impl<F, E, K, V, C, H, T, S> Clone for ImmutableMerkleized<F, E, K, V, C, H, T, S>
+where
+    F: Family,
+    E: Context,
+    K: Key,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<F, K, V>>,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+    Operation<F, K, V>: EncodeShared,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, K, V, C, H, T, S> ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -160,7 +160,6 @@ where
     }
 }
 
-/// Cloning shares the same underlying merkleized batch and database handle.
 impl<F, E, K, V, C, H, T, S> Clone for ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -130,6 +130,26 @@ where
     }
 }
 
+/// Cloning shares the same underlying merkleized batch and database handle.
+impl<F, E, V, H, S, C> Clone for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
+where
+    F: Family,
+    E: Context,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, V>: EncodeShared,
+    Operation<F, V>: CodecRead<Cfg = C>,
+    C: Clone + Send + Sync + 'static,
+    S: Strategy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, V, H, S, C> UnmerkleizedTrait for KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
 where
     F: Family,

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -130,7 +130,6 @@ where
     }
 }
 
-/// Cloning shares the same underlying merkleized batch and database handle.
 impl<F, E, V, H, S, C> Clone for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
 where
     F: Family,

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -152,7 +152,6 @@ where
     }
 }
 
-/// Cloning shares the same underlying merkleized batch and database handle.
 impl<F, E, V, C, H, S> Clone for KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -152,6 +152,25 @@ where
     }
 }
 
+/// Cloning shares the same underlying merkleized batch and database handle.
+impl<F, E, V, C, H, S> Clone for KeylessMerkleized<F, E, V, C, H, S>
+where
+    F: Family,
+    E: Context,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<F, V>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, V>: EncodeShared,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, V, C, H, S> KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -129,10 +129,7 @@ pub trait Unmerkleized: Sized + Send {
 /// The application uses [`root`](Self::root) in block headers, and the wrapper
 /// later finalizes this batch.
 ///
-/// Implementations must be cheap, shareable handles (typically `Arc`-backed):
-/// cloning shares the same underlying batch. The stateful actor relies on this
-/// to retain a forkable pending entry while a clone of the same batch is
-/// committed off the actor loop.
+/// Clones must cheaply share the underlying batch, typically via `Arc`.
 pub trait Merkleized: Sized + Send + Sync + Clone {
     /// The digest type used for the state root.
     type Digest: Digest;

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -128,7 +128,12 @@ pub trait Unmerkleized: Sized + Send {
 ///
 /// The application uses [`root`](Self::root) in block headers, and the wrapper
 /// later finalizes this batch.
-pub trait Merkleized: Sized + Send + Sync {
+///
+/// Implementations must be cheap, shareable handles (typically `Arc`-backed):
+/// cloning shares the same underlying batch. The stateful actor relies on this
+/// to retain a forkable pending entry while a clone of the same batch is
+/// committed off the actor loop.
+pub trait Merkleized: Sized + Send + Sync + Clone {
     /// The digest type used for the state root.
     type Digest: Digest;
 
@@ -246,7 +251,10 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     type Unmerkleized: Send;
 
     /// Tuple of [`ManagedDb::Merkleized`] for every database in the set.
-    type Merkleized: Send + Sync;
+    ///
+    /// Cloning must be cheap and share the same underlying batches (see
+    /// [`Merkleized`]).
+    type Merkleized: Send + Sync + Clone;
 
     /// Configuration needed to construct every database in the set.
     ///

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -272,10 +272,8 @@ where
     /// a crash after this hook runs but before the marshal acknowledgement is
     /// durable may cause the same block to be reported again after restart.
     ///
-    /// Because durable commits are applied off the actor loop, the wrapper may
-    /// invoke this hook on a clone of the application. Implementations must
-    /// not rely on hook invocations sharing instance-local state with other
-    /// application callbacks (share state behind a handle instead).
+    /// This hook may run on a clone of the application. Share state needed by
+    /// other callbacks behind a handle.
     ///
     /// # Panics
     ///

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -272,6 +272,11 @@ where
     /// a crash after this hook runs but before the marshal acknowledgement is
     /// durable may cause the same block to be reported again after restart.
     ///
+    /// Because durable commits are applied off the actor loop, the wrapper may
+    /// invoke this hook on a clone of the application. Implementations must
+    /// not rely on hook invocations sharing instance-local state with other
+    /// application callbacks (share state behind a handle instead).
+    ///
     /// # Panics
     ///
     /// Implementations should panic if post-finalization maintenance fails.


### PR DESCRIPTION
## Overview

Ports the stateful glue changes from https://github.com/commonwarexyz/monorepo/pull/4233. Finalized batches are staged on the actor and applied by a FIFO committer, keeping propose and verify responsive while retaining pending overlays and delaying acknowledgements until the batch is durable.

The port also simplifies commit state tracking and centralizes the durable apply and finalized-hook sequence. It fixes two bugs found along the way: shutdown now waits even when the committer has not been polled yet, and a duplicate finalization cannot be acknowledged while the original commit is still in flight.