### PR TITLE
[storage/index] Push spilled collision inserts in amortized O(1)

### DIFF
--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -11,7 +11,7 @@ use super::partition::Partition;
 use crate::index::Cursor as CursorTrait;
 use commonware_runtime::telemetry::metrics::{Counter, Gauge};
 use std::{
-    collections::{btree_map, hash_map, BTreeMap, HashMap},
+    collections::{btree_map, hash_map, BTreeMap, HashMap, VecDeque},
     ops::Range,
 };
 
@@ -45,7 +45,7 @@ enum Backing<'a, K: Ord + Copy, V> {
     /// Spilled partition: the key's values live in the side-table's `BTreeMap`, re-resolved on each
     /// access (spilling is the rare case, so the extra descent is off the hot path).
     Spilled {
-        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
+        spilled: &'a mut HashMap<usize, BTreeMap<K, VecDeque<V>>>,
         partition: usize,
         key: K,
     },
@@ -63,7 +63,7 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
             } => spilled
                 .get(partition)
                 .and_then(|inner| inner.get(key))
-                .map_or(0, Vec::len),
+                .map_or(0, VecDeque::len),
         }
     }
 
@@ -123,7 +123,7 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                     false
                 }
                 btree_map::Entry::Vacant(run) => {
-                    run.insert(vec![value]);
+                    run.insert(VecDeque::from([value]));
                     true
                 }
             },
@@ -150,7 +150,9 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 let btree_map::Entry::Occupied(mut run) = part.get_mut().entry(*key) else {
                     unreachable!("active cursor must reference a present key")
                 };
-                run.get_mut().remove(off);
+                run.get_mut()
+                    .remove(off)
+                    .expect("active cursor offset must be within the run");
                 if !run.get().is_empty() {
                     return false;
                 }
@@ -204,7 +206,7 @@ impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
 
     /// A cursor over a key's values held in a spilled partition's `BTreeMap`.
     pub(super) const fn spilled(
-        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
+        spilled: &'a mut HashMap<usize, BTreeMap<K, VecDeque<V>>>,
         partition: usize,
         key: K,
         keys: &'a Gauge,

--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -11,7 +11,7 @@ use super::partition::Partition;
 use crate::index::Cursor as CursorTrait;
 use commonware_runtime::telemetry::metrics::{Counter, Gauge};
 use std::{
-    collections::{btree_map, hash_map, BTreeMap, HashMap, VecDeque},
+    collections::{btree_map, hash_map, BTreeMap, HashMap},
     ops::Range,
 };
 
@@ -44,8 +44,12 @@ enum Backing<'a, K: Ord + Copy, V> {
     },
     /// Spilled partition: the key's values live in the side-table's `BTreeMap`, re-resolved on each
     /// access (spilling is the rare case, so the extra descent is off the hot path).
+    ///
+    /// Spilled chains are stored oldest-first (the reverse of run/iteration order, so plain inserts
+    /// can push the newest value at the end), so run offset `off` addresses chain index
+    /// `len - 1 - off` and an insert at run offset `off` lands at chain index `len - off`.
     Spilled {
-        spilled: &'a mut HashMap<usize, BTreeMap<K, VecDeque<V>>>,
+        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
         partition: usize,
         key: K,
     },
@@ -63,7 +67,7 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
             } => spilled
                 .get(partition)
                 .and_then(|inner| inner.get(key))
-                .map_or(0, VecDeque::len),
+                .map_or(0, Vec::len),
         }
     }
 
@@ -75,10 +79,13 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 spilled,
                 partition,
                 key,
-            } => &spilled
-                .get(partition)
-                .and_then(|inner| inner.get(key))
-                .expect("active cursor must reference a present key")[off],
+            } => {
+                let run = spilled
+                    .get(partition)
+                    .and_then(|inner| inner.get(key))
+                    .expect("active cursor must reference a present key");
+                &run[run.len() - 1 - off]
+            }
         }
     }
 
@@ -91,10 +98,12 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 partition,
                 key,
             } => {
-                spilled
+                let run = spilled
                     .get_mut(partition)
                     .and_then(|inner| inner.get_mut(key))
-                    .expect("active cursor must reference a present key")[off] = value;
+                    .expect("active cursor must reference a present key");
+                let idx = run.len() - 1 - off;
+                run[idx] = value;
             }
         }
     }
@@ -119,11 +128,12 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 key,
             } => match spilled.entry(*partition).or_default().entry(*key) {
                 btree_map::Entry::Occupied(mut run) => {
-                    run.get_mut().insert(off, value);
+                    let idx = run.get().len() - off;
+                    run.get_mut().insert(idx, value);
                     false
                 }
                 btree_map::Entry::Vacant(run) => {
-                    run.insert(VecDeque::from([value]));
+                    run.insert(vec![value]);
                     true
                 }
             },
@@ -150,9 +160,8 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 let btree_map::Entry::Occupied(mut run) = part.get_mut().entry(*key) else {
                     unreachable!("active cursor must reference a present key")
                 };
-                run.get_mut()
-                    .remove(off)
-                    .expect("active cursor offset must be within the run");
+                let idx = run.get().len() - 1 - off;
+                run.get_mut().remove(idx);
                 if !run.get().is_empty() {
                     return false;
                 }
@@ -206,7 +215,7 @@ impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
 
     /// A cursor over a key's values held in a spilled partition's `BTreeMap`.
     pub(super) const fn spilled(
-        spilled: &'a mut HashMap<usize, BTreeMap<K, VecDeque<V>>>,
+        spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
         partition: usize,
         key: K,
         keys: &'a Gauge,

--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -6,6 +6,9 @@
 //! must-call-`next` guards, and the metric bookkeeping) is identical for both representations, so it
 //! is written once here; [Backing] holds the only thing that differs: the positional store
 //! operations.
+//!
+//! Runs store their newest value last, and the cursor serves values newest-first, so it walks run
+//! indices descending from the run's end (as the flat index's cursor walks its overflow chain).
 
 use super::partition::Partition;
 use crate::index::Cursor as CursorTrait;
@@ -18,19 +21,21 @@ use std::{
 const MUST_CALL_NEXT: &str = "must call Cursor::next()";
 const NO_ACTIVE_ITEM: &str = "no active item in Cursor";
 
-/// Position of a [Cursor] within its key's value run (offset 0 is the run's first value).
+/// Position of a [Cursor] within its key's value run (offset 0 is the run's first, oldest value).
+/// Iteration serves values newest-first, so it starts at the run's last offset and steps down.
 enum State {
     /// Before the first `next()` or after an `insert()`/`delete()`: the next `next()` returns the
-    /// value at run offset `from`.
-    NeedNext { from: usize },
+    /// value at run offset `from`, or `None` when iteration is exhausted.
+    NeedNext { from: Option<usize> },
     /// `next()` returned the value at run offset `offset`; `update`/`delete`/`insert` are valid.
     Active { offset: usize },
-    /// `next()` returned `None`; only `insert()` (which appends) is valid.
+    /// `next()` returned `None`; only `insert()` (which appends at the oldest position) is valid.
     Done,
 }
 
 /// The store holding a [Cursor]'s value run, abstracting the inline and spilled representations
-/// behind a common positional interface. All offsets are relative to the start of the key's run.
+/// behind a common positional interface. All offsets are relative to the start of the key's run
+/// (offset 0 is the oldest value).
 enum Backing<'a, K: Ord + Copy, V> {
     /// Inline sorted-array partition: the key's values occupy the contiguous index range `run`.
     ///
@@ -44,10 +49,6 @@ enum Backing<'a, K: Ord + Copy, V> {
     },
     /// Spilled partition: the key's values live in the side-table's `BTreeMap`, re-resolved on each
     /// access (spilling is the rare case, so the extra descent is off the hot path).
-    ///
-    /// Spilled chains are stored oldest-first (the reverse of run/iteration order, so plain inserts
-    /// can push the newest value at the end), so run offset `off` addresses chain index
-    /// `len - 1 - off` and an insert at run offset `off` lands at chain index `len - off`.
     Spilled {
         spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
         partition: usize,
@@ -79,13 +80,10 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 spilled,
                 partition,
                 key,
-            } => {
-                let run = spilled
-                    .get(partition)
-                    .and_then(|inner| inner.get(key))
-                    .expect("active cursor must reference a present key");
-                &run[run.len() - 1 - off]
-            }
+            } => &spilled
+                .get(partition)
+                .and_then(|inner| inner.get(key))
+                .expect("active cursor must reference a present key")[off],
         }
     }
 
@@ -98,12 +96,10 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 partition,
                 key,
             } => {
-                let run = spilled
+                spilled
                     .get_mut(partition)
                     .and_then(|inner| inner.get_mut(key))
-                    .expect("active cursor must reference a present key");
-                let idx = run.len() - 1 - off;
-                run[idx] = value;
+                    .expect("active cursor must reference a present key")[off] = value;
             }
         }
     }
@@ -128,8 +124,7 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 key,
             } => match spilled.entry(*partition).or_default().entry(*key) {
                 btree_map::Entry::Occupied(mut run) => {
-                    let idx = run.get().len() - off;
-                    run.get_mut().insert(idx, value);
+                    run.get_mut().insert(off, value);
                     false
                 }
                 btree_map::Entry::Vacant(run) => {
@@ -160,8 +155,7 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
                 let btree_map::Entry::Occupied(mut run) = part.get_mut().entry(*key) else {
                     unreachable!("active cursor must reference a present key")
                 };
-                let idx = run.get().len() - 1 - off;
-                run.get_mut().remove(idx);
+                run.get_mut().remove(off);
                 if !run.get().is_empty() {
                     return false;
                 }
@@ -200,21 +194,22 @@ impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
         items: &'a Gauge,
         pruned: &'a Counter,
     ) -> Self {
+        let from = (run.end - run.start).checked_sub(1);
         Self {
             backing: Backing::Soa {
                 partition,
                 key,
                 run,
             },
-            state: State::NeedNext { from: 0 },
+            state: State::NeedNext { from },
             keys,
             items,
             pruned,
         }
     }
 
-    /// A cursor over a key's values held in a spilled partition's `BTreeMap`.
-    pub(super) const fn spilled(
+    /// A cursor over a key's (present) values held in a spilled partition's `BTreeMap`.
+    pub(super) fn spilled(
         spilled: &'a mut HashMap<usize, BTreeMap<K, Vec<V>>>,
         partition: usize,
         key: K,
@@ -222,13 +217,15 @@ impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
         items: &'a Gauge,
         pruned: &'a Counter,
     ) -> Self {
+        let backing = Backing::Spilled {
+            spilled,
+            partition,
+            key,
+        };
+        let from = backing.len().checked_sub(1);
         Self {
-            backing: Backing::Spilled {
-                spilled,
-                partition,
-                key,
-            },
-            state: State::NeedNext { from: 0 },
+            backing,
+            state: State::NeedNext { from },
             keys,
             items,
             pruned,
@@ -243,12 +240,12 @@ impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for Cursor<'_, K, 
         let off = match self.state {
             State::Done => return None,
             State::NeedNext { from } => from,
-            State::Active { offset } => offset + 1,
+            State::Active { offset } => offset.checked_sub(1),
         };
-        if off >= self.backing.len() {
+        let Some(off) = off else {
             self.state = State::Done;
             return None;
-        }
+        };
         self.state = State::Active { offset: off };
         Some(self.backing.get(off))
     }
@@ -265,17 +262,19 @@ impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for Cursor<'_, K, 
         match self.state {
             State::NeedNext { .. } => panic!("{MUST_CALL_NEXT}"),
             State::Active { offset } => {
-                // Place immediately after the current value (never a new key, so the return is
-                // ignored); `next()` then returns the value after the inserted one, skipping both
-                // the current and the inserted.
-                self.backing.insert(offset + 1, value);
+                // Place immediately after the current value in iteration order: iteration descends,
+                // so that slot is offset `offset` itself, shifting the current value up by one
+                // (never a new key, so the return is ignored). `next()` then returns the value
+                // after the inserted one, skipping both the current and the inserted.
+                self.backing.insert(offset, value);
                 self.items.inc();
-                self.state = State::NeedNext { from: offset + 2 };
+                self.state = State::NeedNext {
+                    from: offset.checked_sub(1),
+                };
             }
             State::Done => {
-                // Append at the oldest position (run end), re-creating the key if it was emptied.
-                let end = self.backing.len();
-                if self.backing.insert(end, value) {
+                // Append at the oldest position (offset 0), re-creating the key if it was emptied.
+                if self.backing.insert(0, value) {
                     self.keys.inc();
                 }
                 self.items.inc();
@@ -296,7 +295,10 @@ impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for Cursor<'_, K, 
         self.items.dec();
         self.pruned.inc();
 
-        // The value after the deleted one shifted into `offset`.
-        self.state = State::NeedNext { from: offset };
+        // Only the already-visited values above `offset` shifted; the value after the deleted one
+        // in iteration order still sits just below `offset`.
+        self.state = State::NeedNext {
+            from: offset.checked_sub(1),
+        };
     }
 }

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -24,8 +24,9 @@
 //!
 //! A partition also fills when a single key collects many values -- keys that collide on the full
 //! prefix, or repeated inserts of one key. The spill covers this too: it triggers on the total
-//! value count, and a spilled key's values form a deque whose newest value is pushed at the front
-//! in amortized O(1), so these inserts stay as cheap as any other. What it cannot bound is how many
+//! value count, and a spilled key's newest value is pushed onto the end of its chain in amortized
+//! O(1) (reads iterate the chain in reverse), so these inserts stay as cheap as any other. What it
+//! cannot bound is how many
 //! values one key holds, and a lookup must scan all of them -- a key with `M` values costs O(M) per
 //! lookup. Every index that resolves collisions pays this (the flat `crate::index::ordered::Index`
 //! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
@@ -48,7 +49,8 @@ use commonware_runtime::{
     Metrics,
 };
 use std::{
-    collections::{btree_map, hash_map, vec_deque, BTreeMap, HashMap, VecDeque},
+    collections::{btree_map, hash_map, BTreeMap, HashMap},
+    iter,
     ops::Bound,
     slice,
 };
@@ -73,11 +75,12 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
-    /// keyed by partition index; each maps translated keys to their values newest-first. A key's
-    /// values form a deque so a colliding insert prepends the newest value in amortized O(1) rather
-    /// than shifting the chain. Empty until a partition fills, whether from honest growth at low
-    /// `P` or adversarial grinding.
-    spilled: HashMap<usize, BTreeMap<T::Key, VecDeque<V>>>,
+    /// keyed by partition index; each maps translated keys to their values oldest-first, the
+    /// reverse of the inline representation. Storing chains oldest-first lets a colliding insert
+    /// push the newest value in amortized O(1) rather than shifting the chain, and read paths
+    /// iterate chains in reverse to serve values newest-first. Empty until a partition fills,
+    /// whether from honest growth at low `P` or adversarial grinding.
+    spilled: HashMap<usize, BTreeMap<T::Key, Vec<V>>>,
 
     /// Sorted-array length at which a partition spills to `spilled`; [SPILL_THRESHOLD] in
     /// production, lowered by tests to exercise spilling cheaply.
@@ -96,10 +99,11 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
 /// Iterator over one translated key's values, newest first, from whichever representation the
 /// partition currently uses.
 enum Values<'a, V> {
-    /// A key's contiguous run in an inline sorted-array partition.
+    /// A key's contiguous run in an inline sorted-array partition (stored newest-first).
     Inline(slice::Iter<'a, V>),
-    /// A key's chain in a spilled partition's `BTreeMap`.
-    Spilled(vec_deque::Iter<'a, V>),
+    /// A key's chain in a spilled partition's `BTreeMap`, reversed because chains are stored
+    /// oldest-first (see the `spilled` field).
+    Spilled(iter::Rev<slice::Iter<'a, V>>),
 }
 
 impl<'a, V> Iterator for Values<'a, V> {
@@ -156,17 +160,21 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         if self.partitions[i].len() < self.threshold {
             return;
         }
-        let inner: BTreeMap<T::Key, VecDeque<V>> = self.partitions[i]
+        let inner: BTreeMap<T::Key, Vec<V>> = self.partitions[i]
             .drain_runs()
             .into_iter()
-            .map(|(k, run)| (k, VecDeque::from(run)))
+            .map(|(k, mut run)| {
+                // Inline runs are newest-first; spilled chains are stored oldest-first.
+                run.reverse();
+                (k, run)
+            })
             .collect();
         self.spilled.insert(i, inner);
     }
 
     /// The `BTreeMap` of spilled partition `i`, or `None` if `i` has not spilled. The empty-map
     /// check skips hashing `i` in the common case where no partition has ever spilled.
-    fn spilled_partition(&self, i: usize) -> Option<&BTreeMap<T::Key, VecDeque<V>>> {
+    fn spilled_partition(&self, i: usize) -> Option<&BTreeMap<T::Key, Vec<V>>> {
         if self.spilled.is_empty() {
             return None;
         }
@@ -183,7 +191,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             .and_then(|inner| inner.get(k))
             .map_or_else(
                 || Values::Inline([].iter()),
-                |run| Values::Spilled(run.iter()),
+                |run| Values::Spilled(run.iter().rev()),
             )
     }
 
@@ -195,7 +203,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             .or_else(|| {
                 self.spilled_partition(i)?
                     .first_key_value()
-                    .map(|(_, v)| Values::Spilled(v.iter()))
+                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
             })
     }
 
@@ -207,7 +215,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             .or_else(|| {
                 self.spilled_partition(i)?
                     .last_key_value()
-                    .map(|(_, v)| Values::Spilled(v.iter()))
+                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
             })
     }
 
@@ -225,7 +233,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
                 self.spilled_partition(i)?
                     .range((Bound::Excluded(*k), Bound::Unbounded))
                     .next()
-                    .map(|(_, v)| Values::Spilled(v.iter()))
+                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
             })
     }
 
@@ -238,7 +246,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
                 self.spilled_partition(i)?
                     .range((Bound::Unbounded, Bound::Excluded(*k)))
                     .next_back()
-                    .map(|(_, v)| Values::Spilled(v.iter()))
+                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
             })
     }
 
@@ -370,10 +378,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
                     &self.pruned,
                 ));
             }
-            self.spilled
-                .get_mut(&i)
-                .unwrap()
-                .insert(k, VecDeque::from([value]));
+            self.spilled.get_mut(&i).unwrap().insert(k, vec![value]);
             self.keys.inc();
             self.items.inc();
             return None;
@@ -407,9 +412,9 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.spilled.is_empty() {
             if let hash_map::Entry::Occupied(mut partition) = self.spilled.entry(i) {
                 match partition.get_mut().entry(k) {
-                    btree_map::Entry::Occupied(mut run) => run.get_mut().push_front(value),
+                    btree_map::Entry::Occupied(mut run) => run.get_mut().push(value),
                     btree_map::Entry::Vacant(run) => {
-                        run.insert(VecDeque::from([value]));
+                        run.insert(vec![value]);
                         self.keys.inc();
                     }
                 }

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -24,13 +24,14 @@
 //!
 //! A partition also fills when a single key collects many values -- keys that collide on the full
 //! prefix, or repeated inserts of one key. The spill covers this too: it triggers on the total
-//! value count, and a spilled key's newest value is pushed onto the end of its chain in amortized
-//! O(1) (reads iterate the chain in reverse), so these inserts stay as cheap as any other. What it
-//! cannot bound is how many
-//! values one key holds, and a lookup must scan all of them -- a key with `M` values costs O(M) per
-//! lookup. Every index that resolves collisions pays this (the flat `crate::index::ordered::Index`
-//! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
-//! use enough prefix bytes and high-entropy keys.
+//! value count, and a colliding insert appends to the end of the key's run in both representations
+//! (an amortized O(1) push once spilled), so these inserts stay as cheap as any other. Runs store
+//! their newest value last, and read paths iterate runs in reverse to serve values newest-first
+//! like the flat index. What spilling cannot bound is how many values one key holds, and a lookup
+//! must scan all of them -- a key with `M` values costs O(M) per lookup. Every index that resolves
+//! collisions pays this (the flat `crate::index::ordered::Index` included); `M` stays near 1 only
+//! when the indexed `P + N`-byte prefix is well-distributed, so use enough prefix bytes and
+//! high-entropy keys.
 
 mod cursor;
 mod partition;
@@ -50,9 +51,7 @@ use commonware_runtime::{
 };
 use std::{
     collections::{btree_map, hash_map, BTreeMap, HashMap},
-    iter,
     ops::Bound,
-    slice,
 };
 
 /// Sorted-array length at which a partition converts to a `BTreeMap`, bounding the O(occupancy)
@@ -75,11 +74,9 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
-    /// keyed by partition index; each maps translated keys to their values oldest-first, the
-    /// reverse of the inline representation. Storing chains oldest-first lets a colliding insert
-    /// push the newest value in amortized O(1) rather than shifting the chain, and read paths
-    /// iterate chains in reverse to serve values newest-first. Empty until a partition fills,
-    /// whether from honest growth at low `P` or adversarial grinding.
+    /// keyed by partition index; each maps translated keys to their value runs, newest value last,
+    /// so a colliding insert is an amortized O(1) push. Empty until a partition fills, whether from
+    /// honest growth at low `P` or adversarial grinding.
     spilled: HashMap<usize, BTreeMap<T::Key, Vec<V>>>,
 
     /// Sorted-array length at which a partition spills to `spilled`; [SPILL_THRESHOLD] in
@@ -94,34 +91,6 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
 
     /// Metric: cumulative values removed (via `remove`, cursor `delete`, or `retain`).
     pruned: Counter,
-}
-
-/// Iterator over one translated key's values, newest first, from whichever representation the
-/// partition currently uses.
-enum Values<'a, V> {
-    /// A key's contiguous run in an inline sorted-array partition (stored newest-first).
-    Inline(slice::Iter<'a, V>),
-    /// A key's chain in a spilled partition's `BTreeMap`, reversed because chains are stored
-    /// oldest-first (see the `spilled` field).
-    Spilled(iter::Rev<slice::Iter<'a, V>>),
-}
-
-impl<'a, V> Iterator for Values<'a, V> {
-    type Item = &'a V;
-
-    fn next(&mut self) -> Option<&'a V> {
-        match self {
-            Self::Inline(values) => values.next(),
-            Self::Spilled(values) => values.next(),
-        }
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        match self {
-            Self::Inline(values) => values.size_hint(),
-            Self::Spilled(values) => values.size_hint(),
-        }
-    }
 }
 
 impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
@@ -160,15 +129,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         if self.partitions[i].len() < self.threshold {
             return;
         }
-        let inner: BTreeMap<T::Key, Vec<V>> = self.partitions[i]
-            .drain_runs()
-            .into_iter()
-            .map(|(k, mut run)| {
-                // Inline runs are newest-first; spilled chains are stored oldest-first.
-                run.reverse();
-                (k, run)
-            })
-            .collect();
+        let inner: BTreeMap<T::Key, Vec<V>> = self.partitions[i].drain_runs().into_iter().collect();
         self.spilled.insert(i, inner);
     }
 
@@ -183,40 +144,31 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 
     /// The values for translated key `k` in partition `i` (empty if absent), from whichever
     /// representation the partition currently uses.
-    fn partition_values(&self, i: usize, k: &T::Key) -> Values<'_, V> {
+    fn partition_values(&self, i: usize, k: &T::Key) -> &[V] {
         if !self.partitions[i].is_empty() {
-            return Values::Inline(self.partitions[i].values(k).iter());
+            return self.partitions[i].values(k);
         }
         self.spilled_partition(i)
             .and_then(|inner| inner.get(k))
-            .map_or_else(
-                || Values::Inline([].iter()),
-                |run| Values::Spilled(run.iter().rev()),
-            )
+            .map_or(&[], Vec::as_slice)
     }
 
     /// Values of the smallest key in partition `i` (None if the partition is empty).
-    fn partition_first(&self, i: usize) -> Option<Values<'_, V>> {
-        self.partitions[i]
-            .first_values()
-            .map(|vals| Values::Inline(vals.iter()))
-            .or_else(|| {
-                self.spilled_partition(i)?
-                    .first_key_value()
-                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
-            })
+    fn partition_first(&self, i: usize) -> Option<&[V]> {
+        self.partitions[i].first_values().or_else(|| {
+            self.spilled_partition(i)?
+                .first_key_value()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Values of the largest key in partition `i` (None if the partition is empty).
-    fn partition_last(&self, i: usize) -> Option<Values<'_, V>> {
-        self.partitions[i]
-            .last_values()
-            .map(|vals| Values::Inline(vals.iter()))
-            .or_else(|| {
-                self.spilled_partition(i)?
-                    .last_key_value()
-                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
-            })
+    fn partition_last(&self, i: usize) -> Option<&[V]> {
+        self.partitions[i].last_values().or_else(|| {
+            self.spilled_partition(i)?
+                .last_key_value()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Whether the index currently holds no keys.
@@ -225,29 +177,23 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
     }
 
     /// Values of the smallest key strictly greater than `k` in partition `i`.
-    fn partition_next_after(&self, i: usize, k: &T::Key) -> Option<Values<'_, V>> {
-        self.partitions[i]
-            .next_values_after(k)
-            .map(|vals| Values::Inline(vals.iter()))
-            .or_else(|| {
-                self.spilled_partition(i)?
-                    .range((Bound::Excluded(*k), Bound::Unbounded))
-                    .next()
-                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
-            })
+    fn partition_next_after(&self, i: usize, k: &T::Key) -> Option<&[V]> {
+        self.partitions[i].next_values_after(k).or_else(|| {
+            self.spilled_partition(i)?
+                .range((Bound::Excluded(*k), Bound::Unbounded))
+                .next()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Values of the largest key strictly less than `k` in partition `i`.
-    fn partition_prev_before(&self, i: usize, k: &T::Key) -> Option<Values<'_, V>> {
-        self.partitions[i]
-            .prev_values_before(k)
-            .map(|vals| Values::Inline(vals.iter()))
-            .or_else(|| {
-                self.spilled_partition(i)?
-                    .range((Bound::Unbounded, Bound::Excluded(*k)))
-                    .next_back()
-                    .map(|(_, v)| Values::Spilled(v.iter().rev()))
-            })
+    fn partition_prev_before(&self, i: usize, k: &T::Key) -> Option<&[V]> {
+        self.partitions[i].prev_values_before(k).or_else(|| {
+            self.spilled_partition(i)?
+                .range((Bound::Unbounded, Bound::Excluded(*k)))
+                .next_back()
+                .map(|(_, v)| v.as_slice())
+        })
     }
 
     /// Number of partitions currently spilled to the side-table.
@@ -276,7 +222,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
-        self.partition_values(i, &k)
+        self.partition_values(i, &k).iter().rev()
     }
 
     fn get_many<'a, K: AsRef<[u8]>>(&'a self, keys: &[K], mut visit: impl FnMut(usize, &'a V))
@@ -296,7 +242,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
             .collect();
         order.sort_unstable();
         for (partition, translated, key_idx) in order {
-            for value in self.partition_values(partition, &translated) {
+            for value in self.partition_values(partition, &translated).iter().rev() {
                 visit(key_idx, value);
             }
         }
@@ -358,7 +304,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
                     &self.pruned,
                 ));
             }
-            self.partitions[i].insert_at(run.start, k, value);
+            self.partitions[i].insert_at(run.end, k, value);
             self.keys.inc();
             self.items.inc();
             self.maybe_spill(i);
@@ -399,7 +345,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             let new_key = run.is_empty();
-            self.partitions[i].insert_at(run.start, k, value);
+            self.partitions[i].insert_at(run.end, k, value);
             self.items.inc();
             if new_key {
                 self.keys.inc();
@@ -512,16 +458,16 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
         if let Some(vals) = self.partition_prev_before(i, &k) {
-            return Some((vals, false));
+            return Some((vals.iter().rev(), false));
         }
         for p in (0..i).rev() {
             if let Some(vals) = self.partition_last(p) {
-                return Some((vals, false));
+                return Some((vals.iter().rev(), false));
             }
         }
         for p in (0..self.partitions.len()).rev() {
             if let Some(vals) = self.partition_last(p) {
-                return Some((vals, true));
+                return Some((vals.iter().rev(), true));
             }
         }
         None
@@ -544,16 +490,16 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
         if let Some(vals) = self.partition_next_after(i, &k) {
-            return Some((vals, false));
+            return Some((vals.iter().rev(), false));
         }
         for p in i + 1..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
-                return Some((vals, false));
+                return Some((vals.iter().rev(), false));
             }
         }
         for p in 0..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
-                return Some((vals, true));
+                return Some((vals.iter().rev(), true));
             }
         }
         None
@@ -571,7 +517,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         // Scan partitions in ascending order for the global first key.
         for p in 0..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
-                return Some(vals);
+                return Some(vals.iter().rev());
             }
         }
         None
@@ -589,7 +535,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         // Scan partitions in descending order for the global last key.
         for p in (0..self.partitions.len()).rev() {
             if let Some(vals) = self.partition_last(p) {
-                return Some(vals);
+                return Some(vals.iter().rev());
             }
         }
         None

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -24,7 +24,8 @@
 //!
 //! A partition also fills when a single key collects many values -- keys that collide on the full
 //! prefix, or repeated inserts of one key. The spill covers this too: it triggers on the total
-//! value count, so these inserts stay as cheap as any other. What it cannot bound is how many
+//! value count, and a spilled key's values form a deque whose newest value is pushed at the front
+//! in amortized O(1), so these inserts stay as cheap as any other. What it cannot bound is how many
 //! values one key holds, and a lookup must scan all of them -- a key with `M` values costs O(M) per
 //! lookup. Every index that resolves collisions pays this (the flat `crate::index::ordered::Index`
 //! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
@@ -47,8 +48,9 @@ use commonware_runtime::{
     Metrics,
 };
 use std::{
-    collections::{btree_map, hash_map, BTreeMap, HashMap},
+    collections::{btree_map, hash_map, vec_deque, BTreeMap, HashMap, VecDeque},
     ops::Bound,
+    slice,
 };
 
 /// Sorted-array length at which a partition converts to a `BTreeMap`, bounding the O(occupancy)
@@ -71,9 +73,11 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
-    /// keyed by partition index; each maps translated keys to their values newest-first. Empty until
-    /// a partition fills, whether from honest growth at low `P` or adversarial grinding.
-    spilled: HashMap<usize, BTreeMap<T::Key, Vec<V>>>,
+    /// keyed by partition index; each maps translated keys to their values newest-first. A key's
+    /// values form a deque so a colliding insert prepends the newest value in amortized O(1) rather
+    /// than shifting the chain. Empty until a partition fills, whether from honest growth at low
+    /// `P` or adversarial grinding.
+    spilled: HashMap<usize, BTreeMap<T::Key, VecDeque<V>>>,
 
     /// Sorted-array length at which a partition spills to `spilled`; [SPILL_THRESHOLD] in
     /// production, lowered by tests to exercise spilling cheaply.
@@ -87,6 +91,33 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
 
     /// Metric: cumulative values removed (via `remove`, cursor `delete`, or `retain`).
     pruned: Counter,
+}
+
+/// Iterator over one translated key's values, newest first, from whichever representation the
+/// partition currently uses.
+enum Values<'a, V> {
+    /// A key's contiguous run in an inline sorted-array partition.
+    Inline(slice::Iter<'a, V>),
+    /// A key's chain in a spilled partition's `BTreeMap`.
+    Spilled(vec_deque::Iter<'a, V>),
+}
+
+impl<'a, V> Iterator for Values<'a, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<&'a V> {
+        match self {
+            Self::Inline(values) => values.next(),
+            Self::Spilled(values) => values.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Inline(values) => values.size_hint(),
+            Self::Spilled(values) => values.size_hint(),
+        }
+    }
 }
 
 impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
@@ -125,13 +156,17 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         if self.partitions[i].len() < self.threshold {
             return;
         }
-        let inner: BTreeMap<T::Key, Vec<V>> = self.partitions[i].drain_runs().into_iter().collect();
+        let inner: BTreeMap<T::Key, VecDeque<V>> = self.partitions[i]
+            .drain_runs()
+            .into_iter()
+            .map(|(k, run)| (k, VecDeque::from(run)))
+            .collect();
         self.spilled.insert(i, inner);
     }
 
     /// The `BTreeMap` of spilled partition `i`, or `None` if `i` has not spilled. The empty-map
     /// check skips hashing `i` in the common case where no partition has ever spilled.
-    fn spilled_partition(&self, i: usize) -> Option<&BTreeMap<T::Key, Vec<V>>> {
+    fn spilled_partition(&self, i: usize) -> Option<&BTreeMap<T::Key, VecDeque<V>>> {
         if self.spilled.is_empty() {
             return None;
         }
@@ -140,31 +175,40 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 
     /// The values for translated key `k` in partition `i` (empty if absent), from whichever
     /// representation the partition currently uses.
-    fn partition_values(&self, i: usize, k: &T::Key) -> &[V] {
+    fn partition_values(&self, i: usize, k: &T::Key) -> Values<'_, V> {
         if !self.partitions[i].is_empty() {
-            return self.partitions[i].values(k);
+            return Values::Inline(self.partitions[i].values(k).iter());
         }
         self.spilled_partition(i)
             .and_then(|inner| inner.get(k))
-            .map_or(&[], Vec::as_slice)
+            .map_or_else(
+                || Values::Inline([].iter()),
+                |run| Values::Spilled(run.iter()),
+            )
     }
 
     /// Values of the smallest key in partition `i` (None if the partition is empty).
-    fn partition_first(&self, i: usize) -> Option<&[V]> {
-        self.partitions[i].first_values().or_else(|| {
-            self.spilled_partition(i)?
-                .first_key_value()
-                .map(|(_, v)| v.as_slice())
-        })
+    fn partition_first(&self, i: usize) -> Option<Values<'_, V>> {
+        self.partitions[i]
+            .first_values()
+            .map(|vals| Values::Inline(vals.iter()))
+            .or_else(|| {
+                self.spilled_partition(i)?
+                    .first_key_value()
+                    .map(|(_, v)| Values::Spilled(v.iter()))
+            })
     }
 
     /// Values of the largest key in partition `i` (None if the partition is empty).
-    fn partition_last(&self, i: usize) -> Option<&[V]> {
-        self.partitions[i].last_values().or_else(|| {
-            self.spilled_partition(i)?
-                .last_key_value()
-                .map(|(_, v)| v.as_slice())
-        })
+    fn partition_last(&self, i: usize) -> Option<Values<'_, V>> {
+        self.partitions[i]
+            .last_values()
+            .map(|vals| Values::Inline(vals.iter()))
+            .or_else(|| {
+                self.spilled_partition(i)?
+                    .last_key_value()
+                    .map(|(_, v)| Values::Spilled(v.iter()))
+            })
     }
 
     /// Whether the index currently holds no keys.
@@ -173,23 +217,29 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
     }
 
     /// Values of the smallest key strictly greater than `k` in partition `i`.
-    fn partition_next_after(&self, i: usize, k: &T::Key) -> Option<&[V]> {
-        self.partitions[i].next_values_after(k).or_else(|| {
-            self.spilled_partition(i)?
-                .range((Bound::Excluded(*k), Bound::Unbounded))
-                .next()
-                .map(|(_, v)| v.as_slice())
-        })
+    fn partition_next_after(&self, i: usize, k: &T::Key) -> Option<Values<'_, V>> {
+        self.partitions[i]
+            .next_values_after(k)
+            .map(|vals| Values::Inline(vals.iter()))
+            .or_else(|| {
+                self.spilled_partition(i)?
+                    .range((Bound::Excluded(*k), Bound::Unbounded))
+                    .next()
+                    .map(|(_, v)| Values::Spilled(v.iter()))
+            })
     }
 
     /// Values of the largest key strictly less than `k` in partition `i`.
-    fn partition_prev_before(&self, i: usize, k: &T::Key) -> Option<&[V]> {
-        self.partitions[i].prev_values_before(k).or_else(|| {
-            self.spilled_partition(i)?
-                .range((Bound::Unbounded, Bound::Excluded(*k)))
-                .next_back()
-                .map(|(_, v)| v.as_slice())
-        })
+    fn partition_prev_before(&self, i: usize, k: &T::Key) -> Option<Values<'_, V>> {
+        self.partitions[i]
+            .prev_values_before(k)
+            .map(|vals| Values::Inline(vals.iter()))
+            .or_else(|| {
+                self.spilled_partition(i)?
+                    .range((Bound::Unbounded, Bound::Excluded(*k)))
+                    .next_back()
+                    .map(|(_, v)| Values::Spilled(v.iter()))
+            })
     }
 
     /// Number of partitions currently spilled to the side-table.
@@ -218,7 +268,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
-        self.partition_values(i, &k).iter()
+        self.partition_values(i, &k)
     }
 
     fn get_many<'a, K: AsRef<[u8]>>(&'a self, keys: &[K], mut visit: impl FnMut(usize, &'a V))
@@ -320,7 +370,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
                     &self.pruned,
                 ));
             }
-            self.spilled.get_mut(&i).unwrap().insert(k, vec![value]);
+            self.spilled
+                .get_mut(&i)
+                .unwrap()
+                .insert(k, VecDeque::from([value]));
             self.keys.inc();
             self.items.inc();
             return None;
@@ -354,9 +407,9 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.spilled.is_empty() {
             if let hash_map::Entry::Occupied(mut partition) = self.spilled.entry(i) {
                 match partition.get_mut().entry(k) {
-                    btree_map::Entry::Occupied(mut run) => run.get_mut().insert(0, value),
+                    btree_map::Entry::Occupied(mut run) => run.get_mut().push_front(value),
                     btree_map::Entry::Vacant(run) => {
-                        run.insert(vec![value]);
+                        run.insert(VecDeque::from([value]));
                         self.keys.inc();
                     }
                 }
@@ -454,16 +507,16 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
         if let Some(vals) = self.partition_prev_before(i, &k) {
-            return Some((vals.iter(), false));
+            return Some((vals, false));
         }
         for p in (0..i).rev() {
             if let Some(vals) = self.partition_last(p) {
-                return Some((vals.iter(), false));
+                return Some((vals, false));
             }
         }
         for p in (0..self.partitions.len()).rev() {
             if let Some(vals) = self.partition_last(p) {
-                return Some((vals.iter(), true));
+                return Some((vals, true));
             }
         }
         None
@@ -486,16 +539,16 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
         if let Some(vals) = self.partition_next_after(i, &k) {
-            return Some((vals.iter(), false));
+            return Some((vals, false));
         }
         for p in i + 1..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
-                return Some((vals.iter(), false));
+                return Some((vals, false));
             }
         }
         for p in 0..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
-                return Some((vals.iter(), true));
+                return Some((vals, true));
             }
         }
         None
@@ -513,7 +566,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         // Scan partitions in ascending order for the global first key.
         for p in 0..self.partitions.len() {
             if let Some(vals) = self.partition_first(p) {
-                return Some(vals.iter());
+                return Some(vals);
             }
         }
         None
@@ -531,7 +584,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Ordered for Index<T, V, P> {
         // Scan partitions in descending order for the global last key.
         for p in (0..self.partitions.len()).rev() {
             if let Some(vals) = self.partition_last(p) {
-                return Some(vals.iter());
+                return Some(vals);
             }
         }
         None

--- a/storage/src/index/partitioned/ordered/partition.rs
+++ b/storage/src/index/partitioned/ordered/partition.rs
@@ -7,8 +7,8 @@
 //!
 //! Multiple values for the same translated key (collisions, or repeated inserts) form a contiguous
 //! run of equal keys. Collisions are rare for well-distributed translated keys, so most runs have
-//! length one. Within a run the newest value is first (lowest index), matching the iteration order
-//! of the non-partitioned index.
+//! length one. Within a run the newest value is last (highest index): the index's insertion path
+//! appends to the run's end, and read paths iterate runs in reverse to serve values newest-first.
 
 use std::ops::Range;
 
@@ -41,10 +41,8 @@ impl<K: Ord + Copy, V> Partition<K, V> {
     }
 
     /// Move every entry out of the partition, leaving it empty, returning one `(key, values)` pair
-    /// per distinct key with its values newest-first.
+    /// per distinct key with its values in run order (oldest first).
     pub(super) fn drain_runs(&mut self) -> Vec<(K, Vec<V>)> {
-        // Each run is already stored newest-first (lowest index), so taking its values in array
-        // order preserves that ordering.
         let keys = std::mem::take(&mut self.keys);
         let vals = std::mem::take(&mut self.vals);
         let mut vals = vals.into_iter();
@@ -104,7 +102,7 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         start..end
     }
 
-    /// The values associated with `key`, newest first (empty if absent).
+    /// The values associated with `key`, oldest first (empty if absent).
     pub(super) fn values(&self, key: &K) -> &[V] {
         &self.vals[self.run_range(key)]
     }
@@ -138,7 +136,7 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         self.vals[idx] = value;
     }
 
-    /// The values of the lexicographically smallest key, newest first (None if the partition is
+    /// The values of the lexicographically smallest key, oldest first (None if the partition is
     /// empty).
     pub(super) fn first_values(&self) -> Option<&[V]> {
         if self.keys.is_empty() {
@@ -147,14 +145,14 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         Some(&self.vals[self.run_starting_at(0)])
     }
 
-    /// The values of the lexicographically largest key, newest first (None if the partition is
+    /// The values of the lexicographically largest key, oldest first (None if the partition is
     /// empty).
     pub(super) fn last_values(&self) -> Option<&[V]> {
         let last = self.keys.len().checked_sub(1)?;
         Some(&self.vals[self.run_ending_at(last)])
     }
 
-    /// The values of the smallest key strictly greater than `key`, newest first (None if no such
+    /// The values of the smallest key strictly greater than `key`, oldest first (None if no such
     /// key exists).
     pub(super) fn next_values_after(&self, key: &K) -> Option<&[V]> {
         let idx = self.keys.partition_point(|k| *k <= *key);
@@ -164,7 +162,7 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         Some(&self.vals[self.run_starting_at(idx)])
     }
 
-    /// The values of the largest key strictly less than `key`, newest first (None if no such key
+    /// The values of the largest key strictly less than `key`, oldest first (None if no such key
     /// exists).
     pub(super) fn prev_values_before(&self, key: &K) -> Option<&[V]> {
         let prev = self.lower_bound(key).checked_sub(1)?;
@@ -176,11 +174,12 @@ impl<K: Ord + Copy, V> Partition<K, V> {
 mod tests {
     use super::*;
 
-    /// Insert `value` as the newest value for `key`, keeping the arrays sorted. The production hot
-    /// path instead reuses the run it already computed (`insert_at(run.start, ..)`) to avoid a
-    /// second `lower_bound`; this helper keeps the tests concise.
+    /// Append `value` as the newest value for `key`, keeping the arrays sorted. The production hot
+    /// path instead reuses the run it already computed (`insert_at(run.end, ..)`) to avoid a second
+    /// lookup; this helper keeps the tests concise.
     fn insert<K: Ord + Copy, V>(p: &mut Partition<K, V>, key: K, value: V) {
-        p.insert_at(p.lower_bound(&key), key, value);
+        let end = p.run_range(&key).end;
+        p.insert_at(end, key, value);
     }
 
     #[test]
@@ -217,25 +216,25 @@ mod tests {
         }
         // next strictly-greater key.
         assert_eq!(p.next_values_after(&5), Some(&[100u64] as &[u64]));
-        assert_eq!(p.next_values_after(&10), Some(&[222u64, 200] as &[u64])); // run, newest first
+        assert_eq!(p.next_values_after(&10), Some(&[200u64, 222] as &[u64])); // run, oldest first
         assert_eq!(p.next_values_after(&20), Some(&[300u64] as &[u64]));
         assert!(p.next_values_after(&30).is_none());
         // prev strictly-less key.
         assert!(p.prev_values_before(&10).is_none());
         assert_eq!(p.prev_values_before(&20), Some(&[100u64] as &[u64]));
-        assert_eq!(p.prev_values_before(&25), Some(&[222u64, 200] as &[u64]));
+        assert_eq!(p.prev_values_before(&25), Some(&[200u64, 222] as &[u64]));
         assert_eq!(p.prev_values_before(&999), Some(&[300u64] as &[u64]));
     }
 
     #[test]
-    fn test_partition_collision_run_newest_first() {
+    fn test_partition_collision_run_newest_last() {
         let mut p = Partition::<u16, u64>::default();
         insert(&mut p, 10, 1);
         insert(&mut p, 20, 2);
-        // Three values collide on key 10; newest is first within the run.
+        // Three values collide on key 10; the newest appends at the run's end.
         insert(&mut p, 10, 11);
         insert(&mut p, 10, 111);
-        assert_eq!(p.values(&10), &[111, 11, 1]);
+        assert_eq!(p.values(&10), &[1, 11, 111]);
         assert_eq!(p.values(&20), &[2]);
         // Keys remain sorted with the run adjacent.
         assert_eq!(p.keys, vec![10, 10, 10, 20]);
@@ -249,12 +248,12 @@ mod tests {
         for (k, v) in [(10u16, 1u64), (10, 11), (20, 2)] {
             insert(&mut p, k, v);
         }
-        // keys=[10,10,20] vals=[11,1,2]; remove the older value of key 10 (index 1).
+        // keys=[10,10,20] vals=[1,11,2]; remove the newer value of key 10 (index 1).
         let removed = p.remove(1);
-        assert_eq!(removed, 1);
+        assert_eq!(removed, 11);
         assert_eq!(p.keys, vec![10, 20]);
-        assert_eq!(p.vals, vec![11, 2]);
-        assert_eq!(p.values(&10), &[11]);
+        assert_eq!(p.vals, vec![1, 2]);
+        assert_eq!(p.values(&10), &[1]);
     }
 
     #[test]
@@ -268,14 +267,14 @@ mod tests {
     #[test]
     fn test_partition_drain_runs() {
         let mut p = Partition::<u16, u64>::default();
-        // Two runs: key 10 with three values (newest-first 111, 11, 1), key 20 with one.
+        // Two runs: key 10 with three appended values, key 20 with one.
         for (k, v) in [(10u16, 1u64), (20, 2), (10, 11), (10, 111)] {
             insert(&mut p, k, v);
         }
         assert_eq!(p.len(), 4);
         let runs = p.drain_runs();
-        // One pair per distinct key, ascending, values newest-first.
-        assert_eq!(runs, vec![(10, vec![111, 11, 1]), (20, vec![2])]);
+        // One pair per distinct key, ascending, values in run order (oldest first).
+        assert_eq!(runs, vec![(10, vec![1, 11, 111]), (20, vec![2])]);
         // The partition is left empty.
         assert!(p.is_empty());
         assert_eq!(p.len(), 0);


### PR DESCRIPTION
## Overview

The partitioned ordered index spills an over-full partition to a `BTreeMap` to bound adversarial flooding, but the spilled representation did not actually bound the same-translated-key collision vector its docs claim to cover. When an insert hit a key already present in a spilled partition, the value chain was a `Vec` prepended with `insert(0, value)`. Each insert shifted the entire chain, so M colliding inserts cost O(M^2) — the same quadratic the spill exists to prevent, and a regression from the flat ordered index, whose head displacement into the overflow map is amortized O(1). Any deployment where untrusted input can repeatedly hit one translated key (a predictable or capped translator, or plain repeated inserts of one key) exposes this as an algorithmic-complexity DoS.

## Change

Spilled chains are now stored oldest-first, so the colliding insert is a plain `push` — amortized O(1) with the same 3-word `Vec` header as before. No consumer requires any value order (archive key lookups document "may return any of the associated values", and QMDB full-key-compares every candidate), but the index battery pins newest-first iteration across implementations, so reads keep serving it by iterating spilled chains in reverse. A `Rev<slice::Iter>` walks the end pointer down instead of the start pointer up, so the reversal is free. Because the inline sorted arrays iterate forward while spilled chains iterate backward, the internal read helpers now return a small two-variant iterator instead of `&[V]`.

Two consequences of the reversed layout:

- Spilling reverses each drained run once, since inline runs are stored newest-first.
- The cursor's spilled backing mirrors positions: run offset `off` addresses chain index `len - 1 - off`, and an insert at run offset `off` lands at chain index `len - off`. The Done-state append (at the oldest position) is therefore an O(chain) front insert, which matches the flat index's cursor exactly and is only reachable after an already-O(chain) iteration, so it introduces no new quadratic surface.

## Validation

Temporarily scaling the existing `run_index_large_collision_chain` battery (50k -> 400k same-key inserts through the spilling fixture) shows the quadratic and its removal:

| same-key inserts | before | after |
|---|---|---|
| 50k | 0.18s | 0.03s |
| 400k | 9.35s | 0.11s |

Before the change, 8x the items cost ~52x the time. After it, growth is linear. The full `index::` suite (156 tests) passes, including the generic cross-implementation battery routed through the spilled representation, which pins newest-first value order, cursor insert/delete/update semantics, metrics, and the de-spill lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
