### PR TITLE
[codec] Add Zeroed type

### DIFF
--- a/codec/conformance.toml
+++ b/codec/conformance.toml
@@ -178,6 +178,10 @@ hash = "dcb27e675ccce4ba82dd6979036b04198235bec00d3cefbc8e25a639ab4a162e"
 n_cases = 65536
 hash = "edc22446bb2952609d0c8daccf2d22f8ad2b71eedfcf45296c3f4db49d78404a"
 
+["commonware_codec::types::zeroed::tests::conformance::CodecConformance<Zeroed>"]
+n_cases = 65536
+hash = "8b1f2c316a515b1bec229b1b824acdc0630e27c2430d33cb3c5049e38b188248"
+
 ["commonware_codec::varint::tests::conformance::CodecConformance<SInt<i128>>"]
 n_cases = 65536
 hash = "42320f03747b52912d8dbb129a5958fe00ebd434a3381e3aa7daca2f48981113"

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -18,6 +18,7 @@ pub mod primitives;
 pub mod range;
 pub mod tuple;
 pub mod vec;
+pub mod zeroed;
 
 /// Read keyed items from [Buf] in ascending order.
 pub(crate) fn read_ordered_map<K, V, F>(

--- a/codec/src/types/zeroed.rs
+++ b/codec/src/types/zeroed.rs
@@ -1,0 +1,105 @@
+//! Zero-filled padding for fixed-width encodings.
+//!
+//! # Status
+//!
+//! This type is **BETA**.
+//!
+//! # Examples
+//!
+//! ```
+//! use commonware_codec::{Decode, Encode, types::zeroed::Zeroed};
+//!
+//! let padding = Zeroed::new(4);
+//! assert_eq!(padding.encode().as_ref(), &[0u8; 4]);
+//! assert_eq!(Zeroed::decode_cfg(&[0u8; 4][..], &4).unwrap(), padding);
+//! ```
+
+use crate::{EncodeSize, Error, Read, Write, util::ensure_zeros};
+use bytes::{Buf, BufMut};
+
+/// A runtime-sized sequence of zero bytes.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Zeroed(usize);
+
+impl Zeroed {
+    /// Creates zero-filled padding of `len` bytes.
+    pub const fn new(len: usize) -> Self {
+        Self(len)
+    }
+}
+
+impl Write for Zeroed {
+    #[inline]
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_bytes(0, self.0);
+    }
+}
+
+impl EncodeSize for Zeroed {
+    #[inline]
+    fn encode_size(&self) -> usize {
+        self.0
+    }
+}
+
+impl Read for Zeroed {
+    type Cfg = usize;
+
+    #[inline]
+    fn read_cfg(buf: &mut impl Buf, len: &Self::Cfg) -> Result<Self, Error> {
+        ensure_zeros(buf, *len)?;
+        Ok(Self::new(*len))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl arbitrary::Arbitrary<'_> for Zeroed {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self::new(u.int_in_range(0..=1024u16)?.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Decode, Encode, Error, Read};
+    use bytes::Buf;
+
+    #[test]
+    fn test_codec() {
+        for len in [0, 1, 64, 255, 256] {
+            let zeroed = Zeroed::new(len);
+            let encoded = zeroed.encode();
+
+            assert_eq!(encoded.len(), len);
+            assert!(encoded.iter().all(|byte| *byte == 0));
+            assert_eq!(Zeroed::decode_cfg(encoded, &len).unwrap(), zeroed);
+        }
+    }
+
+    #[test]
+    fn test_read_validation() {
+        let mut valid = &[0, 0, 7][..];
+        assert_eq!(Zeroed::read_cfg(&mut valid, &2).unwrap(), Zeroed::new(2));
+        assert_eq!(valid.remaining(), 1);
+
+        assert!(matches!(
+            Zeroed::decode_cfg(&[0][..], &2),
+            Err(Error::EndOfBuffer)
+        ));
+        assert!(matches!(
+            Zeroed::decode_cfg(&[0, 1][..], &2),
+            Err(Error::Invalid("codec", "non-zero bytes"))
+        ));
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::*;
+        use crate::conformance::CodecConformance;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<Zeroed>
+        }
+    }
+}

--- a/storage/src/qmdb/any/operation/fixed.rs
+++ b/storage/src/qmdb/any/operation/fixed.rs
@@ -10,8 +10,8 @@ use crate::{
     },
 };
 use commonware_codec::{
-    Codec, CodecFixed, Error as CodecError, FixedSize, ReadExt as _, Write,
-    util::{at_least, ensure_zeros},
+    Codec, CodecFixed, Error as CodecError, FixedSize, Read as _, ReadExt as _, Write,
+    types::zeroed::Zeroed, util::at_least,
 };
 use commonware_runtime::{Buf, BufMut};
 use commonware_utils::Array;
@@ -55,12 +55,12 @@ where
             Operation::Delete(k) => {
                 DELETE_CONTEXT.write(buf);
                 k.write(buf);
-                buf.put_bytes(0, total - delete_op_size::<S::Key>());
+                Zeroed::new(total - delete_op_size::<S::Key>()).write(buf);
             }
             Operation::Update(p) => {
                 UPDATE_CONTEXT.write(buf);
                 p.write(buf);
-                buf.put_bytes(0, total - update_op_size::<S>());
+                Zeroed::new(total - update_op_size::<S>()).write(buf);
             }
             Operation::CommitFloor(metadata, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
@@ -68,10 +68,10 @@ where
                     true.write(buf);
                     metadata.write(buf);
                 } else {
-                    buf.put_bytes(0, V::SIZE + 1);
+                    Zeroed::new(V::SIZE + 1).write(buf);
                 }
                 buf.put_slice(&floor_loc.to_be_bytes());
-                buf.put_bytes(0, total - commit_op_size::<V>());
+                Zeroed::new(total - commit_op_size::<V>()).write(buf);
             }
         }
     }
@@ -86,12 +86,12 @@ where
         match u8::read(buf)? {
             DELETE_CONTEXT => {
                 let key = S::Key::read(buf)?;
-                ensure_zeros(buf, total - delete_op_size::<S::Key>())?;
+                Zeroed::read_cfg(buf, &(total - delete_op_size::<S::Key>()))?;
                 Ok(Operation::Delete(key))
             }
             UPDATE_CONTEXT => {
                 let payload = S::read_cfg(buf, cfg)?;
-                ensure_zeros(buf, total - update_op_size::<S>())?;
+                Zeroed::read_cfg(buf, &(total - update_op_size::<S>()))?;
                 Ok(Operation::Update(payload))
             }
             COMMIT_CONTEXT => {
@@ -99,7 +99,7 @@ where
                 let metadata = if is_some {
                     Some(V::read_cfg(buf, cfg)?)
                 } else {
-                    ensure_zeros(buf, V::SIZE)?;
+                    Zeroed::read_cfg(buf, &V::SIZE)?;
                     None
                 };
                 let floor_loc = Location::new(u64::read(buf)?);
@@ -109,7 +109,7 @@ where
                         "commit floor location overflow",
                     ));
                 }
-                ensure_zeros(buf, total - commit_op_size::<V>())?;
+                Zeroed::read_cfg(buf, &(total - commit_op_size::<V>()))?;
                 Ok(Operation::CommitFloor(metadata, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),


### PR DESCRIPTION
> AI disclosure: This changes have been made with GPT-5.6 Sol (xHigh) but I have manually reviewed them and I take responsibility for its correctness.


## Summary
- add runtime-sized `Zeroed` codec type for zero-filled padding
- validate zero padding without allocation and add codec conformance coverage
- use `Zeroed` in QMDB Any fixed-operation encoding

## Testing
- `just pre-pr`
- `just test-conformance -p commonware-codec zeroed`
- `just test-conformance -p commonware-storage fixed_encoding_u64`

Closes #1703