### PR TITLE
[index] Spill partitions after cursor growth

### DIFF
--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -27,7 +27,7 @@
 //! value count, so a single over-full key still converts the partition and keeps inserts for the
 //! partition's other keys cheap. What it cannot bound is the over-full key itself. Spilled or not,
 //! a key's values form one newest-first run, so prepending its newest value shifts the whole run
-//! (only a cursor insert at the run's end avoids this) and a lookup must scan it -- a key with `M`
+//! (only a cursor insert at the run's end avoids this) and a lookup must scan it. A key with `M`
 //! values costs O(M) per lookup. Every index that resolves collisions pays this scan (the flat
 //! `crate::index::ordered::Index` included); `M` stays near 1 only when the indexed `P + N`-byte
 //! prefix is well-distributed, so use enough prefix bytes and high-entropy keys.

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -30,9 +30,9 @@
 //! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
 //! use enough prefix bytes and high-entropy keys.
 //!
-//! A caller-held cursor can temporarily grow an inline partition to the spill threshold. The next
-//! index mutation of that partition spills it before access. [`Unordered::insert_and_retain`]
-//! performs the check after releasing its internal cursor.
+//! A caller-held cursor can temporarily grow an inline partition to or past the spill threshold.
+//! The next index mutation of that partition spills it before access.
+//! [`Unordered::insert_and_retain`] performs the check after releasing its internal cursor.
 
 mod cursor;
 mod partition;
@@ -690,6 +690,28 @@ mod tests {
             index.insert_and_retain(&other, 5, |_| true);
             assert_eq!(index.spilled_count(), 2);
             assert_eq!(index.get(&other).copied().collect::<Vec<_>>(), vec![4, 5]);
+        });
+    }
+
+    #[test_traced]
+    fn test_spill_after_get_mut_or_insert_cursor_growth() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut index = new_index_spilling(context);
+            let key = [0x10, 0x01];
+
+            index.insert(&key, 1);
+            {
+                let mut cursor = index.get_mut_or_insert(&key, 2).unwrap();
+                assert_eq!(cursor.next().copied(), Some(1));
+                assert_eq!(cursor.next(), None);
+                cursor.insert(2);
+            }
+            assert_eq!(index.spilled_count(), 0);
+
+            // The next replay-style update spills before returning another collision cursor.
+            assert!(index.get_mut_or_insert(&key, 3).is_some());
+            assert_eq!(index.spilled_count(), 1);
+            assert_eq!(index.get(&key).copied().collect::<Vec<_>>(), vec![1, 2]);
         });
     }
 

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -31,8 +31,8 @@
 //! use enough prefix bytes and high-entropy keys.
 //!
 //! A caller-held cursor can temporarily grow an inline partition to or past the spill threshold.
-//! The next index mutation of that partition spills it before access.
-//! [`Unordered::insert_and_retain`] performs the check after releasing its internal cursor.
+//! The next index mutation of that partition spills it before access. `insert_and_retain` performs
+//! the check after releasing its internal cursor.
 
 mod cursor;
 mod partition;

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -24,11 +24,13 @@
 //!
 //! A partition also fills when a single key collects many values -- keys that collide on the full
 //! prefix, or repeated inserts of one key. The spill covers this too: it triggers on the total
-//! value count, so these inserts stay as cheap as any other. What it cannot bound is how many
-//! values one key holds, and a lookup must scan all of them -- a key with `M` values costs O(M) per
-//! lookup. Every index that resolves collisions pays this (the flat `crate::index::ordered::Index`
-//! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
-//! use enough prefix bytes and high-entropy keys.
+//! value count, so a single over-full key still converts the partition and keeps inserts for the
+//! partition's other keys cheap. What it cannot bound is the over-full key itself. Spilled or not,
+//! a key's values form one newest-first run, so prepending its newest value shifts the whole run
+//! (only a cursor insert at the run's end avoids this) and a lookup must scan it -- a key with `M`
+//! values costs O(M) per lookup. Every index that resolves collisions pays this scan (the flat
+//! `crate::index::ordered::Index` included); `M` stays near 1 only when the indexed `P + N`-byte
+//! prefix is well-distributed, so use enough prefix bytes and high-entropy keys.
 //!
 //! A caller-held cursor can temporarily grow an inline partition to or past the spill threshold.
 //! The next index mutation of that partition spills it before access. `insert_and_retain` performs
@@ -116,9 +118,11 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
     }
 
     /// Create a new [Index] with an explicit spill threshold so tests can exercise spilling without
-    /// inserting [SPILL_THRESHOLD] keys.
+    /// inserting [SPILL_THRESHOLD] keys. The threshold must be at least 1: `maybe_spill` relies on
+    /// an already-spilled partition's empty inline array staying strictly below the threshold.
     #[cfg(test)]
     pub(crate) fn with_threshold(ctx: impl Metrics, translator: T, threshold: usize) -> Self {
+        assert!(threshold > 0, "spill threshold must be at least 1");
         let mut index = Self::new(ctx, translator);
         index.threshold = threshold;
         index
@@ -679,7 +683,7 @@ mod tests {
             }
             assert_eq!(index.spilled_count(), 0);
 
-            // The next index mutation spills before modifying the over-full inline partition.
+            // The next index mutation spills the over-full inline partition.
             index.insert(&key, 3);
             assert_eq!(index.spilled_count(), 1);
             assert_eq!(index.get(&key).copied().collect::<Vec<_>>(), vec![3, 1, 2]);
@@ -690,6 +694,40 @@ mod tests {
             index.insert_and_retain(&other, 5, |_| true);
             assert_eq!(index.spilled_count(), 2);
             assert_eq!(index.get(&other).copied().collect::<Vec<_>>(), vec![4, 5]);
+
+            // `get_mut` spills an over-full partition before handing out a cursor, so the cursor
+            // serves the spilled representation.
+            let third = [0x30, 0x01];
+            index.insert(&third, 6);
+            {
+                let mut cursor = index.get_mut(&third).unwrap();
+                assert_eq!(cursor.next().copied(), Some(6));
+                assert_eq!(cursor.next(), None);
+                cursor.insert(7);
+            }
+            assert_eq!(index.spilled_count(), 2);
+            {
+                let mut cursor = index.get_mut(&third).unwrap();
+                assert_eq!(cursor.next().copied(), Some(6));
+                assert_eq!(cursor.next().copied(), Some(7));
+                assert_eq!(cursor.next(), None);
+            }
+            assert_eq!(index.spilled_count(), 3);
+            assert_eq!(index.get(&third).copied().collect::<Vec<_>>(), vec![6, 7]);
+
+            // `remove` spills an over-full partition before access, even for an absent key.
+            let fourth = [0x40, 0x01];
+            index.insert(&fourth, 8);
+            {
+                let mut cursor = index.get_mut(&fourth).unwrap();
+                assert_eq!(cursor.next().copied(), Some(8));
+                assert_eq!(cursor.next(), None);
+                cursor.insert(9);
+            }
+            assert_eq!(index.spilled_count(), 3);
+            index.remove(&[0x40, 0x02]);
+            assert_eq!(index.spilled_count(), 4);
+            assert_eq!(index.get(&fourth).copied().collect::<Vec<_>>(), vec![8, 9]);
         });
     }
 

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -29,6 +29,10 @@
 //! lookup. Every index that resolves collisions pays this (the flat `crate::index::ordered::Index`
 //! included); `M` stays near 1 only when the indexed `P + N`-byte prefix is well-distributed, so
 //! use enough prefix bytes and high-entropy keys.
+//!
+//! A caller-held cursor can temporarily grow an inline partition to the spill threshold. The next
+//! index mutation of that partition spills it before access. [`Unordered::insert_and_retain`]
+//! performs the check after releasing its internal cursor.
 
 mod cursor;
 mod partition;
@@ -247,6 +251,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     fn get_mut<'a>(&'a mut self, key: &[u8]) -> Option<Self::Cursor<'a>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
+        self.maybe_spill(i);
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             if run.is_empty() {
@@ -288,6 +293,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     ) -> Option<Self::Cursor<'a>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
+        self.maybe_spill(i);
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             if !run.is_empty() {
@@ -338,6 +344,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
     fn insert(&mut self, key: &[u8], value: Self::Value) {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
+        self.maybe_spill(i);
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             let new_key = run.is_empty();
@@ -378,6 +385,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         value: Self::Value,
         should_retain: impl Fn(&Self::Value) -> bool,
     ) {
+        let (i, _) = partition_index_and_sub_key::<P>(key);
         if let Some(mut cursor) = self.get_mut(key) {
             cursor.retain(&should_retain);
             if should_retain(&value) {
@@ -386,11 +394,13 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         } else if should_retain(&value) {
             self.insert(key, value);
         }
+        self.maybe_spill(i);
     }
 
     fn remove(&mut self, key: &[u8]) {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         let k = self.translator.transform(sub);
+        self.maybe_spill(i);
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             if run.is_empty() {
@@ -651,6 +661,35 @@ mod tests {
                 index.get(&[0x20, 0x05]).copied().collect::<Vec<_>>(),
                 vec![5]
             );
+        });
+    }
+
+    #[test_traced]
+    fn test_spill_after_cursor_growth() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut index = new_index_spilling(context);
+            let key = [0x10, 0x01];
+
+            index.insert(&key, 1);
+            {
+                let mut cursor = index.get_mut(&key).unwrap();
+                assert_eq!(cursor.next().copied(), Some(1));
+                assert_eq!(cursor.next(), None);
+                cursor.insert(2);
+            }
+            assert_eq!(index.spilled_count(), 0);
+
+            // The next index mutation spills before modifying the over-full inline partition.
+            index.insert(&key, 3);
+            assert_eq!(index.spilled_count(), 1);
+            assert_eq!(index.get(&key).copied().collect::<Vec<_>>(), vec![3, 1, 2]);
+
+            // Mutations that own their cursor can spill as soon as they release it.
+            let other = [0x20, 0x01];
+            index.insert(&other, 4);
+            index.insert_and_retain(&other, 5, |_| true);
+            assert_eq!(index.spilled_count(), 2);
+            assert_eq!(index.get(&other).copied().collect::<Vec<_>>(), vec![4, 5]);
         });
     }
 


### PR DESCRIPTION
## Overview

Independent of #4252, this fixes a path that could grow an inline partition beyond its spill threshold.

During DB initialization, `build_snapshot_from_log` resolves translated-key collisions through `get_mut_or_insert` followed by `Cursor::insert`. Before this change, that cursor-driven insertion path never invoked the spill logic. Replaying a collision-heavy log could therefore grow an inline partition far beyond `SPILL_THRESHOLD`, making initialization increasingly expensive.

## Change

- Check for deferred spilling before mutable index operations access a partition.
- Recheck after `insert_and_retain` releases its internally owned cursor.
- Keep `Cursor` unchanged: a caller-held cursor may temporarily reach the threshold, then the next mutation of that partition spills before access.
- Add regression coverage for both deferred external-cursor spilling and immediate internally owned-cursor spilling.

Because a cursor holds the index's exclusive borrow, the index cannot spill while that cursor is active. Deferring the check until the index regains control avoids adding spill state and drop behavior to every cursor.

## Validation

- `just check-fmt`
- `just test -p commonware-storage index::partitioned::ordered::tests` (16 passed)
- `git diff --check`
