### PR TITLE
[storage] Reconstruct activity bitmap shares on the snapshot workers

### DIFF
--- a/storage/src/index/partitioned/mod.rs
+++ b/storage/src/index/partitioned/mod.rs
@@ -54,9 +54,6 @@ pub(crate) trait Partitioned: Unordered {
     /// Move a populated `range`'s contents into self at the global slot range it was created
     /// with, which must be empty.
     fn install_range(&mut self, range: Self::Range);
-
-    /// Visit every value held across all partitions, in unspecified order.
-    fn for_each_value(&self, f: impl FnMut(&Self::Value));
 }
 
 /// One [Partitioned] worker's restricted view of its partition range: only the cursor
@@ -80,6 +77,9 @@ pub(crate) trait PartitionRange: Sized {
     /// return `None` (see [Unordered::get_mut_or_insert]). The key's partition must fall within
     /// this range.
     fn get_mut_or_insert(&mut self, key: &[u8], value: Self::Value) -> Option<Self::Cursor<'_>>;
+
+    /// Visit every value held across the range, in unspecified order.
+    fn for_each_value(&self, f: impl FnMut(&Self::Value));
 }
 
 /// Get the partition index for the given key, along with the prefix-stripped key for probing

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -139,8 +139,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         index
     }
 
-    /// Visit every value held across all partitions (inline and spilled), in unspecified
-    /// order. Shared by a build worker's range view over its local slots.
+    /// Visit every value held across all partitions (inline and spilled), in unspecified order.
     #[commonware_macros::stability(ALPHA)]
     fn for_each_value_impl(&self, mut f: impl FnMut(&V)) {
         for (p, partition) in self.partitions.iter().enumerate() {

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -1098,6 +1098,36 @@ mod tests {
         });
     }
 
+    /// A worker's value walk must visit every value it holds exactly once, whichever
+    /// representation each partition uses (inline sorted arrays or the spilled side-table),
+    /// since the snapshot build derives the activity bitmap and active-key counts from it.
+    #[test_traced]
+    fn test_range_for_each_value_visits_all_values_once() {
+        deterministic::Runner::default().start(|context| async move {
+            let full = new_index_spilling(context.child("full"));
+
+            // Two distinct keys spill partition 0x80 (threshold 2), then a translated-key
+            // collision appends a second value to a spilled run. Partition 0x81 holds one key
+            // and stays inline.
+            let mut worker = full.new_range(0x80, 2);
+            assert!(worker.get_mut_or_insert(&[0x80, 0x01], 1).is_none());
+            assert!(worker.get_mut_or_insert(&[0x80, 0x02, 0xAA], 2).is_none());
+            assert!(worker.get_mut_or_insert(&[0x80, 0x02, 0xBB], 3).is_some());
+            {
+                let mut cursor = worker.get_mut(&[0x80, 0x02, 0xBB]).unwrap();
+                cursor.next();
+                cursor.insert(3);
+            }
+            assert!(worker.get_mut_or_insert(&[0x81, 0x07], 4).is_none());
+            assert_eq!(worker.index.spilled_count(), 1);
+
+            let mut seen = Vec::new();
+            worker.for_each_value(|v| seen.push(*v));
+            seen.sort_unstable();
+            assert_eq!(seen, vec![1, 2, 3, 4]);
+        });
+    }
+
     /// A worker with a nonzero offset must land its partitions AND its spilled entries at the
     /// global slots `offset + local` when installed. The multi-worker equivalence tests never
     /// spill inside a worker range (their per-partition load stays below the spill threshold), so

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -141,7 +141,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
 
     /// Visit every value held across all partitions (inline and spilled), in unspecified order.
     #[commonware_macros::stability(ALPHA)]
-    fn for_each_value_impl(&self, mut f: impl FnMut(&V)) {
+    fn for_each_value(&self, mut f: impl FnMut(&V)) {
         for (p, partition) in self.partitions.iter().enumerate() {
             for v in partition.values_iter() {
                 f(v);
@@ -436,7 +436,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> PartitionRange for RangeInde
     }
 
     fn for_each_value(&self, f: impl FnMut(&V)) {
-        self.index.for_each_value_impl(f);
+        self.index.for_each_value(f);
     }
 }
 

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -140,7 +140,8 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
     }
 
     /// Visit every value held across all partitions (inline and spilled), in unspecified
-    /// order. Shared by the full index and a build worker's range view.
+    /// order. Shared by a build worker's range view over its local slots.
+    #[commonware_macros::stability(ALPHA)]
     fn for_each_value_impl(&self, mut f: impl FnMut(&V)) {
         for (p, partition) in self.partitions.iter().enumerate() {
             for v in partition.values_iter() {

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -139,6 +139,23 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         index
     }
 
+    /// Visit every value held across all partitions (inline and spilled), in unspecified
+    /// order. Shared by the full index and a build worker's range view.
+    fn for_each_value_impl(&self, mut f: impl FnMut(&V)) {
+        for (p, partition) in self.partitions.iter().enumerate() {
+            for v in partition.values_iter() {
+                f(v);
+            }
+            if let Some(inner) = self.spilled_partition(p) {
+                for vals in inner.values() {
+                    for v in vals {
+                        f(v);
+                    }
+                }
+            }
+        }
+    }
+
     /// Spill partition `i` to the side-table if its sorted array has reached the threshold.
     fn maybe_spill(&mut self, i: usize) {
         if self.partitions[i].len() < self.threshold {
@@ -383,22 +400,6 @@ impl<T: Translator, V: Send + Sync + 'static, const P: usize> Partitioned for In
             self.spilled.insert(lo + local, inner);
         }
     }
-
-    /// Visits inline and spilled values.
-    fn for_each_value(&self, mut f: impl FnMut(&V)) {
-        for (p, partition) in self.partitions.iter().enumerate() {
-            for v in partition.values_iter() {
-                f(v);
-            }
-            if let Some(inner) = self.spilled_partition(p) {
-                for vals in inner.values() {
-                    for v in vals {
-                        f(v);
-                    }
-                }
-            }
-        }
-    }
 }
 
 /// A restricted view of an [Index] covering only a contiguous range of partitions, held by one
@@ -432,6 +433,10 @@ impl<T: Translator, V: Send + Sync, const P: usize> PartitionRange for RangeInde
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         self.index
             .get_mut_or_insert_slot(i - self.offset, sub, value)
+    }
+
+    fn for_each_value(&self, f: impl FnMut(&V)) {
+        self.index.for_each_value_impl(f);
     }
 }
 

--- a/storage/src/index/partitioned/unordered.rs
+++ b/storage/src/index/partitioned/unordered.rs
@@ -227,6 +227,34 @@ mod tests {
         Index::new(ctx, OneCap)
     }
 
+    /// A worker's value walk must visit every value it holds exactly once -- inline values and
+    /// overflow chains alike -- since the snapshot build derives the activity bitmap and
+    /// active-key counts from it.
+    #[test_traced]
+    fn test_range_for_each_value_visits_all_values_once() {
+        deterministic::Runner::default().start(|context| async move {
+            let full = new_index(context.child("full"));
+
+            // Two keys in partition 0x80 that collide on the one-byte translated sub-key (an
+            // overflow chain), one distinct key beside them, and one key in partition 0x81.
+            let mut worker = full.new_range(0x80, 2);
+            assert!(worker.get_mut_or_insert(&[0x80, 0x01, 0xAA], 1).is_none());
+            assert!(worker.get_mut_or_insert(&[0x80, 0x01, 0xBB], 2).is_some());
+            {
+                let mut cursor = worker.get_mut(&[0x80, 0x01, 0xBB]).unwrap();
+                cursor.next();
+                cursor.insert(2);
+            }
+            assert!(worker.get_mut_or_insert(&[0x80, 0x02], 3).is_none());
+            assert!(worker.get_mut_or_insert(&[0x81, 0x07], 4).is_none());
+
+            let mut seen = Vec::new();
+            worker.for_each_value(|v| seen.push(*v));
+            seen.sort_unstable();
+            assert_eq!(seen, vec![1, 2, 3, 4]);
+        });
+    }
+
     /// A worker with a nonzero offset must land its slots at the global partitions
     /// `offset + local` when installed, carrying inline values and overflow chains (the
     /// key/item counts are live through the shared handles, so the `get` asserts are what pin

--- a/storage/src/index/partitioned/unordered.rs
+++ b/storage/src/index/partitioned/unordered.rs
@@ -227,8 +227,8 @@ mod tests {
         Index::new(ctx, OneCap)
     }
 
-    /// A worker's value walk must visit every value it holds exactly once -- inline values and
-    /// overflow chains alike -- since the snapshot build derives the activity bitmap and
+    /// A worker's value walk must visit every value it holds exactly once (inline values and
+    /// overflow chains alike), since the snapshot build derives the activity bitmap and
     /// active-key counts from it.
     #[test_traced]
     fn test_range_for_each_value_visits_all_values_once() {

--- a/storage/src/index/partitioned/unordered.rs
+++ b/storage/src/index/partitioned/unordered.rs
@@ -78,13 +78,6 @@ impl<T: Translator, V: Send + Sync + 'static, const P: usize> Partitioned for In
             self.partitions[lo + local].absorb(slot);
         }
     }
-
-    /// Visits inline and overflow values.
-    fn for_each_value(&self, mut f: impl FnMut(&V)) {
-        for partition in &self.partitions {
-            partition.for_each_value(&mut f);
-        }
-    }
 }
 
 /// A restricted view of an [Index] covering only a contiguous range of partitions, held by one
@@ -117,6 +110,12 @@ impl<T: Translator, V: Send + Sync, const P: usize> PartitionRange for RangeInde
     fn get_mut_or_insert(&mut self, key: &[u8], value: V) -> Option<Self::Cursor<'_>> {
         let (i, sub) = partition_index_and_sub_key::<P>(key);
         self.partitions[i - self.offset].get_mut_or_insert(sub, value)
+    }
+
+    fn for_each_value(&self, mut f: impl FnMut(&V)) {
+        for partition in &self.partitions {
+            partition.for_each_value(&mut f);
+        }
     }
 }
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -764,6 +764,131 @@ pub(crate) mod test {
         });
     }
 
+    /// A multi-worker build's activity bitmap must match the serial build's bit for bit: over a
+    /// log with live keys and deletes (the workers' disjoint shares union), and over a log whose
+    /// keys were all deleted (every share empty, leaving only the final commit's bit).
+    #[test_traced("WARN")]
+    fn test_ordered_partitioned_parallel_init_bitmap_equivalence() {
+        deterministic::Runner::default().start(|context| async move {
+            use crate::{
+                journal::contiguous::Contiguous as _,
+                qmdb::{SnapshotBuild as _, operation::Operation as _},
+            };
+            use std::sync::Arc;
+
+            type BitmapDb<S> =
+                partitioned::Db<mmr::Family, Context, Digest, Digest, Sha256, OneCap, 1, S>;
+
+            /// Rebuild the snapshot from the persisted log serially and with workers, assert the
+            /// `(active_keys, bitmap)` results match, and return the bitmap.
+            async fn assert_builds_match(
+                context: &deterministic::Context,
+                label: &str,
+                expected_active: usize,
+            ) -> commonware_utils::bitmap::BitMap {
+                let mut results = Vec::new();
+                for concurrency in [1usize, 4] {
+                    let cfg =
+                        fixed_db_config_partitioned::<OneCap>("ordered_bitmap_equiv", context);
+                    let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
+                        context
+                            .child("log")
+                            .with_attribute("label", label)
+                            .with_attribute("concurrency", concurrency),
+                        cfg.journal_config,
+                    )
+                    .await
+                    .unwrap();
+                    let floor = crate::qmdb::find_inactivity_floor_at::<mmr::Family, _>(
+                        &log,
+                        Location::new(log.bounds().end),
+                        |op| op.has_floor(),
+                    )
+                    .await
+                    .unwrap();
+                    let log = Arc::new(log);
+                    let mut index =
+                        crate::index::partitioned::ordered::Index::<OneCap, Location, 1>::new(
+                            context
+                                .child("index")
+                                .with_attribute("label", label)
+                                .with_attribute("concurrency", concurrency),
+                            OneCap,
+                        );
+                    let result = index
+                        .build_snapshot(
+                            context
+                                .child("build")
+                                .with_attribute("label", label)
+                                .with_attribute("concurrency", concurrency),
+                            floor,
+                            &log,
+                            core::num::NonZeroUsize::new(concurrency).unwrap(),
+                            NZUsize!(1 << 21),
+                            None,
+                        )
+                        .await
+                        .unwrap();
+                    assert_eq!(result.0, expected_active, "{label}");
+                    results.push(result);
+                }
+                let parallel = results.pop().unwrap();
+                let serial = results.pop().unwrap();
+                assert_eq!(serial, parallel, "{label}");
+                parallel.1
+            }
+
+            // A log with live keys, updates, and deletes: the bitmap holds one bit per active
+            // key plus the final commit.
+            let cfg = fixed_db_config_partitioned::<OneCap>("ordered_bitmap_equiv", &context);
+            let db = BitmapDb::<Sequential>::init(context.child("populate"), cfg)
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0u64..200 {
+                let k = Sha256::hash(&i.to_be_bytes());
+                let v = Sha256::hash(&(i * 7).to_be_bytes());
+                batch = batch.write(k, Some(v));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let mut batch = db.new_batch();
+            for i in (0u64..200).step_by(4) {
+                let k = Sha256::hash(&i.to_be_bytes());
+                batch = batch.write(k, None);
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
+            let bitmap = assert_builds_match(&context, "live", 150).await;
+            assert_eq!(bitmap.count_ones(), 151); // 150 active keys + the final commit
+
+            // Delete every remaining key: all worker shares are empty and only the final
+            // commit's bit stays set.
+            let cfg = fixed_db_config_partitioned::<OneCap>("ordered_bitmap_equiv", &context);
+            let db = BitmapDb::<Sequential>::init(context.child("wipe"), cfg)
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0u64..200 {
+                if i % 4 != 0 {
+                    let k = Sha256::hash(&i.to_be_bytes());
+                    batch = batch.write(k, None);
+                }
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
+            let bitmap = assert_builds_match(&context, "wiped", 0).await;
+            assert_eq!(bitmap.count_ones(), 1); // only the final commit
+        });
+    }
+
     #[test_traced("WARN")]
     fn test_ordered_partitioned_p1_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -506,8 +506,8 @@ where
 
     // Reconstruct this range's share of the activity bitmap (in parallel with the other workers)
     // and count the active keys. Locations are partitioned across workers, so every bit has a
-    // single writer; workers collide only at word granularity (absorbed by the atomic or), and the
-    // join publishes the words, so relaxed ordering suffices.
+    // single writer and workers collide only at word granularity (absorbed by the atomic or).
+    // The join publishes the words, so relaxed ordering suffices.
     let mut active_keys = 0;
     index.for_each_value(|loc| {
         let bit = **loc - activity.start;

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -71,7 +71,10 @@ use commonware_runtime::Spawner;
 use commonware_utils::{bitmap::BitMap, cache::Clock, channel::mpsc};
 use core::{num::NonZeroUsize, ops::Range};
 use futures::{StreamExt as _, future::join_all, pin_mut};
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 use thiserror::Error;
 
 pub mod any;
@@ -462,16 +465,17 @@ type RoutedBatch<K> = Vec<(K, u64, bool)>;
 
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
-/// `reader` and `(location -> key)` cache. Returns the populated worker index along with the
-/// range's share of the activity bitmap (over `activity`, the replayed region) and its active-key
-/// count.
+/// `reader` and `(location -> key)` cache. Sets the bits of the range's active locations in the
+/// shared `active` words (indexed over `activity`, the replayed region) and returns the populated
+/// worker index along with the range's active-key count.
 async fn build_snapshot_worker<F, C, R>(
     log: Arc<C>,
     mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
     mut index: R,
     activity: Range<u64>,
+    active: Arc<Vec<AtomicU64>>,
     cache_size: Option<NonZeroUsize>,
-) -> Result<(R, BitMap, usize), Error<F>>
+) -> Result<(R, usize), Error<F>>
 where
     F: Family,
     C: Contiguous<Item: Operation<F>>,
@@ -500,16 +504,17 @@ where
         }
     }
 
-    // Reconstruct this range's share of the activity bitmap (in parallel with the other workers):
-    // a location is active iff it holds the current operation of an active key. Each active key
-    // holds exactly one location, so the same walk counts the range's active keys.
-    let mut active = BitMap::zeroes(activity.end - activity.start);
+    // Reconstruct this range's share of the activity bitmap (in parallel with the other workers)
+    // and count the active keys. Locations are partitioned across workers, so every bit has a
+    // single writer; workers collide only at word granularity (absorbed by the atomic or), and the
+    // join publishes the words, so relaxed ordering suffices.
     let mut active_keys = 0;
     index.for_each_value(|loc| {
-        active.set(**loc - activity.start, true);
+        let bit = **loc - activity.start;
+        active[(bit / 64) as usize].fetch_or(1 << (bit % 64), Ordering::Relaxed);
         active_keys += 1;
     });
-    Ok((index, active, active_keys))
+    Ok((index, active_keys))
 }
 
 /// Build a snapshot serially on the calling task via [build_snapshot_from_log], collecting each
@@ -591,6 +596,11 @@ where
     let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
     let end = log.bounds().end;
 
+    // All workers share one vector of (atomically updatable) words to track the activity bits.
+    let bits = end - floor;
+    let active: Arc<Vec<AtomicU64>> =
+        Arc::new((0..bits.div_ceil(64)).map(|_| AtomicU64::new(0)).collect());
+
     // Spawn one worker per contiguous partition range, each owning its own reader and cache.
     let mut senders = Vec::with_capacity(workers);
     let mut handles = Vec::with_capacity(workers);
@@ -604,6 +614,7 @@ where
         let lo = w * range_size;
         let range_len = range_size.min(count - lo);
         let worker_index = snapshot.new_range(lo, range_len);
+        let active = active.clone();
         let handle = context
             .child("snapshot_worker")
             .with_attribute("worker", w)
@@ -614,6 +625,7 @@ where
                     rx,
                     worker_index,
                     floor..end,
+                    active,
                     per_worker_cache,
                 )
             });
@@ -668,18 +680,24 @@ where
     let joined = join_all(handles).await;
     routing_result?;
 
-    // Install each worker's partition range into the snapshot (each worker carries its own
-    // partition offset, so installation needs no range arguments) and fold the worker's share
-    // of the activity bitmap and active-key count in. The union of the workers' shares matches
-    // the serial build's per-op push-then-clear, which leaves exactly the bits of each active
-    // key's current location set.
+    // Install each worker's partition range into the snapshot and fold its active-key count in.
     let mut total_items = 0;
-    let mut active: BitMap = BitMap::zeroes(end - floor);
     for handle in joined {
-        let (worker_index, worker_active, worker_keys) = handle??;
+        let (worker_index, worker_keys) = handle??;
         snapshot.install_range(worker_index);
-        active.or(&worker_active);
         total_items += worker_keys;
+    }
+
+    // Reassemble the shared word representation into the returned bitmap.
+    let words = Arc::into_inner(active).expect("workers were joined");
+    let mut words = words.into_iter().map(AtomicU64::into_inner);
+    let mut active = BitMap::with_capacity(bits);
+    for _ in 0..bits / 64 {
+        active.push_chunk(&words.next().expect("word per full chunk").to_le_bytes());
+    }
+    let trailing = words.next().unwrap_or_default();
+    for bit in 0..bits % 64 {
+        active.push((trailing >> bit) & 1 == 1);
     }
 
     // The last operation is the final commit (a log always ends with one), which stays active.

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -69,7 +69,7 @@ use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
 use commonware_runtime::Spawner;
 use commonware_utils::{bitmap::BitMap, cache::Clock, channel::mpsc};
-use core::num::NonZeroUsize;
+use core::{num::NonZeroUsize, ops::Range};
 use futures::{StreamExt as _, future::join_all, pin_mut};
 use std::sync::Arc;
 use thiserror::Error;
@@ -462,13 +462,16 @@ type RoutedBatch<K> = Vec<(K, u64, bool)>;
 
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
-/// `reader` and `(location -> key)` cache. Returns the populated worker index.
+/// `reader` and `(location -> key)` cache. Returns the populated worker index along with the
+/// range's share of the activity bitmap (over `activity`, the replayed region) and its active-key
+/// count.
 async fn build_snapshot_worker<F, C, R>(
     log: Arc<C>,
     mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
     mut index: R,
+    activity: Range<u64>,
     cache_size: Option<NonZeroUsize>,
-) -> Result<R, Error<F>>
+) -> Result<(R, BitMap, usize), Error<F>>
 where
     F: Family,
     C: Contiguous<Item: Operation<F>>,
@@ -496,7 +499,17 @@ where
             }
         }
     }
-    Ok(index)
+
+    // Reconstruct this range's share of the activity bitmap (in parallel with the other workers):
+    // a location is active iff it holds the current operation of an active key. Each active key
+    // holds exactly one location, so the same walk counts the range's active keys.
+    let mut active = BitMap::zeroes(activity.end - activity.start);
+    let mut active_keys = 0;
+    index.for_each_value(|loc| {
+        active.set(**loc - activity.start, true);
+        active_keys += 1;
+    });
+    Ok((index, active, active_keys))
 }
 
 /// Build a snapshot serially on the calling task via [build_snapshot_from_log], collecting each
@@ -576,6 +589,7 @@ where
     // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
     let workers = count.div_ceil(range_size);
     let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
+    let end = log.bounds().end;
 
     // Spawn one worker per contiguous partition range, each owning its own reader and cache.
     let mut senders = Vec::with_capacity(workers);
@@ -595,7 +609,13 @@ where
             .with_attribute("worker", w)
             .dedicated()
             .spawn(move |_| {
-                build_snapshot_worker::<F, C, I::Range>(log, rx, worker_index, per_worker_cache)
+                build_snapshot_worker::<F, C, I::Range>(
+                    log,
+                    rx,
+                    worker_index,
+                    floor..end,
+                    per_worker_cache,
+                )
             });
         handles.push(handle);
     }
@@ -605,7 +625,6 @@ where
     // returned immediately: returning while the worker handles are merely dropped would
     // leave the workers running detached, retaining the log and their range allocations
     // after init has already failed. The stream is also released before the join.
-    let end = log.bounds().end;
     let routing_result: Result<(), Error<F>> = async {
         let stream = log.replay(floor, init_buffer).await?;
         pin_mut!(stream);
@@ -649,23 +668,19 @@ where
     let joined = join_all(handles).await;
     routing_result?;
 
-    // Install each worker's partition range into the snapshot. Each worker carries its own
-    // partition offset, so installation needs no range arguments.
-    for handle in joined {
-        let worker_index = handle??;
-        snapshot.install_range(worker_index);
-    }
-
-    // Reconstruct the activity bitmap in location order: a location is active iff it is the
-    // current location of an active key, or it is the last commit. This matches the serial
-    // build's per-op push-then-clear, which leaves exactly those bits set. Each active key
-    // holds exactly one location in the snapshot, so the same walk counts the active keys.
+    // Install each worker's partition range into the snapshot (each worker carries its own
+    // partition offset, so installation needs no range arguments) and fold the worker's share
+    // of the activity bitmap and active-key count in. The union of the workers' shares matches
+    // the serial build's per-op push-then-clear, which leaves exactly the bits of each active
+    // key's current location set.
     let mut total_items = 0;
     let mut active: BitMap = BitMap::zeroes(end - floor);
-    snapshot.for_each_value(|loc| {
-        active.set(**loc - floor, true);
-        total_items += 1;
-    });
+    for handle in joined {
+        let (worker_index, worker_active, worker_keys) = handle??;
+        snapshot.install_range(worker_index);
+        active.or(&worker_active);
+        total_items += worker_keys;
+    }
 
     // The last operation is the final commit (a log always ends with one), which stays active.
     // An empty log has none.

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -68,13 +68,14 @@ use crate::{
 use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
 use commonware_runtime::Spawner;
-use commonware_utils::{bitmap::BitMap, cache::Clock, channel::mpsc};
+use commonware_utils::{
+    bitmap::{Atomic, BitMap},
+    cache::Clock,
+    channel::mpsc,
+};
 use core::{num::NonZeroUsize, ops::Range};
 use futures::{StreamExt as _, future::join_all, pin_mut};
-use std::sync::{
-    Arc,
-    atomic::{AtomicU64, Ordering},
-};
+use std::sync::Arc;
 use thiserror::Error;
 
 pub mod any;
@@ -466,14 +467,14 @@ type RoutedBatch<K> = Vec<(K, u64, bool)>;
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
 /// `reader` and `(location -> key)` cache. Sets the bits of the range's active locations in the
-/// shared `active` words (indexed over `activity`, the replayed region) and returns the populated
+/// shared `active` bitmap (indexed over `activity`, the replayed region) and returns the populated
 /// worker index along with the range's active-key count.
 async fn build_snapshot_worker<F, C, R>(
     log: Arc<C>,
     mut rx: mpsc::Receiver<RoutedBatch<<C::Item as Operation<F>>::Key>>,
     mut index: R,
     activity: Range<u64>,
-    active: Arc<Vec<AtomicU64>>,
+    active: Arc<Atomic>,
     cache_size: Option<NonZeroUsize>,
 ) -> Result<(R, usize), Error<F>>
 where
@@ -506,12 +507,10 @@ where
 
     // Reconstruct this range's share of the activity bitmap (in parallel with the other workers)
     // and count the active keys. Locations are partitioned across workers, so every bit has a
-    // single writer and workers collide only at word granularity (absorbed by the atomic or).
-    // The join publishes the words, so relaxed ordering suffices.
+    // single writer.
     let mut active_keys = 0;
     index.for_each_value(|loc| {
-        let bit = **loc - activity.start;
-        active[(bit / 64) as usize].fetch_or(1 << (bit % 64), Ordering::Relaxed);
+        active.set(**loc - activity.start);
         active_keys += 1;
     });
     Ok((index, active_keys))
@@ -596,10 +595,8 @@ where
     let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
     let end = log.bounds().end;
 
-    // All workers share one vector of (atomically updatable) words to track the activity bits.
-    let bits = end - floor;
-    let active: Arc<Vec<AtomicU64>> =
-        Arc::new((0..bits.div_ceil(64)).map(|_| AtomicU64::new(0)).collect());
+    // All workers share one atomic bitmap to track the activity bits.
+    let active = Arc::new(Atomic::zeroes(end - floor));
 
     // Spawn one worker per contiguous partition range, each owning its own reader and cache.
     let mut senders = Vec::with_capacity(workers);
@@ -688,17 +685,10 @@ where
         total_items += worker_keys;
     }
 
-    // Reassemble the shared word representation into the returned bitmap.
-    let words = Arc::into_inner(active).expect("workers were joined");
-    let mut words = words.into_iter().map(AtomicU64::into_inner);
-    let mut active = BitMap::with_capacity(bits);
-    for _ in 0..bits / 64 {
-        active.push_chunk(&words.next().expect("word per full chunk").to_le_bytes());
-    }
-    let trailing = words.next().unwrap_or_default();
-    for bit in 0..bits % 64 {
-        active.push((trailing >> bit) & 1 == 1);
-    }
+    // The join reclaimed exclusive ownership of the shared bitmap, so it can be read back.
+    let mut active = Arc::into_inner(active)
+        .expect("workers were joined")
+        .into_bitmap();
 
     // The last operation is the final commit (a log always ends with one), which stays active.
     // An empty log has none.

--- a/utils/src/bitmap/atomic.rs
+++ b/utils/src/bitmap/atomic.rs
@@ -1,11 +1,10 @@
 //! A fixed-length bitmap whose bits can be set concurrently through shared references.
 
 use super::BitMap;
-#[cfg(not(feature = "std"))]
-use alloc::{collections::VecDeque, vec::Vec};
-use core::sync::atomic::{AtomicU64, Ordering};
-#[cfg(feature = "std")]
-use std::collections::VecDeque;
+use std::{
+    collections::VecDeque,
+    sync::atomic::{AtomicU64, Ordering},
+};
 
 /// A fixed-length bitmap whose bits can be set concurrently through shared references.
 ///

--- a/utils/src/bitmap/atomic.rs
+++ b/utils/src/bitmap/atomic.rs
@@ -1,0 +1,123 @@
+//! A fixed-length bitmap whose bits can be set concurrently through shared references.
+
+use super::BitMap;
+#[cfg(not(feature = "std"))]
+use alloc::{collections::VecDeque, vec::Vec};
+use core::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "std")]
+use std::collections::VecDeque;
+
+/// A fixed-length bitmap whose bits can be set concurrently through shared references.
+///
+/// [Atomic::set] uses relaxed ordering, which is published by ownership transfer rather than
+/// by the operations themselves: the bits can only be read back by consuming the map
+/// ([Atomic::into_bitmap]), so whatever reclaims exclusive ownership from the setters
+/// (joining their tasks, `Arc::into_inner`) is what makes their writes visible.
+pub struct Atomic {
+    /// The bits, packed into words (bit `i` is bit `i % 64` of word `i / 64`).
+    ///
+    /// Invariant: `words.len() == len.div_ceil(64)`
+    /// Invariant: All bits at index `i` where `i >= len` are 0.
+    words: Vec<AtomicU64>,
+
+    /// The number of bits in the bitmap.
+    len: u64,
+}
+
+impl Atomic {
+    /// The size of a word in bits.
+    const WORD_BITS: u64 = u64::BITS as u64;
+
+    /// Create a bitmap of `len` zero bits.
+    pub fn zeroes(len: u64) -> Self {
+        let words = (0..len.div_ceil(Self::WORD_BITS))
+            .map(|_| AtomicU64::new(0))
+            .collect();
+        Self { words, len }
+    }
+
+    /// Set `bit` to 1.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bit doesn't exist.
+    pub fn set(&self, bit: u64) {
+        assert!(
+            bit < self.len,
+            "bit {} out of bounds (len: {})",
+            bit,
+            self.len
+        );
+        self.words[(bit / Self::WORD_BITS) as usize]
+            .fetch_or(1 << (bit % Self::WORD_BITS), Ordering::Relaxed);
+    }
+
+    /// Convert into a [BitMap] holding the same bits.
+    ///
+    /// Taking `self` by value means the caller already reclaimed exclusive ownership from
+    /// every setter, which is the synchronization that makes their relaxed writes visible.
+    pub fn into_bitmap(self) -> BitMap {
+        let chunks: VecDeque<_> = self
+            .words
+            .into_iter()
+            .map(|word| word.into_inner().to_le_bytes())
+            .collect();
+        BitMap::from_chunks(chunks, self.len)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The converted bitmap must match a [BitMap] built with plain sets, across lengths
+    /// covering the empty, sub-word, word-aligned, and multi-word-with-tail shapes.
+    #[test]
+    fn test_set_and_into_bitmap_matches_plain_sets() {
+        for len in [0u64, 1, 63, 64, 65, 128, 200] {
+            let atomic = Atomic::zeroes(len);
+            let mut expected = BitMap::zeroes(len);
+            for bit in (0..len).step_by(3).chain(len.checked_sub(1)) {
+                atomic.set(bit);
+                expected.set(bit, true);
+            }
+            assert_eq!(atomic.into_bitmap(), expected, "len {len}");
+        }
+    }
+
+    #[test]
+    fn test_shared_setters() {
+        let atomic = Atomic::zeroes(1000);
+        std::thread::scope(|s| {
+            for stripe in 0..4u64 {
+                let atomic = &atomic;
+                s.spawn(move || {
+                    for bit in (stripe..1000).step_by(4) {
+                        atomic.set(bit);
+                    }
+                });
+            }
+        });
+        assert_eq!(atomic.into_bitmap(), BitMap::ones(1000));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_set_past_len_panics() {
+        Atomic::zeroes(64).set(64);
+    }
+
+    /// A bit past `len` must be rejected even when it lands inside the trailing word's
+    /// allocation, where the word indexing alone would accept it.
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_set_past_len_in_tail_word_panics() {
+        Atomic::zeroes(65).set(70);
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn test_set_on_empty_panics() {
+        Atomic::zeroes(0).set(0);
+    }
+}

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -15,7 +15,9 @@ use core::{
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
+#[cfg(feature = "std")]
 mod atomic;
+#[cfg(feature = "std")]
 pub use atomic::Atomic;
 mod prunable;
 pub use prunable::Prunable;
@@ -115,6 +117,7 @@ impl<const N: usize> BitMap<N> {
     /// # Panics
     ///
     /// Panics if the chunk count does not match `len` or a bit at index >= `len` is set.
+    #[cfg(feature = "std")]
     fn from_chunks(chunks: VecDeque<[u8; N]>, len: u64) -> Self {
         assert_eq!(
             chunks.len() as u64,

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -15,6 +15,8 @@ use core::{
 #[cfg(feature = "std")]
 use std::collections::VecDeque;
 
+mod atomic;
+pub use atomic::Atomic;
 mod prunable;
 pub use prunable::Prunable;
 
@@ -106,6 +108,22 @@ impl<const N: usize> BitMap<N> {
         // Clear trailing bits to maintain invariant
         result.clear_trailing_bits();
         result
+    }
+
+    /// Create a bitmap of `len` bits directly from its chunk representation.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the chunk count does not match `len` or a bit at index >= `len` is set.
+    fn from_chunks(chunks: VecDeque<[u8; N]>, len: u64) -> Self {
+        assert_eq!(
+            chunks.len() as u64,
+            len.div_ceil(Self::CHUNK_SIZE_BITS),
+            "chunk count does not match len"
+        );
+        let mut bitmap = Self { chunks, len };
+        assert!(!bitmap.clear_trailing_bits(), "bit past len set");
+        bitmap
     }
 
     /* Length */


### PR DESCRIPTION
## Summary

The parallel snapshot build reconstructed the activity bitmap as a serial post-join phase: after installing every worker's partition range, the init task walked the full index and set one bit per active key (~0.9s at 50M keys), with every worker idle. Each worker now walks its own partition range before returning — in parallel with the other workers, over data it just built and still has cache-warm — setting the bits of its active locations in a single shared replay-sized word array; after the join, the init task reassembles the words into the bitmap one chunk per word.

- `PartitionRange` gains `for_each_value`; both partitioned variants implement it over their range views.
- `build_snapshot_worker` records its range's active locations in the shared words (relaxed `fetch_or`; the join is the synchronization point) and returns the range's active-key count alongside the populated range.
- The full-index walk (`Partitioned::for_each_value`) had no remaining callers and is removed; the ordered variant's range view delegates to the index's inherent value walk.

The result is identical to the serial build's per-op push-then-clear: each active key holds exactly one location in exactly one worker's range, so every bit has a single writer (workers overlap only at word granularity, which the atomic or absorbs), and the words end with exactly the bits of each active key's current location set (plus the final commit, set by the init task as before). Sharing one allocation keeps peak bitmap memory at one replay-sized map regardless of worker count, and the words are u64s in `BitMap` chunk order, so reassembly is one `push_chunk` per word.

## Measurement

`init_scale` on a 50M-keyspace / 250M-update database (replay region 64.6M ops), AMD EPYC 9354P, warm OS cache, `init_concurrency=8`, interleaved rounds against `main`. Phase timers added for the measurement only; rounds with matched routing times shown (routing swings ±1s run-to-run and is untouched by this change):

| phase | main | this PR |
|---|---|---|
| routing | 10.7s | 10.7s |
| worker drain | 0.36s | 0.45s |
| install + bitmap | **1.13s** | **0.15s** |
| total init | **13.2s** | **12.3s (−7%)** |

The bitmap walk moves from a ~0.9s serial phase into the workers (partially absorbed by the drain window) plus a ~0.15s reassembly.

Sharing one allocation also bounds peak transient bitmap memory. The prior per-worker bitmaps cost `(workers + 1) × replay` bits; the shared word array costs one replay-sized map regardless of worker count — ~65 MB → ~8 MB at `init_concurrency=8` on this database, and ~2.1 GB → ~8 MB at the 256-partition (P1) worker cap.

Both effects apply to the unordered partitioned index, which is also built in parallel. A serial → parallel sweep (same 50M/250M scale, `any::unordered::fixed` P=2) confirms it is a beneficial parallel path in its own right, scaling comparably to ordered:

| `init_concurrency` | uniform | zipf 1.0 |
|---|---|---|
| 1 (serial) | 47.2s (1.00×) | 29.9s (1.00×) |
| 2 | 32.9s (1.44×) | 20.8s (1.44×) |
| 3 | 15.8s (2.99×) | 9.7s (3.08×) |
| 5 | 13.1s (3.61×) | 8.2s (3.67×) |
| 8 | 12.0s (3.93×) | 7.1s (4.19×) |

The shared allocation applies to unordered identically (same peak-memory reduction). Its install+bitmap phase is already negligible (~8 ms), so for unordered the memory bound, not wall time, is the win.

## Validation

- Parallel-init equivalence tests compare the resulting state — including bitmap-derived roots — against the serial build across a concurrency sweep up to 300 workers: ordered at P1/P2/P3 (both `any` and `current`, plus the variable-payload variant) and unordered at P1 (both `any` and `current`; P2's 65,536 sub-indexes are too memory-heavy for the suite). Fresh-db, replay-failure, worker-failure, and empty-log cases exercise the edge paths.
- Full storage suite (2766 tests), glue tests, `check-stability`, and the wasm32 storage build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo
