### PR TITLE
Fix false positive in marshal fuzzer

### DIFF
--- a/consensus/fuzz/src/marshal/single_node/invariant.rs
+++ b/consensus/fuzz/src/marshal/single_node/invariant.rs
@@ -12,13 +12,16 @@ use commonware_consensus::{
     marshal::mocks::harness::{D, TestHarness},
     types::Height,
 };
-use std::collections::{BTreeSet, HashSet};
+use std::{
+    collections::{BTreeSet, HashSet},
+    ops::Range,
+};
 
 /// Run every marshal invariant. Called from the driver at end of run.
 pub fn check_all<H: TestHarness>(
     ready_prefix: u64,
     application_segment_bounds: &[usize],
-    application_ordering_exclusions: &BTreeSet<usize>,
+    application_candidate_stale_ranges: &[Range<usize>],
     segment_starts: &[u64],
     expected_redeliveries: &[Vec<Height>],
     application_delivered: &[(Height, D)],
@@ -27,7 +30,7 @@ pub fn check_all<H: TestHarness>(
     check_ready_prefix_delivered(ready_prefix, application_delivered);
     check_segment_ordering(
         application_segment_bounds,
-        application_ordering_exclusions,
+        application_candidate_stale_ranges,
         segment_starts,
         application_delivered,
     );
@@ -68,9 +71,18 @@ pub fn check_ready_prefix_delivered(ready_prefix: u64, application_delivered: &[
 /// append-only delivery log at restart boundaries. Ack-derived observations
 /// can skip stale handles orphaned by restart or floor changes, so they are
 /// not precise enough for this delivery-order invariant.
+///
+/// Entries in `candidate_stale_ranges` are ambiguous: the driver observed each
+/// range where one floor transition may have orphaned its ack waiters, but
+/// asynchronous mailbox handling can also make the floor stale before it clears
+/// those waiters. Treat each whole range as either stale or live, and require at
+/// least one classification in which every live delivery forms the exact
+/// contiguous sequence. A floor clears all of its pending waiters together, so
+/// individual entries within one range cannot be classified independently.
+/// Unmarked entries are always live and cannot be skipped.
 pub fn check_segment_ordering(
     segment_bounds: &[usize],
-    ordering_exclusions: &BTreeSet<usize>,
+    candidate_stale_ranges: &[Range<usize>],
     segment_starts: &[u64],
     application_delivered: &[(Height, D)],
 ) {
@@ -79,6 +91,26 @@ pub fn check_segment_ordering(
         segment_starts.len() + 1,
         "segment bookkeeping inconsistency",
     );
+    let mut previous_candidate_end = 0;
+    for candidate in candidate_stale_ranges {
+        assert!(
+            candidate.start < candidate.end
+                && candidate.end <= application_delivered.len()
+                && candidate.start >= previous_candidate_end
+                && application_delivered[candidate.clone()]
+                    .iter()
+                    .all(|(height, _)| height.get() != 0),
+            "candidate stale ranges must be non-empty, ordered, non-overlapping, and in bounds: \
+             {candidate_stale_ranges:?}",
+        );
+        assert!(
+            segment_bounds
+                .windows(2)
+                .any(|window| window[0] <= candidate.start && candidate.end <= window[1]),
+            "candidate stale range {candidate:?} crosses an actor segment boundary",
+        );
+        previous_candidate_end = candidate.end;
+    }
     for (segment_idx, window) in segment_bounds.windows(2).enumerate() {
         let (start_idx, end_idx) = (window[0], window[1]);
         if start_idx == end_idx {
@@ -87,34 +119,75 @@ pub fn check_segment_ordering(
         let segment = application_delivered[start_idx..end_idx]
             .iter()
             .enumerate()
-            .filter(|(offset, _)| !ordering_exclusions.contains(&(start_idx + offset)))
-            .map(|(_, (height, _))| *height)
-            .filter(|height| height.get() != 0)
+            .map(|(offset, (height, _))| (start_idx + offset, *height))
+            .filter(|(_, height)| height.get() != 0)
             .collect::<Vec<_>>();
         if segment.is_empty() {
             continue;
         }
         let expected_start = segment_starts[segment_idx];
-        assert_eq!(
-            segment[0].get(),
-            expected_start,
-            "segment #{segment_idx} must start at restored processed height + 1 \
-             ({expected_start}), got {} (segment={:?})",
-            segment[0].get(),
-            segment,
+        assert!(
+            segment_ordering_is_possible(expected_start, &segment, candidate_stale_ranges),
+            "marshal violated in-order delivery within segment #{segment_idx}: no assignment \
+             of ambiguous floor-orphaned deliveries produces a sequence starting at \
+             {expected_start} (segment={segment:?}, candidates={candidate_stale_ranges:?})",
         );
-        for (offset, h) in segment.iter().enumerate() {
-            let expected = expected_start + offset as u64;
-            assert_eq!(
-                h.get(),
-                expected,
-                "marshal violated in-order delivery within segment #{segment_idx}: \
-                 expected height {expected}, observed {} (segment={:?})",
-                h.get(),
-                segment,
-            );
-        }
     }
+}
+
+fn segment_ordering_is_possible(
+    expected_start: u64,
+    segment: &[(usize, Height)],
+    candidate_stale_ranges: &[Range<usize>],
+) -> bool {
+    let mut possible_next = BTreeSet::from([expected_start]);
+    let mut position = 0;
+    while position < segment.len() {
+        let delivery_idx = segment[position].0;
+        let Some(candidate) = candidate_stale_ranges
+            .iter()
+            .find(|candidate| candidate.start == delivery_idx)
+        else {
+            possible_next = consume_deliveries(possible_next, &segment[position..position + 1]);
+            if possible_next.is_empty() {
+                return false;
+            }
+            position += 1;
+            continue;
+        };
+
+        let group_len = candidate.end - candidate.start;
+        let group_end = position + group_len;
+        if group_len == 0
+            || group_end > segment.len()
+            || segment[group_end - 1].0.saturating_add(1) != candidate.end
+        {
+            return false;
+        }
+
+        // One floor transition clears all pending waiters together. Branch once
+        // for the whole observed range: skip all as stale, or consume all as live.
+        let live_next = consume_deliveries(possible_next.clone(), &segment[position..group_end]);
+        possible_next.extend(live_next);
+        position = group_end;
+    }
+    true
+}
+
+fn consume_deliveries(
+    mut possible_next: BTreeSet<u64>,
+    deliveries: &[(usize, Height)],
+) -> BTreeSet<u64> {
+    for (_, height) in deliveries {
+        let mut next = BTreeSet::new();
+        for expected in possible_next {
+            if height.get() == expected {
+                next.insert(expected.saturating_add(1));
+            }
+        }
+        possible_next = next;
+    }
+    possible_next
 }
 
 /// Invariant: at-least-once across restart.

--- a/consensus/fuzz/src/marshal/single_node/runner.rs
+++ b/consensus/fuzz/src/marshal/single_node/runner.rs
@@ -49,10 +49,11 @@ use commonware_storage::archive;
 use commonware_utils::{FuzzRng, NZUsize, channel::oneshot, vec::NonEmptyVec};
 use futures::{FutureExt, StreamExt, future::BoxFuture, task::noop_waker_ref};
 use std::{
-    collections::{BTreeSet, HashSet, VecDeque},
+    collections::{HashSet, VecDeque},
     future::Future,
     hint::black_box,
     num::NonZeroUsize,
+    ops::Range,
     sync::Arc,
     task::{Context, Poll},
     time::Duration,
@@ -98,6 +99,7 @@ fn apply_pending_floor(
     finalized_available: &mut HashSet<u64>,
     processed_height: &mut u64,
     segment_starts: &mut [u64],
+    last_applied_floor: &mut Option<u64>,
 ) -> bool {
     let h = height.get();
     if *pending_floor != Some(h) {
@@ -109,8 +111,24 @@ fn apply_pending_floor(
     if let Some(start) = segment_starts.last_mut() {
         *start = h;
     }
+    *last_applied_floor = Some(h);
     *pending_floor = None;
     true
+}
+
+fn can_install_floor(
+    pending_floor: Option<u64>,
+    floor_height: u64,
+    processed_height: u64,
+    last_applied_floor: Option<u64>,
+    current_segment_empty: bool,
+    only_genesis_pending: bool,
+) -> bool {
+    pending_floor.is_none()
+        && floor_height == processed_height + 1
+        && last_applied_floor.is_none_or(|last| floor_height > last)
+        && current_segment_empty
+        && only_genesis_pending
 }
 
 fn block_available(
@@ -152,23 +170,28 @@ fn block_available(
 /// application queue after already-stale handles are added to the stale queue.
 fn queue_floor_orphaned_acks(
     stale_to_skip: &mut VecDeque<Height>,
-    application_ordering_exclusions: &mut BTreeSet<usize>,
+    application_candidate_stale_ranges: &mut Vec<Range<usize>>,
     pending_acks: &[Height],
     pending_start_idx: usize,
     floor_height: u64,
     ready_prefix: u64,
 ) {
     let stale_len = stale_to_skip.len();
-    let mut pending_iter = pending_acks.iter().enumerate().skip(stale_len);
+    let mut pending_iter = pending_acks.iter().skip(stale_len);
+    let candidate_start = pending_start_idx + stale_len;
+    let mut candidate_len = 0;
     for expected in (floor_height..=ready_prefix).map(Height::new) {
-        let Some((pending_offset, observed)) = pending_iter.next() else {
+        let Some(observed) = pending_iter.next() else {
             break;
         };
         if *observed != expected {
             break;
         }
-        application_ordering_exclusions.insert(pending_start_idx + pending_offset);
         stale_to_skip.push_back(expected);
+        candidate_len += 1;
+    }
+    if candidate_len > 0 {
+        application_candidate_stale_ranges.push(candidate_start..candidate_start + candidate_len);
     }
 }
 
@@ -507,7 +530,7 @@ where
         // repair.
         let mut processed_height: u64 = setup.height.map_or(0, |h| h.get());
         let mut delivery_log: Vec<Height> = Vec::new();
-        let mut application_ordering_exclusions: BTreeSet<usize> = BTreeSet::new();
+        let mut application_candidate_stale_ranges: Vec<Range<usize>> = Vec::new();
         // segment_bounds split the ack-observation log for runner-local
         // bookkeeping. application_segment_bounds split the append-only
         // application delivery log for end-of-run delivery invariants.
@@ -525,6 +548,12 @@ where
         let mut stale_to_skip: VecDeque<Height> = VecDeque::new();
         let mut restart_counter: usize = 0;
         let mut pending_floor: Option<u64> = None;
+        // Applying a floor advances marshal's processed round before the
+        // application acknowledges the floor block. Because this harness maps
+        // each height to the same-numbered round, remember the last applied
+        // floor within the actor lifetime so a duplicate SetFloor is modeled as
+        // stale instead of as another pending-ack-clearing floor transition.
+        let mut last_applied_floor: Option<u64> = None;
         let mut subscriptions = Vec::new();
         let mut parked_queries: Vec<BoxFuture<'static, ()>> = Vec::new();
         let ancestry_fetch_duration = Timed::new(context.histogram(
@@ -559,6 +588,7 @@ where
                         &mut finalized_available,
                         &mut processed_height,
                         &mut segment_starts,
+                        &mut last_applied_floor,
                     );
                 }
                 MarshalEvent::Verify { block_idx } => {
@@ -574,6 +604,7 @@ where
                         &mut finalized_available,
                         &mut processed_height,
                         &mut segment_starts,
+                        &mut last_applied_floor,
                     );
                 }
                 MarshalEvent::Certify { block_idx } => {
@@ -591,6 +622,7 @@ where
                         &mut finalized_available,
                         &mut processed_height,
                         &mut segment_starts,
+                        &mut last_applied_floor,
                     );
                 }
                 MarshalEvent::ReportFinalization { block_idx } => {
@@ -625,6 +657,7 @@ where
                             &mut finalized_available,
                             &mut processed_height,
                             &mut segment_starts,
+                            &mut last_applied_floor,
                         );
                     } else if block_available(&durable_available, &variant_available, h)
                         && h > processed_height
@@ -663,6 +696,7 @@ where
                             &mut finalized_available,
                             &mut processed_height,
                             &mut segment_starts,
+                            &mut last_applied_floor,
                         );
                     }
                     if block_available(&durable_available, &variant_available, h)
@@ -876,11 +910,14 @@ where
                     let current_segment_empty =
                         delivery_log.len() == *segment_bounds.last().unwrap();
                     let mut burst_floor = false;
-                    if pending_floor.is_none()
-                        && floor_height.get() == processed_height + 1
-                        && current_segment_empty
-                        && only_genesis_pending
-                    {
+                    if can_install_floor(
+                        pending_floor,
+                        floor_height.get(),
+                        processed_height,
+                        last_applied_floor,
+                        current_segment_empty,
+                        only_genesis_pending,
+                    ) {
                         handle.mailbox.set_floor(floor_finalization.clone());
                         handle.mailbox.set_floor(floor_finalization);
                         finalization_reported.insert(floor_height.get());
@@ -1072,6 +1109,7 @@ where
                             &mut finalized_available,
                             &mut processed_height,
                             &mut segment_starts,
+                            &mut last_applied_floor,
                         );
                     }
                 }
@@ -1087,11 +1125,14 @@ where
                     let only_genesis_pending = live_pending_acks.iter().all(|h| h.get() == 0);
                     let current_segment_empty =
                         delivery_log.len() == *segment_bounds.last().unwrap();
-                    if pending_floor.is_none()
-                        && h == processed_height + 1
-                        && current_segment_empty
-                        && only_genesis_pending
-                    {
+                    if can_install_floor(
+                        pending_floor,
+                        h,
+                        processed_height,
+                        last_applied_floor,
+                        current_segment_empty,
+                        only_genesis_pending,
+                    ) {
                         let proposal = Proposal::new(
                             round_for_height(height),
                             parent_view(height),
@@ -1110,6 +1151,7 @@ where
                                 &mut finalized_available,
                                 &mut processed_height,
                                 &mut segment_starts,
+                                &mut last_applied_floor,
                             );
                         }
                     }
@@ -1175,6 +1217,7 @@ where
                                 &mut finalized_available,
                                 &mut processed_height,
                                 &mut segment_starts,
+                                &mut last_applied_floor,
                             );
                         }
                     }
@@ -1297,6 +1340,7 @@ where
                     // never got acked do NOT advance this floor.
                     processed_height = setup.height.map_or(0, |h| h.get());
                     pending_floor = None;
+                    last_applied_floor = None;
                 }
                 MarshalEvent::Idle => {}
             }
@@ -1329,7 +1373,7 @@ where
                 let pending_start_idx = application.delivered().len() - pending_acks.len();
                 queue_floor_orphaned_acks(
                     &mut stale_to_skip,
-                    &mut application_ordering_exclusions,
+                    &mut application_candidate_stale_ranges,
                     &pending_acks,
                     pending_start_idx,
                     floor_height,
@@ -1373,7 +1417,7 @@ where
         invariant::check_all::<H>(
             ready_prefix,
             &application_segment_bounds,
-            &application_ordering_exclusions,
+            &application_candidate_stale_ranges,
             &segment_starts,
             &expected_redeliveries,
             &application.delivered(),


### PR DESCRIPTION
A false positive: Marshal had advanced processed_round after applying floor 3 while processed_height remained 2. The harness tracked only height, so it incorrectly treated a duplicate floor 3 as another ack-clearing transition and excluded valid deliveries 3 and 4.
