### PR TITLE
[conformance] Remove dangling references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,10 @@ version = "2026.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
+ "serde",
+ "serde_json",
  "syn 2.0.119",
+ "toml",
 ]
 
 [[package]]

--- a/conformance/TESTING.md
+++ b/conformance/TESTING.md
@@ -17,6 +17,7 @@ just regenerate-conformance -p commonware-codec -p commonware-storage
 ```
 
 Regeneration is an explicit approval of the new format. Do not use it merely to make a failing test pass.
+Conformance checks reject fixtures whose tests no longer exist, and regeneration removes them.
 
 ## New codec types
 

--- a/conformance/macros/Cargo.toml
+++ b/conformance/macros/Cargo.toml
@@ -13,10 +13,20 @@ documentation = "https://docs.rs/commonware-conformance-macros"
 [lib]
 proc-macro = true
 
+[features]
+fixtures = [ "dep:serde", "dep:serde_json", "dep:toml" ]
+
+[[bin]]
+name = "fixtures"
+required-features = ["fixtures"]
+
 [dependencies]
 proc-macro2.workspace = true
 quote.workspace = true
+serde = { workspace = true, features = ["derive"], optional = true }
+serde_json = { workspace = true, optional = true }
 syn = { workspace = true, features = ["full", "parsing"] }
+toml = { workspace = true, optional = true }
 
 [lints]
 workspace = true

--- a/conformance/macros/src/bin/fixtures.rs
+++ b/conformance/macros/src/bin/fixtures.rs
@@ -1,0 +1,242 @@
+#[path = "../naming.rs"]
+mod naming;
+
+use naming::type_to_ident;
+use serde::Deserialize;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    io::stdin,
+    path::{Path, PathBuf},
+    process::ExitCode,
+};
+
+type Inventories = BTreeMap<String, BTreeSet<String>>;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Check,
+    Prune,
+}
+
+impl Mode {
+    fn parse() -> Result<Self, String> {
+        match env::args().nth(1).as_deref() {
+            Some("check") => Ok(Self::Check),
+            Some("prune") => Ok(Self::Prune),
+            _ => Err("usage: fixtures <check|prune>".to_string()),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct TestList {
+    #[serde(rename = "rust-suites")]
+    suites: BTreeMap<String, Suite>,
+}
+
+#[derive(Deserialize)]
+struct Suite {
+    #[serde(rename = "binary-name")]
+    binary_name: String,
+    cwd: PathBuf,
+    status: String,
+    #[serde(default)]
+    testcases: BTreeMap<String, serde::de::IgnoredAny>,
+}
+
+fn collect_inventories(test_list: TestList) -> BTreeMap<PathBuf, Inventories> {
+    let mut files = BTreeMap::<PathBuf, Inventories>::new();
+
+    for suite in test_list.suites.into_values() {
+        if suite.status != "listed" {
+            continue;
+        }
+
+        let binary_name = suite.binary_name.replace('-', "_");
+        let tests = files
+            .entry(suite.cwd.join("conformance.toml"))
+            .or_default()
+            .entry(binary_name.clone())
+            .or_default();
+
+        tests.extend(
+            suite
+                .testcases
+                .into_keys()
+                .filter(|name| name.ends_with("_conformance_"))
+                .map(|name| format!("{binary_name}::{name}")),
+        );
+    }
+
+    files
+}
+
+fn has_test(fixture: &str, tests: &BTreeSet<String>) -> bool {
+    tests.iter().any(|test| {
+        let Some((module, test_name)) = test.rsplit_once("::test_") else {
+            return false;
+        };
+        let Some(type_name) = fixture
+            .strip_prefix(module)
+            .and_then(|suffix| suffix.strip_prefix("::"))
+        else {
+            return false;
+        };
+
+        test_name == format!("{}_conformance_", type_to_ident(type_name))
+    })
+}
+
+fn dangling_entries(file: &toml::Table, inventories: &Inventories) -> Vec<String> {
+    file.keys()
+        .filter(|fixture| {
+            let Some((binary_name, _)) = fixture.split_once("::") else {
+                return false;
+            };
+            let Some(tests) = inventories.get(binary_name) else {
+                return false;
+            };
+            !has_test(fixture, tests)
+        })
+        .cloned()
+        .collect()
+}
+
+fn inspect_file(mode: Mode, file: &mut toml::Table, inventories: &Inventories) -> Vec<String> {
+    let dangling = dangling_entries(file, inventories);
+    if mode == Mode::Prune {
+        for fixture in &dangling {
+            file.remove(fixture);
+        }
+    }
+    dangling
+}
+
+fn process_file(mode: Mode, path: &Path, inventories: &Inventories) -> Result<Vec<String>, String> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+
+    let contents = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read {}: {error}", path.display()))?;
+    let mut file = toml::from_str(&contents).map_err(|error| error.to_string())?;
+    let dangling = inspect_file(mode, &mut file, inventories);
+
+    if mode == Mode::Prune && !dangling.is_empty() {
+        let contents = toml::to_string_pretty(&file).map_err(|error| error.to_string())?;
+        fs::write(path, contents)
+            .map_err(|error| format!("failed to write {}: {error}", path.display()))?;
+    }
+
+    Ok(dangling)
+}
+
+fn run() -> Result<(), String> {
+    let mode = Mode::parse()?;
+    let test_list = serde_json::from_reader(stdin().lock()).map_err(|error| error.to_string())?;
+    let files = collect_inventories(test_list);
+    let mut dangling_count = 0usize;
+
+    for (path, inventories) in files {
+        let dangling = process_file(mode, &path, &inventories)?;
+        for fixture in &dangling {
+            eprintln!("{}: dangling fixture `{fixture}`", path.display());
+        }
+        dangling_count += dangling.len();
+    }
+
+    if mode == Mode::Check && dangling_count > 0 {
+        return Err(format!(
+            "found {dangling_count} dangling conformance fixtures"
+        ));
+    }
+
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    if let Err(error) = run() {
+        eprintln!("error: {error}");
+        return ExitCode::FAILURE;
+    }
+
+    ExitCode::SUCCESS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_file(fixtures: &[&str]) -> toml::Table {
+        fixtures
+            .iter()
+            .map(|fixture| {
+                (
+                    (*fixture).to_string(),
+                    toml::Value::Table(toml::Table::new()),
+                )
+            })
+            .collect()
+    }
+
+    fn inventory(tests: &[&str]) -> Inventories {
+        BTreeMap::from([(
+            "commonware_example".to_string(),
+            tests.iter().map(|test| (*test).to_string()).collect(),
+        )])
+    }
+
+    #[test]
+    fn checks_and_prunes_dangling_entries_in_selected_crates() {
+        const MODULE: &str = "commonware_example::tests::conformance";
+        let live = format!("{MODULE}::CodecConformance<[u8;32]>");
+        let dangling = format!("{MODULE}::CodecConformance<Vec<u16>>");
+        let unrelated = "commonware_other::tests::conformance::CodecConformance<Vec<u8>>";
+        let mut file = fixture_file(&[&live, &dangling, unrelated]);
+        let inventories = inventory(&[&format!(
+            "{MODULE}::test_codec_conformance_u8_32_conformance_"
+        )]);
+
+        assert_eq!(
+            inspect_file(Mode::Check, &mut file, &inventories),
+            std::slice::from_ref(&dangling)
+        );
+        assert_eq!(file.len(), 3);
+
+        assert_eq!(
+            inspect_file(Mode::Prune, &mut file, &inventories),
+            [dangling]
+        );
+        assert_eq!(file.len(), 2);
+        assert!(file.contains_key(unrelated));
+    }
+
+    #[test]
+    fn collects_only_conformance_tests() {
+        let test_list = TestList {
+            suites: BTreeMap::from([(
+                "commonware-example".to_string(),
+                Suite {
+                    binary_name: "commonware_example".to_string(),
+                    cwd: PathBuf::from("/workspace/example"),
+                    status: "listed".to_string(),
+                    testcases: BTreeMap::from([
+                        (
+                            "tests::test_live_conformance_".to_string(),
+                            serde::de::IgnoredAny,
+                        ),
+                        ("tests::test_ordinary".to_string(), serde::de::IgnoredAny),
+                    ]),
+                },
+            )]),
+        };
+
+        let inventories = collect_inventories(test_list);
+
+        assert_eq!(
+            inventories[&PathBuf::from("/workspace/example/conformance.toml")]["commonware_example"],
+            BTreeSet::from(["commonware_example::tests::test_live_conformance_".to_string()])
+        );
+    }
+}

--- a/conformance/macros/src/lib.rs
+++ b/conformance/macros/src/lib.rs
@@ -15,6 +15,9 @@ use syn::{
     punctuated::Punctuated,
 };
 
+mod naming;
+use naming::type_to_ident;
+
 /// A single conformance test entry: `Type` or `Type => n_cases`
 struct ConformanceEntry {
     ty: Type,
@@ -46,49 +49,6 @@ impl Parse for ConformanceInput {
         let entries = Punctuated::parse_terminated(input)?;
         Ok(Self { entries })
     }
-}
-
-/// Convert a type to a valid snake_case function name suffix.
-///
-/// Inserts underscores at PascalCase boundaries and replaces punctuation
-/// with underscores. Consecutive separators are collapsed.
-fn type_to_ident(ty: &Type) -> String {
-    let type_str = quote!(#ty).to_string();
-
-    let mut result = String::with_capacity(type_str.len());
-    let mut prev_was_separator = true;
-
-    for c in type_str.chars() {
-        match c {
-            'A'..='Z' => {
-                if !prev_was_separator && !result.is_empty() {
-                    result.push('_');
-                }
-                result.push(c.to_ascii_lowercase());
-                prev_was_separator = false;
-            }
-            'a'..='z' | '0'..='9' => {
-                result.push(c);
-                prev_was_separator = false;
-            }
-            '_' => {
-                if !prev_was_separator && !result.is_empty() {
-                    result.push('_');
-                }
-                prev_was_separator = true;
-            }
-            '<' | '>' | ',' | ' ' | ':' => {
-                if !prev_was_separator && !result.is_empty() {
-                    result.push('_');
-                }
-                prev_was_separator = true;
-            }
-            // Skip other characters
-            _ => {}
-        }
-    }
-
-    result.trim_end_matches("_").to_string()
 }
 
 /// Define tests for types implementing the
@@ -125,8 +85,9 @@ pub fn conformance_tests(input: TokenStream) -> TokenStream {
             .map(|e| quote!(#e))
             .unwrap_or_else(|| quote!(::commonware_conformance::DEFAULT_CASES));
 
-        let type_name_str = quote!(#ty).to_string().replace(' ', "");
-        let fn_name_suffix = type_to_ident(ty);
+        let type_name = quote!(#ty).to_string();
+        let type_name_str = type_name.replace(' ', "");
+        let fn_name_suffix = type_to_ident(&type_name);
         let fn_name = Ident::new(&format!("test_{fn_name_suffix}"), Span::call_site());
 
         quote! {
@@ -157,7 +118,7 @@ mod tests {
 
     fn ident_for(type_str: &str) -> String {
         let ty: Type = syn::parse_str(type_str).unwrap();
-        type_to_ident(&ty)
+        type_to_ident(&quote!(#ty).to_string())
     }
 
     #[test]

--- a/conformance/macros/src/naming.rs
+++ b/conformance/macros/src/naming.rs
@@ -1,0 +1,32 @@
+/// Convert a type to a valid snake_case function name suffix.
+///
+/// Inserts underscores at PascalCase boundaries and replaces punctuation
+/// with underscores. Consecutive separators are collapsed.
+pub(crate) fn type_to_ident(type_name: &str) -> String {
+    let mut result = String::with_capacity(type_name.len());
+    let mut previous_was_separator = true;
+
+    for character in type_name.chars() {
+        match character {
+            'A'..='Z' => {
+                if !previous_was_separator && !result.is_empty() {
+                    result.push('_');
+                }
+                result.push(character.to_ascii_lowercase());
+                previous_was_separator = false;
+            }
+            'a'..='z' | '0'..='9' => {
+                result.push(character);
+                previous_was_separator = false;
+            }
+            _ => {
+                if !previous_was_separator && !result.is_empty() {
+                    result.push('_');
+                }
+                previous_was_separator = true;
+            }
+        }
+    }
+
+    result.trim_end_matches('_').to_string()
+}

--- a/justfile
+++ b/justfile
@@ -188,11 +188,31 @@ fix-features:
 
 # Test conformance (optionally for specific crates: just test-conformance -p commonware-codec)
 test-conformance *args='':
-    just test --features arbitrary --profile conformance {{ args }}
+    just _conformance check {{ args }}
 
 # Regenerate conformance fixtures (optionally for specific crates: just regenerate-conformance -p commonware-codec)
 regenerate-conformance *args='':
-    RUSTFLAGS="--cfg generate_conformance_tests" just test --features arbitrary --profile conformance {{ args }}
+    RUSTFLAGS="--cfg generate_conformance_tests" just _conformance prune {{ args }}
+
+[private]
+_conformance mode *args='':
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    inventory="$(mktemp)"
+    trap 'rm -f "$inventory"' EXIT
+
+    cargo nextest list --features arbitrary --profile conformance --message-format json {{ args }} > "$inventory"
+
+    if [[ "{{ mode }}" == "check" ]]; then
+        cargo run --quiet -p commonware-conformance-macros --features fixtures --bin fixtures -- check < "$inventory"
+    fi
+
+    just test --features arbitrary --profile conformance {{ args }}
+
+    if [[ "{{ mode }}" == "prune" ]]; then
+        cargo run --quiet -p commonware-conformance-macros --features fixtures --bin fixtures -- prune < "$inventory"
+    fi
 
 # Find public items missing stability annotations.
 unstable-public *args='':


### PR DESCRIPTION
## Summary

- Inventory all conformance tests before running them.
- Fail conformance checks on dangling fixtures and prune them during regeneration.
- Reuse the macro naming logic and gate checker-only dependencies behind a feature.

Closes #2717