### PR TITLE
[consensus/simplex] Recover Own Nullify after Restart

### DIFF
--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -240,37 +240,45 @@ impl<
     }
 
     /// Adds a vote that we constructed ourselves to the verifier.
+    ///
+    /// Duplicate nullifies are ignored (the voter re-sends its nullify vote on
+    /// every timeout retry).
+    ///
+    /// # Panics
+    ///
+    /// Panics if a notarize or finalize vote is added more than once.
     pub fn add_constructed(&mut self, message: Vote<S, D>) {
         match &message {
             Vote::Notarize(notarize) => {
-                // Report activity
-                self.reporter.report(Activity::Notarize(notarize.clone()));
-
                 // Our own votes are already verified
                 assert!(
                     self.votes.insert_notarize(notarize.clone()),
                     "duplicate notarize"
                 );
+
+                // Report activity
+                self.reporter.report(Activity::Notarize(notarize.clone()));
             }
             Vote::Nullify(nullify) => {
+                // The voter re-sends its nullify on every timeout retry (the
+                // batcher's state does not survive a restart), so duplicates
+                // are expected and ignored.
+                if !self.votes.insert_nullify(nullify.clone()) {
+                    return;
+                }
+
                 // Report activity
                 self.reporter.report(Activity::Nullify(nullify.clone()));
-
-                // Our own votes are already verified
-                assert!(
-                    self.votes.insert_nullify(nullify.clone()),
-                    "duplicate nullify"
-                );
             }
             Vote::Finalize(finalize) => {
-                // Report activity
-                self.reporter.report(Activity::Finalize(finalize.clone()));
-
                 // Our own votes are already verified
                 assert!(
                     self.votes.insert_finalize(finalize.clone()),
                     "duplicate finalize"
                 );
+
+                // Report activity
+                self.reporter.report(Activity::Finalize(finalize.clone()));
             }
         }
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -412,9 +412,13 @@ impl<
         let view = self.state.current_view();
         let (retry, nullify) = self.state.construct_nullify(view)?;
 
-        // Process nullify (and persist it if it is a first attempt)
+        // Inform the batcher on every attempt (it ignores duplicate nullifies):
+        // after a restart, the first attempt for a replayed nullify is a retry,
+        // and the batcher (whose state is not persisted) has not seen the vote yet.
+        batcher.constructed(Vote::Nullify(nullify.clone()));
+
+        // Persist the nullify if it is a first attempt
         if !retry {
-            batcher.constructed(Vote::Nullify(nullify.clone()));
             self.handle_nullify(nullify.clone()).await;
             return Some((nullify, None));
         }

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -7285,6 +7285,9 @@ mod tests {
             //    a. Certification of view 4 to succeed (impossible - no context)
             //    b. A nullification certificate for view 4 (impossible - only f votes)
             //    c. A finalization certificate (requires Byzantine to vote finalize)
+            // Use a fixed deadline: timeout retries re-send the nullify vote every
+            // second, which would otherwise restart a per-iteration sleep forever.
+            let deadline = context.current() + Duration::from_secs(5);
             let advanced = loop {
                 select! {
                     msg = batcher_receiver.recv() => {
@@ -7303,7 +7306,7 @@ mod tests {
                             _ => {}
                         }
                     },
-                    _ = context.sleep(Duration::from_secs(5)) => {
+                    _ = context.sleep_until(deadline) => {
                         break false;
                     },
                 }
@@ -7327,6 +7330,7 @@ mod tests {
             mailbox.resolved(Certificate::Finalization(finalization_5));
 
             // Now the validator SHOULD advance (finalization aborts stuck certification)
+            let deadline = context.current() + Duration::from_secs(5);
             let rescued = loop {
                 select! {
                     msg = batcher_receiver.recv() => {
@@ -7336,7 +7340,7 @@ mod tests {
                             break true;
                         }
                     },
-                    _ = context.sleep(Duration::from_secs(5)) => {
+                    _ = context.sleep_until(deadline) => {
                         break false;
                     },
                 }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2855,17 +2855,9 @@ mod tests {
             let mut finalizers = Vec::new();
             for reporter in reporters.iter_mut() {
                 let (mut latest, mut monitor) = reporter.subscribe().await;
-                finalizers.push(context.child("finalizer").spawn(move |context| async move {
-                    let progressed = async {
-                        while latest < required_containers {
-                            latest = monitor.recv().await.expect("event missing");
-                        }
-                    };
-                    select! {
-                        _done = progressed => {},
-                        _timeout = context.sleep(Duration::from_secs(600)) => {
-                            panic!("liveness lost: no progress after crash during nullified view");
-                        },
+                finalizers.push(context.child("finalizer").spawn(move |_| async move {
+                    while latest < required_containers {
+                        latest = monitor.recv().await.expect("event missing");
                     }
                 }));
             }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2736,16 +2736,15 @@ mod tests {
             // view 1.
             let stalled = View::new(1);
             loop {
-                let nullified = reporters
-                    .iter()
-                    .zip(participants.iter().skip(1))
-                    .all(|(reporter, validator)| {
+                let nullified = reporters.iter().zip(participants.iter().skip(1)).all(
+                    |(reporter, validator)| {
                         reporter
                             .nullifies
                             .lock()
                             .get(&stalled)
                             .is_some_and(|nullifiers| nullifiers.contains(validator))
-                    });
+                    },
+                );
                 if nullified {
                     break;
                 }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -2631,6 +2631,251 @@ mod tests {
 
     test_for_all_fixtures!(all_recovery);
 
+    fn all_crash_after_nullify<S, F, L>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+        L: Elector<S>,
+    {
+        // Create context
+        let n = 4;
+        let required_containers = View::new(10);
+        let activity_timeout = ViewDelta::new(10);
+        let skip_timeout = ViewDelta::new(5);
+        let namespace = b"consensus".to_vec();
+        let executor = deterministic::Runner::timed(Duration::from_secs(3600));
+        executor.start(|mut context| async move {
+            // Register participants
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+            let mut oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+            let mut registrations = register_validators(&mut oracle, &participants).await;
+
+            // Participant 0 never starts an engine and no links exist yet, so no
+            // view can produce a certificate before the crash below.
+            let elector = L::default();
+            let relay = Arc::new(mocks::relay::Relay::new());
+            let mut reporters = Vec::new();
+            let mut engine_handlers = Vec::new();
+            for (idx_scheme, validator) in participants.iter().enumerate() {
+                // Skip first peer
+                if idx_scheme == 0 {
+                    continue;
+                }
+
+                // Create scheme context
+                let context = context
+                    .child("validator")
+                    .with_attribute("public_key", validator);
+
+                // Configure engine
+                let reporter_config = mocks::reporter::Config {
+                    participants: participants.clone().try_into().unwrap(),
+                    scheme: schemes[idx_scheme].clone(),
+                    elector: elector.clone(),
+                };
+                let reporter =
+                    mocks::reporter::Reporter::new(context.child("reporter"), reporter_config);
+                reporters.push(reporter.clone());
+                let application_cfg = mocks::application::Config {
+                    hasher: Sha256::default(),
+                    relay: relay.clone(),
+                    me: validator.clone(),
+                    propose_latency: (10.0, 5.0),
+                    verify_latency: (10.0, 5.0),
+                    certify_latency: (10.0, 5.0),
+                    should_certify: mocks::application::Certifier::Always,
+                };
+                let (actor, application) = mocks::application::Application::new(
+                    context.child("application"),
+                    application_cfg,
+                );
+                actor.start();
+                let blocker = oracle.control(validator.clone());
+                let cfg = config::Config {
+                    scheme: schemes[idx_scheme].clone(),
+                    elector: elector.clone(),
+                    blocker,
+                    automaton: application.clone(),
+                    relay: application.clone(),
+                    reporter: reporter.clone(),
+                    strategy: Sequential,
+                    partition: validator.to_string(),
+                    mailbox_size: NZUsize!(1024),
+                    epoch: Epoch::new(333),
+                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(
+                        Epoch::new(333),
+                    )),
+                    leader_timeout: Duration::from_secs(1),
+                    certification_timeout: Duration::from_secs(2),
+                    timeout_retry: Duration::from_secs(10),
+                    fetch_timeout: Duration::from_secs(1),
+                    activity_timeout,
+                    skip_timeout,
+                    fetch_concurrent: NZUsize!(4),
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
+                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                    forwarding: ForwardingPolicy::Disabled,
+                };
+                let engine = Engine::new(context.child("engine"), cfg);
+
+                // Start engine
+                let (pending, recovered, resolver) = registrations
+                    .remove(validator)
+                    .expect("validator should be registered");
+                engine_handlers.push(engine.start(pending, recovered, resolver));
+            }
+
+            // Wait for every online validator to construct its nullify vote for
+            // view 1.
+            let stalled = View::new(1);
+            loop {
+                let nullified = reporters
+                    .iter()
+                    .zip(participants.iter().skip(1))
+                    .all(|(reporter, validator)| {
+                        reporter
+                            .nullifies
+                            .lock()
+                            .get(&stalled)
+                            .is_some_and(|nullifiers| nullifiers.contains(validator))
+                    });
+                if nullified {
+                    break;
+                }
+                context.sleep(Duration::from_millis(100)).await;
+            }
+
+            // The reporter observes our vote via the batcher, which can run ahead
+            // of the voter's journal sync in the same instant. Wait one more tick
+            // so every vote is durable before crashing.
+            context.sleep(Duration::from_secs(1)).await;
+
+            // Crash every online validator before any nullification certificate
+            // can circulate.
+            for handle in engine_handlers.drain(..) {
+                handle.abort();
+                let _ = handle.await;
+            }
+            relay.deregister_all();
+
+            // Restore connectivity between the online validators.
+            let link = Link {
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
+                success_rate: 1.0,
+            };
+            link_validators(
+                &mut oracle,
+                &participants,
+                Action::Link(link),
+                Some(|_, i, j| ![i, j].contains(&0usize)),
+            )
+            .await;
+
+            // Restart every online validator from its journal.
+            let mut reporters = Vec::new();
+            for (idx_scheme, validator) in participants.iter().enumerate() {
+                // Skip first peer
+                if idx_scheme == 0 {
+                    continue;
+                }
+
+                // Create scheme context
+                let context = context
+                    .child("validator_restarted")
+                    .with_attribute("public_key", validator);
+
+                // Configure engine
+                let reporter_config = mocks::reporter::Config {
+                    participants: participants.clone().try_into().unwrap(),
+                    scheme: schemes[idx_scheme].clone(),
+                    elector: elector.clone(),
+                };
+                let reporter =
+                    mocks::reporter::Reporter::new(context.child("reporter"), reporter_config);
+                reporters.push(reporter.clone());
+                let application_cfg = mocks::application::Config {
+                    hasher: Sha256::default(),
+                    relay: relay.clone(),
+                    me: validator.clone(),
+                    propose_latency: (10.0, 5.0),
+                    verify_latency: (10.0, 5.0),
+                    certify_latency: (10.0, 5.0),
+                    should_certify: mocks::application::Certifier::Always,
+                };
+                let (actor, application) = mocks::application::Application::new(
+                    context.child("application"),
+                    application_cfg,
+                );
+                actor.start();
+                let blocker = oracle.control(validator.clone());
+                let cfg = config::Config {
+                    scheme: schemes[idx_scheme].clone(),
+                    elector: elector.clone(),
+                    blocker,
+                    automaton: application.clone(),
+                    relay: application.clone(),
+                    reporter: reporter.clone(),
+                    strategy: Sequential,
+                    partition: validator.to_string(),
+                    mailbox_size: NZUsize!(1024),
+                    epoch: Epoch::new(333),
+                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(
+                        Epoch::new(333),
+                    )),
+                    leader_timeout: Duration::from_secs(1),
+                    certification_timeout: Duration::from_secs(2),
+                    timeout_retry: Duration::from_secs(10),
+                    fetch_timeout: Duration::from_secs(1),
+                    activity_timeout,
+                    skip_timeout,
+                    fetch_concurrent: NZUsize!(4),
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
+                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                    forwarding: ForwardingPolicy::Disabled,
+                };
+                let engine = Engine::new(context.child("engine"), cfg);
+
+                // Start engine
+                let (pending, recovered, resolver) =
+                    register_validator(&mut oracle, validator.clone()).await;
+                engine.start(pending, recovered, resolver);
+            }
+
+            // The restarted validators must reconstruct a nullification for view 1
+            // to make progress (participant 0 never votes, so every remaining vote
+            // is required to reach quorum).
+            let mut finalizers = Vec::new();
+            for reporter in reporters.iter_mut() {
+                let (mut latest, mut monitor) = reporter.subscribe().await;
+                finalizers.push(context.child("finalizer").spawn(move |context| async move {
+                    let progressed = async {
+                        while latest < required_containers {
+                            latest = monitor.recv().await.expect("event missing");
+                        }
+                    };
+                    select! {
+                        _done = progressed => {},
+                        _timeout = context.sleep(Duration::from_secs(600)) => {
+                            panic!("liveness lost: no progress after crash during nullified view");
+                        },
+                    }
+                }));
+            }
+            join_all(finalizers).await;
+        });
+    }
+
+    test_for_all_fixtures!(all_crash_after_nullify);
+
     fn partition<S, F, L>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,


### PR DESCRIPTION
## Bug

If exactly 2f+1 honest validators can nullify a view (the other f contribute nothing) and all of them crash after journaling their nullify votes but before any nullification certificate is assembled, the network deadlocks on restart. Journal replay sets `broadcast_nullify`, so the post-restart timeout takes the retry path, which re-broadcasts the vote to peers but never re-delivers it to the local batcher (whose state is in-memory only). Every batcher then holds the 2f peer votes but not its own, one short of quorum forever.

## Fix

`Voter::timeout` now informs the batcher on every attempt (journaling remains first-attempt-only), and the batcher ignores duplicate nullifies instead of asserting (notarize and finalize keep their asserts since they are never re-sent). The duplicate check runs before reporting and verifier insertion, so retries neither re-report activity nor double-count toward quorum. A new deterministic test, `all_crash_after_nullify`, reproduces the deadlock and passes with the fix.
