### PR TITLE
[storage/qmdb/current] Scan floor-raise candidates under a single bitmap guard 

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -741,10 +741,7 @@ fn fill_candidates<F: Family, const N: usize>(
     limit: usize,
     out: &mut Vec<Location<F>>,
 ) -> Location<F> {
-    let mut raw: Vec<u64> = Vec::with_capacity(limit);
-    let next = bitmap.fill_candidates(*floor, tip, limit, &mut raw);
-    out.extend(raw.into_iter().map(Location::new));
-    Location::new(next)
+    Location::new(bitmap.fill_candidates(*floor, tip, limit, out))
 }
 
 /// Resolve `loc` to an op within the in-memory ancestor region

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -9,9 +9,11 @@
 //! inconsistent bytes; callers must drop invalid batches.
 
 use commonware_utils::{
-    bitmap::{self, Readable as _},
+    bitmap,
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
+#[cfg(test)]
+use commonware_utils::bitmap::Readable as _;
 
 pub(crate) struct Shared<const N: usize> {
     inner: RwLock<bitmap::Prunable<N>>,
@@ -56,33 +58,7 @@ impl<const N: usize> Shared<N> {
         limit: usize,
         out: &mut Vec<u64>,
     ) -> u64 {
-        let guard = self.read();
-        let bitmap_len = bitmap::Readable::<N>::len(&*guard);
-        let committed_end = bitmap_len.min(tip);
-
-        let mut scan = scan_from;
-        if scan < committed_end {
-            let mut ones = guard.ones_iter_from(scan);
-            while out.len() < limit {
-                match ones.next() {
-                    Some(idx) if idx < committed_end => {
-                        out.push(idx);
-                        scan = idx + 1;
-                    }
-                    _ => break,
-                }
-            }
-        }
-        while out.len() < limit {
-            let candidate = scan.max(bitmap_len);
-            if candidate >= tip {
-                scan = candidate;
-                break;
-            }
-            out.push(candidate);
-            scan = candidate + 1;
-        }
-        scan
+        fill_from(&*self.read(), scan_from, tip, limit, out)
     }
 
     /// Return the number of pruned bits. Acquires the read lock briefly.
@@ -96,6 +72,47 @@ impl<const N: usize> Shared<N> {
     pub(crate) fn get_bit(&self, loc: u64) -> bool {
         self.read().get_bit(loc)
     }
+}
+
+/// Core floor-raise scan over any [`bitmap::Readable`]: set bits in `[scan_from, min(len, tip))`
+/// ascending via one `ones_iter_from`, then locations in `[len, tip)` sequentially. Fills `out`
+/// with up to `limit` candidates and returns the next `scan_from`.
+///
+/// The bitmap is read once per chunk (through the iterator), so a `B` whose reads go through
+/// interior mutability must not be mutated for the duration of the call.
+pub(crate) fn fill_from<B: bitmap::Readable<N>, const N: usize>(
+    bitmap: &B,
+    scan_from: u64,
+    tip: u64,
+    limit: usize,
+    out: &mut Vec<u64>,
+) -> u64 {
+    let bitmap_len = bitmap.len();
+    let committed_end = bitmap_len.min(tip);
+
+    let mut scan = scan_from;
+    if scan < committed_end {
+        let mut ones = bitmap.ones_iter_from(scan);
+        while out.len() < limit {
+            match ones.next() {
+                Some(idx) if idx < committed_end => {
+                    out.push(idx);
+                    scan = idx + 1;
+                }
+                _ => break,
+            }
+        }
+    }
+    while out.len() < limit {
+        let candidate = scan.max(bitmap_len);
+        if candidate >= tip {
+            scan = candidate;
+            break;
+        }
+        out.push(candidate);
+        scan = candidate + 1;
+    }
+    scan
 }
 
 impl<const N: usize> std::fmt::Debug for Shared<N> {

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -51,12 +51,12 @@ impl<const N: usize> Shared<N> {
     /// (the test oracle): set bits in the committed prefix are returned in order via one
     /// `ones_iter_from`, then locations at or beyond the committed boundary are returned
     /// sequentially.
-    pub(crate) fn fill_candidates(
+    pub(crate) fn fill_candidates<T: From<u64>>(
         &self,
         scan_from: u64,
         tip: u64,
         limit: usize,
-        out: &mut Vec<u64>,
+        out: &mut Vec<T>,
     ) -> u64 {
         fill_from(&*self.read(), scan_from, tip, limit, out)
     }
@@ -75,17 +75,17 @@ impl<const N: usize> Shared<N> {
 }
 
 /// Core floor-raise scan over any [`bitmap::Readable`]: set bits in `[scan_from, min(len, tip))`
-/// ascending via one `ones_iter_from`, then locations in `[len, tip)` sequentially. Fills `out`
-/// with up to `limit` candidates and returns the next `scan_from`.
+/// ascending via one `ones_iter_from`, then locations in `[max(scan_from, len), tip)`
+/// sequentially. Fills `out` with up to `limit` candidates and returns the next `scan_from`.
 ///
 /// The bitmap is read once per chunk (through the iterator), so a `B` whose reads go through
 /// interior mutability must not be mutated for the duration of the call.
-pub(crate) fn fill_from<B: bitmap::Readable<N>, const N: usize>(
+pub(crate) fn fill_from<B: bitmap::Readable<N>, T: From<u64>, const N: usize>(
     bitmap: &B,
     scan_from: u64,
     tip: u64,
     limit: usize,
-    out: &mut Vec<u64>,
+    out: &mut Vec<T>,
 ) -> u64 {
     let bitmap_len = bitmap.len();
     let committed_end = bitmap_len.min(tip);
@@ -96,7 +96,7 @@ pub(crate) fn fill_from<B: bitmap::Readable<N>, const N: usize>(
         while out.len() < limit {
             match ones.next() {
                 Some(idx) if idx < committed_end => {
-                    out.push(idx);
+                    out.push(idx.into());
                     scan = idx + 1;
                 }
                 _ => break,
@@ -113,7 +113,7 @@ pub(crate) fn fill_from<B: bitmap::Readable<N>, const N: usize>(
             scan = scan.max(committed_end);
             break;
         }
-        out.push(candidate);
+        out.push(candidate.into());
         scan = candidate + 1;
     }
     scan

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -8,12 +8,12 @@
 //! Reads through an invalidated `MerkleizedBatch` (see its "Branch validity" docs) return
 //! inconsistent bytes; callers must drop invalid batches.
 
+#[cfg(test)]
+use commonware_utils::bitmap::Readable as _;
 use commonware_utils::{
     bitmap,
     sync::{RwLock, RwLockReadGuard, RwLockWriteGuard},
 };
-#[cfg(test)]
-use commonware_utils::bitmap::Readable as _;
 
 pub(crate) struct Shared<const N: usize> {
     inner: RwLock<bitmap::Prunable<N>>,
@@ -106,7 +106,11 @@ pub(crate) fn fill_from<B: bitmap::Readable<N>, const N: usize>(
     while out.len() < limit {
         let candidate = scan.max(bitmap_len);
         if candidate >= tip {
-            scan = candidate;
+            // Advance only through the span the ones scan verified clear. When `tip < len`
+            // (a layered bitmap scanned with a committed-boundary tip), bits in
+            // `[committed_end, len)` were never examined and a later call with a larger
+            // `tip` must still see them.
+            scan = scan.max(committed_end);
             break;
         }
         out.push(candidate);

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -48,28 +48,52 @@ pub(crate) struct ChunkOverlay<const N: usize> {
     pub(crate) chunks: AHashMap<usize, [u8; N]>,
     /// Total number of bits (parent + new operations).
     pub(crate) len: u64,
+    /// The parent bitmap's dimensions, captured at construction.
+    parent: Dimensions,
+}
+
+/// Parent-bitmap dimensions captured once per overlay. `chunk_mut` needs them on every newly
+/// materialized chunk, and reading each through a `Base` chain costs a lock acquisition on
+/// the shared committed bitmap, so they are read once instead of per touched chunk.
+#[derive(Clone, Copy, Debug, Default)]
+struct Dimensions {
+    len: u64,
+    complete_chunks: usize,
+    pruned_chunks: usize,
+}
+
+impl Dimensions {
+    fn of<B: bitmap::Readable<N>, const N: usize>(base: &B) -> Self {
+        Self {
+            len: base.len(),
+            complete_chunks: base.complete_chunks(),
+            pruned_chunks: base.pruned_chunks(),
+        }
+    }
 }
 
 impl<const N: usize> ChunkOverlay<N> {
     const CHUNK_BITS: u64 = bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
 
-    fn new(len: u64, capacity: usize) -> Self {
+    /// Create an overlay of `len` total bits on top of `base`. The `base` handed to later
+    /// `set_bit` / `clear_bit` / `chunk_mut` calls must be the bitmap given here.
+    fn new<B: bitmap::Readable<N>>(base: &B, len: u64, capacity: usize) -> Self {
         Self {
             chunks: AHashMap::with_capacity(capacity),
             len,
+            parent: Dimensions::of(base),
         }
     }
 
     /// Load-or-create a chunk: returns a mutable reference to the materialized chunk bytes. On
     /// first access for an existing chunk, reads from `base`.
     fn chunk_mut<B: bitmap::Readable<N>>(&mut self, base: &B, idx: usize) -> &mut [u8; N] {
+        let parent = self.parent;
         self.chunks.entry(idx).or_insert_with(|| {
-            let base_len = base.len();
-            let base_complete = base.complete_chunks();
-            let base_has_partial = !base_len.is_multiple_of(Self::CHUNK_BITS);
-            if idx < base_complete {
+            let base_has_partial = !parent.len.is_multiple_of(Self::CHUNK_BITS);
+            if idx < parent.complete_chunks {
                 base.get_chunk(idx)
-            } else if idx == base_complete && base_has_partial {
+            } else if idx == parent.complete_chunks && base_has_partial {
                 base.last_chunk().0
             } else {
                 bitmap::BitMap::<N>::EMPTY_CHUNK
@@ -85,12 +109,11 @@ impl<const N: usize> ChunkOverlay<N> {
         chunk[rel / 8] |= 1 << (rel % 8);
     }
 
-    /// Clear a single bit (used for superseded locations). `pruned_chunks` is passed in by the
-    /// caller so the hot loop in `build_chunk_overlay` reads it once rather than per call.
-    /// Skips locations in pruned chunks since those bits are already inactive.
-    fn clear_bit<B: bitmap::Readable<N>>(&mut self, base: &B, pruned_chunks: usize, loc: u64) {
+    /// Clear a single bit (used for superseded locations). Skips locations in pruned chunks
+    /// since those bits are already inactive.
+    fn clear_bit<B: bitmap::Readable<N>>(&mut self, base: &B, loc: u64) {
         let idx = bitmap::Prunable::<N>::to_chunk_index(loc);
-        if idx < pruned_chunks {
+        if idx < self.parent.pruned_chunks {
             return;
         }
         let rel = (loc % Self::CHUNK_BITS) as usize;
@@ -674,15 +697,14 @@ where
 {
     let total_bits = base.len() + batch_len as u64;
     let appended_chunks = (batch_len as u64).div_ceil(ChunkOverlay::<N>::CHUNK_BITS) as usize;
-    let mut overlay = ChunkOverlay::new(total_bits, diff.len() + appended_chunks + 1);
-    let pruned_chunks = base.pruned_chunks();
+    let mut overlay = ChunkOverlay::new(base, total_bits, diff.len() + appended_chunks + 1);
 
     // 1. CommitFloor (last op) is always active.
     let commit_loc = batch_base + batch_len as u64 - 1;
     overlay.set_bit(base, commit_loc);
 
     // 2. Inactivate previous CommitFloor.
-    overlay.clear_bit(base, pruned_chunks, batch_base - 1);
+    overlay.clear_bit(base, batch_base - 1);
 
     // 3. Set active bits + clear superseded locations from the diff. The diff is key-sorted,
     // so ancestor resolution streams (one cursor per ancestor diff).
@@ -703,14 +725,14 @@ where
             prev_loc = ancestor_entry.loc();
         }
         if let Some(old) = prev_loc {
-            overlay.clear_bit(base, pruned_chunks, *old);
+            overlay.clear_bit(base, *old);
         }
     }
 
     // Ensure all new complete chunks beyond the parent are materialized, so downstream consumers
     // don't read from the parent and panic on out-of-range indices. Uses chunk_mut to inherit the
     // parent's partial chunk data when idx == parent_complete (avoiding loss of existing bits).
-    let parent_complete = base.complete_chunks();
+    let parent_complete = overlay.parent.complete_chunks;
     let new_complete = overlay.complete_chunks();
     for idx in parent_complete..new_complete {
         overlay.chunk_mut(base, idx);
@@ -1579,9 +1601,9 @@ mod tests {
 
         // One layer: clears committed bits 3 and 6, appends 8..12 (only 9 set).
         let shared = Arc::new(Shared::new(make_bitmap(&bits)));
-        let mut overlay = ChunkOverlay::new(12, 1);
-        overlay.clear_bit(&base, 0, 3);
-        overlay.clear_bit(&base, 0, 6);
+        let mut overlay = ChunkOverlay::new(&base, 12, 1);
+        overlay.clear_bit(&base, 3);
+        overlay.clear_bit(&base, 6);
         overlay.set_bit(&base, 9);
         let one_layer = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: BitmapBatch::Base(Arc::clone(&shared)),
@@ -1591,17 +1613,17 @@ mod tests {
 
         // Two layers, mirroring `fill_candidates_filters_ancestor_clears`.
         let shared = Arc::new(Shared::new(make_bitmap(&bits)));
-        let mut overlay1 = ChunkOverlay::new(12, 2);
-        overlay1.clear_bit(&base, 0, 3);
+        let mut overlay1 = ChunkOverlay::new(&base, 12, 2);
+        overlay1.clear_bit(&base, 3);
         overlay1.set_bit(&base, 9);
         let chain1 = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: BitmapBatch::Base(Arc::clone(&shared)),
             overlay: Arc::new(overlay1),
             shared: Arc::clone(&shared),
         }));
-        let mut overlay2 = ChunkOverlay::new(14, 2);
-        overlay2.clear_bit(&chain1, 0, 6);
-        overlay2.clear_bit(&chain1, 0, 9);
+        let mut overlay2 = ChunkOverlay::new(&chain1, 14, 2);
+        overlay2.clear_bit(&chain1, 6);
+        overlay2.clear_bit(&chain1, 9);
         overlay2.set_bit(&chain1, 13);
         let two_layer = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: chain1,
@@ -1621,8 +1643,8 @@ mod tests {
         };
         let pruned_base = make_pruned();
         let shared = Arc::new(Shared::new(make_pruned()));
-        let mut overlay = ChunkOverlay::new(46, 1);
-        overlay.clear_bit(&pruned_base, 1, 38);
+        let mut overlay = ChunkOverlay::new(&pruned_base, 46, 1);
+        overlay.clear_bit(&pruned_base, 38);
         overlay.set_bit(&pruned_base, 41);
         overlay.set_bit(&pruned_base, 44);
         let pruned = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
@@ -1673,8 +1695,8 @@ mod tests {
         let shared = Arc::new(Shared::new(make_bitmap(&bits)));
 
         // Layer 1 clears committed bit 3 and appends bits 8..12 (only 9 set).
-        let mut overlay1 = ChunkOverlay::new(12, 2);
-        overlay1.clear_bit(&base, 0, 3);
+        let mut overlay1 = ChunkOverlay::new(&base, 12, 2);
+        overlay1.clear_bit(&base, 3);
         overlay1.set_bit(&base, 9);
         let chain1 = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: BitmapBatch::Base(Arc::clone(&shared)),
@@ -1684,9 +1706,9 @@ mod tests {
 
         // Layer 2 (materialized against the layer-1 view, as `build_chunk_overlay` does)
         // clears bits 6 and 9, and appends bits 12..14 (only 13 set).
-        let mut overlay2 = ChunkOverlay::new(14, 2);
-        overlay2.clear_bit(&chain1, 0, 6);
-        overlay2.clear_bit(&chain1, 0, 9);
+        let mut overlay2 = ChunkOverlay::new(&chain1, 14, 2);
+        overlay2.clear_bit(&chain1, 6);
+        overlay2.clear_bit(&chain1, 9);
         overlay2.set_bit(&chain1, 13);
         let chain2 = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: chain1.clone(),
@@ -1722,8 +1744,8 @@ mod tests {
         // Layer touches only chunk 1: clears committed bit 35 and appends bits 40..44
         // (only 41 set). Chunk 0 stays unmaterialized, so the scan must fall through to
         // the committed base there.
-        let mut overlay = ChunkOverlay::new(44, 1);
-        overlay.clear_bit(&base, 0, 35);
+        let mut overlay = ChunkOverlay::new(&base, 44, 1);
+        overlay.clear_bit(&base, 35);
         overlay.set_bit(&base, 41);
         let chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: BitmapBatch::Base(Arc::clone(&shared)),
@@ -1754,9 +1776,10 @@ mod tests {
     fn make_chain(shared: &Arc<Shared<N>>, overlay_lens: &[u64]) -> BitmapBatch<N> {
         let mut chain = BitmapBatch::Base(Arc::clone(shared));
         for &len in overlay_lens {
+            let overlay = Arc::new(ChunkOverlay::new(&chain, len, 0));
             chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
                 parent: chain,
-                overlay: Arc::new(ChunkOverlay::new(len, 0)),
+                overlay,
                 shared: Arc::clone(shared),
             }));
         }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1650,6 +1650,38 @@ mod tests {
         assert_eq!(got, want);
     }
 
+    #[test]
+    fn fill_candidates_continuation_stops_at_committed_boundary() {
+        // Committed bitmap: 8 bits with only bit 1 set. An uncommitted layer appends bits
+        // 8..14 with 9 and 13 active.
+        let mut bits = [false; 8];
+        bits[1] = true;
+        let base = make_bitmap(&bits);
+        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
+        let mut overlay = ChunkOverlay::new(14, 1);
+        overlay.set_bit(&base, 9);
+        overlay.set_bit(&base, 13);
+        let chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: BitmapBatch::Base(Arc::clone(&shared)),
+            overlay: Arc::new(overlay),
+            shared,
+        }));
+
+        // Prefetch-shaped call: `tip` is the committed boundary, below the layered length,
+        // and the committed set bits exhaust before the limit.
+        let mut got = Vec::new();
+        let next = fill_candidates(&chain, Location::new(0), 8, 16, &mut got);
+        assert_eq!(got, vec![Location::new(1)]);
+
+        // The live scan resumes from the continuation with the post-batch tip. The layer's
+        // active bits at 9 and 13 must still be emitted (false negatives are forbidden), so
+        // the continuation must not jump past the committed boundary.
+        let mut resumed = Vec::new();
+        fill_candidates(&chain, next, 16, 16, &mut resumed);
+        let want: Vec<Location> = [9, 13, 14, 15].into_iter().map(Location::new).collect();
+        assert_eq!(resumed, want);
+    }
+
     // ---- trim_committed tests ----
     //
     // `trim_committed` is called from `MerkleizedBatch::new_batch` to strip any `Layer`s whose

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -19,7 +19,7 @@ use crate::{
             operation::{Operation, update},
         },
         batch_chain::Bounds,
-        bitmap::Shared,
+        bitmap::{Shared, fill_from},
         current::{
             db::{compute_db_root, read_graft_inputs},
             grafting,
@@ -109,24 +109,16 @@ impl<const N: usize> ChunkOverlay<N> {
     }
 }
 
-/// Bitmap-accelerated floor scan for a layered `BitmapBatch` chain. Fills `out` with up to
+/// Bitmap-accelerated floor scan over a layered `BitmapBatch` chain. Fills `out` with up to
 /// `limit` floor-raise candidates in `[floor, tip)`, returning the next `floor`. Skips
-/// locations where the committed bitmap bit is unset, avoiding I/O reads for inactive
-/// operations.
+/// locations where the layered bitmap bit is unset (including locations superseded by
+/// uncommitted ancestors), avoiding I/O reads for inactive operations. Produces the same
+/// sequence as repeatedly calling the `next_candidate` test oracle over the chain.
 ///
-/// Mirrors the contract on `any::batch::fill_candidates`: may return only locations that are
-/// *possibly* active in `[floor, tip)`, may skip locations only when known inactive. The
-/// floor-raise loop revalidates each candidate, so false positives are tolerated; false
-/// negatives are forbidden.
-///
-/// Overlay `Layer`s are deliberately ignored: scanning them bit-by-bit costs a fresh chain
-/// walk and base-lock acquisition per candidate, while the terminal [`Shared`] serves the
-/// whole batch under one read guard. This can only widen the candidate set:
-/// - In the committed prefix, layers only clear bits (supersessions -- appends never land
-///   below the committed boundary), so a stale set bit read from the base is a false
-///   positive.
-/// - At or beyond the committed boundary, every location is emitted as a sequential
-///   candidate, which covers all layer appends.
+/// One scan iterator serves the whole batch: overlay chunks resolve lock-free and the
+/// committed base is locked once per untouched chunk, rather than several times per
+/// candidate. The iterator's chunk caching is sound here because bitmap mutators require
+/// `&mut` on the database, which cannot coexist with the `&db` a merkleize holds.
 pub(crate) fn fill_candidates<F: Graftable, const N: usize>(
     bitmap: &BitmapBatch<N>,
     floor: Location<F>,
@@ -135,7 +127,7 @@ pub(crate) fn fill_candidates<F: Graftable, const N: usize>(
     out: &mut Vec<Location<F>>,
 ) -> Location<F> {
     let mut raw: Vec<u64> = Vec::with_capacity(limit);
-    let next = bitmap.shared().fill_candidates(*floor, tip, limit, &mut raw);
+    let next = fill_from(bitmap, *floor, tip, limit, &mut raw);
     out.extend(raw.into_iter().map(Location::new));
     Location::new(next)
 }
@@ -1586,28 +1578,75 @@ mod tests {
     }
 
     #[test]
-    fn fill_candidates_ignores_layers() {
+    fn fill_candidates_filters_ancestor_clears() {
         let bits = [true, false, true, true, false, false, true, false];
         let base = make_bitmap(&bits);
         let shared = Arc::new(Shared::new(make_bitmap(&bits)));
-        // Layer clears committed bit 3 and appends bits 8..12 (only 9 set).
-        let mut overlay = ChunkOverlay::new(12, 2);
-        overlay.clear_bit(&base, 0, 3);
-        overlay.set_bit(&base, 9);
+
+        // Layer 1 clears committed bit 3 and appends bits 8..12 (only 9 set).
+        let mut overlay1 = ChunkOverlay::new(12, 2);
+        overlay1.clear_bit(&base, 0, 3);
+        overlay1.set_bit(&base, 9);
+        let chain1 = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: BitmapBatch::Base(Arc::clone(&shared)),
+            overlay: Arc::new(overlay1),
+            shared: Arc::clone(&shared),
+        }));
+
+        // Layer 2 (materialized against the layer-1 view, as `build_chunk_overlay` does)
+        // clears bits 6 and 9, and appends bits 12..14 (only 13 set).
+        let mut overlay2 = ChunkOverlay::new(14, 2);
+        overlay2.clear_bit(&chain1, 0, 6);
+        overlay2.clear_bit(&chain1, 0, 9);
+        overlay2.set_bit(&chain1, 13);
+        let chain2 = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: chain1.clone(),
+            overlay: Arc::new(overlay2),
+            shared,
+        }));
+
+        // Bits cleared by any layer are skipped (no wasted log reads), set bits -- committed
+        // or appended, from whichever layer materialized the chunk last -- are emitted
+        // ascending, and locations at or beyond the layered length up to `tip` are emitted
+        // sequentially.
+        let scan = |chain: &BitmapBatch<N>, tip: u64| {
+            let mut got = Vec::new();
+            fill_candidates(chain, Location::new(0), tip, 16, &mut got);
+            got
+        };
+        let want = |locs: &[u64]| locs.iter().copied().map(Location::new).collect::<Vec<_>>();
+        assert_eq!(scan(&chain1, 12), want(&[0, 2, 6, 9]));
+        assert_eq!(scan(&chain2, 14), want(&[0, 2, 13]));
+        assert_eq!(scan(&chain2, 16), want(&[0, 2, 13, 14, 15]));
+    }
+
+    #[test]
+    fn fill_candidates_mixes_overlay_and_base_chunks() {
+        // Base spans two chunks (N=4 -> 32-bit chunks): full chunk 0 plus a partial chunk 1.
+        let mut bits = [false; 40];
+        for i in [1, 30, 33, 35, 38] {
+            bits[i] = true;
+        }
+        let base = make_bitmap(&bits);
+        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
+
+        // Layer touches only chunk 1: clears committed bit 35 and appends bits 40..44
+        // (only 41 set). Chunk 0 stays unmaterialized, so the scan must fall through to
+        // the committed base there.
+        let mut overlay = ChunkOverlay::new(44, 1);
+        overlay.clear_bit(&base, 0, 35);
+        overlay.set_bit(&base, 41);
         let chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
             parent: BitmapBatch::Base(Arc::clone(&shared)),
             overlay: Arc::new(overlay),
             shared,
         }));
+
+        // Chunk 0 bits come from the base, chunk 1 bits from the overlay (35 filtered,
+        // the appended 41 emitted).
         let mut got = Vec::new();
-        fill_candidates(&chain, Location::new(0), 12, 16, &mut got);
-        // Committed set bits (0, 2, 3, 6) are all emitted -- including 3, which the layer
-        // cleared (a permitted false positive) -- then 8..12 sequentially, covering the
-        // layer's appends without per-location filtering.
-        let want: Vec<Location> = [0, 2, 3, 6, 8, 9, 10, 11]
-            .into_iter()
-            .map(Location::new)
-            .collect();
+        fill_candidates(&chain, Location::new(0), 44, 16, &mut got);
+        let want: Vec<Location> = [1, 30, 33, 38, 41].into_iter().map(Location::new).collect();
         assert_eq!(got, want);
     }
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -126,10 +126,7 @@ pub(crate) fn fill_candidates<F: Graftable, const N: usize>(
     limit: usize,
     out: &mut Vec<Location<F>>,
 ) -> Location<F> {
-    let mut raw: Vec<u64> = Vec::with_capacity(limit);
-    let next = fill_from(bitmap, *floor, tip, limit, &mut raw);
-    out.extend(raw.into_iter().map(Location::new));
-    Location::new(next)
+    Location::new(fill_from(bitmap, *floor, tip, limit, out))
 }
 
 /// Adapter that resolves ops MMR nodes for a batch's `compute_current_layer`.
@@ -1453,8 +1450,8 @@ mod tests {
     // ---- next_candidate tests ----
 
     /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in
-    /// `[floor, tip)` over a flat committed bitmap. `fill_candidates_matches_oracle` proves
-    /// the production scan produces exactly this sequence.
+    /// `[floor, tip)` over any [`bitmap::Readable`]. `fill_candidates_matches_oracle` proves
+    /// the production scan produces exactly this sequence over every chain shape.
     fn next_candidate<B: bitmap::Readable<N2>, const N2: usize>(
         bitmap: &B,
         floor: Location,
@@ -1554,25 +1551,117 @@ mod tests {
 
     #[test]
     fn fill_candidates_matches_oracle() {
-        let bits = [true, false, true, true, false, false, true, false];
-        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
-        let chain = BitmapBatch::Base(Arc::clone(&shared));
-        let oracle_bm = make_bitmap(&bits);
-        let tip = 12; // extends past the committed bitmap
-        for floor in 0..=tip {
-            let mut want = Vec::new();
-            let mut scan = Location::new(floor);
-            while let Some(c) = next_candidate(&oracle_bm, scan, tip) {
-                want.push(c);
-                scan = Location::new(*c + 1);
+        // Sequence parity plus split-resume for one (chain, tip): the scan matches
+        // single-stepping the oracle over the same chain, and any split point resumes
+        // seamlessly via the returned continuation.
+        fn assert_matches(name: &str, chain: &BitmapBatch<N>, tip: u64) {
+            for floor in 0..=tip {
+                let mut want = Vec::new();
+                let mut scan = Location::new(floor);
+                while let Some(c) = next_candidate(chain, scan, tip) {
+                    want.push(c);
+                    scan = Location::new(*c + 1);
+                }
+                for split in 0..=want.len() {
+                    let mut got = Vec::new();
+                    let next = fill_candidates(chain, Location::new(floor), tip, split, &mut got);
+                    fill_candidates(chain, next, tip, want.len() + 1, &mut got);
+                    assert_eq!(got, want, "{name} floor={floor} split={split}");
+                }
             }
-            // Any split point yields the same overall sequence: the continuation returned by
-            // the first call seamlessly resumes the second.
-            for split in 0..=want.len() {
+        }
+
+        let bits = [true, false, true, true, false, false, true, false];
+        let base = make_bitmap(&bits);
+
+        // Flat committed base.
+        let flat = BitmapBatch::Base(Arc::new(Shared::new(make_bitmap(&bits))));
+
+        // One layer: clears committed bits 3 and 6, appends 8..12 (only 9 set).
+        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
+        let mut overlay = ChunkOverlay::new(12, 1);
+        overlay.clear_bit(&base, 0, 3);
+        overlay.clear_bit(&base, 0, 6);
+        overlay.set_bit(&base, 9);
+        let one_layer = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: BitmapBatch::Base(Arc::clone(&shared)),
+            overlay: Arc::new(overlay),
+            shared,
+        }));
+
+        // Two layers, mirroring `fill_candidates_filters_ancestor_clears`.
+        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
+        let mut overlay1 = ChunkOverlay::new(12, 2);
+        overlay1.clear_bit(&base, 0, 3);
+        overlay1.set_bit(&base, 9);
+        let chain1 = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: BitmapBatch::Base(Arc::clone(&shared)),
+            overlay: Arc::new(overlay1),
+            shared: Arc::clone(&shared),
+        }));
+        let mut overlay2 = ChunkOverlay::new(14, 2);
+        overlay2.clear_bit(&chain1, 0, 6);
+        overlay2.clear_bit(&chain1, 0, 9);
+        overlay2.set_bit(&chain1, 13);
+        let two_layer = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: chain1,
+            overlay: Arc::new(overlay2),
+            shared,
+        }));
+
+        // Pruned base: 40 bits with chunk 0 pruned (33 and 38 set beyond the pruned
+        // boundary), plus a layer clearing 38 and appending 40..46 (41 and 44 set).
+        let make_pruned = || {
+            let mut bits = [false; 40];
+            bits[33] = true;
+            bits[38] = true;
+            let mut bm = make_bitmap(&bits);
+            bm.prune_to_bit(32);
+            bm
+        };
+        let pruned_base = make_pruned();
+        let shared = Arc::new(Shared::new(make_pruned()));
+        let mut overlay = ChunkOverlay::new(46, 1);
+        overlay.clear_bit(&pruned_base, 1, 38);
+        overlay.set_bit(&pruned_base, 41);
+        overlay.set_bit(&pruned_base, 44);
+        let pruned = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: BitmapBatch::Base(Arc::clone(&shared)),
+            overlay: Arc::new(overlay),
+            shared,
+        }));
+
+        for (name, chain, committed) in [
+            ("flat", flat, 8),
+            ("one-layer", one_layer, 8),
+            ("two-layer", two_layer, 8),
+            ("pruned-base", pruned, 40),
+        ] {
+            let len = bitmap::Readable::<N>::len(&chain);
+            for tip in [committed, len, len + 3] {
+                assert_matches(name, &chain, tip);
+            }
+
+            // Prefetch-then-live handoff: the prefetch is clamped to the committed
+            // boundary and the live scan resumes from the continuation with the
+            // post-batch tip. Nothing the raise must revalidate may be lost across the
+            // handoff (false negatives are forbidden): every set bit in `[floor, len)`
+            // and every location in `[len, tip)`.
+            let tip = len + 3;
+            let cap = tip as usize;
+            let pruned_bits = bitmap::Readable::<N>::pruned_bits(&chain);
+            for floor in pruned_bits..=committed {
                 let mut got = Vec::new();
-                let next = fill_candidates(&chain, Location::new(floor), tip, split, &mut got);
-                fill_candidates(&chain, next, tip, want.len() + 1, &mut got);
-                assert_eq!(got, want, "floor={floor} split={split}");
+                let next = fill_candidates(&chain, Location::new(floor), committed, cap, &mut got);
+                fill_candidates(&chain, next, tip, cap, &mut got);
+                assert!(got.is_sorted_by(|a, b| a < b), "{name} floor={floor}");
+                for loc in floor..tip {
+                    let must_emit = loc >= len || bitmap::Readable::<N>::get_bit(&chain, loc);
+                    assert!(
+                        !must_emit || got.contains(&Location::new(loc)),
+                        "{name} floor={floor} lost {loc}"
+                    );
+                }
             }
         }
     }
@@ -1648,38 +1737,6 @@ mod tests {
         fill_candidates(&chain, Location::new(0), 44, 16, &mut got);
         let want: Vec<Location> = [1, 30, 33, 38, 41].into_iter().map(Location::new).collect();
         assert_eq!(got, want);
-    }
-
-    #[test]
-    fn fill_candidates_continuation_stops_at_committed_boundary() {
-        // Committed bitmap: 8 bits with only bit 1 set. An uncommitted layer appends bits
-        // 8..14 with 9 and 13 active.
-        let mut bits = [false; 8];
-        bits[1] = true;
-        let base = make_bitmap(&bits);
-        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
-        let mut overlay = ChunkOverlay::new(14, 1);
-        overlay.set_bit(&base, 9);
-        overlay.set_bit(&base, 13);
-        let chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
-            parent: BitmapBatch::Base(Arc::clone(&shared)),
-            overlay: Arc::new(overlay),
-            shared,
-        }));
-
-        // Prefetch-shaped call: `tip` is the committed boundary, below the layered length,
-        // and the committed set bits exhaust before the limit.
-        let mut got = Vec::new();
-        let next = fill_candidates(&chain, Location::new(0), 8, 16, &mut got);
-        assert_eq!(got, vec![Location::new(1)]);
-
-        // The live scan resumes from the continuation with the post-batch tip. The layer's
-        // active bits at 9 and 13 must still be emitted (false negatives are forbidden), so
-        // the continuation must not jump past the committed boundary.
-        let mut resumed = Vec::new();
-        fill_candidates(&chain, next, 16, 16, &mut resumed);
-        let want: Vec<Location> = [9, 13, 14, 15].into_iter().map(Location::new).collect();
-        assert_eq!(resumed, want);
     }
 
     // ---- trim_committed tests ----

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -109,56 +109,35 @@ impl<const N: usize> ChunkOverlay<N> {
     }
 }
 
-/// Bitmap-accelerated floor scan over a layered `BitmapBatch` chain. Skips locations where the
-/// bitmap bit is unset, avoiding I/O reads for inactive operations.
+/// Bitmap-accelerated floor scan for a layered `BitmapBatch` chain. Fills `out` with up to
+/// `limit` floor-raise candidates in `[floor, tip)`, returning the next `floor`. Skips
+/// locations where the committed bitmap bit is unset, avoiding I/O reads for inactive
+/// operations.
 ///
 /// Mirrors the contract on `any::batch::fill_candidates`: may return only locations that are
 /// *possibly* active in `[floor, tip)`, may skip locations only when known inactive. The
 /// floor-raise loop revalidates each candidate, so false positives are tolerated; false
 /// negatives are forbidden.
 ///
-/// False positives can arise two ways:
-/// - In the committed prefix, an uncommitted ancestor batch in the chain may have superseded
-///   the location -- the committed bitmap doesn't reflect uncommitted shadows.
-/// - Beyond the committed bitmap, locations are returned as sequential candidates (one per
-///   index) without per-location filtering, so any inactive uncommitted op shows up here.
-pub(crate) fn next_candidate<F: Graftable, B: bitmap::Readable<N>, const N: usize>(
-    bitmap: &B,
-    floor: Location<F>,
-    tip: u64,
-) -> Option<Location<F>> {
-    let floor = *floor;
-    let bitmap_len = bitmap.len();
-    let committed_end = bitmap_len.min(tip);
-    if floor < committed_end
-        && let Some(idx) = bitmap.ones_iter_from(floor).next()
-        && idx < committed_end
-    {
-        return Some(Location::<F>::new(idx));
-    }
-    let candidate = floor.max(bitmap_len);
-    (candidate < tip).then(|| Location::<F>::new(candidate))
-}
-
-/// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` over the layered
-/// `BitmapBatch` chain, returning the next `floor`. Produces the same sequence as repeatedly
-/// calling [`next_candidate`].
-pub(crate) fn fill_candidates<F: Graftable, B: bitmap::Readable<N>, const N: usize>(
-    bitmap: &B,
+/// Overlay `Layer`s are deliberately ignored: scanning them bit-by-bit costs a fresh chain
+/// walk and base-lock acquisition per candidate, while the terminal [`Shared`] serves the
+/// whole batch under one read guard. This can only widen the candidate set:
+/// - In the committed prefix, layers only clear bits (supersessions -- appends never land
+///   below the committed boundary), so a stale set bit read from the base is a false
+///   positive.
+/// - At or beyond the committed boundary, every location is emitted as a sequential
+///   candidate, which covers all layer appends.
+pub(crate) fn fill_candidates<F: Graftable, const N: usize>(
+    bitmap: &BitmapBatch<N>,
     floor: Location<F>,
     tip: u64,
     limit: usize,
     out: &mut Vec<Location<F>>,
 ) -> Location<F> {
-    let mut scan = floor;
-    while out.len() < limit {
-        let Some(candidate) = next_candidate(bitmap, scan, tip) else {
-            break;
-        };
-        out.push(candidate);
-        scan = Location::<F>::new(*candidate + 1);
-    }
-    scan
+    let mut raw: Vec<u64> = Vec::with_capacity(limit);
+    let next = bitmap.shared().fill_candidates(*floor, tip, limit, &mut raw);
+    out.extend(raw.into_iter().map(Location::new));
+    Location::new(next)
 }
 
 /// Adapter that resolves ops MMR nodes for a batch's `compute_current_layer`.
@@ -1481,6 +1460,27 @@ mod tests {
 
     // ---- next_candidate tests ----
 
+    /// Single-step oracle for [`fill_candidates`]: return the next floor-raise candidate in
+    /// `[floor, tip)` over a flat committed bitmap. `fill_candidates_matches_oracle` proves
+    /// the production scan produces exactly this sequence.
+    fn next_candidate<B: bitmap::Readable<N2>, const N2: usize>(
+        bitmap: &B,
+        floor: Location,
+        tip: u64,
+    ) -> Option<Location> {
+        let floor = *floor;
+        let bitmap_len = bitmap.len();
+        let committed_end = bitmap_len.min(tip);
+        if floor < committed_end
+            && let Some(idx) = bitmap.ones_iter_from(floor).next()
+            && idx < committed_end
+        {
+            return Some(Location::new(idx));
+        }
+        let candidate = floor.max(bitmap_len);
+        (candidate < tip).then(|| Location::new(candidate))
+    }
+
     #[test]
     fn bitmap_scan_all_active() {
         let bm = make_bitmap(&[true; 8]);
@@ -1558,6 +1558,57 @@ mod tests {
         );
         // Empty bitmap, tip = 0: no candidates.
         assert_eq!(next_candidate(&bm, Location::new(0), 0), None);
+    }
+
+    #[test]
+    fn fill_candidates_matches_oracle() {
+        let bits = [true, false, true, true, false, false, true, false];
+        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
+        let chain = BitmapBatch::Base(Arc::clone(&shared));
+        let oracle_bm = make_bitmap(&bits);
+        let tip = 12; // extends past the committed bitmap
+        for floor in 0..=tip {
+            let mut want = Vec::new();
+            let mut scan = Location::new(floor);
+            while let Some(c) = next_candidate(&oracle_bm, scan, tip) {
+                want.push(c);
+                scan = Location::new(*c + 1);
+            }
+            // Any split point yields the same overall sequence: the continuation returned by
+            // the first call seamlessly resumes the second.
+            for split in 0..=want.len() {
+                let mut got = Vec::new();
+                let next = fill_candidates(&chain, Location::new(floor), tip, split, &mut got);
+                fill_candidates(&chain, next, tip, want.len() + 1, &mut got);
+                assert_eq!(got, want, "floor={floor} split={split}");
+            }
+        }
+    }
+
+    #[test]
+    fn fill_candidates_ignores_layers() {
+        let bits = [true, false, true, true, false, false, true, false];
+        let base = make_bitmap(&bits);
+        let shared = Arc::new(Shared::new(make_bitmap(&bits)));
+        // Layer clears committed bit 3 and appends bits 8..12 (only 9 set).
+        let mut overlay = ChunkOverlay::new(12, 2);
+        overlay.clear_bit(&base, 0, 3);
+        overlay.set_bit(&base, 9);
+        let chain = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+            parent: BitmapBatch::Base(Arc::clone(&shared)),
+            overlay: Arc::new(overlay),
+            shared,
+        }));
+        let mut got = Vec::new();
+        fill_candidates(&chain, Location::new(0), 12, 16, &mut got);
+        // Committed set bits (0, 2, 3, 6) are all emitted -- including 3, which the layer
+        // cleared (a permitted false positive) -- then 8..12 sequentially, covering the
+        // layer's appends without per-location filtering.
+        let want: Vec<Location> = [0, 2, 3, 6, 8, 9, 10, 11]
+            .into_iter()
+            .map(Location::new)
+            .collect();
+        assert_eq!(got, want);
     }
 
     // ---- trim_committed tests ----


### PR DESCRIPTION
## Problem

The floor raise consumes ~`total_steps` ascending candidates from the activity bitmap per merkleize. The `any` variant gathers them with one read guard and one `OnesIter` (`Shared::fill_candidates`). The `current` variant instead looped a single-step helper over its layered `BitmapBatch` chain: every candidate constructed a fresh `OnesIter`, and construction is the expensive part — at the common depth (a `Base` chain) it costs four read-lock acquisitions on the shared committed bitmap (`len` twice, `pruned_chunks`, `get_chunk`) plus a chunk copy, exactly the setup the iterator exists to amortize. Consecutive candidates usually share a 256-bit chunk, so the same chunk was re-locked and re-copied many times.

## Change

`current::batch::fill_candidates` now delegates to the terminal `Shared::fill_candidates` at the bottom of the chain — one guard, one iterator, same as `any`.

Overlay `Layer`s are deliberately ignored, which is contract-safe because it can only widen the candidate set (false positives are permitted and revalidated by the raise; false negatives are forbidden):

- In the committed prefix, layers only **clear** bits — `build_chunk_overlay` sets bits solely at locations `>= batch_base`, so appends never land below the committed boundary. A stale set bit read from the base is a false positive the raise already filters via `superseded_locs`.
- At or beyond the committed boundary, every location is emitted as a sequential candidate, covering all layer appends.

At depth 0 the candidate sequence is bit-for-bit identical to before (the constantinople bench produces identical roots per iteration). With uncommitted ancestor batches, ancestor-superseded locations are now emitted and revalidated instead of pre-filtered — the same trade `any` makes, since its bitmap never reflects uncommitted batches either.

The single-step `next_candidate` moves into `mod tests` as the oracle, mirroring `any`. New tests: `fill_candidates_matches_oracle` (sequence parity plus seamless resume at every split point) and `fill_candidates_ignores_layers` (cleared committed bit still emitted; layer appends emitted sequentially).

## Results

`cargo bench --bench constantinople` (depth 0, 1M keys, 32,768 updates), back-to-back A/B:

| | baseline p50 | fixed p50 |
|---|---|---|
| `current::unordered::fixed::mmb` | 9.61 ms | 8.95 ms (−7%) |
| `current::ordered::fixed::mmb` | 11.89 ms | 11.05 ms (−7%) |
