### PR TITLE
[workflows] Add stale-PR workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,11 @@ on:
     - cron: '0 8 * * *' # Run at 08:00 UTC every day
 
 permissions:
+  # Persist state in the Actions cache between runs when operations-per-run
+  # is exhausted mid-backlog.
+  actions: write
+  # PR labels and comments go through the issues API, so both are required
+  # even though this workflow only manages PRs.
   pull-requests: write
   issues: write
 
@@ -17,15 +22,26 @@ jobs:
       - name: Label and close stale PRs
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
+          # Warn after 60 days of inactivity, then close 14 days after the
+          # warning if there is still no response. Any comment or push after
+          # the warning removes the label and resets the clock.
           days-before-pr-stale: 60
           days-before-pr-close: 14
+          # Only manage PRs; leave issues untouched.
           days-before-issue-stale: -1
           days-before-issue-close: -1
           stale-pr-label: stale
+          # PRs with either label are never marked stale (e.g. blocked on
+          # another PR, or intentionally long-lived).
           exempt-pr-labels: blocked,keep-open
           stale-pr-message: >
             This PR has been inactive for 60 days and will be closed in 14 days.
             Comment or push to keep it open, or add the `keep-open` label.
           close-pr-message: >
             Closed as stale. Rebase and reopen if you'd like to pick it back up.
+          # Process oldest PRs first so the existing backlog is handled before
+          # newer PRs.
+          ascending: true
+          # Cap API calls per run (a close costs ~3 operations); unfinished
+          # work resumes on the next run.
           operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,31 @@
+name: Stale
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * *' # Run at 08:00 UTC every day
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  stale:
+    name: Close Stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Label and close stale PRs
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
+        with:
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          stale-pr-label: stale
+          exempt-pr-labels: blocked,keep-open
+          stale-pr-message: >
+            This PR has been inactive for 60 days and will be closed in 14 days.
+            Comment or push to keep it open, or add the `keep-open` label.
+          close-pr-message: >
+            Closed as stale. Rebase and reopen if you'd like to pick it back up.
+          operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,7 @@ jobs:
   stale:
     name: Close Stale PRs
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Label and close stale PRs
         uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9


### PR DESCRIPTION
## Summary

Adds a daily scheduled workflow using [`actions/stale`](https://github.com/actions/stale) to manage inactive PRs, replacing manual sweeps (like the one on July 15) with an automated two-phase flow that always warns before closing.

## Lifecycle of an inactive PR

| Day | What happens |
|-----|--------------|
| 0 | Last activity on the PR (comment, push, label change, etc.) |
| 60 | Bot applies the `stale` label and comments a warning |
| 74 | If the warning got no response, bot closes the PR with a reopen-friendly message |

- **Any activity before day 60** restarts the 60-day clock.
- **Any comment or push during the 14-day warning window** removes the `stale` label and restarts the 60-day clock.
- **Closed PRs lose nothing** — branch, diff, and review history survive; rebase and reopen to resume.

## Opting out

Two labels exempt a PR from the bot entirely:

- `blocked` — waiting on another PR or external dependency (e.g. #3220 was blocked on #3234 and got swept anyway; this label prevents that).
- `keep-open` — intentionally long-lived.

> **Note:** these labels don't exist in the repo yet and must be created before merge (the action won't create exemption labels itself).

## Scope and safety

- **PRs only** — issues are never touched (`days-before-issue-stale: -1`).
- **Drafts are included.** If warnings on WIP drafts prove annoying, `exempt-draft-pr: true` is a one-line follow-up.
- **Oldest PRs first** (`ascending: true`) so the backlog is handled before newer PRs.
- **API usage is capped** at 100 operations per run (~30 PRs actioned; a close costs ~3 calls) to stay well inside the token's 1,000 req/hour limit and avoid notification bursts. State persists in the Actions cache (`actions: write`), so a run cut off by the cap resumes where it stopped the next day.
- **The bot's own comments don't count as activity**, so a warned PR can't keep itself alive.
- Action pinned to a full commit SHA (v9) and job has a 15-minute timeout, matching the other workflows.
- `workflow_dispatch` is enabled for manual test runs.

## Effect of the first run

As of July 16, six open PRs are past the 60-day threshold and would receive the warning (none would be closed — closing requires the label to have been present for 14 days): #3608, #3664 (draft), #3613, #3714 (draft), #3647 (draft), #3771. Absent a response, those would close around July 30.
