### PR TITLE
[consensus/marshal] Track fork tree

### DIFF
--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -122,6 +122,13 @@ impl<B: Block> Ancestry<B> for BoxedAncestry<B> {
     fn peek(&self) -> Option<&B> {
         self.0.peek_erased()
     }
+
+    fn descendants(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
+        self.0.descendants_erased(start)
+    }
 }
 
 impl<B: Block> Stream for BoxedAncestry<B> {
@@ -135,6 +142,11 @@ impl<B: Block> Stream for BoxedAncestry<B> {
 trait ErasedAncestry<B: Block>: Stream<Item = Arc<B>> + Send + Unpin + 'static {
     fn peek_erased(&self) -> Option<&B>;
 
+    fn descendants_erased(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> BoxFuture<'_, Option<BoxedAncestry<B>>>;
+
     fn clone_box(&self) -> Box<dyn ErasedAncestry<B>>;
 }
 
@@ -145,6 +157,15 @@ where
 {
     fn peek_erased(&self) -> Option<&B> {
         Ancestry::peek(self)
+    }
+
+    fn descendants_erased(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> BoxFuture<'_, Option<BoxedAncestry<B>>> {
+        Ancestry::descendants(self, start)
+            .map(|ancestry| ancestry.map(BoxedAncestry::new))
+            .boxed()
     }
 
     fn clone_box(&self) -> Box<dyn ErasedAncestry<B>> {
@@ -207,6 +228,13 @@ where
             .front()
             .map(Arc::as_ref)
             .or_else(|| self.tail.peek())
+    }
+
+    fn descendants(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
+        self.tail.descendants(start)
     }
 }
 
@@ -423,6 +451,8 @@ where
 
         Self {
             buffered: self.buffered.clone(),
+            chain: self.chain.clone(),
+            tip: self.tip,
             marshal,
             fetch_duration,
             clock,
@@ -619,6 +649,8 @@ pub struct DescendantStream<M: BlockProvider, C: Clock> {
     marshal: M,
     fetch_duration: Timed,
     clock: Arc<C>,
+    /// The block whose child is currently being fetched.
+    pending_parent: Option<Arc<M::Block>>,
     #[pin]
     pending: OptionFuture<PendingDescendantFetch<M::Block>>,
 }
@@ -643,6 +675,7 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
             marshal,
             fetch_duration,
             clock,
+            pending_parent: None,
             pending: None.into(),
         }
     }
@@ -666,6 +699,7 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
             marshal,
             fetch_duration,
             clock,
+            pending_parent: None,
             pending: None.into(),
         }
     }
@@ -675,6 +709,36 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
     /// exhausted.
     pub fn peek(&self) -> Option<&M::Block> {
         self.buffered.front().map(Arc::as_ref)
+    }
+}
+
+impl<M, C> Clone for DescendantStream<M, C>
+where
+    M: BlockProvider,
+    C: Clock,
+{
+    fn clone(&self) -> Self {
+        let marshal = self.marshal.clone();
+        let fetch_duration = self.fetch_duration.clone();
+        let clock = self.clock.clone();
+        let pending = self
+            .pending_parent
+            .as_ref()
+            .map(|parent| {
+                timed_descendant_fetch(&clock, &marshal, parent, self.tip, &fetch_duration)
+            })
+            .into();
+
+        Self {
+            buffered: self.buffered.clone(),
+            chain: self.chain.clone(),
+            tip: self.tip,
+            marshal,
+            fetch_duration,
+            clock,
+            pending_parent: self.pending_parent.clone(),
+            pending,
+        }
     }
 }
 
@@ -732,6 +796,7 @@ where
                     *this.tip,
                     this.fetch_duration,
                 );
+                *this.pending_parent = Some(block.clone());
                 *this.pending.as_mut() = Some(future).into();
 
                 // Explicitly poll the next future to kick off the fetch. If
@@ -740,15 +805,21 @@ where
                     Poll::Ready(Some(Some((link, child)))) => {
                         assert_extends(&link, child.as_ref());
                         this.buffered.push_back(child);
+                        *this.pending_parent = None;
                     }
                     Poll::Ready(Some(None)) => {
                         *this.pending.as_mut() = None.into();
+                        *this.pending_parent = None;
                     }
-                    Poll::Ready(None) | Poll::Pending => {}
+                    Poll::Ready(None) => {
+                        *this.pending_parent = None;
+                    }
+                    Poll::Pending => {}
                 }
             } else {
                 // The tip has been reached; finish the stream.
                 *this.pending.as_mut() = None.into();
+                *this.pending_parent = None;
             }
 
             return Poll::Ready(Some(block));
@@ -758,10 +829,12 @@ where
             Poll::Pending => Poll::Pending,
             Poll::Ready(None) | Poll::Ready(Some(None)) => {
                 *this.pending.as_mut() = None.into();
+                *this.pending_parent = None;
                 Poll::Ready(None)
             }
             Poll::Ready(Some(Some((link, block)))) => {
                 assert_extends(&link, block.as_ref());
+                *this.pending_parent = None;
                 if block.digest() != *this.tip {
                     let future = timed_descendant_fetch(
                         this.clock,
@@ -770,6 +843,7 @@ where
                         *this.tip,
                         this.fetch_duration,
                     );
+                    *this.pending_parent = Some(block.clone());
                     *this.pending.as_mut() = Some(future).into();
 
                     // Explicitly poll the next future to kick off the fetch.
@@ -778,15 +852,21 @@ where
                         Poll::Ready(Some(Some((link, child)))) => {
                             assert_extends(&link, child.as_ref());
                             this.buffered.push_back(child);
+                            *this.pending_parent = None;
                         }
                         Poll::Ready(Some(None)) => {
                             *this.pending.as_mut() = None.into();
+                            *this.pending_parent = None;
                         }
-                        Poll::Ready(None) | Poll::Pending => {}
+                        Poll::Ready(None) => {
+                            *this.pending_parent = None;
+                        }
+                        Poll::Pending => {}
                     }
                 } else {
                     // The tip has been reached; finish the stream.
                     *this.pending.as_mut() = None.into();
+                    *this.pending_parent = None;
                 }
 
                 Poll::Ready(Some(block))
@@ -828,6 +908,32 @@ mod test {
                     .map(Arc::new),
             )
         }
+
+        fn get_descendant(
+            &self,
+            start: BlockID<Sha256Digest>,
+            tip: BlockID<Sha256Digest>,
+        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
+        {
+            let result = (|| {
+                let BlockID::Digest(tip) = tip else {
+                    return None;
+                };
+                let mut cursor = tip;
+                loop {
+                    let block = self.0.iter().find(|block| block.digest() == cursor)?;
+                    let found = match start {
+                        BlockID::Height(height) => block.height() == height,
+                        BlockID::Digest(digest) => block.digest() == digest,
+                    };
+                    if found {
+                        return Some((Arc::new(block.clone()), tip));
+                    }
+                    cursor = block.parent;
+                }
+            })();
+            std::future::ready(result)
+        }
     }
 
     type TestBlock = Block<Sha256Digest, ()>;
@@ -865,30 +971,11 @@ mod test {
 
         fn get_descendant(
             &self,
-            start: BlockID<Sha256Digest>,
-            tip: BlockID<Sha256Digest>,
+            _start: BlockID<Sha256Digest>,
+            _tip: BlockID<Sha256Digest>,
         ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
         {
-            // Walk parent links from the tip down to locate the start on
-            // the tip's chain.
-            let result = (|| {
-                let BlockID::Digest(tip) = tip else {
-                    return None;
-                };
-                let mut cursor = tip;
-                loop {
-                    let block = self.0.iter().find(|b| b.digest() == cursor)?;
-                    let found = match start {
-                        BlockID::Height(height) => block.height() == height,
-                        BlockID::Digest(digest) => block.digest() == digest,
-                    };
-                    if found {
-                        return Some((Arc::new(block.clone()), tip));
-                    }
-                    cursor = block.parent;
-                }
-            })();
-            std::future::ready(result)
+            std::future::ready(None)
         }
     }
 

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -50,8 +50,8 @@ fn sort_and_validate_chain<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -
         let parent = &window[0];
         let child = &window[1];
         assert_eq!(
-            parent.height().next(),
-            child.height(),
+            child.height().previous(),
+            Some(parent.height()),
             "initial blocks must be contiguous in height"
         );
         assert_eq!(
@@ -265,17 +265,24 @@ where
 #[derive(Clone)]
 struct SuffixedAncestry<B: Block, S> {
     head: S,
-    head_exhausted: bool,
+    phase: SuffixPhase,
     blocks: VecDeque<Arc<B>>,
     chain: Vec<Arc<B>>,
     last: Option<(Height, B::Digest)>,
+}
+
+#[derive(Clone, Copy)]
+enum SuffixPhase {
+    Head,
+    Suffix,
+    Done,
 }
 
 impl<B: Block, S> SuffixedAncestry<B, S> {
     fn new(head: S, chain: Vec<Arc<B>>) -> Self {
         Self {
             head,
-            head_exhausted: false,
+            phase: SuffixPhase::Head,
             blocks: chain.clone().into(),
             chain,
             last: None,
@@ -285,16 +292,63 @@ impl<B: Block, S> SuffixedAncestry<B, S> {
 
 impl<B: Block, S> Unpin for SuffixedAncestry<B, S> {}
 
+impl<B: Block, S> SuffixedAncestry<B, S> {
+    // Switches to the fixed suffix only when the yielded head proves that the
+    // splice is contiguous. A descendant head may end early when local state
+    // is pruned, in which case the composite stream must end with it.
+    fn attach_suffix(&mut self) {
+        let Some((height, digest)) = self.last else {
+            self.blocks.clear();
+            self.phase = SuffixPhase::Done;
+            return;
+        };
+
+        while self
+            .blocks
+            .front()
+            .is_some_and(|block| block.height() < height)
+        {
+            self.blocks.pop_front();
+        }
+
+        let Some(block) = self.blocks.front() else {
+            self.phase = SuffixPhase::Done;
+            return;
+        };
+        let connected = if block.height() == height {
+            block.digest() == digest
+        } else {
+            block.height().previous() == Some(height) && block.parent() == digest
+        };
+        if !connected {
+            self.blocks.clear();
+            self.phase = SuffixPhase::Done;
+            return;
+        }
+
+        // The overlapping block was already yielded by the head.
+        if block.height() == height {
+            self.blocks.pop_front();
+        }
+        self.phase = if self.blocks.is_empty() {
+            SuffixPhase::Done
+        } else {
+            SuffixPhase::Suffix
+        };
+    }
+}
+
 impl<B, S> Ancestry<B> for SuffixedAncestry<B, S>
 where
     B: Block,
     S: Ancestry<B>,
 {
     fn peek(&self) -> Option<&B> {
-        if !self.head_exhausted {
-            return self.head.peek();
+        match self.phase {
+            SuffixPhase::Head => self.head.peek(),
+            SuffixPhase::Suffix => self.blocks.front().map(Arc::as_ref),
+            SuffixPhase::Done => None,
         }
-        self.blocks.front().map(Arc::as_ref)
     }
 
     fn descendants(
@@ -334,35 +388,23 @@ where
     type Item = Arc<B>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if !self.head_exhausted {
+        if matches!(self.phase, SuffixPhase::Head) {
             match Pin::new(&mut self.head).poll_next(cx) {
                 Poll::Ready(Some(block)) => {
                     self.last = Some((block.height(), block.digest()));
                     return Poll::Ready(Some(block));
                 }
                 Poll::Pending => return Poll::Pending,
-                Poll::Ready(None) => self.head_exhausted = true,
+                Poll::Ready(None) => self.attach_suffix(),
             }
         }
 
-        while let Some(block) = self.blocks.pop_front() {
-            if let Some((height, digest)) = self.last {
-                if block.height() < height {
-                    continue;
-                }
-                if block.height() == height {
-                    assert_eq!(
-                        block.digest(),
-                        digest,
-                        "overlapping blocks must share a digest"
-                    );
-                    continue;
-                }
-                assert_extends(&(height, digest), block.as_ref());
+        if matches!(self.phase, SuffixPhase::Suffix) {
+            if let Some(block) = self.blocks.pop_front() {
+                self.last = Some((block.height(), block.digest()));
+                return Poll::Ready(Some(block));
             }
-
-            self.last = Some((block.height(), block.digest()));
-            return Poll::Ready(Some(block));
+            self.phase = SuffixPhase::Done;
         }
 
         Poll::Ready(None)
@@ -411,6 +453,44 @@ pub trait BlockProvider: Clone + Send + 'static {
     ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
     + Send
     + 'static;
+
+    /// Retrieves the next non-empty, contiguous batch from `start` toward
+    /// `tip`, together with the resolved tip digest.
+    ///
+    /// Providers can override this to amortize lookup work across multiple
+    /// blocks. The default resolves the complete chain through singular
+    /// lookups.
+    #[allow(clippy::type_complexity)]
+    fn get_descendants(
+        &self,
+        start: BlockID<<Self::Block as Digestible>::Digest>,
+        tip: BlockID<<Self::Block as Digestible>::Digest>,
+    ) -> impl Future<
+        Output = Option<(
+            Vec<Arc<Self::Block>>,
+            <Self::Block as Digestible>::Digest,
+        )>,
+    > + Send
+    + 'static {
+        let provider = self.clone();
+        async move {
+            let (block, tip) = provider.get_descendant(start, tip).await?;
+            let mut blocks = vec![block];
+            while blocks.last()?.digest() != tip {
+                let parent = blocks.last()?;
+                let next = parent.height().get().checked_add(1).map(Height::new)?;
+                let (block, resolved_tip) = provider
+                    .get_descendant(BlockID::Height(next), BlockID::Digest(tip))
+                    .await?;
+                if resolved_tip != tip {
+                    return None;
+                }
+                assert_extends(&(parent.height(), parent.digest()), block.as_ref());
+                blocks.push(block);
+            }
+            Some((blocks, tip))
+        }
+    }
 }
 
 // Expected parent height and digest for a pending fetch.
@@ -447,8 +527,8 @@ impl<D: Digest> ExpectedParent<D> {
 fn assert_extends<B: Block>(last: &(Height, B::Digest), block: &B) {
     let (height, digest) = last;
     assert_eq!(
-        block.height(),
-        height.next(),
+        block.height().previous(),
+        Some(*height),
         "block must be contiguous in height"
     );
     assert_eq!(
@@ -605,11 +685,12 @@ where
                     fetch_duration,
                 ));
             }
-            let (block, tip) = marshal.get_descendant(start, BlockID::Digest(tip?)).await?;
-            Some(DescendantStream::new(
+            let descendants = marshal.get_descendants(start, BlockID::Digest(tip?));
+            let (batch, tip) = timed_fetch(&clock, &fetch_duration, descendants).await?;
+            Some(DescendantStream::from_batch(
                 clock,
                 marshal,
-                block,
+                batch,
                 tip,
                 fetch_duration,
             ))
@@ -714,11 +795,11 @@ where
 
 // A pending descendant fetch paired with the chain link it must extend.
 type PendingDescendantFetch<B> =
-    BoxFuture<'static, Option<((Height, <B as Digestible>::Digest), Arc<B>)>>;
+    BoxFuture<'static, Option<((Height, <B as Digestible>::Digest), Vec<Arc<B>>)>>;
 
-// Builds a pending fetch for the block directly above `parent` in `tip`'s
-// ancestry, recording successful fetch latency and carrying the link the
-// fetched block must extend.
+// Builds a pending fetch for the ancestry batch starting directly above
+// `parent`, recording successful fetch latency and carrying the link the
+// fetched batch must extend.
 fn timed_descendant_fetch<C, M>(
     clock: &Arc<C>,
     marshal: &M,
@@ -731,20 +812,41 @@ where
     M: BlockProvider,
 {
     let link = (parent.height(), parent.digest());
+    let Some(next) = link.0.get().checked_add(1).map(Height::new) else {
+        return std::future::ready(None).boxed();
+    };
     timed_fetch(
         clock,
         fetch_duration,
         marshal
-            .get_descendant(BlockID::Height(link.0.next()), BlockID::Digest(tip))
-            .map(move |block| block.map(|(block, _)| (link, block))),
+            .get_descendants(BlockID::Height(next), BlockID::Digest(tip))
+            .map(move |blocks| {
+                blocks.and_then(|(blocks, _)| (!blocks.is_empty()).then_some((link, blocks)))
+            }),
     )
+}
+
+fn buffer_descendants<B: Block>(
+    link: &(Height, B::Digest),
+    blocks: Vec<Arc<B>>,
+    buffered: &mut VecDeque<Arc<B>>,
+) {
+    let blocks = sort_and_validate_chain(blocks);
+    assert_extends(
+        link,
+        blocks
+            .first()
+            .expect("descendant batch must not be empty")
+            .as_ref(),
+    );
+    buffered.extend(blocks);
 }
 
 /// Yields a tip's ancestry in ascending height order, from a chosen ancestor
 /// up to the tip itself.
 ///
-/// The stream is armed with its first block and lazily fetches each following
-/// block from the provider (prefetching the next block while the previous one
+/// The stream is armed with its first batch and lazily fetches following
+/// batches from the provider (prefetching the next batch while the previous one
 /// is consumed), mirroring [AncestorStream] in the opposite direction. It
 /// finishes once the tip is yielded, and ends early if the next block becomes
 /// unavailable locally (e.g. its branch was pruned by a finalization, or a
@@ -777,7 +879,8 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
     ///
     /// `start` must lie in the ancestry of `tip`; providers validate this
     /// when resolving the anchor (see [BlockProvider::get_descendant]).
-    pub(crate) fn new(
+    #[cfg(test)]
+    fn new(
         clock: Arc<C>,
         marshal: M,
         start: Arc<M::Block>,
@@ -811,6 +914,29 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
         Self {
             buffered: chain.clone().into(),
             chain: Some(chain),
+            tip,
+            marshal,
+            fetch_duration,
+            clock,
+            pending_parent: None,
+            pending: None.into(),
+        }
+    }
+
+    /// Creates a forward stream from a provider batch that may not yet reach
+    /// the resolved tip.
+    fn from_batch(
+        clock: Arc<C>,
+        marshal: M,
+        batch: Vec<Arc<M::Block>>,
+        tip: <M::Block as Digestible>::Digest,
+        fetch_duration: Timed,
+    ) -> Self {
+        let batch = sort_and_validate_chain(batch);
+        assert!(!batch.is_empty(), "descendant batch must not be empty");
+        Self {
+            buffered: batch.into(),
+            chain: None,
             tip,
             marshal,
             fetch_duration,
@@ -883,8 +1009,9 @@ where
             if let Some(chain) = chain {
                 return Some(Self::from_chain(clock, marshal, chain, fetch_duration));
             }
-            let (block, tip) = marshal.get_descendant(start, BlockID::Digest(tip)).await?;
-            Some(Self::new(clock, marshal, block, tip, fetch_duration))
+            let descendants = marshal.get_descendants(start, BlockID::Digest(tip));
+            let (batch, tip) = timed_fetch(&clock, &fetch_duration, descendants).await?;
+            Some(Self::from_batch(clock, marshal, batch, tip, fetch_duration))
         }
     }
 }
@@ -899,95 +1026,58 @@ where
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
 
-        // If a block has been buffered, return it and queue the next fetch
-        // if the tip has not been reached.
-        if let Some(block) = this.buffered.pop_front() {
-            if let Some(child) = this.buffered.front() {
-                assert_extends(&(block.height(), block.digest()), child.as_ref());
-            } else if block.digest() != *this.tip {
-                let future = timed_descendant_fetch(
-                    this.clock,
-                    this.marshal,
-                    &block,
-                    *this.tip,
-                    this.fetch_duration,
-                );
-                *this.pending_parent = Some(block.clone());
-                *this.pending.as_mut() = Some(future).into();
-
-                // Explicitly poll the next future to kick off the fetch. If
-                // it's already ready, buffer it for the next poll.
-                match this.pending.as_mut().poll(cx) {
-                    Poll::Ready(Some(Some((link, child)))) => {
-                        assert_extends(&link, child.as_ref());
-                        this.buffered.push_back(child);
-                        *this.pending_parent = None;
-                    }
-                    Poll::Ready(Some(None)) => {
-                        *this.pending.as_mut() = None.into();
-                        *this.pending_parent = None;
-                    }
-                    Poll::Ready(None) => {
-                        *this.pending_parent = None;
-                    }
-                    Poll::Pending => {}
+        if this.buffered.is_empty() {
+            match this.pending.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) | Poll::Ready(Some(None)) => {
+                    *this.pending.as_mut() = None.into();
+                    *this.pending_parent = None;
+                    return Poll::Ready(None);
                 }
-            } else {
-                // The tip has been reached; finish the stream.
-                *this.pending.as_mut() = None.into();
-                *this.pending_parent = None;
+                Poll::Ready(Some(Some((link, blocks)))) => {
+                    buffer_descendants(&link, blocks, this.buffered);
+                    *this.pending_parent = None;
+                }
             }
-
-            return Poll::Ready(Some(block));
         }
 
-        match this.pending.as_mut().poll(cx) {
-            Poll::Pending => Poll::Pending,
-            Poll::Ready(None) | Poll::Ready(Some(None)) => {
-                *this.pending.as_mut() = None.into();
-                *this.pending_parent = None;
-                Poll::Ready(None)
-            }
-            Poll::Ready(Some(Some((link, block)))) => {
-                assert_extends(&link, block.as_ref());
-                *this.pending_parent = None;
-                if block.digest() != *this.tip {
-                    let future = timed_descendant_fetch(
-                        this.clock,
-                        this.marshal,
-                        &block,
-                        *this.tip,
-                        this.fetch_duration,
-                    );
-                    *this.pending_parent = Some(block.clone());
-                    *this.pending.as_mut() = Some(future).into();
+        let Some(block) = this.buffered.pop_front() else {
+            return Poll::Ready(None);
+        };
+        if let Some(child) = this.buffered.front() {
+            assert_extends(&(block.height(), block.digest()), child.as_ref());
+        } else if block.digest() != *this.tip {
+            let future = timed_descendant_fetch(
+                this.clock,
+                this.marshal,
+                &block,
+                *this.tip,
+                this.fetch_duration,
+            );
+            *this.pending_parent = Some(block.clone());
+            *this.pending.as_mut() = Some(future).into();
 
-                    // Explicitly poll the next future to kick off the fetch.
-                    // If it's already ready, buffer it for the next poll.
-                    match this.pending.as_mut().poll(cx) {
-                        Poll::Ready(Some(Some((link, child)))) => {
-                            assert_extends(&link, child.as_ref());
-                            this.buffered.push_back(child);
-                            *this.pending_parent = None;
-                        }
-                        Poll::Ready(Some(None)) => {
-                            *this.pending.as_mut() = None.into();
-                            *this.pending_parent = None;
-                        }
-                        Poll::Ready(None) => {
-                            *this.pending_parent = None;
-                        }
-                        Poll::Pending => {}
-                    }
-                } else {
-                    // The tip has been reached; finish the stream.
+            // Kick off the next batch while the current block is consumed.
+            match this.pending.as_mut().poll(cx) {
+                Poll::Ready(Some(Some((link, blocks)))) => {
+                    buffer_descendants(&link, blocks, this.buffered);
+                    *this.pending_parent = None;
+                }
+                Poll::Ready(Some(None)) => {
                     *this.pending.as_mut() = None.into();
                     *this.pending_parent = None;
                 }
-
-                Poll::Ready(Some(block))
+                Poll::Ready(None) => {
+                    *this.pending_parent = None;
+                }
+                Poll::Pending => {}
             }
+        } else {
+            *this.pending.as_mut() = None.into();
+            *this.pending_parent = None;
         }
+
+        Poll::Ready(Some(block))
     }
 }
 
@@ -1005,6 +1095,7 @@ mod test {
     };
     use commonware_utils::{channel::oneshot, sync::Mutex};
     use futures::StreamExt;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     #[derive(Default, Clone)]
     struct MockProvider(Vec<Block<Sha256Digest, ()>>);
@@ -1049,6 +1140,62 @@ mod test {
                 }
             })();
             std::future::ready(result)
+        }
+    }
+
+    #[derive(Clone)]
+    struct BulkProvider {
+        chain: Arc<Vec<Block<Sha256Digest, ()>>>,
+        singular: Arc<AtomicUsize>,
+        bulk: Arc<AtomicUsize>,
+    }
+
+    impl BlockProvider for BulkProvider {
+        type Block = Block<Sha256Digest, ()>;
+
+        fn subscribe_parent(
+            &self,
+            _block: &Self::Block,
+        ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
+            std::future::ready(None)
+        }
+
+        fn get_descendant(
+            &self,
+            _start: BlockID<Sha256Digest>,
+            _tip: BlockID<Sha256Digest>,
+        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
+        {
+            self.singular.fetch_add(1, Ordering::Relaxed);
+            std::future::ready(None)
+        }
+
+        fn get_descendants(
+            &self,
+            start: BlockID<Sha256Digest>,
+            tip: BlockID<Sha256Digest>,
+        ) -> impl Future<Output = Option<(Vec<Arc<Self::Block>>, Sha256Digest)>> + Send + 'static
+        {
+            self.bulk.fetch_add(1, Ordering::Relaxed);
+            let chain = self.chain.clone();
+            async move {
+                let BlockID::Digest(tip) = tip else {
+                    return None;
+                };
+                let position = chain.iter().position(|block| match start {
+                    BlockID::Height(height) => block.height() == height,
+                    BlockID::Digest(digest) => block.digest() == digest,
+                })?;
+                Some((
+                    chain[position..]
+                        .iter()
+                        .take(8)
+                        .cloned()
+                        .map(Arc::new)
+                        .collect(),
+                    tip,
+                ))
+            }
         }
     }
 
@@ -1244,6 +1391,31 @@ mod test {
     }
 
     #[test]
+    fn test_descendants_use_bounded_bulk_lookups() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(0, 64);
+            let singular = Arc::new(AtomicUsize::new(0));
+            let bulk = Arc::new(AtomicUsize::new(0));
+            let provider = BulkProvider {
+                chain: Arc::new(chain.clone()),
+                singular: singular.clone(),
+                bulk: bulk.clone(),
+            };
+            let ancestry = stream(&context, provider, [chain.last().unwrap().clone()]);
+
+            let descendants = ancestry
+                .descendants(BlockID::Height(Height::zero()))
+                .await
+                .expect("bulk chain should resolve")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(descendants.len(), chain.len());
+            assert_eq!(bulk.load(Ordering::Relaxed), 8);
+            assert_eq!(singular.load(Ordering::Relaxed), 0);
+        });
+    }
+
+    #[test]
     fn test_from_iter_descendants_survive_consumption() {
         deterministic::Runner::default().start(|_| async move {
             let parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
@@ -1397,6 +1569,27 @@ mod test {
                 overlapping,
                 vec![Arc::new(ancestor), Arc::new(parent), Arc::new(tip)]
             );
+        });
+    }
+
+    #[test]
+    fn test_with_prefix_descendants_stop_when_tail_ends_before_prefix() {
+        deterministic::Runner::default().start(|_| async move {
+            let start = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::zero(), 0);
+            let missing = Block::new::<Sha256>((), start.digest(), Height::new(1), 1);
+            let tip = Block::new::<Sha256>((), missing.digest(), Height::new(2), 2);
+            let ancestry = with_prefix(
+                [Arc::new(tip)],
+                from_iter([Arc::new(start.clone())]),
+            );
+
+            let forward = ancestry
+                .descendants(BlockID::Digest(start.digest()))
+                .await
+                .expect("start is present in the tail")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(forward, vec![Arc::new(start)]);
         });
     }
 

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -42,14 +42,39 @@ pub trait Ancestry<B: Block>: Stream<Item = Arc<B>> + Clone + Send + Unpin + 'st
     ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send;
 }
 
+fn sort_and_validate_chain<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -> Vec<Arc<B>> {
+    let mut chain = blocks.into_iter().collect::<Vec<_>>();
+    chain.sort_by_key(|block| block.height());
+
+    for window in chain.windows(2) {
+        let parent = &window[0];
+        let child = &window[1];
+        assert_eq!(
+            parent.height().next(),
+            child.height(),
+            "initial blocks must be contiguous in height"
+        );
+        assert_eq!(
+            parent.digest(),
+            child.parent(),
+            "initial blocks must be contiguous in ancestry"
+        );
+    }
+
+    chain
+}
+
 /// Creates an ancestry stream from a fixed sequence of blocks.
 ///
 /// Blocks are yielded in iterator order and no parent fetching is performed. This is useful when
 /// the caller wants to bound the ancestry available to the application.
+///
+/// # Panics
+///
+/// Panics if the blocks do not form a contiguous chain.
 pub fn from_iter<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -> impl Ancestry<B> {
     let blocks: VecDeque<_> = blocks.into_iter().collect();
-    let mut chain: Vec<_> = blocks.iter().cloned().collect();
-    chain.sort_by_key(|block| block.height());
+    let chain = sort_and_validate_chain(blocks.iter().cloned());
     BoundedAncestry { blocks, chain }
 }
 
@@ -356,22 +381,7 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
         initial: impl IntoIterator<Item = Arc<M::Block>>,
         fetch_duration: Timed,
     ) -> Self {
-        let mut buffered = initial.into_iter().collect::<Vec<_>>();
-        buffered.sort_by_key(|block| block.height());
-
-        // Check that the initial blocks are contiguous in height.
-        buffered.windows(2).for_each(|window| {
-            assert_eq!(
-                window[0].height().next(),
-                window[1].height(),
-                "initial blocks must be contiguous in height"
-            );
-            assert_eq!(
-                window[0].digest(),
-                window[1].parent(),
-                "initial blocks must be contiguous in ancestry"
-            );
-        });
+        let buffered = sort_and_validate_chain(initial);
 
         let tip = buffered.last().map(|block| block.digest());
         Self {
@@ -976,6 +986,25 @@ mod test {
             let results = forward.collect::<Vec<_>>().await;
             assert_eq!(results, vec![Arc::new(parent), Arc::new(child)]);
         });
+    }
+
+    #[test]
+    #[should_panic = "initial blocks must be contiguous in height"]
+    fn test_from_iter_panics_on_non_contiguous_height() {
+        let parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
+        let child = Block::new::<Sha256>((), parent.digest(), Height::new(3), 3);
+
+        let _ = from_iter([Arc::new(child), Arc::new(parent)]);
+    }
+
+    #[test]
+    #[should_panic = "initial blocks must be contiguous in ancestry"]
+    fn test_from_iter_panics_on_non_contiguous_ancestry() {
+        let expected_parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
+        let wrong_parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 2);
+        let child = Block::new::<Sha256>((), expected_parent.digest(), Height::new(2), 3);
+
+        let _ = from_iter([Arc::new(child), Arc::new(wrong_parent)]);
     }
 
     #[test]

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -1,7 +1,13 @@
-//! A stream that yields the ancestors of a block while prefetching parents.
+//! Streams over a block's ancestry.
+//!
+//! [AncestorStream] walks backward from a block toward genesis, prefetching
+//! parents as it goes. [DescendantStream] walks the same ancestry forward:
+//! starting from a chosen ancestor, it yields blocks in ascending height
+//! order until it reaches the tip whose ancestry defines the chain.
 
-use crate::{Block, Heightable, types::Height};
+use crate::{Block, Heightable, marshal::BlockID, types::Height};
 use commonware_cryptography::{Digest, Digestible};
+use commonware_macros::stability;
 use commonware_runtime::{Clock, telemetry::metrics::histogram::Timed};
 use futures::{
     FutureExt, Stream,
@@ -21,6 +27,19 @@ pub trait Ancestry<B: Block>: Stream<Item = Arc<B>> + Clone + Send + Unpin + 'st
     /// Peeks at the latest block in the stream without consuming it. Returns [None]
     /// if the stream does not yet have a block available or has been exhausted.
     fn peek(&self) -> Option<&B>;
+
+    /// Returns a forward stream over this ancestry's chain, yielding blocks
+    /// in ascending height order from `start` up to this ancestry's tip.
+    ///
+    /// `start` identifies where iteration begins within the chain: a height
+    /// or a digest on the chain.
+    ///
+    /// Only locally known blocks are served; no network fetches are issued.
+    /// Returns `None` when `start` does not lie in the locally known chain.
+    fn descendants(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send;
 }
 
 /// Creates an ancestry stream from a fixed sequence of blocks.
@@ -28,9 +47,10 @@ pub trait Ancestry<B: Block>: Stream<Item = Arc<B>> + Clone + Send + Unpin + 'st
 /// Blocks are yielded in iterator order and no parent fetching is performed. This is useful when
 /// the caller wants to bound the ancestry available to the application.
 pub fn from_iter<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -> impl Ancestry<B> {
-    BoundedAncestry {
-        blocks: blocks.into_iter().collect(),
-    }
+    let blocks: VecDeque<_> = blocks.into_iter().collect();
+    let mut chain: Vec<_> = blocks.iter().cloned().collect();
+    chain.sort_by_key(|block| block.height());
+    BoundedAncestry { blocks, chain }
 }
 
 /// Prepends a fixed sequence of blocks to an existing ancestry stream.
@@ -101,7 +121,11 @@ where
 
 #[derive(Clone)]
 struct BoundedAncestry<B: Block> {
+    /// Blocks remaining to yield, in caller-provided order.
     blocks: VecDeque<Arc<B>>,
+    /// The chain fixed at construction, ascending in height, serving forward
+    /// walks regardless of how much of the stream has been consumed.
+    chain: Vec<Arc<B>>,
 }
 
 impl<B: Block> Unpin for BoundedAncestry<B> {}
@@ -109,6 +133,25 @@ impl<B: Block> Unpin for BoundedAncestry<B> {}
 impl<B: Block> Ancestry<B> for BoundedAncestry<B> {
     fn peek(&self) -> Option<&B> {
         self.blocks.front().map(Arc::as_ref)
+    }
+
+    fn descendants(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
+        // A bounded ancestry is fully in memory: serve the chain fixed at
+        // construction from the start onward, in ascending height order.
+        let position = match start {
+            BlockID::Height(height) => self.chain.iter().position(|b| b.height() == height),
+            BlockID::Digest(digest) => self.chain.iter().position(|b| b.digest() == digest),
+        };
+        std::future::ready(position.map(|position| {
+            let chain = self.chain[position..].to_vec();
+            Self {
+                blocks: chain.clone().into(),
+                chain,
+            }
+        }))
     }
 }
 
@@ -156,8 +199,8 @@ where
     }
 }
 
-/// An interface for providing parent blocks.
-pub trait BlockProvider: Send + 'static {
+/// An interface for providing blocks from a locally known ancestry.
+pub trait BlockProvider: Clone + Send + 'static {
     /// The block type the provider walks.
     type Block: Block;
 
@@ -177,6 +220,27 @@ pub trait BlockProvider: Send + 'static {
         &self,
         block: &Self::Block,
     ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static;
+
+    /// Retrieve the block at `start` within the locally known ancestry of
+    /// `tip`, together with the resolved tip digest.
+    ///
+    /// The chain is defined by the ancestry of `tip`, which may be an
+    /// unfinalized candidate (a fork tracked by marshal) or a finalized
+    /// block. Finalized blocks are served from storage and candidates from
+    /// marshal's in-memory fork tree. Unlike [Self::subscribe_parent], this
+    /// lookup never waits and never fetches from the network.
+    ///
+    /// Returns `None` when `tip` is unknown locally, `start` does not lie in
+    /// the tip's locally known ancestry, or the block at `start` is not
+    /// locally available.
+    #[allow(clippy::type_complexity)]
+    fn get_descendant(
+        &self,
+        start: BlockID<<Self::Block as Digestible>::Digest>,
+        tip: BlockID<<Self::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
+    + Send
+    + 'static;
 }
 
 // Expected parent height and digest for a pending fetch.
@@ -209,6 +273,38 @@ impl<D: Digest> ExpectedParent<D> {
     }
 }
 
+// Asserts that `block` directly extends the chain link `last`.
+fn assert_extends<B: Block>(last: &(Height, B::Digest), block: &B) {
+    let (height, digest) = last;
+    assert_eq!(
+        block.height(),
+        height.next(),
+        "block must be contiguous in height"
+    );
+    assert_eq!(
+        block.parent(),
+        *digest,
+        "block must be contiguous in ancestry"
+    );
+}
+
+// Wraps `fetch`, recording its latency on success.
+fn timed_fetch<C, T>(
+    clock: &Arc<C>,
+    fetch_duration: &Timed,
+    fetch: impl Future<Output = Option<T>> + Send + 'static,
+) -> BoxFuture<'static, Option<T>>
+where
+    C: Clock,
+    T: Send + 'static,
+{
+    let timer = fetch_duration.timer(clock.as_ref());
+    let clock = clock.clone();
+    fetch
+        .map(move |result| result.inspect(|_| timer.observe(clock.as_ref())))
+        .boxed()
+}
+
 // Builds a pending parent fetch that records successful fetch latency and carries the
 // expected relationship for validation when the parent is delivered.
 fn timed_parent_fetch<C, M>(
@@ -222,17 +318,13 @@ where
     M: BlockProvider,
 {
     let expected = ExpectedParent::from_child(child);
-    let timer = fetch_duration.timer(clock.as_ref());
-    let clock = clock.clone();
-    marshal
-        .subscribe_parent(child)
-        .map(move |parent| {
-            parent.map(|parent| {
-                timer.observe(clock.as_ref());
-                (expected, parent)
-            })
-        })
-        .boxed()
+    timed_fetch(
+        clock,
+        fetch_duration,
+        marshal
+            .subscribe_parent(child)
+            .map(move |parent| parent.map(|parent| (expected, parent))),
+    )
 }
 
 /// Yields the ancestors of a block while prefetching parents, including the
@@ -240,6 +332,9 @@ where
 #[pin_project]
 pub struct AncestorStream<M: BlockProvider, C: Clock> {
     buffered: Vec<Arc<M::Block>>,
+    /// The digest of the highest initial block, identifying the chain this
+    /// stream walks.
+    tip: Option<<M::Block as Digestible>::Digest>,
     marshal: M,
     fetch_duration: Timed,
     clock: Arc<C>,
@@ -254,6 +349,7 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
     /// # Panics
     ///
     /// Panics if the initial blocks are not contiguous.
+    #[stability(ALPHA)]
     pub(crate) fn new(
         clock: Arc<C>,
         marshal: M,
@@ -277,9 +373,11 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
             );
         });
 
+        let tip = buffered.last().map(|block| block.digest());
         Self {
             marshal,
             buffered,
+            tip,
             fetch_duration,
             clock,
             pending_child: None,
@@ -327,6 +425,26 @@ where
 {
     fn peek(&self) -> Option<&M::Block> {
         Self::peek(self)
+    }
+
+    fn descendants(
+        &self,
+        start: BlockID<<M::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<M::Block>>> + Send {
+        let tip = self.tip;
+        let marshal = self.marshal.clone();
+        let clock = self.clock.clone();
+        let fetch_duration = self.fetch_duration.clone();
+        async move {
+            let (block, tip) = marshal.get_descendant(start, BlockID::Digest(tip?)).await?;
+            Some(DescendantStream::new(
+                clock,
+                marshal,
+                block,
+                tip,
+                fetch_duration,
+            ))
+        }
     }
 }
 
@@ -425,6 +543,200 @@ where
     }
 }
 
+// A pending descendant fetch paired with the chain link it must extend.
+type PendingDescendantFetch<B> =
+    BoxFuture<'static, Option<((Height, <B as Digestible>::Digest), Arc<B>)>>;
+
+// Builds a pending fetch for the block directly above `parent` in `tip`'s
+// ancestry, recording successful fetch latency and carrying the link the
+// fetched block must extend.
+fn timed_descendant_fetch<C, M>(
+    clock: &Arc<C>,
+    marshal: &M,
+    parent: &M::Block,
+    tip: <M::Block as Digestible>::Digest,
+    fetch_duration: &Timed,
+) -> PendingDescendantFetch<M::Block>
+where
+    C: Clock,
+    M: BlockProvider,
+{
+    let link = (parent.height(), parent.digest());
+    timed_fetch(
+        clock,
+        fetch_duration,
+        marshal
+            .get_descendant(BlockID::Height(link.0.next()), BlockID::Digest(tip))
+            .map(move |block| block.map(|(block, _)| (link, block))),
+    )
+}
+
+/// Yields a tip's ancestry in ascending height order, from a chosen ancestor
+/// up to the tip itself.
+///
+/// The stream is armed with its first block and lazily fetches each following
+/// block from the provider (prefetching the next block while the previous one
+/// is consumed), mirroring [AncestorStream] in the opposite direction. It
+/// finishes once the tip is yielded, and ends early if the next block becomes
+/// unavailable locally (e.g. its branch was pruned by a finalization, or a
+/// finalized block was pruned while iterating).
+///
+/// # Panics
+///
+/// Panics if fetched blocks do not form a contiguous chain, which indicates
+/// local storage corruption.
+#[pin_project]
+pub struct DescendantStream<M: BlockProvider, C: Clock> {
+    /// The next block to yield.
+    buffered: Option<Arc<M::Block>>,
+    /// The digest of the tip; the stream finishes once it is yielded.
+    tip: <M::Block as Digestible>::Digest,
+    marshal: M,
+    fetch_duration: Timed,
+    clock: Arc<C>,
+    #[pin]
+    pending: OptionFuture<PendingDescendantFetch<M::Block>>,
+}
+
+impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
+    /// Creates a new [DescendantStream] armed with the first block of the
+    /// walk, ending at `tip`.
+    ///
+    /// `start` must lie in the ancestry of `tip`; providers validate this
+    /// when resolving the anchor (see [BlockProvider::get_descendant]).
+    pub(crate) fn new(
+        clock: Arc<C>,
+        marshal: M,
+        start: Arc<M::Block>,
+        tip: <M::Block as Digestible>::Digest,
+        fetch_duration: Timed,
+    ) -> Self {
+        Self {
+            buffered: Some(start),
+            tip,
+            marshal,
+            fetch_duration,
+            clock,
+            pending: None.into(),
+        }
+    }
+
+    /// Peeks at the next block in the stream without consuming it. Returns
+    /// [None] if the stream does not yet have a block available or has been
+    /// exhausted.
+    pub fn peek(&self) -> Option<&M::Block> {
+        self.buffered.as_deref()
+    }
+}
+
+impl<M, C> Ancestry<M::Block> for DescendantStream<M, C>
+where
+    M: BlockProvider,
+    C: Clock,
+{
+    fn peek(&self) -> Option<&M::Block> {
+        Self::peek(self)
+    }
+
+    fn descendants(
+        &self,
+        start: BlockID<<M::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<M::Block>>> + Send {
+        let tip = self.tip;
+        let marshal = self.marshal.clone();
+        let clock = self.clock.clone();
+        let fetch_duration = self.fetch_duration.clone();
+        async move {
+            let (block, tip) = marshal.get_descendant(start, BlockID::Digest(tip)).await?;
+            Some(Self::new(clock, marshal, block, tip, fetch_duration))
+        }
+    }
+}
+
+impl<M, C> Stream for DescendantStream<M, C>
+where
+    M: BlockProvider,
+    C: Clock,
+{
+    type Item = Arc<M::Block>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+
+        // If a block has been buffered, return it and queue the next fetch
+        // if the tip has not been reached.
+        if let Some(block) = this.buffered.take() {
+            if block.digest() != *this.tip {
+                let future = timed_descendant_fetch(
+                    this.clock,
+                    this.marshal,
+                    &block,
+                    *this.tip,
+                    this.fetch_duration,
+                );
+                *this.pending.as_mut() = Some(future).into();
+
+                // Explicitly poll the next future to kick off the fetch. If
+                // it's already ready, buffer it for the next poll.
+                match this.pending.as_mut().poll(cx) {
+                    Poll::Ready(Some(Some((link, child)))) => {
+                        assert_extends(&link, child.as_ref());
+                        *this.buffered = Some(child);
+                    }
+                    Poll::Ready(Some(None)) => {
+                        *this.pending.as_mut() = None.into();
+                    }
+                    Poll::Ready(None) | Poll::Pending => {}
+                }
+            } else {
+                // The tip has been reached; finish the stream.
+                *this.pending.as_mut() = None.into();
+            }
+
+            return Poll::Ready(Some(block));
+        }
+
+        match this.pending.as_mut().poll(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) | Poll::Ready(Some(None)) => {
+                *this.pending.as_mut() = None.into();
+                Poll::Ready(None)
+            }
+            Poll::Ready(Some(Some((link, block)))) => {
+                assert_extends(&link, block.as_ref());
+                if block.digest() != *this.tip {
+                    let future = timed_descendant_fetch(
+                        this.clock,
+                        this.marshal,
+                        &block,
+                        *this.tip,
+                        this.fetch_duration,
+                    );
+                    *this.pending.as_mut() = Some(future).into();
+
+                    // Explicitly poll the next future to kick off the fetch.
+                    // If it's already ready, buffer it for the next poll.
+                    match this.pending.as_mut().poll(cx) {
+                        Poll::Ready(Some(Some((link, child)))) => {
+                            assert_extends(&link, child.as_ref());
+                            *this.buffered = Some(child);
+                        }
+                        Poll::Ready(Some(None)) => {
+                            *this.pending.as_mut() = None.into();
+                        }
+                        Poll::Ready(None) | Poll::Pending => {}
+                    }
+                } else {
+                    // The tip has been reached; finish the stream.
+                    *this.pending.as_mut() = None.into();
+                }
+
+                Poll::Ready(Some(block))
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -492,6 +804,34 @@ mod test {
             self.subscriptions.lock().push(subscription);
             parent.map(Result::ok)
         }
+
+        fn get_descendant(
+            &self,
+            start: BlockID<Sha256Digest>,
+            tip: BlockID<Sha256Digest>,
+        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
+        {
+            // Walk parent links from the tip down to locate the start on
+            // the tip's chain.
+            let result = (|| {
+                let BlockID::Digest(tip) = tip else {
+                    return None;
+                };
+                let mut cursor = tip;
+                loop {
+                    let block = self.0.iter().find(|b| b.digest() == cursor)?;
+                    let found = match start {
+                        BlockID::Height(height) => block.height() == height,
+                        BlockID::Digest(digest) => block.digest() == digest,
+                    };
+                    if found {
+                        return Some((Arc::new(block.clone()), tip));
+                    }
+                    cursor = block.parent;
+                }
+            })();
+            std::future::ready(result)
+        }
     }
 
     #[derive(Clone)]
@@ -504,6 +844,18 @@ mod test {
             _block: &Self::Block,
         ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
             std::future::ready(Some(Arc::new(self.0.clone())))
+        }
+
+        fn get_descendant(
+            &self,
+            _start: BlockID<Sha256Digest>,
+            tip: BlockID<Sha256Digest>,
+        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
+        {
+            let BlockID::Digest(tip) = tip else {
+                return std::future::ready(None);
+            };
+            std::future::ready(Some((Arc::new(self.0.clone()), tip)))
         }
     }
 
@@ -604,6 +956,25 @@ mod test {
             let block = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
             let stream = stream(&context, MockProvider::default(), [block.clone()]);
             assert_eq!(peek_height(stream), Some(block.height()));
+        });
+    }
+
+    #[test]
+    fn test_from_iter_descendants_survive_consumption() {
+        deterministic::Runner::default().start(|_| async move {
+            let parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
+            let child = Block::new::<Sha256>((), parent.digest(), Height::new(2), 2);
+            let mut ancestry = from_iter([Arc::new(child.clone()), Arc::new(parent.clone())]);
+
+            // Consuming the tip must not remove it from the chain served by
+            // forward walks.
+            assert_eq!(ancestry.next().await.as_deref(), Some(&child));
+            let forward = ancestry
+                .descendants(BlockID::Digest(parent.digest()))
+                .await
+                .expect("start on chain");
+            let results = forward.collect::<Vec<_>>().await;
+            assert_eq!(results, vec![Arc::new(parent), Arc::new(child)]);
         });
     }
 
@@ -767,6 +1138,149 @@ mod test {
 
             let results = stream.collect::<Vec<_>>().await;
             assert_eq!(results, vec![Arc::new(block3)]);
+        });
+    }
+
+    /// Builds a chain of `len` contiguous blocks starting at height `start`.
+    fn make_chain(start: u64, len: u64) -> Vec<Block<Sha256Digest, ()>> {
+        let mut blocks = Vec::new();
+        let mut parent = Sha256Digest::EMPTY;
+        for height in start..start + len {
+            let block = Block::new::<Sha256>((), parent, Height::new(height), height);
+            parent = block.digest();
+            blocks.push(block);
+        }
+        blocks
+    }
+
+    fn descendant_stream<M>(
+        context: &deterministic::Context,
+        provider: M,
+        start: M::Block,
+        tip: Sha256Digest,
+    ) -> DescendantStream<M, deterministic::Context>
+    where
+        M: BlockProvider<Block = Block<Sha256Digest, ()>>,
+    {
+        let stream_context = context.child("descendant_stream");
+        let fetch_duration = timed(&stream_context);
+        DescendantStream::new(
+            Arc::new(stream_context),
+            provider,
+            Arc::new(start),
+            tip,
+            fetch_duration,
+        )
+    }
+
+    #[test]
+    fn test_descendant_walks_chain_to_tip() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(0, 5);
+            let provider = MockProvider(chain.clone());
+
+            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
+            let results = stream.collect::<Vec<_>>().await;
+            assert_eq!(
+                results,
+                chain.iter().cloned().map(Arc::new).collect::<Vec<_>>()
+            );
+        });
+    }
+
+    #[test]
+    fn test_descendant_single_block_when_start_is_tip() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(3, 1);
+            let provider = MockProvider(chain.clone());
+
+            let mut stream =
+                descendant_stream(&context, provider, chain[0].clone(), chain[0].digest());
+            assert_eq!(stream.peek(), Some(&chain[0]));
+            assert_eq!(stream.next().await.as_deref(), Some(&chain[0]));
+            assert_eq!(stream.peek(), None);
+            assert_eq!(stream.next().await, None);
+        });
+    }
+
+    #[test]
+    fn test_descendant_missing_block_ends_stream() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(0, 5);
+
+            // The block at height 2 is missing locally, so the provider can
+            // no longer connect the tip's chain to the next requested height;
+            // the walk ends after the anchor.
+            let mut stored = chain.clone();
+            stored.remove(2);
+            let provider = MockProvider(stored);
+
+            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
+            let results = stream.collect::<Vec<_>>().await;
+            assert_eq!(results, vec![Arc::new(chain[0].clone())]);
+        });
+    }
+
+    #[test]
+    fn test_descendant_peek_available_through_ancestry_trait() {
+        deterministic::Runner::default().start(|context| async move {
+            fn peek_height(ancestry: impl Ancestry<Block<Sha256Digest, ()>>) -> Option<Height> {
+                ancestry.peek().map(Heightable::height)
+            }
+
+            let block = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
+            let stream = descendant_stream(
+                &context,
+                MockProvider::default(),
+                block.clone(),
+                block.digest(),
+            );
+            assert_eq!(peek_height(stream), Some(block.height()));
+        });
+    }
+
+    #[test]
+    fn test_descendant_restarts_from_any_position() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(0, 5);
+            let provider = MockProvider(chain.clone());
+
+            // A forward stream can itself be flipped to a new start on the
+            // same chain through the Ancestry trait.
+            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
+            let restarted = stream
+                .descendants(BlockID::Height(Height::new(2)))
+                .await
+                .expect("restart within chain");
+            let results = restarted.collect::<Vec<_>>().await;
+            assert_eq!(
+                results,
+                chain[2..].iter().cloned().map(Arc::new).collect::<Vec<_>>()
+            );
+
+            // A start outside the chain resolves to nothing.
+            let provider = MockProvider(chain.clone());
+            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
+            assert!(
+                stream
+                    .descendants(BlockID::Height(Height::new(9)))
+                    .await
+                    .is_none()
+            );
+        });
+    }
+
+    #[test]
+    #[should_panic = "block must be contiguous in height"]
+    fn test_descendant_panics_on_non_contiguous_fetched_block() {
+        deterministic::Runner::default().start(|context| async move {
+            // The provider serves a block that does not extend the anchor.
+            let anchor = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
+            let lying = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(9), 9);
+            let provider = WrongParentProvider(lying);
+
+            let stream = descendant_stream(&context, provider, anchor, Sha256::fill(0xAB));
+            let _ = stream.collect::<Vec<_>>().await;
         });
     }
 }

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -11,7 +11,7 @@ use commonware_macros::stability;
 use commonware_runtime::{Clock, telemetry::metrics::histogram::Timed};
 use futures::{
     FutureExt, Stream,
-    future::{BoxFuture, OptionFuture},
+    future::{BoxFuture, Either, OptionFuture},
 };
 use pin_project::pin_project;
 use std::{
@@ -89,13 +89,20 @@ pub fn from_iter<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -> impl Anc
 /// Prepends a fixed sequence of blocks to an existing ancestry stream.
 ///
 /// Blocks are yielded in iterator order before the tail is polled.
+///
+/// # Panics
+///
+/// Panics if the prefixed blocks do not form a contiguous chain.
 pub fn with_prefix<B, S>(blocks: impl IntoIterator<Item = Arc<B>>, tail: S) -> impl Ancestry<B>
 where
     B: Block,
     S: Ancestry<B>,
 {
+    let blocks: VecDeque<_> = blocks.into_iter().collect();
+    let chain = sort_and_validate_chain(blocks.iter().cloned());
     PrefixedAncestry {
-        blocks: blocks.into_iter().collect(),
+        blocks,
+        chain,
         tail,
     }
 }
@@ -213,6 +220,7 @@ impl<B: Block> Stream for BoundedAncestry<B> {
 #[derive(Clone)]
 struct PrefixedAncestry<B: Block, S> {
     blocks: VecDeque<Arc<B>>,
+    chain: Vec<Arc<B>>,
     tail: S,
 }
 
@@ -234,7 +242,7 @@ where
         &self,
         start: BlockID<B::Digest>,
     ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
-        self.tail.descendants(start)
+        descendants_with_suffix(&self.tail, &self.chain, start)
     }
 }
 
@@ -250,6 +258,114 @@ where
             return Poll::Ready(Some(block));
         }
         Pin::new(&mut self.tail).poll_next(cx)
+    }
+}
+
+/// A forward ancestry stream extended by a fixed chain suffix.
+#[derive(Clone)]
+struct SuffixedAncestry<B: Block, S> {
+    head: S,
+    head_exhausted: bool,
+    blocks: VecDeque<Arc<B>>,
+    chain: Vec<Arc<B>>,
+    last: Option<(Height, B::Digest)>,
+}
+
+impl<B: Block, S> SuffixedAncestry<B, S> {
+    fn new(head: S, chain: Vec<Arc<B>>) -> Self {
+        Self {
+            head,
+            head_exhausted: false,
+            blocks: chain.clone().into(),
+            chain,
+            last: None,
+        }
+    }
+}
+
+impl<B: Block, S> Unpin for SuffixedAncestry<B, S> {}
+
+impl<B, S> Ancestry<B> for SuffixedAncestry<B, S>
+where
+    B: Block,
+    S: Ancestry<B>,
+{
+    fn peek(&self) -> Option<&B> {
+        if !self.head_exhausted {
+            return self.head.peek();
+        }
+        self.blocks.front().map(Arc::as_ref)
+    }
+
+    fn descendants(
+        &self,
+        start: BlockID<B::Digest>,
+    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
+        descendants_with_suffix(&self.head, &self.chain, start)
+    }
+}
+
+fn descendants_with_suffix<'a, B, S>(
+    head: &'a S,
+    chain: &[Arc<B>],
+    start: BlockID<B::Digest>,
+) -> impl Future<Output = Option<BoxedAncestry<B>>> + Send + 'a
+where
+    B: Block,
+    S: Ancestry<B>,
+{
+    if let Some(suffix) = chain_suffix(chain, start) {
+        return Either::Left(std::future::ready(Some(BoxedAncestry::new(from_iter(
+            suffix,
+        )))));
+    }
+
+    let chain = chain.to_vec();
+    Either::Right(head.descendants(start).map(move |head| {
+        head.map(|head| BoxedAncestry::new(SuffixedAncestry::new(head, chain)))
+    }))
+}
+
+impl<B, S> Stream for SuffixedAncestry<B, S>
+where
+    B: Block,
+    S: Ancestry<B>,
+{
+    type Item = Arc<B>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        if !self.head_exhausted {
+            match Pin::new(&mut self.head).poll_next(cx) {
+                Poll::Ready(Some(block)) => {
+                    self.last = Some((block.height(), block.digest()));
+                    return Poll::Ready(Some(block));
+                }
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(None) => self.head_exhausted = true,
+            }
+        }
+
+        while let Some(block) = self.blocks.pop_front() {
+            if let Some((height, digest)) = self.last {
+                if block.height() < height {
+                    continue;
+                }
+                if block.height() == height {
+                    assert_eq!(
+                        block.digest(),
+                        digest,
+                        "overlapping blocks must share a digest"
+                    );
+                    continue;
+                }
+                assert_extends(&(height, digest), block.as_ref());
+            }
+
+            self.last = Some((block.height(), block.digest()));
+            return Poll::Ready(Some(block));
+        }
+
+        Poll::Ready(None)
     }
 }
 
@@ -1220,6 +1336,67 @@ mod test {
             assert_eq!(ancestry.peek(), Some(&parent));
             assert_eq!(ancestry.next().await.as_deref(), Some(&parent));
             assert_eq!(ancestry.peek(), None);
+        });
+    }
+
+    #[test]
+    fn test_with_prefix_descendants_include_prefix() {
+        deterministic::Runner::default().start(|_| async move {
+            let ancestor = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::zero(), 0);
+            let parent = Block::new::<Sha256>((), ancestor.digest(), Height::new(1), 1);
+            let tip = Block::new::<Sha256>((), parent.digest(), Height::new(2), 2);
+            let ancestry = with_prefix(
+                [Arc::new(tip.clone()), Arc::new(parent.clone())],
+                from_iter([Arc::new(ancestor.clone())]),
+            );
+
+            let from_tail = ancestry
+                .descendants(BlockID::Digest(ancestor.digest()))
+                .await
+                .expect("tail block should be on chain")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(
+                from_tail,
+                vec![
+                    Arc::new(ancestor.clone()),
+                    Arc::new(parent.clone()),
+                    Arc::new(tip.clone()),
+                ]
+            );
+
+            let from_prefix = ancestry
+                .descendants(BlockID::Digest(parent.digest()))
+                .await
+                .expect("prefix block should be on chain")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(
+                from_prefix,
+                vec![Arc::new(parent.clone()), Arc::new(tip.clone())]
+            );
+
+            let mut tail = from_iter([
+                Arc::new(tip.clone()),
+                Arc::new(parent.clone()),
+                Arc::new(ancestor.clone()),
+            ]);
+            assert_eq!(tail.next().await.as_deref(), Some(&tip));
+            assert_eq!(tail.next().await.as_deref(), Some(&parent));
+            let ancestry = with_prefix(
+                [Arc::new(tip.clone()), Arc::new(parent.clone())],
+                tail,
+            );
+            let overlapping = ancestry
+                .descendants(BlockID::Digest(ancestor.digest()))
+                .await
+                .expect("consumed blocks should remain on the chain")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(
+                overlapping,
+                vec![Arc::new(ancestor), Arc::new(parent), Arc::new(tip)]
+            );
         });
     }
 

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -64,6 +64,14 @@ fn sort_and_validate_chain<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -
     chain
 }
 
+fn chain_suffix<B: Block>(chain: &[Arc<B>], start: BlockID<B::Digest>) -> Option<Vec<Arc<B>>> {
+    let position = match start {
+        BlockID::Height(height) => chain.iter().position(|block| block.height() == height),
+        BlockID::Digest(digest) => chain.iter().position(|block| block.digest() == digest),
+    }?;
+    Some(chain[position..].to_vec())
+}
+
 /// Creates an ancestry stream from a fixed sequence of blocks.
 ///
 /// Blocks are yielded in iterator order and no parent fetching is performed. This is useful when
@@ -166,16 +174,9 @@ impl<B: Block> Ancestry<B> for BoundedAncestry<B> {
     ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
         // A bounded ancestry is fully in memory: serve the chain fixed at
         // construction from the start onward, in ascending height order.
-        let position = match start {
-            BlockID::Height(height) => self.chain.iter().position(|b| b.height() == height),
-            BlockID::Digest(digest) => self.chain.iter().position(|b| b.digest() == digest),
-        };
-        std::future::ready(position.map(|position| {
-            let chain = self.chain[position..].to_vec();
-            Self {
-                blocks: chain.clone().into(),
-                chain,
-            }
+        std::future::ready(chain_suffix(&self.chain, start).map(|chain| Self {
+            blocks: chain.clone().into(),
+            chain,
         }))
     }
 }
@@ -357,6 +358,8 @@ where
 #[pin_project]
 pub struct AncestorStream<M: BlockProvider, C: Clock> {
     buffered: Vec<Arc<M::Block>>,
+    /// The initial chain fixed at construction, ascending in height.
+    chain: Vec<Arc<M::Block>>,
     /// The digest of the highest initial block, identifying the chain this
     /// stream walks.
     tip: Option<<M::Block as Digestible>::Digest>,
@@ -381,12 +384,13 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
         initial: impl IntoIterator<Item = Arc<M::Block>>,
         fetch_duration: Timed,
     ) -> Self {
-        let buffered = sort_and_validate_chain(initial);
+        let chain = sort_and_validate_chain(initial);
 
-        let tip = buffered.last().map(|block| block.digest());
+        let tip = chain.last().map(|block| block.digest());
         Self {
             marshal,
-            buffered,
+            buffered: chain.clone(),
+            chain,
             tip,
             fetch_duration,
             clock,
@@ -441,11 +445,20 @@ where
         &self,
         start: BlockID<<M::Block as Digestible>::Digest>,
     ) -> impl Future<Output = Option<impl Ancestry<M::Block>>> + Send {
+        let chain = chain_suffix(&self.chain, start);
         let tip = self.tip;
         let marshal = self.marshal.clone();
         let clock = self.clock.clone();
         let fetch_duration = self.fetch_duration.clone();
         async move {
+            if let Some(chain) = chain {
+                return Some(DescendantStream::from_chain(
+                    clock,
+                    marshal,
+                    chain,
+                    fetch_duration,
+                ));
+            }
             let (block, tip) = marshal.get_descendant(start, BlockID::Digest(tip?)).await?;
             Some(DescendantStream::new(
                 clock,
@@ -597,8 +610,10 @@ where
 /// local storage corruption.
 #[pin_project]
 pub struct DescendantStream<M: BlockProvider, C: Clock> {
-    /// The next block to yield.
-    buffered: Option<Arc<M::Block>>,
+    /// Blocks ready to yield in ascending height order.
+    buffered: VecDeque<Arc<M::Block>>,
+    /// A complete chain known at construction, when available.
+    chain: Option<Vec<Arc<M::Block>>>,
     /// The digest of the tip; the stream finishes once it is yielded.
     tip: <M::Block as Digestible>::Digest,
     marshal: M,
@@ -622,7 +637,31 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
         fetch_duration: Timed,
     ) -> Self {
         Self {
-            buffered: Some(start),
+            buffered: [start].into(),
+            chain: None,
+            tip,
+            marshal,
+            fetch_duration,
+            clock,
+            pending: None.into(),
+        }
+    }
+
+    /// Creates a forward stream from a complete in-memory chain.
+    fn from_chain(
+        clock: Arc<C>,
+        marshal: M,
+        chain: Vec<Arc<M::Block>>,
+        fetch_duration: Timed,
+    ) -> Self {
+        let chain = sort_and_validate_chain(chain);
+        let tip = chain
+            .last()
+            .expect("descendant chain must not be empty")
+            .digest();
+        Self {
+            buffered: chain.clone().into(),
+            chain: Some(chain),
             tip,
             marshal,
             fetch_duration,
@@ -635,7 +674,7 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
     /// [None] if the stream does not yet have a block available or has been
     /// exhausted.
     pub fn peek(&self) -> Option<&M::Block> {
-        self.buffered.as_deref()
+        self.buffered.front().map(Arc::as_ref)
     }
 }
 
@@ -652,11 +691,18 @@ where
         &self,
         start: BlockID<<M::Block as Digestible>::Digest>,
     ) -> impl Future<Output = Option<impl Ancestry<M::Block>>> + Send {
+        let chain = self
+            .chain
+            .as_ref()
+            .and_then(|chain| chain_suffix(chain, start));
         let tip = self.tip;
         let marshal = self.marshal.clone();
         let clock = self.clock.clone();
         let fetch_duration = self.fetch_duration.clone();
         async move {
+            if let Some(chain) = chain {
+                return Some(Self::from_chain(clock, marshal, chain, fetch_duration));
+            }
             let (block, tip) = marshal.get_descendant(start, BlockID::Digest(tip)).await?;
             Some(Self::new(clock, marshal, block, tip, fetch_duration))
         }
@@ -675,8 +721,10 @@ where
 
         // If a block has been buffered, return it and queue the next fetch
         // if the tip has not been reached.
-        if let Some(block) = this.buffered.take() {
-            if block.digest() != *this.tip {
+        if let Some(block) = this.buffered.pop_front() {
+            if let Some(child) = this.buffered.front() {
+                assert_extends(&(block.height(), block.digest()), child.as_ref());
+            } else if block.digest() != *this.tip {
                 let future = timed_descendant_fetch(
                     this.clock,
                     this.marshal,
@@ -691,7 +739,7 @@ where
                 match this.pending.as_mut().poll(cx) {
                     Poll::Ready(Some(Some((link, child)))) => {
                         assert_extends(&link, child.as_ref());
-                        *this.buffered = Some(child);
+                        this.buffered.push_back(child);
                     }
                     Poll::Ready(Some(None)) => {
                         *this.pending.as_mut() = None.into();
@@ -729,7 +777,7 @@ where
                     match this.pending.as_mut().poll(cx) {
                         Poll::Ready(Some(Some((link, child)))) => {
                             assert_extends(&link, child.as_ref());
-                            *this.buffered = Some(child);
+                            this.buffered.push_back(child);
                         }
                         Poll::Ready(Some(None)) => {
                             *this.pending.as_mut() = None.into();
@@ -966,6 +1014,29 @@ mod test {
             let block = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
             let stream = stream(&context, MockProvider::default(), [block.clone()]);
             assert_eq!(peek_height(stream), Some(block.height()));
+        });
+    }
+
+    #[test]
+    fn test_descendants_use_initial_chain_when_tip_is_unknown_to_provider() {
+        deterministic::Runner::default().start(|context| async move {
+            let parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
+            let child = Block::new::<Sha256>((), parent.digest(), Height::new(2), 2);
+            let mut ancestry = stream(
+                &context,
+                MockProvider::default(),
+                [child.clone(), parent.clone()],
+            );
+
+            assert_eq!(ancestry.next().await.as_deref(), Some(&child));
+            let descendants = ancestry
+                .descendants(BlockID::Digest(parent.digest()))
+                .await
+                .expect("initial chain should not require the provider to know its tip");
+            assert_eq!(
+                descendants.collect::<Vec<_>>().await,
+                vec![Arc::new(parent), Arc::new(child)]
+            );
         });
     }
 

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -11,7 +11,8 @@ use commonware_macros::stability;
 use commonware_runtime::{Clock, telemetry::metrics::histogram::Timed};
 use futures::{
     FutureExt, Stream,
-    future::{BoxFuture, Either, OptionFuture},
+    future::{BoxFuture, OptionFuture},
+    stream::{BoxStream, StreamExt as _},
 };
 use pin_project::pin_project;
 use std::{
@@ -39,7 +40,7 @@ pub trait Ancestry<B: Block>: Stream<Item = Arc<B>> + Clone + Send + Unpin + 'st
     fn descendants(
         &self,
         start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send;
+    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send;
 }
 
 fn sort_and_validate_chain<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -> Vec<Arc<B>> {
@@ -82,29 +83,8 @@ fn chain_suffix<B: Block>(chain: &[Arc<B>], start: BlockID<B::Digest>) -> Option
 /// Panics if the blocks do not form a contiguous chain.
 pub fn from_iter<B: Block>(blocks: impl IntoIterator<Item = Arc<B>>) -> impl Ancestry<B> {
     let blocks: VecDeque<_> = blocks.into_iter().collect();
-    let chain = sort_and_validate_chain(blocks.iter().cloned());
+    let chain = Arc::from(sort_and_validate_chain(blocks.iter().cloned()));
     BoundedAncestry { blocks, chain }
-}
-
-/// Prepends a fixed sequence of blocks to an existing ancestry stream.
-///
-/// Blocks are yielded in iterator order before the tail is polled.
-///
-/// # Panics
-///
-/// Panics if the prefixed blocks do not form a contiguous chain.
-pub fn with_prefix<B, S>(blocks: impl IntoIterator<Item = Arc<B>>, tail: S) -> impl Ancestry<B>
-where
-    B: Block,
-    S: Ancestry<B>,
-{
-    let blocks: VecDeque<_> = blocks.into_iter().collect();
-    let chain = sort_and_validate_chain(blocks.iter().cloned());
-    PrefixedAncestry {
-        blocks,
-        chain,
-        tail,
-    }
 }
 
 /// Type-erased ancestry stream that preserves cloneability.
@@ -133,7 +113,7 @@ impl<B: Block> Ancestry<B> for BoxedAncestry<B> {
     fn descendants(
         &self,
         start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
+    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send {
         self.0.descendants_erased(start)
     }
 }
@@ -152,7 +132,7 @@ trait ErasedAncestry<B: Block>: Stream<Item = Arc<B>> + Send + Unpin + 'static {
     fn descendants_erased(
         &self,
         start: BlockID<B::Digest>,
-    ) -> BoxFuture<'_, Option<BoxedAncestry<B>>>;
+    ) -> BoxFuture<'_, Option<BoxStream<'static, Arc<B>>>>;
 
     fn clone_box(&self) -> Box<dyn ErasedAncestry<B>>;
 }
@@ -169,9 +149,9 @@ where
     fn descendants_erased(
         &self,
         start: BlockID<B::Digest>,
-    ) -> BoxFuture<'_, Option<BoxedAncestry<B>>> {
+    ) -> BoxFuture<'_, Option<BoxStream<'static, Arc<B>>>> {
         Ancestry::descendants(self, start)
-            .map(|ancestry| ancestry.map(BoxedAncestry::new))
+            .map(|ancestry| ancestry.map(|stream| stream.boxed()))
             .boxed()
     }
 
@@ -186,7 +166,7 @@ struct BoundedAncestry<B: Block> {
     blocks: VecDeque<Arc<B>>,
     /// The chain fixed at construction, ascending in height, serving forward
     /// walks regardless of how much of the stream has been consumed.
-    chain: Vec<Arc<B>>,
+    chain: Arc<[Arc<B>]>,
 }
 
 impl<B: Block> Unpin for BoundedAncestry<B> {}
@@ -199,13 +179,10 @@ impl<B: Block> Ancestry<B> for BoundedAncestry<B> {
     fn descendants(
         &self,
         start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
+    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send {
         // A bounded ancestry is fully in memory: serve the chain fixed at
         // construction from the start onward, in ascending height order.
-        std::future::ready(chain_suffix(&self.chain, start).map(|chain| Self {
-            blocks: chain.clone().into(),
-            chain,
-        }))
+        std::future::ready(chain_suffix(&self.chain, start).map(futures::stream::iter))
     }
 }
 
@@ -214,200 +191,6 @@ impl<B: Block> Stream for BoundedAncestry<B> {
 
     fn poll_next(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         Poll::Ready(self.blocks.pop_front())
-    }
-}
-
-#[derive(Clone)]
-struct PrefixedAncestry<B: Block, S> {
-    blocks: VecDeque<Arc<B>>,
-    chain: Vec<Arc<B>>,
-    tail: S,
-}
-
-impl<B: Block, S> Unpin for PrefixedAncestry<B, S> {}
-
-impl<B, S> Ancestry<B> for PrefixedAncestry<B, S>
-where
-    B: Block,
-    S: Ancestry<B>,
-{
-    fn peek(&self) -> Option<&B> {
-        self.blocks
-            .front()
-            .map(Arc::as_ref)
-            .or_else(|| self.tail.peek())
-    }
-
-    fn descendants(
-        &self,
-        start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
-        descendants_with_suffix(&self.tail, &self.chain, start)
-    }
-}
-
-impl<B, S> Stream for PrefixedAncestry<B, S>
-where
-    B: Block,
-    S: Ancestry<B>,
-{
-    type Item = Arc<B>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if let Some(block) = self.blocks.pop_front() {
-            return Poll::Ready(Some(block));
-        }
-        Pin::new(&mut self.tail).poll_next(cx)
-    }
-}
-
-/// A forward ancestry stream extended by a fixed chain suffix.
-#[derive(Clone)]
-struct SuffixedAncestry<B: Block, S> {
-    head: S,
-    phase: SuffixPhase,
-    blocks: VecDeque<Arc<B>>,
-    chain: Vec<Arc<B>>,
-    last: Option<(Height, B::Digest)>,
-}
-
-#[derive(Clone, Copy)]
-enum SuffixPhase {
-    Head,
-    Suffix,
-    Done,
-}
-
-impl<B: Block, S> SuffixedAncestry<B, S> {
-    fn new(head: S, chain: Vec<Arc<B>>) -> Self {
-        Self {
-            head,
-            phase: SuffixPhase::Head,
-            blocks: chain.clone().into(),
-            chain,
-            last: None,
-        }
-    }
-}
-
-impl<B: Block, S> Unpin for SuffixedAncestry<B, S> {}
-
-impl<B: Block, S> SuffixedAncestry<B, S> {
-    // Switches to the fixed suffix only when the yielded head proves that the
-    // splice is contiguous. A descendant head may end early when local state
-    // is pruned, in which case the composite stream must end with it.
-    fn attach_suffix(&mut self) {
-        let Some((height, digest)) = self.last else {
-            self.blocks.clear();
-            self.phase = SuffixPhase::Done;
-            return;
-        };
-
-        while self
-            .blocks
-            .front()
-            .is_some_and(|block| block.height() < height)
-        {
-            self.blocks.pop_front();
-        }
-
-        let Some(block) = self.blocks.front() else {
-            self.phase = SuffixPhase::Done;
-            return;
-        };
-        let connected = if block.height() == height {
-            block.digest() == digest
-        } else {
-            block.height().previous() == Some(height) && block.parent() == digest
-        };
-        if !connected {
-            self.blocks.clear();
-            self.phase = SuffixPhase::Done;
-            return;
-        }
-
-        // The overlapping block was already yielded by the head.
-        if block.height() == height {
-            self.blocks.pop_front();
-        }
-        self.phase = if self.blocks.is_empty() {
-            SuffixPhase::Done
-        } else {
-            SuffixPhase::Suffix
-        };
-    }
-}
-
-impl<B, S> Ancestry<B> for SuffixedAncestry<B, S>
-where
-    B: Block,
-    S: Ancestry<B>,
-{
-    fn peek(&self) -> Option<&B> {
-        match self.phase {
-            SuffixPhase::Head => self.head.peek(),
-            SuffixPhase::Suffix => self.blocks.front().map(Arc::as_ref),
-            SuffixPhase::Done => None,
-        }
-    }
-
-    fn descendants(
-        &self,
-        start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<B>>> + Send {
-        descendants_with_suffix(&self.head, &self.chain, start)
-    }
-}
-
-fn descendants_with_suffix<'a, B, S>(
-    head: &'a S,
-    chain: &[Arc<B>],
-    start: BlockID<B::Digest>,
-) -> impl Future<Output = Option<BoxedAncestry<B>>> + Send + 'a
-where
-    B: Block,
-    S: Ancestry<B>,
-{
-    if let Some(suffix) = chain_suffix(chain, start) {
-        return Either::Left(std::future::ready(Some(BoxedAncestry::new(from_iter(
-            suffix,
-        )))));
-    }
-
-    let chain = chain.to_vec();
-    Either::Right(head.descendants(start).map(move |head| {
-        head.map(|head| BoxedAncestry::new(SuffixedAncestry::new(head, chain)))
-    }))
-}
-
-impl<B, S> Stream for SuffixedAncestry<B, S>
-where
-    B: Block,
-    S: Ancestry<B>,
-{
-    type Item = Arc<B>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        if matches!(self.phase, SuffixPhase::Head) {
-            match Pin::new(&mut self.head).poll_next(cx) {
-                Poll::Ready(Some(block)) => {
-                    self.last = Some((block.height(), block.digest()));
-                    return Poll::Ready(Some(block));
-                }
-                Poll::Pending => return Poll::Pending,
-                Poll::Ready(None) => self.attach_suffix(),
-            }
-        }
-
-        if matches!(self.phase, SuffixPhase::Suffix) {
-            if let Some(block) = self.blocks.pop_front() {
-                self.last = Some((block.height(), block.digest()));
-                return Poll::Ready(Some(block));
-            }
-            self.phase = SuffixPhase::Done;
-        }
-
-        Poll::Ready(None)
     }
 }
 
@@ -432,65 +215,42 @@ pub trait BlockProvider: Clone + Send + 'static {
         &self,
         block: &Self::Block,
     ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static;
+}
 
-    /// Retrieve the block at `start` within the locally known ancestry of
-    /// `tip`, together with the resolved tip digest.
-    ///
-    /// The chain is defined by the ancestry of `tip`, which may be an
-    /// unfinalized candidate (a fork tracked by marshal) or a finalized
-    /// block. Finalized blocks are served from storage and candidates from
-    /// marshal's in-memory fork tree. Unlike [Self::subscribe_parent], this
-    /// lookup never waits and never fetches from the network.
-    ///
-    /// Returns `None` when `tip` is unknown locally, `start` does not lie in
-    /// the tip's locally known ancestry, or the block at `start` is not
-    /// locally available.
-    #[allow(clippy::type_complexity)]
-    fn get_descendant(
-        &self,
-        start: BlockID<<Self::Block as Digestible>::Digest>,
-        tip: BlockID<<Self::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
-    + Send
-    + 'static;
+/// An interface for forward walks over locally known block ancestry.
+pub trait DescendantProvider: BlockProvider {
+    /// Opaque state used to continue a forward ancestry walk.
+    type Cursor: Clone + Send + 'static;
 
     /// Retrieves the next non-empty, contiguous batch from `start` toward
     /// `tip`, together with the resolved tip digest.
-    ///
-    /// Providers can override this to amortize lookup work across multiple
-    /// blocks. The default resolves the complete chain through singular
-    /// lookups.
-    #[allow(clippy::type_complexity)]
     fn get_descendants(
         &self,
-        start: BlockID<<Self::Block as Digestible>::Digest>,
-        tip: BlockID<<Self::Block as Digestible>::Digest>,
-    ) -> impl Future<
-        Output = Option<(
-            Vec<Arc<Self::Block>>,
-            <Self::Block as Digestible>::Digest,
-        )>,
-    > + Send
-    + 'static {
-        let provider = self.clone();
-        async move {
-            let (block, tip) = provider.get_descendant(start, tip).await?;
-            let mut blocks = vec![block];
-            while blocks.last()?.digest() != tip {
-                let parent = blocks.last()?;
-                let next = parent.height().get().checked_add(1).map(Height::new)?;
-                let (block, resolved_tip) = provider
-                    .get_descendant(BlockID::Height(next), BlockID::Digest(tip))
-                    .await?;
-                if resolved_tip != tip {
-                    return None;
-                }
-                assert_extends(&(parent.height(), parent.digest()), block.as_ref());
-                blocks.push(block);
-            }
-            Some((blocks, tip))
-        }
-    }
+        request: DescendantRequest<<Self::Block as Digestible>::Digest, Self::Cursor>,
+    ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static;
+}
+
+/// A request to start or continue a forward ancestry walk.
+pub enum DescendantRequest<D: Digest, C> {
+    /// Starts a walk at `start` within the ancestry of `tip`.
+    Start {
+        /// The first block to return.
+        start: BlockID<D>,
+        /// The block whose ancestry defines the chain.
+        tip: BlockID<D>,
+    },
+    /// Continues a previously started walk.
+    Continue(C),
+}
+
+/// One non-empty page of a forward ancestry walk.
+pub struct DescendantPage<B: Block, C> {
+    /// Contiguous blocks in ascending height order.
+    pub blocks: Vec<Arc<B>>,
+    /// The resolved digest of the walk's tip.
+    pub tip: B::Digest,
+    /// State for retrieving the next page, if any.
+    pub cursor: Option<C>,
 }
 
 // Expected parent height and digest for a pending fetch.
@@ -577,13 +337,39 @@ where
     )
 }
 
+fn prefetch_parent<B: Block>(
+    child: Arc<B>,
+    future: PendingFetch<B>,
+    buffered: &mut Vec<Arc<B>>,
+    pending_child: &mut Option<Arc<B>>,
+    mut pending: Pin<&mut OptionFuture<PendingFetch<B>>>,
+    cx: &mut Context<'_>,
+) {
+    *pending_child = Some(child);
+    pending.as_mut().set(Some(future).into());
+
+    match pending.as_mut().poll(cx) {
+        Poll::Ready(Some(Some((expected, parent)))) => {
+            expected.assert_matches(parent.as_ref());
+            buffered.push(parent);
+            *pending_child = None;
+        }
+        Poll::Ready(Some(None)) => {
+            pending.as_mut().set(None.into());
+            *pending_child = None;
+        }
+        Poll::Ready(None) => *pending_child = None,
+        Poll::Pending => {}
+    }
+}
+
 /// Yields the ancestors of a block while prefetching parents, including the
 /// height-zero genesis block if it is available.
 #[pin_project]
 pub struct AncestorStream<M: BlockProvider, C: Clock> {
     buffered: Vec<Arc<M::Block>>,
     /// The initial chain fixed at construction, ascending in height.
-    chain: Vec<Arc<M::Block>>,
+    chain: Arc<[Arc<M::Block>]>,
     /// The digest of the highest initial block, identifying the chain this
     /// stream walks.
     tip: Option<<M::Block as Digestible>::Digest>,
@@ -608,12 +394,12 @@ impl<M: BlockProvider, C: Clock> AncestorStream<M, C> {
         initial: impl IntoIterator<Item = Arc<M::Block>>,
         fetch_duration: Timed,
     ) -> Self {
-        let chain = sort_and_validate_chain(initial);
+        let chain: Arc<[Arc<M::Block>]> = Arc::from(sort_and_validate_chain(initial));
 
         let tip = chain.last().map(|block| block.digest());
         Self {
             marshal,
-            buffered: chain.clone(),
+            buffered: chain.iter().cloned().collect(),
             chain,
             tip,
             fetch_duration,
@@ -660,7 +446,7 @@ where
 
 impl<M, C> Ancestry<M::Block> for AncestorStream<M, C>
 where
-    M: BlockProvider + Clone,
+    M: DescendantProvider + Clone,
     C: Clock,
 {
     fn peek(&self) -> Option<&M::Block> {
@@ -670,7 +456,9 @@ where
     fn descendants(
         &self,
         start: BlockID<<M::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<M::Block>>> + Send {
+    ) -> impl Future<
+        Output = Option<impl Stream<Item = Arc<M::Block>> + Send + Unpin + 'static>,
+    > + Send {
         let chain = chain_suffix(&self.chain, start);
         let tip = self.tip;
         let marshal = self.marshal.clone();
@@ -685,13 +473,19 @@ where
                     fetch_duration,
                 ));
             }
-            let descendants = marshal.get_descendants(start, BlockID::Digest(tip?));
-            let (batch, tip) = timed_fetch(&clock, &fetch_duration, descendants).await?;
-            Some(DescendantStream::from_batch(
+            let tip = tip?;
+            let descendants = marshal.get_descendants(DescendantRequest::Start {
+                start,
+                tip: BlockID::Digest(tip),
+            });
+            let page = timed_fetch(&clock, &fetch_duration, descendants).await?;
+            if page.tip != tip {
+                return None;
+            }
+            Some(DescendantStream::from_page(
                 clock,
                 marshal,
-                batch,
-                tip,
+                page,
                 fetch_duration,
             ))
         }
@@ -716,28 +510,19 @@ where
             let should_walk_parent = height > END_BOUND;
             let end_of_buffered = this.buffered.is_empty();
             if should_walk_parent && end_of_buffered {
-                let future =
-                    timed_parent_fetch(this.clock, this.marshal, &block, this.fetch_duration);
-                *this.pending_child = Some(block.clone());
-                *this.pending.as_mut() = Some(future).into();
-
-                // Explicitly poll the next future to kick off the fetch. If it's already ready,
-                // buffer it for the next poll.
-                match this.pending.as_mut().poll(cx) {
-                    Poll::Ready(Some(Some((expected, parent)))) => {
-                        expected.assert_matches(parent.as_ref());
-                        this.buffered.push(parent);
-                        *this.pending_child = None;
-                    }
-                    Poll::Ready(Some(None)) => {
-                        *this.pending.as_mut() = None.into();
-                        *this.pending_child = None;
-                    }
-                    Poll::Ready(None) => {
-                        *this.pending_child = None;
-                    }
-                    Poll::Pending => {}
-                }
+                prefetch_parent(
+                    block.clone(),
+                    timed_parent_fetch(
+                        this.clock,
+                        this.marshal,
+                        block.as_ref(),
+                        this.fetch_duration,
+                    ),
+                    this.buffered,
+                    this.pending_child,
+                    this.pending.as_mut(),
+                    cx,
+                );
             } else if !should_walk_parent {
                 // No more parents to fetch; Finish the stream.
                 *this.pending.as_mut() = None.into();
@@ -759,28 +544,19 @@ where
                 let height = block.height();
                 let should_walk_parent = height > END_BOUND;
                 if should_walk_parent {
-                    let future =
-                        timed_parent_fetch(this.clock, this.marshal, &block, this.fetch_duration);
-                    *this.pending_child = Some(block.clone());
-                    *this.pending.as_mut() = Some(future).into();
-
-                    // Explicitly poll the next future to kick off the fetch. If it's already ready,
-                    // buffer it for the next poll.
-                    match this.pending.as_mut().poll(cx) {
-                        Poll::Ready(Some(Some((expected, parent)))) => {
-                            expected.assert_matches(parent.as_ref());
-                            this.buffered.push(parent);
-                            *this.pending_child = None;
-                        }
-                        Poll::Ready(Some(None)) => {
-                            *this.pending.as_mut() = None.into();
-                            *this.pending_child = None;
-                        }
-                        Poll::Ready(None) => {
-                            *this.pending_child = None;
-                        }
-                        Poll::Pending => {}
-                    }
+                    prefetch_parent(
+                        block.clone(),
+                        timed_parent_fetch(
+                            this.clock,
+                            this.marshal,
+                            block.as_ref(),
+                            this.fetch_duration,
+                        ),
+                        this.buffered,
+                        this.pending_child,
+                        this.pending.as_mut(),
+                        cx,
+                    );
                 } else {
                     // No more parents to fetch; Finish the stream.
                     *this.pending.as_mut() = None.into();
@@ -794,8 +570,8 @@ where
 }
 
 // A pending descendant fetch paired with the chain link it must extend.
-type PendingDescendantFetch<B> =
-    BoxFuture<'static, Option<((Height, <B as Digestible>::Digest), Vec<Arc<B>>)>>;
+type PendingDescendantFetch<B, C> =
+    BoxFuture<'static, Option<((Height, <B as Digestible>::Digest), DescendantPage<B, C>)>>;
 
 // Builds a pending fetch for the ancestry batch starting directly above
 // `parent`, recording successful fetch latency and carrying the link the
@@ -804,24 +580,24 @@ fn timed_descendant_fetch<C, M>(
     clock: &Arc<C>,
     marshal: &M,
     parent: &M::Block,
+    cursor: M::Cursor,
     tip: <M::Block as Digestible>::Digest,
     fetch_duration: &Timed,
-) -> PendingDescendantFetch<M::Block>
+) -> PendingDescendantFetch<M::Block, M::Cursor>
 where
     C: Clock,
-    M: BlockProvider,
+    M: DescendantProvider,
 {
     let link = (parent.height(), parent.digest());
-    let Some(next) = link.0.get().checked_add(1).map(Height::new) else {
-        return std::future::ready(None).boxed();
-    };
     timed_fetch(
         clock,
         fetch_duration,
         marshal
-            .get_descendants(BlockID::Height(next), BlockID::Digest(tip))
-            .map(move |blocks| {
-                blocks.and_then(|(blocks, _)| (!blocks.is_empty()).then_some((link, blocks)))
+            .get_descendants(DescendantRequest::Continue(cursor))
+            .map(move |page| {
+                page.and_then(|page| {
+                    (page.tip == tip && !page.blocks.is_empty()).then_some((link, page))
+                })
             }),
     )
 }
@@ -829,6 +605,7 @@ where
 fn buffer_descendants<B: Block>(
     link: &(Height, B::Digest),
     blocks: Vec<Arc<B>>,
+    tip: B::Digest,
     buffered: &mut VecDeque<Arc<B>>,
 ) {
     let blocks = sort_and_validate_chain(blocks);
@@ -839,6 +616,13 @@ fn buffer_descendants<B: Block>(
             .expect("descendant batch must not be empty")
             .as_ref(),
     );
+    if let Some(position) = blocks.iter().position(|block| block.digest() == tip) {
+        assert_eq!(
+            position + 1,
+            blocks.len(),
+            "descendant batch must end at the requested tip"
+        );
+    }
     buffered.extend(blocks);
 }
 
@@ -848,57 +632,29 @@ fn buffer_descendants<B: Block>(
 /// The stream is armed with its first batch and lazily fetches following
 /// batches from the provider (prefetching the next batch while the previous one
 /// is consumed), mirroring [AncestorStream] in the opposite direction. It
-/// finishes once the tip is yielded, and ends early if the next block becomes
-/// unavailable locally (e.g. its branch was pruned by a finalization, or a
-/// finalized block was pruned while iterating).
+/// finishes once the tip is yielded. Candidate ancestry is snapshotted when
+/// the walk starts; finalized archive pages remain lazy and can end early if
+/// they become unavailable locally while iterating.
 ///
 /// # Panics
 ///
 /// Panics if fetched blocks do not form a contiguous chain, which indicates
 /// local storage corruption.
 #[pin_project]
-pub struct DescendantStream<M: BlockProvider, C: Clock> {
+pub struct DescendantStream<M: DescendantProvider, C: Clock> {
     /// Blocks ready to yield in ascending height order.
     buffered: VecDeque<Arc<M::Block>>,
-    /// A complete chain known at construction, when available.
-    chain: Option<Vec<Arc<M::Block>>>,
     /// The digest of the tip; the stream finishes once it is yielded.
     tip: <M::Block as Digestible>::Digest,
     marshal: M,
     fetch_duration: Timed,
     clock: Arc<C>,
-    /// The block whose child is currently being fetched.
-    pending_parent: Option<Arc<M::Block>>,
+    cursor: Option<M::Cursor>,
     #[pin]
-    pending: OptionFuture<PendingDescendantFetch<M::Block>>,
+    pending: OptionFuture<PendingDescendantFetch<M::Block, M::Cursor>>,
 }
 
-impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
-    /// Creates a new [DescendantStream] armed with the first block of the
-    /// walk, ending at `tip`.
-    ///
-    /// `start` must lie in the ancestry of `tip`; providers validate this
-    /// when resolving the anchor (see [BlockProvider::get_descendant]).
-    #[cfg(test)]
-    fn new(
-        clock: Arc<C>,
-        marshal: M,
-        start: Arc<M::Block>,
-        tip: <M::Block as Digestible>::Digest,
-        fetch_duration: Timed,
-    ) -> Self {
-        Self {
-            buffered: [start].into(),
-            chain: None,
-            tip,
-            marshal,
-            fetch_duration,
-            clock,
-            pending_parent: None,
-            pending: None.into(),
-        }
-    }
-
+impl<M: DescendantProvider, C: Clock> DescendantStream<M, C> {
     /// Creates a forward stream from a complete in-memory chain.
     fn from_chain(
         clock: Arc<C>,
@@ -912,36 +668,33 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
             .expect("descendant chain must not be empty")
             .digest();
         Self {
-            buffered: chain.clone().into(),
-            chain: Some(chain),
+            buffered: chain.into(),
             tip,
             marshal,
             fetch_duration,
             clock,
-            pending_parent: None,
+            cursor: None,
             pending: None.into(),
         }
     }
 
     /// Creates a forward stream from a provider batch that may not yet reach
     /// the resolved tip.
-    fn from_batch(
+    fn from_page(
         clock: Arc<C>,
         marshal: M,
-        batch: Vec<Arc<M::Block>>,
-        tip: <M::Block as Digestible>::Digest,
+        page: DescendantPage<M::Block, M::Cursor>,
         fetch_duration: Timed,
     ) -> Self {
-        let batch = sort_and_validate_chain(batch);
+        let batch = sort_and_validate_chain(page.blocks);
         assert!(!batch.is_empty(), "descendant batch must not be empty");
         Self {
             buffered: batch.into(),
-            chain: None,
-            tip,
+            tip: page.tip,
             marshal,
             fetch_duration,
             clock,
-            pending_parent: None,
+            cursor: page.cursor,
             pending: None.into(),
         }
     }
@@ -954,71 +707,9 @@ impl<M: BlockProvider, C: Clock> DescendantStream<M, C> {
     }
 }
 
-impl<M, C> Clone for DescendantStream<M, C>
-where
-    M: BlockProvider,
-    C: Clock,
-{
-    fn clone(&self) -> Self {
-        let marshal = self.marshal.clone();
-        let fetch_duration = self.fetch_duration.clone();
-        let clock = self.clock.clone();
-        let pending = self
-            .pending_parent
-            .as_ref()
-            .map(|parent| {
-                timed_descendant_fetch(&clock, &marshal, parent, self.tip, &fetch_duration)
-            })
-            .into();
-
-        Self {
-            buffered: self.buffered.clone(),
-            chain: self.chain.clone(),
-            tip: self.tip,
-            marshal,
-            fetch_duration,
-            clock,
-            pending_parent: self.pending_parent.clone(),
-            pending,
-        }
-    }
-}
-
-impl<M, C> Ancestry<M::Block> for DescendantStream<M, C>
-where
-    M: BlockProvider,
-    C: Clock,
-{
-    fn peek(&self) -> Option<&M::Block> {
-        Self::peek(self)
-    }
-
-    fn descendants(
-        &self,
-        start: BlockID<<M::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<impl Ancestry<M::Block>>> + Send {
-        let chain = self
-            .chain
-            .as_ref()
-            .and_then(|chain| chain_suffix(chain, start));
-        let tip = self.tip;
-        let marshal = self.marshal.clone();
-        let clock = self.clock.clone();
-        let fetch_duration = self.fetch_duration.clone();
-        async move {
-            if let Some(chain) = chain {
-                return Some(Self::from_chain(clock, marshal, chain, fetch_duration));
-            }
-            let descendants = marshal.get_descendants(start, BlockID::Digest(tip));
-            let (batch, tip) = timed_fetch(&clock, &fetch_duration, descendants).await?;
-            Some(Self::from_batch(clock, marshal, batch, tip, fetch_duration))
-        }
-    }
-}
-
 impl<M, C> Stream for DescendantStream<M, C>
 where
-    M: BlockProvider,
+    M: DescendantProvider,
     C: Clock,
 {
     type Item = Arc<M::Block>;
@@ -1031,12 +722,11 @@ where
                 Poll::Pending => return Poll::Pending,
                 Poll::Ready(None) | Poll::Ready(Some(None)) => {
                     *this.pending.as_mut() = None.into();
-                    *this.pending_parent = None;
                     return Poll::Ready(None);
                 }
-                Poll::Ready(Some(Some((link, blocks)))) => {
-                    buffer_descendants(&link, blocks, this.buffered);
-                    *this.pending_parent = None;
+                Poll::Ready(Some(Some((link, page)))) => {
+                    buffer_descendants(&link, page.blocks, *this.tip, this.buffered);
+                    *this.cursor = page.cursor;
                 }
             }
         }
@@ -1044,37 +734,37 @@ where
         let Some(block) = this.buffered.pop_front() else {
             return Poll::Ready(None);
         };
-        if let Some(child) = this.buffered.front() {
+        if block.digest() == *this.tip {
+            this.buffered.clear();
+            *this.pending.as_mut() = None.into();
+        } else if let Some(child) = this.buffered.front() {
             assert_extends(&(block.height(), block.digest()), child.as_ref());
-        } else if block.digest() != *this.tip {
+        } else {
+            let Some(cursor) = this.cursor.take() else {
+                return Poll::Ready(Some(block));
+            };
             let future = timed_descendant_fetch(
                 this.clock,
                 this.marshal,
                 &block,
+                cursor,
                 *this.tip,
                 this.fetch_duration,
             );
-            *this.pending_parent = Some(block.clone());
             *this.pending.as_mut() = Some(future).into();
 
             // Kick off the next batch while the current block is consumed.
             match this.pending.as_mut().poll(cx) {
-                Poll::Ready(Some(Some((link, blocks)))) => {
-                    buffer_descendants(&link, blocks, this.buffered);
-                    *this.pending_parent = None;
+                Poll::Ready(Some(Some((link, page)))) => {
+                    buffer_descendants(&link, page.blocks, *this.tip, this.buffered);
+                    *this.cursor = page.cursor;
                 }
                 Poll::Ready(Some(None)) => {
                     *this.pending.as_mut() = None.into();
-                    *this.pending_parent = None;
                 }
-                Poll::Ready(None) => {
-                    *this.pending_parent = None;
-                }
+                Poll::Ready(None) => {}
                 Poll::Pending => {}
             }
-        } else {
-            *this.pending.as_mut() = None.into();
-            *this.pending_parent = None;
         }
 
         Poll::Ready(Some(block))
@@ -1116,25 +806,38 @@ mod test {
             )
         }
 
-        fn get_descendant(
+    }
+
+    impl DescendantProvider for MockProvider {
+        type Cursor = ();
+
+        fn get_descendants(
             &self,
-            start: BlockID<Sha256Digest>,
-            tip: BlockID<Sha256Digest>,
-        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
-        {
+            request: DescendantRequest<Sha256Digest, Self::Cursor>,
+        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static {
             let result = (|| {
+                let DescendantRequest::Start { start, tip } = request else {
+                    return None;
+                };
                 let BlockID::Digest(tip) = tip else {
                     return None;
                 };
                 let mut cursor = tip;
+                let mut blocks = Vec::new();
                 loop {
                     let block = self.0.iter().find(|block| block.digest() == cursor)?;
+                    blocks.push(Arc::new(block.clone()));
                     let found = match start {
                         BlockID::Height(height) => block.height() == height,
                         BlockID::Digest(digest) => block.digest() == digest,
                     };
                     if found {
-                        return Some((Arc::new(block.clone()), tip));
+                        blocks.reverse();
+                        return Some(DescendantPage {
+                            blocks,
+                            tip,
+                            cursor: None,
+                        });
                     }
                     cursor = block.parent;
                 }
@@ -1146,7 +849,6 @@ mod test {
     #[derive(Clone)]
     struct BulkProvider {
         chain: Arc<Vec<Block<Sha256Digest, ()>>>,
-        singular: Arc<AtomicUsize>,
         bulk: Arc<AtomicUsize>,
     }
 
@@ -1160,46 +862,77 @@ mod test {
             std::future::ready(None)
         }
 
-        fn get_descendant(
-            &self,
-            _start: BlockID<Sha256Digest>,
-            _tip: BlockID<Sha256Digest>,
-        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
-        {
-            self.singular.fetch_add(1, Ordering::Relaxed);
-            std::future::ready(None)
-        }
+    }
+
+    impl DescendantProvider for BulkProvider {
+        type Cursor = usize;
 
         fn get_descendants(
             &self,
-            start: BlockID<Sha256Digest>,
-            tip: BlockID<Sha256Digest>,
-        ) -> impl Future<Output = Option<(Vec<Arc<Self::Block>>, Sha256Digest)>> + Send + 'static
-        {
+            request: DescendantRequest<Sha256Digest, Self::Cursor>,
+        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static {
             self.bulk.fetch_add(1, Ordering::Relaxed);
             let chain = self.chain.clone();
             async move {
-                let BlockID::Digest(tip) = tip else {
-                    return None;
+                let position = match request {
+                    DescendantRequest::Start { start, tip } => {
+                        let BlockID::Digest(tip) = tip else {
+                            return None;
+                        };
+                        if tip != chain.last()?.digest() {
+                            return None;
+                        }
+                        chain.iter().position(|block| match start {
+                            BlockID::Height(height) => block.height() == height,
+                            BlockID::Digest(digest) => block.digest() == digest,
+                        })?
+                    }
+                    DescendantRequest::Continue(position) => position,
                 };
-                let position = chain.iter().position(|block| match start {
-                    BlockID::Height(height) => block.height() == height,
-                    BlockID::Digest(digest) => block.digest() == digest,
-                })?;
-                Some((
-                    chain[position..]
+                let end = position.saturating_add(8).min(chain.len());
+                Some(DescendantPage {
+                    blocks: chain[position..end]
                         .iter()
-                        .take(8)
                         .cloned()
                         .map(Arc::new)
                         .collect(),
-                    tip,
-                ))
+                    tip: chain.last()?.digest(),
+                    cursor: (end < chain.len()).then_some(end),
+                })
             }
         }
     }
 
     type TestBlock = Block<Sha256Digest, ()>;
+
+    #[derive(Clone)]
+    struct PageProvider {
+        pages: Arc<Mutex<VecDeque<DescendantPage<TestBlock, ()>>>>,
+    }
+
+    impl BlockProvider for PageProvider {
+        type Block = TestBlock;
+
+        fn subscribe_parent(
+            &self,
+            _block: &Self::Block,
+        ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
+            std::future::ready(None)
+        }
+    }
+
+    impl DescendantProvider for PageProvider {
+        type Cursor = ();
+
+        fn get_descendants(
+            &self,
+            _request: DescendantRequest<Sha256Digest, Self::Cursor>,
+        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static
+        {
+            std::future::ready(self.pages.lock().pop_front())
+        }
+    }
+
     type ParentSubscription = oneshot::Sender<Arc<TestBlock>>;
 
     #[derive(Default, Clone)]
@@ -1232,18 +965,11 @@ mod test {
             parent.map(Result::ok)
         }
 
-        fn get_descendant(
-            &self,
-            _start: BlockID<Sha256Digest>,
-            _tip: BlockID<Sha256Digest>,
-        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
-        {
-            std::future::ready(None)
-        }
     }
 
     #[derive(Clone)]
     struct WrongParentProvider(Block<Sha256Digest, ()>);
+
     impl BlockProvider for WrongParentProvider {
         type Block = Block<Sha256Digest, ()>;
 
@@ -1252,18 +978,6 @@ mod test {
             _block: &Self::Block,
         ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
             std::future::ready(Some(Arc::new(self.0.clone())))
-        }
-
-        fn get_descendant(
-            &self,
-            _start: BlockID<Sha256Digest>,
-            tip: BlockID<Sha256Digest>,
-        ) -> impl Future<Output = Option<(Arc<Self::Block>, Sha256Digest)>> + Send + 'static
-        {
-            let BlockID::Digest(tip) = tip else {
-                return std::future::ready(None);
-            };
-            std::future::ready(Some((Arc::new(self.0.clone()), tip)))
         }
     }
 
@@ -1394,11 +1108,9 @@ mod test {
     fn test_descendants_use_bounded_bulk_lookups() {
         deterministic::Runner::default().start(|context| async move {
             let chain = make_chain(0, 64);
-            let singular = Arc::new(AtomicUsize::new(0));
             let bulk = Arc::new(AtomicUsize::new(0));
             let provider = BulkProvider {
                 chain: Arc::new(chain.clone()),
-                singular: singular.clone(),
                 bulk: bulk.clone(),
             };
             let ancestry = stream(&context, provider, [chain.last().unwrap().clone()]);
@@ -1411,7 +1123,67 @@ mod test {
                 .await;
             assert_eq!(descendants.len(), chain.len());
             assert_eq!(bulk.load(Ordering::Relaxed), 8);
-            assert_eq!(singular.load(Ordering::Relaxed), 0);
+        });
+    }
+
+    #[test]
+    fn test_descendants_reject_changed_tip() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(0, 3);
+            let wrong_tip = Sha256::fill(0xAB);
+            let provider = PageProvider {
+                pages: Arc::new(Mutex::new(
+                    [
+                        DescendantPage {
+                            blocks: vec![Arc::new(chain[0].clone())],
+                            tip: chain[2].digest(),
+                            cursor: Some(()),
+                        },
+                        DescendantPage {
+                            blocks: vec![Arc::new(chain[1].clone())],
+                            tip: wrong_tip,
+                            cursor: None,
+                        },
+                    ]
+                    .into(),
+                )),
+            };
+            let ancestry = stream(&context, provider, [chain[2].clone()]);
+            let descendants = ancestry
+                .descendants(BlockID::Height(Height::zero()))
+                .await
+                .expect("initial page should resolve")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(descendants, vec![Arc::new(chain[0].clone())]);
+        });
+    }
+
+    #[test]
+    fn test_descendants_stop_at_tip_with_buffered_child() {
+        deterministic::Runner::default().start(|context| async move {
+            let chain = make_chain(0, 4);
+            let provider = PageProvider {
+                pages: Arc::new(Mutex::new(
+                    [DescendantPage {
+                        blocks: chain.iter().cloned().map(Arc::new).collect(),
+                        tip: chain[2].digest(),
+                        cursor: None,
+                    }]
+                    .into(),
+                )),
+            };
+            let ancestry = stream(&context, provider, [chain[2].clone()]);
+            let descendants = ancestry
+                .descendants(BlockID::Height(Height::zero()))
+                .await
+                .expect("page should resolve")
+                .collect::<Vec<_>>()
+                .await;
+            assert_eq!(
+                descendants,
+                chain[..3].iter().cloned().map(Arc::new).collect::<Vec<_>>()
+            );
         });
     }
 
@@ -1478,118 +1250,6 @@ mod test {
             assert_eq!(ancestry.next().await.as_deref(), Some(&parent));
             assert_eq!(ancestry.peek(), None);
             assert_eq!(ancestry.next().await, None);
-        });
-    }
-
-    #[test]
-    fn test_with_prefix_peeks_tail_when_prefix_empty() {
-        deterministic::Runner::default().start(|_| async move {
-            let block = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
-            let mut ancestry = with_prefix([], from_iter([Arc::new(block.clone())]));
-
-            assert_eq!(ancestry.peek(), Some(&block));
-            assert_eq!(ancestry.next().await.as_deref(), Some(&block));
-            assert_eq!(ancestry.peek(), None);
-        });
-    }
-
-    #[test]
-    fn test_with_prefix_peeks_tail_after_prefix_consumed() {
-        deterministic::Runner::default().start(|_| async move {
-            let parent = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
-            let child = Block::new::<Sha256>((), parent.digest(), Height::new(2), 2);
-            let mut ancestry = with_prefix(
-                [Arc::new(child.clone())],
-                from_iter([Arc::new(parent.clone())]),
-            );
-
-            assert_eq!(ancestry.peek(), Some(&child));
-            assert_eq!(ancestry.next().await.as_deref(), Some(&child));
-            assert_eq!(ancestry.peek(), Some(&parent));
-            assert_eq!(ancestry.next().await.as_deref(), Some(&parent));
-            assert_eq!(ancestry.peek(), None);
-        });
-    }
-
-    #[test]
-    fn test_with_prefix_descendants_include_prefix() {
-        deterministic::Runner::default().start(|_| async move {
-            let ancestor = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::zero(), 0);
-            let parent = Block::new::<Sha256>((), ancestor.digest(), Height::new(1), 1);
-            let tip = Block::new::<Sha256>((), parent.digest(), Height::new(2), 2);
-            let ancestry = with_prefix(
-                [Arc::new(tip.clone()), Arc::new(parent.clone())],
-                from_iter([Arc::new(ancestor.clone())]),
-            );
-
-            let from_tail = ancestry
-                .descendants(BlockID::Digest(ancestor.digest()))
-                .await
-                .expect("tail block should be on chain")
-                .collect::<Vec<_>>()
-                .await;
-            assert_eq!(
-                from_tail,
-                vec![
-                    Arc::new(ancestor.clone()),
-                    Arc::new(parent.clone()),
-                    Arc::new(tip.clone()),
-                ]
-            );
-
-            let from_prefix = ancestry
-                .descendants(BlockID::Digest(parent.digest()))
-                .await
-                .expect("prefix block should be on chain")
-                .collect::<Vec<_>>()
-                .await;
-            assert_eq!(
-                from_prefix,
-                vec![Arc::new(parent.clone()), Arc::new(tip.clone())]
-            );
-
-            let mut tail = from_iter([
-                Arc::new(tip.clone()),
-                Arc::new(parent.clone()),
-                Arc::new(ancestor.clone()),
-            ]);
-            assert_eq!(tail.next().await.as_deref(), Some(&tip));
-            assert_eq!(tail.next().await.as_deref(), Some(&parent));
-            let ancestry = with_prefix(
-                [Arc::new(tip.clone()), Arc::new(parent.clone())],
-                tail,
-            );
-            let overlapping = ancestry
-                .descendants(BlockID::Digest(ancestor.digest()))
-                .await
-                .expect("consumed blocks should remain on the chain")
-                .collect::<Vec<_>>()
-                .await;
-            assert_eq!(
-                overlapping,
-                vec![Arc::new(ancestor), Arc::new(parent), Arc::new(tip)]
-            );
-        });
-    }
-
-    #[test]
-    fn test_with_prefix_descendants_stop_when_tail_ends_before_prefix() {
-        deterministic::Runner::default().start(|_| async move {
-            let start = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::zero(), 0);
-            let missing = Block::new::<Sha256>((), start.digest(), Height::new(1), 1);
-            let tip = Block::new::<Sha256>((), missing.digest(), Height::new(2), 2);
-            let ancestry = with_prefix(
-                [Arc::new(tip)],
-                from_iter([Arc::new(start.clone())]),
-            );
-
-            let forward = ancestry
-                .descendants(BlockID::Digest(start.digest()))
-                .await
-                .expect("start is present in the tail")
-                .collect::<Vec<_>>()
-                .await;
-            assert_eq!(forward, vec![Arc::new(start)]);
         });
     }
 
@@ -1710,134 +1370,4 @@ mod test {
         blocks
     }
 
-    fn descendant_stream<M>(
-        context: &deterministic::Context,
-        provider: M,
-        start: M::Block,
-        tip: Sha256Digest,
-    ) -> DescendantStream<M, deterministic::Context>
-    where
-        M: BlockProvider<Block = Block<Sha256Digest, ()>>,
-    {
-        let stream_context = context.child("descendant_stream");
-        let fetch_duration = timed(&stream_context);
-        DescendantStream::new(
-            Arc::new(stream_context),
-            provider,
-            Arc::new(start),
-            tip,
-            fetch_duration,
-        )
-    }
-
-    #[test]
-    fn test_descendant_walks_chain_to_tip() {
-        deterministic::Runner::default().start(|context| async move {
-            let chain = make_chain(0, 5);
-            let provider = MockProvider(chain.clone());
-
-            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
-            let results = stream.collect::<Vec<_>>().await;
-            assert_eq!(
-                results,
-                chain.iter().cloned().map(Arc::new).collect::<Vec<_>>()
-            );
-        });
-    }
-
-    #[test]
-    fn test_descendant_single_block_when_start_is_tip() {
-        deterministic::Runner::default().start(|context| async move {
-            let chain = make_chain(3, 1);
-            let provider = MockProvider(chain.clone());
-
-            let mut stream =
-                descendant_stream(&context, provider, chain[0].clone(), chain[0].digest());
-            assert_eq!(stream.peek(), Some(&chain[0]));
-            assert_eq!(stream.next().await.as_deref(), Some(&chain[0]));
-            assert_eq!(stream.peek(), None);
-            assert_eq!(stream.next().await, None);
-        });
-    }
-
-    #[test]
-    fn test_descendant_missing_block_ends_stream() {
-        deterministic::Runner::default().start(|context| async move {
-            let chain = make_chain(0, 5);
-
-            // The block at height 2 is missing locally, so the provider can
-            // no longer connect the tip's chain to the next requested height;
-            // the walk ends after the anchor.
-            let mut stored = chain.clone();
-            stored.remove(2);
-            let provider = MockProvider(stored);
-
-            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
-            let results = stream.collect::<Vec<_>>().await;
-            assert_eq!(results, vec![Arc::new(chain[0].clone())]);
-        });
-    }
-
-    #[test]
-    fn test_descendant_peek_available_through_ancestry_trait() {
-        deterministic::Runner::default().start(|context| async move {
-            fn peek_height(ancestry: impl Ancestry<Block<Sha256Digest, ()>>) -> Option<Height> {
-                ancestry.peek().map(Heightable::height)
-            }
-
-            let block = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
-            let stream = descendant_stream(
-                &context,
-                MockProvider::default(),
-                block.clone(),
-                block.digest(),
-            );
-            assert_eq!(peek_height(stream), Some(block.height()));
-        });
-    }
-
-    #[test]
-    fn test_descendant_restarts_from_any_position() {
-        deterministic::Runner::default().start(|context| async move {
-            let chain = make_chain(0, 5);
-            let provider = MockProvider(chain.clone());
-
-            // A forward stream can itself be flipped to a new start on the
-            // same chain through the Ancestry trait.
-            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
-            let restarted = stream
-                .descendants(BlockID::Height(Height::new(2)))
-                .await
-                .expect("restart within chain");
-            let results = restarted.collect::<Vec<_>>().await;
-            assert_eq!(
-                results,
-                chain[2..].iter().cloned().map(Arc::new).collect::<Vec<_>>()
-            );
-
-            // A start outside the chain resolves to nothing.
-            let provider = MockProvider(chain.clone());
-            let stream = descendant_stream(&context, provider, chain[0].clone(), chain[4].digest());
-            assert!(
-                stream
-                    .descendants(BlockID::Height(Height::new(9)))
-                    .await
-                    .is_none()
-            );
-        });
-    }
-
-    #[test]
-    #[should_panic = "block must be contiguous in height"]
-    fn test_descendant_panics_on_non_contiguous_fetched_block() {
-        deterministic::Runner::default().start(|context| async move {
-            // The provider serves a block that does not extend the anchor.
-            let anchor = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(1), 1);
-            let lying = Block::new::<Sha256>((), Sha256Digest::EMPTY, Height::new(9), 9);
-            let provider = WrongParentProvider(lying);
-
-            let stream = descendant_stream(&context, provider, anchor, Sha256::fill(0xAB));
-            let _ = stream.collect::<Vec<_>>().await;
-        });
-    }
 }

--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -113,7 +113,8 @@ impl<B: Block> Ancestry<B> for BoxedAncestry<B> {
     fn descendants(
         &self,
         start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send {
+    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send
+    {
         self.0.descendants_erased(start)
     }
 }
@@ -179,7 +180,8 @@ impl<B: Block> Ancestry<B> for BoundedAncestry<B> {
     fn descendants(
         &self,
         start: BlockID<B::Digest>,
-    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send {
+    ) -> impl Future<Output = Option<impl Stream<Item = Arc<B>> + Send + Unpin + 'static>> + Send
+    {
         // A bounded ancestry is fully in memory: serve the chain fixed at
         // construction from the start onward, in ascending height order.
         std::future::ready(chain_suffix(&self.chain, start).map(futures::stream::iter))
@@ -456,9 +458,8 @@ where
     fn descendants(
         &self,
         start: BlockID<<M::Block as Digestible>::Digest>,
-    ) -> impl Future<
-        Output = Option<impl Stream<Item = Arc<M::Block>> + Send + Unpin + 'static>,
-    > + Send {
+    ) -> impl Future<Output = Option<impl Stream<Item = Arc<M::Block>> + Send + Unpin + 'static>> + Send
+    {
         let chain = chain_suffix(&self.chain, start);
         let tip = self.tip;
         let marshal = self.marshal.clone();
@@ -805,7 +806,6 @@ mod test {
                     .map(Arc::new),
             )
         }
-
     }
 
     impl DescendantProvider for MockProvider {
@@ -814,7 +814,8 @@ mod test {
         fn get_descendants(
             &self,
             request: DescendantRequest<Sha256Digest, Self::Cursor>,
-        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static {
+        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static
+        {
             let result = (|| {
                 let DescendantRequest::Start { start, tip } = request else {
                     return None;
@@ -861,7 +862,6 @@ mod test {
         ) -> impl Future<Output = Option<Arc<Self::Block>>> + Send + 'static {
             std::future::ready(None)
         }
-
     }
 
     impl DescendantProvider for BulkProvider {
@@ -870,7 +870,8 @@ mod test {
         fn get_descendants(
             &self,
             request: DescendantRequest<Sha256Digest, Self::Cursor>,
-        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static {
+        ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static
+        {
             self.bulk.fetch_add(1, Ordering::Relaxed);
             let chain = self.chain.clone();
             async move {
@@ -891,11 +892,7 @@ mod test {
                 };
                 let end = position.saturating_add(8).min(chain.len());
                 Some(DescendantPage {
-                    blocks: chain[position..end]
-                        .iter()
-                        .cloned()
-                        .map(Arc::new)
-                        .collect(),
+                    blocks: chain[position..end].iter().cloned().map(Arc::new).collect(),
                     tip: chain.last()?.digest(),
                     cursor: (end < chain.len()).then_some(end),
                 })
@@ -964,7 +961,6 @@ mod test {
             self.subscriptions.lock().push(subscription);
             parent.map(Result::ok)
         }
-
     }
 
     #[derive(Clone)]
@@ -1369,5 +1365,4 @@ mod test {
         }
         blocks
     }
-
 }

--- a/consensus/src/marshal/application/validation.rs
+++ b/consensus/src/marshal/application/validation.rs
@@ -94,7 +94,7 @@ pub(crate) fn is_block_in_expected_epoch<ES: Epocher>(
 /// Returns true when `block_height` is exactly the successor of `parent_height`.
 #[inline]
 pub(crate) fn has_contiguous_height(parent_height: Height, block_height: Height) -> bool {
-    parent_height.next() == block_height
+    block_height.previous() == Some(parent_height)
 }
 
 #[cfg(test)]
@@ -189,5 +189,9 @@ mod tests {
     fn test_has_contiguous_height() {
         assert!(has_contiguous_height(Height::new(6), Height::new(7)));
         assert!(!has_contiguous_height(Height::new(6), Height::new(8)));
+        assert!(!has_contiguous_height(
+            Height::new(u64::MAX),
+            Height::new(u64::MAX)
+        ));
     }
 }

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -382,55 +382,48 @@ where
                     }
                 };
 
-                // Start the candidate store immediately: it depends on neither the
-                // parent fetch (which may hit the network) nor the verdict below.
-                // Storing before validation is intentional: these caches provide
-                // candidate availability/recovery, not a validity decision. This
-                // task gates the finalize vote by resolving true only after both
-                // app verification succeeds and the store is durable.
+                // Await and validate the parent before admitting the candidate
+                // to marshal's durable caches and fork tree.
+                let parent = select! {
+                    _ = tx.closed() => {
+                        debug!(reason = "consensus dropped receiver", "skipping verification");
+                        return;
+                    },
+                    result = parent_request => match result {
+                        Ok(parent) => parent,
+                        Err(_) => {
+                            debug!(reason = "failed to fetch parent", "skipping verification");
+                            return;
+                        }
+                    },
+                };
+
+                if let Err(err) = validate_block::<H, _, _>(
+                    &epocher,
+                    block.as_ref(),
+                    parent.as_ref(),
+                    &consensus_context,
+                    commitment,
+                    parent_commitment,
+                ) {
+                    debug!(
+                        ?err,
+                        expected_commitment = %commitment,
+                        block_commitment = %block.commitment(),
+                        expected_parent_commitment = %parent_commitment,
+                        parent_commitment = %parent.commitment(),
+                        expected_parent = %parent.digest(),
+                        block_parent = %block.parent(),
+                        parent_height = %parent.height(),
+                        block_height = %block.height(),
+                        "block failed coded invariant validation"
+                    );
+                    tx.send_lossy(GateOutcome::Ready(false));
+                    return;
+                }
+
                 let store = stage.store(&marshal, round, Arc::clone(&block));
                 let verify = async {
-                    // Await the parent fetch we started above.
-                    let parent = select! {
-                        _ = tx.closed() => {
-                            debug!(
-                                reason = "consensus dropped receiver",
-                                "skipping verification"
-                            );
-                            return None;
-                        },
-                        result = parent_request => match result {
-                            Ok(parent) => parent,
-                            Err(_) => {
-                                debug!(reason = "failed to fetch parent", "skipping verification");
-                                return None;
-                            }
-                        },
-                    };
-
-                    if let Err(err) = validate_block::<H, _, _>(
-                        &epocher,
-                        block.as_ref(),
-                        parent.as_ref(),
-                        &consensus_context,
-                        commitment,
-                        parent_commitment,
-                    ) {
-                        debug!(
-                            ?err,
-                            expected_commitment = %commitment,
-                            block_commitment = %block.commitment(),
-                            expected_parent_commitment = %parent_commitment,
-                            parent_commitment = %parent.commitment(),
-                            expected_parent = %parent.digest(),
-                            block_parent = %block.parent(),
-                            parent_height = %parent.height(),
-                            block_height = %block.height(),
-                            "block failed coded invariant validation"
-                        );
-                        return Some(false);
-                    }
-
                     let ancestry_stream = marshal.ancestor_stream(
                         Arc::new(runtime_context.child("ancestor_stream")),
                         [block.inner_shared(), parent.inner_shared()],
@@ -469,9 +462,7 @@ where
                 };
                 let (verdict, durable) = futures::join!(verify, store);
 
-                // Publish only when the block is both valid and durable. App-invalid
-                // candidates may already be in the cache from the concurrent store above,
-                // so the gate verdict is the authority for consensus progress.
+                // Publish only when the block is both valid and durable.
                 if let Some(application_valid) = gates::resolve(verdict, durable) {
                     tx.send_lossy(GateOutcome::Ready(application_valid));
                 }

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -973,6 +973,16 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_coding_ancestry_from_stream() {
+        harness::ancestry_from_stream::<CodingHarness>();
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_ancestry_from_rebuild() {
+        harness::ancestry_from_rebuild::<CodingHarness>();
+    }
+
+    #[test_traced("WARN")]
     fn test_coding_finalize_same_height_different_views() {
         harness::finalize_same_height_different_views::<CodingHarness>();
     }

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -201,6 +201,17 @@ where
     + 'static {
         self.resolve_descendant(start, tip)
     }
+
+    #[allow(clippy::type_complexity)]
+    fn get_descendants(
+        &self,
+        start: BlockID<<Self::Block as Digestible>::Digest>,
+        tip: BlockID<<Self::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<(Vec<Arc<Self::Block>>, <Self::Block as Digestible>::Digest)>>
+    + Send
+    + 'static {
+        self.resolve_descendants(start, tip)
+    }
 }
 
 #[cfg(test)]

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -189,7 +189,6 @@ where
         });
         async move { receiver?.await.ok().map(|block| block.inner_shared()) }
     }
-
 }
 
 impl<S, B, C, H, P> DescendantProvider for Mailbox<S, Coding<B, C, H, P>>

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -1,6 +1,7 @@
 use crate::{
     CertifiableBlock,
     marshal::{
+        BlockID,
         ancestry::BlockProvider,
         coding::{
             shards,
@@ -188,6 +189,17 @@ where
             )
         });
         async move { receiver?.await.ok().map(|block| block.inner_shared()) }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn get_descendant(
+        &self,
+        start: BlockID<<Self::Block as Digestible>::Digest>,
+        tip: BlockID<<Self::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
+    + Send
+    + 'static {
+        self.resolve_descendant(start, tip)
     }
 }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -1,13 +1,12 @@
 use crate::{
     CertifiableBlock,
     marshal::{
-        BlockID,
-        ancestry::BlockProvider,
+        ancestry::{BlockProvider, DescendantPage, DescendantProvider, DescendantRequest},
         coding::{
             shards,
             types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_participants},
         },
-        core::{Buffer, CommitmentFallback, Mailbox, Variant},
+        core::{Buffer, CommitmentFallback, DescendantCursor, Mailbox, Variant},
     },
     simplex::{scheme::Scheme as SimplexScheme, types::Context},
     types::{Round, coding::Commitment},
@@ -191,26 +190,24 @@ where
         async move { receiver?.await.ok().map(|block| block.inner_shared()) }
     }
 
-    #[allow(clippy::type_complexity)]
-    fn get_descendant(
-        &self,
-        start: BlockID<<Self::Block as Digestible>::Digest>,
-        tip: BlockID<<Self::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
-    + Send
-    + 'static {
-        self.resolve_descendant(start, tip)
-    }
+}
 
-    #[allow(clippy::type_complexity)]
+impl<S, B, C, H, P> DescendantProvider for Mailbox<S, Coding<B, C, H, P>>
+where
+    S: Scheme,
+    B: CertifiableBlock<Context = Context<Commitment, P>>,
+    C: CodingScheme,
+    H: Hasher,
+    P: PublicKey,
+{
+    type Cursor = DescendantCursor<Coding<B, C, H, P>>;
+
     fn get_descendants(
         &self,
-        start: BlockID<<Self::Block as Digestible>::Digest>,
-        tip: BlockID<<Self::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<(Vec<Arc<Self::Block>>, <Self::Block as Digestible>::Digest)>>
-    + Send
-    + 'static {
-        self.resolve_descendants(start, tip)
+        request: DescendantRequest<<Self::Block as Digestible>::Digest, Self::Cursor>,
+    ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static
+    {
+        self.resolve_descendants(request)
     }
 }
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -5,7 +5,7 @@ use super::{
     delivery::PendingVerification,
     durability::{DispatchGate, Durable as _},
     floor::Floor,
-    mailbox::{CommitmentFallback, Mailbox, Message},
+    mailbox::{CommitmentFallback, DescendantCursor, Mailbox, Message},
     stream::Stream,
     subscriptions::{Key as SubscriptionKey, KeyFor as SubscriptionKeyFor, Subscriptions},
     tree::ForkTree,
@@ -15,6 +15,7 @@ use crate::{
     Block, Epochable, Heightable, Reporter,
     marshal::{
         BlockID, Config, Identifier, Start, Update,
+        ancestry::{DescendantPage, DescendantRequest},
         resolver::handler::{self, Annotation, Key, Request},
         store::{Blocks, Certificates},
     },
@@ -851,14 +852,13 @@ where
             Message::GetProcessedHeight { response, .. } => {
                 response.send_lossy(self.stream.processed_height());
             }
-            Message::GetDescendant {
-                start,
-                tip,
+            Message::GetDescendants {
+                request,
                 response,
                 ..
             } => {
-                let block = self.resolve_descendant(start, tip).await;
-                response.send_lossy(block);
+                let page = self.resolve_descendants(request).await;
+                response.send_lossy(page);
             }
             Message::HintFinalized {
                 height, targets, ..
@@ -1467,7 +1467,7 @@ where
                     )
                 });
                 if admitted {
-                    self.track_candidate(&block);
+                    self.track_parent(&block);
                 }
 
                 // Round-bound proposal-parent fetches are `Key::Notarized`
@@ -2233,6 +2233,13 @@ where
         }
     }
 
+    /// Tracks `block` only when an admitted child references it as its parent.
+    fn track_parent(&mut self, block: &Arc<V::Block>) {
+        if self.tree.insert_parent(block) {
+            let _ = self.pending_blocks.try_set(self.tree.len() as u64);
+        }
+    }
+
     /// Records a newly finalized block, pruning fork candidates it
     /// supersedes.
     fn finalize_forks(&mut self, height: Height, digest: <V::Block as Digestible>::Digest) {
@@ -2281,17 +2288,29 @@ where
         debug!(blocks = self.tree.len(), "rebuilt fork tree");
     }
 
-    /// Resolves the next bounded batch of locally known ancestry from `start`
-    /// toward `tip`, returning it with the resolved tip digest.
-    ///
-    /// Returns `None` when `tip` is unknown locally, `start` does not lie on
-    /// the tip's chain, or the block at `start` is not locally available.
-    #[allow(clippy::type_complexity)]
-    async fn resolve_descendant(
+    /// Resolves the next bounded page of a descendant walk.
+    async fn resolve_descendants(
+        &self,
+        request: DescendantRequest<
+            <V::Block as Digestible>::Digest,
+            DescendantCursor<V>,
+        >,
+    ) -> Option<DescendantPage<V::Block, DescendantCursor<V>>> {
+        let cursor = match request {
+            DescendantRequest::Start { start, tip } => {
+                self.start_descendants(start, tip).await?
+            }
+            DescendantRequest::Continue(cursor) => cursor,
+        };
+        self.continue_descendants(cursor).await
+    }
+
+    /// Resolves a walk's endpoints and snapshots its candidate suffix once.
+    async fn start_descendants(
         &self,
         start: BlockID<<V::Block as Digestible>::Digest>,
         tip: BlockID<<V::Block as Digestible>::Digest>,
-    ) -> Option<(Vec<Arc<V::Block>>, <V::Block as Digestible>::Digest)> {
+    ) -> Option<DescendantCursor<V>> {
         // Resolve the tip to a digest. Height-identified tips can only name
         // finalized blocks.
         let tip = match tip {
@@ -2321,17 +2340,23 @@ where
         // Resolve the starting position to a height. A digest names a
         // specific block: it is served directly when it is a candidate on
         // this branch, and located in the finalized store otherwise.
-        let (start_height, located) = match start {
-            BlockID::Height(height) => (height, None),
+        let (start_height, located, next_candidate) = match start {
+            BlockID::Height(height) => (height, None, 0),
             BlockID::Digest(digest) => {
                 if let Some(position) = candidates
                     .iter()
                     .position(|block| block.digest() == digest)
                 {
-                    return Some((candidates[position..].to_vec(), tip));
+                    return Some(DescendantCursor {
+                        tip,
+                        next_finalized: None,
+                        finalized_end: None,
+                        candidates: Arc::from(candidates),
+                        next_candidate: position,
+                    });
                 }
                 let block = self.get_finalized_block_by_digest(&digest).await?;
-                (block.height(), Some(block))
+                (block.height(), Some(block), 0)
             }
         };
         if start_height > tip_height {
@@ -2354,41 +2379,76 @@ where
                 .delta_from(first.height())
                 .expect("start height must be at or above the first candidate")
                 .get() as usize;
-            return Some((candidates[offset..].to_vec(), tip));
+            return Some(DescendantCursor {
+                tip,
+                next_finalized: None,
+                finalized_end: None,
+                candidates: Arc::from(candidates),
+                next_candidate: offset,
+            });
         }
 
         // At or below the finalized boundary: the candidate segment must
         // connect to the finalized chain, and the block must be stored (a
         // digest-identified start was already located above).
         let boundary = boundary?;
-        let mut blocks = Vec::new();
-        let mut height = start_height;
-        let mut located = located;
-        let reached_boundary;
-        loop {
-            let block = if height == start_height {
-                match located.take() {
-                    Some(block) => block,
-                    None => self.get_finalized_block(height).await?,
-                }
+        // A digest-identified finalized start was located above; height starts
+        // are verified lazily when the first page is read.
+        if let Some(block) = located
+            && block.height() != start_height
+        {
+            return None;
+        }
+        Some(DescendantCursor {
+            tip,
+            next_finalized: Some(start_height),
+            finalized_end: Some(boundary),
+            candidates: Arc::from(candidates),
+            next_candidate,
+        })
+    }
+
+    /// Advances a resolved descendant cursor by at most one actor-sized page.
+    async fn continue_descendants(
+        &self,
+        mut cursor: DescendantCursor<V>,
+    ) -> Option<DescendantPage<V::Block, DescendantCursor<V>>> {
+        let mut blocks = Vec::with_capacity(DESCENDANT_BATCH_SIZE);
+
+        while let (Some(height), Some(end)) = (cursor.next_finalized, cursor.finalized_end) {
+            blocks.push(Arc::new(self.get_finalized_block(height).await?));
+            cursor.next_finalized = if height == end {
+                None
             } else {
-                self.get_finalized_block(height).await?
+                height.get().checked_add(1).map(Height::new)
             };
-            blocks.push(Arc::new(block));
-            if height == boundary {
-                reached_boundary = true;
-                break;
-            }
             if blocks.len() == DESCENDANT_BATCH_SIZE {
-                reached_boundary = false;
                 break;
             }
-            height = height.get().checked_add(1).map(Height::new)?;
         }
-        if reached_boundary {
-            blocks.extend(candidates);
+
+        let remaining = DESCENDANT_BATCH_SIZE - blocks.len();
+        let end = cursor
+            .next_candidate
+            .saturating_add(remaining)
+            .min(cursor.candidates.len());
+        blocks.extend(
+            cursor.candidates[cursor.next_candidate..end]
+                .iter()
+                .cloned(),
+        );
+        cursor.next_candidate = end;
+
+        if blocks.is_empty() {
+            return None;
         }
-        Some((blocks, tip))
+        let has_more = cursor.next_finalized.is_some()
+            || cursor.next_candidate < cursor.candidates.len();
+        Some(DescendantPage {
+            blocks,
+            tip: cursor.tip,
+            cursor: has_more.then_some(cursor),
+        })
     }
 
     /// Attempt to repair any identified gaps in the finalized blocks archive. The total

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -8,12 +8,13 @@ use super::{
     mailbox::{CommitmentFallback, Mailbox, Message},
     stream::Stream,
     subscriptions::{Key as SubscriptionKey, KeyFor as SubscriptionKeyFor, Subscriptions},
+    tree::ForkTree,
     variant::NoBuffer,
 };
 use crate::{
     Block, Epochable, Heightable, Reporter,
     marshal::{
-        Config, Identifier as BlockID, Start, Update,
+        BlockID, Config, Identifier, Start, Update,
         resolver::handler::{self, Annotation, Key, Request},
         store::{Blocks, Certificates},
     },
@@ -138,6 +139,8 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
+    // Candidate forks above the last finalized block
+    tree: ForkTree<V::Block>,
     // Defers application dispatch of finalized-archive writes until a sync
     // covering them completes
     dispatch_gate: DispatchGate,
@@ -155,6 +158,8 @@ where
     finalized_height: Gauge,
     // Latest processed height
     processed_height: Gauge,
+    // Number of candidate blocks tracked above the finalized tip
+    pending_blocks: Gauge,
 }
 
 impl<E, V, P, FC, FB, ES, T, A> Actor<E, V, P, FC, FB, ES, T, A>
@@ -224,6 +229,10 @@ where
         // Create metrics
         let finalized_height = context.gauge("finalized_height", "Finalized height of application");
         let processed_height = context.gauge("processed_height", "Processed height of application");
+        let pending_blocks = context.gauge(
+            "pending_blocks",
+            "Number of candidate blocks tracked above the finalized tip",
+        );
         if let Some(last_processed_height) = last_processed_height {
             let _ = processed_height.try_set(last_processed_height.get());
         }
@@ -251,12 +260,14 @@ where
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
+                tree: ForkTree::new(),
                 dispatch_gate: DispatchGate::default(),
                 cache,
                 finalizations_by_height,
                 finalized_blocks,
                 finalized_height,
                 processed_height,
+                pending_blocks,
             },
             Mailbox::new(sender),
             last_processed_height,
@@ -391,6 +402,10 @@ where
             // Load persisted cache epochs so find_block can discover blocks
             // written before the last shutdown.
             self.cache = self.cache.load_persisted_epochs().await;
+
+            // Rebuild the in-memory fork tree from cached candidate blocks.
+            self.rebuild_forks(tip.map(|(height, digest, _)| (height, digest)))
+                .await;
 
             // A configured floor follows the same path as `SetFloor`: verify it,
             // then apply a local anchor or fetch the anchor block.
@@ -599,15 +614,15 @@ where
                     // TODO: Instead of pulling out the entire block, determine the
                     // height directly from the archive by mapping the digest to
                     // the index, which is the same as the height.
-                    BlockID::Digest(digest) => self
+                    Identifier::Digest(digest) => self
                         .finalized_blocks
                         .get(ArchiveID::Key(&digest))
                         .await
                         .ok()
                         .flatten()
                         .map(|b| (b.height(), digest)),
-                    BlockID::Height(height) => self.get_info_by_height(height).await,
-                    BlockID::Latest => self.get_latest().await.map(|(h, d, _)| (h, d)),
+                    Identifier::Height(height) => self.get_info_by_height(height).await,
+                    Identifier::Latest => self.get_latest().await.map(|(h, d, _)| (h, d)),
                 };
                 response.send_lossy(info);
             }
@@ -802,18 +817,18 @@ where
                 response,
                 ..
             } => match identifier {
-                BlockID::Digest(digest) => {
+                Identifier::Digest(digest) => {
                     let result = self
                         .find_block_by_digest(buffer, digest)
                         .await
                         .map(Arc::unwrap_or_clone);
                     response.send_lossy(result);
                 }
-                BlockID::Height(height) => {
+                Identifier::Height(height) => {
                     let result = self.get_finalized_block(height).await;
                     response.send_lossy(result);
                 }
-                BlockID::Latest => {
+                Identifier::Latest => {
                     let block = match self.get_latest().await {
                         Some((_, digest, _)) => self.find_block_by_digest(buffer, digest).await,
                         None => None,
@@ -830,6 +845,15 @@ where
             }
             Message::GetProcessedHeight { response, .. } => {
                 response.send_lossy(self.stream.processed_height());
+            }
+            Message::GetDescendant {
+                start,
+                tip,
+                response,
+                ..
+            } => {
+                let block = self.resolve_descendant(start, tip).await;
+                response.send_lossy(block);
             }
             Message::HintFinalized {
                 height, targets, ..
@@ -1259,6 +1283,10 @@ where
     ) -> (Box<Self>, bool) {
         self.block_subscriptions.notify(Arc::clone(&block));
 
+        // Track the block as a fork candidate until a finalization decides
+        // its fate.
+        self.track_candidate(&block);
+
         if !self.floor.matches_pending_anchor(V::commitment(&block)) {
             return (self, false);
         }
@@ -1332,6 +1360,9 @@ where
         )
         .expect("failed to store floor anchor");
         self = self.sync_finalized().await;
+
+        // The floor anchor is finalized: re-anchor the fork tree above it.
+        self.finalize_forks(height, digest);
 
         if height > self.tip {
             application.report(Update::Tip(round, height, digest));
@@ -1952,6 +1983,17 @@ where
         }
     }
 
+    /// Get a finalized block from the immutable archive by digest.
+    async fn get_finalized_block_by_digest(
+        &self,
+        digest: &<V::Block as Digestible>::Digest,
+    ) -> Option<V::Block> {
+        match self.finalized_blocks.get(ArchiveID::Key(digest)).await {
+            Ok(stored) => stored.map(|stored| stored.into()),
+            Err(e) => panic!("failed to get block: {e}"),
+        }
+    }
+
     /// Get a finalization from the archive by height.
     async fn get_finalization_by_height(
         &self,
@@ -2051,6 +2093,10 @@ where
             }
         )
         .unwrap_or_else(|e| panic!("failed to finalize: {e}"));
+
+        // The stored block extends the finalized chain: advance the fork tree
+        // root and prune candidates the finalization supersedes.
+        self.finalize_forks(height, digest);
 
         // The write above is buffered and readable before it is durable, so
         // hold dispatch at or above it until a sync covers it.
@@ -2162,6 +2208,141 @@ where
         self.find_block_in_storage_by_commitment(commitment)
             .await
             .map(Arc::new)
+    }
+
+    // -------------------- Fork Tree --------------------
+
+    /// Tracks `block` as a fork candidate until a finalization decides its
+    /// fate.
+    fn track_candidate(&mut self, block: &Arc<V::Block>) {
+        if self.tree.insert(block) {
+            let _ = self.pending_blocks.try_set(self.tree.len() as u64);
+        }
+    }
+
+    /// Records a newly finalized block, pruning fork candidates it
+    /// supersedes.
+    fn finalize_forks(&mut self, height: Height, digest: <V::Block as Digestible>::Digest) {
+        self.tree.finalize(height, digest);
+        let _ = self.pending_blocks.try_set(self.tree.len() as u64);
+    }
+
+    /// Rebuilds the in-memory fork tree from the prunable caches.
+    ///
+    /// The tree is anchored at the highest locally known finalized block and
+    /// repopulated with every cached candidate block above it. Candidates
+    /// that were only ever observed via broadcast (never cached) are not
+    /// restored.
+    async fn rebuild_forks(&mut self, anchor: Option<(Height, <V::Block as Digestible>::Digest)>) {
+        // Anchor at the highest stored block when it leads the highest known
+        // finalization: the block archive can durably lead the finalization
+        // archive after an unclean shutdown (their syncs are independent),
+        // and every stored block is a walkback-validated chain member. This
+        // also covers a genesis anchor written before any finalization.
+        let anchor = match self.finalized_blocks.last_index() {
+            Some(height) if anchor.is_none_or(|(known, _)| known < height) => self
+                .get_finalized_block(height)
+                .await
+                .map(|block| (height, block.digest())),
+            _ => anchor,
+        };
+        if let Some((height, digest)) = anchor {
+            self.tree.finalize(height, digest);
+        }
+
+        let tree = &mut self.tree;
+        self.cache
+            .visit_blocks(|stored| {
+                let block: V::Block = stored.into();
+                tree.insert(&Arc::new(block));
+            })
+            .await;
+        let _ = self.pending_blocks.try_set(self.tree.len() as u64);
+        debug!(blocks = self.tree.len(), "rebuilt fork tree");
+    }
+
+    /// Resolves the block at `start` within the locally known ancestry of
+    /// `tip`, returning it with the resolved tip digest.
+    ///
+    /// Returns `None` when `tip` is unknown locally, `start` does not lie on
+    /// the tip's chain, or the block at `start` is not locally available.
+    #[allow(clippy::type_complexity)]
+    async fn resolve_descendant(
+        &self,
+        start: BlockID<<V::Block as Digestible>::Digest>,
+        tip: BlockID<<V::Block as Digestible>::Digest>,
+    ) -> Option<(Arc<V::Block>, <V::Block as Digestible>::Digest)> {
+        // Resolve the tip to a digest. Height-identified tips can only name
+        // finalized blocks.
+        let tip = match tip {
+            BlockID::Digest(digest) => digest,
+            BlockID::Height(height) => self.get_finalized_block(height).await?.digest(),
+        };
+
+        // Resolve the tip to a candidate branch or a finalized block. The
+        // boundary is the height of the last finalized block in the tip's
+        // ancestry, when locally known: the fork tree root for a connected
+        // branch, or the tip itself when the tip is already finalized.
+        let (candidates, boundary, tip_height) = match self.tree.branch(&tip) {
+            Some(branch) => {
+                let tip_height = branch
+                    .blocks
+                    .last()
+                    .expect("branch must contain its tip")
+                    .height();
+                (branch.blocks, branch.root, tip_height)
+            }
+            None => {
+                let block = self.get_finalized_block_by_digest(&tip).await?;
+                (Vec::new(), Some(block.height()), block.height())
+            }
+        };
+
+        // Resolve the starting position to a height. A digest names a
+        // specific block: it is served directly when it is a candidate on
+        // this branch, and located in the finalized store otherwise.
+        let (start_height, located) = match start {
+            BlockID::Height(height) => (height, None),
+            BlockID::Digest(digest) => {
+                if let Some(block) = candidates.iter().find(|block| block.digest() == digest) {
+                    return Some((Arc::clone(block), tip));
+                }
+                let block = self.get_finalized_block_by_digest(&digest).await?;
+                (block.height(), Some(block))
+            }
+        };
+        if start_height > tip_height {
+            return None;
+        }
+
+        // Within the candidate segment: serve from the branch. A block
+        // located in the finalized store never resolves here: it is not a
+        // candidate on this branch (checked above), so a finalized block at
+        // a candidate height is provably not on the tip's chain. This is
+        // reachable when the block archive durably leads the fork tree root
+        // after an unclean shutdown.
+        if let Some(first) = candidates.first()
+            && start_height >= first.height()
+        {
+            if located.is_some() {
+                return None;
+            }
+            let offset = start_height
+                .delta_from(first.height())
+                .expect("start height must be at or above the first candidate")
+                .get() as usize;
+            return Some((Arc::clone(&candidates[offset]), tip));
+        }
+
+        // At or below the finalized boundary: the candidate segment must
+        // connect to the finalized chain, and the block must be stored (a
+        // digest-identified start was already located above).
+        boundary?;
+        let block = match located {
+            Some(block) => block,
+            None => self.get_finalized_block(start_height).await?,
+        };
+        Some((Arc::new(block), tip))
     }
 
     /// Attempt to repair any identified gaps in the finalized blocks archive. The total

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -2243,7 +2243,8 @@ where
             Some(height) if anchor.is_none_or(|(known, _)| known < height) => self
                 .get_finalized_block(height)
                 .await
-                .map(|block| (height, block.digest())),
+                .map(|block| (height, block.digest()))
+                .or(anchor),
             _ => anchor,
         };
         if let Some((height, digest)) = anchor {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -62,6 +62,9 @@ use tracing::{Instrument as _, Span, debug, info_span, warn};
 // may differ from the block digest for coded variants.
 type ResolverRequestFor<V> = Key<<V as Variant>::Commitment>;
 
+// Bounds archive work performed by one descendant mailbox request.
+const DESCENDANT_BATCH_SIZE: usize = 64;
+
 // A resolver delivery plus the peer-validity response channel. Local
 // annotations on the delivery decide how accepted data is used.
 struct ResolverDelivery<V: Variant> {
@@ -678,6 +681,7 @@ where
             Message::Certified {
                 round, block, ack, ..
             } => {
+                self.track_candidate(&block);
                 (self, _) = self
                     .ingest(Arc::clone(&block), buffer, application, resolver)
                     .await;
@@ -737,6 +741,7 @@ where
                 // data. If the block is not locally available, remember the
                 // certificate and wait for a later finalization/repair path.
                 if let Some(block) = self.find_block_by_commitment(buffer, commitment).await {
+                    self.track_candidate(&block);
                     (self, _) = self
                         .ingest(Arc::clone(&block), buffer, application, resolver)
                         .await;
@@ -1248,6 +1253,7 @@ where
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> Box<Self> {
+        self.track_candidate(&block);
         (self, _) = self
             .ingest(Arc::clone(&block), buffer, application, resolver)
             .await;
@@ -1282,10 +1288,6 @@ where
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> (Box<Self>, bool) {
         self.block_subscriptions.notify(Arc::clone(&block));
-
-        // Track the block as a fork candidate until a finalization decides
-        // its fate.
-        self.track_candidate(&block);
 
         if !self.floor.matches_pending_anchor(V::commitment(&block)) {
             return (self, false);
@@ -1455,6 +1457,18 @@ where
                 let annotations = subscribers
                     .map_into(|(annotation, _)| annotation)
                     .into_vec();
+                let certified = annotations
+                    .iter()
+                    .any(|annotation| matches!(annotation, Annotation::Certified { .. }));
+                let admitted = annotations.iter().any(|annotation| {
+                    matches!(
+                        annotation,
+                        Annotation::Certified { height: expected } if *expected == height
+                    )
+                });
+                if admitted {
+                    self.track_candidate(&block);
+                }
 
                 // Round-bound proposal-parent fetches are `Key::Notarized`
                 // deliveries and are handled below. In this block-keyed path,
@@ -1479,9 +1493,7 @@ where
                             application,
                         )
                         .await;
-                } else if annotations
-                    .iter()
-                    .any(|annotation| matches!(annotation, Annotation::Certified { .. }))
+                } else if certified
                     && height > self.floor.processed_height()
                     && let Some(bounds) = self.epocher.containing(height)
                 {
@@ -1731,6 +1743,7 @@ where
                     // bookkeeping below never runs ahead of storage.
                     let height = block.height();
                     let block = Arc::new(block);
+                    self.track_candidate(&block);
                     let block_sync;
                     (self.cache, block_sync) = self
                         .cache
@@ -2258,12 +2271,18 @@ where
                 tree.insert(&Arc::new(block));
             })
             .await;
+        self.cache
+            .visit_certified_blocks(|stored| {
+                let block: V::Block = stored.into();
+                tree.insert_parent(&Arc::new(block));
+            })
+            .await;
         let _ = self.pending_blocks.try_set(self.tree.len() as u64);
         debug!(blocks = self.tree.len(), "rebuilt fork tree");
     }
 
-    /// Resolves the block at `start` within the locally known ancestry of
-    /// `tip`, returning it with the resolved tip digest.
+    /// Resolves the next bounded batch of locally known ancestry from `start`
+    /// toward `tip`, returning it with the resolved tip digest.
     ///
     /// Returns `None` when `tip` is unknown locally, `start` does not lie on
     /// the tip's chain, or the block at `start` is not locally available.
@@ -2272,7 +2291,7 @@ where
         &self,
         start: BlockID<<V::Block as Digestible>::Digest>,
         tip: BlockID<<V::Block as Digestible>::Digest>,
-    ) -> Option<(Arc<V::Block>, <V::Block as Digestible>::Digest)> {
+    ) -> Option<(Vec<Arc<V::Block>>, <V::Block as Digestible>::Digest)> {
         // Resolve the tip to a digest. Height-identified tips can only name
         // finalized blocks.
         let tip = match tip {
@@ -2305,8 +2324,11 @@ where
         let (start_height, located) = match start {
             BlockID::Height(height) => (height, None),
             BlockID::Digest(digest) => {
-                if let Some(block) = candidates.iter().find(|block| block.digest() == digest) {
-                    return Some((Arc::clone(block), tip));
+                if let Some(position) = candidates
+                    .iter()
+                    .position(|block| block.digest() == digest)
+                {
+                    return Some((candidates[position..].to_vec(), tip));
                 }
                 let block = self.get_finalized_block_by_digest(&digest).await?;
                 (block.height(), Some(block))
@@ -2332,18 +2354,41 @@ where
                 .delta_from(first.height())
                 .expect("start height must be at or above the first candidate")
                 .get() as usize;
-            return Some((Arc::clone(&candidates[offset]), tip));
+            return Some((candidates[offset..].to_vec(), tip));
         }
 
         // At or below the finalized boundary: the candidate segment must
         // connect to the finalized chain, and the block must be stored (a
         // digest-identified start was already located above).
-        boundary?;
-        let block = match located {
-            Some(block) => block,
-            None => self.get_finalized_block(start_height).await?,
-        };
-        Some((Arc::new(block), tip))
+        let boundary = boundary?;
+        let mut blocks = Vec::new();
+        let mut height = start_height;
+        let mut located = located;
+        let reached_boundary;
+        loop {
+            let block = if height == start_height {
+                match located.take() {
+                    Some(block) => block,
+                    None => self.get_finalized_block(height).await?,
+                }
+            } else {
+                self.get_finalized_block(height).await?
+            };
+            blocks.push(Arc::new(block));
+            if height == boundary {
+                reached_boundary = true;
+                break;
+            }
+            if blocks.len() == DESCENDANT_BATCH_SIZE {
+                reached_boundary = false;
+                break;
+            }
+            height = height.get().checked_add(1).map(Height::new)?;
+        }
+        if reached_boundary {
+            blocks.extend(candidates);
+        }
+        Some((blocks, tip))
     }
 
     /// Attempt to repair any identified gaps in the finalized blocks archive. The total

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -853,9 +853,7 @@ where
                 response.send_lossy(self.stream.processed_height());
             }
             Message::GetDescendants {
-                request,
-                response,
-                ..
+                request, response, ..
             } => {
                 let page = self.resolve_descendants(request).await;
                 response.send_lossy(page);
@@ -2291,15 +2289,10 @@ where
     /// Resolves the next bounded page of a descendant walk.
     async fn resolve_descendants(
         &self,
-        request: DescendantRequest<
-            <V::Block as Digestible>::Digest,
-            DescendantCursor<V>,
-        >,
+        request: DescendantRequest<<V::Block as Digestible>::Digest, DescendantCursor<V>>,
     ) -> Option<DescendantPage<V::Block, DescendantCursor<V>>> {
         let cursor = match request {
-            DescendantRequest::Start { start, tip } => {
-                self.start_descendants(start, tip).await?
-            }
+            DescendantRequest::Start { start, tip } => self.start_descendants(start, tip).await?,
             DescendantRequest::Continue(cursor) => cursor,
         };
         self.continue_descendants(cursor).await
@@ -2343,9 +2336,7 @@ where
         let (start_height, located, next_candidate) = match start {
             BlockID::Height(height) => (height, None, 0),
             BlockID::Digest(digest) => {
-                if let Some(position) = candidates
-                    .iter()
-                    .position(|block| block.digest() == digest)
+                if let Some(position) = candidates.iter().position(|block| block.digest() == digest)
                 {
                     return Some(DescendantCursor {
                         tip,
@@ -2442,8 +2433,8 @@ where
         if blocks.is_empty() {
             return None;
         }
-        let has_more = cursor.next_finalized.is_some()
-            || cursor.next_candidate < cursor.candidates.len();
+        let has_more =
+            cursor.next_finalized.is_some() || cursor.next_candidate < cursor.candidates.len();
         Some(DescendantPage {
             blocks,
             tip: cursor.tip,

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -631,6 +631,35 @@ where
         None
     }
 
+    /// Visits every block held by the prunable caches (verified, notarized,
+    /// and certified) across all initialized epochs.
+    ///
+    /// Used to rebuild in-memory candidate state on startup. The same block
+    /// may be visited more than once if it is present in multiple archives.
+    pub(crate) async fn visit_blocks(&self, mut visit: impl FnMut(V::StoredBlock)) {
+        for cache in self.caches.values() {
+            let archives = [
+                &cache.verified_blocks,
+                &cache.notarized_blocks,
+                &cache.certified_blocks,
+            ];
+            for archive in archives {
+                let ranges: Vec<_> = archive.ranges().collect();
+                for (start, end) in ranges {
+                    for index in start..=end {
+                        let values = archive
+                            .get_all(index)
+                            .await
+                            .expect("failed to read cached blocks");
+                        for value in values.into_iter().flatten() {
+                            visit(value);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     /// Prune the view-indexed caches below the given round.
     pub(crate) async fn prune_by_view(mut self, round: Round) -> Self {
         // Remove and close prunable archives from older epochs

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -631,18 +631,16 @@ where
         None
     }
 
-    /// Visits every block held by the prunable caches (verified, notarized,
-    /// and certified) across all initialized epochs.
+    /// Visits every locally admitted block held by the verified and notarized
+    /// caches across all initialized epochs.
     ///
     /// Used to rebuild in-memory candidate state on startup. The same block
     /// may be visited more than once if it is present in multiple archives.
     pub(crate) async fn visit_blocks(&self, mut visit: impl FnMut(V::StoredBlock)) {
         for cache in self.caches.values() {
-            let archives = [
-                &cache.verified_blocks,
-                &cache.notarized_blocks,
-                &cache.certified_blocks,
-            ];
+            // Certified ancestry responses require structural admission during
+            // the separate child-first pass below.
+            let archives = [&cache.verified_blocks, &cache.notarized_blocks];
             for archive in archives {
                 let ranges: Vec<_> = archive.ranges().collect();
                 for (start, end) in ranges {
@@ -655,6 +653,35 @@ where
                             visit(value);
                         }
                     }
+                }
+            }
+        }
+    }
+
+    /// Visits cached certified ancestry blocks from highest to lowest height.
+    ///
+    /// These responses require a tracked child to prove structural admission
+    /// during fork-tree reconstruction, so children must be visited first.
+    pub(crate) async fn visit_certified_blocks(&self, mut visit: impl FnMut(V::StoredBlock)) {
+        for cache in self.caches.values().rev() {
+            let ranges: Vec<_> = cache.certified_blocks.ranges().collect();
+            for (start, end) in ranges.into_iter().rev() {
+                let mut index = end;
+                loop {
+                    let values = cache
+                        .certified_blocks
+                        .get_all(index)
+                        .await
+                        .expect("failed to read cached certified blocks");
+                    for value in values.into_iter().flatten() {
+                        visit(value);
+                    }
+                    if index == start {
+                        break;
+                    }
+                    index = index
+                        .checked_sub(1)
+                        .expect("certified block range must be ordered");
                 }
             }
         }

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -1,7 +1,10 @@
 use super::{Variant, durability::Durable as _};
 use crate::{
     Reporter,
-    marshal::{BlockID, Identifier},
+    marshal::{
+        Identifier,
+        ancestry::{DescendantPage, DescendantRequest},
+    },
     simplex::types::{Activity, Finalization, Notarization},
     types::{Height, Round},
 };
@@ -19,6 +22,27 @@ use std::{
     sync::Arc,
 };
 use tracing::{Span, info_span};
+
+/// Opaque continuation for a locally known descendant walk.
+pub struct DescendantCursor<V: Variant> {
+    pub(crate) tip: <V::Block as Digestible>::Digest,
+    pub(crate) next_finalized: Option<Height>,
+    pub(crate) finalized_end: Option<Height>,
+    pub(crate) candidates: Arc<[Arc<V::Block>]>,
+    pub(crate) next_candidate: usize,
+}
+
+impl<V: Variant> Clone for DescendantCursor<V> {
+    fn clone(&self) -> Self {
+        Self {
+            tip: self.tip,
+            next_finalized: self.next_finalized,
+            finalized_end: self.finalized_end,
+            candidates: Arc::clone(&self.candidates),
+            next_candidate: self.next_candidate,
+        }
+    }
+}
 
 /// Messages sent to the marshal [Actor](super::Actor).
 ///
@@ -110,18 +134,16 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
     },
     /// A request to retrieve the block at `start` within the locally known
     /// ancestry of `tip`, together with the resolved tip digest.
-    GetDescendant {
+    GetDescendants {
         /// The span carried with this request.
         span: Span,
-        /// The position of the block within the tip's ancestry.
-        start: BlockID<<V::Block as Digestible>::Digest>,
-        /// The block whose ancestry defines the chain.
-        tip: BlockID<<V::Block as Digestible>::Digest>,
-        /// A channel to send the resolved block and tip digest.
-        #[allow(clippy::type_complexity)]
-        response: oneshot::Sender<
-            Option<(Vec<Arc<V::Block>>, <V::Block as Digestible>::Digest)>,
+        /// A request to start or continue the walk.
+        request: DescendantRequest<
+            <V::Block as Digestible>::Digest,
+            DescendantCursor<V>,
         >,
+        /// A channel to send the next page.
+        response: oneshot::Sender<Option<DescendantPage<V::Block, DescendantCursor<V>>>>,
     },
     /// A hint to fetch a notarized block by round without adding another local subscriber.
     ///
@@ -303,7 +325,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             | Self::Notarization { span, .. }
             | Self::Finalization { span, .. }
             | Self::GetProcessedHeight { span, .. }
-            | Self::GetDescendant { span, .. }
+            | Self::GetDescendants { span, .. }
             | Self::HintFinalized { span, .. }
             | Self::HintNotarized { span, .. }
             | Self::SetFloor { span, .. }
@@ -318,7 +340,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             Self::GetBlock { .. } => "get_block",
             Self::GetFinalization { .. } => "get_finalization",
             Self::GetProcessedHeight { .. } => "get_processed_height",
-            Self::GetDescendant { .. } => "get_descendant",
+            Self::GetDescendants { .. } => "get_descendants",
             Self::HintFinalized { .. } => "hint_finalized",
             Self::SubscribeByDigest { .. } => "subscribe_by_digest",
             Self::SubscribeByCommitment { .. } => "subscribe_by_commitment",
@@ -346,8 +368,12 @@ impl<S: Scheme, V: Variant> Message<S, V> {
                 identifier: Identifier::Height(height),
                 ..
             }
-            | Self::GetDescendant {
-                start: BlockID::Height(height),
+            | Self::GetDescendants {
+                request:
+                    DescendantRequest::Start {
+                        start: crate::marshal::BlockID::Height(height),
+                        ..
+                    },
                 ..
             }
             | Self::GetFinalization { height, .. } => Some(*height) < current,
@@ -364,8 +390,13 @@ impl<S: Scheme, V: Variant> Message<S, V> {
                 identifier: Identifier::Digest(_) | Identifier::Latest,
                 ..
             }
-            | Self::GetDescendant {
-                start: BlockID::Digest(_),
+            | Self::GetDescendants {
+                request:
+                    DescendantRequest::Start {
+                        start: crate::marshal::BlockID::Digest(_),
+                        ..
+                    }
+                    | DescendantRequest::Continue(_),
                 ..
             }
             | Self::GetProcessedHeight { .. } => false,
@@ -389,7 +420,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             }
             Self::GetFinalization { response, .. } => response.is_closed(),
             Self::GetProcessedHeight { response, .. } => response.is_closed(),
-            Self::GetDescendant { response, .. } => response.is_closed(),
+            Self::GetDescendants { response, .. } => response.is_closed(),
             Self::SubscribeByDigest { response, .. }
             | Self::SubscribeByCommitment { response, .. } => response.is_closed(),
             Self::HintNotarized { .. } => false,
@@ -804,56 +835,34 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         });
     }
 
-    /// Retrieves the block at `start` within the locally known ancestry of
-    /// `tip`, together with the resolved tip digest.
-    ///
-    /// The chain is defined by the ancestry of `tip`, which may be a candidate
-    /// block above the last finalization (a fork tracked by marshal) or a
-    /// finalized block. This never fetches from the network: it serves
-    /// finalized blocks from storage and fork candidates from marshal's
-    /// in-memory ancestry tree.
-    ///
-    /// Backs the [BlockProvider::get_descendant] implementations of every
-    /// variant.
-    #[allow(clippy::type_complexity)]
-    pub(crate) fn resolve_descendant(
-        &self,
-        start: BlockID<<V::Block as Digestible>::Digest>,
-        tip: BlockID<<V::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<(Arc<V::ApplicationBlock>, <V::Block as Digestible>::Digest)>>
-    + Send
-    + 'static {
-        let descendants = self.resolve_descendants(start, tip);
-        async move {
-            let (blocks, tip) = descendants.await?;
-            Some((blocks.into_iter().next()?, tip))
-        }
-    }
-
-    /// Retrieves the next contiguous batch from `start` toward `tip`.
-    #[allow(clippy::type_complexity)]
+    /// Retrieves the next contiguous page of a descendant walk.
     pub(crate) fn resolve_descendants(
         &self,
-        start: BlockID<<V::Block as Digestible>::Digest>,
-        tip: BlockID<<V::Block as Digestible>::Digest>,
-    ) -> impl Future<
-        Output = Option<(
-            Vec<Arc<V::ApplicationBlock>>,
+        request: DescendantRequest<
             <V::Block as Digestible>::Digest,
-        )>,
-    > + Send
+            DescendantCursor<V>,
+        >,
+    ) -> impl Future<Output = Option<DescendantPage<V::ApplicationBlock, DescendantCursor<V>>>>
+    + Send
     + 'static {
         let mailbox = self.clone();
         async move {
             let (response, receiver) = oneshot::channel();
-            let _ = mailbox.sender.enqueue(Message::GetDescendant {
-                span: info_span!("marshal.mailbox.get_descendant", tip = ?tip),
-                start,
-                tip,
+            let _ = mailbox.sender.enqueue(Message::GetDescendants {
+                span: info_span!("marshal.mailbox.get_descendants"),
+                request,
                 response,
             });
-            let (blocks, tip) = receiver.await.ok().flatten()?;
-            Some((blocks.into_iter().map(V::into_inner_shared).collect(), tip))
+            let page = receiver.await.ok().flatten()?;
+            Some(DescendantPage {
+                blocks: page
+                    .blocks
+                    .into_iter()
+                    .map(V::into_inner_shared)
+                    .collect(),
+                tip: page.tip,
+                cursor: page.cursor,
+            })
         }
     }
 
@@ -997,7 +1006,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
 }
 
 commonware_macros::stability_scope!(ALPHA {
-    use crate::marshal::ancestry::{AncestorStream, Ancestry, BlockProvider};
+    use crate::marshal::ancestry::{AncestorStream, Ancestry, DescendantProvider};
     use commonware_runtime::{Clock, telemetry::metrics::histogram::Timed};
 
     impl<S: Scheme, V: Variant> Mailbox<S, V> {
@@ -1017,7 +1026,7 @@ commonware_macros::stability_scope!(ALPHA {
             fetch_duration: Timed,
         ) -> impl Ancestry<V::ApplicationBlock> + use<S, V, I, C>
         where
-            Self: BlockProvider<Block = V::ApplicationBlock>,
+            Self: DescendantProvider<Block = V::ApplicationBlock>,
             I: IntoIterator<Item = Arc<V::ApplicationBlock>>,
             C: Clock,
         {

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -138,10 +138,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The span carried with this request.
         span: Span,
         /// A request to start or continue the walk.
-        request: DescendantRequest<
-            <V::Block as Digestible>::Digest,
-            DescendantCursor<V>,
-        >,
+        request: DescendantRequest<<V::Block as Digestible>::Digest, DescendantCursor<V>>,
         /// A channel to send the next page.
         response: oneshot::Sender<Option<DescendantPage<V::Block, DescendantCursor<V>>>>,
     },
@@ -838,10 +835,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// Retrieves the next contiguous page of a descendant walk.
     pub(crate) fn resolve_descendants(
         &self,
-        request: DescendantRequest<
-            <V::Block as Digestible>::Digest,
-            DescendantCursor<V>,
-        >,
+        request: DescendantRequest<<V::Block as Digestible>::Digest, DescendantCursor<V>>,
     ) -> impl Future<Output = Option<DescendantPage<V::ApplicationBlock, DescendantCursor<V>>>>
     + Send
     + 'static {
@@ -855,11 +849,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
             });
             let page = receiver.await.ok().flatten()?;
             Some(DescendantPage {
-                blocks: page
-                    .blocks
-                    .into_iter()
-                    .map(V::into_inner_shared)
-                    .collect(),
+                blocks: page.blocks.into_iter().map(V::into_inner_shared).collect(),
                 tip: page.tip,
                 cursor: page.cursor,
             })

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -1,10 +1,7 @@
 use super::{Variant, durability::Durable as _};
 use crate::{
     Reporter,
-    marshal::{
-        Identifier,
-        ancestry::{AncestorStream, Ancestry, BlockProvider},
-    },
+    marshal::{BlockID, Identifier},
     simplex::types::{Activity, Finalization, Notarization},
     types::{Height, Round},
 };
@@ -14,13 +11,11 @@ use commonware_actor::{
 };
 use commonware_cryptography::{Digestible, certificate::Scheme};
 use commonware_p2p::Recipients;
-use commonware_runtime::{
-    Clock, Handle,
-    telemetry::{metrics::histogram::Timed, traces::TracedExt as _},
-};
+use commonware_runtime::{Handle, telemetry::traces::TracedExt as _};
 use commonware_utils::{channel::oneshot, vec::NonEmptyVec};
 use std::{
     collections::{BTreeMap, VecDeque, btree_map::Entry},
+    future::Future,
     sync::Arc,
 };
 use tracing::{Span, info_span};
@@ -112,6 +107,19 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         fallback: CommitmentFallback,
         /// A channel to send the retrieved block.
         response: oneshot::Sender<Arc<V::Block>>,
+    },
+    /// A request to retrieve the block at `start` within the locally known
+    /// ancestry of `tip`, together with the resolved tip digest.
+    GetDescendant {
+        /// The span carried with this request.
+        span: Span,
+        /// The position of the block within the tip's ancestry.
+        start: BlockID<<V::Block as Digestible>::Digest>,
+        /// The block whose ancestry defines the chain.
+        tip: BlockID<<V::Block as Digestible>::Digest>,
+        /// A channel to send the resolved block and tip digest.
+        #[allow(clippy::type_complexity)]
+        response: oneshot::Sender<Option<(Arc<V::Block>, <V::Block as Digestible>::Digest)>>,
     },
     /// A hint to fetch a notarized block by round without adding another local subscriber.
     ///
@@ -293,6 +301,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             | Self::Notarization { span, .. }
             | Self::Finalization { span, .. }
             | Self::GetProcessedHeight { span, .. }
+            | Self::GetDescendant { span, .. }
             | Self::HintFinalized { span, .. }
             | Self::HintNotarized { span, .. }
             | Self::SetFloor { span, .. }
@@ -307,6 +316,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             Self::GetBlock { .. } => "get_block",
             Self::GetFinalization { .. } => "get_finalization",
             Self::GetProcessedHeight { .. } => "get_processed_height",
+            Self::GetDescendant { .. } => "get_descendant",
             Self::HintFinalized { .. } => "hint_finalized",
             Self::SubscribeByDigest { .. } => "subscribe_by_digest",
             Self::SubscribeByCommitment { .. } => "subscribe_by_commitment",
@@ -334,6 +344,10 @@ impl<S: Scheme, V: Variant> Message<S, V> {
                 identifier: Identifier::Height(height),
                 ..
             }
+            | Self::GetDescendant {
+                start: BlockID::Height(height),
+                ..
+            }
             | Self::GetFinalization { height, .. } => Some(*height) < current,
             // Hints only inform the actor about heights strictly above the floor
             Self::HintFinalized { height, .. } => Some(*height) <= current,
@@ -346,6 +360,10 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             }
             | Self::GetInfo {
                 identifier: Identifier::Digest(_) | Identifier::Latest,
+                ..
+            }
+            | Self::GetDescendant {
+                start: BlockID::Digest(_),
                 ..
             }
             | Self::GetProcessedHeight { .. } => false,
@@ -369,6 +387,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             }
             Self::GetFinalization { response, .. } => response.is_closed(),
             Self::GetProcessedHeight { response, .. } => response.is_closed(),
+            Self::GetDescendant { response, .. } => response.is_closed(),
             Self::SubscribeByDigest { response, .. }
             | Self::SubscribeByCommitment { response, .. } => response.is_closed(),
             Self::HintNotarized { .. } => false,
@@ -622,29 +641,6 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         Self { sender }
     }
 
-    /// Create an ancestor stream that fetches missing parents by commitment.
-    ///
-    /// This stream is always a fetching stream. Callers must only use it after
-    /// they already have a block that is safe to verify, certify, build on, or
-    /// repair from. From that point, every parent walked by the stream is part of
-    /// a certified ancestry chain, and the stream can derive each missing
-    /// parent's height from its child before issuing a height-bound request.
-    ///
-    /// Do not use this to wait for pending candidate proposal data.
-    pub(crate) fn ancestor_stream<I, C>(
-        &self,
-        clock: Arc<C>,
-        initial: I,
-        fetch_duration: Timed,
-    ) -> impl Ancestry<V::ApplicationBlock> + use<S, V, I, C>
-    where
-        Self: BlockProvider<Block = V::ApplicationBlock>,
-        I: IntoIterator<Item = Arc<V::ApplicationBlock>>,
-        C: Clock,
-    {
-        AncestorStream::new(clock, self.clone(), initial, fetch_duration)
-    }
-
     /// Retrieve `(height, digest)` for a finalized block by height, digest, or latest.
     pub async fn get_info(
         &self,
@@ -806,28 +802,37 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         });
     }
 
-    /// Returns a stream over the ancestry of a given block, leading up to genesis.
+    /// Retrieves the block at `start` within the locally known ancestry of
+    /// `tip`, together with the resolved tip digest.
     ///
-    /// This stream may fetch missing parents because callers should only request
-    /// ancestry for data they already have locally and are willing to build on,
-    /// verify, certify, or repair from. It is not a candidate fetch path.
+    /// The chain is defined by the ancestry of `tip`, which may be a candidate
+    /// block above the last finalization (a fork tracked by marshal) or a
+    /// finalized block. This never fetches from the network: it serves
+    /// finalized blocks from storage and fork candidates from marshal's
+    /// in-memory ancestry tree.
     ///
-    /// If the starting block is not found, `None` is returned.
-    pub async fn ancestry<C>(
+    /// Backs the [BlockProvider::get_descendant] implementations of every
+    /// variant.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn resolve_descendant(
         &self,
-        clock: Arc<C>,
-        (fallback, start_digest): (DigestFallback, <V::Block as Digestible>::Digest),
-        fetch_duration: Timed,
-    ) -> Option<impl Ancestry<V::ApplicationBlock> + use<S, V, C>>
-    where
-        Self: BlockProvider<Block = V::ApplicationBlock>,
-        C: Clock,
-    {
-        let receiver = self.subscribe_by_digest(start_digest, fallback);
-        receiver.await.ok().map(|block| {
-            let block = V::into_inner_shared(block);
-            self.ancestor_stream(clock, [block], fetch_duration)
-        })
+        start: BlockID<<V::Block as Digestible>::Digest>,
+        tip: BlockID<<V::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<(Arc<V::ApplicationBlock>, <V::Block as Digestible>::Digest)>>
+    + Send
+    + 'static {
+        let mailbox = self.clone();
+        async move {
+            let (response, receiver) = oneshot::channel();
+            let _ = mailbox.sender.enqueue(Message::GetDescendant {
+                span: info_span!("marshal.mailbox.get_descendant", tip = ?tip),
+                start,
+                tip,
+                response,
+            });
+            let (block, tip) = receiver.await.ok().flatten()?;
+            Some((V::into_inner_shared(block), tip))
+        }
     }
 
     /// Returns the verified block previously persisted for `round`, if any.
@@ -968,6 +973,36 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         })
     }
 }
+
+commonware_macros::stability_scope!(ALPHA {
+    use crate::marshal::ancestry::{AncestorStream, Ancestry, BlockProvider};
+    use commonware_runtime::{Clock, telemetry::metrics::histogram::Timed};
+
+    impl<S: Scheme, V: Variant> Mailbox<S, V> {
+        /// Create an ancestor stream that fetches missing parents by commitment.
+        ///
+        /// This stream is always a fetching stream. Callers must only use it after
+        /// they already have a block that is safe to verify, certify, build on, or
+        /// repair from. From that point, every parent walked by the stream is part of
+        /// a certified ancestry chain, and the stream can derive each missing
+        /// parent's height from its child before issuing a height-bound request.
+        ///
+        /// Do not use this to wait for pending candidate proposal data.
+        pub(crate) fn ancestor_stream<I, C>(
+            &self,
+            clock: Arc<C>,
+            initial: I,
+            fetch_duration: Timed,
+        ) -> impl Ancestry<V::ApplicationBlock> + use<S, V, I, C>
+        where
+            Self: BlockProvider<Block = V::ApplicationBlock>,
+            I: IntoIterator<Item = Arc<V::ApplicationBlock>>,
+            C: Clock,
+        {
+            AncestorStream::new(clock, self.clone(), initial, fetch_duration)
+        }
+    }
+});
 
 impl<S: Scheme, V: Variant> Reporter for Mailbox<S, V> {
     type Activity = Activity<S, V::Commitment>;

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -119,7 +119,9 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         tip: BlockID<<V::Block as Digestible>::Digest>,
         /// A channel to send the resolved block and tip digest.
         #[allow(clippy::type_complexity)]
-        response: oneshot::Sender<Option<(Arc<V::Block>, <V::Block as Digestible>::Digest)>>,
+        response: oneshot::Sender<
+            Option<(Vec<Arc<V::Block>>, <V::Block as Digestible>::Digest)>,
+        >,
     },
     /// A hint to fetch a notarized block by round without adding another local subscriber.
     ///
@@ -821,6 +823,26 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     ) -> impl Future<Output = Option<(Arc<V::ApplicationBlock>, <V::Block as Digestible>::Digest)>>
     + Send
     + 'static {
+        let descendants = self.resolve_descendants(start, tip);
+        async move {
+            let (blocks, tip) = descendants.await?;
+            Some((blocks.into_iter().next()?, tip))
+        }
+    }
+
+    /// Retrieves the next contiguous batch from `start` toward `tip`.
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn resolve_descendants(
+        &self,
+        start: BlockID<<V::Block as Digestible>::Digest>,
+        tip: BlockID<<V::Block as Digestible>::Digest>,
+    ) -> impl Future<
+        Output = Option<(
+            Vec<Arc<V::ApplicationBlock>>,
+            <V::Block as Digestible>::Digest,
+        )>,
+    > + Send
+    + 'static {
         let mailbox = self.clone();
         async move {
             let (response, receiver) = oneshot::channel();
@@ -830,8 +852,8 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
                 tip,
                 response,
             });
-            let (block, tip) = receiver.await.ok().flatten()?;
-            Some((V::into_inner_shared(block), tip))
+            let (blocks, tip) = receiver.await.ok().flatten()?;
+            Some((blocks.into_iter().map(V::into_inner_shared).collect(), tip))
         }
     }
 

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -53,7 +53,7 @@ mod floor;
 mod stream;
 
 mod mailbox;
-pub use mailbox::{CommitmentFallback, DigestFallback, Mailbox};
+pub use mailbox::{CommitmentFallback, DescendantCursor, DigestFallback, Mailbox};
 
 mod subscriptions;
 pub(crate) mod tree;

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -56,5 +56,6 @@ mod mailbox;
 pub use mailbox::{CommitmentFallback, DigestFallback, Mailbox};
 
 mod subscriptions;
+pub(crate) mod tree;
 mod variant;
 pub use variant::{Buffer, Variant};

--- a/consensus/src/marshal/core/tree.rs
+++ b/consensus/src/marshal/core/tree.rs
@@ -1,0 +1,458 @@
+//! In-memory tree of candidate blocks above the last finalized block.
+//!
+//! The tree holds every fork marshal has observed above the finalized tip. It
+//! is pruned each time marshal learns of a new finalization and rebuilt from
+//! the prunable caches on startup. Together with the finalized block archive,
+//! it makes the full locally known ancestry of any candidate tip addressable
+//! by height (see [`crate::marshal::ancestry::DescendantStream`]).
+
+use crate::{Block, types::Height};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+/// A contiguous chain of candidate blocks ending at a requested tip.
+pub(crate) struct Branch<B: Block> {
+    /// Blocks in ascending height order. The last block is the tip.
+    pub blocks: Vec<Arc<B>>,
+    /// The height of the finalized root, when the first block extends it,
+    /// making the branch part of the locally known ancestry below the root.
+    pub root: Option<Height>,
+}
+
+/// An in-memory tree of all candidate forks above the last finalized block.
+///
+/// The tree is anchored at a root, the highest block known to be finalized.
+/// Every stored block sits strictly above the root. Blocks whose parents are
+/// not locally known ("dangling") are retained: they may still connect once
+/// the intermediate blocks arrive, and they are pruned once a finalization
+/// proves them conflicting or passes their height.
+///
+/// Candidate blocks are adversarial input: a block can lie about its height
+/// or its parent while keeping a valid digest. The tree therefore enforces
+/// the chain invariant (a block's parent is exactly one height below it) on
+/// every edge it exposes: [Self::insert] rejects blocks that provably violate
+/// it against tracked state, [Self::finalize] removes blocks that claim the
+/// finalized block as parent from the wrong height, and [Self::branch] stops
+/// walking at any remaining unverifiable edge.
+pub(crate) struct ForkTree<B: Block> {
+    /// The height and digest of the highest known finalized block.
+    root: Option<(Height, B::Digest)>,
+    /// Candidate blocks by digest.
+    nodes: BTreeMap<B::Digest, Arc<B>>,
+    /// Candidate blocks at each height.
+    by_height: BTreeMap<Height, Vec<Arc<B>>>,
+}
+
+impl<B: Block> ForkTree<B> {
+    /// Creates an empty tree with no root.
+    ///
+    /// Until [`Self::finalize`] installs a root, all inserted blocks are
+    /// accepted as candidates.
+    pub(crate) const fn new() -> Self {
+        Self {
+            root: None,
+            nodes: BTreeMap::new(),
+            by_height: BTreeMap::new(),
+        }
+    }
+
+    /// Returns the number of candidate blocks tracked.
+    pub(crate) fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Inserts a candidate block.
+    ///
+    /// Returns `false` if the block is already tracked, sits at or below the
+    /// root, provably conflicts with the finalized chain (a child of the root
+    /// height that does not extend the root), or provably violates the chain
+    /// invariant (its claimed parent is tracked at a height other than one
+    /// below its own).
+    pub(crate) fn insert(&mut self, block: &Arc<B>) -> bool {
+        // Deduplicate first: re-ingestion of an already tracked block is the
+        // common case.
+        let digest = block.digest();
+        if self.nodes.contains_key(&digest) {
+            return false;
+        }
+
+        let height = block.height();
+        let parent = block.parent();
+        if let Some((root_height, root_digest)) = &self.root {
+            if height <= *root_height {
+                return false;
+            }
+            // A candidate directly above the root must extend it, and a
+            // candidate claiming the root as its parent must sit directly
+            // above it. Either mismatch is a provable lie.
+            if (height == root_height.next()) != (parent == *root_digest) {
+                return false;
+            }
+        }
+
+        // A candidate whose tracked parent is not exactly one height below
+        // lies about its height or its parent.
+        if let Some(tracked) = self.nodes.get(&parent)
+            && tracked.height().next() != height
+        {
+            return false;
+        }
+
+        self.nodes.insert(digest, Arc::clone(block));
+        self.by_height
+            .entry(height)
+            .or_default()
+            .push(Arc::clone(block));
+        true
+    }
+
+    /// Records a newly finalized block, pruning every candidate it supersedes.
+    ///
+    /// Candidates at or below `height` are dropped, as are candidates that
+    /// provably conflict with the finalized block: children of `height` that
+    /// do not extend `digest`, and their known descendants. Dangling
+    /// candidates above `height` are kept until a later finalization decides
+    /// them. Finalizations at or below the current root are ignored.
+    pub(crate) fn finalize(&mut self, height: Height, digest: B::Digest) {
+        if let Some((root_height, _)) = &self.root
+            && height <= *root_height
+        {
+            return;
+        }
+        self.root = Some((height, digest));
+
+        // Drop candidates at or below the new root.
+        let above = self.by_height.split_off(&height.next());
+        for blocks in self.by_height.values() {
+            for stale in blocks {
+                self.nodes.remove(&stale.digest());
+            }
+        }
+        self.by_height = above;
+
+        // Sweep ascending: a child of the root height conflicts unless it
+        // extends the finalized digest, a candidate claiming the finalized
+        // block as parent from any other height lies about its ancestry, and
+        // above the boundary a candidate conflicts when its parent was
+        // removed by this sweep. The chain invariant (parent height is
+        // exactly one below) makes a single pass complete. Candidates whose
+        // parents were never tracked cannot be classified and survive.
+        let nodes = &mut self.nodes;
+        let boundary = height.next();
+        let mut conflicting = BTreeSet::new();
+        for (&level, blocks) in self.by_height.iter_mut() {
+            blocks.retain(|candidate| {
+                let parent = candidate.parent();
+                let conflicts = if parent == digest {
+                    level != boundary
+                } else if level == boundary {
+                    true
+                } else {
+                    conflicting.contains(&parent)
+                };
+                if conflicts {
+                    conflicting.insert(candidate.digest());
+                    nodes.remove(&candidate.digest());
+                }
+                !conflicts
+            });
+        }
+        self.by_height.retain(|_, blocks| !blocks.is_empty());
+    }
+
+    /// Returns the chain of candidate blocks ending at `tip`, walking parent
+    /// links as far down as locally known.
+    ///
+    /// Returns `None` if `tip` is not tracked. The branch carries the root
+    /// height when its first block extends the finalized root. The walk stops
+    /// at any edge that is not contiguous in height (a block inserted before
+    /// its claimed parent can lie about the relationship), reporting the
+    /// branch as disconnected.
+    pub(crate) fn branch(&self, tip: &B::Digest) -> Option<Branch<B>> {
+        let mut blocks: Vec<Arc<B>> = Vec::new();
+        let mut cursor = *tip;
+        let root = loop {
+            let Some(block) = self.nodes.get(&cursor) else {
+                if blocks.is_empty() {
+                    return None;
+                }
+                break None;
+            };
+            if let Some(lowest) = blocks.last()
+                && block.height().next() != lowest.height()
+            {
+                break None;
+            }
+            cursor = block.parent();
+            blocks.push(Arc::clone(block));
+            if let Some((root_height, root_digest)) = &self.root
+                && cursor == *root_digest
+            {
+                break Some(*root_height);
+            }
+        };
+        blocks.reverse();
+        Some(Branch { blocks, root })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Heightable as _, marshal::mocks::block::Block};
+    use commonware_cryptography::{
+        Digest as _, Digestible as _, Sha256, sha256::Digest as Sha256Digest,
+    };
+
+    type TestBlock = Block<Sha256Digest, ()>;
+
+    fn block(parent: Sha256Digest, height: u64, seed: u64) -> Arc<TestBlock> {
+        Arc::new(TestBlock::new::<Sha256>(
+            (),
+            parent,
+            Height::new(height),
+            seed,
+        ))
+    }
+
+    /// Builds a chain of `len` blocks starting at `height` on `parent`,
+    /// seeding digests with `seed` to keep forks distinct.
+    fn chain(parent: Sha256Digest, height: u64, len: u64, seed: u64) -> Vec<Arc<TestBlock>> {
+        let mut blocks = Vec::new();
+        let mut parent = parent;
+        for offset in 0..len {
+            let next = block(parent, height + offset, seed + offset);
+            parent = next.digest();
+            blocks.push(next);
+        }
+        blocks
+    }
+
+    #[test]
+    fn insert_rejects_duplicates_and_stale_heights() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 5, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // At or below the root.
+        assert!(!tree.insert(&root));
+        assert!(!tree.insert(&block(Sha256Digest::EMPTY, 4, 1)));
+
+        // A valid child inserts once.
+        let child = block(root.digest(), 6, 2);
+        assert!(tree.insert(&child));
+        assert!(!tree.insert(&child));
+        assert_eq!(tree.len(), 1);
+    }
+
+    #[test]
+    fn insert_rejects_conflicting_root_child() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 5, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // A child height block not extending the root conflicts.
+        assert!(!tree.insert(&block(Sha256Digest::EMPTY, 6, 1)));
+
+        // A dangling block above the child height is retained.
+        assert!(tree.insert(&block(Sha256Digest::EMPTY, 7, 2)));
+    }
+
+    #[test]
+    fn insert_accepts_everything_without_root() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        assert!(tree.insert(&block(Sha256Digest::EMPTY, 0, 0)));
+        assert!(tree.insert(&block(Sha256Digest::EMPTY, 100, 1)));
+        assert_eq!(tree.len(), 2);
+    }
+
+    #[test]
+    fn finalize_prunes_conflicting_forks_and_keeps_extension() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // Two forks off the root, both three blocks long.
+        let canonical = chain(root.digest(), 1, 3, 10);
+        let fork = chain(root.digest(), 1, 3, 20);
+        for block in canonical.iter().chain(fork.iter()) {
+            assert!(tree.insert(block));
+        }
+        assert_eq!(tree.len(), 6);
+
+        // Finalizing the first canonical block removes the fork entirely.
+        tree.finalize(canonical[0].height(), canonical[0].digest());
+        assert_eq!(tree.len(), 2);
+        for block in &canonical[1..] {
+            assert!(tree.branch(&block.digest()).is_some());
+        }
+        for block in &fork {
+            assert!(tree.branch(&block.digest()).is_none());
+        }
+    }
+
+    #[test]
+    fn finalize_keeps_dangling_candidates() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // A candidate whose parent is unknown locally.
+        let dangling = block(Sha256Digest::EMPTY, 5, 1);
+        assert!(tree.insert(&dangling));
+
+        // Finalizing below its height cannot classify it.
+        let next = block(root.digest(), 1, 2);
+        assert!(tree.insert(&next));
+        tree.finalize(next.height(), next.digest());
+        assert!(tree.branch(&dangling.digest()).is_some());
+
+        // Finalizing at its height removes it.
+        tree.finalize(dangling.height(), Sha256::fill(0xAB));
+        assert!(tree.branch(&dangling.digest()).is_none());
+    }
+
+    #[test]
+    fn finalize_prunes_descendants_of_conflicts_but_not_dangling() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // A fork with descendants, plus a dangling chain above the boundary.
+        let canonical = chain(root.digest(), 1, 1, 10);
+        let fork = chain(root.digest(), 1, 4, 20);
+        let dangling = chain(Sha256Digest::EMPTY, 3, 2, 30);
+        for block in canonical.iter().chain(fork.iter()).chain(dangling.iter()) {
+            assert!(tree.insert(block));
+        }
+
+        tree.finalize(canonical[0].height(), canonical[0].digest());
+
+        // The conflicting fork is gone, including descendants above the boundary.
+        for block in &fork {
+            assert!(tree.branch(&block.digest()).is_none());
+        }
+        // The dangling chain survives: its ancestry is not locally decidable.
+        for block in &dangling {
+            assert!(tree.branch(&block.digest()).is_some());
+        }
+    }
+
+    #[test]
+    fn finalize_ignores_stale_and_skips_levels() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        let canonical = chain(root.digest(), 1, 5, 10);
+        for block in &canonical {
+            assert!(tree.insert(block));
+        }
+
+        // A stale finalization is a no-op.
+        tree.finalize(Height::zero(), Sha256Digest::EMPTY);
+        assert_eq!(tree.len(), 5);
+
+        // Jumping several levels prunes everything at or below the new root.
+        tree.finalize(canonical[3].height(), canonical[3].digest());
+        assert_eq!(tree.len(), 1);
+
+        // The root advanced: candidates at or below it are rejected, and only
+        // extensions of the new root are accepted directly above it.
+        assert!(!tree.insert(&canonical[2]));
+        assert!(!tree.insert(&block(root.digest(), 5, 20)));
+        assert!(tree.insert(&block(canonical[3].digest(), 5, 21)));
+    }
+
+    #[test]
+    fn insert_rejects_provable_chain_invariant_violations() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 5, 0);
+        tree.finalize(root.height(), root.digest());
+
+        let child = block(root.digest(), 6, 1);
+        assert!(tree.insert(&child));
+
+        // A block claiming a tracked parent from the wrong height lies about
+        // its height or its parent.
+        assert!(!tree.insert(&block(child.digest(), 100, 2)));
+        // A block claiming the root as parent from the wrong height lies too.
+        assert!(!tree.insert(&block(root.digest(), 50, 3)));
+        // The truthful equivalents are accepted.
+        assert!(tree.insert(&block(child.digest(), 7, 4)));
+        assert_eq!(tree.len(), 2);
+    }
+
+    #[test]
+    fn branch_stops_at_incontiguous_edge() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // A lying block is inserted while its claimed parent is unknown, so
+        // the violation is not provable yet.
+        let parent = block(root.digest(), 1, 1);
+        let liar = block(parent.digest(), 9, 2);
+        assert!(tree.insert(&liar));
+        assert!(tree.insert(&parent));
+
+        // The walk must not fabricate ancestry across the lying edge.
+        let branch = tree.branch(&liar.digest()).expect("branch");
+        assert!(branch.root.is_none());
+        assert_eq!(branch.blocks.len(), 1);
+        assert_eq!(branch.blocks[0].digest(), liar.digest());
+    }
+
+    #[test]
+    fn finalize_removes_wrong_height_root_children() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // A dangling block claims a future finalized block as its parent
+        // from the wrong height. The parent is never tracked, so the lie is
+        // not provable at insertion time.
+        let next = block(root.digest(), 1, 1);
+        let liar = block(next.digest(), 9, 2);
+        assert!(tree.insert(&liar));
+
+        // Once the parent finalizes, the lie is provable and the block is
+        // swept out.
+        tree.finalize(next.height(), next.digest());
+        assert!(tree.branch(&liar.digest()).is_none());
+        assert_eq!(tree.len(), 0);
+    }
+
+    #[test]
+    fn branch_reports_connectivity() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        // Unknown tip.
+        assert!(tree.branch(&Sha256Digest::EMPTY).is_none());
+
+        // Connected chain of three blocks.
+        let canonical = chain(root.digest(), 1, 3, 10);
+        for block in &canonical {
+            assert!(tree.insert(block));
+        }
+        let branch = tree.branch(&canonical[2].digest()).expect("branch");
+        assert!(branch.root.is_some());
+        assert_eq!(branch.blocks.len(), 3);
+        for (block, expected) in branch.blocks.iter().zip(canonical.iter()) {
+            assert_eq!(block.digest(), expected.digest());
+        }
+
+        // A dangling chain walks down as far as known and reports disconnected.
+        let dangling = chain(Sha256Digest::EMPTY, 7, 2, 20);
+        for block in &dangling {
+            assert!(tree.insert(block));
+        }
+        let branch = tree.branch(&dangling[1].digest()).expect("branch");
+        assert!(branch.root.is_none());
+        assert_eq!(branch.blocks.len(), 2);
+    }
+}

--- a/consensus/src/marshal/core/tree.rs
+++ b/consensus/src/marshal/core/tree.rs
@@ -43,6 +43,8 @@ pub(crate) struct ForkTree<B: Block> {
     nodes: BTreeMap<B::Digest, Arc<B>>,
     /// Candidate blocks at each height.
     by_height: BTreeMap<Height, Vec<Arc<B>>>,
+    /// Parent digests referenced by candidates at each child height.
+    parents_by_height: BTreeMap<Height, BTreeSet<B::Digest>>,
 }
 
 impl<B: Block> ForkTree<B> {
@@ -55,6 +57,7 @@ impl<B: Block> ForkTree<B> {
             root: None,
             nodes: BTreeMap::new(),
             by_height: BTreeMap::new(),
+            parents_by_height: BTreeMap::new(),
         }
     }
 
@@ -87,7 +90,7 @@ impl<B: Block> ForkTree<B> {
             // A candidate directly above the root must extend it, and a
             // candidate claiming the root as its parent must sit directly
             // above it. Either mismatch is a provable lie.
-            if (height == root_height.next()) != (parent == *root_digest) {
+            if (height.previous() == Some(*root_height)) != (parent == *root_digest) {
                 return false;
             }
         }
@@ -95,7 +98,7 @@ impl<B: Block> ForkTree<B> {
         // A candidate whose tracked parent is not exactly one height below
         // lies about its height or its parent.
         if let Some(tracked) = self.nodes.get(&parent)
-            && tracked.height().next() != height
+            && height.previous() != Some(tracked.height())
         {
             return false;
         }
@@ -105,7 +108,28 @@ impl<B: Block> ForkTree<B> {
             .entry(height)
             .or_default()
             .push(Arc::clone(block));
+        self.parents_by_height
+            .entry(height)
+            .or_default()
+            .insert(parent);
         true
+    }
+
+    /// Inserts a cached ancestry block only when it is the structurally valid
+    /// parent of an already tracked candidate.
+    pub(crate) fn insert_parent(&mut self, block: &Arc<B>) -> bool {
+        let Some(child_height) = block.height().get().checked_add(1).map(Height::new) else {
+            return false;
+        };
+        let digest = block.digest();
+        if !self
+            .parents_by_height
+            .get(&child_height)
+            .is_some_and(|parents| parents.contains(&digest))
+        {
+            return false;
+        }
+        self.insert(block)
     }
 
     /// Records a newly finalized block, pruning every candidate it supersedes.
@@ -124,8 +148,13 @@ impl<B: Block> ForkTree<B> {
         self.root = Some((height, digest));
 
         // Drop candidates at or below the new root.
-        let above = self.by_height.split_off(&height.next());
+        let mut above = self.by_height.split_off(&height);
         for blocks in self.by_height.values() {
+            for stale in blocks {
+                self.nodes.remove(&stale.digest());
+            }
+        }
+        if let Some(blocks) = above.remove(&height) {
             for stale in blocks {
                 self.nodes.remove(&stale.digest());
             }
@@ -140,14 +169,13 @@ impl<B: Block> ForkTree<B> {
         // exactly one below) makes a single pass complete. Candidates whose
         // parents were never tracked cannot be classified and survive.
         let nodes = &mut self.nodes;
-        let boundary = height.next();
         let mut conflicting = BTreeSet::new();
         for (&level, blocks) in self.by_height.iter_mut() {
             blocks.retain(|candidate| {
                 let parent = candidate.parent();
                 let conflicts = if parent == digest {
-                    level != boundary
-                } else if level == boundary {
+                    level.previous() != Some(height)
+                } else if level.previous() == Some(height) {
                     true
                 } else {
                     conflicting.contains(&parent)
@@ -160,6 +188,13 @@ impl<B: Block> ForkTree<B> {
             });
         }
         self.by_height.retain(|_, blocks| !blocks.is_empty());
+        self.parents_by_height.clear();
+        for (&level, blocks) in &self.by_height {
+            self.parents_by_height
+                .entry(level)
+                .or_default()
+                .extend(blocks.iter().map(|block| block.parent()));
+        }
     }
 
     /// Returns the chain of candidate blocks ending at `tip`, walking parent
@@ -181,7 +216,7 @@ impl<B: Block> ForkTree<B> {
                 break None;
             };
             if let Some(lowest) = blocks.last()
-                && block.height().next() != lowest.height()
+                && lowest.height().previous() != Some(block.height())
             {
                 break None;
             }
@@ -383,6 +418,36 @@ mod tests {
         // The truthful equivalents are accepted.
         assert!(tree.insert(&block(child.digest(), 7, 4)));
         assert_eq!(tree.len(), 2);
+    }
+
+    #[test]
+    fn maximum_height_is_handled_without_overflow() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        let maximum = block(Sha256Digest::EMPTY, u64::MAX, 1);
+        assert!(tree.insert(&maximum));
+        assert!(!tree.insert(&block(maximum.digest(), u64::MAX, 2)));
+
+        tree.finalize(maximum.height(), maximum.digest());
+        assert_eq!(tree.len(), 0);
+        assert!(!tree.insert(&block(maximum.digest(), u64::MAX, 3)));
+    }
+
+    #[test]
+    fn cached_parent_requires_a_tracked_child() {
+        let mut tree = ForkTree::<TestBlock>::new();
+        let root = block(Sha256Digest::EMPTY, 0, 0);
+        tree.finalize(root.height(), root.digest());
+
+        let parent = block(root.digest(), 1, 1);
+        assert!(!tree.insert_parent(&parent));
+
+        let child = block(parent.digest(), 2, 2);
+        assert!(tree.insert(&child));
+        assert!(tree.insert_parent(&parent));
+        assert!(tree.branch(&child.digest()).unwrap().root.is_some());
     }
 
     #[test]

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -5278,14 +5278,13 @@ where
         ));
 
         // Anchor an ancestry at each tip, as an application would hold them.
-        let fork_a_ancestry =
-            ancestry_at::<H>(
-                &handle,
-                &clock,
-                &fetch_duration,
-                H::digest(fork_a.last().unwrap()),
-            )
-            .await;
+        let fork_a_ancestry = ancestry_at::<H>(
+            &handle,
+            &clock,
+            &fetch_duration,
+            H::digest(fork_a.last().unwrap()),
+        )
+        .await;
         let fork_b_ancestry =
             ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_b[1])).await;
         let finalized_ancestry =

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -3895,7 +3895,10 @@ pub fn reject_stale_block_delivery_after_floor_update<H: TestHarness>() {
 
 /// Regression test: commitment-fetched blocks must wake subscribers and cache by
 /// decoded height even when the local pruning hint is far ahead.
-pub fn commitment_fetch_height_hint_mismatch_wakes_subscriber<H: TestHarness>() {
+pub fn commitment_fetch_height_hint_mismatch_wakes_subscriber<H: TestHarness>()
+where
+    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+{
     let runner = deterministic::Runner::timed(Duration::from_secs(60));
     runner.start(|mut context| async move {
         let Fixture {
@@ -3980,6 +3983,16 @@ pub fn commitment_fetch_height_hint_mismatch_wakes_subscriber<H: TestHarness>() 
             .await
             .expect("height-hint-mismatched fetch should cache by decoded height");
         assert_eq!(cached.height(), actual_height);
+        assert!(
+            BlockProvider::get_descendant(
+                &victim_handle.mailbox,
+                actual_height.into(),
+                (&received.digest()).into(),
+            )
+            .await
+            .is_none(),
+            "height-hint-mismatched fetch must not enter the fork tree"
+        );
     });
 }
 

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -5233,7 +5233,7 @@ where
 
         // Finalize blocks at heights 1-5.
         let genesis = (
-            Sha256::hash(b""),
+            Sha256::hash(&[b""]),
             H::genesis_parent_commitment(participants.len() as u16),
         );
         let blocks = finalize_chain::<H>(
@@ -5328,7 +5328,7 @@ where
             BlockProvider::get_descendant(
                 &handle.mailbox,
                 Height::new(1).into(),
-                (&Sha256::hash(b"unknown")).into(),
+                (&Sha256::hash(&[b"unknown"])).into(),
             )
             .await
             .is_none()
@@ -5392,7 +5392,7 @@ where
 
         // Finalize blocks at heights 1-3.
         let genesis = (
-            Sha256::hash(b""),
+            Sha256::hash(&[b""]),
             H::genesis_parent_commitment(participants.len() as u16),
         );
         let blocks = finalize_chain::<H>(

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -7,13 +7,13 @@ use crate::{
     Heightable, Reporter,
     marshal::{
         Identifier,
-        ancestry::BlockProvider,
+        ancestry::{Ancestry, BlockProvider},
         coding::{
             Coding, shards,
             types::{CodedBlock, coding_config_for_participants, hash_context},
         },
         config::{Config, Start},
-        core::{Actor, CommitmentFallback, DigestFallback, Mailbox},
+        core::{Actor, CommitmentFallback, DigestFallback, Mailbox, Variant},
         mocks::{application::Application, block::Block},
         resolver::p2p as resolver,
         standard::Standard,
@@ -59,6 +59,7 @@ use std::{
     collections::BTreeMap,
     future::Future,
     num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize},
+    ops::RangeInclusive,
     sync::Arc,
     time::{Duration, Instant},
 };
@@ -5072,15 +5073,13 @@ where
             "Histogram of time taken to fetch a block via the ancestry stream, in seconds",
             Buckets::LOCAL,
         ));
-        let ancestry = handle
-            .mailbox
-            .ancestry(
-                Arc::new(context.child("ancestor_stream")),
-                (DigestFallback::Wait, commitment),
-                fetch_duration,
-            )
-            .await
-            .unwrap();
+        let ancestry = ancestry_at::<H>(
+            &handle,
+            &Arc::new(context.child("ancestor_stream")),
+            &fetch_duration,
+            commitment,
+        )
+        .await;
         let blocks = ancestry.collect::<Vec<_>>().await;
 
         // Ensure correct delivery order: 5,4,3,2,1
@@ -5088,6 +5087,374 @@ where
         (0..5).for_each(|i| {
             assert_eq!(blocks[i].height().get(), 5 - i as u64);
         });
+    })
+}
+
+/// Asserts that `stream` yields exactly `expected` in order, comparing digests.
+async fn assert_stream_yields<H: TestHarness>(
+    stream: impl Ancestry<H::ApplicationBlock>,
+    expected: &[&H::TestBlock],
+) {
+    let collected = stream.collect::<Vec<_>>().await;
+    assert_eq!(collected.len(), expected.len());
+    for (block, expected) in collected.iter().zip(expected) {
+        assert_eq!(block.height(), H::height(expected));
+        assert_eq!(block.digest(), H::digest(expected));
+    }
+}
+
+/// Builds an ancestry stream anchored at the locally available block `tip`,
+/// as an application would receive it.
+async fn ancestry_at<H: TestHarness>(
+    handle: &ValidatorHandle<H>,
+    clock: &Arc<deterministic::Context>,
+    fetch_duration: &Timed,
+    tip: D,
+) -> impl Ancestry<H::ApplicationBlock>
+where
+    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+{
+    let block = handle.mailbox.get_block(&tip).await.expect("tip block");
+    handle.mailbox.ancestor_stream(
+        clock.clone(),
+        [<H::Variant as Variant>::owned_into_inner_shared(block)],
+        fetch_duration.clone(),
+    )
+}
+
+/// Waits until `mailbox` holds a finalization at `height`.
+async fn wait_for_finalization<H: TestHarness>(
+    context: &deterministic::Context,
+    mailbox: &Mailbox<S, H::Variant>,
+    height: Height,
+) {
+    while mailbox.get_finalization(height).await.is_none() {
+        context.sleep(Duration::from_millis(10)).await;
+    }
+}
+
+/// Proposes a chain of candidate blocks over `heights` on `parent`, offsetting
+/// timestamps by `seed` and views by `view_offset`.
+async fn propose_chain<H: TestHarness>(
+    handle: &mut ValidatorHandle<H>,
+    (mut parent, mut parent_commitment): (D, H::Commitment),
+    heights: RangeInclusive<u64>,
+    seed: u64,
+    view_offset: u64,
+    participants: u16,
+) -> Vec<H::TestBlock> {
+    let mut blocks = Vec::new();
+    for i in heights {
+        let block = H::make_test_block(
+            parent,
+            parent_commitment,
+            Height::new(i),
+            seed + i,
+            participants,
+        );
+        H::propose(
+            handle,
+            Round::new(Epoch::zero(), View::new(view_offset + i)),
+            &block,
+        )
+        .await;
+        parent = H::digest(&block);
+        parent_commitment = H::commitment(&block);
+        blocks.push(block);
+    }
+    blocks
+}
+
+/// Proposes and finalizes a chain of blocks over `heights` on `parent`,
+/// waiting until the last finalization is locally available.
+async fn finalize_chain<H: TestHarness>(
+    context: &deterministic::Context,
+    handle: &mut ValidatorHandle<H>,
+    schemes: &[S],
+    (mut parent, mut parent_commitment): (D, H::Commitment),
+    heights: RangeInclusive<u64>,
+    participants: u16,
+) -> Vec<H::TestBlock> {
+    let mut blocks = Vec::new();
+    let end = *heights.end();
+    for i in heights {
+        let block = H::make_test_block(parent, parent_commitment, Height::new(i), i, participants);
+        let round = Round::new(Epoch::zero(), View::new(i));
+        H::propose(handle, round, &block).await;
+        context.sleep(LINK.latency).await;
+
+        let proposal = Proposal {
+            round,
+            parent: View::new(i - 1),
+            payload: H::commitment(&block),
+        };
+        let finalization = H::make_finalization(proposal, schemes, QUORUM);
+        H::report_finalization(&mut handle.mailbox, finalization).await;
+
+        parent = H::digest(&block);
+        parent_commitment = H::commitment(&block);
+        blocks.push(block);
+    }
+    wait_for_finalization::<H>(context, &handle.mailbox, Height::new(end)).await;
+    blocks
+}
+
+/// Test forward ancestry iteration across finalized storage and fork candidates.
+pub fn ancestry_from_stream<H: TestHarness>()
+where
+    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+{
+    let runner = deterministic::Runner::timed(Duration::from_secs(60));
+    runner.start(|mut context| async move {
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+        let mut oracle = setup_network_with_participants(
+            context.child("network"),
+            NZUsize!(1),
+            participants.clone(),
+        )
+        .await;
+
+        let me = participants[0].clone();
+        let setup = H::setup_validator(
+            context.child("validator").with_attribute("index", 0),
+            &mut oracle,
+            me,
+            ConstantProvider::new(schemes[0].clone()),
+        )
+        .await;
+        let mut handle = ValidatorHandle {
+            mailbox: setup.mailbox,
+            extra: setup.extra,
+        };
+
+        // Finalize blocks at heights 1-5.
+        let genesis = (
+            Sha256::hash(b""),
+            H::genesis_parent_commitment(participants.len() as u16),
+        );
+        let blocks = finalize_chain::<H>(
+            &context,
+            &mut handle,
+            &schemes,
+            genesis,
+            1..=5,
+            participants.len() as u16,
+        )
+        .await;
+
+        // Build two competing forks above the finalized tip: fork A at
+        // heights 6-8 and fork B at heights 6-7. Both extend block 5.
+        let tip = (H::digest(&blocks[4]), H::commitment(&blocks[4]));
+        let fork_a =
+            propose_chain::<H>(&mut handle, tip, 6..=8, 0, 0, participants.len() as u16).await;
+        let fork_b =
+            propose_chain::<H>(&mut handle, tip, 6..=7, 100, 10, participants.len() as u16).await;
+
+        let clock = Arc::new(context.child("descendant_stream"));
+        let fetch_duration = Timed::new(context.histogram(
+            "descendant_fetch_duration",
+            "Histogram of time taken to fetch a block via the descendant stream, in seconds",
+            Buckets::LOCAL,
+        ));
+
+        // Anchor an ancestry at each tip, as an application would hold them.
+        let fork_a_ancestry =
+            ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_a[2])).await;
+        let fork_b_ancestry =
+            ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_b[1])).await;
+        let finalized_ancestry =
+            ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&blocks[3])).await;
+
+        // Walk the full chain from height 1 to fork A's tip.
+        let stream = fork_a_ancestry
+            .descendants(Height::new(1).into())
+            .await
+            .expect("full walk to fork A");
+        let expected: Vec<_> = blocks.iter().chain(fork_a.iter()).collect();
+        assert_stream_yields::<H>(stream, &expected).await;
+
+        // Walk from a finalized height to fork B's tip.
+        let stream = fork_b_ancestry
+            .descendants(Height::new(3).into())
+            .await
+            .expect("walk to fork B");
+        let expected: Vec<_> = blocks[2..].iter().chain(fork_b.iter()).collect();
+        assert_stream_yields::<H>(stream, &expected).await;
+
+        // Start from a finalized digest.
+        let stream = fork_a_ancestry
+            .descendants((&H::digest(&blocks[3])).into())
+            .await
+            .expect("digest start");
+        let expected: Vec<_> = blocks[3..].iter().chain(fork_a.iter()).collect();
+        assert_stream_yields::<H>(stream, &expected).await;
+
+        // A digest on a sibling fork is not on fork A's chain.
+        assert!(
+            fork_a_ancestry
+                .descendants((&H::digest(&fork_b[0])).into())
+                .await
+                .is_none()
+        );
+
+        // Start at the last finalized block in the tip's ancestry.
+        let stream = fork_a_ancestry
+            .descendants(Height::new(5).into())
+            .await
+            .expect("finalized boundary start");
+        let expected: Vec<_> = blocks[4..].iter().chain(fork_a.iter()).collect();
+        assert_stream_yields::<H>(stream, &expected).await;
+
+        // A finalized block works as the tip.
+        let stream = finalized_ancestry
+            .descendants(Height::new(2).into())
+            .await
+            .expect("finalized tip");
+        assert_stream_yields::<H>(stream, &blocks[1..4].iter().collect::<Vec<_>>()).await;
+
+        // A start above the tip resolves to nothing, as does an unknown tip
+        // at the provider.
+        assert!(
+            fork_a_ancestry
+                .descendants(Height::new(9).into())
+                .await
+                .is_none()
+        );
+        assert!(
+            BlockProvider::get_descendant(
+                &handle.mailbox,
+                Height::new(1).into(),
+                (&Sha256::hash(b"unknown")).into(),
+            )
+            .await
+            .is_none()
+        );
+
+        // Finalizing fork A's first block prunes fork B.
+        let proposal = Proposal {
+            round: Round::new(Epoch::zero(), View::new(6)),
+            parent: View::new(5),
+            payload: H::commitment(&fork_a[0]),
+        };
+        let finalization = H::make_finalization(proposal, &schemes, QUORUM);
+        H::report_finalization(&mut handle.mailbox, finalization).await;
+        wait_for_finalization::<H>(&context, &handle.mailbox, Height::new(6)).await;
+        assert!(
+            fork_b_ancestry
+                .descendants(Height::new(6).into())
+                .await
+                .is_none()
+        );
+        let stream = fork_a_ancestry
+            .descendants(Height::new(6).into())
+            .await
+            .expect("fork A after finalization");
+        let expected: Vec<_> = fork_a.iter().collect();
+        assert_stream_yields::<H>(stream, &expected).await;
+    })
+}
+
+/// Test that the fork tree is rebuilt from cached candidates on startup.
+pub fn ancestry_from_rebuild<H: TestHarness>()
+where
+    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+{
+    let runner = deterministic::Runner::timed(Duration::from_secs(60));
+    runner.start(|mut context| async move {
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+        let mut oracle = setup_network_with_participants(
+            context.child("network"),
+            NZUsize!(1),
+            participants.clone(),
+        )
+        .await;
+
+        let me = participants[0].clone();
+        let setup = H::setup_validator(
+            context.child("validator").with_attribute("index", 0),
+            &mut oracle,
+            me.clone(),
+            ConstantProvider::new(schemes[0].clone()),
+        )
+        .await;
+        let mut handle = ValidatorHandle {
+            mailbox: setup.mailbox,
+            extra: setup.extra,
+        };
+
+        // Finalize blocks at heights 1-3.
+        let genesis = (
+            Sha256::hash(b""),
+            H::genesis_parent_commitment(participants.len() as u16),
+        );
+        let blocks = finalize_chain::<H>(
+            &context,
+            &mut handle,
+            &schemes,
+            genesis,
+            1..=3,
+            participants.len() as u16,
+        )
+        .await;
+
+        // Persist competing candidates above the finalized tip: fork A at
+        // heights 4-5 and fork B at height 4.
+        let tip = (H::digest(&blocks[2]), H::commitment(&blocks[2]));
+        let fork_a =
+            propose_chain::<H>(&mut handle, tip, 4..=5, 0, 0, participants.len() as u16).await;
+        let fork_b =
+            propose_chain::<H>(&mut handle, tip, 4..=4, 100, 10, participants.len() as u16)
+                .await
+                .remove(0);
+
+        // Crash the actor and restart it over the same storage.
+        setup.actor_handle.abort();
+        let _ = setup.actor_handle.await;
+        let restarted = H::setup_validator(
+            context
+                .child("validator")
+                .with_attribute("index", 0)
+                .with_attribute("restart", 1),
+            &mut oracle,
+            me,
+            ConstantProvider::new(schemes[0].clone()),
+        )
+        .await;
+        let handle = ValidatorHandle::<H> {
+            mailbox: restarted.mailbox,
+            extra: restarted.extra,
+        };
+
+        let clock = Arc::new(context.child("descendant_stream"));
+        let fetch_duration = Timed::new(context.histogram(
+            "descendant_fetch_duration",
+            "Histogram of time taken to fetch a block via the descendant stream, in seconds",
+            Buckets::LOCAL,
+        ));
+
+        // The rebuilt tree serves both forks without re-ingesting them.
+        let stream = ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_a[1]))
+            .await
+            .descendants(Height::new(2).into())
+            .await
+            .expect("fork A after restart");
+        let expected: Vec<_> = blocks[1..].iter().chain(fork_a.iter()).collect();
+        assert_stream_yields::<H>(stream, &expected).await;
+
+        let stream = ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_b))
+            .await
+            .descendants(Height::new(3).into())
+            .await
+            .expect("fork B after restart");
+        assert_stream_yields::<H>(stream, &[&blocks[2], &fork_b]).await;
     })
 }
 

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -7,7 +7,7 @@ use crate::{
     Heightable, Reporter,
     marshal::{
         Identifier,
-        ancestry::{Ancestry, BlockProvider},
+        ancestry::{Ancestry, DescendantProvider, DescendantRequest},
         coding::{
             Coding, shards,
             types::{CodedBlock, coding_config_for_participants, hash_context},
@@ -3897,7 +3897,7 @@ pub fn reject_stale_block_delivery_after_floor_update<H: TestHarness>() {
 /// decoded height even when the local pruning hint is far ahead.
 pub fn commitment_fetch_height_hint_mismatch_wakes_subscriber<H: TestHarness>()
 where
-    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+    Mailbox<S, H::Variant>: DescendantProvider<Block = H::ApplicationBlock>,
 {
     let runner = deterministic::Runner::timed(Duration::from_secs(60));
     runner.start(|mut context| async move {
@@ -3984,10 +3984,12 @@ where
             .expect("height-hint-mismatched fetch should cache by decoded height");
         assert_eq!(cached.height(), actual_height);
         assert!(
-            BlockProvider::get_descendant(
+            DescendantProvider::get_descendants(
                 &victim_handle.mailbox,
-                actual_height.into(),
-                (&received.digest()).into(),
+                DescendantRequest::Start {
+                    start: actual_height.into(),
+                    tip: (&received.digest()).into(),
+                },
             )
             .await
             .is_none(),
@@ -5020,7 +5022,7 @@ pub fn hint_finalized_triggers_fetch<H: TestHarness>() {
 /// Test ancestry stream.
 pub fn ancestry_stream<H: TestHarness>()
 where
-    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+    Mailbox<S, H::Variant>: DescendantProvider<Block = H::ApplicationBlock>,
 {
     let runner = deterministic::Runner::timed(Duration::from_secs(60));
     runner.start(|mut context| async move {
@@ -5105,7 +5107,7 @@ where
 
 /// Asserts that `stream` yields exactly `expected` in order, comparing digests.
 async fn assert_stream_yields<H: TestHarness>(
-    stream: impl Ancestry<H::ApplicationBlock>,
+    stream: impl futures::Stream<Item = Arc<H::ApplicationBlock>> + Unpin,
     expected: &[&H::TestBlock],
 ) {
     let collected = stream.collect::<Vec<_>>().await;
@@ -5125,7 +5127,7 @@ async fn ancestry_at<H: TestHarness>(
     tip: D,
 ) -> impl Ancestry<H::ApplicationBlock>
 where
-    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+    Mailbox<S, H::Variant>: DescendantProvider<Block = H::ApplicationBlock>,
 {
     let block = handle.mailbox.get_block(&tip).await.expect("tip block");
     handle.mailbox.ancestor_stream(
@@ -5215,7 +5217,7 @@ async fn finalize_chain<H: TestHarness>(
 /// Test forward ancestry iteration across finalized storage and fork candidates.
 pub fn ancestry_from_stream<H: TestHarness>()
 where
-    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+    Mailbox<S, H::Variant>: DescendantProvider<Block = H::ApplicationBlock>,
 {
     let runner = deterministic::Runner::timed(Duration::from_secs(60));
     runner.start(|mut context| async move {
@@ -5259,11 +5261,12 @@ where
         )
         .await;
 
-        // Build two competing forks above the finalized tip: fork A at
-        // heights 6-8 and fork B at heights 6-7. Both extend block 5.
+        // Build two competing forks above the finalized tip: fork A is long
+        // enough to cross the descendant page boundary, while fork B remains
+        // a short sibling. Both extend block 5.
         let tip = (H::digest(&blocks[4]), H::commitment(&blocks[4]));
         let fork_a =
-            propose_chain::<H>(&mut handle, tip, 6..=8, 0, 0, participants.len() as u16).await;
+            propose_chain::<H>(&mut handle, tip, 6..=70, 0, 0, participants.len() as u16).await;
         let fork_b =
             propose_chain::<H>(&mut handle, tip, 6..=7, 100, 10, participants.len() as u16).await;
 
@@ -5276,11 +5279,37 @@ where
 
         // Anchor an ancestry at each tip, as an application would hold them.
         let fork_a_ancestry =
-            ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_a[2])).await;
+            ancestry_at::<H>(
+                &handle,
+                &clock,
+                &fetch_duration,
+                H::digest(fork_a.last().unwrap()),
+            )
+            .await;
         let fork_b_ancestry =
             ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&fork_b[1])).await;
         let finalized_ancestry =
             ancestry_at::<H>(&handle, &clock, &fetch_duration, H::digest(&blocks[3])).await;
+
+        // The provider bounds the combined finalized and candidate portions
+        // of every page and continues from a candidate snapshot.
+        let mut request = DescendantRequest::Start {
+            start: Height::new(1).into(),
+            tip: (&H::digest(fork_a.last().unwrap())).into(),
+        };
+        let mut page_sizes = Vec::new();
+        loop {
+            let page = DescendantProvider::get_descendants(&handle.mailbox, request)
+                .await
+                .expect("descendant page");
+            page_sizes.push(page.blocks.len());
+            assert!(page.blocks.len() <= 64);
+            let Some(cursor) = page.cursor else {
+                break;
+            };
+            request = DescendantRequest::Continue(cursor);
+        }
+        assert_eq!(page_sizes, vec![64, 6]);
 
         // Walk the full chain from height 1 to fork A's tip.
         let stream = fork_a_ancestry
@@ -5333,15 +5362,17 @@ where
         // at the provider.
         assert!(
             fork_a_ancestry
-                .descendants(Height::new(9).into())
+                .descendants(Height::new(100).into())
                 .await
                 .is_none()
         );
         assert!(
-            BlockProvider::get_descendant(
+            DescendantProvider::get_descendants(
                 &handle.mailbox,
-                Height::new(1).into(),
-                (&Sha256::hash(&[b"unknown"])).into(),
+                DescendantRequest::Start {
+                    start: Height::new(1).into(),
+                    tip: (&Sha256::hash(&[b"unknown"])).into(),
+                },
             )
             .await
             .is_none()
@@ -5374,7 +5405,7 @@ where
 /// Test that the fork tree is rebuilt from cached candidates on startup.
 pub fn ancestry_from_rebuild<H: TestHarness>()
 where
-    Mailbox<S, H::Variant>: BlockProvider<Block = H::ApplicationBlock>,
+    Mailbox<S, H::Variant>: DescendantProvider<Block = H::ApplicationBlock>,
 {
     let runner = deterministic::Runner::timed(Duration::from_secs(60));
     runner.start(|mut context| async move {

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -34,6 +34,16 @@
 //! only concerns itself with verifying a valid finalization exists for a block, not that a specific finalization
 //! exists. This means different Marshals may have different finalizations for the same block persisted to disk._
 //!
+//! ## Ancestry
+//!
+//! The actor maintains an in-memory tree of all candidate forks above the last finalized block,
+//! pruned each time a new finalization is learned and rebuilt from the prunable caches on startup.
+//! Combined with the finalized block archive, this makes the locally known ancestry of any tip
+//! addressable: [`ancestry::AncestorStream`] walks a chain backward toward genesis (fetching
+//! missing parents), and any [`ancestry::Ancestry`] can be flipped forward with
+//! [`ancestry::Ancestry::descendants`], iterating the same chain from any height or digest within
+//! it up to the ancestry's tip.
+//!
 //! ## Backfill
 //!
 //! The actor provides a backfill mechanism for missing blocks. If the actor notices a gap in its
@@ -94,7 +104,34 @@ commonware_macros::stability_scope!(ALPHA {
 #[cfg(test)]
 pub mod mocks;
 
+/// An identifier for a block within a chain's ancestry.
+///
+/// Unlike [Identifier], a [BlockID] always names a specific block: ancestry
+/// walks have no notion of "latest".
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlockID<D: Digest> {
+    /// The height of the block.
+    Height(Height),
+    /// The digest of the block.
+    Digest(D),
+}
+
+// Allows using heights directly for convenience.
+impl<D: Digest> From<Height> for BlockID<D> {
+    fn from(src: Height) -> Self {
+        Self::Height(src)
+    }
+}
+
+// Allows using &Digest directly for convenience.
+impl<D: Digest> From<&D> for BlockID<D> {
+    fn from(src: &D) -> Self {
+        Self::Digest(*src)
+    }
+}
+
 /// An identifier for a block request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Identifier<D: Digest> {
     /// The height of the block to retrieve.
     Height(Height),

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -266,44 +266,39 @@ where
             async move {
                 let round = context.round;
 
-                // Start the candidate store immediately: it depends on neither the
-                // parent fetch (which may hit the network) nor the verdict below.
-                // Storing before validation is intentional: these caches provide
-                // candidate availability/recovery, not a validity decision. This
-                // task gates the finalize vote by resolving true only after both
-                // app verification succeeds and the store is durable.
-                let store = stage.store(&marshal, round, Arc::clone(&block));
-                let verify = async {
-                    // Validate the parent we already started fetching.
-                    let parent = match await_and_validate_parent(
-                        context.parent.1,
-                        block.as_ref(),
-                        parent_request,
-                        &mut tx,
-                    )
-                    .await
-                    {
-                        Some(ParentCheck::Valid(parent)) => parent,
-                        Some(ParentCheck::Invalid) => return Some(false),
-                        None => return None,
-                    };
-                    run_app_verify(
-                        runtime_context,
-                        context,
-                        Arc::clone(&block),
-                        parent,
-                        &mut application,
-                        &marshal,
-                        &mut tx,
-                        ancestor_fetch_duration,
-                    )
-                    .await
+                // Admit the candidate only after its fetched parent proves the
+                // block's structural relationship.
+                let parent = match await_and_validate_parent(
+                    context.parent.1,
+                    block.as_ref(),
+                    parent_request,
+                    &mut tx,
+                )
+                .await
+                {
+                    Some(ParentCheck::Valid(parent)) => parent,
+                    Some(ParentCheck::Invalid) => {
+                        tx.send_lossy(GateOutcome::Ready(false));
+                        return;
+                    }
+                    None => return,
                 };
+                // The durable store can overlap application verification once
+                // the candidate is structurally admitted.
+                let store = stage.store(&marshal, round, Arc::clone(&block));
+                let verify = run_app_verify(
+                    runtime_context,
+                    context,
+                    Arc::clone(&block),
+                    parent,
+                    &mut application,
+                    &marshal,
+                    &mut tx,
+                    ancestor_fetch_duration,
+                );
                 let (verdict, durable) = futures::join!(verify, store);
 
-                // Publish only when the block is both valid and durable. App-invalid
-                // candidates may already be in the cache from the concurrent store above,
-                // so the gate verdict is the authority for consensus progress.
+                // Publish only when the block is both valid and durable.
                 if let Some(application_valid) = gates::resolve(verdict, durable) {
                     tx.send_lossy(GateOutcome::Ready(application_valid));
                 }

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -1563,9 +1563,9 @@ mod tests {
     /// Inline analog of the deferred equivocation test. A proposal that names
     /// the certified view-1 parent for a block built on the view-2 block
     /// fails structural parent validation and is rejected for voting. The
-    /// candidate is nevertheless stored durably, and certification of the
-    /// honest notarization for the same `(round, digest)` must use that
-    /// durability result rather than the context-scoped verification verdict.
+    /// candidate is not admitted, and certification of the honest notarization
+    /// for the same `(round, digest)` must recover it independently rather than
+    /// reuse the context-scoped verification verdict.
     #[test_traced("WARN")]
     fn test_certify_not_poisoned_by_equivocating_parent_verify() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -517,42 +517,37 @@ where
                 let parent_request =
                     parent_request.expect("non-reproposal has a parent subscription");
 
-                // Start the candidate store immediately: it depends on neither the
-                // parent fetch (which may hit the network) nor the verdict below.
-                // Storing before validation is intentional: these caches provide
-                // candidate availability/recovery, not a validity decision. The
-                // notarize vote follows the app verdict, while certify independently
-                // awaits the registered durability gate.
-                //
-                // The verify future below aborts when consensus drops its receiver
-                // (the view exited via nullification or finalization), even though
-                // certification can still fire for a nullified view. That is
-                // deliberate: inline certification does not need the local app
-                // verdict (a notarization implies f+1 honest validators already
-                // verified), and the store still completes through the join.
+                // Admit the candidate only after its fetched parent proves the
+                // block's structural relationship.
+                let parent = match await_and_validate_parent(
+                    context.parent.1,
+                    block.as_ref(),
+                    parent_request,
+                    &mut tx,
+                )
+                .await
+                {
+                    Some(ParentCheck::Valid(parent)) => parent,
+                    Some(ParentCheck::Invalid) => {
+                        tx.send_lossy(false);
+                        durable_tx.send_lossy(GateOutcome::Recover);
+                        return;
+                    }
+                    None => {
+                        durable_tx.send_lossy(GateOutcome::Recover);
+                        return;
+                    }
+                };
+
+                // Once admitted, durability overlaps application verification.
+                // Certification can still await this store independently of the
+                // local application verdict.
                 let store = async {
                     if marshal.verified(round, Arc::clone(&block)).await {
                         durable_tx.send_lossy(GateOutcome::Ready(true));
                     }
                 };
                 let verify_then_vote = async {
-                    // Non-reproposal path: validate the parent we already started
-                    // fetching.
-                    let parent = match await_and_validate_parent(
-                        context.parent.1,
-                        block.as_ref(),
-                        parent_request,
-                        &mut tx,
-                    )
-                    .await
-                    {
-                        Some(ParentCheck::Valid(parent)) => parent,
-                        Some(ParentCheck::Invalid) => {
-                            tx.send_lossy(false);
-                            return Some(false);
-                        }
-                        None => return None,
-                    };
                     let valid = run_app_verify(
                         runtime_context,
                         context,

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -572,16 +572,22 @@ mod tests {
         type Block = T::Block;
         type Error = T::Error;
 
-        async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
-            self.inner.put(block).await
+        async fn put(mut self, block: Self::Block) -> Result<Self, Self::Error> {
+            self.inner = self.inner.put(block).await?;
+            Ok(self)
         }
 
-        async fn sync(&mut self) -> Result<(), Self::Error> {
-            self.inner.sync().await
+        async fn sync(mut self) -> Result<Self, Self::Error> {
+            self.inner = self.inner.sync().await?;
+            Ok(self)
         }
 
-        async fn start_sync(&mut self) -> Result<commonware_runtime::Handle<()>, Self::Error> {
-            self.inner.start_sync().await
+        async fn start_sync(
+            mut self,
+        ) -> Result<(Self, commonware_runtime::Handle<()>), Self::Error> {
+            let handle;
+            (self.inner, handle) = self.inner.start_sync().await?;
+            Ok((self, handle))
         }
 
         async fn get(
@@ -596,8 +602,9 @@ mod tests {
             self.inner.get(id).await
         }
 
-        async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
-            self.inner.prune(min).await
+        async fn prune(mut self, min: Height) -> Result<Self, Self::Error> {
+            self.inner = self.inner.prune(min).await?;
+            Ok(self)
         }
 
         fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -46,7 +46,7 @@ mod tests {
         Automaton, CertifiableAutomaton, Heightable, Relay, Reporter,
         marshal::{
             Identifier, Update,
-            ancestry::BlockProvider,
+            ancestry::{BlockProvider, DescendantProvider, DescendantRequest},
             application::gates::{GateOutcome, Gates},
             config::{Config, Start},
             core::{
@@ -683,14 +683,16 @@ mod tests {
                 )
                 .await;
 
-            let descendant = BlockProvider::get_descendant(
+            let descendants = DescendantProvider::get_descendants(
                 &mailbox,
-                Height::new(3).into(),
-                (&block_four.digest()).into(),
+                DescendantRequest::Start {
+                    start: Height::new(3).into(),
+                    tip: (&block_four.digest()).into(),
+                },
             )
             .await
             .expect("cached candidate should remain connected to the finalized tip");
-            assert_eq!(descendant.0.digest(), block_three.digest());
+            assert_eq!(descendants.blocks[0].digest(), block_three.digest());
         });
     }
 
@@ -1501,20 +1503,17 @@ mod tests {
 
     #[test_traced("WARN")]
     fn test_standard_ancestry_stream() {
-        harness::ancestry_stream::<InlineHarness>();
-        harness::ancestry_stream::<DeferredHarness>();
+        harness::ancestry_stream::<StandardHarness>();
     }
 
     #[test_traced("WARN")]
     fn test_standard_ancestry_from_stream() {
-        harness::ancestry_from_stream::<InlineHarness>();
-        harness::ancestry_from_stream::<DeferredHarness>();
+        harness::ancestry_from_stream::<StandardHarness>();
     }
 
     #[test_traced("WARN")]
     fn test_standard_ancestry_from_rebuild() {
-        harness::ancestry_from_rebuild::<InlineHarness>();
-        harness::ancestry_from_rebuild::<DeferredHarness>();
+        harness::ancestry_from_rebuild::<StandardHarness>();
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -563,6 +563,130 @@ mod tests {
             .expect("failed to seed notarized block");
     }
 
+    struct MissingBlockStore<T> {
+        inner: T,
+        missing: Height,
+    }
+
+    impl<T: crate::marshal::store::Blocks> crate::marshal::store::Blocks for MissingBlockStore<T> {
+        type Block = T::Block;
+        type Error = T::Error;
+
+        async fn put(&mut self, block: Self::Block) -> Result<(), Self::Error> {
+            self.inner.put(block).await
+        }
+
+        async fn sync(&mut self) -> Result<(), Self::Error> {
+            self.inner.sync().await
+        }
+
+        async fn start_sync(&mut self) -> Result<commonware_runtime::Handle<()>, Self::Error> {
+            self.inner.start_sync().await
+        }
+
+        async fn get(
+            &self,
+            id: commonware_storage::archive::Identifier<'_, <Self::Block as Digestible>::Digest>,
+        ) -> Result<Option<Self::Block>, Self::Error> {
+            if let commonware_storage::archive::Identifier::Index(index) = &id
+                && *index == self.missing.get()
+            {
+                return Ok(None);
+            }
+            self.inner.get(id).await
+        }
+
+        async fn prune(&mut self, min: Height) -> Result<(), Self::Error> {
+            self.inner.prune(min).await
+        }
+
+        fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
+            self.inner.missing_items(start, max)
+        }
+
+        fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
+            self.inner.next_gap(value)
+        }
+
+        fn last_index(&self) -> Option<Height> {
+            self.inner.last_index()
+        }
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_rebuild_preserves_tip_when_archive_last_block_is_missing() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let me = participants[0].clone();
+            let partition_prefix = format!("rebuild-archive-miss-{me}");
+
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let block_one = make_raw_block(genesis.digest(), Height::new(1), 100);
+            let block_two = make_raw_block(block_one.digest(), Height::new(2), 200);
+            let block_three = make_raw_block(block_two.digest(), Height::new(3), 300);
+            let block_four = make_raw_block(block_three.digest(), Height::new(4), 400);
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    Round::new(Epoch::zero(), View::new(3)),
+                    View::new(2),
+                    StandardHarness::commitment(&block_three),
+                ),
+                &schemes,
+                QUORUM,
+            );
+
+            seed_inconsistent_restart_state(
+                context.child("storage"),
+                &partition_prefix,
+                &[
+                    block_one,
+                    block_two,
+                    block_three.clone(),
+                    block_four.clone(),
+                ],
+                &[(Height::new(3), finalization)],
+            )
+            .await;
+            seed_cache_block(
+                context.child("storage"),
+                &partition_prefix,
+                Epoch::zero(),
+                View::new(4),
+                &block_four,
+            )
+            .await;
+
+            let (mailbox, _buffer, _resolver, _actor_handle) =
+                start_standard_actor_with_block_store(
+                    context.child("validator"),
+                    &partition_prefix,
+                    ConstantProvider::new(schemes[0].clone()),
+                    Application::<B>::manual_ack(),
+                    None::<RecordingBuffer>,
+                    Start::Genesis(genesis),
+                    |inner| MissingBlockStore {
+                        inner,
+                        missing: Height::new(4),
+                    },
+                )
+                .await;
+
+            let descendant = BlockProvider::get_descendant(
+                &mailbox,
+                Height::new(3).into(),
+                (&block_four.digest()).into(),
+            )
+            .await
+            .expect("cached candidate should remain connected to the finalized tip");
+            assert_eq!(descendant.0.digest(), block_three.digest());
+        });
+    }
+
     // Verifies that a validator whose finalized-blocks archive is missing
     // the block at the tip (has finalization for height 2 but only block 1)
     // fetches the missing block from a peer on restart.
@@ -4000,6 +4124,38 @@ mod tests {
         P: Provider<Scope = Epoch, Scheme = S>,
         Buf: crate::marshal::core::Buffer<Standard<B>, PublicKey = PublicKey> + Clone,
     {
+        start_standard_actor_with_block_store(
+            context,
+            partition_prefix,
+            provider,
+            application,
+            buffer,
+            start,
+            std::convert::identity,
+        )
+        .await
+    }
+
+    async fn start_standard_actor_with_block_store<R, Buf, P, FB>(
+        context: deterministic::Context,
+        partition_prefix: &str,
+        provider: P,
+        application: R,
+        buffer: Option<Buf>,
+        start: Start<S, D, B>,
+        wrap: impl FnOnce(immutable::Archive<deterministic::Context, D, B>) -> FB,
+    ) -> (
+        Mailbox<S, Standard<B>>,
+        Option<Buf>,
+        RecordingResolver,
+        commonware_runtime::Handle<()>,
+    )
+    where
+        R: Reporter<Activity = Update<B>>,
+        P: Provider<Scope = Epoch, Scheme = S>,
+        FB: crate::marshal::store::Blocks<Block = B>,
+        Buf: crate::marshal::core::Buffer<Standard<B>, PublicKey = PublicKey> + Clone,
+    {
         let config = Config {
             provider,
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
@@ -4075,6 +4231,7 @@ mod tests {
         )
         .await
         .expect("failed to initialize finalized blocks archive");
+        let finalized_blocks = wrap(finalized_blocks);
         let (actor, mailbox, _) = Actor::init(
             context.child("actor"),
             finalizations_by_height,

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -1375,6 +1375,18 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_standard_ancestry_from_stream() {
+        harness::ancestry_from_stream::<InlineHarness>();
+        harness::ancestry_from_stream::<DeferredHarness>();
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_ancestry_from_rebuild() {
+        harness::ancestry_from_rebuild::<InlineHarness>();
+        harness::ancestry_from_rebuild::<DeferredHarness>();
+    }
+
+    #[test_traced("WARN")]
     fn test_standard_finalize_same_height_different_views() {
         harness::finalize_same_height_different_views::<InlineHarness>();
         harness::finalize_same_height_different_views::<DeferredHarness>();

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -6,6 +6,7 @@
 use crate::{
     Block,
     marshal::{
+        BlockID,
         ancestry::BlockProvider,
         core::{Buffer, CommitmentFallback, Mailbox, Variant},
     },
@@ -139,5 +140,16 @@ where
             )
         });
         async move { receiver?.await.ok() }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn get_descendant(
+        &self,
+        start: BlockID<<Self::Block as Digestible>::Digest>,
+        tip: BlockID<<Self::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
+    + Send
+    + 'static {
+        self.resolve_descendant(start, tip)
     }
 }

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -6,9 +6,8 @@
 use crate::{
     Block,
     marshal::{
-        BlockID,
-        ancestry::BlockProvider,
-        core::{Buffer, CommitmentFallback, Mailbox, Variant},
+        ancestry::{BlockProvider, DescendantPage, DescendantProvider, DescendantRequest},
+        core::{Buffer, CommitmentFallback, DescendantCursor, Mailbox, Variant},
     },
     simplex::scheme::Scheme as SimplexScheme,
     types::Round,
@@ -142,25 +141,20 @@ where
         async move { receiver?.await.ok() }
     }
 
-    #[allow(clippy::type_complexity)]
-    fn get_descendant(
-        &self,
-        start: BlockID<<Self::Block as Digestible>::Digest>,
-        tip: BlockID<<Self::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<(Arc<Self::Block>, <Self::Block as Digestible>::Digest)>>
-    + Send
-    + 'static {
-        self.resolve_descendant(start, tip)
-    }
+}
 
-    #[allow(clippy::type_complexity)]
+impl<S, B> DescendantProvider for Mailbox<S, Standard<B>>
+where
+    S: Scheme,
+    B: Block,
+{
+    type Cursor = DescendantCursor<Standard<B>>;
+
     fn get_descendants(
         &self,
-        start: BlockID<<Self::Block as Digestible>::Digest>,
-        tip: BlockID<<Self::Block as Digestible>::Digest>,
-    ) -> impl Future<Output = Option<(Vec<Arc<Self::Block>>, <Self::Block as Digestible>::Digest)>>
-    + Send
-    + 'static {
-        self.resolve_descendants(start, tip)
+        request: DescendantRequest<<Self::Block as Digestible>::Digest, Self::Cursor>,
+    ) -> impl Future<Output = Option<DescendantPage<Self::Block, Self::Cursor>>> + Send + 'static
+    {
+        self.resolve_descendants(request)
     }
 }

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -152,4 +152,15 @@ where
     + 'static {
         self.resolve_descendant(start, tip)
     }
+
+    #[allow(clippy::type_complexity)]
+    fn get_descendants(
+        &self,
+        start: BlockID<<Self::Block as Digestible>::Digest>,
+        tip: BlockID<<Self::Block as Digestible>::Digest>,
+    ) -> impl Future<Output = Option<(Vec<Arc<Self::Block>>, <Self::Block as Digestible>::Digest)>>
+    + Send
+    + 'static {
+        self.resolve_descendants(start, tip)
+    }
 }

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -140,7 +140,6 @@ where
         });
         async move { receiver?.await.ok() }
     }
-
 }
 
 impl<S, B> DescendantProvider for Mailbox<S, Standard<B>>

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -31,7 +31,7 @@ use commonware_consensus::{
     Block, CertifiableBlock, Heightable, Roundable,
     marshal::{
         Identifier,
-        ancestry::{self as marshal_ancestry, Ancestry, BlockProvider},
+        ancestry::{Ancestry, BlockProvider},
         core::{Mailbox as MarshalMailbox, Variant as MarshalVariant},
     },
     types::{Height, Round},
@@ -248,7 +248,7 @@ where
         context: &E,
         marshal: MarshalMailbox<S, V>,
         (runtime_context, consensus_context): (E, A::Context),
-        mut ancestry: impl Ancestry<A::Block>,
+        ancestry: impl Ancestry<A::Block>,
         input: Input<A::Input, A::Provider>,
         mut response: oneshot::Sender<Option<A::Block>>,
     ) where
@@ -257,8 +257,9 @@ where
         MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
     {
         let timer = self.metrics.propose_duration.timer(context);
+        let mut inspection = ancestry.clone();
 
-        let parent = match fetch_ancestor(&mut response, &mut ancestry).await {
+        let parent = match fetch_ancestor(&mut response, &mut inspection).await {
             Some(Some(parent)) => parent,
             Some(None) => {
                 response.send_lossy(None);
@@ -270,7 +271,7 @@ where
             }
         };
         let parent_digest = parent.digest();
-        let ancestry = marshal_ancestry::with_prefix([Arc::clone(&parent)], ancestry);
+        drop(inspection);
 
         let round = consensus_context.round();
         let batches = match self
@@ -339,7 +340,7 @@ where
         context: &E,
         marshal: MarshalMailbox<S, V>,
         (runtime_context, consensus_context): (E, A::Context),
-        mut ancestry: impl Ancestry<A::Block>,
+        ancestry: impl Ancestry<A::Block>,
         mut response: oneshot::Sender<bool>,
     ) where
         S: Scheme,
@@ -347,8 +348,9 @@ where
         MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
     {
         let timer = self.metrics.verify_duration.timer(context);
+        let mut inspection = ancestry.clone();
 
-        let block = match fetch_ancestor(&mut response, &mut ancestry).await {
+        let block = match fetch_ancestor(&mut response, &mut inspection).await {
             Some(Some(block)) => block,
             Some(None) => {
                 debug!("verification request waiting on incomplete block ancestry");
@@ -419,7 +421,7 @@ where
         }
 
         let round = consensus_context.round();
-        let parent = match fetch_ancestor(&mut response, &mut ancestry).await {
+        let parent = match fetch_ancestor(&mut response, &mut inspection).await {
             Some(Some(parent)) => parent,
             Some(None) => {
                 debug!(
@@ -438,6 +440,7 @@ where
             }
         };
         let parent_digest = parent.digest();
+        drop(inspection);
         let batches = match self
             .prepare_batches(context, marshal, parent.clone(), &mut response)
             .await
@@ -472,11 +475,13 @@ where
             }
         };
 
-        let ancestry = marshal_ancestry::with_prefix([block.clone(), parent], ancestry);
         let verified = match await_or_cancel(
             &mut response,
-            self.app
-                .verify((runtime_context, consensus_context), ancestry, batches),
+            self.app.verify(
+                (runtime_context, consensus_context),
+                ancestry,
+                batches,
+            ),
         )
         .await
         {
@@ -929,7 +934,7 @@ mod tests {
     use commonware_codec::{Encode, EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
     use commonware_consensus::{
         Block as ConsensusBlock, CertifiableBlock, Heightable, Roundable,
-        marshal::{BlockID, ancestry::{Ancestry, BlockProvider}},
+        marshal::ancestry::{Ancestry, BlockProvider},
         simplex::{mocks::scheme::Scheme as MockScheme, types::Context as ConsensusContext},
         types::{Epoch, Height, Round, View},
     };
@@ -953,7 +958,6 @@ mod tests {
     use futures::StreamExt;
     use std::{
         collections::{BTreeMap, VecDeque},
-        future,
         future::Future,
         num::NonZeroUsize,
         sync::{
@@ -1273,14 +1277,6 @@ mod tests {
             let parent = block.parent();
             async move { provider.fetch_by_digest(parent).map(Arc::new) }
         }
-
-        fn get_descendant(
-            &self,
-            _start: BlockID<Digest>,
-            _tip: BlockID<Digest>,
-        ) -> impl Future<Output = Option<(Arc<Self::Block>, Digest)>> + Send + 'static {
-            future::ready(None)
-        }
     }
 
     #[derive(Clone, Default)]
@@ -1320,14 +1316,6 @@ mod tests {
                     .flatten()
                     .map(Arc::new)
             }
-        }
-
-        fn get_descendant(
-            &self,
-            _start: BlockID<Digest>,
-            _tip: BlockID<Digest>,
-        ) -> impl Future<Output = Option<(Arc<Self::Block>, Digest)>> + Send + 'static {
-            future::ready(None)
         }
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -929,7 +929,7 @@ mod tests {
     use commonware_codec::{Encode, EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
     use commonware_consensus::{
         Block as ConsensusBlock, CertifiableBlock, Heightable, Roundable,
-        marshal::ancestry::{Ancestry, BlockProvider},
+        marshal::ancestry::{Ancestry, BlockProvider}, marshal::{BlockID, ancestry::BlockProvider},
         simplex::{mocks::scheme::Scheme as MockScheme, types::Context as ConsensusContext},
         types::{Epoch, Height, Round, View},
     };
@@ -953,6 +953,7 @@ mod tests {
     use futures::StreamExt;
     use std::{
         collections::{BTreeMap, VecDeque},
+        future,
         future::Future,
         num::NonZeroUsize,
         sync::{
@@ -1272,6 +1273,14 @@ mod tests {
             let parent = block.parent();
             async move { provider.fetch_by_digest(parent).map(Arc::new) }
         }
+
+        fn get_descendant(
+            &self,
+            _start: BlockID<Digest>,
+            _tip: BlockID<Digest>,
+        ) -> impl Future<Output = Option<(Arc<Self::Block>, Digest)>> + Send + 'static {
+            future::ready(None)
+        }
     }
 
     #[derive(Clone, Default)]
@@ -1311,6 +1320,14 @@ mod tests {
                     .flatten()
                     .map(Arc::new)
             }
+        }
+
+        fn get_descendant(
+            &self,
+            _start: BlockID<Digest>,
+            _tip: BlockID<Digest>,
+        ) -> impl Future<Output = Option<(Arc<Self::Block>, Digest)>> + Send + 'static {
+            future::ready(None)
         }
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -929,7 +929,7 @@ mod tests {
     use commonware_codec::{Encode, EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
     use commonware_consensus::{
         Block as ConsensusBlock, CertifiableBlock, Heightable, Roundable,
-        marshal::ancestry::{Ancestry, BlockProvider}, marshal::{BlockID, ancestry::BlockProvider},
+        marshal::{BlockID, ancestry::{Ancestry, BlockProvider}},
         simplex::{mocks::scheme::Scheme as MockScheme, types::Context as ConsensusContext},
         types::{Epoch, Height, Round, View},
     };

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -477,11 +477,8 @@ where
 
         let verified = match await_or_cancel(
             &mut response,
-            self.app.verify(
-                (runtime_context, consensus_context),
-                ancestry,
-                batches,
-            ),
+            self.app
+                .verify((runtime_context, consensus_context), ancestry, batches),
         )
         .await
         {


### PR DESCRIPTION
## Overview

Adds an in-memory tree of pending blocks into marshal. This enables marshal to expose a structured set of pending forks, enabling a `DescendantStream` that walks towards a known tip starting from an arbitrary point in history.

closes #2083 