### PR TITLE
[storage] Fix storage header truncation

### DIFF
--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -142,18 +142,24 @@ impl crate::Storage for Storage {
         // Assume empty files are newly created. Existing empty files will be synced too; that's OK.
         let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
+        // For a new file, durably persist it and its directory entries before writing
+        // any header byte.
+        if raw_len == 0 {
+            file.sync_all()
+                .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+            sync_dir(parent)?;
+            if !parent_existed {
+                sync_dir(&self.storage_directory)?;
+            }
+        }
+
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
         let (blob_version, logical_len) = if Header::missing(raw_len) {
-            // New or partially-created blob: reset it and write a fresh header.
-            // Truncate to *empty* before writing the header (rather than extending to
-            // header size first and then writing the magic), so blob creation is
-            // crash-atomic. If an unclean shutdown interrupts this, the file is left
-            // either empty or shorter than a header, both of which this branch treats
-            // as new and rewrites on the next open. Extending to header size first and
-            // then writing the magic would instead leave a header-sized, all-zero file
-            // if the process died in between, which the "existing blob" branch below
-            // rejects as corrupt.
+            // New or partially-created blob: reset it and write a fresh header. The
+            // file grows only as header bytes are written, so a create interrupted by
+            // a process crash leaves some prefix of the header, which the next open
+            // resets here instead of rejecting as corrupt below.
             let (header, blob_version) = Header::new(&versions);
             file.set_len(0)
                 .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
@@ -163,14 +169,6 @@ impl crate::Storage for Storage {
                 .map_err(|_| Error::WriteFailed)?;
             file.sync_all()
                 .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-            // For new files, sync the parent directory to ensure the directory entry is durable.
-            if raw_len == 0 {
-                sync_dir(parent)?;
-                if !parent_existed {
-                    sync_dir(&self.storage_directory)?;
-                }
-            }
 
             (blob_version, 0)
         } else {
@@ -603,6 +601,44 @@ mod tests {
         assert!(err
             .to_string()
             .starts_with("blob corrupt: partition/6261645f6d61676963 reason: invalid magic"));
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_blob_partial_header_reset() {
+        // Any file shorter than a header must reset to a valid, empty blob on open
+        // rather than fail as corrupt.
+        let (storage, storage_directory) = create_test_storage();
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+
+        for prefix_len in 0..Header::SIZE {
+            let name = format!("short_{prefix_len}");
+            let path = partition_path.join(hex(name.as_bytes()));
+            // Seed a file shorter than a full header.
+            std::fs::write(&path, vec![0u8; prefix_len]).unwrap();
+
+            let (blob, size) = storage
+                .open("partition", name.as_bytes())
+                .await
+                .expect("interrupted create should recover, not fail");
+            assert_eq!(size, 0, "recovered blob should be empty");
+            drop(blob);
+
+            // The recovered blob is a valid header-only file and reopens cleanly.
+            let raw = std::fs::read(&path).unwrap();
+            assert_eq!(
+                raw.len(),
+                Header::SIZE,
+                "recovered blob should be header-only"
+            );
+            assert_eq!(&raw[..Header::MAGIC_LENGTH], &Header::MAGIC);
+            storage
+                .open("partition", name.as_bytes())
+                .await
+                .expect("reopen after recovery should succeed");
+        }
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -145,9 +145,17 @@ impl crate::Storage for Storage {
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
         let (blob_version, logical_len) = if Header::missing(raw_len) {
-            // New (or corrupted) blob - truncate and write header with latest version
+            // New or partially-created blob: reset it and write a fresh header.
+            // Truncate to *empty* before writing the header (rather than extending to
+            // header size first and then writing the magic), so blob creation is
+            // crash-atomic. If an unclean shutdown interrupts this, the file is left
+            // either empty or shorter than a header, both of which this branch treats
+            // as new and rewrites on the next open. Extending to header size first and
+            // then writing the magic would instead leave a header-sized, all-zero file
+            // if the process died in between, which the "existing blob" branch below
+            // rejects as corrupt.
             let (header, blob_version) = Header::new(&versions);
-            file.set_len(Header::SIZE_U64)
+            file.set_len(0)
                 .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
             file.seek(SeekFrom::Start(0))
                 .map_err(|_| Error::WriteFailed)?;

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -143,9 +143,17 @@ impl crate::Storage for Storage {
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
         let (blob_version, logical_size) = if Header::missing(len) {
-            // New or corrupted blob - truncate and write header with latest version
+            // New or partially-created blob: reset it and write a fresh header.
+            // Truncate to *empty* before writing the header (rather than extending to
+            // header size first and then writing the magic), so blob creation is
+            // crash-atomic. If an unclean shutdown interrupts this, the file is left
+            // either empty or shorter than a header, both of which this branch treats
+            // as new and rewrites on the next open. Extending to header size first and
+            // then writing the magic would instead leave a header-sized, all-zero file
+            // if the process died in between, which the "existing blob" branch below
+            // rejects as corrupt.
             let (header, blob_version) = Header::new(&versions);
-            file.set_len(Header::SIZE_U64)
+            file.set_len(0)
                 .await
                 .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
             file.write_all(&header.encode())
@@ -431,6 +439,53 @@ mod tests {
         assert!(
             matches!(result, Err(crate::Error::BlobCorrupt(_, _, reason)) if reason.contains("invalid magic"))
         );
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// A create interrupted by an unclean shutdown must never leave a blob that a
+    /// later open rejects as corrupt. Because the header is written in a single write
+    /// (no prior file extension), any interrupted create leaves the file shorter than
+    /// a header, which reopen treats as new and rewrites. Every such prefix length
+    /// must therefore recover to a valid, empty blob rather than a header-sized,
+    /// all-zero file (which `test_blob_magic_mismatch` shows would be fatal).
+    #[tokio::test]
+    async fn test_interrupted_create_is_recoverable() {
+        let storage_directory =
+            env::temp_dir().join(format!("test_interrupted_create_{}", rand::random::<u64>()));
+        let storage = Storage::new(
+            Config {
+                storage_directory: storage_directory.clone(),
+                maximum_buffer_size: 1024 * 1024,
+            },
+            test_pool(),
+        );
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+
+        for prefix_len in 0..Header::SIZE {
+            let name = format!("torn_{prefix_len}");
+            let path = partition_path.join(hex(name.as_bytes()));
+            // Simulate a create interrupted after `prefix_len` of the header's bytes
+            // reached disk (a create can never leave more than a partial header).
+            std::fs::write(&path, vec![0u8; prefix_len]).unwrap();
+
+            let (blob, size) = storage
+                .open("partition", name.as_bytes())
+                .await
+                .expect("interrupted create should recover, not fail");
+            assert_eq!(size, 0, "recovered blob should be empty");
+            drop(blob);
+
+            // The recovered blob is a valid header-only file and reopens cleanly.
+            let raw = std::fs::read(&path).unwrap();
+            assert_eq!(raw.len(), Header::SIZE, "recovered blob should be header-only");
+            assert_eq!(&raw[..Header::MAGIC_LENGTH], &Header::MAGIC);
+            storage
+                .open("partition", name.as_bytes())
+                .await
+                .expect("reopen after recovery should succeed");
+        }
 
         let _ = std::fs::remove_dir_all(&storage_directory);
     }

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -143,15 +143,10 @@ impl crate::Storage for Storage {
         // Handle header: new/corrupted blobs get a fresh header written,
         // existing blobs have their header read.
         let (blob_version, logical_size) = if Header::missing(len) {
-            // New or partially-created blob: reset it and write a fresh header.
-            // Truncate to *empty* before writing the header (rather than extending to
-            // header size first and then writing the magic), so blob creation is
-            // crash-atomic. If an unclean shutdown interrupts this, the file is left
-            // either empty or shorter than a header, both of which this branch treats
-            // as new and rewrites on the next open. Extending to header size first and
-            // then writing the magic would instead leave a header-sized, all-zero file
-            // if the process died in between, which the "existing blob" branch below
-            // rejects as corrupt.
+            // New or partially-created blob: reset it and write a fresh header. The
+            // file grows only as header bytes are written, so a create interrupted by
+            // a process crash leaves some prefix of the header, which the next open
+            // resets here instead of rejecting as corrupt below.
             let (header, blob_version) = Header::new(&versions);
             file.set_len(0)
                 .await
@@ -443,16 +438,12 @@ mod tests {
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
-    /// A create interrupted by an unclean shutdown must never leave a blob that a
-    /// later open rejects as corrupt. Because the header is written in a single write
-    /// (no prior file extension), any interrupted create leaves the file shorter than
-    /// a header, which reopen treats as new and rewrites. Every such prefix length
-    /// must therefore recover to a valid, empty blob rather than a header-sized,
-    /// all-zero file (which `test_blob_magic_mismatch` shows would be fatal).
+    /// Any file shorter than a header must reset to a valid, empty blob on open
+    /// rather than fail as corrupt.
     #[tokio::test]
-    async fn test_interrupted_create_is_recoverable() {
+    async fn test_blob_partial_header_reset() {
         let storage_directory =
-            env::temp_dir().join(format!("test_interrupted_create_{}", rand::random::<u64>()));
+            env::temp_dir().join(format!("test_partial_header_reset_{}", random_suffix()));
         let storage = Storage::new(
             Config {
                 storage_directory: storage_directory.clone(),
@@ -464,10 +455,9 @@ mod tests {
         std::fs::create_dir_all(&partition_path).unwrap();
 
         for prefix_len in 0..Header::SIZE {
-            let name = format!("torn_{prefix_len}");
+            let name = format!("short_{prefix_len}");
             let path = partition_path.join(hex(name.as_bytes()));
-            // Simulate a create interrupted after `prefix_len` of the header's bytes
-            // reached disk (a create can never leave more than a partial header).
+            // Seed a file shorter than a full header.
             std::fs::write(&path, vec![0u8; prefix_len]).unwrap();
 
             let (blob, size) = storage
@@ -479,7 +469,11 @@ mod tests {
 
             // The recovered blob is a valid header-only file and reopens cleanly.
             let raw = std::fs::read(&path).unwrap();
-            assert_eq!(raw.len(), Header::SIZE, "recovered blob should be header-only");
+            assert_eq!(
+                raw.len(),
+                Header::SIZE,
+                "recovered blob should be header-only"
+            );
             assert_eq!(&raw[..Header::MAGIC_LENGTH], &Header::MAGIC);
             storage
                 .open("partition", name.as_bytes())


### PR DESCRIPTION
Hey @patrick-ogrady I have one more 😅 

I have implemented a [fuzzer](https://github.com/matter-labs/zksync-os-server/tree/popzxc-simplex-consensus/tools/chaos) for my consensus integration, and it, among other things, repeatedly kills and restarts active validators.

During the latest run it detected a panic with `BlobCorrupt("consensus-engine-epoch-95", "invalid magic: expected [C,W,I,C], found [0,0,0,0]")`. If relevant, the fuzzer was running a 16-hour run with short epochs & dense kills -- e.g. a lot of epochs and a lot of `sigkill`s.

Investigation shown that the likely bug is that the node was killed after a new blob header was resized but before anything was written there -- and after restart it has read zeroed header and returned an error.
This fix makes truncation change the size to 0, so the above problem shouldn't be possible.

[AI usage disclosure: the investigation/fix were done with help of LLMs, but I manually verified the process at all the stages]