### PR TITLE
Process segments bounds to resolve false positive

### DIFF
--- a/consensus/fuzz/src/marshal/single_node/invariant.rs
+++ b/consensus/fuzz/src/marshal/single_node/invariant.rs
@@ -18,6 +18,7 @@ use std::collections::{BTreeSet, HashSet};
 pub fn check_all<H: TestHarness>(
     ready_prefix: u64,
     application_segment_bounds: &[usize],
+    application_ordering_exclusions: &BTreeSet<usize>,
     segment_starts: &[u64],
     expected_redeliveries: &[Vec<Height>],
     application_delivered: &[(Height, D)],
@@ -26,6 +27,7 @@ pub fn check_all<H: TestHarness>(
     check_ready_prefix_delivered(ready_prefix, application_delivered);
     check_segment_ordering(
         application_segment_bounds,
+        application_ordering_exclusions,
         segment_starts,
         application_delivered,
     );
@@ -68,6 +70,7 @@ pub fn check_ready_prefix_delivered(ready_prefix: u64, application_delivered: &[
 /// not precise enough for this delivery-order invariant.
 pub fn check_segment_ordering(
     segment_bounds: &[usize],
+    ordering_exclusions: &BTreeSet<usize>,
     segment_starts: &[u64],
     application_delivered: &[(Height, D)],
 ) {
@@ -83,7 +86,9 @@ pub fn check_segment_ordering(
         }
         let segment = application_delivered[start_idx..end_idx]
             .iter()
-            .map(|(height, _)| *height)
+            .enumerate()
+            .filter(|(offset, _)| !ordering_exclusions.contains(&(start_idx + offset)))
+            .map(|(_, (height, _))| *height)
             .filter(|height| height.get() != 0)
             .collect::<Vec<_>>();
         if segment.is_empty() {

--- a/consensus/fuzz/src/marshal/single_node/invariant.rs
+++ b/consensus/fuzz/src/marshal/single_node/invariant.rs
@@ -17,16 +17,23 @@ use std::collections::{BTreeSet, HashSet};
 /// Run every marshal invariant. Called from the driver at end of run.
 pub fn check_all<H: TestHarness>(
     ready_prefix: u64,
-    delivery_log: &[Height],
-    segment_bounds: &[usize],
+    application_segment_bounds: &[usize],
     segment_starts: &[u64],
     expected_redeliveries: &[Vec<Height>],
     application_delivered: &[(Height, D)],
     canonical: &[H::TestBlock],
 ) {
     check_ready_prefix_delivered(ready_prefix, application_delivered);
-    check_segment_ordering(segment_bounds, segment_starts, delivery_log);
-    check_redelivery_after_restart(expected_redeliveries, segment_bounds, delivery_log);
+    check_segment_ordering(
+        application_segment_bounds,
+        segment_starts,
+        application_delivered,
+    );
+    check_redelivery_after_restart(
+        expected_redeliveries,
+        application_segment_bounds,
+        application_delivered,
+    );
     check_digest_fidelity::<H>(application_delivered, canonical);
 }
 
@@ -55,12 +62,14 @@ pub fn check_ready_prefix_delivered(ready_prefix: u64, application_delivered: &[
 /// Within each actor instance (segment between restarts) marshal must
 /// deliver heights starting at `restored processed_height + 1` and
 /// advance strictly by one. The driver pre-populates `segment_starts`
-/// from each `setup.height` and `segment_bounds` from the delivery_log
-/// positions at restart boundaries.
+/// from each `setup.height` and `segment_bounds` from the application's
+/// append-only delivery log at restart boundaries. Ack-derived observations
+/// can skip stale handles orphaned by restart or floor changes, so they are
+/// not precise enough for this delivery-order invariant.
 pub fn check_segment_ordering(
     segment_bounds: &[usize],
     segment_starts: &[u64],
-    delivery_log: &[Height],
+    application_delivered: &[(Height, D)],
 ) {
     assert_eq!(
         segment_bounds.len(),
@@ -72,7 +81,14 @@ pub fn check_segment_ordering(
         if start_idx == end_idx {
             continue;
         }
-        let segment = &delivery_log[start_idx..end_idx];
+        let segment = application_delivered[start_idx..end_idx]
+            .iter()
+            .map(|(height, _)| *height)
+            .filter(|height| height.get() != 0)
+            .collect::<Vec<_>>();
+        if segment.is_empty() {
+            continue;
+        }
         let expected_start = segment_starts[segment_idx];
         assert_eq!(
             segment[0].get(),
@@ -105,7 +121,7 @@ pub fn check_segment_ordering(
 pub fn check_redelivery_after_restart(
     expected_redeliveries: &[Vec<Height>],
     segment_bounds: &[usize],
-    delivery_log: &[Height],
+    application_delivered: &[(Height, D)],
 ) {
     assert_eq!(
         segment_bounds.len(),
@@ -117,9 +133,9 @@ pub fn check_redelivery_after_restart(
             continue;
         }
         let post_restart_start = segment_bounds[restart_idx + 1];
-        let post_restart: HashSet<u64> = delivery_log[post_restart_start..]
+        let post_restart: HashSet<u64> = application_delivered[post_restart_start..]
             .iter()
-            .map(|h| h.get())
+            .map(|(height, _)| height.get())
             .collect();
         for h in expected {
             assert!(

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -501,11 +501,13 @@ where
         // repair.
         let mut processed_height: u64 = setup.height.map_or(0, |h| h.get());
         let mut delivery_log: Vec<Height> = Vec::new();
-        // segment_bounds[i]..segment_bounds[i+1] is the i-th segment of
-        // delivery_log. segment_starts[i] is the height the i-th actor
-        // instance is expected to begin delivery at (its restored
-        // processed height + 1).
+        // segment_bounds split the ack-observation log for runner-local
+        // bookkeeping. application_segment_bounds split the append-only
+        // application delivery log for end-of-run delivery invariants.
+        // segment_starts[i] is the height the i-th actor instance is expected
+        // to begin delivery at (its restored processed height + 1).
         let mut segment_bounds: Vec<usize> = vec![0];
+        let mut application_segment_bounds: Vec<usize> = vec![0];
         let mut segment_starts: Vec<u64> = vec![setup.height.map_or(0, |h| h.get()) + 1];
         // For each restart, the heights pending ack at the moment of
         // restart. A later actor instance must redeliver each one.
@@ -1250,6 +1252,7 @@ where
                     }
                     expected_redeliveries.push(pending_real);
                     segment_bounds.push(delivery_log.len());
+                    application_segment_bounds.push(application.delivered().len());
 
                     actor_handle.abort();
                     let _ = actor_handle.await;
@@ -1355,11 +1358,11 @@ where
             "stale ack bookkeeping retained unmatched entries: {stale_to_skip:?}",
         );
         segment_bounds.push(delivery_log.len());
+        application_segment_bounds.push(application.delivered().len());
 
         invariant::check_all::<H>(
             ready_prefix,
-            &delivery_log,
-            &segment_bounds,
+            &application_segment_bounds,
             &segment_starts,
             &expected_redeliveries,
             &application.delivered(),

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -50,7 +50,7 @@ use commonware_storage::archive;
 use commonware_utils::{channel::oneshot, vec::NonEmptyVec, FuzzRng, NZUsize};
 use futures::{future::BoxFuture, task::noop_waker_ref, FutureExt, StreamExt};
 use std::{
-    collections::{HashSet, VecDeque},
+    collections::{BTreeSet, HashSet, VecDeque},
     future::Future,
     hint::black_box,
     num::NonZeroUsize,
@@ -153,15 +153,22 @@ fn block_available(
 /// application queue after already-stale handles are added to the stale queue.
 fn queue_floor_orphaned_acks(
     stale_to_skip: &mut VecDeque<Height>,
+    application_ordering_exclusions: &mut BTreeSet<usize>,
     pending_acks: &[Height],
+    pending_start_idx: usize,
     floor_height: u64,
     ready_prefix: u64,
 ) {
-    let mut pending_iter = pending_acks.iter().skip(stale_to_skip.len());
+    let stale_len = stale_to_skip.len();
+    let mut pending_iter = pending_acks.iter().enumerate().skip(stale_len);
     for expected in (floor_height..=ready_prefix).map(Height::new) {
-        if pending_iter.next().copied() != Some(expected) {
+        let Some((pending_offset, observed)) = pending_iter.next() else {
+            break;
+        };
+        if *observed != expected {
             break;
         }
+        application_ordering_exclusions.insert(pending_start_idx + pending_offset);
         stale_to_skip.push_back(expected);
     }
 }
@@ -501,6 +508,7 @@ where
         // repair.
         let mut processed_height: u64 = setup.height.map_or(0, |h| h.get());
         let mut delivery_log: Vec<Height> = Vec::new();
+        let mut application_ordering_exclusions: BTreeSet<usize> = BTreeSet::new();
         // segment_bounds split the ack-observation log for runner-local
         // bookkeeping. application_segment_bounds split the append-only
         // application delivery log for end-of-run delivery invariants.
@@ -1319,9 +1327,12 @@ where
                 // (live). Observe the application queue after the drain so speculative
                 // floor bookkeeping does not create unmatched strict stale entries.
                 let pending_acks = application.pending_ack_heights();
+                let pending_start_idx = application.delivered().len() - pending_acks.len();
                 queue_floor_orphaned_acks(
                     &mut stale_to_skip,
+                    &mut application_ordering_exclusions,
                     &pending_acks,
+                    pending_start_idx,
                     floor_height,
                     ready_prefix_before,
                 );
@@ -1363,6 +1374,7 @@ where
         invariant::check_all::<H>(
             ready_prefix,
             &application_segment_bounds,
+            &application_ordering_exclusions,
             &segment_starts,
             &expected_redeliveries,
             &application.delivered(),


### PR DESCRIPTION
Fix marshal single-node fuzz invariants to use the append-only application delivery log