### PR TITLE
[index] Append collision values

### DIFF
--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -2561,7 +2561,8 @@ mod tests {
         }
         assert_eq!(index.keys(), 1);
         assert_eq!(index.items(), ITEMS);
-        assert_eq!(index.get(b"").count(), ITEMS);
+        let expected: Vec<u64> = (0..ITEMS as u64).collect();
+        assert_values(index, b"", &expected);
     }
 
     #[test_traced]

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -123,6 +123,8 @@ pub trait Unordered: Send + Sync {
         Self: 'a;
 
     /// Returns an iterator over all values associated with a translated key.
+    ///
+    /// The iteration order is implementation-defined.
     fn get<'a>(&'a self, key: &[u8]) -> impl Iterator<Item = &'a Self::Value> + Send + 'a
     where
         Self::Value: 'a;
@@ -272,6 +274,18 @@ mod tests {
         thread,
     };
 
+    fn values<I: Unordered<Value = u64>>(index: &I, key: &[u8]) -> Vec<u64> {
+        index.get(key).copied().collect()
+    }
+
+    fn assert_values<I: Unordered<Value = u64>>(index: &I, key: &[u8], expected: &[u64]) {
+        let mut actual = values(index, key);
+        actual.sort_unstable();
+        let mut expected = expected.to_vec();
+        expected.sort_unstable();
+        assert_eq!(actual, expected);
+    }
+
     fn run_index_basic<I: Unordered<Value = u64>>(index: &mut I) {
         // Generate a collision and check metrics to make sure it's captured
         let key = b"duplicate".as_slice();
@@ -280,15 +294,17 @@ mod tests {
         index.insert(key, 3);
         assert_eq!(index.keys(), 1);
 
-        // Check that the values are in the expected newest-first order.
-        assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![3, 2, 1]);
+        assert_values(index, key, &[1, 2, 3]);
 
         // Ensure cursor terminates
         {
             let mut cursor = index.get_mut(key).unwrap();
-            assert_eq!(*cursor.next().unwrap(), 3);
-            assert_eq!(*cursor.next().unwrap(), 2);
-            assert_eq!(*cursor.next().unwrap(), 1);
+            let mut seen = Vec::new();
+            while let Some(value) = cursor.next() {
+                seen.push(*value);
+            }
+            seen.sort_unstable();
+            assert_eq!(seen, vec![1, 2, 3]);
             assert!(cursor.next().is_none());
         }
 
@@ -296,7 +312,7 @@ mod tests {
         index.insert(key, 3);
         index.insert(key, 4);
         index.retain(key, |i| *i != 3);
-        assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![4, 2, 1]);
+        assert_values(index, key, &[1, 2, 4]);
         index.retain(key, |_| false);
         // Try removing all of a keys values.
         assert_eq!(
@@ -361,7 +377,7 @@ mod tests {
                 run_index_get_many,
                 run_index_cursor_find,
                 run_index_key_lengths_and_metrics,
-                run_index_value_order,
+                run_index_values,
                 run_index_remove_specific,
                 run_index_empty_key,
                 run_index_mutate_through_iterator,
@@ -532,9 +548,10 @@ mod tests {
         let keys: Vec<&[u8]> = vec![b"zz", b"missing", b"ab", b"zz"];
         let mut visits: Vec<Vec<u64>> = vec![Vec::new(); keys.len()];
         index.get_many(&keys, |key_idx, value| visits[key_idx].push(*value));
+        visits[2].sort_unstable();
         assert_eq!(visits[0], vec![4]);
         assert!(visits[1].is_empty());
-        assert_eq!(visits[2], vec![3, 2, 1]);
+        assert_eq!(visits[2], vec![1, 2, 3]);
         assert_eq!(visits[3], vec![4]);
 
         // Empty input visits nothing.
@@ -727,16 +744,16 @@ mod tests {
         index.insert(b"ab", 2);
         index.insert(b"abc", 3);
 
-        assert_eq!(index.get(b"ab").copied().collect::<Vec<_>>(), vec![3, 2]);
-        assert_eq!(index.get(b"abc").copied().collect::<Vec<_>>(), vec![3, 2]);
+        assert_values(index, b"ab", &[2, 3]);
+        assert_values(index, b"abc", &[2, 3]);
 
         index.insert(b"ab", 4);
-        assert_eq!(index.get(b"ab").copied().collect::<Vec<_>>(), vec![4, 3, 2]);
+        assert_values(index, b"ab", &[2, 3, 4]);
         assert_eq!(index.keys(), 2);
         assert_eq!(index.items(), 4);
 
         index.retain(b"ab", |v| *v != 4);
-        assert_eq!(index.get(b"ab").copied().collect::<Vec<_>>(), vec![3, 2]);
+        assert_values(index, b"ab", &[2, 3]);
         assert_eq!(index.keys(), 2);
         assert_eq!(index.items(), 3);
 
@@ -747,7 +764,7 @@ mod tests {
         );
         assert_eq!(index.keys(), 1);
         assert_eq!(index.items(), 1);
-        assert_eq!(index.get(b"a").copied().collect::<Vec<_>>(), vec![1]);
+        assert_values(index, b"a", &[1]);
     }
 
     #[test_traced]
@@ -783,45 +800,42 @@ mod tests {
         });
     }
 
-    fn run_index_value_order<I: Unordered<Value = u64>>(index: &mut I) {
+    fn run_index_values<I: Unordered<Value = u64>>(index: &mut I) {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
         index.insert(b"key", 3);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![3, 2, 1]
-        );
+        assert_values(index, b"key", &[1, 2, 3]);
     }
 
     #[test_traced]
-    fn test_hash_index_value_order() {
+    fn test_hash_index_values() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_unordered(context);
-            run_index_value_order(&mut index);
+            run_index_values(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_ordered_index_value_order() {
+    fn test_ordered_index_values() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             let mut index = new_ordered(context);
-            run_index_value_order(&mut index);
+            run_index_values(&mut index);
         });
     }
 
     #[test_traced]
-    fn test_partitioned_index_value_order() {
+    fn test_partitioned_index_values() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
             {
                 let mut index = new_partitioned_unordered(context.child("unordered"));
-                run_index_value_order(&mut index);
+                run_index_values(&mut index);
             }
             {
                 let mut index = new_partitioned_ordered(context.child("ordered"));
-                run_index_value_order(&mut index);
+                run_index_values(&mut index);
             }
         });
     }
@@ -831,9 +845,9 @@ mod tests {
         index.insert(b"key", 2);
         index.insert(b"key", 3);
         index.retain(b"key", |v| *v != 2);
-        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![3, 1]);
+        assert_values(index, b"key", &[1, 3]);
         index.retain(b"key", |v| *v != 1);
-        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![3]);
+        assert_values(index, b"key", &[3]);
     }
 
     #[test_traced]
@@ -933,10 +947,7 @@ mod tests {
                 cursor.update(old + 10);
             }
         }
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![13, 12, 11]
-        );
+        assert_values(index, b"key", &[11, 12, 13]);
     }
 
     #[test_traced]
@@ -977,21 +988,16 @@ mod tests {
         index.insert(b"key", 2);
         index.insert(b"key", 3);
         index.insert(b"key", 4);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![4, 3, 2, 1]
-        );
+        let mut expected = values(index, b"key");
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 4);
-            assert_eq!(*cursor.next().unwrap(), 3);
+            assert_eq!(*cursor.next().unwrap(), expected[0]);
+            assert_eq!(*cursor.next().unwrap(), expected[1]);
             let _ = cursor.next().unwrap();
             cursor.update(99);
         }
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![4, 3, 99, 1]
-        );
+        expected[2] = 99;
+        assert_eq!(values(index, b"key"), expected);
     }
 
     #[test_traced]
@@ -1032,56 +1038,45 @@ mod tests {
         index.insert(b"key", 20);
         index.insert(b"key", 30);
         index.insert(b"key", 40);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![40, 30, 20, 10]
-        );
+        let mut expected = values(index, b"key");
+        assert_values(index, b"key", &[10, 20, 30, 40]);
         assert_eq!(index.pruned(), 0);
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 40);
+            assert_eq!(*cursor.next().unwrap(), expected[0]);
             cursor.delete();
         }
+        expected.remove(0);
         assert_eq!(index.pruned(), 1);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![30, 20, 10]
-        );
+        assert_eq!(values(index, b"key"), expected);
         index.insert(b"key", 50);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![50, 30, 20, 10]
-        );
+        expected.push(50);
+        assert_values(index, b"key", &expected);
+        expected = values(index, b"key");
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 50);
-            assert_eq!(*cursor.next().unwrap(), 30);
-            assert_eq!(*cursor.next().unwrap(), 20);
+            assert_eq!(*cursor.next().unwrap(), expected[0]);
+            assert_eq!(*cursor.next().unwrap(), expected[1]);
+            assert_eq!(*cursor.next().unwrap(), expected[2]);
             cursor.delete();
         }
+        expected.remove(2);
         assert_eq!(index.pruned(), 2);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![50, 30, 10]
-        );
+        assert_eq!(values(index, b"key"), expected);
         index.insert(b"key", 60);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![60, 50, 30, 10]
-        );
+        expected.push(60);
+        assert_values(index, b"key", &expected);
+        expected = values(index, b"key");
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 60);
-            assert_eq!(*cursor.next().unwrap(), 50);
-            assert_eq!(*cursor.next().unwrap(), 30);
-            assert_eq!(*cursor.next().unwrap(), 10);
+            for value in &expected {
+                assert_eq!(*cursor.next().unwrap(), *value);
+            }
             cursor.delete();
         }
+        expected.pop();
         assert_eq!(index.pruned(), 3);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![60, 50, 30]
-        );
+        assert_eq!(values(index, b"key"), expected);
         index.remove(b"key");
         assert_eq!(index.keys(), 0);
         assert_eq!(index.items(), 0);
@@ -1146,12 +1141,7 @@ mod tests {
             assert_eq!(*iter.next().unwrap(), 42);
         }
         index.insert(b"key", 100);
-        let mut iter = index.get(b"key");
-        assert_eq!(*iter.next().unwrap(), 100);
-        assert_eq!(*iter.next().unwrap(), 1);
-        assert_eq!(*iter.next().unwrap(), 42);
-        assert_eq!(*iter.next().unwrap(), 3);
-        assert!(iter.next().is_none());
+        assert_values(index, b"key", &[1, 3, 42, 100]);
     }
 
     #[test_traced]
@@ -1237,14 +1227,13 @@ mod tests {
         }
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 3);
-            cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 2);
-            cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 1);
-            cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 0);
-            cursor.delete();
+            let mut removed = Vec::new();
+            while let Some(value) = cursor.next().copied() {
+                removed.push(value);
+                cursor.delete();
+            }
+            removed.sort_unstable();
+            assert_eq!(removed, vec![0, 1, 2, 3]);
             assert_eq!(cursor.next(), None);
             cursor.insert(4);
             assert_eq!(cursor.next(), None);
@@ -1643,15 +1632,16 @@ mod tests {
         for i in 0..4 {
             index.insert(b"key", i);
         }
+        let expected = values(index, b"key");
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 3);
-            assert_eq!(*cursor.next().unwrap(), 2);
+            assert_eq!(*cursor.next().unwrap(), expected[0]);
+            assert_eq!(*cursor.next().unwrap(), expected[1]);
             cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 1);
+            assert_eq!(*cursor.next().unwrap(), expected[2]);
             cursor.delete();
         }
-        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![3, 0]);
+        assert_eq!(values(index, b"key"), vec![expected[0], expected[3]]);
     }
 
     #[test_traced]
@@ -1693,14 +1683,13 @@ mod tests {
         }
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 3);
-            cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 2);
-            cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 1);
-            cursor.delete();
-            assert_eq!(*cursor.next().unwrap(), 0);
-            cursor.delete();
+            let mut removed = Vec::new();
+            while let Some(value) = cursor.next().copied() {
+                removed.push(value);
+                cursor.delete();
+            }
+            removed.sort_unstable();
+            assert_eq!(removed, vec![0, 1, 2, 3]);
             assert_eq!(cursor.next(), None);
         }
         assert_eq!(index.keys(), 0);
@@ -1957,9 +1946,10 @@ mod tests {
     fn run_index_cursor_insert_with_next<I: Unordered<Value = u64>>(index: &mut I) {
         index.insert(b"key", 123);
         index.insert(b"key", 456);
+        let expected = values(index, b"key");
         let mut cursor = index.get_mut(b"key").unwrap();
-        assert_eq!(*cursor.next().unwrap(), 456);
-        assert_eq!(*cursor.next().unwrap(), 123);
+        assert_eq!(*cursor.next().unwrap(), expected[0]);
+        assert_eq!(*cursor.next().unwrap(), expected[1]);
         cursor.insert(789);
         assert_eq!(cursor.next(), None);
         cursor.insert(999);
@@ -2006,7 +1996,7 @@ mod tests {
         index.insert(b"key", 123);
         index.insert(b"key", 456);
         let mut cursor = index.get_mut(b"key").unwrap();
-        assert_eq!(*cursor.next().unwrap(), 456);
+        assert!(cursor.next().is_some());
         cursor.delete();
         cursor.delete();
     }
@@ -2034,10 +2024,11 @@ mod tests {
     fn run_index_cursor_delete_last_then_next<I: Unordered<Value = u64>>(index: &mut I) {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
+        let expected = values(index, b"key");
         {
             let mut cursor = index.get_mut(b"key").unwrap();
-            assert_eq!(*cursor.next().unwrap(), 2);
-            assert_eq!(*cursor.next().unwrap(), 1);
+            assert_eq!(*cursor.next().unwrap(), expected[0]);
+            assert_eq!(*cursor.next().unwrap(), expected[1]);
             cursor.delete();
             assert!(cursor.next().is_none());
             assert!(cursor.next().is_none());
@@ -2083,11 +2074,12 @@ mod tests {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
         index.insert(b"key", 3);
+        let expected = values(index, b"key");
         let mut cur = index.get_mut(b"key").unwrap();
-        assert_eq!(*cur.next().unwrap(), 3);
-        assert_eq!(*cur.next().unwrap(), 2);
+        assert_eq!(*cur.next().unwrap(), expected[0]);
+        assert_eq!(*cur.next().unwrap(), expected[1]);
         cur.delete();
-        assert_eq!(*cur.next().unwrap(), 1);
+        assert_eq!(*cur.next().unwrap(), expected[2]);
         assert!(cur.next().is_none());
         assert!(cur.next().is_none());
     }
@@ -2114,16 +2106,17 @@ mod tests {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
         index.insert(b"key", 3);
+        let expected = values(index, b"key");
         {
             let mut cur = index.get_mut(b"key").unwrap();
-            assert_eq!(*cur.next().unwrap(), 3);
+            assert_eq!(*cur.next().unwrap(), expected[0]);
             cur.delete();
-            assert_eq!(*cur.next().unwrap(), 2);
-            assert_eq!(*cur.next().unwrap(), 1);
+            assert_eq!(*cur.next().unwrap(), expected[1]);
+            assert_eq!(*cur.next().unwrap(), expected[2]);
             assert!(cur.next().is_none());
             assert!(cur.next().is_none());
         }
-        assert_eq!(index.get(b"key").copied().collect::<Vec<_>>(), vec![2, 1]);
+        assert_eq!(values(index, b"key"), expected[1..]);
     }
 
     #[test_traced]
@@ -2148,24 +2141,18 @@ mod tests {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
         index.insert(b"key", 3);
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![3, 2, 1]
-        );
+        let expected = values(index, b"key");
         {
             let mut cur = index.get_mut(b"key").unwrap();
-            assert_eq!(*cur.next().unwrap(), 3);
+            assert_eq!(*cur.next().unwrap(), expected[0]);
             cur.delete();
-            assert_eq!(*cur.next().unwrap(), 2);
+            assert_eq!(*cur.next().unwrap(), expected[1]);
             cur.insert(4);
-            assert_eq!(*cur.next().unwrap(), 1);
+            assert_eq!(*cur.next().unwrap(), expected[2]);
             assert!(cur.next().is_none());
             assert!(cur.next().is_none());
         }
-        assert_eq!(
-            index.get(b"key").copied().collect::<Vec<_>>(),
-            vec![2, 4, 1]
-        );
+        assert_eq!(values(index, b"key"), vec![expected[1], 4, expected[2]]);
     }
 
     #[test_traced]
@@ -2204,10 +2191,11 @@ mod tests {
     fn run_index_insert_at_entry_then_next<I: Unordered<Value = u64>>(index: &mut I) {
         index.insert(b"key", 1);
         index.insert(b"key", 2);
+        let expected = values(index, b"key");
         let mut cur = index.get_mut(b"key").unwrap();
-        assert_eq!(*cur.next().unwrap(), 2);
+        assert_eq!(*cur.next().unwrap(), expected[0]);
         cur.insert(99);
-        assert_eq!(*cur.next().unwrap(), 1);
+        assert_eq!(*cur.next().unwrap(), expected[1]);
         assert!(cur.next().is_none());
     }
 
@@ -2248,7 +2236,7 @@ mod tests {
         index.insert(b"key", 10);
         index.insert(b"key", 20);
         let mut cur = index.get_mut(b"key").unwrap();
-        assert_eq!(*cur.next().unwrap(), 20);
+        assert!(cur.next().is_some());
         cur.insert(15);
         cur.delete();
     }
@@ -2293,8 +2281,8 @@ mod tests {
         index.insert(b"key", 10);
         index.insert(b"key", 20);
         let mut cur = index.get_mut(b"key").unwrap();
-        assert_eq!(*cur.next().unwrap(), 20);
-        assert_eq!(*cur.next().unwrap(), 10);
+        assert!(cur.next().is_some());
+        assert!(cur.next().is_some());
         cur.delete();
         cur.insert(15);
     }
@@ -2339,7 +2327,7 @@ mod tests {
         index.insert(b"key", 10);
         index.insert(b"key", 20);
         let mut cur = index.get_mut(b"key").unwrap();
-        assert_eq!(*cur.next().unwrap(), 20);
+        assert!(cur.next().is_some());
         cur.insert(15);
         cur.insert(25);
     }
@@ -2434,15 +2422,13 @@ mod tests {
         for i in 0..5 {
             index.insert(b"z", i);
         }
+        let expected = values(index, b"z");
         {
             let mut cur = index.get_mut(b"z").unwrap();
             cur.next();
             cur.next();
         }
-        assert_eq!(
-            index.get(b"z").copied().collect::<Vec<_>>(),
-            vec![4, 3, 2, 1, 0]
-        );
+        assert_eq!(values(index, b"z"), expected);
     }
 
     #[test_traced]
@@ -2573,6 +2559,9 @@ mod tests {
         for i in 0..ITEMS {
             index.insert(b"", i as u64);
         }
+        assert_eq!(index.keys(), 1);
+        assert_eq!(index.items(), ITEMS);
+        assert_eq!(index.get(b"").count(), ITEMS);
     }
 
     #[test_traced]

--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -262,7 +262,7 @@ impl<K: Ord + Copy + Send + Sync, V: Send + Sync> CursorTrait for Cursor<'_, K, 
                 self.state = State::NeedNext { from: offset + 2 };
             }
             State::Done => {
-                // Append at the oldest position (run end), re-creating the key if it was emptied.
+                // Append at the run end, re-creating the key if it was emptied.
                 let end = self.backing.len();
                 if self.backing.insert(end, value) {
                     self.keys.inc();

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -23,12 +23,14 @@
 //!   effectively unreachable under honest load).
 //!
 //! A partition also fills when a single key collects many values -- keys that collide on the full
-//! prefix, or repeated inserts of one key. The spill covers this too: it triggers on the total
-//! value count, so these inserts stay as cheap as any other. What it cannot bound is how many
-//! values one key holds, and a lookup must scan all of them -- a key with `M` values costs O(M) per
-//! lookup. Every index that resolves collisions pays this (the flat `crate::index::ordered::Index`
-//! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
-//! use enough prefix bytes and high-entropy keys.
+//! prefix, or repeated inserts of one key. Values append to the end of a key's run. In the
+//! single-key case this makes inline inserts append-only, and after spilling they remain
+//! append-only in the run's `Vec`. Other inline inserts may shift later key runs, but the spill
+//! threshold bounds this cost. What spilling cannot bound is how many values one key holds, and a
+//! lookup must scan all of them -- a key with `M` values costs O(M) per lookup. Every index that
+//! resolves collisions pays this (the flat `crate::index::ordered::Index` included); `M` stays near
+//! 1 only when the indexed `P + N`-byte prefix is well-distributed, so use enough prefix bytes and
+//! high-entropy keys.
 
 mod cursor;
 mod partition;
@@ -71,8 +73,8 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     partitions: Box<[Partition<T::Key, V>]>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
-    /// keyed by partition index; each maps translated keys to their values newest-first. Empty until
-    /// a partition fills, whether from honest growth at low `P` or adversarial grinding.
+    /// keyed by partition index; each maps translated keys to their value runs. Empty until a
+    /// partition fills, whether from honest growth at low `P` or adversarial grinding.
     spilled: HashMap<usize, BTreeMap<T::Key, Vec<V>>>,
 
     /// Sorted-array length at which a partition spills to `spilled`; [SPILL_THRESHOLD] in
@@ -300,7 +302,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
                     &self.pruned,
                 ));
             }
-            self.partitions[i].insert_at(run.start, k, value);
+            self.partitions[i].insert_at(run.end, k, value);
             self.keys.inc();
             self.items.inc();
             self.maybe_spill(i);
@@ -341,7 +343,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             let new_key = run.is_empty();
-            self.partitions[i].insert_at(run.start, k, value);
+            self.partitions[i].insert_at(run.end, k, value);
             self.items.inc();
             if new_key {
                 self.keys.inc();
@@ -354,7 +356,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.spilled.is_empty() {
             if let hash_map::Entry::Occupied(mut partition) = self.spilled.entry(i) {
                 match partition.get_mut().entry(k) {
-                    btree_map::Entry::Occupied(mut run) => run.get_mut().insert(0, value),
+                    btree_map::Entry::Occupied(mut run) => run.get_mut().push(value),
                     btree_map::Entry::Vacant(run) => {
                         run.insert(vec![value]);
                         self.keys.inc();
@@ -632,7 +634,7 @@ mod tests {
             assert_eq!(index.keys(), 3);
             assert_eq!(index.items(), 3);
 
-            // Values are served correctly from the spilled representation, newest-first.
+            // Values are served correctly from the spilled representation in append order.
             assert_eq!(
                 index.get(&[0x10, 0x01]).copied().collect::<Vec<_>>(),
                 vec![1]
@@ -640,7 +642,7 @@ mod tests {
             index.insert(&[0x10, 0x02], 22);
             assert_eq!(
                 index.get(&[0x10, 0x02]).copied().collect::<Vec<_>>(),
-                vec![22, 2]
+                vec![2, 22]
             );
             assert_eq!(index.items(), 4);
 
@@ -846,20 +848,20 @@ mod tests {
             index.insert(key, 3);
             assert_eq!(index.keys(), 1);
             assert_eq!(index.items(), 3);
-            assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![3, 2, 1]);
+            assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![1, 2, 3]);
 
             {
                 let mut cursor = index.get_mut(key).unwrap();
-                assert_eq!(*cursor.next().unwrap(), 3);
-                assert_eq!(*cursor.next().unwrap(), 2);
                 assert_eq!(*cursor.next().unwrap(), 1);
+                assert_eq!(*cursor.next().unwrap(), 2);
+                assert_eq!(*cursor.next().unwrap(), 3);
                 assert!(cursor.next().is_none());
             }
 
             index.insert(key, 3);
             index.insert(key, 4);
             index.retain(key, |i| *i != 3);
-            assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![4, 2, 1]);
+            assert_eq!(index.get(key).copied().collect::<Vec<_>>(), vec![1, 2, 4]);
 
             index.retain(key, |_| false);
             assert_eq!(
@@ -923,7 +925,7 @@ mod tests {
             index.get_many(&keys, |key_idx, value| visits[key_idx].push(*value));
             assert_eq!(visits[0], vec![4]);
             assert!(visits[1].is_empty());
-            assert_eq!(visits[2], vec![3, 2, 1]);
+            assert_eq!(visits[2], vec![1, 2, 3]);
             assert_eq!(visits[3], vec![4]);
         });
     }
@@ -932,7 +934,7 @@ mod tests {
     fn test_soa_insert_and_retain() {
         deterministic::Runner::default().start(|context| async move {
             let mut index = new_index(context);
-            // Keep both: new value joins as oldest.
+            // Keep both: new value appends to the run.
             index.insert(b"k", 1u64);
             index.insert_and_retain(b"k", 2, |_| true);
             assert_eq!(index.get(b"k").copied().collect::<Vec<_>>(), vec![1, 2]);
@@ -1004,11 +1006,11 @@ mod tests {
             assert_eq!(it.next(), Some(&1));
             assert_eq!(it.next(), None);
 
-            // From k1's bucket: jumps partitions to k2's collision run (newest first).
+            // From k1's bucket: jumps partitions to k2's collision run.
             let (mut it, wrapped) = index.next_translated_key(&hex!("0x0b02F2")).unwrap();
             assert!(!wrapped);
-            assert_eq!(it.next(), Some(&22));
             assert_eq!(it.next(), Some(&21));
+            assert_eq!(it.next(), Some(&22));
             assert_eq!(it.next(), None);
 
             // From the last key: cycles to the first.
@@ -1024,8 +1026,8 @@ mod tests {
             // Previous bucket below 1d is 1c's collision run.
             let (mut it, wrapped) = index.prev_translated_key(&hex!("0x1d0102")).unwrap();
             assert!(!wrapped);
-            assert_eq!(it.next(), Some(&22));
             assert_eq!(it.next(), Some(&21));
+            assert_eq!(it.next(), Some(&22));
             assert_eq!(it.next(), None);
         });
     }

--- a/storage/src/index/partitioned/ordered/partition.rs
+++ b/storage/src/index/partitioned/ordered/partition.rs
@@ -7,8 +7,7 @@
 //!
 //! Multiple values for the same translated key (collisions, or repeated inserts) form a contiguous
 //! run of equal keys. Collisions are rare for well-distributed translated keys, so most runs have
-//! length one. Within a run the newest value is first (lowest index), matching the iteration order
-//! of the non-partitioned index.
+//! length one. The index's insertion path appends new values to the end of an existing run.
 
 use std::ops::Range;
 
@@ -41,10 +40,8 @@ impl<K: Ord + Copy, V> Partition<K, V> {
     }
 
     /// Move every entry out of the partition, leaving it empty, returning one `(key, values)` pair
-    /// per distinct key with its values newest-first.
+    /// per distinct key with its values in their current run order.
     pub(super) fn drain_runs(&mut self) -> Vec<(K, Vec<V>)> {
-        // Each run is already stored newest-first (lowest index), so taking its values in array
-        // order preserves that ordering.
         let keys = std::mem::take(&mut self.keys);
         let vals = std::mem::take(&mut self.vals);
         let mut vals = vals.into_iter();
@@ -104,7 +101,7 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         start..end
     }
 
-    /// The values associated with `key`, newest first (empty if absent).
+    /// The values associated with `key` in their current run order (empty if absent).
     pub(super) fn values(&self, key: &K) -> &[V] {
         &self.vals[self.run_range(key)]
     }
@@ -138,8 +135,8 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         self.vals[idx] = value;
     }
 
-    /// The values of the lexicographically smallest key, newest first (None if the partition is
-    /// empty).
+    /// The values of the lexicographically smallest key in their current run order (None if the
+    /// partition is empty).
     pub(super) fn first_values(&self) -> Option<&[V]> {
         if self.keys.is_empty() {
             return None;
@@ -147,15 +144,15 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         Some(&self.vals[self.run_starting_at(0)])
     }
 
-    /// The values of the lexicographically largest key, newest first (None if the partition is
-    /// empty).
+    /// The values of the lexicographically largest key in their current run order (None if the
+    /// partition is empty).
     pub(super) fn last_values(&self) -> Option<&[V]> {
         let last = self.keys.len().checked_sub(1)?;
         Some(&self.vals[self.run_ending_at(last)])
     }
 
-    /// The values of the smallest key strictly greater than `key`, newest first (None if no such
-    /// key exists).
+    /// The values of the smallest key strictly greater than `key` in their current run order (None
+    /// if no such key exists).
     pub(super) fn next_values_after(&self, key: &K) -> Option<&[V]> {
         let idx = self.keys.partition_point(|k| *k <= *key);
         if idx >= self.keys.len() {
@@ -164,8 +161,8 @@ impl<K: Ord + Copy, V> Partition<K, V> {
         Some(&self.vals[self.run_starting_at(idx)])
     }
 
-    /// The values of the largest key strictly less than `key`, newest first (None if no such key
-    /// exists).
+    /// The values of the largest key strictly less than `key` in their current run order (None if
+    /// no such key exists).
     pub(super) fn prev_values_before(&self, key: &K) -> Option<&[V]> {
         let prev = self.lower_bound(key).checked_sub(1)?;
         Some(&self.vals[self.run_ending_at(prev)])
@@ -176,11 +173,12 @@ impl<K: Ord + Copy, V> Partition<K, V> {
 mod tests {
     use super::*;
 
-    /// Insert `value` as the newest value for `key`, keeping the arrays sorted. The production hot
-    /// path instead reuses the run it already computed (`insert_at(run.start, ..)`) to avoid a
-    /// second `lower_bound`; this helper keeps the tests concise.
+    /// Append `value` to `key`'s run, keeping the arrays sorted. The production hot path instead
+    /// reuses the run it already computed (`insert_at(run.end, ..)`) to avoid a second lookup; this
+    /// helper keeps the tests concise.
     fn insert<K: Ord + Copy, V>(p: &mut Partition<K, V>, key: K, value: V) {
-        p.insert_at(p.lower_bound(&key), key, value);
+        let end = p.run_range(&key).end;
+        p.insert_at(end, key, value);
     }
 
     #[test]
@@ -217,25 +215,25 @@ mod tests {
         }
         // next strictly-greater key.
         assert_eq!(p.next_values_after(&5), Some(&[100u64] as &[u64]));
-        assert_eq!(p.next_values_after(&10), Some(&[222u64, 200] as &[u64])); // run, newest first
+        assert_eq!(p.next_values_after(&10), Some(&[200u64, 222] as &[u64]));
         assert_eq!(p.next_values_after(&20), Some(&[300u64] as &[u64]));
         assert!(p.next_values_after(&30).is_none());
         // prev strictly-less key.
         assert!(p.prev_values_before(&10).is_none());
         assert_eq!(p.prev_values_before(&20), Some(&[100u64] as &[u64]));
-        assert_eq!(p.prev_values_before(&25), Some(&[222u64, 200] as &[u64]));
+        assert_eq!(p.prev_values_before(&25), Some(&[200u64, 222] as &[u64]));
         assert_eq!(p.prev_values_before(&999), Some(&[300u64] as &[u64]));
     }
 
     #[test]
-    fn test_partition_collision_run_newest_first() {
+    fn test_partition_collision_run_append_order() {
         let mut p = Partition::<u16, u64>::default();
         insert(&mut p, 10, 1);
         insert(&mut p, 20, 2);
-        // Three values collide on key 10; newest is first within the run.
+        // Three values collide on key 10 and append within the run.
         insert(&mut p, 10, 11);
         insert(&mut p, 10, 111);
-        assert_eq!(p.values(&10), &[111, 11, 1]);
+        assert_eq!(p.values(&10), &[1, 11, 111]);
         assert_eq!(p.values(&20), &[2]);
         // Keys remain sorted with the run adjacent.
         assert_eq!(p.keys, vec![10, 10, 10, 20]);
@@ -249,12 +247,12 @@ mod tests {
         for (k, v) in [(10u16, 1u64), (10, 11), (20, 2)] {
             insert(&mut p, k, v);
         }
-        // keys=[10,10,20] vals=[11,1,2]; remove the older value of key 10 (index 1).
+        // keys=[10,10,20] vals=[1,11,2]; remove the newer value of key 10 (index 1).
         let removed = p.remove(1);
-        assert_eq!(removed, 1);
+        assert_eq!(removed, 11);
         assert_eq!(p.keys, vec![10, 20]);
-        assert_eq!(p.vals, vec![11, 2]);
-        assert_eq!(p.values(&10), &[11]);
+        assert_eq!(p.vals, vec![1, 2]);
+        assert_eq!(p.values(&10), &[1]);
     }
 
     #[test]
@@ -268,14 +266,14 @@ mod tests {
     #[test]
     fn test_partition_drain_runs() {
         let mut p = Partition::<u16, u64>::default();
-        // Two runs: key 10 with three values (newest-first 111, 11, 1), key 20 with one.
+        // Two runs: key 10 with three appended values, key 20 with one.
         for (k, v) in [(10u16, 1u64), (20, 2), (10, 11), (10, 111)] {
             insert(&mut p, k, v);
         }
         assert_eq!(p.len(), 4);
         let runs = p.drain_runs();
-        // One pair per distinct key, ascending, values newest-first.
-        assert_eq!(runs, vec![(10, vec![111, 11, 1]), (20, vec![2])]);
+        // One pair per distinct key, ascending, preserving each run's order.
+        assert_eq!(runs, vec![(10, vec![1, 11, 111]), (20, vec![2])]);
         // The partition is left empty.
         assert!(p.is_empty());
         assert_eq!(p.len(), 0);

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -120,8 +120,8 @@ where
 
     /// Set a key to a value.
     ///
-    /// The key must not already exist in the database or in any ancestor batch
-    /// in the chain. Setting a key that already exists causes undefined behavior.
+    /// If the key already exists in the database or an ancestor batch, reads
+    /// of it may return any of its written values.
     pub fn set(mut self, key: K, value: V::Value) -> Self {
         self.mutations.insert(key, value);
         self

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -2196,7 +2196,8 @@ pub(super) mod test {
     /// Same key set across two sequential applied batches. This breaks the key-uniqueness
     /// invariant, so reads may return any of the written values. `get()` must still return one
     /// of them, live and across a restart, and after pruning every other version it returns the
-    /// survivor.
+    /// survivor. The prune check runs on a never-restarted db so the snapshot still holds both
+    /// locations and `get()` must skip the pruned one within the bucket.
     ///
     /// `open_db_small_sections` must return a DB whose log has `items_per_section=1`
     /// so pruning is per-item.
@@ -2246,21 +2247,38 @@ pub(super) mod test {
         assert!(live == v1 || live == v2);
 
         // A restart must also serve one of the written values.
-        db.sync().await.unwrap();
+        db.commit().await.unwrap();
         drop(db);
-        let mut db = open_db_small_sections(context.child("reopen")).await;
+        let db = open_db_small_sections(context.child("reopen")).await;
         let reopened = db.get(&key).await.unwrap().unwrap();
         assert!(reopened == v1 || reopened == v2);
+        db.destroy().await.unwrap();
 
-        // Raise the floor so pruning past the first Set is allowed.
-        // Layout continues: 5=Commit(floor=4)
-        db.apply_batch(db.new_batch().merkleize(&db, None, Location::new(4)).await)
-            .await
-            .unwrap();
+        // Rebuild the same history on a fresh db without restarting, so the
+        // snapshot bucket holds both locations. Floor=4 permits prune(2).
+        // Layout: 0=initial commit, 1=Set(key,v1), 2=Commit, 3=Set(key,v2),
+        // 4=Commit(floor=4)
+        let mut db = open_db_small_sections(context.child("prune")).await;
+        db.apply_batch(
+            db.new_batch()
+                .set(key, v1)
+                .merkleize(&db, None, Location::new(0))
+                .await,
+        )
+        .await
+        .unwrap();
+        db.apply_batch(
+            db.new_batch()
+                .set(key, v2)
+                .merkleize(&db, None, Location::new(4))
+                .await,
+        )
+        .await
+        .unwrap();
 
-        // Prune past the first Set (loc 1). With items_per_section=1,
-        // pruning to loc 2 should remove the blob containing loc 1, leaving
-        // v2 as the only retrievable version.
+        // Prune past the first Set (loc 1). With items_per_section=1, pruning
+        // to loc 2 removes the blob containing loc 1. get() must skip the
+        // pruned location within the bucket and serve the survivor.
         db.prune(Location::new(2)).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v2));
 
@@ -3210,6 +3228,7 @@ pub(super) mod test {
 
         // Commit A: Set(key, v1) with floor=0.
         commit_sets(&mut db, [(key, v1)], None).await;
+        let first_size = db.bounds().end;
 
         // Commit B: Set(key, v2) with floor=0. Either written value may be served.
         commit_sets(&mut db, [(key, v2)], None).await;
@@ -3231,6 +3250,11 @@ pub(super) mod test {
         db.rewind(second_size).await.unwrap();
         let rewound = db.get(&key).await.unwrap().unwrap();
         assert!(rewound == v1 || rewound == v2);
+
+        // Rewind further to commit A: the v2 entry is dropped and get() must
+        // serve v1, proving the gap fill restored the v1 location.
+        db.rewind(first_size).await.unwrap();
+        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         db.destroy().await.unwrap();
     }
@@ -3283,6 +3307,11 @@ pub(super) mod test {
         db.rewind(second_size).await.unwrap();
         let rewound = db.get(&key).await.unwrap().unwrap();
         assert!(rewound == v1 || rewound == v2);
+
+        // Rewind further to commit A: the v2 entry is dropped and get() must
+        // serve v1, proving the gap fill restored the v1 location.
+        db.rewind(first_size).await.unwrap();
+        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -149,8 +149,8 @@ pub struct Config<T: Translator, J, S: Strategy> {
 ///
 /// # Invariant
 ///
-/// A key must be set at most once across the database history. Writing the same key more than
-/// once is undefined behavior.
+/// A key must be set at most once across the database history. If a key is set more than once,
+/// reads of that key may return any of its written values.
 ///
 /// Use [fixed::Db] or [variable::Db] for concrete instantiations.
 pub struct Immutable<
@@ -583,13 +583,12 @@ where
 
         // If the rewind target has a lower floor than the current snapshot was
         // built from, insert keys from the gap [rewind_floor, old_floor) that
-        // were excluded by the higher-floor reconstruction.
-        //
-        // Iterate in reverse so front-insertion preserves ascending loc order
-        // for repeated keys, matching the ordering that apply_batch produces.
+        // were excluded by the higher-floor reconstruction. A key written more
+        // than once may end up with multiple snapshot entries, and reads of it
+        // may return any of its written values.
         if rewind_floor < old_floor {
             let gap_end = core::cmp::min(*old_floor, rewind_size);
-            for loc in (*rewind_floor..gap_end).rev() {
+            for loc in *rewind_floor..gap_end {
                 if let Operation::Set(key, _) = self.journal.journal.read(loc).await? {
                     self.snapshot.insert(&key, Location::new(loc));
                 }
@@ -2194,9 +2193,10 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    /// Same key set across two sequential applied batches. The immutable DB
-    /// keeps all versions -- `get()` returns the earliest non-pruned value.
-    /// After pruning the first version, `get()` returns the second.
+    /// Same key set across two sequential applied batches. This breaks the key-uniqueness
+    /// invariant, so reads may return any of the written values. `get()` must still return one
+    /// of them, live and across a restart, and after pruning every other version it returns the
+    /// survivor.
     ///
     /// `open_db_small_sections` must return a DB whose log has `items_per_section=1`
     /// so pruning is per-item.
@@ -2232,21 +2232,35 @@ pub(super) mod test {
 
         // Second batch sets same key to different value.
         // Layout continues: 3=Set(key,v2), 4=Commit
-        // Floor=4 so that prune(2) succeeds (2 <= 4).
         db.apply_batch(
             db.new_batch()
                 .set(key, v2)
-                .merkleize(&db, None, Location::new(4))
+                .merkleize(&db, None, Location::new(0))
                 .await,
         )
         .await
         .unwrap();
 
-        // Immutable DB returns the earliest non-pruned value.
-        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+        // Either written value may be served for the repeated key.
+        let live = db.get(&key).await.unwrap().unwrap();
+        assert!(live == v1 || live == v2);
+
+        // A restart must also serve one of the written values.
+        db.sync().await.unwrap();
+        drop(db);
+        let mut db = open_db_small_sections(context.child("reopen")).await;
+        let reopened = db.get(&key).await.unwrap().unwrap();
+        assert!(reopened == v1 || reopened == v2);
+
+        // Raise the floor so pruning past the first Set is allowed.
+        // Layout continues: 5=Commit(floor=4)
+        db.apply_batch(db.new_batch().merkleize(&db, None, Location::new(4)).await)
+            .await
+            .unwrap();
 
         // Prune past the first Set (loc 1). With items_per_section=1,
-        // pruning to loc 2 should remove the blob containing loc 1.
+        // pruning to loc 2 should remove the blob containing loc 1, leaving
+        // v2 as the only retrievable version.
         db.prune(Location::new(2)).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v2));
 
@@ -3173,9 +3187,8 @@ pub(super) mod test {
         db.destroy().await.unwrap();
     }
 
-    /// Regression: rewind-after-reopen with a repeated key in the floor gap.
-    /// The gap-fill must maintain the same ordering as the live `apply_batch`
-    /// path so `get()` returns the same value.
+    /// Rewind-after-reopen with a repeated key in the floor gap. The gap fill
+    /// must restore the key, and reads may return any of its written values.
     #[boxed]
     pub(crate) async fn test_immutable_rewind_after_reopen_repeated_key_gap<F: Family, V, C>(
         context: deterministic::Context,
@@ -3198,10 +3211,11 @@ pub(super) mod test {
         // Commit A: Set(key, v1) with floor=0.
         commit_sets(&mut db, [(key, v1)], None).await;
 
-        // Commit B: Set(key, v2) with floor=0. get() returns v1 (earliest).
+        // Commit B: Set(key, v2) with floor=0. Either written value may be served.
         commit_sets(&mut db, [(key, v2)], None).await;
         let second_size = db.bounds().end;
-        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+        let live = db.get(&key).await.unwrap().unwrap();
+        assert!(live == v1 || live == v2);
 
         // Commit C: raises floor above both earlier writes.
         commit_sets_with_floor(&mut db, [(k3, v3)], None, second_size).await;
@@ -3215,14 +3229,15 @@ pub(super) mod test {
 
         // Rewind to commit B: gap fill re-inserts both Set(key,...) entries.
         db.rewind(second_size).await.unwrap();
-        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+        let rewound = db.get(&key).await.unwrap().unwrap();
+        assert!(rewound == v1 || rewound == v2);
 
         db.destroy().await.unwrap();
     }
 
-    /// Regression: after restart, the snapshot can contain the newer write for
-    /// a repeated key. If rewind restores an older write for that same key, the
-    /// older write must be checked first, matching the pre-restart snapshot.
+    /// After restart, the snapshot can contain only the newer write for a
+    /// repeated key. Rewind restores the older write's snapshot entry, and
+    /// reads may return any of the written values.
     #[boxed]
     pub(crate) async fn test_immutable_rewind_after_reopen_mixed_gap_retained<F: Family, V, C>(
         context: deterministic::Context,
@@ -3246,10 +3261,11 @@ pub(super) mod test {
         commit_sets(&mut db, [(key, v1)], None).await;
         let first_size = db.bounds().end;
 
-        // Commit B: Set(key, v2), floor=0. get() returns v1 (earliest).
+        // Commit B: Set(key, v2), floor=0. Either written value may be served.
         commit_sets(&mut db, [(key, v2)], None).await;
         let second_size = db.bounds().end;
-        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+        let live = db.get(&key).await.unwrap().unwrap();
+        assert!(live == v1 || live == v2);
 
         // Commit C: raises floor to first_size, so loc=0 is below floor but
         // loc for v2 is retained.
@@ -3262,10 +3278,11 @@ pub(super) mod test {
         let mut db = open_db(context.child("second")).await;
         assert_eq!(db.get(&key).await.unwrap(), Some(v2));
 
-        // Rewind to commit B: gap fill re-inserts the v1 write. The older
-        // write must appear before the retained v2 entry so get() returns v1.
+        // Rewind to commit B: gap fill re-inserts the v1 write alongside the
+        // retained v2 entry, and get() serves one of the two.
         db.rewind(second_size).await.unwrap();
-        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+        let rewound = db.get(&key).await.unwrap().unwrap();
+        assert!(rewound == v1 || rewound == v2);
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -373,10 +373,6 @@ where
 
 /// Find and return the location of the update operation for `key`, if it exists. The cursor is
 /// positioned at the matching location, and can be used to update or delete the key.
-///
-/// # Panics
-///
-/// Panics if `key` is not found in the snapshot or if `old_loc` is not found in the cursor.
 async fn find_update_op<F, R>(
     reader: &R,
     cursor: &mut impl Cursor<Value = Location<F>>,


### PR DESCRIPTION
## Overview

Alternative to #4251.

The partitioned ordered index currently prepends to a collision run with `Vec::insert(0, value)`. Once the partition spills, repeated inserts for the same translated key shift the entire unbounded value chain, making M inserts O(M^2).

We do not need newest-first value order to fix this. Binary search operates on the parallel translated-key array, not on values within an equal-key run. Appending at the run end keeps equal keys contiguous and places the new entry before the next greater key, so the key array remains sorted.

## Change

- Insert inline collision values at `run.end` instead of `run.start`.
- Keep spilled collision runs as `Vec<V>` and use `push` instead of `insert(0, ...)`.
- Document `Unordered::get` value iteration order as implementation-defined.
- Make generic index tests validate collision contents without assuming newest-first order, while retaining cursor-relative mutation coverage.
- Strengthen the 50,000-value collision test to verify key/item counts and full retrieval.

This keeps the spilled representation contiguous. A sole inline collision run is append-only before the 512-entry spill threshold, and its spilled `Vec` remains amortized O(1) per insert afterward.

## Validation

- `just test -p commonware-storage index:: --no-fail-fast` (156 passed)
- `just test -p commonware-storage` (2,740 passed)
- `just test -p commonware-storage large_collision_chain --no-fail-fast` (3 passed)
- `just test -p commonware-storage test_partitioned_ordered_spilling --no-fail-fast` (passed)
- `just clippy -p commonware-storage`
- `just check-stability`
- `cargo fmt --all -- --check`
- `git diff --check`
