### PR TITLE
[consensus/simplex] Simplify Resolver Usage

### DIFF
--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -19,14 +19,18 @@ use commonware_cryptography::Digest;
 use commonware_macros::select_loop;
 use commonware_p2p::{Blocker, Receiver, Sender, utils::StaticProvider};
 use commonware_parallel::Strategy;
-use commonware_resolver::{Fetch, Resolver as _, p2p};
+use commonware_resolver::{Fetch, Resolver, p2p};
 use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, spawn_cell,
     telemetry::traces::TracedExt as _,
 };
-use commonware_utils::{channel::fallible::OneshotExt, ordered::Quorum, sequence::U64};
+use commonware_utils::{
+    channel::{fallible::OneshotExt, oneshot},
+    ordered::Quorum,
+    sequence::U64,
+};
 use rand_core::CryptoRng;
-use std::{num::NonZeroUsize, time::Duration};
+use std::{collections::BTreeMap, num::NonZeroUsize, time::Duration};
 use tracing::{debug, info_span};
 
 /// Requests are made concurrently to multiple peers.
@@ -47,6 +51,12 @@ pub struct Actor<
     fetch_timeout: Duration,
 
     state: State<S, D>,
+
+    /// Responses to notarization deliveries, keyed by notarization view and
+    /// answered with the view's certification verdict (see [Self::certified])
+    /// or accepted when a floor raise makes them obsolete (see
+    /// [Self::apply_effects]).
+    held: BTreeMap<View, Vec<oneshot::Sender<bool>>>,
 
     mailbox_receiver: mailbox::Receiver<MailboxMessage<S, D>>,
 }
@@ -73,6 +83,8 @@ impl<
                 fetch_timeout: cfg.fetch_timeout,
 
                 state: State::new(cfg.fetch_concurrent),
+
+                held: BTreeMap::new(),
 
                 mailbox_receiver: receiver,
             },
@@ -143,13 +155,11 @@ impl<
                 let _guard = span.entered();
                 match message {
                     MailboxMessage::Certificate { certificate, .. } => {
-                        // Certificates from mailbox have no associated request view
-                        let effects = self.state.handle(certificate, None);
+                        let effects = self.state.handle(certificate);
                         self.apply_effects(&mut resolver, effects);
                     }
                     MailboxMessage::Certified { round, success, .. } => {
-                        let effects = self.state.handle_certified(round.view(), success);
-                        self.apply_effects(&mut resolver, effects);
+                        self.certified(&mut resolver, round.view(), success);
                     }
                 }
             },
@@ -162,10 +172,36 @@ impl<
         }
     }
 
-    /// Applies the side effects requested by [super::state::State] to the resolver.
-    fn apply_effects(
+    /// Handles a certification outcome from the voter.
+    ///
+    /// Responses held for the view's notarization deliveries are answered
+    /// with the verdict. Success completes those fetches. Failure blocks the
+    /// peers that served the uncertifiable notarization and the resolver
+    /// retries the still-pending requests, mirroring how [Self::validate]
+    /// treats peers that serve a notarization for a view already marked
+    /// failed. No copy of that notarization can certify anywhere, so the
+    /// view cannot finalize and honest participants nullify it: the retried
+    /// request is eventually answered by that covering nullification (or by
+    /// a certificate at a higher view).
+    fn certified<R: Resolver<Key = U64, Subscriber = ()>>(
         &mut self,
-        resolver: &mut p2p::Mailbox<U64, S::PublicKey>,
+        resolver: &mut R,
+        view: View,
+        success: bool,
+    ) {
+        if let Some(responses) = self.held.remove(&view) {
+            for response in responses {
+                response.send_lossy(success);
+            }
+        }
+        let effects = self.state.handle_certified(view, success);
+        self.apply_effects(resolver, effects);
+    }
+
+    /// Applies the side effects requested by [super::state::State] to the resolver.
+    fn apply_effects<R: Resolver<Key = U64, Subscriber = ()>>(
+        &mut self,
+        resolver: &mut R,
         effects: Vec<Effect>,
     ) {
         for effect in effects {
@@ -180,6 +216,17 @@ impl<
                     let _ = resolver.retain(move |candidate, _| *candidate != key);
                 }
                 Effect::RetainAbove(floor) => {
+                    // A certification at or below the floor may be aborted
+                    // rather than reported, so a response held for it would
+                    // wait forever. The requests it answered are obsolete
+                    // (retained out below): accept them so their fetches
+                    // complete without blocking the serving peers.
+                    let retained = self.held.split_off(&floor.next());
+                    for (_, responses) in std::mem::replace(&mut self.held, retained) {
+                        for response in responses {
+                            response.send_lossy(true);
+                        }
+                    }
                     let floor = U64::from(floor);
                     let _ = resolver.retain(move |candidate, _| *candidate > floor);
                 }
@@ -189,9 +236,9 @@ impl<
 
     /// Issues a resolver fetch for `view`, attaching a span that records why the
     /// fetch was needed and which view's processing caused it.
-    fn fetch(
+    fn fetch<R: Resolver<Key = U64, Subscriber = ()>>(
         &self,
-        resolver: &mut p2p::Mailbox<U64, S::PublicKey>,
+        resolver: &mut R,
         view: View,
         cause: View,
         reason: FetchReason,
@@ -294,11 +341,11 @@ impl<
     }
 
     /// Handles a message from the [p2p::Engine].
-    fn handle_resolver(
+    fn handle_resolver<R: Resolver<Key = U64, Subscriber = ()>>(
         &mut self,
         message: HandlerMessage,
         voter: &mut voter::Mailbox<S, D>,
-        resolver: &mut p2p::Mailbox<U64, S::PublicKey>,
+        resolver: &mut R,
     ) {
         match message {
             HandlerMessage::Deliver {
@@ -327,7 +374,22 @@ impl<
                     response.send_lossy(false);
                     return;
                 };
-                response.send_lossy(true);
+
+                // A notarization only answers the request if its proposal
+                // certifies, so hold the response and answer it with the
+                // certification verdict (see [Self::certified]). Other
+                // certificates are complete answers on their own.
+                match &parsed {
+                    Certificate::Notarization(notarization) => {
+                        self.held
+                            .entry(notarization.view())
+                            .or_default()
+                            .push(response);
+                    }
+                    Certificate::Finalization(_) | Certificate::Nullification(_) => {
+                        response.send_lossy(true);
+                    }
+                }
 
                 // Notify voter as soon as possible
                 let resolved = info_span!(
@@ -338,8 +400,7 @@ impl<
                 );
                 resolved.in_scope(|| voter.resolved(parsed.clone()));
 
-                // Process message with the request view for tracking
-                let effects = self.state.handle(parsed, Some(view));
+                let effects = self.state.handle(parsed);
                 self.apply_effects(resolver, effects);
             }
             HandlerMessage::Produce { view, response } => {
@@ -360,5 +421,241 @@ impl<
                 response.send_lossy(certificate.encode());
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::test_helpers::*, *};
+    use crate::simplex::scheme::ed25519;
+    use commonware_actor::Feedback;
+    use commonware_cryptography::{
+        certificate::mocks::Fixture, ed25519::PublicKey, sha256::Digest as Sha256Digest,
+    };
+    use commonware_macros::test_async;
+    use commonware_parallel::Sequential;
+    use commonware_runtime::{Runner, Supervisor, deterministic};
+    use commonware_utils::{NZUsize, sync::Mutex};
+    use std::{collections::BTreeSet, sync::Arc};
+
+    const NAMESPACE: &[u8] = b"resolver-actor";
+    const EPOCH: Epoch = Epoch::new(9);
+
+    type TestScheme = ed25519::Scheme;
+    type TestActor =
+        Actor<deterministic::Context, TestScheme, NoopBlocker, Sha256Digest, Sequential>;
+
+    #[derive(Clone, Default)]
+    struct NoopBlocker;
+
+    impl Blocker for NoopBlocker {
+        type PublicKey = PublicKey;
+
+        fn block(&mut self, _peer: Self::PublicKey) -> Feedback {
+            Feedback::Ok
+        }
+    }
+
+    /// Tracks the set of pending requests the way the resolver engine would.
+    #[derive(Clone, Default)]
+    struct RecordingResolver {
+        outstanding: Arc<Mutex<BTreeSet<U64>>>,
+    }
+
+    impl RecordingResolver {
+        fn outstanding(&self) -> Vec<u64> {
+            self.outstanding.lock().iter().map(u64::from).collect()
+        }
+    }
+
+    impl Resolver for RecordingResolver {
+        type Key = U64;
+        type Subscriber = ();
+
+        fn fetch<F>(&mut self, key: F) -> Feedback
+        where
+            F: Into<Fetch<U64, ()>> + Send,
+        {
+            self.outstanding.lock().insert(key.into().key);
+            Feedback::Ok
+        }
+
+        fn fetch_all<F>(&mut self, keys: Vec<F>) -> Feedback
+        where
+            F: Into<Fetch<U64, ()>> + Send,
+        {
+            for key in keys {
+                self.fetch(key);
+            }
+            Feedback::Ok
+        }
+
+        fn retain(&mut self, predicate: impl Fn(&U64, &()) -> bool + Send + 'static) -> Feedback {
+            self.outstanding.lock().retain(|key| predicate(key, &()));
+            Feedback::Ok
+        }
+    }
+
+    fn build_actor(context: deterministic::Context, scheme: TestScheme) -> TestActor {
+        let (actor, _) = Actor::new(
+            context,
+            Config {
+                scheme,
+                blocker: NoopBlocker,
+                strategy: Sequential,
+                epoch: EPOCH,
+                mailbox_size: NZUsize!(8),
+                fetch_concurrent: NZUsize!(4),
+                fetch_timeout: Duration::from_secs(1),
+            },
+        );
+        actor
+    }
+
+    #[test_async]
+    async fn apply_effects_maintains_resolver_pending_set() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let mut actor = build_actor(context, verifier.clone());
+            let mut resolver = RecordingResolver::default();
+
+            // The first certificate opens the fetch window below it.
+            let nullification = build_nullification(&schemes, &verifier, EPOCH, View::new(5));
+            let effects = actor
+                .state
+                .handle(Certificate::Nullification(nullification));
+            actor.apply_effects(&mut resolver, effects);
+            assert_eq!(resolver.outstanding(), vec![1, 2, 3, 4]);
+
+            // A nullification removes exactly its own request.
+            let nullification = build_nullification(&schemes, &verifier, EPOCH, View::new(2));
+            let effects = actor
+                .state
+                .handle(Certificate::Nullification(nullification));
+            actor.apply_effects(&mut resolver, effects);
+            assert_eq!(resolver.outstanding(), vec![1, 3, 4]);
+
+            // A floor raise drops the requests at and below it.
+            let finalization = build_finalization(&schemes, &verifier, EPOCH, View::new(3));
+            let effects = actor.state.handle(Certificate::Finalization(finalization));
+            actor.apply_effects(&mut resolver, effects);
+            assert_eq!(resolver.outstanding(), vec![4]);
+
+            // The request at the floor view itself must not survive.
+            let finalization = build_finalization(&schemes, &verifier, EPOCH, View::new(4));
+            let effects = actor.state.handle(Certificate::Finalization(finalization));
+            actor.apply_effects(&mut resolver, effects);
+            assert!(resolver.outstanding().is_empty());
+        });
+    }
+
+    #[test_async]
+    async fn notarization_response_answered_with_certification_verdict() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
+            let mut voter = voter::Mailbox::new(voter_tx);
+            let mut actor = build_actor(context, verifier.clone());
+            let mut resolver = RecordingResolver::default();
+
+            // The response to a notarization delivery is withheld until the
+            // voter reports the certification outcome.
+            let notarization = build_notarization(&schemes, &verifier, EPOCH, View::new(6));
+            let (response, receiver) = oneshot::channel();
+            actor.handle_resolver(
+                HandlerMessage::Deliver {
+                    span: tracing::Span::none(),
+                    view: View::new(6),
+                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
+                        .encode(),
+                    response,
+                },
+                &mut voter,
+                &mut resolver,
+            );
+            assert!(actor.held.contains_key(&View::new(6)));
+
+            // A failed certification rejects the response, so the resolver
+            // blocks the serving peer and retries the request itself.
+            actor.certified(&mut resolver, View::new(6), false);
+            assert!(actor.held.is_empty());
+            assert!(!receiver.await.unwrap());
+        });
+    }
+
+    #[test_async]
+    async fn certified_notarization_response_accepted() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
+            let mut voter = voter::Mailbox::new(voter_tx);
+            let mut actor = build_actor(context, verifier.clone());
+            let mut resolver = RecordingResolver::default();
+
+            let notarization = build_notarization(&schemes, &verifier, EPOCH, View::new(6));
+            let (response, receiver) = oneshot::channel();
+            actor.handle_resolver(
+                HandlerMessage::Deliver {
+                    span: tracing::Span::none(),
+                    view: View::new(6),
+                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
+                        .encode(),
+                    response,
+                },
+                &mut voter,
+                &mut resolver,
+            );
+
+            actor.certified(&mut resolver, View::new(6), true);
+            assert!(actor.held.is_empty());
+            assert!(receiver.await.unwrap());
+        });
+    }
+
+    #[test_async]
+    async fn held_responses_accepted_when_floor_passes_them() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
+            let mut voter = voter::Mailbox::new(voter_tx);
+            let mut actor = build_actor(context, verifier.clone());
+            let mut resolver = RecordingResolver::default();
+
+            let notarization = build_notarization(&schemes, &verifier, EPOCH, View::new(6));
+            let (response, receiver) = oneshot::channel();
+            actor.handle_resolver(
+                HandlerMessage::Deliver {
+                    span: tracing::Span::none(),
+                    view: View::new(6),
+                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
+                        .encode(),
+                    response,
+                },
+                &mut voter,
+                &mut resolver,
+            );
+            assert!(actor.held.contains_key(&View::new(6)));
+
+            // A floor raise past the notarization may abort its certification
+            // without a report, so the held response is accepted (the request
+            // it answered is retained out in the same batch).
+            let finalization = build_finalization(&schemes, &verifier, EPOCH, View::new(8));
+            let effects = actor.state.handle(Certificate::Finalization(finalization));
+            actor.apply_effects(&mut resolver, effects);
+            assert!(actor.held.is_empty());
+            assert!(receiver.await.unwrap());
+        });
     }
 }

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -59,6 +59,15 @@ pub struct Actor<
     /// answered with the view's certification verdict (see [Self::certified])
     /// or accepted when a floor raise makes them obsolete (see
     /// [Self::apply_effects]).
+    ///
+    /// A view maps to multiple responses when copies of its notarization
+    /// answer several outstanding requests, which is common when lagging:
+    /// peers serve their floor certificate for any request at or below it,
+    /// so one verdict resolves every request that notarization answered.
+    /// A single request can never hold two responses under one view: the
+    /// engine delivers at most one response per key at a time, and a key is
+    /// only redelivered after a failure verdict, which marks the view failed
+    /// and makes [Self::validate] reject further copies of its notarization.
     held: BTreeMap<View, Vec<oneshot::Sender<bool>>>,
 
     mailbox_receiver: mailbox::Receiver<MailboxMessage<S, D>>,
@@ -402,6 +411,8 @@ impl<
                 );
                 resolved.in_scope(|| voter.resolved(parsed.clone()));
 
+                // Recording the notarization makes it a floor candidate, so the
+                // certification verdict (see [Self::certified]) can act on it.
                 let effects = self.state.handle(parsed);
                 self.apply_effects(resolver, effects);
             }

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -50,6 +50,9 @@ pub struct Actor<
     mailbox_size: NonZeroUsize,
     fetch_timeout: Duration,
 
+    /// Certificates known between the floor and the current view. Serves
+    /// [HandlerMessage::Produce] requests and emits the [Effect]s the actor
+    /// applies to the resolver (see [Self::apply_effects]).
     state: State<S, D>,
 
     /// Responses to notarization deliveries, keyed by notarization view and
@@ -173,22 +176,21 @@ impl<
     }
 
     /// Handles a certification outcome from the voter.
-    ///
-    /// Responses held for the view's notarization deliveries are answered
-    /// with the verdict. Success completes those fetches. Failure blocks the
-    /// peers that served the uncertifiable notarization and the resolver
-    /// retries the still-pending requests, mirroring how [Self::validate]
-    /// treats peers that serve a notarization for a view already marked
-    /// failed. No copy of that notarization can certify anywhere, so the
-    /// view cannot finalize and honest participants nullify it: the retried
-    /// request is eventually answered by that covering nullification (or by
-    /// a certificate at a higher view).
     fn certified<R: Resolver<Key = U64, Subscriber = ()>>(
         &mut self,
         resolver: &mut R,
         view: View,
         success: bool,
     ) {
+        // Answer the responses held for the view's notarization deliveries.
+        // Success completes those fetches. Failure blocks the peers that
+        // served the uncertifiable notarization and the resolver retries the
+        // still-pending requests, mirroring how [Self::validate] treats peers
+        // that serve a notarization for a view already marked failed. No copy
+        // of that notarization can certify anywhere, so the view cannot
+        // finalize and honest participants nullify it: the retried request is
+        // eventually answered by that covering nullification (or by a
+        // certificate at a higher view).
         if let Some(responses) = self.held.remove(&view) {
             for response in responses {
                 response.send_lossy(success);

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -25,3 +25,71 @@ pub struct Config<S: Scheme, B: Blocker, T: Strategy> {
     pub fetch_concurrent: NonZeroUsize,
     pub fetch_timeout: Duration,
 }
+
+/// Certificate builders shared by the resolver test modules.
+#[cfg(test)]
+mod test_helpers {
+    use crate::{
+        simplex::{
+            scheme::ed25519,
+            types::{
+                Finalization, Finalize, Notarization, Notarize, Nullification, Nullify, Proposal,
+            },
+        },
+        types::{Epoch, Round, View},
+    };
+    use commonware_cryptography::sha256::Digest as Sha256Digest;
+    use commonware_parallel::Sequential;
+
+    type TestScheme = ed25519::Scheme;
+
+    pub(super) fn build_nullification(
+        schemes: &[TestScheme],
+        verifier: &TestScheme,
+        epoch: Epoch,
+        view: View,
+    ) -> Nullification<TestScheme> {
+        let round = Round::new(epoch, view);
+        let votes: Vec<_> = schemes
+            .iter()
+            .map(|scheme| Nullify::sign::<Sha256Digest>(scheme, round).unwrap())
+            .collect();
+        Nullification::from_nullifies(verifier, &votes, &Sequential).expect("nullification quorum")
+    }
+
+    pub(super) fn build_notarization(
+        schemes: &[TestScheme],
+        verifier: &TestScheme,
+        epoch: Epoch,
+        view: View,
+    ) -> Notarization<TestScheme, Sha256Digest> {
+        let proposal = Proposal::new(
+            Round::new(epoch, view),
+            view.previous().unwrap_or(View::zero()),
+            Sha256Digest::from([view.get() as u8; 32]),
+        );
+        let votes: Vec<_> = schemes
+            .iter()
+            .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
+            .collect();
+        Notarization::from_notarizes(verifier, &votes, &Sequential).expect("notarization quorum")
+    }
+
+    pub(super) fn build_finalization(
+        schemes: &[TestScheme],
+        verifier: &TestScheme,
+        epoch: Epoch,
+        view: View,
+    ) -> Finalization<TestScheme, Sha256Digest> {
+        let proposal = Proposal::new(
+            Round::new(epoch, view),
+            view.previous().unwrap_or(View::zero()),
+            Sha256Digest::from([view.get() as u8; 32]),
+        );
+        let votes: Vec<_> = schemes
+            .iter()
+            .map(|scheme| Finalize::sign(scheme, proposal.clone()).unwrap())
+            .collect();
+        Finalization::from_finalizes(verifier, &votes, &Sequential).expect("finalization quorum")
+    }
+}

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -394,6 +394,7 @@ mod tests {
         let (schemes, verifier) = ed25519_fixture();
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(10));
 
+        // Handling a notarization requests the missing nullifications below it
         let notarization_v5 = build_notarization(&schemes, &verifier, EPOCH, View::new(5));
         let effects = state.handle(Certificate::Notarization(notarization_v5));
         assert_eq!(
@@ -407,8 +408,11 @@ mod tests {
         );
         assert!(!state.is_failed(View::new(5)));
 
+        // Certification fails for view 5
         let effects = state.handle_certified(View::new(5), false);
 
+        // View 5 is marked failed and only the failed view is re-requested: the
+        // requests its notarization answered are retried by the resolver engine
         assert!(state.is_failed(View::new(5)));
         assert_eq!(effects, vec![fetch(5, 5, FetchReason::CertificationFailed)]);
     }
@@ -418,6 +422,7 @@ mod tests {
         let (schemes, verifier) = ed25519_fixture();
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(10));
 
+        // Handling a notarization requests the missing nullifications below it
         let notarization_v5 = build_notarization(&schemes, &verifier, EPOCH, View::new(5));
         let effects = state.handle(Certificate::Notarization(notarization_v5.clone()));
         assert_eq!(
@@ -430,8 +435,10 @@ mod tests {
             ]
         );
 
+        // Certification succeeds for view 5
         let effects = state.handle_certified(View::new(5), true);
 
+        // The certified notarization becomes the floor and view 5 is not marked failed
         assert!(
             matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v5)
         );

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use commonware_cryptography::{Digest, certificate::Scheme};
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, HashSet},
     num::NonZeroUsize,
 };
 
@@ -14,7 +14,6 @@ use std::{
 pub(crate) enum FetchReason {
     MissingNullification,
     CertificationFailed,
-    SatisfiedByFailedNotarization,
 }
 
 impl FetchReason {
@@ -23,7 +22,6 @@ impl FetchReason {
         match self {
             Self::MissingNullification => "missing_nullification",
             Self::CertificationFailed => "certification_failed",
-            Self::SatisfiedByFailedNotarization => "satisfied_by_failed_notarization",
         }
     }
 }
@@ -62,10 +60,6 @@ pub struct State<S: Scheme, D: Digest> {
     /// Next view to consider when fetching. Avoids re-scanning
     /// views we've already requested or have nullifications for.
     fetch_floor: View,
-    /// Maps notarization view -> request views it satisfied.
-    /// When a higher-view notarization satisfies a lower-view request,
-    /// we track it here so we can re-request on certification failure.
-    satisfied_by: HashMap<View, BTreeSet<View>>,
     /// Views where certification has failed. Only nullifications
     /// are accepted for these views.
     failed_views: HashSet<View>,
@@ -81,7 +75,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
             nullifications: BTreeMap::new(),
             fetch_concurrent: fetch_concurrent.get(),
             fetch_floor: View::zero(),
-            satisfied_by: HashMap::new(),
             failed_views: HashSet::new(),
         }
     }
@@ -92,12 +85,7 @@ impl<S: Scheme, D: Digest> State<S, D> {
     }
 
     /// Handle a new certificate and return any effects the resolver actor should apply.
-    ///
-    /// The `request` parameter is the view that was originally requested
-    /// when this certificate was fetched. If the certificate is a notarization
-    /// at a higher view, we track that the request was "satisfied by" this
-    /// notarization so we can re-request on certification failure.
-    pub fn handle(&mut self, certificate: Certificate<S, D>, request: Option<View>) -> Vec<Effect> {
+    pub fn handle(&mut self, certificate: Certificate<S, D>) -> Vec<Effect> {
         let cause = certificate.view();
         let mut effects = Vec::new();
         match certificate {
@@ -114,9 +102,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
                 let view = notarization.view();
                 if self.encounter_view(view) {
                     self.notarizations.insert(view, notarization);
-                    if let Some(request) = request {
-                        self.satisfied_by.entry(view).or_default().insert(request);
-                    }
                 }
             }
             Certificate::Finalization(finalization) => {
@@ -134,6 +119,10 @@ impl<S: Scheme, D: Digest> State<S, D> {
     }
 
     /// Handle a certification result from the voter.
+    ///
+    /// A failure does not re-request the views the failed notarization was
+    /// fetched for: the actor answers their responses with the certification
+    /// verdict, so the resolver engine retries those requests itself.
     pub fn handle_certified(&mut self, view: View, success: bool) -> Vec<Effect> {
         let mut effects = Vec::new();
         if success {
@@ -147,9 +136,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
                 self.floor = Some(Certificate::Notarization(notarization));
                 effects.push(self.prune());
             }
-
-            // Clean up satisfaction tracking
-            self.satisfied_by.remove(&view);
         } else {
             // Discard notarization and mark view as failed (ensures we can penalize
             // malicious peers that hand us useless notarizations)
@@ -164,17 +150,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
                     cause: view,
                     reason: FetchReason::CertificationFailed,
                 });
-            }
-
-            // Re-request any lower views this notarization had satisfied
-            if let Some(satisfied_views) = self.satisfied_by.remove(&view) {
-                for &v in satisfied_views.iter().filter(|v| **v > floor) {
-                    effects.push(Effect::Fetch {
-                        view: v,
-                        cause: view,
-                        reason: FetchReason::SatisfiedByFailedNotarization,
-                    });
-                }
             }
         }
         effects
@@ -251,7 +226,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
         let floor = self.floor_view();
         self.notarizations.retain(|view, _| *view > floor);
         self.nullifications.retain(|view, _| *view > floor);
-        self.satisfied_by.retain(|view, _| *view > floor);
         self.failed_views.retain(|view| *view > floor);
         Effect::RetainAbove(floor)
     }
@@ -259,18 +233,9 @@ impl<S: Scheme, D: Digest> State<S, D> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::{
-        simplex::{
-            scheme::ed25519,
-            types::{
-                Finalization, Finalize, Notarization, Notarize, Nullification, Nullify, Proposal,
-            },
-        },
-        types::{Epoch, Round, View},
-    };
+    use super::{super::test_helpers::*, *};
+    use crate::{simplex::scheme::ed25519, types::Epoch};
     use commonware_cryptography::{certificate::mocks::Fixture, sha256::Digest as Sha256Digest};
-    use commonware_parallel::Sequential;
     use commonware_utils::{NZUsize, test_rng};
 
     const NAMESPACE: &[u8] = b"resolver-state";
@@ -286,53 +251,6 @@ mod tests {
         (schemes, verifier)
     }
 
-    fn build_nullification(
-        schemes: &[TestScheme],
-        verifier: &TestScheme,
-        view: View,
-    ) -> Nullification<TestScheme> {
-        let round = Round::new(EPOCH, view);
-        let votes: Vec<_> = schemes
-            .iter()
-            .map(|scheme| Nullify::sign::<Sha256Digest>(scheme, round).unwrap())
-            .collect();
-        Nullification::from_nullifies(verifier, &votes, &Sequential).expect("nullification quorum")
-    }
-
-    fn build_notarization(
-        schemes: &[TestScheme],
-        verifier: &TestScheme,
-        view: View,
-    ) -> Notarization<TestScheme, Sha256Digest> {
-        let proposal = Proposal::new(
-            Round::new(EPOCH, view),
-            view.previous().unwrap_or(View::zero()),
-            Sha256Digest::from([view.get() as u8; 32]),
-        );
-        let votes: Vec<_> = schemes
-            .iter()
-            .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
-            .collect();
-        Notarization::from_notarizes(verifier, &votes, &Sequential).expect("notarization quorum")
-    }
-
-    fn build_finalization(
-        schemes: &[TestScheme],
-        verifier: &TestScheme,
-        view: View,
-    ) -> Finalization<TestScheme, Sha256Digest> {
-        let proposal = Proposal::new(
-            Round::new(EPOCH, view),
-            view.previous().unwrap_or(View::zero()),
-            Sha256Digest::from([view.get() as u8; 32]),
-        );
-        let votes: Vec<_> = schemes
-            .iter()
-            .map(|scheme| Finalize::sign(scheme, proposal.clone()).unwrap())
-            .collect();
-        Finalization::from_finalizes(verifier, &votes, &Sequential).expect("finalization quorum")
-    }
-
     fn fetch(view: u64, cause: u64, reason: FetchReason) -> Effect {
         Effect::Fetch {
             view: View::new(view),
@@ -346,8 +264,8 @@ mod tests {
         let (schemes, verifier) = ed25519_fixture();
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(2));
 
-        let nullification_v4 = build_nullification(&schemes, &verifier, View::new(4));
-        let effects = state.handle(Certificate::Nullification(nullification_v4.clone()), None);
+        let nullification_v4 = build_nullification(&schemes, &verifier, EPOCH, View::new(4));
+        let effects = state.handle(Certificate::Nullification(nullification_v4.clone()));
         assert_eq!(state.current_view, View::new(4));
         assert!(
             matches!(state.get(View::new(4)), Some(Certificate::Nullification(n)) if n == &nullification_v4)
@@ -361,8 +279,8 @@ mod tests {
             ]
         );
 
-        let nullification_v2 = build_nullification(&schemes, &verifier, View::new(2));
-        let effects = state.handle(Certificate::Nullification(nullification_v2.clone()), None);
+        let nullification_v2 = build_nullification(&schemes, &verifier, EPOCH, View::new(2));
+        let effects = state.handle(Certificate::Nullification(nullification_v2.clone()));
         assert_eq!(state.current_view, View::new(4));
         assert!(
             matches!(state.get(View::new(2)), Some(Certificate::Nullification(n)) if n == &nullification_v2)
@@ -375,8 +293,8 @@ mod tests {
             ]
         );
 
-        let nullification_v1 = build_nullification(&schemes, &verifier, View::new(1));
-        let effects = state.handle(Certificate::Nullification(nullification_v1.clone()), None);
+        let nullification_v1 = build_nullification(&schemes, &verifier, EPOCH, View::new(1));
+        let effects = state.handle(Certificate::Nullification(nullification_v1.clone()));
         assert_eq!(state.current_view, View::new(4));
         assert!(
             matches!(state.get(View::new(1)), Some(Certificate::Nullification(n)) if n == &nullification_v1)
@@ -390,8 +308,8 @@ mod tests {
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(10));
 
         for view in 4..=6 {
-            let nullification = build_nullification(&schemes, &verifier, View::new(view));
-            let effects = state.handle(Certificate::Nullification(nullification), None);
+            let nullification = build_nullification(&schemes, &verifier, EPOCH, View::new(view));
+            let effects = state.handle(Certificate::Nullification(nullification));
             if view == 4 {
                 assert_eq!(
                     effects,
@@ -409,16 +327,16 @@ mod tests {
         assert_eq!(state.current_view, View::new(6));
 
         // Notarization does not set floor or prune
-        let notarization = build_notarization(&schemes, &verifier, View::new(6));
-        let effects = state.handle(Certificate::Notarization(notarization), None);
+        let notarization = build_notarization(&schemes, &verifier, EPOCH, View::new(6));
+        let effects = state.handle(Certificate::Notarization(notarization));
 
         assert!(state.floor.is_none());
         assert_eq!(state.nullifications.len(), 3); // nullifications remain
         assert!(effects.is_empty());
 
         // Finalization sets floor and prunes
-        let finalization = build_finalization(&schemes, &verifier, View::new(6));
-        let effects = state.handle(Certificate::Finalization(finalization.clone()), None);
+        let finalization = build_finalization(&schemes, &verifier, EPOCH, View::new(6));
+        let effects = state.handle(Certificate::Finalization(finalization.clone()));
         assert!(
             matches!(state.floor.as_ref(), Some(Certificate::Finalization(f)) if f == &finalization)
         );
@@ -433,8 +351,8 @@ mod tests {
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(2));
 
         // Finalization sets floor
-        let finalization = build_finalization(&schemes, &verifier, View::new(3));
-        let effects = state.handle(Certificate::Finalization(finalization.clone()), None);
+        let finalization = build_finalization(&schemes, &verifier, EPOCH, View::new(3));
+        let effects = state.handle(Certificate::Finalization(finalization.clone()));
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(3))]);
         assert!(
             matches!(state.get(View::new(1)), Some(Certificate::Finalization(f)) if f == &finalization)
@@ -444,8 +362,8 @@ mod tests {
         );
 
         // New nullification is kept
-        let nullification_v4 = build_nullification(&schemes, &verifier, View::new(4));
-        let effects = state.handle(Certificate::Nullification(nullification_v4.clone()), None);
+        let nullification_v4 = build_nullification(&schemes, &verifier, EPOCH, View::new(4));
+        let effects = state.handle(Certificate::Nullification(nullification_v4.clone()));
         assert_eq!(effects, vec![Effect::Remove(View::new(4))]);
         assert!(
             matches!(state.get(View::new(4)), Some(Certificate::Nullification(n)) if n == &nullification_v4)
@@ -455,8 +373,8 @@ mod tests {
         );
 
         // Old nullification is ignored
-        let nullification_v1 = build_nullification(&schemes, &verifier, View::new(1));
-        let effects = state.handle(Certificate::Nullification(nullification_v1), None);
+        let nullification_v1 = build_nullification(&schemes, &verifier, EPOCH, View::new(1));
+        let effects = state.handle(Certificate::Nullification(nullification_v1));
         assert!(effects.is_empty());
         assert!(
             matches!(state.get(View::new(1)), Some(Certificate::Finalization(f)) if f == &finalization)
@@ -473,16 +391,12 @@ mod tests {
     }
 
     #[test]
-    fn certification_failure_re_requests_satisfied_views() {
+    fn certification_failure_re_requests_failed_view() {
         let (schemes, verifier) = ed25519_fixture();
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(10));
 
-        // Notarization at view 5 satisfies request for view 2
-        let notarization_v5 = build_notarization(&schemes, &verifier, View::new(5));
-        let effects = state.handle(
-            Certificate::Notarization(notarization_v5),
-            Some(View::new(2)),
-        );
+        let notarization_v5 = build_notarization(&schemes, &verifier, EPOCH, View::new(5));
+        let effects = state.handle(Certificate::Notarization(notarization_v5));
         assert_eq!(
             effects,
             vec![
@@ -492,39 +406,21 @@ mod tests {
                 fetch(4, 5, FetchReason::MissingNullification),
             ]
         );
-
-        // Verify tracking
-        assert!(state.satisfied_by.contains_key(&View::new(5)));
-        assert!(state.satisfied_by[&View::new(5)].contains(&View::new(2)));
         assert!(!state.is_failed(View::new(5)));
 
-        // Certification fails for view 5
         let effects = state.handle_certified(View::new(5), false);
 
-        // View 5 should be marked as failed
         assert!(state.is_failed(View::new(5)));
-        // Satisfied_by should be cleaned up
-        assert!(!state.satisfied_by.contains_key(&View::new(5)));
-        assert_eq!(
-            effects,
-            vec![
-                fetch(5, 5, FetchReason::CertificationFailed),
-                fetch(2, 5, FetchReason::SatisfiedByFailedNotarization),
-            ]
-        );
+        assert_eq!(effects, vec![fetch(5, 5, FetchReason::CertificationFailed)]);
     }
 
     #[test]
-    fn certification_success_clears_tracking() {
+    fn certification_success_sets_floor() {
         let (schemes, verifier) = ed25519_fixture();
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(10));
 
-        // Notarization at view 5 satisfies request for view 2
-        let notarization_v5 = build_notarization(&schemes, &verifier, View::new(5));
-        let effects = state.handle(
-            Certificate::Notarization(notarization_v5.clone()),
-            Some(View::new(2)),
-        );
+        let notarization_v5 = build_notarization(&schemes, &verifier, EPOCH, View::new(5));
+        let effects = state.handle(Certificate::Notarization(notarization_v5.clone()));
         assert_eq!(
             effects,
             vec![
@@ -535,19 +431,12 @@ mod tests {
             ]
         );
 
-        assert!(state.satisfied_by.contains_key(&View::new(5)));
-
-        // Certification succeeds for view 5
         let effects = state.handle_certified(View::new(5), true);
 
-        // Floor should be set
         assert!(
             matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v5)
         );
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(5))]);
-        // Tracking should be cleaned up
-        assert!(!state.satisfied_by.contains_key(&View::new(5)));
-        // View 5 should not be marked as failed
         assert!(!state.is_failed(View::new(5)));
     }
 
@@ -557,8 +446,8 @@ mod tests {
         let mut state: State<TestScheme, Sha256Digest> = State::new(NZUsize!(10));
 
         // Create and certify a notarization at view 5
-        let notarization_v5 = build_notarization(&schemes, &verifier, View::new(5));
-        let effects = state.handle(Certificate::Notarization(notarization_v5.clone()), None);
+        let notarization_v5 = build_notarization(&schemes, &verifier, EPOCH, View::new(5));
+        let effects = state.handle(Certificate::Notarization(notarization_v5.clone()));
         assert_eq!(
             effects,
             vec![
@@ -578,8 +467,8 @@ mod tests {
         assert_eq!(state.floor_view(), View::new(5));
 
         // A finalization at the same view should upgrade the floor
-        let finalization_v5 = build_finalization(&schemes, &verifier, View::new(5));
-        let effects = state.handle(Certificate::Finalization(finalization_v5.clone()), None);
+        let finalization_v5 = build_finalization(&schemes, &verifier, EPOCH, View::new(5));
+        let effects = state.handle(Certificate::Finalization(finalization_v5.clone()));
 
         // Floor should now be the finalization (stronger proof)
         assert!(

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -119,10 +119,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
     }
 
     /// Handle a certification result from the voter.
-    ///
-    /// A failure does not re-request the views the failed notarization was
-    /// fetched for: the actor answers their responses with the certification
-    /// verdict, so the resolver engine retries those requests itself.
     pub fn handle_certified(&mut self, view: View, success: bool) -> Vec<Effect> {
         let mut effects = Vec::new();
         if success {
@@ -142,7 +138,10 @@ impl<S: Scheme, D: Digest> State<S, D> {
             self.notarizations.remove(&view);
             self.failed_views.insert(view);
 
-            // Request nullification for this view (if above floor)
+            // Request nullification for this view (if above floor). The views the
+            // failed notarization was fetched for are not re-requested: the actor
+            // answers their responses with the certification verdict, so the
+            // resolver engine retries those requests itself.
             let floor = self.floor_view();
             if view > floor {
                 effects.push(Effect::Fetch {

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -218,6 +218,19 @@ where
             _ = deadline_pending => {
                 self.fetcher.fetch(&mut sender);
             },
+            // Handle completed consumer deliveries before accepting new work:
+            // a fetch issued in reaction to a delivery's outcome must find the
+            // completed key no longer in flight, not be deduplicated against
+            // it and dropped when it completes.
+            delivery = self.inflight.next_delivery() => {
+                // If the delivery was aborted, its inflight entry was dropped (via
+                // Retain or shutdown) before the consumer finished validating.
+                let (peer, delivery, result) = match delivery {
+                    Ok(delivery) => delivery,
+                    Err(_) => continue,
+                };
+                self.handle_delivery(peer, delivery, result);
+            },
             // Handle mailbox messages
             Some(msg) = self.mailbox.recv() else {
                 error!("mailbox closed");
@@ -273,16 +286,6 @@ where
                         self.record_cancellations(count);
                     }
                 }
-            },
-            // Handle completed consumer deliveries
-            delivery = self.inflight.next_delivery() => {
-                // If the delivery was aborted, its inflight entry was dropped (via
-                // Retain or shutdown) before the consumer finished validating.
-                let (peer, delivery, result) = match delivery {
-                    Ok(delivery) => delivery,
-                    Err(_) => continue,
-                };
-                self.handle_delivery(peer, delivery, result);
             },
             // Handle completed server requests
             serve = self.serves.next_completed() => {

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -112,7 +112,10 @@ mod tests {
     };
     use commonware_utils::{
         NZU32, NZUsize,
-        channel::{fallible::FallibleExt, mpsc, oneshot},
+        channel::{
+            fallible::{FallibleExt, OneshotExt},
+            mpsc, oneshot,
+        },
         non_empty_vec,
         ordered::Set,
         sync::Mutex,
@@ -575,6 +578,98 @@ mod tests {
             let (key_actual, value) = cons_out1.recv().await.unwrap();
             assert_eq!(key_actual, key);
             assert_eq!(value, Bytes::from("data for key 2"));
+        });
+    }
+
+    /// A consumer that hands each delivery's response sender to the test,
+    /// letting it resolve verdicts synchronously (without a task yield).
+    #[derive(Clone)]
+    struct HoldingConsumer {
+        deliveries: mpsc::UnboundedSender<(Key, oneshot::Sender<bool>)>,
+    }
+
+    impl HoldingConsumer {
+        fn new() -> (Self, mpsc::UnboundedReceiver<(Key, oneshot::Sender<bool>)>) {
+            let (deliveries, receiver) = mpsc::unbounded_channel();
+            (Self { deliveries }, receiver)
+        }
+    }
+
+    impl crate::Consumer for HoldingConsumer {
+        type Key = Key;
+        type Value = Bytes;
+        type Subscriber = ();
+
+        fn deliver(
+            &mut self,
+            delivery: Delivery<Self::Key, Self::Subscriber>,
+            _: Self::Value,
+        ) -> oneshot::Receiver<bool> {
+            let (sender, receiver) = oneshot::channel();
+            self.deliveries.send_lossy((delivery.key, sender));
+            receiver
+        }
+    }
+
+    #[test_traced]
+    fn test_fetch_after_accepted_verdict_restarts() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|context| async move {
+            let (mut oracle, mut schemes, peers, mut connections) =
+                setup_network_and_peers(&context, &[1, 2]).await;
+
+            add_link(&mut oracle, LINK.clone(), &peers, 0, 1).await;
+
+            let key = Key(2);
+            let mut prod2 = Producer::default();
+            prod2.insert(key.clone(), Bytes::from("data for key 2"));
+
+            let (cons1, mut deliveries) = HoldingConsumer::new();
+
+            let scheme = schemes.remove(0);
+            let mut mailbox1 = setup_and_spawn_actor(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                cons1,
+                Producer::default(),
+            );
+
+            let scheme = schemes.remove(0);
+            let _mailbox2 = setup_and_spawn_actor(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                dummy_consumer(),
+                prod2,
+            );
+
+            mailbox1.fetch(key.clone());
+            let (first, verdict) = deliveries.recv().await.unwrap();
+            assert_eq!(first, key);
+
+            // Accept the response and re-fetch the key before yielding: both
+            // the completion and the fetch are pending when the engine next
+            // runs, and it must settle the completion first so the re-fetch
+            // starts fresh instead of being deduplicated against the
+            // completing key and dropped with it.
+            verdict.send_lossy(true);
+            mailbox1.fetch(key.clone());
+
+            select! {
+                delivered = deliveries.recv() => {
+                    let (second, verdict) = delivered.unwrap();
+                    assert_eq!(second, key);
+                    verdict.send_lossy(true);
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("re-fetch was dropped with the completed fetch");
+                },
+            }
         });
     }
 


### PR DESCRIPTION
## Bug

The simplex resolver answered a notarization delivery with `true` before the proposal was certified, then leaned on `satisfied_by` bookkeeping to re-request the views that notarization had answered if certification failed. That re-request could be silently swallowed: the actor answers a delivery and reacts to an adjacent `Certified` mailbox message in one synchronous burst, and the resolver engine's biased `select_loop` served mailbox messages before settling completed deliveries — so a re-fetch for a view whose accepted completion was still pending was deduplicated against the in-flight entry, then dropped with it when the completion settled. With `fetch_floor` monotone and the `satisfied_by` entry consumed, the view was never requested again and its nullification gap persisted until an unrelated floor raise. Answering `true` early also meant a peer serving an uncertifiable notarization recorded a successful fetch and was never blocked.

## Fix

Answer the delivery with the final verdict instead (marshal's pattern): notarization responses are held, keyed by notarization view, and answered when the voter reports the certification outcome. Failure blocks each serving peer and the engine natively retries each answered request, so the `satisfied_by` machinery (the map, a `FetchReason` variant, and the `request` parameter on `State::handle`) is deleted outright. Certifications aborted by a finalization are never reported, so floor raises accept any held responses they make obsolete. The engine also settles completed consumer deliveries before accepting new mailbox work, so a fetch issued in reaction to a verdict finds the completed key no longer in flight — a new resolver test, `test_fetch_after_accepted_verdict_restarts`, fails under the old arm order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
