### PR TITLE
[cryptography] Add `bls12381` feature

### DIFF
--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -21,7 +21,7 @@ commonware-actor.workspace = true
 commonware-broadcast.workspace = true
 commonware-codec.workspace = true
 commonware-coding.workspace = true
-commonware-cryptography = { workspace = true, features = ["blst"] }
+commonware-cryptography = { workspace = true, features = ["bls12381"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-math.workspace = true

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -21,7 +21,7 @@ commonware-actor.workspace = true
 commonware-broadcast.workspace = true
 commonware-codec.workspace = true
 commonware-coding.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["blst"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-math.workspace = true

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -18,7 +18,7 @@ ahash = { workspace = true, features = ["no-rng"] }
 anyhow = { workspace = true, optional = true }
 arbitrary = { workspace = true, optional = true, features = ["derive"] }
 blake3 = { workspace = true, features = ["zeroize"] }
-blst = { workspace = true, features = ["no-threads"] }
+blst = { workspace = true, optional = true, features = ["no-threads"] }
 bytes.workspace = true
 cfg-if.workspace = true
 commonware-codec.workspace = true
@@ -84,6 +84,7 @@ bench = false
 
 [features]
 default = [ "std" ]
+blst = [ "dep:blst" ]
 blake3-parallel = [ "blake3/rayon", "std" ]
 mocks = [ "std" ]
 arbitrary = [
@@ -99,6 +100,7 @@ std = [
 	"ahash/std",
 	"anyhow?/std",
 	"blake3/std",
+	"blst",
 	"bytes/std",
 	"chacha20poly1305/getrandom",
 	"commonware-codec/std",
@@ -129,6 +131,7 @@ std = [
 name = "bls12381"
 harness = false
 path = "src/bls12381/benches/bench.rs"
+required-features = [ "std" ]
 
 [[bench]]
 name = "ed25519"
@@ -174,3 +177,4 @@ path = "src/bloomfilter/benches/bench.rs"
 name = "bulletproofs"
 harness = false
 path = "src/zk/bulletproofs/benches/bench.rs"
+required-features = [ "std" ]

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -84,7 +84,7 @@ bench = false
 
 [features]
 default = [ "std" ]
-blst = [ "dep:blst" ]
+bls12381 = [ "dep:blst" ]
 blake3-parallel = [ "blake3/rayon", "std" ]
 mocks = [ "std" ]
 arbitrary = [
@@ -100,7 +100,7 @@ std = [
 	"ahash/std",
 	"anyhow?/std",
 	"blake3/std",
-	"blst",
+	"bls12381",
 	"bytes/std",
 	"chacha20poly1305/getrandom",
 	"commonware-codec/std",

--- a/cryptography/src/bls12381/mod.rs
+++ b/cryptography/src/bls12381/mod.rs
@@ -1,11 +1,4 @@
 //! Distributed Key Generation (DKG), Resharing, Signatures, and Threshold Signatures over the BLS12-381 curve.
-//!
-//! # Features
-//!
-//! This crate has the following features:
-//!
-//! - `portable`: Enables `portable` feature on `blst` (<https://github.com/supranational/blst?tab=readme-ov-file#platform-and-language-compatibility>).
-
 pub mod certificate;
 #[cfg(feature = "std")]
 pub mod dkg;

--- a/cryptography/src/certificate.rs
+++ b/cryptography/src/certificate.rs
@@ -17,7 +17,7 @@
 //!   setup required, and widely supported by hardware security modules. Unlike ed25519, does not
 //!   benefit from batch verification. Certificates contain individual signatures from each signer.
 #![cfg_attr(
-    feature = "blst",
+    feature = "bls12381",
     doc = "
 - [`bls12381_multisig`]: Attributable signatures with aggregated verification. Signatures
   can be aggregated into a single multi-signature for compact certificates while preserving
@@ -53,13 +53,13 @@
 //! whereas the signing key is used for producing and verifying signatures/certificates.
 //!
 #![cfg_attr(
-    feature = "blst",
+    feature = "bls12381",
     doc = "Some cryptographic schemes are only performant when used in batch verification (like
 [`bls12381_multisig`]) and/or are refreshed frequently (like [`bls12381_threshold`])."
 )]
 //! Refer to [ed25519] for an example of a scheme that uses the same key for both purposes.
 
-#[cfg(feature = "blst")]
+#[cfg(feature = "bls12381")]
 pub use crate::bls12381::certificate::{
     multisig as bls12381_multisig, threshold as bls12381_threshold,
 };

--- a/cryptography/src/certificate.rs
+++ b/cryptography/src/certificate.rs
@@ -16,32 +16,32 @@
 //! - [`secp256r1`]: Attributable signatures with individual verification. HSM-friendly, no trusted
 //!   setup required, and widely supported by hardware security modules. Unlike ed25519, does not
 //!   benefit from batch verification. Certificates contain individual signatures from each signer.
-//!
-//! - [`bls12381_multisig`]: Attributable signatures with aggregated verification. Signatures
-//!   can be aggregated into a single multi-signature for compact certificates while preserving
-//!   attribution (signer indices are stored alongside the aggregated signature).
-//!
-//! - [`bls12381_threshold`]: Non-attributable threshold signatures. Produces succinct
-//!   certificates that are constant-size regardless of committee size. Requires a trusted
-//!   setup (distributed key generation) and cannot attribute signatures to individual signers.
-//!
+#![cfg_attr(
+    feature = "blst",
+    doc = "
+- [`bls12381_multisig`]: Attributable signatures with aggregated verification. Signatures
+  can be aggregated into a single multi-signature for compact certificates while preserving
+  attribution (signer indices are stored alongside the aggregated signature).
+
+- [`bls12381_threshold`]: Non-attributable threshold signatures. Produces succinct
+  certificates that are constant-size regardless of committee size. Requires a trusted
+  setup (distributed key generation) and cannot attribute signatures to individual signers.
+"
+)]
 //! # Attributable Schemes and Fault Evidence
 //!
 //! Signing schemes differ in whether per-participant activities can be used as evidence of
 //! either liveness or of committing a fault:
 //!
-//! - **Attributable Schemes** ([`ed25519`], [`secp256r1`], [`bls12381_multisig`]): Individual
-//!   signatures can be presented to some third party as evidence of either liveness or of
-//!   committing a fault.  Certificates contain signer indices alongside individual signatures,
-//!   enabling secure per-participant activity tracking and conflict detection.
+//! - **Attributable Schemes**: Individual signatures can be presented to some third party as
+//!   evidence of either liveness or of committing a fault. Certificates contain signer indices
+//!   alongside individual signatures, enabling secure per-participant activity tracking and
+//!   conflict detection.
 //!
-//! - **Non-Attributable Schemes** ([`bls12381_threshold`]): Individual signatures cannot be
-//!   presented to some third party as evidence of either liveness or of committing a fault
-//!   because they can be forged by other players (often after some quorum of partial signatures
-//!   are collected). With [`bls12381_threshold`], possession of any `t` valid partial signatures
-//!   can be used to forge a partial signature for any other player. Because peer connections are
-//!   authenticated, evidence can be used locally (as it must be sent by said participant) but
-//!   cannot be used by an external observer.
+//! - **Non-Attributable Schemes**: Individual signatures cannot be presented to some third party
+//!   as evidence because they can be forged after collecting a quorum of partial signatures.
+//!   Authenticated peer connections allow this evidence to be used locally, but not by an external
+//!   observer.
 //!
 //! The [`Scheme::is_attributable()`] associated function signals whether evidence can be safely
 //! exposed to third parties.
@@ -52,18 +52,21 @@
 //! is used for assigning a unique order to the participant set and authenticating connections
 //! whereas the signing key is used for producing and verifying signatures/certificates.
 //!
-//! This flexibility is supported because some cryptographic schemes are only performant when
-//! used in batch verification (like [bls12381_multisig]) and/or are refreshed frequently
-//! (like [bls12381_threshold]). Refer to [ed25519] for an example of a scheme that uses the
-//! same key for both purposes.
+#![cfg_attr(
+    feature = "blst",
+    doc = "Some cryptographic schemes are only performant when used in batch verification (like
+[`bls12381_multisig`]) and/or are refreshed frequently (like [`bls12381_threshold`])."
+)]
+//! Refer to [ed25519] for an example of a scheme that uses the same key for both purposes.
 
+#[cfg(feature = "blst")]
+pub use crate::bls12381::certificate::{
+    multisig as bls12381_multisig, threshold as bls12381_threshold,
+};
+pub use crate::ed25519::certificate as ed25519;
 #[commonware_macros::stability(ALPHA)]
 pub use crate::secp256r1::certificate as secp256r1;
 use crate::{Digest, PublicKey};
-pub use crate::{
-    bls12381::certificate::{multisig as bls12381_multisig, threshold as bls12381_threshold},
-    ed25519::certificate as ed25519,
-};
 #[cfg(not(feature = "std"))]
 use alloc::{collections::BTreeSet, sync::Arc, vec, vec::Vec};
 use bytes::{Buf, BufMut, Bytes};
@@ -295,9 +298,8 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
 
     /// Returns whether this scheme benefits from batch verification.
     ///
-    /// Schemes that benefit from batch verification (like [`ed25519`], [`bls12381_multisig`]
-    /// and [`bls12381_threshold`]) should return `true`, allowing callers to optimize by
-    /// deferring verification until multiple signatures are available.
+    /// Schemes that benefit from batch verification should return `true`, allowing callers to
+    /// optimize by deferring verification until multiple signatures are available.
     ///
     /// Schemes that don't benefit from batch verification (like [`secp256r1`]) should
     /// return `false`, indicating that eager per-signature verification is preferred.

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -15,12 +15,15 @@ extern crate alloc;
 
 // Modules containing #[macro_export] macros must use verbose cfg.
 // See rust-lang/rust#52234: macro-expanded macro_export macros cannot be referenced by absolute paths.
-#[cfg(not(any(
-    commonware_stability_GAMMA,
-    commonware_stability_DELTA,
-    commonware_stability_EPSILON,
-    commonware_stability_RESERVED
-)))] // BETA
+#[cfg(all(
+    feature = "blst",
+    not(any(
+        commonware_stability_GAMMA,
+        commonware_stability_DELTA,
+        commonware_stability_EPSILON,
+        commonware_stability_RESERVED
+    ))
+))] // BETA
 pub mod bls12381;
 #[cfg(not(any(
     commonware_stability_GAMMA,
@@ -402,46 +405,55 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_validate() {
         test_validate::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_validate_invalid_public_key() {
         test_validate_invalid_public_key::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_sign_and_verify() {
         test_sign_and_verify::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_sign_and_verify_wrong_message() {
         test_sign_and_verify_wrong_message::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_sign_and_verify_wrong_namespace() {
         test_sign_and_verify_wrong_namespace::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_empty_namespace() {
         test_empty_namespace::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_signature_determinism() {
         test_signature_determinism::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_invalid_signature_publickey_pair() {
         test_invalid_signature_publickey_pair::<bls12381::PrivateKey>();
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_bls12381_len() {
         assert_eq!(bls12381::PublicKey::SIZE, 48);
         assert_eq!(bls12381::Signature::SIZE, 96);

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -16,7 +16,7 @@ extern crate alloc;
 // Modules containing #[macro_export] macros must use verbose cfg.
 // See rust-lang/rust#52234: macro-expanded macro_export macros cannot be referenced by absolute paths.
 #[cfg(all(
-    feature = "blst",
+    feature = "bls12381",
     not(any(
         commonware_stability_GAMMA,
         commonware_stability_DELTA,
@@ -405,55 +405,55 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_validate() {
         test_validate::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_validate_invalid_public_key() {
         test_validate_invalid_public_key::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_sign_and_verify() {
         test_sign_and_verify::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_sign_and_verify_wrong_message() {
         test_sign_and_verify_wrong_message::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_sign_and_verify_wrong_namespace() {
         test_sign_and_verify_wrong_namespace::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_empty_namespace() {
         test_empty_namespace::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_signature_determinism() {
         test_signature_determinism::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_invalid_signature_publickey_pair() {
         test_invalid_signature_publickey_pair::<bls12381::PrivateKey>();
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_bls12381_len() {
         assert_eq!(bls12381::PublicKey::SIZE, 48);
         assert_eq!(bls12381::Signature::SIZE, 96);

--- a/cryptography/src/zk/pedersen_to_plain.rs
+++ b/cryptography/src/zk/pedersen_to_plain.rs
@@ -390,7 +390,7 @@ mod conformance {
 }
 
 #[commonware_macros::stability(ALPHA)]
-#[cfg(all(feature = "blst", any(test, feature = "fuzz")))]
+#[cfg(all(feature = "bls12381", any(test, feature = "fuzz")))]
 pub mod fuzz {
     use super::*;
     use crate::bls12381::primitives::group::{G1 as G, Scalar as F};
@@ -623,7 +623,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "blst")]
+    #[cfg(feature = "bls12381")]
     fn test_fuzz() {
         minifuzz::test(|u| {
             u.arbitrary::<super::fuzz::Plan>()?.run(u)?;

--- a/cryptography/src/zk/pedersen_to_plain.rs
+++ b/cryptography/src/zk/pedersen_to_plain.rs
@@ -390,7 +390,7 @@ mod conformance {
 }
 
 #[commonware_macros::stability(ALPHA)]
-#[cfg(any(test, feature = "fuzz"))]
+#[cfg(all(feature = "blst", any(test, feature = "fuzz")))]
 pub mod fuzz {
     use super::*;
     use crate::bls12381::primitives::group::{G1 as G, Scalar as F};
@@ -583,7 +583,7 @@ pub mod fuzz {
 
 #[cfg(test)]
 mod test {
-    use super::{Claim, Proof, Setup, fuzz};
+    use super::{Claim, Proof, Setup};
     use commonware_codec::{Decode, Encode};
     use commonware_invariants::minifuzz;
     use commonware_math::test::{F, G};
@@ -623,9 +623,10 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "blst")]
     fn test_fuzz() {
         minifuzz::test(|u| {
-            u.arbitrary::<fuzz::Plan>()?.run(u)?;
+            u.arbitrary::<super::fuzz::Plan>()?.run(u)?;
             Ok(())
         });
     }

--- a/examples/bridge/Cargo.toml
+++ b/examples/bridge/Cargo.toml
@@ -18,7 +18,7 @@ clap.workspace = true
 commonware-actor.workspace = true
 commonware-codec.workspace = true
 commonware-consensus.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["std"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-p2p.workspace = true

--- a/examples/reshare/Cargo.toml
+++ b/examples/reshare/Cargo.toml
@@ -20,7 +20,7 @@ commonware-actor.workspace = true
 commonware-broadcast.workspace = true
 commonware-codec.workspace = true
 commonware-consensus.workspace = true
-commonware-cryptography.workspace = true
+commonware-cryptography = { workspace = true, features = ["std"] }
 commonware-formatting.workspace = true
 commonware-macros.workspace = true
 commonware-math.workspace = true


### PR DESCRIPTION
## Overview

Gates `commonware-cryptography`'s `blst` dependency behind a new feature flag. While possible to compile `blst` on most exotic targets, most users don't want to pay for the added binary size or build toolchain complications.

Supersedes https://github.com/commonwarexyz/monorepo/pull/3955
Closes https://github.com/commonwarexyz/monorepo/issues/561