### PR TITLE
[storage] Fix `Oversized` recovery

### DIFF
--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -19,6 +19,13 @@ pub use write::Write;
 struct Completion(Shared<BoxFuture<'static, Result<(), crate::Error>>>);
 
 impl Completion {
+    /// Share the result of `sync`.
+    fn new(
+        sync: impl std::future::Future<Output = Result<(), crate::Error>> + Send + 'static,
+    ) -> Self {
+        Self(sync.boxed().shared())
+    }
+
     /// Return a handle for the sync result.
     fn handle(&self) -> crate::Handle<()> {
         crate::Handle::from_future(self.0.clone())
@@ -30,20 +37,16 @@ impl Completion {
     }
 }
 
-impl From<crate::Handle<()>> for Completion {
-    fn from(handle: crate::Handle<()>) -> Self {
-        Self(handle.boxed().shared())
-    }
-}
-
 /// Tracks whether blob mutations still need a sync.
 ///
 /// Callers rely on three properties:
-/// - Every operation that mutates the blob first waits for an in-flight sync, so a started
+/// - Every operation that mutates the blob first waits for a pending sync, so a started
 ///   sync's coverage is never disturbed by later writes.
-/// - [SyncState::start_sync] on a [SyncState::Pending] state returns the in-flight sync's
-///   handle (completed syncs resolve immediately), so re-requesting a sync is a cheap way to
-///   observe outstanding work.
+/// - [SyncState::start_sync] and [SyncState::start_sync_after] on a [SyncState::Pending]
+///   state return the pending sync's handle (completed syncs resolve immediately), so
+///   re-requesting a sync is a cheap way to observe outstanding work. A reused sync keeps
+///   its original semantics: one started by [SyncState::start_sync_after] progresses only
+///   while observed, even through a handle obtained from [SyncState::start_sync].
 /// - A failure is never lost: every handle cloned from the shared completion reports it, and
 ///   an unobserved failure surfaces from [SyncState::wait_for_pending] on the next operation,
 ///   which also marks the state [SyncState::Dirty] since the mutations still need durability.
@@ -52,7 +55,7 @@ enum SyncState {
     Clean,
     // Unsynced mutations need a sync.
     Dirty,
-    // A started sync is in flight.
+    // A started (possibly gated) sync covers all mutations.
     Pending(Completion),
 }
 
@@ -149,7 +152,40 @@ impl SyncState {
             Self::Clean => crate::Handle::ready(Ok(())),
             Self::Dirty => {
                 // Store a shared completion so repeated calls observe the same sync.
-                let pending = Completion::from(blob.start_sync().await);
+                let pending = Completion::new(blob.start_sync().await);
+                let handle = pending.handle();
+                *self = Self::Pending(pending);
+                handle
+            }
+            Self::Pending(pending) => pending.handle(),
+        }
+    }
+
+    /// Start making pending mutations durable once `gate` resolves successfully, returning a
+    /// handle for completion.
+    ///
+    /// Unlike [SyncState::start_sync], the sync is not in flight when this returns: it is
+    /// issued only after `gate` resolves `Ok` (a gate failure fails the sync without issuing
+    /// it), and it progresses only while the returned handle is polled or when the next
+    /// operation drives it via [SyncState::wait_for_pending]. `gate` must therefore complete
+    /// independently of this state, or the next operation deadlocks waiting for it.
+    ///
+    /// The returned handle covers only this state's mutations: a [SyncState::Clean] state has
+    /// nothing to gate and a [SyncState::Pending] state reuses the in-flight sync, so callers
+    /// composing with `gate` must observe it separately.
+    fn start_sync_after(
+        &mut self,
+        blob: &impl crate::Blob,
+        gate: impl std::future::Future<Output = Result<(), crate::Error>> + Send + 'static,
+    ) -> crate::Handle<()> {
+        match self {
+            Self::Clean => crate::Handle::ready(Ok(())),
+            Self::Dirty => {
+                let blob = blob.clone();
+                let pending = Completion::new(async move {
+                    gate.await?;
+                    blob.sync().await
+                });
                 let handle = pending.handle();
                 *self = Self::Pending(pending);
                 handle

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -161,18 +161,14 @@ impl SyncState {
         }
     }
 
-    /// Start making pending mutations durable once `gate` resolves successfully, returning a
-    /// handle for completion.
+    /// Start making pending mutations durable once `gate` resolves `Ok`, returning a handle
+    /// for completion.
     ///
-    /// Unlike [SyncState::start_sync], the sync is not in flight when this returns: it is
-    /// issued only after `gate` resolves `Ok` (a gate failure fails the sync without issuing
-    /// it), and it progresses only while the returned handle is polled or when the next
-    /// operation drives it via [SyncState::wait_for_pending]. `gate` must therefore complete
-    /// independently of this state, or the next operation deadlocks waiting for it.
-    ///
-    /// The returned handle covers only this state's mutations: a [SyncState::Clean] state has
-    /// nothing to gate and a [SyncState::Pending] state reuses the in-flight sync, so callers
-    /// composing with `gate` must observe it separately.
+    /// The sync is issued only after `gate` resolves (a failure fails it without issuing) and
+    /// progresses only while the handle is polled or the next operation waits for it, so
+    /// `gate` must complete independently of this state. [SyncState::Clean] and
+    /// [SyncState::Pending] states never observe `gate`; composing callers must await it
+    /// separately.
     fn start_sync_after(
         &mut self,
         blob: &impl crate::Blob,

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -965,6 +965,24 @@ impl<B: Blob> Writer<B> {
         self.sync_state.start_sync(&self.blob).await
     }
 
+    /// Flushes buffered data and begins making all pending mutations durable once `gate`
+    /// resolves successfully, returning a completion handle.
+    ///
+    /// Unlike [`Self::start_sync`], the sync is issued only after `gate` resolves `Ok` (a
+    /// gate failure fails it without issuing) and progresses only while the returned
+    /// [`Handle`] is polled or a later writer method waits for it, so `gate` must complete
+    /// independently of this writer. An already-pending sync is reused as-is, without the
+    /// gate.
+    pub async fn start_sync_after(
+        &mut self,
+        gate: impl std::future::Future<Output = Result<(), Error>> + Send + 'static,
+    ) -> Handle<()> {
+        if let Err(err) = self.flush_internal(true, false).await {
+            return Handle::ready(Err(err));
+        }
+        self.sync_state.start_sync_after(&self.blob, gate)
+    }
+
     /// Wait for any started sync to complete without starting a new sync.
     pub async fn wait_for_sync(&mut self) -> Result<(), Error> {
         self.sync_state.wait_for_pending().await

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -966,13 +966,12 @@ impl<B: Blob> Writer<B> {
     }
 
     /// Flushes buffered data and begins making all pending mutations durable once `gate`
-    /// resolves successfully, returning a completion handle.
+    /// resolves `Ok`, returning a completion handle.
     ///
-    /// Unlike [`Self::start_sync`], the sync is issued only after `gate` resolves `Ok` (a
-    /// gate failure fails it without issuing) and progresses only while the returned
-    /// [`Handle`] is polled or a later writer method waits for it, so `gate` must complete
-    /// independently of this writer. An already-pending sync is reused as-is, without the
-    /// gate.
+    /// The sync is issued only after `gate` resolves (a failure fails it without issuing)
+    /// and progresses only while the returned [`Handle`] is polled or a later writer method
+    /// waits for it, so `gate` must complete independently of this writer. An
+    /// already-pending sync is reused as-is, without the gate.
     pub async fn start_sync_after(
         &mut self,
         gate: impl std::future::Future<Output = Result<(), Error>> + Send + 'static,

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -248,13 +248,12 @@ impl<B: Blob> Write<B> {
     }
 
     /// Flush buffered bytes and begin durably syncing mutations tracked by this writer once
-    /// `gate` resolves successfully.
+    /// `gate` resolves `Ok`.
     ///
-    /// Unlike [`Self::start_sync`], the sync is issued only after `gate` resolves `Ok` (a
-    /// gate failure fails it without issuing) and progresses only while the returned
-    /// [`Handle`] is polled or a later writer method waits for it, so `gate` must complete
-    /// independently of this writer. An already-pending sync is reused as-is, without the
-    /// gate.
+    /// The sync is issued only after `gate` resolves (a failure fails it without issuing)
+    /// and progresses only while the returned [`Handle`] is polled or a later writer method
+    /// waits for it, so `gate` must complete independently of this writer. An
+    /// already-pending sync is reused as-is, without the gate.
     pub async fn start_sync_after(
         &mut self,
         gate: impl Future<Output = Result<(), Error>> + Send + 'static,

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -2,7 +2,7 @@ use crate::{
     buffer::{tip::Buffer, SyncState},
     Blob, Buf, BufferPool, BufferPooler, Error, Handle, IoBufs,
 };
-use std::num::NonZeroUsize;
+use std::{future::Future, num::NonZeroUsize};
 
 /// A writer that buffers the raw content of a [Blob] to optimize the performance of appending or
 /// updating data.
@@ -245,6 +245,27 @@ impl<B: Blob> Write<B> {
         }
 
         self.sync_state.start_sync(&self.blob).await
+    }
+
+    /// Flush buffered bytes and begin durably syncing mutations tracked by this writer once
+    /// `gate` resolves successfully.
+    ///
+    /// Unlike [`Self::start_sync`], the sync is issued only after `gate` resolves `Ok` (a
+    /// gate failure fails it without issuing) and progresses only while the returned
+    /// [`Handle`] is polled or a later writer method waits for it, so `gate` must complete
+    /// independently of this writer. An already-pending sync is reused as-is, without the
+    /// gate.
+    pub async fn start_sync_after(
+        &mut self,
+        gate: impl Future<Output = Result<(), Error>> + Send + 'static,
+    ) -> Handle<()> {
+        if let Some((buf, offset)) = self.buffer.take() {
+            if let Err(err) = self.sync_state.write_at(&self.blob, offset, buf).await {
+                return Handle::ready(Err(err));
+            }
+        }
+
+        self.sync_state.start_sync_after(&self.blob, gate)
     }
 
     /// Wait for any started sync to complete without starting a new sync.

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -144,9 +144,9 @@ pub trait Archive: Send {
     ///
     /// The returned handle completes once every write accepted before this call is durable,
     /// including writes covered by a sync that is still in flight, and may need to be polled
-    /// to drive the sync: a dropped handle leaves completion to a later operation on the
-    /// [Archive]. Implementations without a non-blocking sync path may complete the sync
-    /// before returning an already-finished handle.
+    /// to drive the sync: a dropped handle defers completion until a later operation reaches
+    /// the underlying storage. Implementations without a non-blocking sync path may complete
+    /// the sync before returning an already-finished handle.
     fn start_sync(&mut self) -> impl Future<Output = Result<Handle<()>, Error>> + Send {
         async move {
             self.sync().await?;

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -143,8 +143,10 @@ pub trait Archive: Send {
     /// Request that all pending writes are synced.
     ///
     /// The returned handle completes once every write accepted before this call is durable,
-    /// including writes covered by a sync that is still in flight. Implementations without a
-    /// non-blocking sync path may complete the sync before returning an already-finished handle.
+    /// including writes covered by a sync that is still in flight, and may need to be polled
+    /// to drive the sync: a dropped handle leaves completion to a later operation on the
+    /// [Archive]. Implementations without a non-blocking sync path may complete the sync
+    /// before returning an already-finished handle.
     fn start_sync(&mut self) -> impl Future<Output = Result<Handle<()>, Error>> + Send {
         async move {
             self.sync().await?;

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -353,7 +353,7 @@ mod tests {
                 .put_start_sync(1, test_key("aaa"), 10)
                 .await
                 .expect("Failed to start sync");
-            assert_eq!(pending.lock().len(), 2);
+            assert_eq!(pending.lock().len(), 1);
 
             let second = archive
                 .put_start_sync(1, test_key("duplicate"), 99)
@@ -361,7 +361,7 @@ mod tests {
                 .expect("Failed to start duplicate sync");
             assert_eq!(
                 pending.lock().len(),
-                2,
+                1,
                 "duplicate put_start_sync must not issue a new storage sync"
             );
 
@@ -708,7 +708,7 @@ mod tests {
                 .put_start_sync(1, test_key("aaa"), 10)
                 .await
                 .expect("Failed to start first sync");
-            assert_eq!(pending.lock().len(), 2);
+            assert_eq!(pending.lock().len(), 1);
 
             let second = archive
                 .put_start_sync(2, test_key("bbb"), 20)
@@ -716,7 +716,7 @@ mod tests {
                 .expect("Failed to start second sync");
             assert_eq!(
                 pending.lock().len(),
-                4,
+                2,
                 "different sections should be able to have independent in-flight syncs"
             );
 
@@ -759,9 +759,9 @@ mod tests {
                 .put_start_sync(2, test_key("bbb"), 20)
                 .await
                 .expect("Failed to start second sync");
-            assert_eq!(pending.lock().len(), 4);
+            assert_eq!(pending.lock().len(), 2);
 
-            release_next_pending_syncs(&pending, 2);
+            release_next_pending_syncs(&pending, 1);
             first.await.expect("first sync handle should complete");
 
             drop(second);
@@ -798,7 +798,7 @@ mod tests {
                 .put_start_sync(1, test_key("aaa"), 10)
                 .await
                 .expect("Failed to start sync");
-            assert_eq!(pending.lock().len(), 2);
+            assert_eq!(pending.lock().len(), 1);
             fail_pending_syncs(&pending);
 
             archive

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -690,13 +690,11 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
                     "table_size must be a power of 2"
                 );
 
-                // Rewind oversized to the committed section and key size
+                // Rewind oversized to the committed section and key size. The rewind makes
+                // its truncations durable before returning.
                 oversized
                     .rewind(checkpoint.section, checkpoint.oversized_size)
                     .await?;
-
-                // Sync oversized
-                oversized.sync(checkpoint.section).await?;
 
                 // Resize table if needed
                 let expected_table_len = Self::table_offset(checkpoint.table_size);

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -364,6 +364,21 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         self.manager.start_sync(sections).await
     }
 
+    /// Start syncing the given `sections` to storage once `gate` resolves successfully.
+    ///
+    /// The syncs are not in flight when this returns: they are issued only after `gate`
+    /// resolves `Ok` and progress only while the returned handle is polled or a later
+    /// operation on a selected section waits for them, so `gate` must complete independently
+    /// of this journal. The returned handle completes once `gate` and every selected
+    /// section's sync complete, failing with the first error encountered.
+    pub async fn start_sync_after(
+        &mut self,
+        sections: impl crate::Sections,
+        gate: Handle<()>,
+    ) -> Result<Handle<()>, Error> {
+        self.manager.start_sync_after(sections, gate).await
+    }
+
     /// Sync all sections to storage.
     pub async fn sync_all(&mut self) -> Result<(), Error> {
         self.manager.sync_all().await

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -364,13 +364,12 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         self.manager.start_sync(sections).await
     }
 
-    /// Start syncing the given `sections` to storage once `gate` resolves successfully.
+    /// Start syncing the given `sections` to storage once `gate` resolves `Ok`.
     ///
-    /// The syncs are not in flight when this returns: they are issued only after `gate`
-    /// resolves `Ok` and progress only while the returned handle is polled or a later
-    /// operation on a selected section waits for them, so `gate` must complete independently
-    /// of this journal. The returned handle completes once `gate` and every selected
-    /// section's sync complete, failing with the first error encountered.
+    /// The syncs are issued only after `gate` resolves and progress only while the returned
+    /// handle is polled or a later operation on a selected section waits for them, so `gate`
+    /// must complete independently of this journal. The handle completes once `gate` and
+    /// every selected section's sync complete, failing with the first error encountered.
     pub async fn start_sync_after(
         &mut self,
         sections: impl crate::Sections,

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -13,7 +13,7 @@ use commonware_runtime::{
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
     Blob, BufferPool, Error as RError, Handle, Metrics, Storage,
 };
-use futures::future::{join_all, try_join_all};
+use futures::future::{join_all, try_join_all, FutureExt as _};
 use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
@@ -37,6 +37,23 @@ pub trait SectionBuffer: Send + Sync {
     /// underlying blob and may reuse an in-flight handle when no newer writes need syncing.
     fn start_sync(&mut self) -> impl Future<Output = Handle<()>> + Send;
 
+    /// Start making data currently accepted by this buffer durable once `gate` resolves
+    /// successfully.
+    ///
+    /// Buffered writes are flushed immediately, but unlike [SectionBuffer::start_sync] the
+    /// underlying sync is not in flight when this returns: it is issued only after `gate`
+    /// resolves `Ok` (a gate failure fails it without issuing), and it progresses only while
+    /// the returned handle is polled or a later operation waits for it. `gate` must therefore
+    /// complete independently of this buffer, or the next operation deadlocks waiting for it.
+    ///
+    /// The gate orders only a sync started by this call: an already-pending sync (gated or
+    /// not) is reused as-is, and a buffer with nothing to sync resolves immediately, so
+    /// callers composing with `gate` must observe it separately.
+    fn start_sync_after(
+        &mut self,
+        gate: impl Future<Output = Result<(), RError>> + Send + 'static,
+    ) -> impl Future<Output = Handle<()>> + Send;
+
     /// Wait for any started sync to complete without starting a new sync.
     fn wait_for_sync(&mut self) -> impl Future<Output = Result<(), RError>> + Send;
 
@@ -55,6 +72,13 @@ impl<B: Blob> SectionBuffer for Writer<B> {
 
     async fn start_sync(&mut self) -> Handle<()> {
         Self::start_sync(self).await
+    }
+
+    async fn start_sync_after(
+        &mut self,
+        gate: impl Future<Output = Result<(), RError>> + Send + 'static,
+    ) -> Handle<()> {
+        Self::start_sync_after(self, gate).await
     }
 
     async fn wait_for_sync(&mut self) -> Result<(), RError> {
@@ -77,6 +101,13 @@ impl<B: Blob> SectionBuffer for Write<B> {
 
     async fn start_sync(&mut self) -> Handle<()> {
         Self::start_sync(self).await
+    }
+
+    async fn start_sync_after(
+        &mut self,
+        gate: impl Future<Output = Result<(), RError>> + Send + 'static,
+    ) -> Handle<()> {
+        Self::start_sync_after(self, gate).await
     }
 
     async fn wait_for_sync(&mut self) -> Result<(), RError> {
@@ -159,7 +190,8 @@ pub struct Config<F> {
 ///
 /// # In-flight syncs
 ///
-/// Syncs started by [Manager::start_sync] complete in the background, so every path that
+/// Syncs started by [Manager::start_sync] complete in the background, and syncs started by
+/// [Manager::start_sync_after] complete when driven, so every path that
 /// removes a blob from `blobs` (`prune`, `remove_section`, `rewind`, `clear`, `destroy`) must
 /// call [SectionBuffer::wait_for_sync] before dropping it. This resolves the sync's shared
 /// completion first, guaranteeing that caller-held sync handles always report the sync's true
@@ -315,6 +347,43 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         self.synced.inc_by(futures.len() as u64);
         let handles = join_all(futures).await;
         Ok(Handle::from_future(async move {
+            try_join_all(handles).await.map(|_| ())
+        }))
+    }
+
+    /// Start syncing the given `sections` to storage once `gate` resolves successfully.
+    ///
+    /// Each selected buffer follows [SectionBuffer::start_sync_after] semantics: nothing is
+    /// in flight when this returns, and the gated syncs progress only while the returned
+    /// handle is polled or a later operation on a selected section waits for them. The
+    /// returned handle completes once `gate` and every selected section's sync complete,
+    /// failing with the first error encountered.
+    pub async fn start_sync_after(
+        &mut self,
+        sections: impl crate::Sections,
+        gate: Handle<()>,
+    ) -> Result<Handle<()>, Error> {
+        let sections = sections.sections().collect::<BTreeSet<_>>();
+        for &section in &sections {
+            self.prune_guard(section)?;
+        }
+        let gate = gate.shared();
+        let futures: Vec<_> = self
+            .blobs
+            .iter_mut()
+            .filter(|(section, _)| sections.contains(section))
+            .map(|(_, blob)| blob.start_sync_after(gate.clone()))
+            .collect();
+
+        // Count every selected section, including reused and clean no-op syncs, matching
+        // `sync` and `sync_all`.
+        self.synced.inc_by(futures.len() as u64);
+        let handles = join_all(futures).await;
+        Ok(Handle::from_future(async move {
+            // The buffer handles do not uniformly embed the gate (clean buffers resolve
+            // immediately and pending syncs are reused as-is), so the composed handle must
+            // await it itself.
+            gate.await?;
             try_join_all(handles).await.map(|_| ())
         }))
     }
@@ -525,10 +594,7 @@ mod tests {
     use super::*;
     use commonware_runtime::{deterministic, Runner as _, Spawner as _, Supervisor as _};
     use commonware_utils::{channel::oneshot, sync::Mutex};
-    use futures::{
-        future::{BoxFuture, Shared},
-        FutureExt as _,
-    };
+    use futures::future::{BoxFuture, Shared};
     use std::sync::{
         atomic::{AtomicUsize, Ordering},
         Arc,
@@ -568,6 +634,29 @@ mod tests {
             let (sender, receiver) = oneshot::channel();
             self.pending.lock().push(sender);
             let sync = async move {
+                receiver.await.map_err(|_| RError::Closed)??;
+                Ok(())
+            }
+            .boxed()
+            .shared();
+            self.syncing = Some(sync.clone());
+            Handle::from_future(sync)
+        }
+
+        async fn start_sync_after(
+            &mut self,
+            gate: impl Future<Output = Result<(), RError>> + Send + 'static,
+        ) -> Handle<()> {
+            if let Some(syncing) = &self.syncing {
+                return Handle::from_future(syncing.clone());
+            }
+            // Register the pending sync only once the gate resolves, mirroring the runtime
+            // buffers' deferred issuance.
+            let pending = self.pending.clone();
+            let sync = async move {
+                gate.await?;
+                let (sender, receiver) = oneshot::channel();
+                pending.lock().push(sender);
                 receiver.await.map_err(|_| RError::Closed)??;
                 Ok(())
             }
@@ -708,6 +797,83 @@ mod tests {
             first.await.expect("first sync handle should complete");
             second.await.expect("reused sync handle should complete");
             manager.destroy().await.expect("destroy failed");
+        });
+    }
+
+    #[test]
+    fn test_start_sync_after_defers_issuance_until_gate() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = Arc::new(Mutex::new(Vec::new()));
+            let wait_for_syncs = Arc::new(AtomicUsize::new(0));
+            let cfg = test_config(pending.clone(), wait_for_syncs);
+            let mut manager = Manager::init(context.child("manager"), cfg)
+                .await
+                .expect("failed to initialize manager");
+
+            manager
+                .get_or_create(1)
+                .await
+                .expect("failed to create section");
+            let (gate_release, gate) = oneshot::channel::<Result<(), RError>>();
+            let gate = Handle::from_receiver(gate);
+            let handle = manager
+                .start_sync_after(1, gate)
+                .await
+                .expect("failed to start gated sync");
+            futures::pin_mut!(handle);
+
+            // Driving the handle before the gate resolves must not issue the sync.
+            assert!(futures::poll!(handle.as_mut()).is_pending());
+            assert!(
+                pending.lock().is_empty(),
+                "sync must not be issued before the gate resolves"
+            );
+
+            // Once the gate resolves, driving the handle issues the sync.
+            gate_release.send(Ok(())).expect("gate receiver dropped");
+            assert!(futures::poll!(handle.as_mut()).is_pending());
+            assert_eq!(
+                pending.lock().len(),
+                1,
+                "sync must be issued once the gate resolves"
+            );
+
+            release_pending_syncs(&pending);
+            handle.await.expect("gated sync handle should complete");
+            manager.destroy().await.expect("destroy failed");
+        });
+    }
+
+    #[test]
+    fn test_start_sync_after_gate_failure_never_issues_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = Arc::new(Mutex::new(Vec::new()));
+            let wait_for_syncs = Arc::new(AtomicUsize::new(0));
+            let cfg = test_config(pending.clone(), wait_for_syncs);
+            let mut manager = Manager::init(context.child("manager"), cfg)
+                .await
+                .expect("failed to initialize manager");
+
+            manager
+                .get_or_create(1)
+                .await
+                .expect("failed to create section");
+            let gate = Handle::ready(Err(RError::Closed));
+            let handle = manager
+                .start_sync_after(1, gate)
+                .await
+                .expect("failed to start gated sync");
+
+            assert!(handle.await.is_err(), "gate failure must fail the handle");
+            assert!(
+                pending.lock().is_empty(),
+                "sync must never be issued after a gate failure"
+            );
+
+            // The failure resurfaces from the buffer on the next operation.
+            assert!(manager.destroy().await.is_err());
         });
     }
 

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -38,17 +38,13 @@ pub trait SectionBuffer: Send + Sync {
     fn start_sync(&mut self) -> impl Future<Output = Handle<()>> + Send;
 
     /// Start making data currently accepted by this buffer durable once `gate` resolves
-    /// successfully.
+    /// `Ok`.
     ///
-    /// Buffered writes are flushed immediately, but unlike [SectionBuffer::start_sync] the
-    /// underlying sync is not in flight when this returns: it is issued only after `gate`
-    /// resolves `Ok` (a gate failure fails it without issuing), and it progresses only while
-    /// the returned handle is polled or a later operation waits for it. `gate` must therefore
-    /// complete independently of this buffer, or the next operation deadlocks waiting for it.
-    ///
-    /// The gate orders only a sync started by this call: an already-pending sync (gated or
-    /// not) is reused as-is, and a buffer with nothing to sync resolves immediately, so
-    /// callers composing with `gate` must observe it separately.
+    /// Writes are flushed immediately, but the sync is issued only after `gate` resolves (a
+    /// failure fails it without issuing) and progresses only while the returned handle is
+    /// polled or a later operation waits for it, so `gate` must complete independently of
+    /// this buffer. An already-pending sync is reused and a clean buffer resolves
+    /// immediately, neither observing `gate`; composing callers must await it separately.
     fn start_sync_after(
         &mut self,
         gate: impl Future<Output = Result<(), RError>> + Send + 'static,
@@ -351,11 +347,9 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         }))
     }
 
-    /// Start syncing the given `sections` to storage once `gate` resolves successfully.
+    /// Start syncing the given `sections` to storage once `gate` resolves `Ok`.
     ///
-    /// Each selected buffer follows [SectionBuffer::start_sync_after] semantics: nothing is
-    /// in flight when this returns, and the gated syncs progress only while the returned
-    /// handle is polled or a later operation on a selected section waits for them. The
+    /// Each selected buffer follows [SectionBuffer::start_sync_after] semantics. The
     /// returned handle completes once `gate` and every selected section's sync complete,
     /// failing with the first error encountered.
     pub async fn start_sync_after(

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -46,6 +46,16 @@
 //! require reading all values). Value checksums are verified lazily when values are
 //! read via `get_value()`. If the underlying storage is corrupted, `get_value()` will
 //! return a checksum error even though the index entry exists._
+//!
+//! # Limitations
+//!
+//! Recovery trusts any entry whose byte range the glob covers. On storage that can persist
+//! an unsynced index entry together with the glob's length but not the value bytes (no
+//! write-ordering guarantees, e.g. writeback-mode metadata journaling), recovery can adopt
+//! an entry whose reads permanently fail their checksum. Such an entry was never
+//! acknowledged as durable, but it occupies its position until externally repaired.
+//! Eliminating this would require recovery to consult a durably recorded publication bound
+//! instead of blob lengths, which this journal does not maintain.
 
 use super::{
     fixed::{Config as FixedConfig, Journal as FixedJournal},
@@ -375,7 +385,8 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
     /// Start syncing both journals for the given `sections`.
     ///
     /// The returned handle completes once both journals are durable and drives the sync
-    /// while polled; a dropped handle leaves completion to the journal's next operation.
+    /// while polled; a dropped handle defers completion until a later operation reaches the
+    /// underlying blobs (appends absorbed by the write buffers do not).
     pub async fn start_sync(
         &mut self,
         sections: impl crate::Sections,
@@ -955,7 +966,9 @@ mod tests {
             );
         });
 
-        // Neither truncation became durable, so recovery surfaces the pre-rewind state.
+        // Neither truncation was synced, so the deterministic crash model recovers the
+        // exact pre-rewind state. A real backend may incidentally persist the truncations
+        // and recover the post-rewind state instead; both are consistent.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("third"), test_cfg(&context))

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -32,7 +32,10 @@
 //! 3. Orphan value sections (sections in glob but not in index) are removed
 //!
 //! This allows async writes (glob first, then index) while ensuring consistency
-//! after recovery.
+//! after recovery. Durability follows the same discipline: sync makes values durable
+//! before the index (and prune deletes the index before the glob), so a durable index
+//! entry always references durable value bytes and the range check above is sufficient
+//! for crash consistency.
 //!
 //! _Recovery only validates that index entries point to valid byte ranges
 //! within the glob. It does **not** verify value checksums during recovery (this would
@@ -339,37 +342,36 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
     }
 
     /// Sync both journals for the given `sections`.
+    ///
+    /// Values are made durable before the index is synced: recovery validates index entries
+    /// against the glob by byte range only, so an index entry that became durable ahead of its
+    /// value bytes would be adopted referencing lost or later-rewritten data.
     pub async fn sync(&mut self, sections: impl crate::Sections) -> Result<(), Error> {
         let sections = sections.sections().collect::<Vec<_>>();
-        try_join(self.index.sync(&sections), self.values.sync(&sections))
-            .await
-            .map(|_| ())
+        self.values.sync(&sections).await?;
+        self.index.sync(&sections).await
     }
 
     /// Start syncing both journals for the given `sections`.
     ///
-    /// The returned handle completes once both journals' syncs complete, failing with the first
-    /// error encountered.
+    /// Values are durable once this returns; the returned handle completes when the index sync
+    /// does. The index sync must not begin until values are durable (see [Self::sync]), so only
+    /// the index portion runs in the background.
     pub async fn start_sync(
         &mut self,
         sections: impl crate::Sections,
     ) -> Result<Handle<()>, Error> {
         let sections = sections.sections().collect::<Vec<_>>();
-        let (index, values) = try_join(
-            self.index.start_sync(&sections),
-            self.values.start_sync(&sections),
-        )
-        .await?;
-        Ok(Handle::from_future(async move {
-            try_join(index, values).await.map(|_| ())
-        }))
+        self.values.sync(&sections).await?;
+        self.index.start_sync(&sections).await
     }
 
     /// Sync all sections.
+    ///
+    /// Values are made durable before the index is synced (see [Self::sync]).
     pub async fn sync_all(&mut self) -> Result<(), Error> {
-        try_join(self.index.sync_all(), self.values.sync_all())
-            .await
-            .map(|_| ())
+        self.values.sync_all().await?;
+        self.index.sync_all().await
     }
 
     /// Prune both journals. Returns true if any sections were pruned.
@@ -479,8 +481,8 @@ mod tests {
     use commonware_cryptography::Crc32;
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        buffer::paged::CacheRef, deterministic, Blob as _, Buf, BufMut, BufferPooler, Runner,
-        Supervisor as _,
+        buffer::paged::CacheRef, deterministic, mocks::SyncFaultContext, Blob as _, Buf, BufMut,
+        BufferPooler, Runner, Supervisor as _,
     };
     use commonware_utils::{NZUsize, NZU16};
 
@@ -747,6 +749,67 @@ mod tests {
                     .await
                     .expect("synced value durable");
                 assert_eq!(retrieved, value);
+            }
+
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_recovery_never_adopts_entries_for_lost_values() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Boot 1: one fully durable entry/value pair.
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+            oversized.sync(1).await.expect("Failed to sync");
+            drop(oversized);
+
+            // Boot 2: rewind, then append entry 2 at entry 1's glob offset. Entry 2's value
+            // sync fails, so the glob durably holds entry 1's bytes at the range entry 2
+            // references: the index must not become durable ahead of the values.
+            let faulty_values = SyncFaultContext {
+                inner: context.child("second"),
+                fail_partition: "test-values".into(),
+            };
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(faulty_values, test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            oversized.rewind(1, 0).await.expect("Failed to rewind");
+            oversized
+                .append(1, TestEntry::new(2, 0, 0), &[2; 16])
+                .await
+                .expect("Failed to append");
+            assert!(oversized.sync(1).await.is_err(), "value sync must fail");
+            drop(oversized);
+
+            // Boot 3: recovery cannot tell entry 2's range holds stale bytes (entry 1's value
+            // has the same size, so the range check passes). Whatever recovery adopts must
+            // read back the value appended with it.
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("third"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
+            for position in 0..oversized.size(1).expect("size") / chunk {
+                let entry = oversized.get(1, position).await.expect("Failed to get");
+                let (offset, size) = entry.value_location();
+                let value = oversized
+                    .get_value(1, offset, size)
+                    .await
+                    .expect("adopted entry must reference durable bytes");
+                assert_eq!(
+                    value, [entry.id as u8; 16],
+                    "entry {} must read back the value appended with it",
+                    entry.id
+                );
             }
 
             oversized.destroy().await.expect("Failed to destroy");

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -33,9 +33,13 @@
 //!
 //! This allows async writes (glob first, then index) while ensuring consistency
 //! after recovery. Durability follows the same discipline: sync makes values durable
-//! before the index (and prune deletes the index before the glob), so a durable index
-//! entry always references durable value bytes and the range check above is sufficient
-//! for crash consistency.
+//! before the index is synced (and prune deletes the index before the glob), so a durable
+//! index entry always references durable value bytes. Because value offsets are
+//! monotonically increasing within a section, the range check above is then sufficient
+//! for crash consistency, except across a rewind, which frees value ranges for reuse.
+//! Rewinds (including the truncations recovery itself performs) therefore make both
+//! truncations durable before returning, so neither a dropped index entry nor the stale
+//! bytes it referenced can survive a crash once later appends may reuse those offsets.
 //!
 //! _Recovery only validates that index entries point to valid byte ranges
 //! within the glob. It does **not** verify value checksums during recovery (this would
@@ -144,6 +148,8 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
         let chunk_size = FixedJournal::<E, I>::CHUNK_SIZE as u64;
         let sections: Vec<u64> = self.index.sections().collect();
 
+        let mut rewound_index = Vec::new();
+        let mut rewound_values = Vec::new();
         for section in sections {
             let index_size = self.index.size(section)?;
             if index_size == 0 {
@@ -175,6 +181,7 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
                     index_size, aligned_size, "trailing bytes detected: truncating"
                 );
                 self.index.rewind_section(section, aligned_size).await?;
+                rewound_index.push(section);
             }
 
             // If there is nothing, we can exit early and rewind values to 0
@@ -184,6 +191,9 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
                     index_size, "trailing bytes detected: truncating to 0"
                 );
                 self.values.rewind_section(section, 0).await?;
+                if glob_size > 0 {
+                    rewound_values.push(section);
+                }
                 continue;
             }
 
@@ -197,6 +207,7 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
                 let valid_size = valid_count * chunk_size;
                 debug!(section, entry_count, valid_count, "rewinding index");
                 self.index.rewind_section(section, valid_size).await?;
+                rewound_index.push(section);
             }
 
             // Truncate glob trailing garbage (can occur when value was written but
@@ -207,8 +218,17 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
                     glob_size, glob_target, "truncating glob trailing garbage"
                 );
                 self.values.rewind_section(section, glob_target).await?;
+                rewound_values.push(section);
             }
         }
+
+        // Make the truncations durable before appends can reuse the freed value ranges. A
+        // dropped index entry that stayed durable would be adopted by a later recovery
+        // referencing whatever bytes a subsequent append placed at its offsets; stale glob
+        // bytes that stayed durable would satisfy a later entry's range with another
+        // record's frame.
+        self.values.sync(&rewound_values).await?;
+        self.index.sync(&rewound_index).await?;
 
         // Clean up orphan value sections that don't exist in index
         self.cleanup_orphan_value_sections().await?;
@@ -354,16 +374,19 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
 
     /// Start syncing both journals for the given `sections`.
     ///
-    /// Values are durable once this returns; the returned handle completes when the index sync
-    /// does. The index sync must not begin until values are durable (see [Self::sync]), so only
-    /// the index portion runs in the background.
+    /// The returned handle completes once the values and then the index are durable: the index
+    /// sync is issued only after the values sync completes (see [Self::sync]), and a values
+    /// failure fails the handle without issuing it. Neither sync is awaited before returning.
+    /// The gated index sync progresses while the returned handle is polled or when a later
+    /// operation on the journal waits for it; a dropped, unobserved handle leaves the index
+    /// sync unissued until then.
     pub async fn start_sync(
         &mut self,
         sections: impl crate::Sections,
     ) -> Result<Handle<()>, Error> {
         let sections = sections.sections().collect::<Vec<_>>();
-        self.values.sync(&sections).await?;
-        self.index.start_sync(&sections).await
+        let values = self.values.start_sync(&sections).await?;
+        self.index.start_sync_after(&sections, values).await
     }
 
     /// Sync all sections.
@@ -389,6 +412,13 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
     ///
     /// This rewinds the section to the given index size and removes all sections
     /// after the given section. The value size is derived from the last entry.
+    ///
+    /// Both of `section`'s truncations are made durable before returning: freed value ranges
+    /// may be reused by later appends, so neither a dropped index entry nor the stale glob
+    /// bytes it pointed at may survive a crash once new data can occupy those offsets. The
+    /// values are synced before the index (see [Self::sync]), so a crash recovers to either
+    /// the pre-rewind or the post-rewind state. The removals of later sections carry the
+    /// storage layer's removal durability.
     pub async fn rewind(&mut self, section: u64, index_size: u64) -> Result<(), Error> {
         // Rewind index first (this also removes sections after `section`)
         self.index.rewind(section, index_size).await?;
@@ -407,13 +437,20 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
         };
 
         // Rewind values (this also removes sections after `section`)
-        self.values.rewind(section, value_size).await
+        self.values.rewind(section, value_size).await?;
+
+        // Make both truncations durable, values first: retained entries may reference
+        // still-buffered values, which must not become adoptable after them.
+        self.values.sync(section).await?;
+        self.index.sync(section).await
     }
 
     /// Rewind only the given section to a specific index size.
     ///
     /// Unlike `rewind`, this does not affect other sections.
     /// The value size is derived from the last entry after rewinding the index.
+    ///
+    /// Both truncations are made durable before returning (see [Self::rewind]).
     pub async fn rewind_section(&mut self, section: u64, index_size: u64) -> Result<(), Error> {
         // Rewind index first
         self.index.rewind_section(section, index_size).await?;
@@ -432,7 +469,11 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
         };
 
         // Rewind values
-        self.values.rewind_section(section, value_size).await
+        self.values.rewind_section(section, value_size).await?;
+
+        // Make both truncations durable, values first (see Self::rewind).
+        self.values.sync(section).await?;
+        self.index.sync(section).await
     }
 
     /// Get index size for checkpoint.
@@ -755,11 +796,132 @@ mod tests {
         });
     }
 
+    /// Assert that every entry recovery adopted in section 1 reads back the value that was
+    /// appended with it.
+    async fn assert_adopted_entries_consistent(
+        oversized: &Oversized<deterministic::Context, TestEntry, TestValue>,
+    ) {
+        let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
+        for position in 0..oversized.size(1).expect("size") / chunk {
+            let entry = oversized.get(1, position).await.expect("Failed to get");
+            let (offset, size) = entry.value_location();
+            let value = oversized
+                .get_value(1, offset, size)
+                .await
+                .expect("adopted entry must reference durable bytes");
+            assert_eq!(
+                value, [entry.id as u8; 16],
+                "entry {} must read back the value appended with it",
+                entry.id
+            );
+        }
+    }
+
+    #[test_traced]
+    fn test_oversized_rewind_truncation_durable_before_offset_reuse() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            // One fully durable entry/value pair.
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+            oversized.sync(1).await.expect("Failed to sync");
+
+            // Rewind entry 1 away and append entry 2 at entry 1's glob offset, then crash
+            // between the value sync and the index sync: entry 2's bytes (same size, valid
+            // checksum) become durable at the exact range entry 1 referenced. Only the
+            // durable truncation in `rewind` prevents recovery from resurrecting entry 1
+            // pointing at entry 2's value; the range check cannot reject it.
+            oversized.rewind(1, 0).await.expect("Failed to rewind");
+            oversized
+                .append(1, TestEntry::new(2, 0, 0), &[2; 16])
+                .await
+                .expect("Failed to append");
+            oversized
+                .values
+                .sync(1)
+                .await
+                .expect("Failed to sync values");
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            assert_eq!(
+                oversized.size(1).expect("size"),
+                0,
+                "rewound entry must not be revived over reused value bytes"
+            );
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
     #[test_traced]
     fn test_oversized_recovery_never_adopts_entries_for_lost_values() {
+        // Crash 1: entry 1 becomes durable but its value does not (an index write surviving
+        // a crash its value bytes did not).
         let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // Boot 1: one fully durable entry/value pair.
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+            oversized.index.sync(1).await.expect("Failed to sync index");
+        });
+
+        // Boot 2: recovery rewinds entry 1 (its range is out of bounds) and must make that
+        // truncation durable. A new append then reuses entry 1's offset; crash 2 lands after
+        // the value sync and before the index sync.
+        let (_, checkpoint) =
+            deterministic::Runner::from(checkpoint).start_and_recover(|context| async move {
+                let mut oversized: Oversized<_, TestEntry, TestValue> =
+                    Oversized::init(context.child("second"), test_cfg(&context))
+                        .await
+                        .expect("Failed to reinit");
+                assert_eq!(
+                    oversized.size(1).expect("size"),
+                    0,
+                    "entry without durable value bytes must be rewound"
+                );
+                oversized
+                    .append(1, TestEntry::new(2, 0, 0), &[2; 16])
+                    .await
+                    .expect("Failed to append");
+                oversized
+                    .values
+                    .sync(1)
+                    .await
+                    .expect("Failed to sync values");
+            });
+
+        // Boot 3: without a durable truncation in recovery, the index would still hold
+        // entry 1, now range-valid over entry 2's bytes.
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("third"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            assert_adopted_entries_consistent(&oversized).await;
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_rewind_fails_when_truncation_cannot_be_made_durable() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            // One fully durable entry/value pair.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("first"), test_cfg(&context))
                     .await
@@ -771,9 +933,9 @@ mod tests {
             oversized.sync(1).await.expect("Failed to sync");
             drop(oversized);
 
-            // Boot 2: rewind, then append entry 2 at entry 1's glob offset. Entry 2's value
-            // sync fails, so the glob durably holds entry 1's bytes at the range entry 2
-            // references: the index must not become durable ahead of the values.
+            // Boot 2: the glob truncation cannot be made durable, so `rewind` must fail
+            // before the index truncation is issued, rather than let later appends reuse
+            // entry 1's still-durable value range.
             let faulty_values = SyncFaultContext {
                 inner: context.child("second"),
                 fail_partition: "test-values".into(),
@@ -782,36 +944,155 @@ mod tests {
                 Oversized::init(faulty_values, test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
-            oversized.rewind(1, 0).await.expect("Failed to rewind");
-            oversized
-                .append(1, TestEntry::new(2, 0, 0), &[2; 16])
-                .await
-                .expect("Failed to append");
-            assert!(oversized.sync(1).await.is_err(), "value sync must fail");
-            drop(oversized);
+            assert!(
+                oversized.rewind(1, 0).await.is_err(),
+                "rewind must fail when its truncation cannot be made durable"
+            );
+        });
 
-            // Boot 3: recovery cannot tell entry 2's range holds stale bytes (entry 1's value
-            // has the same size, so the range check passes). Whatever recovery adopts must
-            // read back the value appended with it.
+        // Nothing of the failed rewind became durable: recovery surfaces the intact
+        // pre-rewind state.
+        deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("third"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
-            for position in 0..oversized.size(1).expect("size") / chunk {
-                let entry = oversized.get(1, position).await.expect("Failed to get");
-                let (offset, size) = entry.value_location();
-                let value = oversized
-                    .get_value(1, offset, size)
-                    .await
-                    .expect("adopted entry must reference durable bytes");
-                assert_eq!(
-                    value, [entry.id as u8; 16],
-                    "entry {} must read back the value appended with it",
-                    entry.id
-                );
-            }
+            assert_eq!(oversized.size(1).expect("size"), chunk);
+            assert_adopted_entries_consistent(&oversized).await;
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
 
+    #[test_traced]
+    fn test_oversized_start_sync_completion_means_recoverable() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+            let handle = oversized.start_sync(1).await.expect("Failed to start sync");
+            handle.await.expect("sync must complete");
+            // Crash: everything covered by the completed handle must survive.
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
+            assert_eq!(oversized.size(1).expect("size"), chunk);
+            assert_adopted_entries_consistent(&oversized).await;
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_sync_values_failure_never_syncs_index() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let faulty_values = SyncFaultContext {
+                inner: context.child("first"),
+                fail_partition: "test-values".into(),
+            };
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(faulty_values, test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+
+            // The value sync fails, so the index sync must never be issued.
+            assert!(oversized.sync(1).await.is_err(), "value sync must fail");
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            assert_eq!(
+                oversized.size(1).expect("size"),
+                0,
+                "index must not become durable ahead of its values"
+            );
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_start_sync_values_failure_never_syncs_index() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let faulty_values = SyncFaultContext {
+                inner: context.child("first"),
+                fail_partition: "test-values".into(),
+            };
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(faulty_values, test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+
+            // The value sync fails, so the gated index sync must never be issued and the
+            // handle must surface the failure.
+            let handle = oversized.start_sync(1).await.expect("Failed to start sync");
+            assert!(handle.await.is_err(), "value sync must fail");
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            assert_eq!(
+                oversized.size(1).expect("size"),
+                0,
+                "index must not become durable ahead of its values"
+            );
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_start_sync_dropped_handle_driven_by_next_sync() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), test_cfg(&context))
+                    .await
+                    .expect("Failed to init");
+            oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+
+            // Drop the handle without observing it: the gated index sync is not driven, but
+            // the next sync must wait for it and complete the work.
+            let handle = oversized.start_sync(1).await.expect("Failed to start sync");
+            drop(handle);
+            oversized.sync(1).await.expect("Failed to sync");
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), test_cfg(&context))
+                    .await
+                    .expect("Failed to reinit");
+            let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
+            assert_eq!(oversized.size(1).expect("size"), chunk);
+            assert_adopted_entries_consistent(&oversized).await;
             oversized.destroy().await.expect("Failed to destroy");
         });
     }

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -362,37 +362,35 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
     }
 
     /// Sync both journals for the given `sections`.
-    ///
-    /// Values are made durable before the index is synced: recovery validates index entries
-    /// against the glob by byte range only, so an index entry that became durable ahead of its
-    /// value bytes would be adopted referencing lost or later-rewritten data.
     pub async fn sync(&mut self, sections: impl crate::Sections) -> Result<(), Error> {
         let sections = sections.sections().collect::<Vec<_>>();
+
+        // Make values durable before the index: recovery validates index entries against
+        // the glob by byte range only, so an entry that became durable ahead of its value
+        // bytes would be adopted referencing lost or later-rewritten data.
         self.values.sync(&sections).await?;
         self.index.sync(&sections).await
     }
 
     /// Start syncing both journals for the given `sections`.
     ///
-    /// The returned handle completes once the values and then the index are durable: the index
-    /// sync is issued only after the values sync completes (see [Self::sync]), and a values
-    /// failure fails the handle without issuing it. Neither sync is awaited before returning.
-    /// The gated index sync progresses while the returned handle is polled or when a later
-    /// operation on the journal waits for it; a dropped, unobserved handle leaves the index
-    /// sync unissued until then.
+    /// The returned handle completes once both journals are durable and drives the sync
+    /// while polled; a dropped handle leaves completion to the journal's next operation.
     pub async fn start_sync(
         &mut self,
         sections: impl crate::Sections,
     ) -> Result<Handle<()>, Error> {
         let sections = sections.sections().collect::<Vec<_>>();
+
+        // Gate the index sync on the values sync (values go first, see Self::sync): a
+        // values failure fails the handle without the index sync ever being issued.
         let values = self.values.start_sync(&sections).await?;
         self.index.start_sync_after(&sections, values).await
     }
 
     /// Sync all sections.
-    ///
-    /// Values are made durable before the index is synced (see [Self::sync]).
     pub async fn sync_all(&mut self) -> Result<(), Error> {
+        // Values before the index (see Self::sync).
         self.values.sync_all().await?;
         self.index.sync_all().await
     }
@@ -413,11 +411,8 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
     /// This rewinds the section to the given index size and removes all sections
     /// after the given section. The value size is derived from the last entry.
     ///
-    /// Both of `section`'s truncations are made durable before returning: freed value ranges
-    /// may be reused by later appends, so neither a dropped index entry nor the stale glob
-    /// bytes it pointed at may survive a crash once new data can occupy those offsets. The
-    /// values are synced before the index (see [Self::sync]), so a crash recovers to either
-    /// the pre-rewind or the post-rewind state. The removals of later sections carry the
+    /// Both of `section`'s truncations are durable before this returns: a crash recovers to
+    /// either the pre-rewind or the post-rewind state. Removals of later sections carry the
     /// storage layer's removal durability.
     pub async fn rewind(&mut self, section: u64, index_size: u64) -> Result<(), Error> {
         // Rewind index first (this also removes sections after `section`)
@@ -436,13 +431,21 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
             Err(e) => return Err(e),
         };
 
+        // Make retained values durable before their entries: the index sync below flushes
+        // retained entries whose values may still be buffered, and an entry must never be
+        // adoptable ahead of its value bytes.
+        self.values.sync(section).await?;
+
+        // Make the index truncation durable before the values are rewound: rewinding the
+        // values frees their ranges for reuse by later appends, and a dropped index entry
+        // that stayed durable would be adopted referencing whatever bytes a later append
+        // placed at its offsets. Ordering the truncation's durability before the in-memory
+        // values rewind keeps this safe even if this future is cancelled between the two.
+        self.index.sync(section).await?;
+
         // Rewind values (this also removes sections after `section`)
         self.values.rewind(section, value_size).await?;
-
-        // Make both truncations durable, values first: retained entries may reference
-        // still-buffered values, which must not become adoptable after them.
-        self.values.sync(section).await?;
-        self.index.sync(section).await
+        self.values.sync(section).await
     }
 
     /// Rewind only the given section to a specific index size.
@@ -468,12 +471,14 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
             Err(e) => return Err(e),
         };
 
+        // Make retained values, then the index truncation, durable before the values are
+        // rewound (see Self::rewind).
+        self.values.sync(section).await?;
+        self.index.sync(section).await?;
+
         // Rewind values
         self.values.rewind_section(section, value_size).await?;
-
-        // Make both truncations durable, values first (see Self::rewind).
-        self.values.sync(section).await?;
-        self.index.sync(section).await
+        self.values.sync(section).await
     }
 
     /// Get index size for checkpoint.
@@ -933,9 +938,9 @@ mod tests {
             oversized.sync(1).await.expect("Failed to sync");
             drop(oversized);
 
-            // Boot 2: the glob truncation cannot be made durable, so `rewind` must fail
-            // before the index truncation is issued, rather than let later appends reuse
-            // entry 1's still-durable value range.
+            // Boot 2: the glob cannot be synced, so `rewind` must fail before either
+            // truncation is made durable, rather than let later appends reuse entry 1's
+            // still-durable value range.
             let faulty_values = SyncFaultContext {
                 inner: context.child("second"),
                 fail_partition: "test-values".into(),
@@ -950,8 +955,7 @@ mod tests {
             );
         });
 
-        // Nothing of the failed rewind became durable: recovery surfaces the intact
-        // pre-rewind state.
+        // Neither truncation became durable, so recovery surfaces the pre-rewind state.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("third"), test_cfg(&context))


### PR DESCRIPTION
## Problem

`Oversized` recovery validates index entries against the glob by byte range only (`value_offset + value_size <= glob_size`; checksums are verified lazily at read). That check proves some bytes occupy the range, not that they are the bytes written with the entry, so the sync and rewind paths must guarantee an ordering they never enforced. A crash could leave:

- an index entry durable ahead of its value bytes, which recovery adopts referencing lost or torn data (permanent `ChecksumMismatch` on every read), or
- a rewound entry durably present while its freed value range was reused by a later append, which recovery adopts referencing **another record's complete value** — returned silently with a passing checksum.

The second state was also reachable with no explicit rewind at all: recovery's own repairs truncated the journals without making the truncations durable, so a second crash could revive an entry over reused offsets.

Fixes #4260.

## Fix

Two invariants, enforced on every path:

1. **Value bytes become durable before their index entry can.** A surviving entry then either references its own durable bytes or points past the durable glob (recovery rewinds it).
2. **Truncations become durable before the ranges they free can be reused.** A dropped entry can then never survive to alias later bytes, and stale bytes can never survive to satisfy a later entry.

Per operation:

- `sync`/`sync_all`: values fsync, then index fsync, sequentially. A values failure means the index fsync is never issued.
- `start_sync`: the values fsync starts immediately; the index fsync is gated on its completion via a new buffer primitive, `start_sync_after` (flush now, issue the fsync once a gate future resolves `Ok`, registered as the buffer's in-flight sync). The caller path stays nonblocking. The returned handle completes once both journals are durable and drives the gated sync while polled; a dropped handle defers it until a later operation reaches the underlying storage (contract documented on `Archive::start_sync`).
- `rewind`/`rewind_section`: both truncations are made durable before returning, ordered (retained values synced, index truncation synced, then values rewound and synced) so that every crash *and cancellation* point recovers either the pre-rewind or the post-rewind state — offset reuse only becomes possible after the stale entries are durably gone.
- `recover`: truncations performed during recovery are fsynced before init returns, closing the double-crash path.
- The freezer's post-rewind `oversized.sync` is removed (rewind is now self-syncing).

## Limitations

Recovery still trusts any range-covered entry. Storage that persists an unsynced index entry together with the glob's length but not the value bytes (no write-ordering guarantees, e.g. writeback-mode metadata journaling) can make recovery adopt an entry whose reads permanently fail their checksum — detected, never silent, and only for writes that were never acknowledged durable. Eliminating this would require recovery to consult a durably recorded publication bound instead of blob lengths, which is deliberately out of scope. Removals of sections past a rewind point carry the storage layer's removal durability. Both are stated in the module docs.

## Testing

Crash tests via `start_and_recover` (the deterministic runtime drops unsynced state): the rewind offset-reuse alias and the double-crash-through-recovery scenario (both fail on `main`), values-sync failure on the blocking and started paths, handle completion implies recoverable, a dropped handle completed by the next sync, and failed-rewind consistency. Manager-level units pin gated issuance timing and gate-failure semantics. Conformance fixtures are unchanged: the storage audit hashes final durable contents, which this change does not alter.
