### PR TITLE
[consensus/simplex] Stable Leader Feedback (Part 2)

### DIFF
--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -129,7 +129,10 @@ where
         let (sender, receiver) = mailbox::new(context.child("mailbox"), cfg.mailbox_size);
         let mut required_active = participants.quorum::<N3f1>() as usize;
         if scheme.me().is_some() {
-            required_active -= 1;
+            // We are live by construction (we never observe our own messages).
+            required_active = required_active
+                .checked_sub(1)
+                .expect("quorum is never zero");
         }
         (
             Self {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -73,6 +73,12 @@ where
     /// participant. `None` means no activity has been observed.
     last_activity: Vec<Option<SystemTime>>,
 
+    /// Number of observed participants that must be recently active for the
+    /// network to be considered responsive (see [Self::is_active]). We never
+    /// observe our own messages, so when we are a participant we count
+    /// ourselves as live by construction.
+    required_active: usize,
+
     mailbox_receiver: mailbox::Receiver<Message<S, D>>,
 
     added: Counter,
@@ -121,11 +127,16 @@ where
             Buckets::CRYPTOGRAPHY,
         );
         let (sender, receiver) = mailbox::new(context.child("mailbox"), cfg.mailbox_size);
+        let mut required_active = participants.quorum::<N3f1>() as usize;
+        if scheme.me().is_some() {
+            required_active -= 1;
+        }
         (
             Self {
                 context: ContextCell::new(context),
 
                 last_activity: vec![None; participants.len()],
+                required_active,
                 scheme,
 
                 blocker: cfg.blocker,
@@ -191,10 +202,10 @@ where
         let recent =
             |activity: &Option<SystemTime>| activity.is_some_and(|activity| activity >= min_time);
 
-        // If there is not a quorum of recently active participants, then we "fail-open" since we
-        // know the network is not expected to be responsive.
+        // If fewer than the required number of participants are recently active, we "fail-open"
+        // since we know the network is not expected to be responsive.
         let active = self.last_activity.iter().filter(|a| recent(a)).count();
-        if active < self.scheme.participants().quorum::<N3f1>() as usize {
+        if active < self.required_active {
             return true;
         }
 
@@ -397,16 +408,13 @@ where
                         updated_view = current.view;
                     }
                     Message::Constructed(message) => {
-                        // Record activity for ourselves: we never receive our
-                        // own votes from the network, and a quorum-relative
-                        // threshold in is_active would misfire when we are not
-                        // a participant.
-                        if let Some(me) = self.scheme.me() {
-                            self.record_activity(me);
-                        }
-
-                        // Skip votes outside the tracked window
-                        if !self.window(finalized, current.view).admits_vote(view) {
+                        // Skip votes below the retention window. Our own votes
+                        // are not future-bounded: the voter constructs them
+                        // before sending the update that advances our view
+                        // (so they can be ahead of it after a certificate
+                        // jump), and admission bounds exist for untrusted
+                        // network input.
+                        if !self.window(finalized, current.view).retains(view) {
                             continue;
                         }
 

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -2,7 +2,7 @@ use super::{Config, Mailbox, Message, Round};
 use crate::{
     Epochable, Relay, Reporter, Viewable,
     simplex::{
-        Plan, Window,
+        Plan, Viewport,
         actors::voter,
         config::ForwardingPolicy,
         metrics::{Inbound, Peer, TimeoutReason},
@@ -218,8 +218,8 @@ where
 
     /// Returns the window of views the batcher tracks, given the voter's
     /// last-published finalized and current views.
-    const fn window(&self, finalized: View, current: View) -> Window {
-        Window {
+    const fn viewport(&self, finalized: View, current: View) -> Viewport {
+        Viewport {
             finalized,
             current,
             activity_timeout: self.activity_timeout,
@@ -411,13 +411,13 @@ where
                         updated_view = current.view;
                     }
                     Message::Constructed(message) => {
-                        // Skip votes below the retention window. Our own votes
+                        // Skip votes below the viewport floor. Our own votes
                         // are not future-bounded: the voter constructs them
                         // before sending the update that advances our view
                         // (so they can be ahead of it after a certificate
                         // jump), and admission bounds exist for untrusted
                         // network input.
-                        if !self.window(finalized, current.view).retains(view) {
+                        if !self.viewport(finalized, current.view).retains(view) {
                             continue;
                         }
 
@@ -457,8 +457,8 @@ where
                 let view = message.view();
                 self.record_peer_activity(&sender);
 
-                // Skip certificates outside the tracked window
-                if !self.window(finalized, current.view).admits_certificate(view) {
+                // Skip certificates outside the viewport
+                if !self.viewport(finalized, current.view).admits_certificate(view) {
                     continue;
                 }
 
@@ -571,8 +571,8 @@ where
                 let view = message.view();
                 self.record_peer_activity(&sender);
 
-                // Skip votes outside the tracked window
-                if !self.window(finalized, current.view).admits_vote(view) {
+                // Skip votes outside the viewport
+                if !self.viewport(finalized, current.view).admits_vote(view) {
                     continue;
                 }
 
@@ -623,7 +623,7 @@ where
                 // Skip verification and construction for views at or below finalized.
                 //
                 // We still admit votes at or below finalized (see
-                // [Window::retains]) because we want to notify the reporter of
+                // [Viewport::retains]) because we want to notify the reporter of
                 // all votes within the activity timeout (even if we don't need
                 // them in the voter).
                 if updated_view <= finalized {
@@ -728,10 +728,10 @@ where
                 .await;
 
                 // Drop any rounds that are no longer retained
-                let window = self.window(finalized, current.view);
+                let viewport = self.viewport(finalized, current.view);
                 while work
                     .first_key_value()
-                    .is_some_and(|(&view, _)| !window.retains(view))
+                    .is_some_and(|(&view, _)| !viewport.retains(view))
                 {
                     work.pop_first();
                 }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -2,14 +2,14 @@ use super::{Config, Mailbox, Message, Round};
 use crate::{
     Epochable, Relay, Reporter, Viewable,
     simplex::{
-        Plan,
+        Plan, Window,
         actors::voter,
         config::ForwardingPolicy,
         metrics::{Inbound, Peer, TimeoutReason},
         scheme::Scheme,
         types::{Activity, Certificate, Proposal, Vote},
     },
-    types::{Epoch, Participant, Round as Rnd, TermLength, View},
+    types::{Epoch, Participant, Round as Rnd, TermLength, View, ViewDelta},
 };
 use commonware_actor::mailbox;
 use commonware_cryptography::Digest;
@@ -62,6 +62,7 @@ where
     relay: Rl,
     strategy: T,
 
+    activity_timeout: ViewDelta,
     skip_timeout: Duration,
     forwarding: ForwardingPolicy,
     epoch: Epoch,
@@ -132,6 +133,7 @@ where
                 relay: cfg.relay,
                 strategy: cfg.strategy,
 
+                activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
                 forwarding: cfg.forwarding,
                 epoch: cfg.epoch,
@@ -198,6 +200,17 @@ where
 
         // Return true if we have recent activity from the participant.
         recent(&self.last_activity[usize::from(participant)])
+    }
+
+    /// Returns the window of views the batcher tracks, given the voter's
+    /// last-published finalized and current views.
+    const fn window(&self, finalized: View, current: View) -> Window {
+        Window {
+            finalized,
+            current,
+            activity_timeout: self.activity_timeout,
+            term_length: self.term_length,
+        }
     }
 
     /// Maps `missing` participants to targeted forward recipients, excluding self.
@@ -384,13 +397,16 @@ where
                         updated_view = current.view;
                     }
                     Message::Constructed(message) => {
-                        // Record activity for ourselves.
+                        // Record activity for ourselves: we never receive our
+                        // own votes from the network, and a quorum-relative
+                        // threshold in is_active would misfire when we are not
+                        // a participant.
                         if let Some(me) = self.scheme.me() {
                             self.record_activity(me);
                         }
 
-                        // Ignore non-useful votes.
-                        if view <= finalized {
+                        // Skip votes outside the tracked window
+                        if !self.window(finalized, current.view).admits_vote(view) {
                             continue;
                         }
 
@@ -430,9 +446,8 @@ where
                 let view = message.view();
                 self.record_peer_activity(&sender);
 
-                // Ignore certificates below the highest finalized view since they aren't useful.
-                // Allow certificates from arbitrarily-future views since they advance our view.
-                if view <= finalized {
+                // Skip certificates outside the tracked window
+                if !self.window(finalized, current.view).admits_certificate(view) {
                     continue;
                 }
 
@@ -545,18 +560,8 @@ where
                 let view = message.view();
                 self.record_peer_activity(&sender);
 
-                // Ignore votes at or below the finalized tip. Votes dropped here are
-                // never verified or reported: activity reports miss votes that arrive
-                // after finalization (relevant to reporters tracking participation),
-                // and equivocation at or below the tip is not detected or reported
-                // since fault evidence is only collected for views still in progress.
-                if view <= finalized {
-                    continue;
-                }
-
-                // Ignore votes from arbitrarily-future views (DOS via memory
-                // exhaustion); see [`View::admits`] for the allowed window.
-                if !current.view.admits(view, self.term_length) {
+                // Skip votes outside the tracked window
+                if !self.window(finalized, current.view).admits_vote(view) {
                     continue;
                 }
 
@@ -605,6 +610,11 @@ where
                 }
 
                 // Skip verification and construction for views at or below finalized.
+                //
+                // We still admit votes at or below finalized (see
+                // [Window::retains]) because we want to notify the reporter of
+                // all votes within the activity timeout (even if we don't need
+                // them in the voter).
                 if updated_view <= finalized {
                     continue;
                 }
@@ -706,12 +716,13 @@ where
                 .instrument(span)
                 .await;
 
-                // Drop any rounds at or below the highest finalized view (votes
-                // for those views are no longer accepted). Guarded to avoid a
-                // tree split on every message: `finalized` only advances on
-                // view updates.
-                if work.first_key_value().is_some_and(|(&v, _)| v <= finalized) {
-                    work = work.split_off(&finalized.next());
+                // Drop any rounds that are no longer retained
+                let window = self.window(finalized, current.view);
+                while work
+                    .first_key_value()
+                    .is_some_and(|(&view, _)| !window.retains(view))
+                {
+                    work.pop_first();
                 }
             },
         }

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -6,7 +6,7 @@ mod verifier;
 use crate::{
     Relay, Reporter,
     simplex::config::ForwardingPolicy,
-    types::{Epoch, TermLength, View},
+    types::{Epoch, TermLength, View, ViewDelta},
 };
 pub use actor::Actor;
 use commonware_cryptography::certificate::Scheme;
@@ -27,15 +27,15 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
     /// Strategy for parallel operations.
     pub strategy: T,
 
+    pub activity_timeout: ViewDelta,
     pub skip_timeout: Duration,
     pub epoch: Epoch,
     pub mailbox_size: NonZeroUsize,
     pub term_length: TermLength,
     pub forwarding: ForwardingPolicy,
 
-    /// Highest finalized view at startup; votes and certificates at or below
-    /// it are dropped (producing no activity reports) even before the voter's
-    /// first update.
+    /// Highest finalized view at startup; anchors the tracked window before
+    /// the voter's first update.
     pub floor: View,
 }
 
@@ -179,6 +179,7 @@ mod tests {
     /// Batcher [Config] fields that vary across tests; everything else is
     /// fixed by [test_config].
     struct BatcherOptions {
+        activity_timeout: ViewDelta,
         skip_timeout: Duration,
         term_length: TermLength,
         forwarding: ForwardingPolicy,
@@ -188,6 +189,7 @@ mod tests {
     impl Default for BatcherOptions {
         fn default() -> Self {
             Self {
+                activity_timeout: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
                 term_length: TermLength::ONE,
                 forwarding: ForwardingPolicy::Disabled,
@@ -212,6 +214,7 @@ mod tests {
             reporter,
             relay,
             strategy: Sequential,
+            activity_timeout: options.activity_timeout,
             skip_timeout: options.skip_timeout,
             epoch,
             mailbox_size: NZUsize!(128),
@@ -3680,7 +3683,7 @@ mod tests {
         votes_skipped_for_finalized_views(secp256r1::fixture);
     }
 
-    fn startup_votes_below_floor_not_reported<S, F>(mut fixture: F)
+    fn startup_votes_below_activity_window_not_reported<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
@@ -3716,6 +3719,7 @@ mod tests {
                 MockRelay::new(),
                 epoch,
                 BatcherOptions {
+                    activity_timeout: ViewDelta::new(2),
                     floor,
                     ..Default::default()
                 },
@@ -3792,24 +3796,185 @@ mod tests {
                 context.sleep(Duration::from_millis(1)).await;
             }
 
-            // The stale below-floor vote must not have produced any activity
+            // The stale vote below the activity window must not have produced
+            // any activity (votes within `activity_timeout` of the floor are
+            // still reported)
             assert!(
                 reporter.notarizes.lock().get(&stale_view).is_none(),
-                "votes below the restored floor must not be reported before the first update"
+                "votes below the activity window must not be reported before the first update"
             );
         });
     }
 
     #[test_traced]
-    fn test_startup_votes_below_floor_not_reported() {
-        startup_votes_below_floor_not_reported(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        startup_votes_below_floor_not_reported(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        startup_votes_below_floor_not_reported(bls12381_threshold_std::fixture::<MinPk, _>);
-        startup_votes_below_floor_not_reported(bls12381_threshold_std::fixture::<MinSig, _>);
-        startup_votes_below_floor_not_reported(bls12381_multisig::fixture::<MinPk, _>);
-        startup_votes_below_floor_not_reported(bls12381_multisig::fixture::<MinSig, _>);
-        startup_votes_below_floor_not_reported(ed25519::fixture);
-        startup_votes_below_floor_not_reported(secp256r1::fixture);
+    fn test_startup_votes_below_activity_window_not_reported() {
+        startup_votes_below_activity_window_not_reported(
+            bls12381_threshold_vrf::fixture::<MinPk, _>,
+        );
+        startup_votes_below_activity_window_not_reported(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+        );
+        startup_votes_below_activity_window_not_reported(
+            bls12381_threshold_std::fixture::<MinPk, _>,
+        );
+        startup_votes_below_activity_window_not_reported(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+        );
+        startup_votes_below_activity_window_not_reported(bls12381_multisig::fixture::<MinPk, _>);
+        startup_votes_below_activity_window_not_reported(bls12381_multisig::fixture::<MinSig, _>);
+        startup_votes_below_activity_window_not_reported(ed25519::fixture);
+        startup_votes_below_activity_window_not_reported(secp256r1::fixture);
+    }
+
+    fn votes_below_finalized_within_activity_window_reported<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let namespace = b"batcher_test".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            // Get participants
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            // Create simulated network
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            // Setup reporter mock
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            // Initialize batcher actor (participant 0)
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter.clone(),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions {
+                    activity_timeout: ViewDelta::new(2),
+                    ..Default::default()
+                },
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            // Create voter mailbox for batcher to send to
+            let (voter_sender, _voter_receiver) = mailbox::new::<voter::Message<S, Sha256Digest>>(
+                context.child("mailbox"),
+                NZUsize!(1024),
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            // Register a peer on the network and link it to us
+            let link = Link {
+                latency: Duration::from_millis(1),
+                jitter: Duration::from_millis(0),
+                success_rate: 1.0,
+            };
+            let (mut peer_sender, _receiver) = oracle
+                .control(participants[1].clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            oracle
+                .add_link(participants[1].clone(), me.clone(), link)
+                .await
+                .unwrap();
+
+            // Start the batcher and advance past the straggler's view
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+            let finalized = View::new(10);
+            batcher_mailbox.update(
+                Span::none(),
+                finalized.next(),
+                Participant::new(1),
+                finalized,
+                None,
+            );
+
+            // Send a vote below the activity window, which must be ignored
+            let stale_view = View::new(7);
+            let stale_proposal = Proposal::new(
+                Round::new(epoch, stale_view),
+                View::new(6),
+                Sha256::hash(b"stale"),
+            );
+            let stale = Notarize::sign(&schemes[1], stale_proposal).unwrap();
+            peer_sender.send(
+                Recipients::One(me.clone()),
+                Vote::Notarize(stale).encode(),
+                true,
+            );
+            context.sleep(Duration::from_millis(50)).await;
+
+            // Send a straggler vote at or below the finalized tip but within
+            // the activity window, which must still be reported
+            let window_view = View::new(9);
+            let window_proposal = Proposal::new(
+                Round::new(epoch, window_view),
+                View::new(8),
+                Sha256::hash(b"window"),
+            );
+            let window = Notarize::sign(&schemes[1], window_proposal.clone()).unwrap();
+            peer_sender.send(Recipients::One(me), Vote::Notarize(window).encode(), true);
+            while reporter
+                .notarizes
+                .lock()
+                .get(&window_view)
+                .and_then(|payloads| payloads.get(&window_proposal.payload))
+                .is_none_or(|participants| participants.is_empty())
+            {
+                context.sleep(Duration::from_millis(1)).await;
+            }
+
+            // The below-window vote must not have produced any activity
+            assert!(
+                reporter.notarizes.lock().get(&stale_view).is_none(),
+                "votes below the activity window must not be reported"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_votes_below_finalized_within_activity_window_reported() {
+        votes_below_finalized_within_activity_window_reported(
+            bls12381_threshold_vrf::fixture::<MinPk, _>,
+        );
+        votes_below_finalized_within_activity_window_reported(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+        );
+        votes_below_finalized_within_activity_window_reported(
+            bls12381_threshold_std::fixture::<MinPk, _>,
+        );
+        votes_below_finalized_within_activity_window_reported(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+        );
+        votes_below_finalized_within_activity_window_reported(
+            bls12381_multisig::fixture::<MinPk, _>,
+        );
+        votes_below_finalized_within_activity_window_reported(
+            bls12381_multisig::fixture::<MinSig, _>,
+        );
+        votes_below_finalized_within_activity_window_reported(ed25519::fixture);
+        votes_below_finalized_within_activity_window_reported(secp256r1::fixture);
     }
 
     fn latest_vote_metric_tracking<S, F>(mut fixture: F)

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -3977,6 +3977,104 @@ mod tests {
         votes_below_finalized_within_activity_window_reported(secp256r1::fixture);
     }
 
+    fn constructed_votes_are_not_future_bounded<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let namespace = b"batcher_test".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            // Get participants
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            // Create simulated network
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            // Setup reporter mock
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            // Initialize batcher actor (participant 0)
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter.clone(),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            // Create voter mailbox for batcher to send to
+            let (voter_sender, _voter_receiver) = mailbox::new::<voter::Message<S, Sha256Digest>>(
+                context.child("mailbox"),
+                NZUsize!(1024),
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            // Start the batcher at view 1
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+            batcher_mailbox.update(
+                Span::none(),
+                View::new(1),
+                Participant::new(1),
+                View::zero(),
+                None,
+            );
+
+            // A locally constructed vote can be ahead of the batcher's view:
+            // the voter constructs votes before sending the update that
+            // advances it (e.g. after a certificate jump). It must be added
+            // to the verifier, not future-bounded like network input.
+            let future_view = View::new(6);
+            let proposal = Proposal::new(
+                Round::new(epoch, future_view),
+                View::new(1),
+                Sha256::hash(b"ahead"),
+            );
+            let notarize = Notarize::sign(&schemes[0], proposal).unwrap();
+            batcher_mailbox.constructed(Vote::Notarize(notarize));
+            context.sleep(Duration::from_millis(50)).await;
+
+            let metrics = context.encode();
+            assert!(
+                metrics.contains("added_total 1"),
+                "constructed vote ahead of the batcher's view must be added: {metrics}"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_constructed_votes_are_not_future_bounded() {
+        constructed_votes_are_not_future_bounded(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        constructed_votes_are_not_future_bounded(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        constructed_votes_are_not_future_bounded(bls12381_threshold_std::fixture::<MinPk, _>);
+        constructed_votes_are_not_future_bounded(bls12381_threshold_std::fixture::<MinSig, _>);
+        constructed_votes_are_not_future_bounded(bls12381_multisig::fixture::<MinPk, _>);
+        constructed_votes_are_not_future_bounded(bls12381_multisig::fixture::<MinSig, _>);
+        constructed_votes_are_not_future_bounded(ed25519::fixture);
+        constructed_votes_are_not_future_bounded(secp256r1::fixture);
+    }
+
     fn latest_vote_metric_tracking<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -34,7 +34,7 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
     pub term_length: TermLength,
     pub forwarding: ForwardingPolicy,
 
-    /// Highest finalized view at startup; anchors the tracked window before
+    /// Highest finalized view at startup; anchors the viewport before
     /// the voter's first update.
     pub floor: View,
 }

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -3,6 +3,61 @@
 //! certified (or finalized) view that it knows about. Thus, it either requires covering
 //! nullification evidence for intermediate views, or a higher floor. It will request the required
 //! nullifications from the resolver. Other nodes will either serve such nullifications, or higher floors.
+//!
+//! # Fetch Strategy
+//!
+//! A nullification covers the view it was created for and the rest of that view's term, and a
+//! request only accepts nullifications from its own term (see [`crate::types::View::covers`]).
+//! One request per term, at its lowest uncovered view, is therefore sufficient: whatever answers
+//! it covers the rest of the term, and a higher floor moots it. The fetch scan requests each
+//! term's anchor and advances a cursor past everything it scanned:
+//!
+//! ```text
+//! term:      [1  2  3  4  5] [6 . . . 10] [11 . . . 15]    current = 14
+//! request:   [1]             [6]          [11]             cursor -> 16
+//!
+//! nullification@4 covers 4..=5:  only a request keyed in [4, 5] retrieves it
+//! nullification@4 for request 6: rejected (wrong term)
+//! ```
+//!
+//! Requests stay pending in the resolver until answered or retained out, so the cursor never
+//! revisits scanned views on its own (a rescan re-issues fetches for requests that are still
+//! pending, which the resolver engine deduplicates).
+//!
+//! # Mid-Term Floor Raises
+//!
+//! A floor raise landing inside a term (a certified notarization or a finalization at a mid-term
+//! view) strands the term's tail: the anchor request is retained out with the floor, requests in
+//! later terms reject this term's nullifications, and the cursor is already past it. Nothing
+//! would ever re-request the tail, so a validator whose parent chain rests at the floor could
+//! never validate proposals that skip it:
+//!
+//! ```text
+//! floor raises to 3, mid-term of [1, 5]:
+//!
+//! term:      [1  2  3 |  4  5] [6 . . . 10] [11 . . . 15]
+//!                     ^floor
+//! request:    x          ??    [6]          [11]
+//!            (retained out)    (reject term-1 evidence)
+//! ```
+//!
+//! Pruning repairs this by pulling the cursor back to just above the floor, so a later scan
+//! re-requests the tail. Anchors whose requests are still pending are re-issued along the way
+//! and deduplicated by the engine, while anchors with a stored covering nullification are
+//! skipped:
+//!
+//! ```text
+//! pull-back: cursor = min(cursor, floor + 1) = 4
+//!
+//! next scan: fetch(4), then the later anchors: fetch(6), fetch(11)
+//!                                              (still pending: deduplicated)
+//!
+//! term:      [1  2  3 |  4  5] [6 . . . 10] [11 . . . 15]
+//! request:              [4]    [6]          [11]
+//! ```
+//!
+//! With single-view terms every view is its own anchor, a floor raise can never land mid-term,
+//! and the pull-back never fires.
 
 mod actor;
 mod ingress;

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -8,9 +8,9 @@
 //!
 //! A nullification covers the view it was created for and the rest of that view's term, and a
 //! request only accepts nullifications from its own term (see [`crate::types::View::covers`]).
-//! One request per term, at its lowest uncovered view, is therefore sufficient: whatever answers
-//! it covers the rest of the term, and a higher floor moots it. The fetch scan requests each
-//! term's anchor and advances a cursor past everything it scanned:
+//! One request per term, at its lowest uncovered view (the term's "anchor"), is therefore
+//! sufficient: whatever answers it covers the rest of the term, and a higher floor moots it. The
+//! fetch scan requests each term's anchor and advances a cursor past everything it scanned:
 //!
 //! ```text
 //! term:      [1  2  3  4  5] [6 . . . 10] [11 . . . 15]    current = 14

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -58,8 +58,8 @@ pub struct State<S: Scheme, D: Digest> {
     nullifications: BTreeMap<View, Certificate<S, D>>,
     /// Window of requests to send to the resolver.
     fetch_concurrent: usize,
-    /// Lowest view that fetch scans still need to consider (see
-    /// [Self::fetch_missing]). Views below this cursor have already been
+    /// Lowest anchor that fetch scans still need to consider (see
+    /// [Self::fetch_missing]). Anchors below this cursor have already been
     /// requested or are covered by a stored nullification. A floor raise
     /// landing mid-term pulls it back to just above the floor (see
     /// [Self::prune]).
@@ -222,10 +222,10 @@ impl<S: Scheme, D: Digest> State<S, D> {
     /// Return requests for any missing nullifications.
     ///
     /// Scans from the cursor (never below the floor), requesting each term's
-    /// lowest uncovered view and advancing the cursor past everything
-    /// scanned. Requests stay pending in the resolver until answered or
-    /// retained out (we must eventually receive a nullification at the
-    /// anchor or a notarization/finalization at a higher view). See the
+    /// anchor and advancing the cursor past everything scanned. Requests
+    /// stay pending in the resolver until answered or retained out (we must
+    /// eventually receive a nullification at the anchor or a
+    /// notarization/finalization at a higher view). See the
     /// [module docs](super) for the full strategy, including how mid-term
     /// floor raises pull the cursor back.
     fn fetch_missing(&mut self, cause: View) -> Vec<Effect> {

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -58,12 +58,11 @@ pub struct State<S: Scheme, D: Digest> {
     nullifications: BTreeMap<View, Certificate<S, D>>,
     /// Window of requests to send to the resolver.
     fetch_concurrent: usize,
-    /// Lowest anchor that fetch scans still need to consider. Anchors below
-    /// this cursor have already been requested or are covered by a stored
-    /// nullification; rescanning them would re-issue fetches for requests
-    /// already answered (e.g. by a notarization pending certification).
-    /// Re-fetches after certification failure bypass this cursor, and a
-    /// floor raise landing mid-term pulls it back to just above the floor.
+    /// Lowest view that fetch scans still need to consider (see
+    /// [Self::fetch_missing]). Views below this cursor have already been
+    /// requested or are covered by a stored nullification. A floor raise
+    /// landing mid-term pulls it back to just above the floor (see
+    /// [Self::prune]).
     fetch_floor: View,
     /// Number of views in each leader term.
     term_length: TermLength,
@@ -222,17 +221,13 @@ impl<S: Scheme, D: Digest> State<S, D> {
 
     /// Return requests for any missing nullifications.
     ///
-    /// Scans the cursor view (never below the floor, and mid-term after a
-    /// floor-raise pull-back), then subsequent term anchors, advancing the
-    /// cursor past every view scanned so later calls do not re-request
-    /// them. Requests stay pending in the resolver until
-    /// answered or retained out (we must eventually receive a nullification
-    /// at the anchor or a notarization/finalization at a higher view). The
-    /// one case where a scanned term can lose its request — a floor raise
-    /// landing mid-term — pulls the cursor back (see [Self::prune]) so a
-    /// later scan re-requests the term tail. That rescan can also re-issue
-    /// anchors whose requests are still pending, which the resolver engine
-    /// deduplicates.
+    /// Scans from the cursor (never below the floor), requesting each term's
+    /// lowest uncovered view and advancing the cursor past everything
+    /// scanned. Requests stay pending in the resolver until answered or
+    /// retained out (we must eventually receive a nullification at the
+    /// anchor or a notarization/finalization at a higher view). See the
+    /// [module docs](super) for the full strategy, including how mid-term
+    /// floor raises pull the cursor back.
     fn fetch_missing(&mut self, cause: View) -> Vec<Effect> {
         let mut effects = Vec::with_capacity(self.fetch_concurrent);
         let mut cursor = self.fetch_floor.max(self.floor_view().next());
@@ -259,13 +254,10 @@ impl<S: Scheme, D: Digest> State<S, D> {
             .retain(|view, _| covers_above_floor(*view, term_length, floor));
         self.failed_views.retain(|view| *view > floor);
 
-        // A floor inside a partially-fetched term strands the rest of the
-        // term: the term's anchor request is retained out (its key is not
-        // above the floor), later-keyed requests accept nothing from this
-        // term, and the fetch cursor has already scanned past it. Pull the
-        // cursor back to just above the floor so a fetch scan re-requests
-        // the term tail once it falls below the current view (the cursor
-        // may exceed the current view here, so an eager fetch could not).
+        // A floor inside a partially-fetched term strands the term's tail
+        // (see the module docs). Pull the cursor back to just above the
+        // floor so a later scan re-requests the tail (the cursor may exceed
+        // the current view here, so an eager fetch could not).
         let next = floor.next();
         if !next.is_term_start(self.term_length) {
             self.fetch_floor = self.fetch_floor.min(next);

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -730,8 +730,8 @@ impl<
         match msg {
             Message::Proposal { proposal, .. } => {
                 let view = proposal.view();
-                if !self.state.is_interesting_vote(view) {
-                    trace!(%view, "proposal is not interesting");
+                if !self.state.admits_vote(view) {
+                    trace!(%view, "proposal outside tracked window");
                     return None;
                 }
                 trace!(%view, "received proposal");
@@ -747,8 +747,8 @@ impl<
             } => {
                 // Certificates can come from future views (they advance our view)
                 let view = certificate.view();
-                if !self.state.is_interesting_certificate(view) {
-                    trace!(%view, "certificate is not interesting");
+                if !self.state.admits_certificate(view) {
+                    trace!(%view, "certificate outside tracked window");
                     return None;
                 }
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -731,7 +731,7 @@ impl<
             Message::Proposal { proposal, .. } => {
                 let view = proposal.view();
                 if !self.state.admits_vote(view) {
-                    trace!(%view, "proposal outside tracked window");
+                    trace!(%view, "proposal outside viewport");
                     return None;
                 }
                 trace!(%view, "received proposal");
@@ -748,7 +748,7 @@ impl<
                 // Certificates can come from future views (they advance our view)
                 let view = certificate.view();
                 if !self.state.admits_certificate(view) {
-                    trace!(%view, "certificate outside tracked window");
+                    trace!(%view, "certificate outside viewport");
                     return None;
                 }
 

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -1142,7 +1142,7 @@ mod tests {
 
             // Establish Prune Floor (50 - 10 + 5 = 45)
             //
-            // Theoretical interesting floor is 50-10 = 40.
+            // Theoretical retention floor is 50-10 = 40.
             // We want journal pruned at 45.
             let lf_target = View::new(50);
             let journal_floor_target = lf_target
@@ -1217,10 +1217,10 @@ mod tests {
                 _ => panic!("unexpected resolver message"),
             }
 
-            // Send notarization below oldest interesting view (42)
+            // Send notarization below oldest tracked view (42)
             //
             // problematic_view (42) < journal_floor_target (45)
-            // interesting(42, false) -> 42 + AT(10) >= LF(50) -> 52 >= 50
+            // Window::retains(42): 42 >= floor (LF(50) - AT(10) = 40)
             let problematic_view = journal_floor_target.saturating_sub(ViewDelta::new(3));
             let proposal_bft = Proposal::new(
                 Round::new(Epoch::new(333), problematic_view),

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -1220,7 +1220,7 @@ mod tests {
             // Send notarization below oldest tracked view (42)
             //
             // problematic_view (42) < journal_floor_target (45)
-            // Window::retains(42): 42 >= floor (LF(50) - AT(10) = 40)
+            // Viewport::retains(42): 42 >= floor (LF(50) - AT(10) = 40)
             let problematic_view = journal_floor_target.saturating_sub(ViewDelta::new(3));
             let proposal_bft = Proposal::new(
                 Round::new(Epoch::new(333), problematic_view),

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -475,7 +475,11 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     pub fn add_nullification(&mut self, nullification: Nullification<S>) -> bool {
         let view = nullification.view();
 
-        // Skip to the start of the next term.
+        // Skip to the start of the next term. This needs no finalization
+        // guard: a nullification below `last_finalized` in an earlier term
+        // targets a view at or below it (`enter_view` only advances), and one
+        // in the same term cannot exist (see [Same-Term Vote
+        // Safety](crate::simplex#same-term-vote-safety)).
         let next_view = view.next_term_start(self.term_length());
         self.enter_view(next_view);
         self.set_leader(next_view, Some(&nullification.certificate));

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -2,7 +2,7 @@ use super::round::Round;
 use crate::{
     Viewable,
     simplex::{
-        Floor, Window,
+        Floor, Viewport,
         elector::Elector,
         metrics::{Leader, Timeout, TimeoutReason},
         scheme::Scheme,
@@ -206,7 +206,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
     /// Returns the lowest view that must remain in memory to satisfy the activity timeout.
     pub fn min_active(&self) -> View {
-        self.window().floor()
+        self.viewport().floor()
     }
 
     /// Returns the term length of the elector.
@@ -215,8 +215,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     }
 
     /// Returns the window of views this state machine tracks.
-    fn window(&self) -> Window {
-        Window {
+    fn viewport(&self) -> Viewport {
+        Viewport {
             finalized: self.last_finalized,
             current: self.view,
             activity_timeout: self.activity_timeout,
@@ -224,15 +224,15 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         }
     }
 
-    /// Returns whether a vote for `pending` is tracked (see [Window::admits_vote]).
+    /// Returns whether a vote for `pending` is tracked (see [Viewport::admits_vote]).
     pub fn admits_vote(&self, pending: View) -> bool {
-        self.window().admits_vote(pending)
+        self.viewport().admits_vote(pending)
     }
 
     /// Returns whether a certificate for `pending` is tracked (see
-    /// [Window::admits_certificate]).
+    /// [Viewport::admits_certificate]).
     pub fn admits_certificate(&self, pending: View) -> bool {
-        self.window().admits_certificate(pending)
+        self.viewport().admits_certificate(pending)
     }
 
     /// Returns true when the local signer is the participant with index `idx`.

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -2,7 +2,7 @@ use super::round::Round;
 use crate::{
     Viewable,
     simplex::{
-        Floor,
+        Floor, Window,
         elector::Elector,
         metrics::{Leader, Timeout, TimeoutReason},
         scheme::Scheme,
@@ -80,40 +80,6 @@ impl ParentPayloadError {
             Self::MissingNullification { .. } | Self::ParentNotCertified { .. } => false,
         }
     }
-}
-
-/// The minimum view we are tracking both in-memory and on-disk.
-const fn min_active(activity_timeout: ViewDelta, last_finalized: View) -> View {
-    last_finalized.saturating_sub(activity_timeout)
-}
-
-/// Whether or not a view is interesting to us.
-///
-/// This is a function of both `min_active` and whether `pending` is too far in
-/// the future relative to `current`.
-fn interesting(
-    activity_timeout: ViewDelta,
-    last_finalized: View,
-    current: View,
-    pending: View,
-    allow_unbounded_future: bool,
-    term_length: TermLength,
-) -> bool {
-    // If the view is genesis, skip it, genesis doesn't have votes
-    if pending.is_zero() {
-        return false;
-    }
-    if pending < min_active(activity_timeout, last_finalized) {
-        return false;
-    }
-    // If we don't allow unbounded future views, we still find two future views interesting:
-    // the next view and the first view of the next term. Certificates set
-    // `allow_unbounded_future` because they are self-certifying (see
-    // [`View::admits`]).
-    if !allow_unbounded_future && !current.admits(pending, term_length) {
-        return false;
-    }
-    true
 }
 
 /// Configuration for initializing [`State`].
@@ -239,8 +205,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     }
 
     /// Returns the lowest view that must remain in memory to satisfy the activity timeout.
-    pub const fn min_active(&self) -> View {
-        min_active(self.activity_timeout, self.last_finalized)
+    pub fn min_active(&self) -> View {
+        self.window().floor()
     }
 
     /// Returns the term length of the elector.
@@ -248,28 +214,25 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.elector.terms().length()
     }
 
-    /// Returns whether a vote for `pending` is still relevant for progress.
-    pub fn is_interesting_vote(&self, pending: View) -> bool {
-        interesting(
-            self.activity_timeout,
-            self.last_finalized,
-            self.view,
-            pending,
-            false,
-            self.term_length(),
-        )
+    /// Returns the window of views this state machine tracks.
+    fn window(&self) -> Window {
+        Window {
+            finalized: self.last_finalized,
+            current: self.view,
+            activity_timeout: self.activity_timeout,
+            term_length: self.term_length(),
+        }
     }
 
-    /// Returns whether a certificate for `pending` is relevant for progress.
-    pub fn is_interesting_certificate(&self, pending: View) -> bool {
-        interesting(
-            self.activity_timeout,
-            self.last_finalized,
-            self.view,
-            pending,
-            true,
-            self.term_length(),
-        )
+    /// Returns whether a vote for `pending` is tracked (see [Window::admits_vote]).
+    pub fn admits_vote(&self, pending: View) -> bool {
+        self.window().admits_vote(pending)
+    }
+
+    /// Returns whether a certificate for `pending` is tracked (see
+    /// [Window::admits_certificate]).
+    pub fn admits_certificate(&self, pending: View) -> bool {
+        self.window().admits_certificate(pending)
     }
 
     /// Returns true when the local signer is the participant with index `idx`.
@@ -3762,93 +3725,6 @@ mod tests {
                 "late-arriving finalization at the nullified view should unblock the finalize vote"
             );
         });
-    }
-
-    #[test]
-    fn test_interesting() {
-        let activity_timeout = ViewDelta::new(10);
-        let term_length = TermLength::new(NZU32!(10));
-
-        assert!(!interesting(
-            activity_timeout,
-            View::zero(),
-            View::zero(),
-            View::zero(),
-            false,
-            term_length,
-        ));
-
-        // Below min_active
-        assert!(!interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(5),
-            false,
-            term_length,
-        ));
-
-        // At min_active boundary
-        assert!(interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(10),
-            false,
-            term_length,
-        ));
-
-        // strict mode allows only current.next and current.next_term_start above current
-        assert!(interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(26),
-            false,
-            term_length,
-        ));
-        assert!(interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(31),
-            false,
-            term_length,
-        ));
-        assert!(!interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(27),
-            false,
-            term_length,
-        ));
-        assert!(!interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(34),
-            false,
-            term_length,
-        ));
-
-        // unbounded future still respects lower bound
-        assert!(!interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(9),
-            true,
-            term_length,
-        ));
-        assert!(interesting(
-            activity_timeout,
-            View::new(20),
-            View::new(25),
-            View::new(10_000),
-            true,
-            term_length,
-        ));
     }
 
     #[test]

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -132,9 +132,10 @@ where
 
     /// Reporter for the consensus engine.
     ///
-    /// All activity for views still in progress is exported; votes that arrive at or below
-    /// the highest finalized view are dropped without being reported (see the completeness
-    /// note on [`crate::simplex::types::Activity`]). Consider wrapping with
+    /// Activity is exported for every tracked view, including votes that arrive up to
+    /// `activity_timeout` views below the highest finalized view; votes below that window
+    /// are dropped without being reported. Reported votes are not guaranteed to be
+    /// verified (see [`crate::simplex::types::Activity`]). Consider wrapping with
     /// [`crate::simplex::scheme::reporter::AttributableReporter`] to automatically filter
     /// and verify activities based on scheme attributability.
     pub reporter: F,

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -62,54 +62,86 @@ pub trait Config<S: Scheme>: Clone + Default + Send + 'static {
 }
 
 /// Leadership term structure reported by an [`Elector`].
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
-pub enum Terms {
-    /// Every view is its own term: a new leader is elected each view, and
-    /// leader rotation itself bounds how long finality can stall.
-    ///
-    /// This variant is the only way to configure single-view terms:
-    /// [`Terms::Stable`] with a length of 1 is rejected at engine
-    /// construction.
-    #[default]
-    Rotating,
-    /// Views are grouped into terms of `length` consecutive views served by
-    /// one leader.
-    Stable {
-        /// Number of consecutive views per term (greater than 1).
-        ///
-        /// Consensus-critical: every participant must configure the same
-        /// value (see [`TermLength`]).
-        length: TermLength,
-        /// Maximum time an entered view may remain unfinalized before this
-        /// participant abandons the term: on expiry it treats its current
-        /// view as timed out and votes nullify, which (with a quorum) forms
-        /// a nullification covering the rest of the term and evicts the
-        /// leader.
-        ///
-        /// A Byzantine stable leader can keep every per-view timer satisfied
-        /// while preventing finality: each view notarizes and certifies, but
-        /// no finalization certificate forms. With single-view terms, leader
-        /// rotation bounds such a stall to one view. With longer terms, this
-        /// timeout bounds it instead.
-        stall_timeout: Duration,
-    },
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Terms {
+    /// Number of consecutive views per term (one if and only if rotating).
+    length: TermLength,
+    /// Term-abandonment timeout (set if and only if `length` exceeds one).
+    stall_timeout: Option<Duration>,
 }
 
 impl Terms {
-    /// Returns the number of consecutive views per term.
-    pub const fn length(&self) -> TermLength {
-        match self {
-            Self::Rotating => TermLength::ONE,
-            Self::Stable { length, .. } => *length,
+    /// Every view is its own term: a new leader is elected each view, and
+    /// leader rotation itself bounds how long finality can stall.
+    pub const fn rotating() -> Self {
+        Self {
+            length: TermLength::ONE,
+            stall_timeout: None,
         }
     }
 
-    /// Returns the term-abandonment timeout, if stable leaders are configured.
-    pub const fn stall_timeout(&self) -> Option<Duration> {
-        match self {
-            Self::Rotating => None,
-            Self::Stable { stall_timeout, .. } => Some(*stall_timeout),
+    /// Views are grouped into terms of `length` consecutive views served by
+    /// one leader.
+    ///
+    /// The length is consensus-critical: every participant must configure
+    /// the same value (see [`TermLength`]).
+    ///
+    /// `stall_timeout` is local policy: the maximum time an entered view may
+    /// remain unfinalized before this participant abandons the term. On
+    /// expiry it treats its current view as timed out and votes nullify,
+    /// which (with a quorum) forms a nullification covering the rest of the
+    /// term and evicts the leader.
+    ///
+    /// A Byzantine stable leader can keep every per-view timer satisfied
+    /// while preventing finality: each view notarizes and certifies, but
+    /// no finalization certificate forms. With single-view terms, leader
+    /// rotation bounds such a stall to one view. With longer terms, this
+    /// timeout bounds it instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `length` is 1 or if `stall_timeout` is zero. Single-view
+    /// terms are [`Terms::rotating`] (the default), where per-view timeouts
+    /// already bound a stall.
+    pub const fn stable(length: TermLength, stall_timeout: Duration) -> Self {
+        assert!(
+            length.get() > 1,
+            "stable leaders require a term length greater than 1"
+        );
+        assert!(
+            !stall_timeout.is_zero(),
+            "stable leaders require a stall timeout greater than zero"
+        );
+        Self {
+            length,
+            stall_timeout: Some(stall_timeout),
         }
+    }
+
+    /// Returns the number of consecutive views per term.
+    ///
+    /// Returns [`TermLength::ONE`] if and only if this is [`Terms::rotating`].
+    /// A length of one is the definition of rotation, not an approximation of
+    /// it: all term arithmetic ([`View::covers`], [`View::admits`],
+    /// [`View::term_index`], [`View::next_term_start`]) reduces exactly to
+    /// per-view behavior at length one. The only regime fact the length does
+    /// not carry is the stall deadline, which callers read from
+    /// [`Terms::stall_timeout`].
+    pub const fn length(&self) -> TermLength {
+        self.length
+    }
+
+    /// Returns the term-abandonment timeout, if stable leaders are configured.
+    ///
+    /// Returns `Some` if and only if [`Self::length`] is greater than one.
+    pub const fn stall_timeout(&self) -> Option<Duration> {
+        self.stall_timeout
+    }
+}
+
+impl Default for Terms {
+    fn default() -> Self {
+        Self::rotating()
     }
 }
 
@@ -179,25 +211,24 @@ impl<H: Hasher> RoundRobin<H> {
     pub fn shuffled(seed: &[u8]) -> Self {
         Self {
             seed: Some(seed.to_vec()),
-            terms: Terms::Rotating,
+            terms: Terms::rotating(),
             _phantom: PhantomData,
         }
     }
 
     /// Enables stable leaders: `term_length` consecutive views share a leader,
     /// and a term abandoned after `stall_timeout` evicts them (see
-    /// [`Terms::Stable`]).
+    /// [`Terms::stable`]).
     ///
     /// The term length is consensus-critical: every participant must configure
     /// the same value (see [`TermLength`]). The timeout is local policy.
     ///
-    /// A `term_length` of 1 is rejected at engine construction (single-view
-    /// terms need no timeout and are the default).
+    /// # Panics
+    ///
+    /// Panics if `term_length` is 1 or `stall_timeout` is zero (see
+    /// [`Terms::stable`]).
     pub const fn with_term(mut self, term_length: TermLength, stall_timeout: Duration) -> Self {
-        self.terms = Terms::Stable {
-            length: term_length,
-            stall_timeout,
-        };
+        self.terms = Terms::stable(term_length, stall_timeout);
         self
     }
 }
@@ -264,7 +295,7 @@ impl<S: Scheme> Elector<S> for RoundRobinElector<S> {
 /// certificate is available.
 ///
 /// This elector does not support stable leaders: it has no term-length
-/// configuration and [`Elector::terms`] always returns [`Terms::Rotating`].
+/// configuration and [`Elector::terms`] always returns [`Terms::rotating`].
 ///
 /// Only works with [`super::scheme::bls12381_threshold::vrf`]
 /// (implements [`super::scheme::bls12381_threshold::vrf::Seedable`]).
@@ -324,7 +355,7 @@ where
     V: Variant,
 {
     fn terms(&self) -> Terms {
-        Terms::Rotating
+        Terms::rotating()
     }
 
     fn elect(

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -71,7 +71,7 @@ pub enum Terms {
     /// [`Terms::Stable`] with a length of 1 is rejected at engine
     /// construction.
     #[default]
-    Single,
+    Rotating,
     /// Views are grouped into terms of `length` consecutive views served by
     /// one leader.
     Stable {
@@ -99,7 +99,7 @@ impl Terms {
     /// Returns the number of consecutive views per term.
     pub const fn length(&self) -> TermLength {
         match self {
-            Self::Single => TermLength::ONE,
+            Self::Rotating => TermLength::ONE,
             Self::Stable { length, .. } => *length,
         }
     }
@@ -107,7 +107,7 @@ impl Terms {
     /// Returns the term-abandonment timeout, if stable leaders are configured.
     pub const fn stall_timeout(&self) -> Option<Duration> {
         match self {
-            Self::Single => None,
+            Self::Rotating => None,
             Self::Stable { stall_timeout, .. } => Some(*stall_timeout),
         }
     }
@@ -179,7 +179,7 @@ impl<H: Hasher> RoundRobin<H> {
     pub fn shuffled(seed: &[u8]) -> Self {
         Self {
             seed: Some(seed.to_vec()),
-            terms: Terms::Single,
+            terms: Terms::Rotating,
             _phantom: PhantomData,
         }
     }
@@ -264,7 +264,7 @@ impl<S: Scheme> Elector<S> for RoundRobinElector<S> {
 /// certificate is available.
 ///
 /// This elector does not support stable leaders: it has no term-length
-/// configuration and [`Elector::terms`] always returns [`Terms::Single`].
+/// configuration and [`Elector::terms`] always returns [`Terms::Rotating`].
 ///
 /// Only works with [`super::scheme::bls12381_threshold::vrf`]
 /// (implements [`super::scheme::bls12381_threshold::vrf::Seedable`]).
@@ -324,7 +324,7 @@ where
     V: Variant,
 {
     fn terms(&self) -> Terms {
-        Terms::Single
+        Terms::Rotating
     }
 
     fn elect(

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -87,6 +87,7 @@ impl<
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,
                 mailbox_size: cfg.mailbox_size,
+                activity_timeout: cfg.activity_timeout,
                 skip_timeout: cfg.skip_timeout,
                 term_length,
                 forwarding: cfg.forwarding,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -61,15 +61,7 @@ impl<
         let elector = cfg.elector.build(cfg.scheme.participants());
         let terms = elector.terms();
         let term_length = terms.length();
-        if let elector::Terms::Stable {
-            length,
-            stall_timeout,
-        } = terms
-        {
-            assert!(
-                length.get() > 1,
-                "stable leaders require a term length greater than 1"
-            );
+        if let Some(stall_timeout) = terms.stall_timeout() {
             assert!(
                 stall_timeout > cfg.certification_timeout,
                 "stall timeout must be greater than certification timeout"

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -421,7 +421,7 @@ cfg_if::cfg_if! {
         /// The window of views an actor tracks, bounded below by retention
         /// and above by admission policy.
         #[derive(Clone, Copy)]
-        pub(crate) struct Window {
+        pub(crate) struct Viewport {
             /// Highest finalized view observed.
             pub finalized: View,
             /// View currently being driven.
@@ -432,7 +432,7 @@ cfg_if::cfg_if! {
             pub term_length: TermLength,
         }
 
-        impl Window {
+        impl Viewport {
             /// Returns the lowest view retained (genesis is never tracked).
             pub const fn floor(&self) -> View {
                 self.finalized.saturating_sub(self.activity_timeout)
@@ -2666,7 +2666,7 @@ mod tests {
                     }
                     // A few views may still nullify while lagging validators
                     // catch up after relinking, but a working skip timeout
-                    // bounds that to a handful of views, not the window.
+                    // bounds that to a handful of views, not the viewport.
                     let tolerated_missing = 3;
                     assert!(
                         found >= activity_timeout.get().saturating_sub(tolerated_missing),
@@ -6712,8 +6712,8 @@ mod tests {
     test_for_all_fixtures!(twins, level = "INFO");
 
     #[test]
-    fn test_window() {
-        let window = Window {
+    fn test_viewport() {
+        let viewport = Viewport {
             finalized: View::new(20),
             current: View::new(25),
             activity_timeout: ViewDelta::new(10),
@@ -6721,25 +6721,25 @@ mod tests {
         };
 
         // Genesis is never tracked
-        assert!(!window.retains(View::zero()));
+        assert!(!viewport.retains(View::zero()));
 
         // Retention floor is activity_timeout below finalized
-        assert_eq!(window.floor(), View::new(10));
-        assert!(!window.retains(View::new(9)));
-        assert!(window.retains(View::new(10)));
+        assert_eq!(viewport.floor(), View::new(10));
+        assert!(!viewport.retains(View::new(9)));
+        assert!(viewport.retains(View::new(10)));
 
         // Votes are admitted up to the next view or the next term start
-        assert!(window.admits_vote(View::new(10)));
-        assert!(window.admits_vote(View::new(25)));
-        assert!(window.admits_vote(View::new(26)));
-        assert!(window.admits_vote(View::new(31)));
-        assert!(!window.admits_vote(View::new(5)));
-        assert!(!window.admits_vote(View::new(27)));
-        assert!(!window.admits_vote(View::new(34)));
+        assert!(viewport.admits_vote(View::new(10)));
+        assert!(viewport.admits_vote(View::new(25)));
+        assert!(viewport.admits_vote(View::new(26)));
+        assert!(viewport.admits_vote(View::new(31)));
+        assert!(!viewport.admits_vote(View::new(5)));
+        assert!(!viewport.admits_vote(View::new(27)));
+        assert!(!viewport.admits_vote(View::new(34)));
 
         // Certificates are admitted from arbitrarily far ahead but still
         // respect the retention floor
-        assert!(!window.admits_certificate(View::new(9)));
-        assert!(window.admits_certificate(View::new(10_000)));
+        assert!(!viewport.admits_certificate(View::new(9)));
+        assert!(viewport.admits_certificate(View::new(10_000)));
     }
 }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -126,10 +126,11 @@
 //!   length, see [`elector::Terms`]) and we are still in the same term, we locally time out the
 //!   current view and vote `nullify`. In practice, this tracks the oldest unfinalized view we have
 //!   entered in the current term.
-//! * Votes for views at or below the highest finalized view are ignored on arrival: they produce no
-//!   activity reports, and equivocation at or below the finalized tip is not detected or reported.
-//!   Downstream systems consuming per-vote activity (rewards, slashing) only observe votes for views
-//!   still in progress.
+//! * Votes are tracked down to `activity_timeout` views below the highest finalized view: late
+//!   votes in that window are still reported (and equivocation there is still detected), even
+//!   though they are no longer verified or used for certificate construction. Votes below the
+//!   window are ignored on arrival, so downstream systems consuming per-vote activity (rewards,
+//!   slashing) never observe them.
 //!
 //! ## Protocol Properties
 //!
@@ -406,7 +407,7 @@ pub mod types;
 
 cfg_if::cfg_if! {
     if #[cfg(not(target_arch = "wasm32"))] {
-        use crate::types::Round;
+        use crate::types::{Round, TermLength, View, ViewDelta};
         use commonware_cryptography::PublicKey;
         use commonware_p2p::Recipients;
 
@@ -416,6 +417,51 @@ cfg_if::cfg_if! {
         mod engine;
         pub use engine::Engine;
         mod metrics;
+
+        /// The window of views an actor tracks, bounded below by retention
+        /// and above by admission policy.
+        #[derive(Clone, Copy)]
+        pub(crate) struct Window {
+            /// Highest finalized view observed.
+            pub finalized: View,
+            /// View currently being driven.
+            pub current: View,
+            /// Views retained below `finalized` (for reporting and backfill).
+            pub activity_timeout: ViewDelta,
+            /// Number of views in each leader term.
+            pub term_length: TermLength,
+        }
+
+        impl Window {
+            /// Returns the lowest view retained (genesis is never tracked).
+            pub const fn floor(&self) -> View {
+                self.finalized.saturating_sub(self.activity_timeout)
+            }
+
+            /// Returns whether `view` is retained: at or above the activity
+            /// floor and not genesis. Views up to `activity_timeout` below
+            /// `finalized` are kept so late votes are still reported (even
+            /// when no longer needed for progress).
+            pub const fn retains(&self, view: View) -> bool {
+                !view.is_zero() && view.get() >= self.floor().get()
+            }
+
+            /// Returns whether a vote at `view` is tracked: retained and no
+            /// further ahead than the next view or the first view of the next
+            /// term, bounding memory committed to unverified votes (see
+            /// [`View::admits`]).
+            pub const fn admits_vote(&self, view: View) -> bool {
+                self.retains(view) && self.current.admits(view, self.term_length)
+            }
+
+            /// Returns whether a certificate at `view` is tracked: certificates
+            /// are self-certifying and may arrive from arbitrarily far ahead
+            /// (letting a lagging participant fast-forward), so only retention
+            /// bounds them.
+            pub const fn admits_certificate(&self, view: View) -> bool {
+                self.retains(view)
+            }
+        }
 
         /// Describes how a payload should be broadcast to the network.
         pub enum Plan<P: PublicKey> {
@@ -6664,4 +6710,36 @@ mod tests {
     }
 
     test_for_all_fixtures!(twins, level = "INFO");
+
+    #[test]
+    fn test_window() {
+        let window = Window {
+            finalized: View::new(20),
+            current: View::new(25),
+            activity_timeout: ViewDelta::new(10),
+            term_length: TermLength::new(commonware_utils::NZU32!(10)),
+        };
+
+        // Genesis is never tracked
+        assert!(!window.retains(View::zero()));
+
+        // Retention floor is activity_timeout below finalized
+        assert_eq!(window.floor(), View::new(10));
+        assert!(!window.retains(View::new(9)));
+        assert!(window.retains(View::new(10)));
+
+        // Votes are admitted up to the next view or the next term start
+        assert!(window.admits_vote(View::new(10)));
+        assert!(window.admits_vote(View::new(25)));
+        assert!(window.admits_vote(View::new(26)));
+        assert!(window.admits_vote(View::new(31)));
+        assert!(!window.admits_vote(View::new(5)));
+        assert!(!window.admits_vote(View::new(27)));
+        assert!(!window.admits_vote(View::new(34)));
+
+        // Certificates are admitted from arbitrarily far ahead but still
+        // respect the retention floor
+        assert!(!window.admits_certificate(View::new(9)));
+        assert!(window.admits_certificate(View::new(10_000)));
+    }
 }

--- a/consensus/src/simplex/scheme/mod.rs
+++ b/consensus/src/simplex/scheme/mod.rs
@@ -20,7 +20,7 @@
 //! exposed. For applications only interested in collecting evidence for liveness/faults, use [`reporter::AttributableReporter`]
 //! which automatically handles filtering and verification based on scheme (hiding votes/proofs that are not attributable). To
 //! observe all exported activity, process all messages passed through the [`crate::Reporter`] interface (note that reports
-//! are not exhaustive: votes at or below the finalized tip are dropped without being reported, see
+//! are not exhaustive: votes below the activity window are dropped without being reported, see
 //! [`crate::simplex::types::Activity`]).
 //!
 //! # BLS12-381 Threshold Variants

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -1908,13 +1908,6 @@ where
 /// Activity represents all possible activities that can occur in the consensus protocol.
 /// This includes both regular consensus messages and fault evidence.
 ///
-/// # Completeness
-///
-/// Reports are not exhaustive: votes that arrive at or below the finalized
-/// tip are dropped before verification, so per-validator activity (e.g. used
-/// for rewards) can miss late votes and equivocation at or below the tip is
-/// not reported.
-///
 /// # Verification
 ///
 /// Some activities issued by consensus are not guaranteed to be cryptographically verified (i.e. if not needed


### PR DESCRIPTION
Related: #3352

- **Add `Viewport`**: replaces `interesting()` (six positional arguments, a mode flag, and a `term_length` that was dead whenever `allow_unbounded_future` was set) with a named policy struct shared by the batcher and voter: `retains` (the retention floor), `admits_vote` (retention plus the term-aware future bound from `View::admits`), and `admits_certificate` (retention only: certificates are self-certifying and let a lagging node fast-forward). All view-window checks in both actors route through it, so the window semantics live in one place.
- **Restore retention below the tip**: votes are tracked and reported down to `activity_timeout` views below the last finalized view again (matching `main`), rather than dropped at the tip — preserving straggler participation reports and sub-tip equivocation evidence (`ConflictingNotarize`/`NullifyFinalize`) for reporter consumers. The batcher regains `activity_timeout`, and docs that described the tip-drop (`Activity`, protocol overview, `Config::reporter`) are updated to the restored boundary.
- **Stop future-bounding our own votes**: the voter constructs votes before sending the update that advances the batcher's view, so after a certificate jump a locally constructed vote can be ahead of it — `Constructed` now gates on retention only (admission bounds exist for untrusted network input), pinned by `test_constructed_votes_are_not_future_bounded`.
- **Simplify the fast-timeout quorum check**: instead of recording our own activity alongside observed peers, the batcher caches `required_active` (quorum minus one when we are a participant, since we never observe our own messages and are live by construction).
- **Make `Terms` valid by construction**: `Terms` is now a struct with private fields built only by `Terms::rotating()` (length one, no stall timeout) and `Terms::stable(length, stall_timeout)` (asserts a length greater than 1 and a non-zero timeout), so `Terms::length()` returns `TermLength::ONE` if and only if leaders rotate every view — for any `Elector` impl, not just configurations that pass the engine's checks. The engine keeps only the relational assert that needs its config (`stall_timeout > certification_timeout`), and the single-view regime is named rotating (previously `Terms::Single`) to pair with stable as leader-tenure regimes.
- **Document the resolver fetch strategy**: the resolver module docs now diagram term-anchor requests, the same-term coverage rule, and why a mid-term floor raise pulls the fetch cursor back (including that a rescan re-issues still-pending anchors, which the resolver engine deduplicates), and the `State` docs use the same "anchor" vocabulary. Also documents why `add_nullification` needs no finalization guard (earlier-term sub-tip nullifications no-op by view monotonicity; same-term pairs are unforgeable per Same-Term Vote Safety).
- **Tests**: `test_viewport` covers the policy directly; new `votes_below_finalized_within_activity_window_reported` pins that in-window votes at or below the tip are reported while below-window votes are not; the startup-floor test is adapted to the activity-window boundary.

Also renames `is_interesting_*` → `admits_*` to match `Viewport`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
