### PR TITLE
[storage/ordinal] Checksum serialized bytes directly

### DIFF
--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -2148,6 +2148,9 @@ mod tests {
                 store.put(4, DummyValue { value: 4 }).await.unwrap();
 
                 store.sync().await.unwrap();
+
+                // A record whose CRC matches but whose value fails to parse is invalid
+                assert!(matches!(store.get(2).await, Err(Error::InvalidRecord(2))));
             }
 
             // Reinitialize without bits and verify uncheckpointed data is deleted.

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -1,6 +1,6 @@
 use super::{Config, Error};
 use crate::{Context, rmap::RMap};
-use commonware_codec::{CodecFixed, Encode, FixedSize, Read, ReadExt, Write as CodecWrite};
+use commonware_codec::{CodecFixed, FixedSize, Read, ReadExt, Write as CodecWrite};
 use commonware_cryptography::{Crc32, crc32};
 use commonware_formatting::hex;
 use commonware_runtime::{
@@ -24,13 +24,21 @@ struct Record<V: CodecFixed<Cfg = ()>> {
 }
 
 impl<V: CodecFixed<Cfg = ()>> Record<V> {
-    fn new(value: V) -> Self {
-        let crc = Crc32::checksum(&value.encode());
-        Self { value, crc }
+    /// Serialize `value` followed by the CRC of its serialized bytes.
+    fn encode(value: &V) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::SIZE);
+        value.write(&mut buf);
+        let crc = Crc32::checksum(&buf);
+        crc.write(&mut buf);
+        buf
     }
 
-    fn is_valid(&self) -> bool {
-        self.crc == Crc32::checksum(&self.value.encode())
+    /// Deserialize a record, returning the value only if the stored CRC matches the raw
+    /// value bytes.
+    fn decode_valid(mut buf: &[u8]) -> Option<V> {
+        let crc = Crc32::checksum(buf.get(..V::SIZE)?);
+        let record = Self::read(&mut buf).ok()?;
+        (record.crc == crc).then_some(record.value)
     }
 }
 
@@ -63,7 +71,10 @@ where
 {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
         let value = V::arbitrary(u)?;
-        Ok(Self::new(value))
+        let mut buf = Vec::with_capacity(V::SIZE);
+        value.write(&mut buf);
+        let crc = Crc32::checksum(&buf);
+        Ok(Self { value, crc })
     }
 }
 
@@ -228,15 +239,12 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
 
                     // A committed record that is missing or invalid cannot be recovered
                     replay_blob.seek_to(offset)?;
-                    let mut record_buf = replay_blob.read(Record::<V>::SIZE).await?;
-                    if let Ok(record) = Record::<V>::read(&mut record_buf)
-                        && record.is_valid()
-                    {
-                        items += 1;
-                        intervals.insert(index);
-                        continue;
+                    let record_buf = replay_blob.read(Record::<V>::SIZE).await?.coalesce();
+                    if Record::<V>::decode_valid(record_buf.as_ref()).is_none() {
+                        return Err(Error::MissingRecord(index));
                     }
-                    return Err(Error::MissingRecord(index));
+                    items += 1;
+                    intervals.insert(index);
                 }
             }
         }
@@ -303,8 +311,7 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         // Write the value to the blob
         let blob = self.blobs.get_mut(&section).unwrap();
         let offset = (index % items_per_blob) * Record::<V>::SIZE as u64;
-        let record = Record::new(value);
-        blob.write_at(offset, record.encode_mut()).await?;
+        blob.write_at(offset, Record::encode(&value)).await?;
         self.pending.insert(section);
 
         // Add to intervals
@@ -327,15 +334,12 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
         let section = index / items_per_blob;
         let blob = self.blobs.get(&section).unwrap();
         let offset = (index % items_per_blob) * Record::<V>::SIZE as u64;
-        let mut read_buf = blob.read_at(offset, Record::<V>::SIZE).await?;
-        let record = Record::<V>::read(&mut read_buf)?;
+        let read_buf = blob.read_at(offset, Record::<V>::SIZE).await?.coalesce();
 
         // If record is valid, return it
-        if record.is_valid() {
-            Ok(Some(record.value))
-        } else {
-            Err(Error::InvalidRecord(index))
-        }
+        let value =
+            Record::<V>::decode_valid(read_buf.as_ref()).ok_or(Error::InvalidRecord(index))?;
+        Ok(Some(value))
     }
 
     /// Check if an index exists.

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -28,6 +28,7 @@ impl<V: CodecFixed<Cfg = ()>> Record<V> {
     fn encode(value: &V) -> Vec<u8> {
         let mut buf = Vec::with_capacity(Self::SIZE);
         value.write(&mut buf);
+        assert_eq!(buf.len(), V::SIZE, "write() did not write expected bytes");
         let crc = Crc32::checksum(&buf);
         crc.write(&mut buf);
         buf


### PR DESCRIPTION
Every `Ordinal` record is a fixed-size value followed by a CRC of the value's bytes. The old code never had those bytes on hand when it needed the checksum, so it serialized the value an extra time at every step:

- `put` encoded the value once just to compute the CRC, then encoded it a second time to write it.
- `get` decoded the value from disk, then re-encoded it just to check the CRC.
- Replay at startup did the same re-encode for every committed record.

Each extra encode also came with a heap allocation.

Now the CRC is computed directly from the bytes being written or read:

- `Record::encode` serializes the value once into the record buffer, checksums those bytes, and appends the CRC.
- `Record::decode_valid` checksums the value bytes as they came off disk, then decodes them — through the unchanged `Read` impl, so the record format is still defined in one place.

The bytes on disk are identical to before; the `Record` codec conformance test passes against the existing fixtures.

## Impact

| bench | main | this PR | change |
|---|---|---|---|
| `restart/items=10000` | 1.00 ms | 0.61 ms | **−39%** |
| `restart/items=50000` | 4.96 ms | 3.05 ms | **−39%** |
| `restart/items=100000` | 9.77 ms | 6.14 ms | **−37%** |
| `put/items=10000` | 24.4 ms | 24.7 ms | noise |
| `get/mode=serial reads=10000` | 71.9 ms | 71.8 ms | noise |