### PR TITLE
Improve coverage for qmdb

### DIFF
--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -286,3 +286,59 @@ path = "fuzz_targets/qmdb_keyless_compact.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "qmgb_gen_any_ordered_variable"
+path = "fuzz_targets/qmgb_gen_any_ordered_variable.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_current_ordered_variable"
+path = "fuzz_targets/qmgb_gen_current_ordered_variable.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_immutable_fixed"
+path = "fuzz_targets/qmgb_gen_immutable_fixed.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_immutable_compact"
+path = "fuzz_targets/qmgb_gen_immutable_compact.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_keyless_fixed"
+path = "fuzz_targets/qmgb_gen_keyless_fixed.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_keyless_compact_fixed"
+path = "fuzz_targets/qmgb_gen_keyless_compact_fixed.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_partitioned"
+path = "fuzz_targets/qmgb_gen_partitioned.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "qmgb_gen_stream_sync"
+path = "fuzz_targets/qmgb_gen_stream_sync.rs"
+test = false
+doc = false
+bench = false

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -34,6 +34,7 @@ type RawValue = [u8; 32];
 
 /// Maximum write buffer size.
 const MAX_WRITE_BUF: usize = 2048;
+const MAX_OPERATIONS: usize = 50;
 
 type Db<F> = Current<F, deterministic::Context, Key, Value, Sha256, TwoCap, 32, Sequential>;
 
@@ -68,25 +69,49 @@ enum CurrentOperation {
 }
 
 /// Fuzz input containing fault injection parameters and operations.
-#[derive(Arbitrary, Debug)]
+#[derive(Debug)]
 struct FuzzInput {
     seed: u64,
-    #[arbitrary(with = bounded_page_size)]
     page_size: u16,
-    #[arbitrary(with = bounded_page_cache_size)]
     page_cache_size: usize,
-    #[arbitrary(with = bounded_items_per_blob)]
     merkle_items_per_blob: u64,
-    #[arbitrary(with = bounded_items_per_blob)]
     log_items_per_blob: u64,
-    #[arbitrary(with = bounded_write_buffer)]
     write_buffer: usize,
-    #[arbitrary(with = bounded_nonzero_rate)]
     sync_failure_rate: f64,
-    #[arbitrary(with = bounded_nonzero_rate)]
     write_failure_rate: f64,
     operations: Vec<CurrentOperation>,
     raw_bytes: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let seed = u.arbitrary()?;
+        let page_size = bounded_page_size(u)?;
+        let page_cache_size = bounded_page_cache_size(u)?;
+        let merkle_items_per_blob = bounded_items_per_blob(u)?;
+        let log_items_per_blob = bounded_items_per_blob(u)?;
+        let write_buffer = bounded_write_buffer(u)?;
+        let sync_failure_rate = bounded_nonzero_rate(u)?;
+        let write_failure_rate = bounded_nonzero_rate(u)?;
+        let num_operations = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let operations = (0..num_operations)
+            .map(|_| CurrentOperation::arbitrary(u))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            seed,
+            page_size,
+            page_cache_size,
+            merkle_items_per_blob,
+            log_items_per_blob,
+            write_buffer,
+            sync_failure_rate,
+            write_failure_rate,
+            operations,
+            raw_bytes,
+        })
+    }
 }
 
 fn make_config(
@@ -189,10 +214,6 @@ async fn commit_pending<F: Graftable>(
 }
 
 fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
-    if input.operations.is_empty() {
-        return;
-    }
-
     let page_size = NonZeroU16::new(input.page_size).unwrap();
     let page_cache_size = NonZeroUsize::new(input.page_cache_size).unwrap();
     let merkle_items_per_blob = input.merkle_items_per_blob;

--- a/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_batch_root.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_runtime::{
@@ -54,7 +54,9 @@ struct FuzzInput {
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
         let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
@@ -73,7 +75,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
             initial,
             parent,
             child,
-            raw_bytes: u.bytes(u.len())?.to_vec(),
+            raw_bytes,
         })
     }
 }
@@ -150,7 +152,42 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                 Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
             };
         }
+        let parent_keys = input
+            .parent
+            .iter()
+            .map(|mutation| match mutation {
+                Mutation::Write { key, .. } | Mutation::Delete { key } => key_from_seed(*key),
+            })
+            .collect::<Vec<_>>();
+        let parent_key_refs = parent_keys.iter().collect::<Vec<_>>();
+        let parent_many = batch.get_many(&parent_key_refs, &db).await.unwrap();
+        let mut parent_single = Vec::with_capacity(parent_keys.len());
+        for key in &parent_keys {
+            parent_single.push(batch.get(key, &db).await.unwrap());
+        }
+        assert_eq!(
+            parent_many, parent_single,
+            "unmerkleized batch get_many diverged from repeated get"
+        );
         let parent = batch.merkleize(&db, None).await.unwrap();
+        assert_eq!(
+            parent.bounds().base_size,
+            *db.bounds().end,
+            "parent batch should start at the committed database size"
+        );
+        assert!(
+            parent.bounds().total_size > parent.bounds().base_size,
+            "merkleized batch should include a commit operation"
+        );
+        let parent_many = parent.get_many(&parent_key_refs, &db).await.unwrap();
+        let mut parent_single = Vec::with_capacity(parent_keys.len());
+        for key in &parent_keys {
+            parent_single.push(parent.get(key, &db).await.unwrap());
+        }
+        assert_eq!(
+            parent_many, parent_single,
+            "merkleized batch get_many diverged from repeated get"
+        );
         let mut batch = parent.new_batch::<Sha256>();
         for mutation in &input.child {
             batch = match mutation {
@@ -166,6 +203,27 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
         // committed wrapper state. Both canonical and ops roots must match.
         let (db, _) = db.apply_batch(parent).await.unwrap();
         let db = db.commit().await.unwrap();
+        let snapshot = db.to_batch();
+        assert_eq!(
+            snapshot.root(),
+            db.root(),
+            "snapshot root should match the database"
+        );
+        assert_eq!(
+            snapshot.ops_root(),
+            db.ops_root(),
+            "snapshot ops root should match the database"
+        );
+        assert_eq!(
+            snapshot.bounds().total_size,
+            *db.bounds().end,
+            "snapshot size should match the database"
+        );
+        assert_eq!(
+            snapshot.sync_boundary(),
+            db.sync_boundary(),
+            "snapshot sync boundary should match the database"
+        );
 
         let mut batch = db.new_batch();
         for mutation in &input.child {
@@ -177,6 +235,48 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
             };
         }
         let committed_child = batch.merkleize(&db, None).await.unwrap();
+
+        assert_eq!(
+            pending_child.bounds().base_size,
+            committed_child.bounds().base_size,
+            "child base size depended on pending-vs-committed parent path"
+        );
+        assert_eq!(
+            pending_child.bounds().total_size,
+            committed_child.bounds().total_size,
+            "child total size depended on pending-vs-committed parent path"
+        );
+        assert_eq!(
+            pending_child.sync_boundary(),
+            committed_child.sync_boundary(),
+            "child sync boundary depended on pending-vs-committed parent path"
+        );
+        assert!(
+            db.validate_batch(&pending_child).is_ok(),
+            "child of the committed parent should validate"
+        );
+        assert!(
+            db.validate_batch(&committed_child).is_ok(),
+            "fresh child of the committed database should validate"
+        );
+
+        let child_keys = input
+            .child
+            .iter()
+            .map(|mutation| match mutation {
+                Mutation::Write { key, .. } | Mutation::Delete { key } => key_from_seed(*key),
+            })
+            .collect::<Vec<_>>();
+        let child_key_refs = child_keys.iter().collect::<Vec<_>>();
+        let pending_many = pending_child.get_many(&child_key_refs, &db).await.unwrap();
+        let committed_many = committed_child
+            .get_many(&child_key_refs, &db)
+            .await
+            .unwrap();
+        assert_eq!(
+            pending_many, committed_many,
+            "child reads depended on pending-vs-committed parent path"
+        );
 
         assert_eq!(
             pending_child.root(),
@@ -200,6 +300,23 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
             db.ops_root(),
             committed_child.ops_root(),
             "pending child ops root diverged"
+        );
+        assert_eq!(
+            db.bounds().end,
+            commonware_storage::merkle::Location::<F>::new(committed_child.bounds().total_size),
+            "applied child size should match its batch bounds"
+        );
+        assert_eq!(
+            db.sync_boundary(),
+            committed_child.sync_boundary(),
+            "applied child sync boundary should match its batch"
+        );
+        assert!(
+            matches!(
+                db.validate_batch(&committed_child),
+                Err(commonware_storage::qmdb::Error::StaleBatch { .. })
+            ),
+            "sibling child should be stale after the other branch is applied"
         );
 
         db.destroy().await.unwrap();

--- a/storage/fuzz/fuzz_targets/current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/current_unordered_operations.rs
@@ -1,13 +1,20 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::{Sha256, sha256::Digest};
-use commonware_parallel::Sequential;
+use commonware_parallel::{Sequential, Strategy as _};
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{Graftable, Location, full::Config as MerkleConfig, mmb, mmr},
-    qmdb::current::{FixedConfig as Config, unordered::fixed::Db as CurrentDb},
+    qmdb::{
+        any::unordered::{Update as UnorderedUpdate, fixed::Operation as UnorderedOperation},
+        current::{
+            FixedConfig as Config, proof::verify_proof_and_extract_digests,
+            unordered::fixed::Db as CurrentDb,
+        },
+        verify_proof, verify_proof_and_pinned_nodes,
+    },
     translator::TwoCap,
 };
 use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize, sequence::FixedBytes};
@@ -39,6 +46,19 @@ enum CurrentOperation {
     Prune,
     OpCount,
     Root,
+    GetMetadata,
+    OpsRootWitness {
+        other_ops_root: RawValue,
+    },
+    OpsHistoricalProof {
+        start_loc: u64,
+        max_ops: NonZeroU64,
+    },
+    PinnedProof {
+        start_loc: u64,
+        max_ops: NonZeroU64,
+    },
+    Sync,
     RangeProof {
         start_loc: u64,
         max_ops: NonZeroU64,
@@ -53,6 +73,10 @@ enum CurrentOperation {
         bad_partial_digest: Option<[u8; 32]>,
         max_ops: NonZeroU64,
         chunk_xor: [u8; 32],
+    },
+    Rewind,
+    Strategy {
+        values: [u8; 4],
     },
 }
 
@@ -70,7 +94,9 @@ struct FuzzInput {
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let initial_writes = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let operations = (0..num_ops)
@@ -79,7 +105,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
         Ok(FuzzInput {
             initial_writes,
             operations,
-            raw_bytes: u.bytes(u.len())?.to_vec(),
+            raw_bytes,
         })
     }
 }
@@ -127,11 +153,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let initial_writes = data.initial_writes;
     let operations = data.operations.clone();
     runner.start(|context| async move {
-        let page_cache = CacheRef::from_pooler(
-            &context,
-            PAGE_SIZE,
-            NZUsize!(PAGE_CACHE_SIZE),
-        );
+        let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE));
         let cfg = Config {
             merkle_config: MerkleConfig {
                 journal_partition: format!("fuzz-current-{suffix}-merkle-journal"),
@@ -198,7 +220,11 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 CurrentOperation::Delete { key } => {
                     let k = Key::new(*key);
                     // Check if key exists in committed state or pending writes.
-                    let key_existed = db.get(&k).await.expect("Get before delete should not fail").is_some()
+                    let key_existed = db
+                        .get(&k)
+                        .await
+                        .expect("Get before delete should not fail")
+                        .is_some()
                         || pending_expected.get(key).is_some_and(|v| v.is_some());
                     if key_existed {
                         pending_writes.push((k, None));
@@ -217,11 +243,20 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         Some(Some(expected_value)) => {
                             assert!(result.is_some(), "Expected value for key {key:?}");
                             let actual_value = result.expect("Should have value");
-                            let actual_bytes: &[u8; 32] = actual_value.as_ref().try_into().expect("Value should be 32 bytes");
-                            assert_eq!(actual_bytes, expected_value, "Value mismatch for key {key:?}");
+                            let actual_bytes: &[u8; 32] = actual_value
+                                .as_ref()
+                                .try_into()
+                                .expect("Value should be 32 bytes");
+                            assert_eq!(
+                                actual_bytes, expected_value,
+                                "Value mismatch for key {key:?}"
+                            );
                         }
                         Some(None) => {
-                            assert!(result.is_none(), "Expected no value for deleted key {key:?}");
+                            assert!(
+                                result.is_none(),
+                                "Expected no value for deleted key {key:?}"
+                            );
                         }
                         None => {
                             assert!(result.is_none(), "Expected no value for unset key {key:?}");
@@ -242,22 +277,202 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 }
 
                 CurrentOperation::Commit => {
-                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
                     committed_op_count = db.bounds().end;
                     db
                 }
 
                 CurrentOperation::Prune => {
-                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
                     committed_op_count = db.bounds().end;
                     let boundary = db.sync_boundary();
                     db.prune(boundary).await.expect("Prune should not fail")
                 }
 
                 CurrentOperation::Root => {
-                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
                     committed_op_count = db.bounds().end;
-                    let _root = db.root();
+                    assert_eq!(
+                        db.root(),
+                        db.to_batch().root(),
+                        "database and snapshot roots should match",
+                    );
+                    db
+                }
+
+                CurrentOperation::GetMetadata => {
+                    assert!(
+                        db.get_metadata()
+                            .await
+                            .expect("metadata read should not fail")
+                            .is_none(),
+                        "commits without metadata should not produce metadata"
+                    );
+                    db
+                }
+
+                CurrentOperation::OpsRootWitness { other_ops_root } => {
+                    let witness = db
+                        .ops_root_witness()
+                        .await
+                        .expect("ops root witness should not fail");
+                    let ops_root = db.ops_root();
+                    let root = db.root();
+                    assert_eq!(
+                        witness.root::<Sha256>(&ops_root),
+                        root,
+                        "ops root witness should reconstruct the canonical root"
+                    );
+                    assert!(
+                        witness.verify::<Sha256>(&ops_root, &root),
+                        "ops root witness should authenticate the ops root"
+                    );
+                    let other_ops_root = Digest::from(*other_ops_root);
+                    if other_ops_root != ops_root {
+                        assert!(
+                            !witness.verify::<Sha256>(&other_ops_root, &root),
+                            "ops root witness should reject a different ops root",
+                        );
+                    }
+                    db
+                }
+
+                CurrentOperation::OpsHistoricalProof { start_loc, max_ops } => {
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
+                    committed_op_count = db.bounds().end;
+                    let bounds = db.bounds();
+                    let retained = *bounds.end - *bounds.start;
+                    if retained == 0 {
+                        db
+                    } else {
+                        let start = Location::<F>::new(*bounds.start + start_loc % retained);
+                        let (proof, ops) = db
+                            .ops_historical_proof(bounds.end, start, *max_ops)
+                            .await
+                            .expect("ops historical proof should not fail");
+                        assert!(
+                            verify_proof::<Sha256, _, _>(&proof, start, &ops, &db.ops_root()),
+                            "ops historical proof should verify against the ops root"
+                        );
+                        db
+                    }
+                }
+
+                CurrentOperation::PinnedProof { start_loc, max_ops } => {
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
+                    committed_op_count = db.bounds().end;
+                    let bounds = db.bounds();
+                    let lower = db.sync_boundary().max(bounds.start);
+                    let retained = *bounds.end - *lower;
+                    if retained == 0 {
+                        db
+                    } else {
+                        let start = Location::<F>::new(*lower + start_loc % retained);
+                        let (proof, ops) = db
+                            .ops_historical_proof(bounds.end, start, *max_ops)
+                            .await
+                            .expect("ops historical proof should not fail");
+                        let pinned = db
+                            .pinned_nodes_at(start)
+                            .await
+                            .expect("pinned node lookup should not fail");
+                        assert!(
+                            verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                                &proof,
+                                start,
+                                &ops,
+                                &pinned,
+                                &db.ops_root(),
+                            ),
+                            "proof and pinned nodes should verify against the ops root"
+                        );
+                        db
+                    }
+                }
+
+                CurrentOperation::Sync => {
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
+                    committed_op_count = db.bounds().end;
+                    let root = db.root();
+                    let ops_root = db.ops_root();
+                    let bounds = db.bounds();
+                    let metadata = db
+                        .get_metadata()
+                        .await
+                        .expect("metadata read should not fail");
+                    let db = db.sync().await.expect("sync should not fail");
+                    assert_eq!(db.root(), root, "sync should preserve the canonical root");
+                    assert_eq!(db.ops_root(), ops_root, "sync should preserve the ops root");
+                    assert_eq!(db.bounds(), bounds, "sync should preserve retained bounds");
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("metadata read should not fail"),
+                        metadata,
+                        "sync should preserve metadata"
+                    );
+                    db
+                }
+
+                CurrentOperation::Rewind => {
+                    let root = db.root();
+                    let ops_root = db.ops_root();
+                    let bounds = db.bounds();
+                    let db = db
+                        .rewind(bounds.end)
+                        .await
+                        .expect("rewinding to the current tip should not fail");
+                    assert_eq!(db.root(), root);
+                    assert_eq!(db.ops_root(), ops_root);
+                    assert_eq!(db.bounds(), bounds);
+                    db
+                }
+
+                CurrentOperation::Strategy { values } => {
+                    let expected = values.iter().map(|value| u64::from(*value)).sum::<u64>();
+                    let actual = db.strategy().fold(
+                        values,
+                        || 0u64,
+                        |sum, value| sum + u64::from(*value),
+                        |left, right| left + right,
+                    );
+                    assert_eq!(actual, expected, "database strategy produced a wrong fold");
                     db
                 }
 
@@ -267,7 +482,13 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         continue;
                     }
 
-                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
@@ -286,10 +507,25 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                                 start_loc,
                                 &ops,
                                 &chunks,
-                                &current_root
-                                ),
-                                "Range proof verification failed for start_loc={start_loc}, max_ops={max_ops}"
-                            );
+                                &current_root,
+                            ),
+                            "database range proof verification should succeed",
+                        );
+                        assert!(
+                            proof.verify::<Sha256, _, 32>(start_loc, &ops, &chunks, &current_root,),
+                            "range proof should verify against the canonical root",
+                        );
+                        assert!(
+                            verify_proof_and_extract_digests::<F, _, Sha256, _, 32>(
+                                &proof,
+                                start_loc,
+                                &ops,
+                                &chunks,
+                                &current_root,
+                            )
+                            .is_ok(),
+                            "verified range proof should yield positioned digests"
+                        );
                     }
                     db
                 }
@@ -306,76 +542,97 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     if current_op_count == 0 {
                         continue;
                     }
-                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
                     committed_op_count = db.bounds().end;
 
                     let current_op_count = db.bounds().end;
                     let start_loc = Location::<F>::new(start_loc % current_op_count.as_u64());
                     let root = db.root();
 
-                    if let Ok((range_proof, ops, chunks)) = db
-                        .range_proof(start_loc, *max_ops)
-                        .await {
+                    if let Ok((range_proof, ops, chunks)) =
+                        db.range_proof(start_loc, *max_ops).await
+                    {
                         // Try to verify the proof when providing bad proof digests.
                         let bad_digests = bad_digests.iter().map(|d| Digest::from(*d)).collect();
                         if range_proof.proof.digests != bad_digests {
                             let mut bad_digest_proof = range_proof.clone();
                             bad_digest_proof.proof.digests = bad_digests;
-                            assert!(!Db::<F>::verify_range_proof(
-                                &bad_digest_proof,
-                                start_loc,
-                                &ops,
-                                &chunks,
-                                &root
-                            ), "proof with bad digests should not verify");
+                            assert!(
+                                !Db::<F>::verify_range_proof(
+                                    &bad_digest_proof,
+                                    start_loc,
+                                    &ops,
+                                    &chunks,
+                                    &root
+                                ),
+                                "proof with bad digests should not verify"
+                            );
                         }
 
                         let bad_pending_digest = (*bad_pending_digest).map(Digest::from);
-                        if let Ok(bad_pending) = <F::PendingChunk<Digest>>::try_from(bad_pending_digest)
+                        if let Ok(bad_pending) =
+                            <F::PendingChunk<Digest>>::try_from(bad_pending_digest)
                             && range_proof.pending_chunk_digest != bad_pending
                         {
                             let mut bad_pending_proof = range_proof.clone();
                             bad_pending_proof.pending_chunk_digest = bad_pending;
-                            assert!(!Db::<F>::verify_range_proof(
-                                &bad_pending_proof,
-                                start_loc,
-                                &ops,
-                                &chunks,
-                                &root
-                            ), "proof with bad pending chunk digest should not verify");
+                            assert!(
+                                !Db::<F>::verify_range_proof(
+                                    &bad_pending_proof,
+                                    start_loc,
+                                    &ops,
+                                    &chunks,
+                                    &root
+                                ),
+                                "proof with bad pending chunk digest should not verify"
+                            );
                         }
 
                         let bad_partial_digest = (*bad_partial_digest).map(Digest::from);
                         if range_proof.partial_chunk_digest != bad_partial_digest {
                             let mut bad_partial_proof = range_proof.clone();
                             bad_partial_proof.partial_chunk_digest = bad_partial_digest;
-                            assert!(!Db::<F>::verify_range_proof(
-                                &bad_partial_proof,
-                                start_loc,
-                                &ops,
-                                &chunks,
-                                &root
-                            ), "proof with bad partial chunk digest should not verify");
+                            assert!(
+                                !Db::<F>::verify_range_proof(
+                                    &bad_partial_proof,
+                                    start_loc,
+                                    &ops,
+                                    &chunks,
+                                    &root
+                                ),
+                                "proof with bad partial chunk digest should not verify"
+                            );
                         }
 
                         // Try to verify the proof when providing bad input chunks.
-                        let bad_chunks: Vec<[u8; 32]> = chunks.iter().map(|c| {
-                            let mut corrupted = *c;
-                            for (b, x) in corrupted.iter_mut().zip(chunk_xor.iter()) {
-                                *b ^= *x;
-                            }
-                            corrupted
-                        }).collect();
+                        let bad_chunks: Vec<[u8; 32]> = chunks
+                            .iter()
+                            .map(|c| {
+                                let mut corrupted = *c;
+                                for (b, x) in corrupted.iter_mut().zip(chunk_xor.iter()) {
+                                    *b ^= *x;
+                                }
+                                corrupted
+                            })
+                            .collect();
                         if chunks != bad_chunks {
-                            assert!(!Db::<F>::verify_range_proof(
-                                &range_proof,
-                                start_loc,
-                                &ops,
-                                &bad_chunks,
-                                &root
-                            ), "proof with bad chunks should not verify");
+                            assert!(
+                                !Db::<F>::verify_range_proof(
+                                    &range_proof,
+                                    start_loc,
+                                    &ops,
+                                    &bad_chunks,
+                                    &root
+                                ),
+                                "proof with bad chunks should not verify"
+                            );
                         }
-
                     }
                     db
                 }
@@ -383,20 +640,53 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 CurrentOperation::KeyValueProof { key } => {
                     let k = Key::new(*key);
 
-                    let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                    let db = commit_pending(
+                        db,
+                        &mut pending_writes,
+                        &mut committed_state,
+                        &mut pending_expected,
+                    )
+                    .await;
                     committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     match db.key_value_proof(k.clone()).await {
                         Ok(proof) => {
-                            let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
-                            let verification_result = Db::<F>::verify_key_value_proof(
-                                k,
-                                value,
-                                &proof,
-                                &current_root,
+                            let value = db
+                                .get(&k)
+                                .await
+                                .expect("get should not fail")
+                                .expect("key should exist");
+                            let operation: UnorderedOperation<F, Key, Value> =
+                                UnorderedOperation::Update(UnorderedUpdate(
+                                    k.clone(),
+                                    value.clone(),
+                                ));
+                            assert!(
+                                proof.verify::<Sha256, _>(operation, &current_root),
+                                "operation proof should verify against the canonical root",
                             );
-                            assert!(verification_result, "Key value proof verification failed for key {key:?}");
+                            assert!(
+                                Db::<F>::verify_key_value_proof(
+                                    k.clone(),
+                                    value.clone(),
+                                    &proof,
+                                    &current_root,
+                                ),
+                                "Key value proof verification failed for key {key:?}"
+                            );
+                            let other_value = Value::new(*key);
+                            if other_value != value {
+                                assert!(
+                                    !Db::<F>::verify_key_value_proof(
+                                        k,
+                                        other_value,
+                                        &proof,
+                                        &current_root,
+                                    ),
+                                    "key value proof should reject a different value",
+                                );
+                            }
                         }
                         Err(commonware_storage::qmdb::Error::KeyNotFound) => {
                             let expected_value = committed_state.get(key);
@@ -415,9 +705,14 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
         // Final commit to ensure all pending operations are persisted.
         if !pending_writes.is_empty() {
-            db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+            db = commit_pending(
+                db,
+                &mut pending_writes,
+                &mut committed_state,
+                &mut pending_expected,
+            )
+            .await;
         }
-
 
         for key in &all_keys {
             let k = Key::new(*key);
@@ -427,11 +722,20 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 Some(Some(expected_value)) => {
                     assert!(result.is_some(), "Lost value for key {key:?} at end");
                     let actual_value = result.expect("Should have value");
-                    let actual_bytes: &[u8; 32] = actual_value.as_ref().try_into().expect("Value should be 32 bytes");
-                    assert_eq!(actual_bytes, expected_value, "Final value mismatch for key {key:?}");
+                    let actual_bytes: &[u8; 32] = actual_value
+                        .as_ref()
+                        .try_into()
+                        .expect("Value should be 32 bytes");
+                    assert_eq!(
+                        actual_bytes, expected_value,
+                        "Final value mismatch for key {key:?}"
+                    );
                 }
                 Some(None) => {
-                    assert!(result.is_none(), "Deleted key {key:?} should remain deleted");
+                    assert!(
+                        result.is_none(),
+                        "Deleted key {key:?} should remain deleted"
+                    );
                 }
                 None => {
                     assert!(result.is_none(), "Unset key {key:?} should not exist");

--- a/storage/fuzz/fuzz_targets/oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/oversized_recovery.rs
@@ -149,10 +149,21 @@ impl<'a> Arbitrary<'a> for CorruptionType {
     }
 }
 
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum SyncOperation {
+    Scalar,
+    Array,
+    ArrayRef,
+    Slice,
+    Vec,
+    BTreeSet,
+}
+
 #[derive(Arbitrary, Debug)]
 struct FuzzInput {
     /// Number of entries per section (1-10)
     entries_per_section: [u8; 3],
+    sync_operations: [SyncOperation; 3],
     /// Corruptions to apply before recovery
     corruptions: Vec<CorruptionType>,
     /// Whether to sync before corruption
@@ -206,7 +217,25 @@ fn fuzz(input: FuzzInput) {
                 let _ = oversized.append(section, entry, &value).await;
                 entry_id += 1;
             }
-            let _ = oversized.sync(section).await;
+            match input.sync_operations[section_idx] {
+                SyncOperation::Scalar => assert!(oversized.sync(section).await.is_ok()),
+                SyncOperation::Array => assert!(oversized.sync([section]).await.is_ok()),
+                SyncOperation::ArrayRef => {
+                    let sections = [section];
+                    assert!(oversized.sync(&sections).await.is_ok());
+                }
+                SyncOperation::Slice => {
+                    let sections = [section];
+                    assert!(oversized.sync(&sections[..]).await.is_ok());
+                }
+                SyncOperation::Vec => assert!(oversized.sync(vec![section]).await.is_ok()),
+                SyncOperation::BTreeSet => assert!(
+                    oversized
+                        .sync(std::collections::BTreeSet::from([section]))
+                        .await
+                        .is_ok()
+                ),
+            }
         }
 
         if input.sync_before_corrupt {

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -2,7 +2,7 @@
 
 use arbitrary::Arbitrary;
 use commonware_cryptography::Sha256;
-use commonware_parallel::Sequential;
+use commonware_parallel::{Sequential, Strategy as _};
 use commonware_runtime::{
     BufferPooler, Runner, Supervisor as _, buffer::paged::CacheRef, deterministic,
 };
@@ -57,17 +57,21 @@ enum Operation {
     OpCount,
     Root,
     SimulateFailure,
+    Rewind,
+    Strategy {
+        values: [u8; 4],
+    },
 }
 
 impl<'a> Arbitrary<'a> for Operation {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice: u8 = u.arbitrary()?;
-        match choice % 14 {
+        match choice % 16 {
             0 => {
                 let key = u.arbitrary()?;
                 let value_len: u16 = u.arbitrary()?;
                 let actual_len = ((value_len as usize) % 10000) + 1;
-                let value_bytes = u.bytes(actual_len)?.to_vec();
+                let value_bytes = u.bytes(actual_len.min(u.len()))?.to_vec();
                 Ok(Operation::Update { key, value_bytes })
             }
             1 => {
@@ -79,7 +83,7 @@ impl<'a> Arbitrary<'a> for Operation {
                 let metadata_bytes = if has_metadata {
                     let metadata_len: u16 = u.arbitrary()?;
                     let actual_len = ((metadata_len as usize) % 1000) + 1;
-                    Some(u.bytes(actual_len)?.to_vec())
+                    Some(u.bytes(actual_len.min(u.len()))?.to_vec())
                 } else {
                     None
                 };
@@ -112,7 +116,11 @@ impl<'a> Arbitrary<'a> for Operation {
             9 => Ok(Operation::InactivityFloorLoc),
             10 => Ok(Operation::OpCount),
             11 => Ok(Operation::Root),
-            12 | 13 => Ok(Operation::SimulateFailure {}),
+            12 => Ok(Operation::SimulateFailure {}),
+            13 => Ok(Operation::Rewind),
+            14 | 15 => Ok(Operation::Strategy {
+                values: u.arbitrary()?,
+            }),
             _ => unreachable!(),
         }
     }
@@ -126,11 +134,12 @@ struct FuzzInput {
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let ops = (0..num_ops)
             .map(|_| Operation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
-        let raw_bytes = u.bytes(u.len())?.to_vec();
         Ok(FuzzInput { ops, raw_bytes })
     }
 }
@@ -189,16 +198,24 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
         > = BTreeMap::new();
 
         let mut pending_writes: Vec<(Key, Option<Vec<u8>>)> = Vec::new();
+        let mut pending_expected: BTreeMap<Key, Option<Vec<u8>>> = BTreeMap::new();
+        let mut committed_state: BTreeMap<Key, Vec<u8>> = BTreeMap::new();
+        let mut expected_metadata = None;
+        let mut expected_op_count = db.bounds().end;
 
         for op in &input.ops {
             db = match op {
                 Operation::Update { key, value_bytes } => {
-                    pending_writes.push((Key::new(*key), Some(value_bytes.to_vec())));
+                    let key = Key::new(*key);
+                    pending_writes.push((key.clone(), Some(value_bytes.to_vec())));
+                    pending_expected.insert(key, Some(value_bytes.clone()));
                     db
                 }
 
                 Operation::Delete { key } => {
-                    pending_writes.push((Key::new(*key), None));
+                    let key = Key::new(*key);
+                    pending_writes.push((key.clone(), None));
+                    pending_expected.insert(key, None);
                     db
                 }
 
@@ -208,11 +225,25 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, metadata_bytes.clone()).await.unwrap();
-                    let (db, _) = db
+                    let expected_end = Location::new(merkleized.bounds().total_size);
+                    let (db, applied) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
+                    assert_eq!(applied, expected_op_count..expected_end);
+                    expected_op_count = expected_end;
                     let db = db.commit().await.expect("Commit should not fail");
+                    for (key, value) in std::mem::take(&mut pending_expected) {
+                        match value {
+                            Some(value) => {
+                                committed_state.insert(key, value);
+                            }
+                            None => {
+                                committed_state.remove(&key);
+                            }
+                        }
+                    }
+                    expected_metadata = metadata_bytes.clone();
                     historical_roots.insert(db.bounds().end, db.root());
                     db
                 }
@@ -223,12 +254,23 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                 }
 
                 Operation::Get { key } => {
-                    let _ = db.get(&Key::new(*key)).await;
+                    let key = Key::new(*key);
+                    assert_eq!(
+                        db.get(&key).await.expect("Get should not fail"),
+                        committed_state.get(&key).cloned(),
+                        "Get disagreed with the committed model",
+                    );
                     db
                 }
 
                 Operation::GetMetadata => {
-                    let _ = db.get_metadata().await;
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("Metadata read should not fail"),
+                        expected_metadata,
+                        "Metadata disagreed with the committed model",
+                    );
                     db
                 }
 
@@ -239,11 +281,25 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    let (db, _) = db
+                    let expected_end = Location::new(merkleized.bounds().total_size);
+                    let (db, applied) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
+                    assert_eq!(applied, expected_op_count..expected_end);
+                    expected_op_count = expected_end;
                     let db = db.commit().await.expect("Commit should not fail");
+                    for (key, value) in std::mem::take(&mut pending_expected) {
+                        match value {
+                            Some(value) => {
+                                committed_state.insert(key, value);
+                            }
+                            None => {
+                                committed_state.remove(&key);
+                            }
+                        }
+                    }
+                    expected_metadata = None;
                     historical_roots.insert(db.bounds().end, db.root());
                     let start_loc = Location::<F>::new(*start_loc % (*F::MAX_LEAVES + 1));
                     let op_count = db.bounds().end;
@@ -269,11 +325,25 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    let (db, _) = db
+                    let expected_end = Location::new(merkleized.bounds().total_size);
+                    let (db, applied) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
+                    assert_eq!(applied, expected_op_count..expected_end);
+                    expected_op_count = expected_end;
                     let db = db.commit().await.expect("Commit should not fail");
+                    for (key, value) in std::mem::take(&mut pending_expected) {
+                        match value {
+                            Some(value) => {
+                                committed_state.insert(key, value);
+                            }
+                            None => {
+                                committed_state.remove(&key);
+                            }
+                        }
+                    }
+                    expected_metadata = None;
                     historical_roots.insert(db.bounds().end, db.root());
                     let op_count = {
                         let idx = (*size as usize) % historical_roots.len();
@@ -303,21 +373,72 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    let (db, _) = db
+                    let expected_end = Location::new(merkleized.bounds().total_size);
+                    let (db, applied) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
+                    assert_eq!(applied, expected_op_count..expected_end);
+                    expected_op_count = expected_end;
+                    for (key, value) in std::mem::take(&mut pending_expected) {
+                        match value {
+                            Some(value) => {
+                                committed_state.insert(key, value);
+                            }
+                            None => {
+                                committed_state.remove(&key);
+                            }
+                        }
+                    }
+                    expected_metadata = None;
                     historical_roots.insert(db.bounds().end, db.root());
                     db.sync().await.expect("Sync should not fail")
                 }
 
                 Operation::InactivityFloorLoc => {
-                    let _ = db.sync_boundary();
+                    let bounds = db.bounds();
+                    let boundary = db.sync_boundary();
+                    assert!(bounds.start <= boundary && boundary <= expected_op_count);
                     db
                 }
 
                 Operation::OpCount => {
-                    let _ = db.bounds().end;
+                    assert_eq!(db.bounds().end, expected_op_count);
+                    assert_eq!(db.is_empty(), committed_state.is_empty());
+                    db
+                }
+
+                Operation::Rewind => {
+                    let expected_root = db.root();
+                    let expected_bounds = db.bounds();
+                    let expected_metadata_before = db
+                        .get_metadata()
+                        .await
+                        .expect("Metadata read should not fail");
+                    let db = db
+                        .rewind(expected_bounds.end)
+                        .await
+                        .expect("Rewinding to the current tip should not fail");
+                    assert_eq!(db.root(), expected_root);
+                    assert_eq!(db.bounds(), expected_bounds);
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("Metadata read should not fail"),
+                        expected_metadata_before,
+                    );
+                    db
+                }
+
+                Operation::Strategy { values } => {
+                    let expected = values.iter().map(|value| u64::from(*value)).sum::<u64>();
+                    let actual = db.strategy().fold(
+                        values,
+                        || 0u64,
+                        |sum, value| sum + u64::from(*value),
+                        |left, right| left + right,
+                    );
+                    assert_eq!(actual, expected, "database strategy produced a wrong fold");
                     db
                 }
 
@@ -328,19 +449,45 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                         batch = batch.write(k, v);
                     }
                     let merkleized = batch.merkleize(&db, None).await.unwrap();
-                    let (db, _) = db
+                    let expected_end = Location::new(merkleized.bounds().total_size);
+                    let expected_root = merkleized.root();
+                    let (db, applied) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("commit should not fail");
+                    assert_eq!(applied, expected_op_count..expected_end);
+                    expected_op_count = expected_end;
                     let db = db.commit().await.expect("Commit should not fail");
+                    for (key, value) in std::mem::take(&mut pending_expected) {
+                        match value {
+                            Some(value) => {
+                                committed_state.insert(key, value);
+                            }
+                            None => {
+                                committed_state.remove(&key);
+                            }
+                        }
+                    }
+                    expected_metadata = None;
                     historical_roots.insert(db.bounds().end, db.root());
-                    let _ = db.root();
+                    assert_eq!(
+                        db.root(),
+                        expected_root,
+                        "Committed root disagreed with its batch"
+                    );
                     db
                 }
 
                 Operation::SimulateFailure => {
                     // Simulate unclean shutdown by dropping the db without committing
+                    let durable_root = db.root();
+                    let durable_bounds = db.bounds();
+                    let durable_metadata = db
+                        .get_metadata()
+                        .await
+                        .expect("Metadata read should not fail");
                     pending_writes.clear();
+                    pending_expected.clear();
                     historical_roots.clear();
                     drop(db);
 
@@ -351,7 +498,25 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
                     )
                     .await
                     .expect("Failed to init source db");
+                    assert_eq!(db.root(), durable_root, "reopen changed the durable root");
+                    assert_eq!(
+                        db.bounds(),
+                        durable_bounds,
+                        "reopen changed the durable bounds",
+                    );
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("Metadata read should not fail"),
+                        durable_metadata,
+                        "reopen changed durable metadata",
+                    );
                     restarts += 1;
+                    expected_op_count = db.bounds().end;
+                    expected_metadata = db
+                        .get_metadata()
+                        .await
+                        .expect("Metadata read should not fail");
                     db
                 }
             };
@@ -362,10 +527,12 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, test_name: &str) {
             batch = batch.write(k, v);
         }
         let merkleized = batch.merkleize(&db, None).await.unwrap();
-        let (db, _) = db
+        let expected_end = Location::new(merkleized.bounds().total_size);
+        let (db, applied) = db
             .apply_batch(merkleized)
             .await
             .expect("commit should not fail");
+        assert_eq!(applied, expected_op_count..expected_end);
         db.destroy().await.expect("Destroy should not fail");
     });
 }

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -3,7 +3,7 @@
 use arbitrary::Arbitrary;
 use commonware_codec::RangeCfg;
 use commonware_cryptography::{Hasher, Sha256, sha256::Digest};
-use commonware_parallel::Sequential;
+use commonware_parallel::{Sequential, Strategy as _};
 use commonware_runtime::{BufferPooler, Runner, buffer::paged::CacheRef, deterministic};
 use commonware_storage::{
     journal::contiguous::variable::Config as VConfig,
@@ -39,6 +39,14 @@ enum ImmutableOperation {
     Get {
         key_seed: u64,
     },
+    GetMany {
+        first_key_seed: u64,
+        second_key_seed: u64,
+    },
+    BatchReads {
+        first_key_seed: u64,
+        second_key_seed: u64,
+    },
     Commit {
         has_metadata: bool,
         metadata_size: usize,
@@ -58,8 +66,19 @@ enum ImmutableOperation {
     },
     GetMetadata,
     OpCount,
+    Size,
     OldestRetainedLoc,
+    SyncBoundary,
+    Sync,
+    Rewind {
+        idx: u8,
+    },
+    ValidateBatch,
+    ToBatch,
     Root,
+    Strategy {
+        values: [u8; 4],
+    },
 }
 
 #[derive(Debug)]
@@ -71,6 +90,8 @@ struct FuzzInput {
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let seed = u.arbitrary()?;
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let mut operations = Vec::with_capacity(num_ops);
@@ -79,7 +100,6 @@ impl<'a> Arbitrary<'a> for FuzzInput {
             operations.push(u.arbitrary()?);
         }
 
-        let raw_bytes = u.bytes(u.len())?.to_vec();
         Ok(FuzzInput {
             seed,
             operations,
@@ -167,6 +187,13 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let mut set_locations: Vec<(Digest, Location<F>)> = Vec::new();
             let mut last_commit_loc: Option<Location<F>> = None;
             let mut pending_sets: Vec<(Digest, Vec<u8>)> = Vec::new();
+            let mut expected_metadata = db.get_metadata().await.unwrap();
+            let mut commit_history = vec![(
+                db.size(),
+                db.root(),
+                db.inactivity_floor_loc(),
+                db.get_metadata().await.unwrap(),
+            )];
 
             for op in operations {
                 db = match op {
@@ -187,7 +214,63 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
 
                     ImmutableOperation::Get { key_seed } => {
                         let key = generate_key(&mut rng, key_seed);
-                        let _ = db.get(&key).await;
+                        let actual = db.get(&key).await;
+                        match actual {
+                            Ok(value) => assert_eq!(
+                                db.get_many(&[&key]).await.unwrap(),
+                                vec![value],
+                                "single and batched reads disagreed",
+                            ),
+                            Err(_) => assert!(db.get_many(&[&key]).await.is_err()),
+                        }
+                        db
+                    }
+
+                    ImmutableOperation::GetMany {
+                        first_key_seed,
+                        second_key_seed,
+                    } => {
+                        let first = generate_key(&mut rng, first_key_seed);
+                        let second = generate_key(&mut rng, second_key_seed);
+                        let expected = vec![
+                            db.get(&first).await.unwrap(),
+                            db.get(&second).await.unwrap(),
+                        ];
+                        assert_eq!(db.get_many(&[&first, &second]).await.unwrap(), expected);
+                        db
+                    }
+
+                    ImmutableOperation::BatchReads {
+                        first_key_seed,
+                        second_key_seed,
+                    } => {
+                        let first = generate_key(&mut rng, first_key_seed);
+                        let second = generate_key(&mut rng, second_key_seed);
+                        let mut batch = db.new_batch();
+                        for (key, value) in &pending_sets {
+                            batch = batch.set(*key, value.clone());
+                        }
+                        let expected = vec![
+                            batch.get(&first, &db).await.unwrap(),
+                            batch.get(&second, &db).await.unwrap(),
+                        ];
+                        assert_eq!(
+                            batch.get_many(&[&first, &second], &db).await.unwrap(),
+                            expected
+                        );
+                        let merkleized =
+                            batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+                        assert_eq!(
+                            merkleized.get_many(&[&first, &second], &db).await.unwrap(),
+                            vec![
+                                merkleized.get(&first, &db).await.unwrap(),
+                                merkleized.get(&second, &db).await.unwrap(),
+                            ]
+                        );
+                        assert_eq!(
+                            merkleized.bounds().total_size,
+                            db.size().as_u64() + pending_sets.len() as u64 + 1
+                        );
                         db
                     }
 
@@ -222,10 +305,24 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         } else {
                             db.inactivity_floor_loc()
                         };
+                        let expected_metadata_after = metadata.clone();
                         let merkleized = batch.merkleize(&db, metadata, floor).await;
+                        let expected_root = merkleized.root();
+                        let expected_size = Location::new(merkleized.bounds().total_size);
                         let (db, _) = db.apply_batch(merkleized).await.unwrap();
                         let db = db.commit().await.unwrap();
+                        assert_eq!(db.size(), expected_size);
+                        assert_eq!(db.root(), expected_root);
+                        assert_eq!(db.inactivity_floor_loc(), floor);
+                        assert_eq!(db.get_metadata().await.unwrap(), expected_metadata_after);
+                        expected_metadata = expected_metadata_after;
                         last_commit_loc = Some(db.bounds().end - 1);
+                        commit_history.push((
+                            db.size(),
+                            db.root(),
+                            db.inactivity_floor_loc(),
+                            db.get_metadata().await.unwrap(),
+                        ));
                         db
                     }
 
@@ -247,10 +344,21 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             // but never below the current floor (monotonicity).
                             let floor = safe_loc.max(db.inactivity_floor_loc());
                             let merkleized = batch.merkleize(&db, None, floor).await;
+                            let expected_root = merkleized.root();
                             let (db, _) = db.apply_batch(merkleized).await.unwrap();
                             let db = db.commit().await.unwrap();
+                            expected_metadata = None;
                             last_commit_loc = Some(db.bounds().end - 1);
+                            commit_history.push((
+                                db.size(),
+                                db.root(),
+                                db.inactivity_floor_loc(),
+                                db.get_metadata().await.unwrap(),
+                            ));
+                            let size = db.size();
                             let db = db.prune(safe_loc).await.expect("prune should not fail");
+                            assert_eq!(db.size(), size);
+                            assert_eq!(db.root(), expected_root);
                             let oldest = db.bounds().start;
                             set_locations.retain(|(_, l)| *l >= oldest);
                             keys_set.retain(|(_, l)| *l >= oldest);
@@ -284,11 +392,31 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             let merkleized = batch.merkleize(&db, None, floor).await;
                             let (db, _) = db.apply_batch(merkleized).await.unwrap();
                             let db = db.commit().await.unwrap();
+                            expected_metadata = None;
                             last_commit_loc = Some(db.bounds().end - 1);
+                            commit_history.push((
+                                db.size(),
+                                db.root(),
+                                db.inactivity_floor_loc(),
+                                db.get_metadata().await.unwrap(),
+                            ));
                             if let Ok((proof, ops)) = db.proof(safe_start, safe_max_ops).await {
                                 let root = db.root();
-                                let _ =
-                                    verify_proof::<Sha256, _, _>(&proof, safe_start, &ops, &root);
+                                assert!(verify_proof::<Sha256, _, _>(
+                                    &proof, safe_start, &ops, &root
+                                ));
+                                let pinned = db.pinned_nodes_at(safe_start).await.unwrap();
+                                assert!(commonware_storage::qmdb::verify_proof_and_pinned_nodes::<
+                                    Sha256,
+                                    _,
+                                    _,
+                                >(
+                                    &proof, safe_start, &ops, &pinned, &root,
+                                ));
+                                for op in &ops {
+                                    assert_eq!(op.key().is_some(), !op.is_commit());
+                                    assert_eq!(op.has_floor().is_some(), op.is_commit());
+                                }
                             }
                             db
                         } else {
@@ -301,25 +429,30 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         start_loc,
                         max_ops,
                     } => {
-                        let op_count = db.bounds().end;
-                        if op_count > 0 && pending_sets.is_empty() {
-                            let safe_size = (size % op_count.as_u64()).max(1);
-                            let safe_size = Location::new(safe_size);
-                            let safe_start = start_loc % safe_size.as_u64();
-                            let safe_start = Location::new(safe_start);
+                        let bounds = db.bounds();
+                        let candidates = commit_history
+                            .iter()
+                            .filter(|(candidate_size, _, floor, _)| {
+                                *candidate_size > bounds.start && *floor >= bounds.start
+                            })
+                            .collect::<Vec<_>>();
+                        if !candidates.is_empty() && pending_sets.is_empty() {
+                            let expected = candidates[size as usize % candidates.len()];
+                            let safe_size = expected.0;
+                            let retained = (safe_size - bounds.start).as_u64();
+                            let safe_start = bounds.start + (start_loc % retained);
                             let safe_max_ops =
                                 NonZeroU64::new((max_ops % MAX_PROOF_OPS).max(1)).unwrap();
-
-                            let floor = db.inactivity_floor_loc();
-                            let batch = db.new_batch().merkleize(&db, None, floor).await;
-                            let (db, _) = db.apply_batch(batch).await.unwrap();
-                            let db = db.commit().await.unwrap();
-                            last_commit_loc = Some(db.bounds().end - 1);
-                            if safe_start >= db.bounds().start {
-                                let _ = db
-                                    .historical_proof(safe_size, safe_start, safe_max_ops)
-                                    .await;
-                            }
+                            let (proof, ops) = db
+                                .historical_proof(safe_size, safe_start, safe_max_ops)
+                                .await
+                                .expect("retained commit should produce a historical proof");
+                            assert!(verify_proof::<Sha256, _, _>(
+                                &proof,
+                                safe_start,
+                                &ops,
+                                &expected.1,
+                            ));
                             db
                         } else {
                             db
@@ -327,17 +460,97 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                     }
 
                     ImmutableOperation::GetMetadata => {
-                        let _ = db.get_metadata().await;
+                        assert_eq!(db.get_metadata().await.unwrap(), expected_metadata);
                         db
                     }
 
                     ImmutableOperation::OpCount => {
-                        let _ = db.bounds().end;
+                        assert_eq!(db.bounds().end, db.size());
+                        db
+                    }
+
+                    ImmutableOperation::Size => {
+                        assert_eq!(db.size(), db.bounds().end);
                         db
                     }
 
                     ImmutableOperation::OldestRetainedLoc => {
-                        let _ = db.bounds().start;
+                        assert!(db.bounds().start <= db.inactivity_floor_loc());
+                        assert!(db.bounds().start <= db.size());
+                        db
+                    }
+
+                    ImmutableOperation::SyncBoundary => {
+                        assert_eq!(db.sync_boundary(), db.inactivity_floor_loc());
+                        db
+                    }
+
+                    ImmutableOperation::Sync => {
+                        let expected = (
+                            db.size(),
+                            db.root(),
+                            db.inactivity_floor_loc(),
+                            db.get_metadata().await.unwrap(),
+                        );
+                        let db = db.sync().await.unwrap();
+                        assert_eq!(
+                            (
+                                db.size(),
+                                db.root(),
+                                db.inactivity_floor_loc(),
+                                db.get_metadata().await.unwrap(),
+                            ),
+                            expected
+                        );
+                        db
+                    }
+
+                    ImmutableOperation::Rewind { idx } => {
+                        let bounds = db.bounds();
+                        let candidates = commit_history
+                            .iter()
+                            .filter(|(size, _, floor, _)| {
+                                *size > bounds.start && *floor >= bounds.start
+                            })
+                            .collect::<Vec<_>>();
+                        if candidates.len() < 2 {
+                            db
+                        } else {
+                            let expected = candidates[idx as usize % (candidates.len() - 1)];
+                            let target = expected.0;
+                            let db = db.rewind(target).await.unwrap();
+                            assert_eq!(db.size(), expected.0);
+                            assert_eq!(db.root(), expected.1);
+                            assert_eq!(db.inactivity_floor_loc(), expected.2);
+                            assert_eq!(db.get_metadata().await.unwrap(), expected.3);
+                            expected_metadata = expected.3.clone();
+                            commit_history.retain(|(size, _, _, _)| *size <= target);
+                            keys_set.retain(|(_, loc)| *loc < target);
+                            set_locations.retain(|(_, loc)| *loc < target);
+                            last_commit_loc = Some(target - 1);
+                            db
+                        }
+                    }
+
+                    ImmutableOperation::ValidateBatch => {
+                        let before = (db.size(), db.root(), db.inactivity_floor_loc());
+                        let mut batch = db.new_batch();
+                        for (key, value) in &pending_sets {
+                            batch = batch.set(*key, value.clone());
+                        }
+                        let merkleized =
+                            batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+                        assert!(db.validate_batch(&merkleized).is_ok());
+                        assert_eq!((db.size(), db.root(), db.inactivity_floor_loc()), before);
+                        db
+                    }
+
+                    ImmutableOperation::ToBatch => {
+                        let batch = db.to_batch();
+                        assert_eq!(batch.root(), db.root());
+                        assert_eq!(batch.bounds().base_size, db.size().as_u64());
+                        assert_eq!(batch.bounds().total_size, db.size().as_u64());
+                        assert_eq!(batch.bounds().inactivity_floor, db.inactivity_floor_loc());
                         db
                     }
 
@@ -354,10 +567,30 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                         }
                         let floor = db.inactivity_floor_loc();
                         let merkleized = batch.merkleize(&db, None, floor).await;
+                        let expected_root = merkleized.root();
                         let (db, _) = db.apply_batch(merkleized).await.unwrap();
                         let db = db.commit().await.unwrap();
+                        expected_metadata = None;
                         last_commit_loc = Some(db.bounds().end - 1);
-                        let _ = db.root();
+                        assert_eq!(db.root(), expected_root);
+                        commit_history.push((
+                            db.size(),
+                            db.root(),
+                            db.inactivity_floor_loc(),
+                            db.get_metadata().await.unwrap(),
+                        ));
+                        db
+                    }
+
+                    ImmutableOperation::Strategy { values } => {
+                        let expected = values.iter().map(|value| u64::from(*value)).sum::<u64>();
+                        let actual = db.strategy().fold(
+                            values,
+                            || 0u64,
+                            |sum, value| sum + u64::from(value),
+                            |left, right| left + right,
+                        );
+                        assert_eq!(actual, expected, "database strategy produced a wrong fold");
                         db
                     }
                 };

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -47,9 +47,9 @@ enum FloorKind {
     Current,
     /// Advance to the commit location (the tight upper bound).
     AdvanceToCommit,
-    /// Floor one below the current floor — must be rejected as `FloorRegressed`.
+    /// Floor one below the current floor - must be rejected as `FloorRegressed`.
     BadRegression,
-    /// Floor one past the commit location — must be rejected as `FloorBeyondSize`.
+    /// Floor one past the commit location - must be rejected as `FloorBeyondSize`.
     BadBeyondCommit,
 }
 
@@ -75,7 +75,7 @@ enum Operation {
         metadata_bytes: Option<Vec<u8>>,
         floor_kind: FloorKind,
     },
-    /// Build a two-level batch chain (parent → child) and apply the child directly. The
+    /// Build a two-level batch chain (parent -> child) and apply the child directly. The
     /// parent's floor is intentionally invalid (regressed or beyond its own commit location);
     /// this exercises the per-ancestor validation path in `apply_batch`.
     BadChainedCommit {
@@ -175,7 +175,7 @@ impl<'a> Arbitrary<'a> for Operation {
             }
             12 => Ok(Operation::SimulateFailure {}),
             13 => {
-                // Only Bad* kinds make sense here — the ancestor is guaranteed unapplied.
+                // Only Bad* kinds make sense here - the ancestor is guaranteed unapplied.
                 let ancestor_kind = match u.arbitrary::<bool>()? {
                     false => FloorKind::BadRegression,
                     true => FloorKind::BadBeyondCommit,
@@ -403,13 +403,13 @@ fn fuzz_family<F: Family, S: Strategy>(
                         _ => continue, // only bad kinds are meaningful here
                     };
 
-                    // Don't drain pending_appends — keep them for future ops. Build from scratch.
+                    // Don't drain pending_appends - keep them for future ops. Build from scratch.
                     let parent = db
                         .new_batch()
                         .append(vec![0u8; 1])
                         .merkleize(&db, None, parent_floor).await;
                     // child: valid on its own; only the ancestor should trip the check.
-                    let child_floor = parent_floor; // stay ≥ parent_floor even if parent is bad
+                    let child_floor = parent_floor; // stay >= parent_floor even if parent is bad
                     let child = parent
                         .new_batch::<Sha256>()
                         .append(vec![1u8; 1])
@@ -581,7 +581,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                     let oldest = db.bounds().start;
                     let candidates = commit_history
                         .iter()
-                        .filter(|(size, _, _, _)| *size > oldest)
+                        .filter(|(size, _, floor, _)| *size > oldest && *floor >= oldest)
                         .collect::<Vec<_>>();
                     if candidates.len() < 2 {
                         db
@@ -744,7 +744,9 @@ fn fuzz_family<F: Family, S: Strategy>(
                     let bounds = db.bounds();
                     let candidates = commit_history
                         .iter()
-                        .filter(|(size, _, _, _)| *size > bounds.start)
+                        .filter(|(size, _, floor, _)| {
+                            *size > bounds.start && *floor >= bounds.start
+                        })
                         .collect::<Vec<_>>();
                     let expected = candidates[*size_offset as usize % candidates.len()];
                     let retained = (expected.0 - bounds.start).as_u64();

--- a/storage/fuzz/fuzz_targets/qmdb_keyless.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless.rs
@@ -12,7 +12,7 @@ use commonware_storage::{
     qmdb::{
         Error,
         keyless::variable::{Config, Db as Keyless},
-        verify_proof,
+        verify_proof, verify_proof_and_pinned_nodes,
     },
 };
 use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize};
@@ -84,12 +84,25 @@ enum Operation {
     Get {
         loc_offset: u32,
     },
+    GetMany {
+        first_offset: u32,
+        second_offset: u32,
+    },
+    BatchReads {
+        loc_offset: u32,
+    },
     GetMetadata,
     Prune,
     Sync,
     OpCount,
     LastCommitLoc,
     OldestRetainedLoc,
+    SyncBoundary,
+    Rewind {
+        idx: u8,
+    },
+    ValidateBatch,
+    ToBatch,
     Root,
     Proof {
         start_offset: u32,
@@ -101,16 +114,19 @@ enum Operation {
         max_ops: u16,
     },
     SimulateFailure {},
+    Strategy {
+        values: [u8; 4],
+    },
 }
 
 impl<'a> Arbitrary<'a> for Operation {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice: u8 = u.arbitrary()?;
-        match choice % 14 {
+        match choice % 21 {
             0 => {
                 let value_len: u16 = u.arbitrary()?;
                 let actual_len = ((value_len as usize) % 10000) + 1;
-                let value_bytes = u.bytes(actual_len)?.to_vec();
+                let value_bytes = u.bytes(actual_len.min(u.len()))?.to_vec();
                 Ok(Operation::Append { value_bytes })
             }
             1 => {
@@ -118,7 +134,7 @@ impl<'a> Arbitrary<'a> for Operation {
                 let metadata_bytes = if has_metadata {
                     let metadata_len: u16 = u.arbitrary()?;
                     let actual_len = ((metadata_len as usize) % 1000) + 1;
-                    Some(u.bytes(actual_len)?.to_vec())
+                    Some(u.bytes(actual_len.min(u.len()))?.to_vec())
                 } else {
                     None
                 };
@@ -166,6 +182,22 @@ impl<'a> Arbitrary<'a> for Operation {
                 };
                 Ok(Operation::BadChainedCommit { ancestor_kind })
             }
+            14 => Ok(Operation::GetMany {
+                first_offset: u.arbitrary()?,
+                second_offset: u.arbitrary()?,
+            }),
+            15 => Ok(Operation::BatchReads {
+                loc_offset: u.arbitrary()?,
+            }),
+            16 => Ok(Operation::SyncBoundary),
+            17 => Ok(Operation::Rewind {
+                idx: u.arbitrary()?,
+            }),
+            18 => Ok(Operation::ValidateBatch),
+            19 => Ok(Operation::ToBatch),
+            20 => Ok(Operation::Strategy {
+                values: u.arbitrary()?,
+            }),
             _ => unreachable!(),
         }
     }
@@ -179,11 +211,12 @@ struct FuzzInput {
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let ops = (0..num_ops)
             .map(|_| Operation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
-        let raw_bytes = u.bytes(u.len())?.to_vec();
         Ok(FuzzInput { ops, raw_bytes })
     }
 }
@@ -256,6 +289,13 @@ fn fuzz_family<F: Family, S: Strategy>(
         let mut restarts = 0usize;
 
         let mut pending_appends: Vec<Vec<u8>> = Vec::new();
+        let mut expected_metadata = db.get_metadata().await.unwrap();
+        let mut commit_history = vec![(
+            db.bounds().end,
+            db.root(),
+            db.inactivity_floor_loc(),
+            db.get_metadata().await.unwrap(),
+        )];
 
         for op in &input.ops {
             db = match op {
@@ -298,11 +338,25 @@ fn fuzz_family<F: Family, S: Strategy>(
 
                     match expect_err {
                         None => {
+                            let expected_root = merkleized.root();
+                            let expected_size = Location::new(merkleized.bounds().total_size);
                             let (db, _) = db
                                 .apply_batch(merkleized)
                                 .await
                                 .expect("Commit should not fail");
-                            db.commit().await.expect("Commit should not fail")
+                            let db = db.commit().await.expect("Commit should not fail");
+                            assert_eq!(db.bounds().end, expected_size);
+                            assert_eq!(db.root(), expected_root);
+                            assert_eq!(db.inactivity_floor_loc(), floor);
+                            assert_eq!(db.get_metadata().await.unwrap(), metadata_bytes.clone());
+                            expected_metadata = metadata_bytes.clone();
+                            commit_history.push((
+                                db.bounds().end,
+                                db.root(),
+                                db.inactivity_floor_loc(),
+                                db.get_metadata().await.unwrap(),
+                            ));
+                            db
                         }
                         Some(kind) => {
                             // Snapshot state; the reject must not mutate persisted state.
@@ -378,16 +432,66 @@ fn fuzz_family<F: Family, S: Strategy>(
                 }
 
                 Operation::Get { loc_offset } => {
-                    let op_count = db.bounds().end;
-                    if op_count > 0 {
-                        let loc = (*loc_offset as u64) % op_count.as_u64();
-                        let _ = db.get(loc.into()).await;
+                    let bounds = db.bounds();
+                    if bounds.start < bounds.end {
+                        let retained = (bounds.end - bounds.start).as_u64();
+                        let loc = bounds.start + (*loc_offset as u64 % retained);
+                        let value = db.get(loc).await.expect("retained get should not fail");
+                        assert_eq!(db.get_many(&[loc]).await.unwrap(), vec![value]);
+                    }
+                    db
+                }
+
+                Operation::GetMany {
+                    first_offset,
+                    second_offset,
+                } => {
+                    let bounds = db.bounds();
+                    if bounds.start < bounds.end {
+                        let len = (bounds.end - bounds.start).as_u64();
+                        let mut locs = vec![
+                            bounds.start + (*first_offset as u64 % len),
+                            bounds.start + (*second_offset as u64 % len),
+                        ];
+                        locs.sort();
+                        locs.dedup();
+                        let mut expected = Vec::with_capacity(locs.len());
+                        for loc in &locs {
+                            expected.push(db.get(*loc).await.unwrap());
+                        }
+                        assert_eq!(db.get_many(&locs).await.unwrap(), expected);
+                    }
+                    db
+                }
+
+                Operation::BatchReads { loc_offset } => {
+                    let mut batch = db.new_batch();
+                    for value in &pending_appends {
+                        batch = batch.append(value.clone());
+                    }
+                    let bounds = db.bounds();
+                    if bounds.start < batch.size() {
+                        let len = (batch.size() - bounds.start).as_u64();
+                        let loc = bounds.start + (*loc_offset as u64 % len);
+                        let expected = batch.get(loc, &db).await.unwrap();
+                        assert_eq!(batch.get_many(&[loc], &db).await.unwrap(), vec![expected]);
+                        let merkleized = batch
+                            .merkleize(&db, None, db.inactivity_floor_loc())
+                            .await;
+                        assert_eq!(
+                            merkleized.get_many(&[loc], &db).await.unwrap(),
+                            vec![merkleized.get(loc, &db).await.unwrap()]
+                        );
+                        assert_eq!(
+                            merkleized.bounds().total_size,
+                            db.bounds().end.as_u64() + pending_appends.len() as u64 + 1
+                        );
                     }
                     db
                 }
 
                 Operation::GetMetadata => {
-                    let _ = db.get_metadata().await;
+                    assert_eq!(db.get_metadata().await.unwrap(), expected_metadata);
                     db
                 }
 
@@ -403,13 +507,25 @@ fn fuzz_family<F: Family, S: Strategy>(
                     let end = db.bounds().end;
                     let floor = Location::<F>::new(end.as_u64() + pending_count);
                     let merkleized = batch.merkleize(&db, None, floor).await;
+                    let expected_root = merkleized.root();
                     let (db, _) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("Commit should not fail");
                     let db = db.commit().await.expect("Commit should not fail");
+                    expected_metadata = None;
+                    commit_history.push((
+                        db.bounds().end,
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata().await.unwrap(),
+                    ));
+                    let size = db.bounds().end;
                     let floor = db.inactivity_floor_loc();
-                    db.prune(floor).await.expect("Prune should not fail")
+                    let db = db.prune(floor).await.expect("Prune should not fail");
+                    assert_eq!(db.bounds().end, size);
+                    assert_eq!(db.root(), expected_root);
+                    db
                 }
 
                 Operation::Sync => {
@@ -422,21 +538,91 @@ fn fuzz_family<F: Family, S: Strategy>(
                         .apply_batch(merkleized)
                         .await
                         .expect("Commit should not fail");
-                    db.sync().await.expect("Sync should not fail")
+                    let expected_root = db.root();
+                    let expected_size = db.bounds().end;
+                    let expected_floor = db.inactivity_floor_loc();
+                    let db = db.sync().await.expect("Sync should not fail");
+                    assert_eq!(db.root(), expected_root);
+                    assert_eq!(db.bounds().end, expected_size);
+                    assert_eq!(db.inactivity_floor_loc(), expected_floor);
+                    assert_eq!(db.get_metadata().await.unwrap(), None);
+                    expected_metadata = None;
+                    commit_history.push((
+                        db.bounds().end,
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata().await.unwrap(),
+                    ));
+                    db
                 }
 
                 Operation::OpCount => {
-                    let _ = db.bounds().end;
+                    assert_eq!(db.bounds().end, db.last_commit_loc() + 1);
                     db
                 }
 
                 Operation::LastCommitLoc => {
-                    let _ = db.last_commit_loc();
+                    assert_eq!(db.last_commit_loc() + 1, db.bounds().end);
                     db
                 }
 
                 Operation::OldestRetainedLoc => {
-                    let _ = db.bounds().start;
+                    assert!(db.bounds().start <= db.inactivity_floor_loc());
+                    assert!(db.bounds().start <= db.bounds().end);
+                    db
+                }
+
+                Operation::SyncBoundary => {
+                    assert_eq!(db.sync_boundary(), db.inactivity_floor_loc());
+                    db
+                }
+
+                Operation::Rewind { idx } => {
+                    let oldest = db.bounds().start;
+                    let candidates = commit_history
+                        .iter()
+                        .filter(|(size, _, _, _)| *size > oldest)
+                        .collect::<Vec<_>>();
+                    if candidates.len() < 2 {
+                        db
+                    } else {
+                        let expected = candidates[*idx as usize % (candidates.len() - 1)];
+                        let target = expected.0;
+                        let db = db.rewind(target).await.expect("Rewind should not fail");
+                        assert_eq!(db.bounds().end, expected.0);
+                        assert_eq!(db.root(), expected.1);
+                        assert_eq!(db.inactivity_floor_loc(), expected.2);
+                        assert_eq!(db.get_metadata().await.unwrap(), expected.3);
+                        expected_metadata = expected.3.clone();
+                        let db = db.commit().await.expect("Rewind commit should not fail");
+                        commit_history.retain(|(size, _, _, _)| *size <= target);
+                        db
+                    }
+                }
+
+                Operation::ValidateBatch => {
+                    let before = (db.bounds(), db.root(), db.inactivity_floor_loc());
+                    let mut batch = db.new_batch();
+                    for value in &pending_appends {
+                        batch = batch.append(value.clone());
+                    }
+                    let merkleized = batch
+                        .merkleize(&db, None, db.inactivity_floor_loc())
+                        .await;
+                    assert!(db.validate_batch(&merkleized).is_ok());
+                    assert_eq!(
+                        (db.bounds(), db.root(), db.inactivity_floor_loc()),
+                        before
+                    );
+                    db
+                }
+
+                Operation::ToBatch => {
+                    let batch = db.to_batch();
+                    assert_eq!(batch.root(), db.root());
+                    assert_eq!(batch.bounds().base_size, db.bounds().end.as_u64());
+                    assert_eq!(batch.bounds().total_size, db.bounds().end.as_u64());
+                    assert_eq!(batch.bounds().inactivity_floor, db.inactivity_floor_loc());
                     db
                 }
 
@@ -446,12 +632,32 @@ fn fuzz_family<F: Family, S: Strategy>(
                         batch = batch.append(v);
                     }
                     let merkleized = batch.merkleize(&db, None, db.inactivity_floor_loc()).await;
+                    let expected_root = merkleized.root();
                     let (db, _) = db
                         .apply_batch(merkleized)
                         .await
                         .expect("Commit should not fail");
                     let db = db.commit().await.expect("Commit should not fail");
-                    let _ = db.root();
+                    assert_eq!(db.root(), expected_root);
+                    expected_metadata = None;
+                    commit_history.push((
+                        db.bounds().end,
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata().await.unwrap(),
+                    ));
+                    db
+                }
+
+                Operation::Strategy { values } => {
+                    let expected = values.iter().map(|value| u64::from(*value)).sum::<u64>();
+                    let actual = db.strategy().fold(
+                        values,
+                        || 0u64,
+                        |sum, value| sum + u64::from(*value),
+                        |left, right| left + right,
+                    );
+                    assert_eq!(actual, expected, "database strategy produced a wrong fold");
                     db
                 }
 
@@ -473,6 +679,13 @@ fn fuzz_family<F: Family, S: Strategy>(
                         .await
                         .expect("Commit should not fail");
                     let db = db.commit().await.expect("Commit should not fail");
+                    expected_metadata = None;
+                    commit_history.push((
+                        db.bounds().end,
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata().await.unwrap(),
+                    ));
                     let start_loc = (*start_offset as u64) % op_count.as_u64();
                     let max_ops_value = ((*max_ops as u64) % MAX_PROOF_OPS) + 1;
                     let start_loc: Location<F> = Location::new(start_loc);
@@ -486,6 +699,22 @@ fn fuzz_family<F: Family, S: Strategy>(
                                 &root),
                             "Failed to verify proof for start loc{start_loc} with ops {max_ops} ops",
                         );
+                        let pinned = db.pinned_nodes_at(start_loc).await.unwrap();
+                        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                            &proof,
+                            start_loc,
+                            &ops,
+                            &pinned,
+                            &root,
+                        ));
+                        for op in ops {
+                            let floor = op.has_floor();
+                            let value = op.into_value();
+                            assert!(
+                                floor.is_some() || value.is_some(),
+                                "an append must contain a value"
+                            );
+                        }
                     }
                     db
                 }
@@ -495,10 +724,6 @@ fn fuzz_family<F: Family, S: Strategy>(
                     start_offset,
                     max_ops,
                 } => {
-                    let op_count = db.bounds().end;
-                    if op_count == 0 {
-                        continue;
-                    }
                     let mut batch = db.new_batch();
                     for v in pending_appends.drain(..) {
                         batch = batch.append(v);
@@ -509,33 +734,44 @@ fn fuzz_family<F: Family, S: Strategy>(
                         .await
                         .expect("Commit should not fail");
                     let db = db.commit().await.expect("Commit should not fail");
-                    // Use post-commit op_count so it's consistent with the root.
-                    let op_count = db.bounds().end;
-                    let size = ((*size_offset as u64) % op_count.as_u64()) + 1;
-                    let size: Location<F> = Location::new(size);
-                    let start_loc = (*start_offset as u64) % *size;
-                    let start_loc: Location<F> = Location::new(start_loc);
+                    expected_metadata = None;
+                    commit_history.push((
+                        db.bounds().end,
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata().await.unwrap(),
+                    ));
+                    let bounds = db.bounds();
+                    let candidates = commit_history
+                        .iter()
+                        .filter(|(size, _, _, _)| *size > bounds.start)
+                        .collect::<Vec<_>>();
+                    let expected = candidates[*size_offset as usize % candidates.len()];
+                    let retained = (expected.0 - bounds.start).as_u64();
+                    let start_loc = bounds.start + (*start_offset as u64 % retained);
                     let max_ops_value = ((*max_ops as u64) % MAX_PROOF_OPS) + 1;
-                    let root = db.root();
-                    if let Ok((proof, ops)) = db
-                        .historical_proof(op_count, start_loc, NZU64!(max_ops_value))
-                            .await {
-                            assert!(
-                                verify_proof::<Sha256, _, _>(
-                                    &proof,
-                                    start_loc,
-                                    &ops,
-                                    &root),
-                                "Failed to verify historical proof for start loc{start_loc} with max ops {max_ops}",
-                            );
-                        }
+                    let (proof, ops) = db
+                        .historical_proof(expected.0, start_loc, NZU64!(max_ops_value))
+                        .await
+                        .expect("retained commit should produce a historical proof");
+                    assert!(
+                        verify_proof::<Sha256, _, _>(&proof, start_loc, &ops, &expected.1),
+                        "Failed to verify historical proof for start loc{start_loc} with max ops {max_ops}",
+                    );
                     db
                 }
 
                 Operation::SimulateFailure{} => {
                     pending_appends.clear();
                     drop(db);
-                    reopen(&context, suffix, &strategy, &mut restarts).await
+                    let db = reopen(&context, suffix, &strategy, &mut restarts).await;
+                    let expected = commit_history.last().unwrap();
+                    assert_eq!(db.bounds().end, expected.0);
+                    assert_eq!(db.root(), expected.1);
+                    assert_eq!(db.inactivity_floor_loc(), expected.2);
+                    assert_eq!(db.get_metadata().await.unwrap(), expected.3);
+                    expected_metadata = expected.3.clone();
+                    db
                 }
             };
         }

--- a/storage/fuzz/fuzz_targets/qmdb_keyless_compact.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_keyless_compact.rs
@@ -48,9 +48,9 @@ enum FloorKind {
     Current,
     /// Advance to the commit location (the tight upper bound).
     AdvanceToCommit,
-    /// Floor one below the current floor — must be rejected as `FloorRegressed`.
+    /// Floor one below the current floor - must be rejected as `FloorRegressed`.
     BadRegression,
-    /// Floor one past the commit location — must be rejected as `FloorBeyondSize`.
+    /// Floor one past the commit location - must be rejected as `FloorBeyondSize`.
     BadBeyondCommit,
 }
 

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batching.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
@@ -50,12 +50,29 @@ enum QmdbOperation {
     Delete { key: RawKey },
     Commit { value: RawValue },
     Get { key: RawKey },
+    BatchGet { key: RawKey },
+    ToBatch { key: RawKey },
 }
 
-#[derive(Arbitrary, Debug)]
+#[derive(Debug)]
 struct FuzzInput {
     operations: Vec<QmdbOperation>,
     raw_bytes: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let num_operations = u.int_in_range(1..=MAX_OPS)?;
+        let operations = (0..num_operations)
+            .map(|_| QmdbOperation::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            operations,
+            raw_bytes,
+        })
+    }
 }
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(111);
@@ -74,6 +91,15 @@ async fn commit_pending<F: MerkleFamily>(
         batch = batch.write(k, v);
     }
     let merkleized = batch.merkleize(&db, metadata).await.unwrap();
+    assert_eq!(
+        merkleized.bounds().base_size,
+        *db.bounds().end,
+        "batch should start at the current database tip",
+    );
+    assert!(
+        db.validate_batch(&merkleized).is_ok(),
+        "fresh batch should validate",
+    );
     let (db, _) = db
         .apply_batch(merkleized)
         .await
@@ -187,6 +213,66 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             }
                         }
                         all_keys.insert(*key);
+                        db
+                    }
+
+                    QmdbOperation::BatchGet { key } => {
+                        let mut batch = db.new_batch();
+                        for (key, value) in pending_writes.iter().cloned() {
+                            batch = batch.write(key, value);
+                        }
+                        let raw_key = *key;
+                        let key = Key::new(raw_key);
+                        let actual = batch
+                            .get(&key, &db)
+                            .await
+                            .expect("batch get should not fail");
+                        let expected = if pending_deletes.contains(&raw_key) {
+                            None
+                        } else {
+                            pending_inserts
+                                .get(&raw_key)
+                                .or_else(|| committed_state.get(&raw_key))
+                                .map(|value| Value::new(*value))
+                        };
+                        assert_eq!(actual, expected, "batch get disagreed with pending model");
+                        assert_eq!(
+                            batch
+                                .get_many(&[&key, &key], &db)
+                                .await
+                                .expect("batch get many should not fail"),
+                            vec![actual.clone(), actual],
+                            "batch get many disagreed with batch get",
+                        );
+                        db
+                    }
+
+                    QmdbOperation::ToBatch { key } => {
+                        let batch = db.to_batch();
+                        assert_eq!(batch.root(), db.root(), "base batch root differed from DB");
+                        assert_eq!(
+                            batch.bounds().total_size,
+                            *db.bounds().end,
+                            "base batch size differed from DB",
+                        );
+                        let key = Key::new(*key);
+                        let actual = batch
+                            .get(&key, &db)
+                            .await
+                            .expect("merkleized batch get should not fail");
+                        assert_eq!(
+                            actual,
+                            db.get(&key).await.expect("get should not fail"),
+                            "base batch get differed from DB",
+                        );
+                        assert_eq!(
+                            batch
+                                .get_many(&[&key, &key], &db)
+                                .await
+                                .expect("merkleized batch get many should not fail"),
+                            vec![actual.clone(), actual],
+                            "merkleized batch get many disagreed with batch get",
+                        );
                         db
                     }
                 };

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_operations.rs
@@ -1,6 +1,7 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
+use commonware_codec::Encode as _;
 use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_parallel::Sequential;
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
@@ -10,13 +11,15 @@ use commonware_storage::{
     merkle::{Family as MerkleFamily, Location, Proof, mmb, mmr},
     mmr::full::Config as MerkleConfig,
     qmdb::{
+        self,
         any::{
             FixedConfig as Config,
             db::Db as AnyDb,
             ordered::{Operation, Update},
             value::FixedEncoding,
         },
-        verify_proof,
+        create_multi_proof, create_proof_store, verify_multi_proof, verify_proof,
+        verify_proof_and_extract_digests, verify_proof_and_pinned_nodes,
     },
     translator::EightCap,
 };
@@ -76,10 +79,25 @@ enum QmdbOperation {
     },
 }
 
-#[derive(Arbitrary, Debug)]
+#[derive(Debug)]
 struct FuzzInput {
     operations: Vec<QmdbOperation>,
     raw_bytes: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let num_operations = u.int_in_range(1..=MAX_OPS)?;
+        let operations = (0..num_operations)
+            .map(|_| QmdbOperation::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            operations,
+            raw_bytes,
+        })
+    }
 }
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(555);
@@ -220,6 +238,100 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                                     &current_root),
                                 "Proof verification failed for start_loc={adjusted_start}, max_ops={max_ops}",
                             );
+
+                            let hasher = qmdb::hasher::<Sha256>();
+                            let elements = log.iter().map(|op| op.encode()).collect::<Vec<_>>();
+                            let pinned_nodes = proof.digests.as_slice();
+                            assert_eq!(
+                                verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                                    &proof,
+                                    adjusted_start,
+                                    &log,
+                                    pinned_nodes,
+                                    &current_root,
+                                ),
+                                proof.verify_proof_and_pinned_nodes(
+                                    &hasher,
+                                    &elements,
+                                    adjusted_start,
+                                    pinned_nodes,
+                                    &current_root,
+                                ),
+                                "Pinned proof wrapper disagreed with the Merkle verifier",
+                            );
+
+                            let extracted = verify_proof_and_extract_digests::<Sha256, _, _>(
+                                &proof,
+                                adjusted_start,
+                                &log,
+                                &current_root,
+                            )
+                            .expect("Verified proof should yield authenticated digests");
+                            assert_eq!(
+                                extracted,
+                                proof
+                                    .verify_range_inclusion_and_extract_digests(
+                                        &hasher,
+                                        &elements,
+                                        adjusted_start,
+                                        &current_root,
+                                    )
+                                    .expect("Verified Merkle proof should yield authenticated digests"),
+                                "Extracted proof digests differed from the Merkle verifier",
+                            );
+
+                            let proof_store = create_proof_store::<Sha256, _, _>(
+                                &proof,
+                                adjusted_start,
+                                &log,
+                                &current_root,
+                            )
+                            .expect("Verified proof should create a proof store");
+                            let locations = (0..log.len())
+                                .map(|offset| {
+                                    adjusted_start
+                                        .checked_add(offset as u64)
+                                        .expect("Proven operation location should not overflow")
+                                })
+                                .collect::<Vec<_>>();
+                            assert!(!locations.is_empty(), "Generated proof should contain operations");
+
+                            let multi_proof =
+                                create_multi_proof(&proof_store, &locations, &extracted);
+                            let expected_multi_proof =
+                                proof_store.multi_proof(&locations, &extracted);
+                            assert_eq!(
+                                multi_proof.as_ref().ok(),
+                                expected_multi_proof.as_ref().ok(),
+                                "Multi-proof wrapper disagreed with the proof store",
+                            );
+                            assert_eq!(
+                                multi_proof
+                                    .as_ref()
+                                    .err()
+                                    .map(core::mem::discriminant),
+                                expected_multi_proof
+                                    .as_ref()
+                                    .err()
+                                    .map(core::mem::discriminant),
+                                "Multi-proof wrapper returned a different error",
+                            );
+
+                            if let Ok(multi_proof) = multi_proof {
+                                let selected_ops = locations
+                                    .iter()
+                                    .copied()
+                                    .zip(log.iter().cloned())
+                                    .collect::<Vec<_>>();
+                                assert!(
+                                    verify_multi_proof::<Sha256, _, _>(
+                                        &multi_proof,
+                                        &selected_ops,
+                                        &current_root,
+                                    ),
+                                    "Generated multi-proof should verify",
+                                );
+                            }
                         }
                         db
                     }
@@ -244,12 +356,23 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             if let Ok(res) = db
                                 .proof(adjusted_start, *max_ops)
                                 .await {
-                                    let _ = verify_proof::<Sha256, _, _>(
+                                let elements =
+                                    res.1.iter().map(|op| op.encode()).collect::<Vec<_>>();
+                                assert_eq!(
+                                    verify_proof::<Sha256, _, _>(
                                         &proof,
                                         adjusted_start,
                                         &res.1,
-                                        &current_root);
-
+                                        &current_root,
+                                    ),
+                                    proof.verify_range_inclusion(
+                                        &qmdb::hasher::<Sha256>(),
+                                        &elements,
+                                        adjusted_start,
+                                        &current_root,
+                                    ),
+                                    "Proof wrapper disagreed with the Merkle verifier",
+                                );
                             }
                         }
                         db

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -55,6 +55,8 @@ struct FuzzInput {
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
         let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
@@ -73,7 +75,7 @@ impl<'a> Arbitrary<'a> for FuzzInput {
             initial,
             parent,
             child,
-            raw_bytes: u.bytes(u.len())?.to_vec(),
+            raw_bytes,
         })
     }
 }
@@ -135,6 +137,10 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             );
         }
         let initial = batch.merkleize(&db, None).await.unwrap();
+        assert!(
+            db.validate_batch(&initial).is_ok(),
+            "fresh batch should validate"
+        );
         let (db, _) = db.apply_batch(initial).await.unwrap();
         let db = db.commit().await.unwrap();
 
@@ -151,6 +157,10 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             };
         }
         let parent = batch.merkleize(&db, None).await.unwrap();
+        assert!(
+            db.validate_batch(&parent).is_ok(),
+            "fresh parent should validate"
+        );
         let mut batch = parent.new_batch::<Sha256>();
         for mutation in &input.child {
             batch = match mutation {
@@ -160,12 +170,59 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
             };
         }
+        let probe_key = match &input.child[0] {
+            Mutation::Write { key, .. } | Mutation::Delete { key } => key_from_seed(*key),
+        };
+        let unmerkleized_value = batch
+            .get(&probe_key, &db)
+            .await
+            .expect("unmerkleized batch get should not fail");
+        assert_eq!(
+            batch
+                .get_many(&[&probe_key, &probe_key], &db)
+                .await
+                .expect("unmerkleized batch get many should not fail"),
+            vec![unmerkleized_value.clone(), unmerkleized_value.clone()],
+            "unmerkleized batch get many disagreed with batch get",
+        );
         let pending_child = batch.merkleize(&db, None).await.unwrap();
+        assert_eq!(
+            pending_child.bounds().base_size,
+            parent.bounds().total_size,
+            "child should start at its parent tip",
+        );
 
         // Commit the parent, then rebuild the same logical child from the
         // committed DB state. Both speculative roots must match.
         let (db, _) = db.apply_batch(parent).await.unwrap();
         let db = db.commit().await.unwrap();
+        let base = db.to_batch();
+        assert_eq!(base.root(), db.root(), "base batch root differed from DB");
+        assert_eq!(
+            base.bounds().total_size,
+            *db.bounds().end,
+            "base batch size differed from DB",
+        );
+        assert!(
+            db.validate_batch(&pending_child).is_ok(),
+            "child of the applied parent should validate",
+        );
+        assert_eq!(
+            pending_child
+                .get(&probe_key, &db)
+                .await
+                .expect("merkleized batch get should not fail"),
+            unmerkleized_value,
+            "merkleized child read differed from its unmerkleized read",
+        );
+        assert_eq!(
+            pending_child
+                .get_many(&[&probe_key, &probe_key], &db)
+                .await
+                .expect("merkleized batch get many should not fail"),
+            vec![unmerkleized_value.clone(), unmerkleized_value],
+            "merkleized batch get many disagreed with batch get",
+        );
 
         let mut batch = db.new_batch();
         for mutation in &input.child {

--- a/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_operations.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Unstructured};
 use commonware_cryptography::Sha256;
 use commonware_parallel::Sequential;
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
@@ -32,6 +32,7 @@ type Value = FixedBytes<64>;
 type RawKey = [u8; 32];
 type RawValue = [u8; 64];
 const BITMAP_CHUNK_BYTES: usize = 64;
+const MAX_OPERATIONS: usize = 50;
 
 type GenericDb<F> = AnyDb<
     F,
@@ -53,12 +54,28 @@ enum QmdbOperation {
     Root,
     Proof { start_loc: u64, max_ops: u64 },
     Get { key: RawKey },
+    GetMany { keys: [RawKey; 2] },
 }
 
-#[derive(Arbitrary, Debug)]
+#[derive(Debug)]
 struct FuzzInput {
     operations: Vec<QmdbOperation>,
     raw_bytes: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let num_operations = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let operations = (0..num_operations)
+            .map(|_| QmdbOperation::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            operations,
+            raw_bytes,
+        })
+    }
 }
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(223);
@@ -69,16 +86,24 @@ async fn commit_pending<F: MerkleFamily>(
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     committed_state: &mut HashMap<RawKey, Option<RawValue>>,
     pending_expected: &mut HashMap<RawKey, Option<RawValue>>,
+    expected_op_count: &mut Location<F>,
 ) -> GenericDb<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
     let merkleized = batch.merkleize(&db, None).await.unwrap();
-    let (db, _) = db
+    let expected_end = Location::new(merkleized.bounds().total_size);
+    let (db, applied) = db
         .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
+    assert_eq!(
+        applied,
+        *expected_op_count..expected_end,
+        "applied operation range disagreed with the modeled log tip",
+    );
+    *expected_op_count = expected_end;
     let db = db.commit().await.expect("commit fsync should not fail");
     committed_state.extend(pending_expected.drain());
     db
@@ -128,6 +153,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
             let mut pending_expected: HashMap<RawKey, Option<RawValue>> = HashMap::new();
             let mut all_keys: HashSet<RawKey> = HashSet::new();
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
+            let mut expected_op_count = db.bounds().end;
 
             for op in &operations {
                 db = match op {
@@ -156,17 +182,39 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     }
 
                     QmdbOperation::OpCount => {
-                        let _ = db.bounds().end;
+                        assert_eq!(
+                            db.bounds().end,
+                            expected_op_count,
+                            "operation count disagreed with the modeled log tip",
+                        );
                         db
                     }
 
                     QmdbOperation::Commit => {
-                        commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await
+                        commit_pending(
+                            db,
+                            &mut pending_writes,
+                            &mut committed_state,
+                            &mut pending_expected,
+                            &mut expected_op_count,
+                        )
+                        .await
                     }
 
                     QmdbOperation::Root => {
-                        let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
-                        db.root();
+                        let db = commit_pending(
+                            db,
+                            &mut pending_writes,
+                            &mut committed_state,
+                            &mut pending_expected,
+                            &mut expected_op_count,
+                        )
+                        .await;
+                        assert_eq!(
+                            db.root(),
+                            db.to_batch().root(),
+                            "database root disagreed with its base batch view",
+                        );
                         db
                     }
 
@@ -176,7 +224,14 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                             continue;
                         }
 
-                        let db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                        let db = commit_pending(
+                            db,
+                            &mut pending_writes,
+                            &mut committed_state,
+                            &mut pending_expected,
+                            &mut expected_op_count,
+                        )
+                        .await;
                         let current_root = db.root();
                         let actual_op_count = db.bounds().end;
                         let adjusted_start = Location::<F>::new(*start_loc % *actual_op_count);
@@ -227,12 +282,40 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         all_keys.insert(*key);
                         db
                     }
+
+                    QmdbOperation::GetMany { keys } => {
+                        let encoded_keys = keys.map(Key::new);
+                        let key_refs = [&encoded_keys[0], &encoded_keys[1]];
+                        let values = db
+                            .get_many(&key_refs)
+                            .await
+                            .expect("get many should not fail");
+                        for (key, value) in keys.iter().zip(values) {
+                            let expected = committed_state
+                                .get(key)
+                                .and_then(Option::as_ref)
+                                .map(|value| Value::new(*value));
+                            assert_eq!(
+                                value,
+                                expected,
+                                "batched get disagreed with committed model",
+                            );
+                        }
+                        db
+                    }
                 };
             }
 
             // Final commit to ensure all operations are persisted.
             if !pending_writes.is_empty() {
-                db = commit_pending(db, &mut pending_writes, &mut committed_state, &mut pending_expected).await;
+                db = commit_pending(
+                    db,
+                    &mut pending_writes,
+                    &mut committed_state,
+                    &mut pending_expected,
+                    &mut expected_op_count,
+                )
+                .await;
             }
 
             // Comprehensive final verification - check ALL keys ever touched.

--- a/storage/fuzz/fuzz_targets/qmgb_gen_any_ordered_variable.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_any_ordered_variable.rs
@@ -5,27 +5,20 @@ use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_parallel::Sequential;
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
 use commonware_storage::{
-    index::ordered::Index,
-    journal::contiguous::fixed::{Config as FConfig, Journal},
+    journal::contiguous::variable::Config as VConfig,
     merkle::{Family as MerkleFamily, Location, Proof, mmb, mmr},
     mmr::full::Config as MerkleConfig,
     qmdb::{
-        any::{
-            FixedConfig as Config,
-            db::Db as AnyDb,
-            ordered::{Operation, Update},
-            value::FixedEncoding,
-        },
+        any::{VariableConfig as Config, ordered::variable::Db as AnyDb},
         create_multi_proof, create_proof_store, verify_multi_proof, verify_proof,
         verify_proof_and_extract_digests, verify_proof_and_pinned_nodes,
     },
     translator::EightCap,
 };
 use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize, sequence::FixedBytes};
-use futures::StreamExt as _;
 use libfuzzer_sys::fuzz_target;
 use std::{
-    collections::{BTreeMap, HashMap, HashSet},
+    collections::{HashMap, HashSet},
     num::{NonZeroU16, NonZeroU64},
 };
 
@@ -33,18 +26,7 @@ type Key = FixedBytes<32>;
 type Value = FixedBytes<64>;
 type RawKey = [u8; 32];
 type RawValue = [u8; 64];
-const BITMAP_CHUNK_BYTES: usize = 64;
-
-type GenericDb<F> = AnyDb<
-    F,
-    deterministic::Context,
-    Journal<deterministic::Context, Operation<F, Key, FixedEncoding<Value>>>,
-    Index<EightCap, Location<F>>,
-    Sha256,
-    Update<Key, FixedEncoding<Value>>,
-    BITMAP_CHUNK_BYTES,
-    Sequential,
->;
+type GenericDb<F> = AnyDb<F, deterministic::Context, Key, Value, Sha256, EightCap, Sequential>;
 
 const MAX_OPS: usize = 25;
 
@@ -73,17 +55,8 @@ enum QmdbOperation {
     Get {
         key: RawKey,
     },
-    GetMany {
-        keys: [RawKey; 2],
-    },
-    GetAll {
-        key: RawKey,
-    },
     GetSpan {
         key: RawKey,
-    },
-    StreamRange {
-        start: RawKey,
     },
 }
 
@@ -114,27 +87,22 @@ const PAGE_CACHE_SIZE: usize = 100;
 async fn commit_pending<F: MerkleFamily>(
     db: GenericDb<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
-    committed_state: &mut BTreeMap<RawKey, RawValue>,
+    committed_state: &mut HashMap<RawKey, RawValue>,
     pending_inserts: &mut HashMap<RawKey, RawValue>,
     pending_deletes: &mut HashSet<RawKey>,
-    expected_op_count: &mut Location<F>,
 ) -> GenericDb<F> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
+    let start = db.bounds().end;
     let merkleized = batch.merkleize(&db, None).await.unwrap();
-    let expected_end = Location::new(merkleized.bounds().total_size);
-    let (db, applied) = db
+    let (db, range) = db
         .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
-    assert_eq!(
-        applied,
-        *expected_op_count..expected_end,
-        "applied operation range disagreed with the modeled log tip",
-    );
-    *expected_op_count = expected_end;
+    assert_eq!(range.start, start);
+    assert_eq!(range.end, db.bounds().end);
     let db = db.commit().await.expect("commit fsync should not fail");
     for key in pending_deletes.drain() {
         committed_state.remove(&key);
@@ -155,19 +123,21 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 PAGE_SIZE,
                 NZUsize!(PAGE_CACHE_SIZE),
             );
-            let cfg = Config::<EightCap, Sequential> {
+            let cfg = Config::<EightCap, ((), ()), Sequential> {
                 merkle_config: MerkleConfig {
-                    journal_partition: format!("test-qmdb-mmr-journal-{suffix}"),
-                    metadata_partition: format!("test-qmdb-mmr-metadata-{suffix}"),
+                    journal_partition: format!("test-qmdb-ordered-variable-mmr-journal-{suffix}"),
+                    metadata_partition: format!("test-qmdb-ordered-variable-mmr-metadata-{suffix}"),
                     items_per_blob: NZU64!(500000),
                     write_buffer: NZUsize!(1024),
                     strategy: Sequential,
                     page_cache: page_cache.clone(),
                 },
-                journal_config: FConfig {
-                    partition: format!("test-qmdb-log-journal-{suffix}"),
-                    items_per_blob: NZU64!(500000),
+                journal_config: VConfig {
+                    partition: format!("test-qmdb-ordered-variable-log-journal-{suffix}"),
+                    items_per_section: NZU64!(500000),
                     write_buffer: NZUsize!(1024),
+                    compression: None,
+                    codec_config: ((), ()),
                     page_cache,
                 },
                 translator: EightCap,
@@ -176,19 +146,18 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 init_concurrency: (),
             };
 
-            let mut db: GenericDb<F> =
-                commonware_storage::qmdb::any::init(context.child("storage"), cfg)
-                    .await
-                    .expect("init qmdb");
+            let mut db: GenericDb<F> = AnyDb::init(context.child("storage"), cfg)
+                .await
+                .expect("init qmdb ordered variable");
 
             // committed_state tracks state after apply_batch. pending_expected tracks
             // uncommitted mutations that haven't been applied yet.
-            let mut committed_state: BTreeMap<RawKey, RawValue> = BTreeMap::new();
+            let mut committed_state: HashMap<RawKey, RawValue> = HashMap::new();
             let mut pending_inserts: HashMap<RawKey, RawValue> = HashMap::new();
             let mut pending_deletes: HashSet<RawKey> = HashSet::new();
             let mut all_keys: HashSet<RawKey> = HashSet::new();
             let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
-            let mut expected_op_count = db.bounds().end;
+            let mut committed_op_count = db.bounds().end;
 
             for op in operations.iter().take(MAX_OPS) {
                 db = match op {
@@ -212,39 +181,25 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     }
 
                     QmdbOperation::OpCount => {
-                        assert_eq!(
-                            db.bounds().end,
-                            expected_op_count,
-                            "operation count disagreed with the modeled log tip",
-                        );
+                        assert_eq!(db.bounds().end, committed_op_count);
                         db
                     }
 
                     QmdbOperation::Commit => {
-                        commit_pending(
+                        let db = commit_pending(
                             db, &mut pending_writes, &mut committed_state,
-                            &mut pending_inserts, &mut pending_deletes, &mut expected_op_count,
-                        ).await
+                            &mut pending_inserts, &mut pending_deletes,
+                        ).await;
+                        committed_op_count = db.bounds().end;
+                        db
                     }
 
                     QmdbOperation::Root => {
-                        let db = commit_pending(
-                            db, &mut pending_writes, &mut committed_state,
-                            &mut pending_inserts, &mut pending_deletes, &mut expected_op_count,
-                        ).await;
-                        assert_eq!(
-                            db.root(),
-                            db.to_batch().root(),
-                            "database root disagreed with its base batch view",
-                        );
+                        assert_eq!(db.root(), db.to_batch().root());
                         db
                     }
 
                     QmdbOperation::Proof { start_loc, max_ops } => {
-                        let db = commit_pending(
-                            db, &mut pending_writes, &mut committed_state,
-                            &mut pending_inserts, &mut pending_deletes, &mut expected_op_count,
-                        ).await;
                         let actual_op_count = db.bounds().end;
 
                         if actual_op_count > 0 {
@@ -330,10 +285,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                     }
 
                     QmdbOperation::ArbitraryProof { start_loc, max_ops , proof_leaves, digests} => {
-                        let db = commit_pending(
-                            db, &mut pending_writes, &mut committed_state,
-                            &mut pending_inserts, &mut pending_deletes, &mut expected_op_count,
-                        ).await;
                         let actual_op_count = db.bounds().end;
 
                         let proof = Proof {
@@ -359,8 +310,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                                     !verified
                                         || (proof.leaves == expected_proof.leaves
                                             && proof.inactive_peaks
-                                                == expected_proof.inactive_peaks
-                                            && proof.digests == expected_proof.digests),
+                                                == expected_proof.inactive_peaks),
                                     "an accepted arbitrary proof should describe the authenticated tree",
                                 );
                             }
@@ -390,107 +340,13 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                         db
                     }
 
-                    QmdbOperation::GetMany { keys } => {
-                        let encoded_keys = keys.map(Key::new);
-                        let key_refs = [&encoded_keys[0], &encoded_keys[1]];
-                        let values = db
-                            .get_many(&key_refs)
-                            .await
-                            .expect("get many should not fail");
-                        for (key, value) in keys.iter().zip(values) {
-                            let expected = committed_state
-                                .get(key)
-                                .map(|value| Value::new(*value));
-                            assert_eq!(
-                                value,
-                                expected,
-                                "batched get disagreed with committed model",
-                            );
-                        }
-                        db
-                    }
-
-                    QmdbOperation::GetAll { key } => {
-                        let actual = db
-                            .get_all(&Key::new(*key))
-                            .await
-                            .expect("get all should not fail");
-                        let expected = committed_state.get(key).map(|value| {
-                            let next = committed_state
-                                .range((std::ops::Bound::Excluded(*key), std::ops::Bound::Unbounded))
-                                .next()
-                                .or_else(|| committed_state.first_key_value())
-                                .expect("active key implies non-empty state")
-                                .0;
-                            (Value::new(*value), Key::new(*next))
-                        });
-                        assert_eq!(actual, expected, "get all disagreed with ordered model");
-                        db
-                    }
-
                     QmdbOperation::GetSpan { key } => {
                         let k = Key::new(*key);
                         let result = db.get_span(&k).await.expect("get should not fail");
-                        assert_eq!(
-                            result.is_some(),
-                            !committed_state.is_empty(),
-                            "span should be empty only if the model is empty",
-                        );
-                        if let Some((_, update)) = result {
-                            let (expected_key, expected_value) = committed_state
-                                .range(..=*key)
-                                .next_back()
-                                .or_else(|| committed_state.last_key_value())
-                                .expect("a returned span requires a non-empty model");
-                            let expected_next = committed_state
-                                .range((
-                                    std::ops::Bound::Excluded(*expected_key),
-                                    std::ops::Bound::Unbounded,
-                                ))
-                                .next()
-                                .or_else(|| committed_state.first_key_value())
-                                .expect("a returned span requires a non-empty model")
-                                .0;
-                            assert_eq!(update.key, Key::new(*expected_key));
-                            assert_eq!(update.value, Value::new(*expected_value));
-                            assert_eq!(update.next_key, Key::new(*expected_next));
-                            assert!(
-                                GenericDb::<F>::span_contains(&update.key, &update.next_key, &k),
-                                "returned span does not contain the requested key",
-                            );
-                        }
-                        db
-                    }
-
-                    QmdbOperation::StreamRange { start } => {
-                        let actual = {
-                            let stream = db
-                                .stream_range(Key::new(*start))
-                                .await
-                                .expect("stream range should not fail");
-                            futures::pin_mut!(stream);
-                            let mut actual = Vec::new();
-                            while let Some(entry) = stream.next().await {
-                                actual.push(entry.expect("stream entry should not fail"));
-                            }
-                            actual
-                        };
-                        let expected = committed_state
-                            .range(*start..)
-                            .map(|(key, value)| (Key::new(*key), Value::new(*value)))
-                            .collect::<Vec<_>>();
-                        assert_eq!(actual, expected, "stream range disagreed with ordered model");
+                        assert_eq!(result.is_some(), !db.is_empty(), "span should be empty only if db is empty");
                         db
                     }
                 };
-            }
-
-            // Final commit to ensure all operations are persisted.
-            if !pending_writes.is_empty() {
-                db = commit_pending(
-                    db, &mut pending_writes, &mut committed_state,
-                    &mut pending_inserts, &mut pending_deletes, &mut expected_op_count,
-                ).await;
             }
 
             // Comprehensive final verification - check ALL keys ever touched.
@@ -516,15 +372,6 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 }
             }
 
-            let batch = db.new_batch().merkleize(&db, None).await.unwrap();
-            let (db, _) = db
-                .apply_batch(batch)
-                .await
-                .expect("final commit should not fail");
-            let db = db
-                .commit()
-                .await
-                .expect("final commit fsync should not fail");
             db.destroy().await.expect("destroy should not fail");
         }
     });

--- a/storage/fuzz/fuzz_targets/qmgb_gen_current_ordered_variable.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_current_ordered_variable.rs
@@ -1,17 +1,16 @@
 #![no_main]
 
-use arbitrary::{Arbitrary, Unstructured};
+use arbitrary::Arbitrary;
 use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_parallel::Sequential;
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
 use commonware_storage::{
-    journal::contiguous::fixed::Config as FConfig,
+    journal::contiguous::variable::Config as VConfig,
     merkle::{Graftable, Location, full::Config as MerkleConfig, mmb, mmr},
-    qmdb::current::{FixedConfig as Config, ordered::fixed::Db as CurrentDb},
+    qmdb::current::{VariableConfig as Config, ordered::variable::Db as CurrentDb},
     translator::TwoCap,
 };
 use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize, sequence::FixedBytes};
-use futures::{StreamExt as _, pin_mut};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::{HashMap, HashSet},
@@ -61,35 +60,25 @@ enum CurrentOperation {
     ExclusionProof {
         key: RawKey,
     },
-    StreamRange {
-        start: RawKey,
-    },
 }
 
 const MAX_OPERATIONS: usize = 100;
 
-// The number of key/values to write to the db at the start of each fuzz run. This value is
-// chosen to be large enough to ensure there is at least one pending chunk.
-const MAX_INITIAL_WRITES: u16 = 320;
-
 #[derive(Debug)]
 struct FuzzInput {
-    initial_writes: u16,
     operations: Vec<CurrentOperation>,
     raw_bytes: Vec<u8>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
-    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let raw_len = u.len().min(8);
         let raw_bytes = u.bytes(raw_len)?.to_vec();
-        let initial_writes = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let operations = (0..num_ops)
             .map(|_| CurrentOperation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(FuzzInput {
-            initial_writes,
             operations,
             raw_bytes,
         })
@@ -102,15 +91,6 @@ const MERKLE_ITEMS_PER_BLOB: u64 = 11;
 const LOG_ITEMS_PER_BLOB: u64 = 7;
 const WRITE_BUFFER_SIZE: usize = 1024;
 
-// Generates a deterministic key/value pair for seeding the db.
-fn generate_seed_kv(index: u64) -> (RawKey, RawValue) {
-    let mut key = [0u8; 32];
-    key[..8].copy_from_slice(&index.to_be_bytes());
-    let mut value = [0u8; 32];
-    value[24..].copy_from_slice(&index.to_be_bytes());
-    (key, value)
-}
-
 async fn commit_pending<F: Graftable>(
     db: Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
@@ -122,11 +102,14 @@ async fn commit_pending<F: Graftable>(
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
+    let start = db.bounds().end;
     let merkleized = batch.merkleize(&db, None).await.unwrap();
-    let (db, _) = db
+    let (db, range) = db
         .apply_batch(merkleized)
         .await
         .expect("commit should not fail");
+    assert_eq!(range.start, start);
+    assert_eq!(range.end, db.bounds().end);
     let db = db.commit().await.expect("commit fsync should not fail");
     for key in pending_deletes.drain() {
         committed_state.remove(&key);
@@ -140,7 +123,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::new(cfg);
 
     let suffix = suffix.to_string();
-    let initial_writes = data.initial_writes;
     let operations = data.operations.clone();
     runner.start(|context| async move {
         let page_cache = CacheRef::from_pooler(
@@ -150,20 +132,22 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         );
         let cfg = Config {
             merkle_config: MerkleConfig {
-                journal_partition: format!("fuzz-current-ord-{suffix}-merkle-journal"),
-                metadata_partition: format!("fuzz-current-ord-{suffix}-merkle-metadata"),
+                journal_partition: format!("fuzz-current-ord-var-{suffix}-merkle-journal"),
+                metadata_partition: format!("fuzz-current-ord-var-{suffix}-merkle-metadata"),
                 items_per_blob: NZU64!(MERKLE_ITEMS_PER_BLOB),
                 write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
                 strategy: Sequential,
                 page_cache: page_cache.clone(),
             },
-            journal_config: FConfig {
-                partition: format!("fuzz-current-ord-{suffix}-log-journal"),
-                items_per_blob: NZU64!(LOG_ITEMS_PER_BLOB),
+            journal_config: VConfig {
+                partition: format!("fuzz-current-ord-var-{suffix}-log-journal"),
+                items_per_section: NZU64!(LOG_ITEMS_PER_BLOB),
                 write_buffer: NZUsize!(WRITE_BUFFER_SIZE),
+                compression: None,
+                codec_config: ((), ()),
                 page_cache,
             },
-            grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
+            grafted_metadata_partition: format!("fuzz-current-ord-var-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
             init_buffer: NZUsize!(1 << 21),
@@ -181,25 +165,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
         let mut pending_deletes: HashSet<RawKey> = HashSet::new();
         let mut all_keys = HashSet::new();
         let mut pending_writes: Vec<(Key, Option<Value>)> = Vec::new();
-        let mut committed_op_count = Location::<F>::new(1);
-
-        for i in 0..u64::from(initial_writes) {
-            let (key, value) = generate_seed_kv(i);
-            pending_writes.push((Key::new(key), Some(Value::new(value))));
-            pending_inserts.insert(key, value);
-            all_keys.insert(key);
-        }
-        if !pending_writes.is_empty() {
-            db = commit_pending(
-                db,
-                &mut pending_writes,
-                &mut committed_state,
-                &mut pending_inserts,
-                &mut pending_deletes,
-            )
-            .await;
-            committed_op_count = db.bounds().end;
-        }
+        let mut committed_op_count = db.bounds().end;
 
         for op in &operations {
             db = match op {
@@ -271,26 +237,12 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 }
 
                 CurrentOperation::Prune => {
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
                     let boundary = db.sync_boundary();
                     db.prune(boundary).await.expect("Prune should not fail")
                 }
 
                 CurrentOperation::Root => {
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
-                    assert_eq!(
-                        db.root(),
-                        db.to_batch().root(),
-                        "database and snapshot roots should match",
-                    );
+                    assert_eq!(db.root(), db.to_batch().root());
                     db
                 }
 
@@ -300,11 +252,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                         continue;
                     }
 
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     let current_op_count = db.bounds().end;
@@ -343,12 +290,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     if current_op_count == 0 {
                         continue;
                     }
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
-
                     let current_op_count = db.bounds().end;
                     let start_loc = Location::<F>::new(start_loc % current_op_count.as_u64());
                     let root = db.root();
@@ -423,11 +364,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 CurrentOperation::KeyValueProof { key } => {
                     let k = Key::new(*key);
 
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     match db.key_value_proof(k.clone()).await {
@@ -454,11 +390,6 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                 CurrentOperation::ExclusionProof { key } => {
                     let k = Key::new(*key);
 
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
                     let current_root = db.root();
 
                     match db.exclusion_proof(&k).await {
@@ -479,49 +410,8 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     }
                     db
                 }
-
-                CurrentOperation::StreamRange { start } => {
-                    let db = commit_pending(
-                        db, &mut pending_writes, &mut committed_state,
-                        &mut pending_inserts, &mut pending_deletes,
-                    ).await;
-                    committed_op_count = db.bounds().end;
-                    let mut expected = committed_state
-                        .iter()
-                        .filter(|(key, _)| *key >= start)
-                        .map(|(key, value)| (*key, *value))
-                        .collect::<Vec<_>>();
-                    expected.sort_unstable_by_key(|(key, _)| *key);
-
-                    let actual = {
-                        let stream = db
-                            .stream_range(Key::new(*start))
-                            .await
-                            .expect("range stream should not fail");
-                        pin_mut!(stream);
-                        let mut actual = Vec::new();
-                        while let Some(item) = stream.next().await {
-                            let (key, value) = item.expect("range stream item should not fail");
-                            let key: &[u8; 32] = key.as_ref().try_into().expect("key length");
-                            let value: &[u8; 32] = value.as_ref().try_into().expect("value length");
-                            actual.push((*key, *value));
-                        }
-                        actual
-                    };
-                    assert_eq!(actual, expected, "range stream should match the ordered model");
-                    db
-                }
             };
         }
-
-        // Final commit to ensure all pending operations are persisted.
-        if !pending_writes.is_empty() {
-            db = commit_pending(
-                db, &mut pending_writes, &mut committed_state,
-                &mut pending_inserts, &mut pending_deletes,
-            ).await;
-        }
-
 
         for key in &all_keys {
             let k = Key::new(*key);

--- a/storage/fuzz/fuzz_targets/qmgb_gen_immutable_compact.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_immutable_compact.rs
@@ -1,0 +1,433 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use commonware_cryptography::{Sha256, sha256::Digest};
+use commonware_parallel::Sequential;
+use commonware_runtime::{
+    BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::{
+    journal::contiguous::variable::Config as JournalConfig,
+    merkle::{Family, Location, mmb, mmr},
+    qmdb::{
+        immutable::{
+            fixed::{CompactConfig as FixedConfig, CompactDb as FixedDb},
+            variable::{CompactConfig as VariableConfig, CompactDb as VariableDb},
+        },
+        sync::compact,
+    },
+};
+use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize};
+use libfuzzer_sys::fuzz_target;
+use std::{collections::BTreeSet, num::NonZeroU16, sync::Arc};
+
+const MAX_OPERATIONS: usize = 40;
+const PAGE_SIZE: NonZeroU16 = NZU16!(137);
+type VariableCodec = ((), (commonware_codec::RangeCfg<usize>, ()));
+
+#[derive(Arbitrary, Clone, Debug)]
+enum Operation {
+    Set {
+        key: [u8; 32],
+        value: [u8; 32],
+    },
+    Commit {
+        metadata: Option<[u8; 32]>,
+        advance_floor: bool,
+    },
+    Sync,
+    Rewind {
+        index: u8,
+    },
+    Prune {
+        index: u8,
+    },
+    ToBatch,
+    Target,
+    CompactSync,
+    Root,
+    Metadata,
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    raw_bytes: Vec<u8>,
+    operations: Vec<Operation>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let operation_count = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let operations = (0..operation_count)
+            .map(|_| Operation::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            raw_bytes,
+            operations,
+        })
+    }
+}
+
+#[derive(Clone)]
+struct Commit<D, V> {
+    size: u64,
+    root: D,
+    metadata: Option<V>,
+}
+
+fn witness_config(name: &str, pooler: &impl BufferPooler) -> JournalConfig<()> {
+    JournalConfig {
+        partition: format!("{name}-witness"),
+        items_per_section: NZU64!(7),
+        compression: None,
+        codec_config: (),
+        page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(8)),
+        write_buffer: NZUsize!(1024),
+    }
+}
+
+fn fixed_config(name: &str, pooler: &impl BufferPooler) -> FixedConfig<Sequential> {
+    FixedConfig {
+        strategy: Sequential,
+        witness: witness_config(name, pooler),
+        commit_codec_config: (),
+    }
+}
+
+fn variable_config(
+    name: &str,
+    pooler: &impl BufferPooler,
+) -> VariableConfig<VariableCodec, Sequential> {
+    VariableConfig {
+        strategy: Sequential,
+        witness: witness_config(name, pooler),
+        commit_codec_config: ((), ((0..=32).into(), ())),
+    }
+}
+
+fn fuzz_fixed<F: Family>(input: &FuzzInput, name: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let config = fixed_config(name, &context);
+        let mut db: FixedDb<F, _, Digest, Digest, Sha256, Sequential> =
+            FixedDb::init(context.child("db"), config.clone())
+                .await
+                .expect("initialize fixed compact immutable db");
+        let mut pending = Vec::new();
+        let mut seen = BTreeSet::new();
+        let mut commits = vec![Commit {
+            size: db.size().as_u64(),
+            root: db.root(),
+            metadata: db.get_metadata(),
+        }];
+        let mut sync_id = 0usize;
+
+        for operation in &input.operations {
+            match operation {
+                Operation::Set { key, value } => {
+                    if seen.insert(*key) {
+                        pending.push((Digest::from(*key), Digest::from(*value)));
+                    }
+                }
+                Operation::Commit {
+                    metadata,
+                    advance_floor,
+                } => {
+                    let commit_loc = db.size().as_u64() + pending.len() as u64;
+                    let floor = if *advance_floor {
+                        Location::new(commit_loc)
+                    } else {
+                        db.inactivity_floor_loc()
+                    };
+                    let mut batch = db.new_batch();
+                    for (key, value) in pending.drain(..) {
+                        batch = batch.set(key, value);
+                    }
+                    let batch = batch
+                        .merkleize(&db, metadata.map(Digest::from), floor)
+                        .await;
+                    assert!(db.validate_batch(&batch).is_ok());
+                    let expected_root = batch.root();
+                    let start = db.size();
+                    let range;
+                    (db, range) = db.apply_batch(batch).expect("apply fixed compact batch");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, db.size());
+                    assert_eq!(db.root(), expected_root);
+                    db = db.commit().await.expect("commit fixed compact db");
+                    commits.push(Commit {
+                        size: db.size().as_u64(),
+                        root: db.root(),
+                        metadata: db.get_metadata(),
+                    });
+                }
+                Operation::Sync => {
+                    let expected = (
+                        db.size(),
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata(),
+                    );
+                    db = db.sync().await.expect("sync fixed compact db");
+                    assert_eq!(
+                        (
+                            db.size(),
+                            db.root(),
+                            db.inactivity_floor_loc(),
+                            db.get_metadata(),
+                        ),
+                        expected,
+                        "sync should preserve fixed compact immutable state"
+                    );
+                    commits.push(Commit {
+                        size: db.size().as_u64(),
+                        root: db.root(),
+                        metadata: db.get_metadata(),
+                    });
+                }
+                Operation::Rewind { index } => {
+                    let commit = commits[*index as usize % commits.len()].clone();
+                    db = db
+                        .rewind(Location::new(commit.size))
+                        .await
+                        .expect("rewind fixed compact db");
+                    assert_eq!(db.root(), commit.root);
+                    assert_eq!(db.get_metadata(), commit.metadata);
+                    commits.retain(|candidate| candidate.size <= commit.size);
+                }
+                Operation::Prune { index } => {
+                    let boundary = commits[*index as usize % commits.len()].size;
+                    let expected = (db.size(), db.root(), db.get_metadata());
+                    db = db
+                        .prune(Location::new(boundary))
+                        .await
+                        .expect("prune fixed compact db");
+                    assert_eq!(
+                        (db.size(), db.root(), db.get_metadata()),
+                        expected,
+                        "prune should preserve fixed compact immutable state"
+                    );
+                    commits.retain(|candidate| candidate.size >= boundary);
+                }
+                Operation::ToBatch => {
+                    let snapshot = db.to_batch();
+                    assert_eq!(snapshot.root(), db.root());
+                    assert_eq!(snapshot.bounds().total_size, db.size().as_u64());
+                }
+                Operation::Target => {
+                    let target = db.target();
+                    assert!(target.validate().is_ok());
+                    assert_eq!(target.root, db.root());
+                }
+                Operation::CompactSync => {
+                    let target = db.target();
+                    let expected_size = db.size();
+                    let source = Arc::new(db);
+                    let client_config = fixed_config(&format!("{name}-client-{sync_id}"), &context);
+                    let client: FixedDb<F, _, Digest, Digest, Sha256, Sequential> =
+                        compact::sync(compact::Config {
+                            context: context.child("client"),
+                            resolver: source.clone(),
+                            target: target.clone(),
+                            db_config: client_config,
+                            update_rx: None,
+                            finish_rx: None,
+                            reached_target_tx: None,
+                        })
+                        .await
+                        .expect("compact-sync fixed immutable db");
+                    assert_eq!(client.root(), target.root);
+                    assert_eq!(client.size(), expected_size);
+                    assert_eq!(client.get_metadata(), source.get_metadata());
+                    client
+                        .destroy()
+                        .await
+                        .expect("destroy fixed compact client");
+                    db = Arc::try_unwrap(source).unwrap_or_else(|_| panic!("source still shared"));
+                    sync_id += 1;
+                }
+                Operation::Root => assert_eq!(db.root(), db.to_batch().root()),
+                Operation::Metadata => {
+                    assert_eq!(db.get_metadata(), commits.last().unwrap().metadata)
+                }
+            }
+        }
+
+        db.destroy()
+            .await
+            .expect("destroy fixed compact immutable db");
+    });
+}
+
+fn fuzz_variable<F: Family>(input: &FuzzInput, name: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let config = variable_config(name, &context);
+        let mut db: VariableDb<F, _, Digest, Vec<u8>, Sha256, VariableCodec, Sequential> =
+            VariableDb::init(context.child("db"), config.clone())
+                .await
+                .expect("initialize variable compact immutable db");
+        let mut pending = Vec::new();
+        let mut seen = BTreeSet::new();
+        let mut commits = vec![Commit {
+            size: db.size().as_u64(),
+            root: db.root(),
+            metadata: db.get_metadata(),
+        }];
+        let mut sync_id = 0usize;
+
+        for operation in &input.operations {
+            match operation {
+                Operation::Set { key, value } => {
+                    if seen.insert(*key) {
+                        pending.push((Digest::from(*key), value.to_vec()));
+                    }
+                }
+                Operation::Commit {
+                    metadata,
+                    advance_floor,
+                } => {
+                    let commit_loc = db.size().as_u64() + pending.len() as u64;
+                    let floor = if *advance_floor {
+                        Location::new(commit_loc)
+                    } else {
+                        db.inactivity_floor_loc()
+                    };
+                    let mut batch = db.new_batch();
+                    for (key, value) in pending.drain(..) {
+                        batch = batch.set(key, value);
+                    }
+                    let batch = batch
+                        .merkleize(&db, metadata.map(|value| value.to_vec()), floor)
+                        .await;
+                    assert!(db.validate_batch(&batch).is_ok());
+                    let expected_root = batch.root();
+                    let start = db.size();
+                    let range;
+                    (db, range) = db.apply_batch(batch).expect("apply variable compact batch");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, db.size());
+                    assert_eq!(db.root(), expected_root);
+                    db = db.commit().await.expect("commit variable compact db");
+                    commits.push(Commit {
+                        size: db.size().as_u64(),
+                        root: db.root(),
+                        metadata: db.get_metadata(),
+                    });
+                }
+                Operation::Sync => {
+                    let expected = (
+                        db.size(),
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata(),
+                    );
+                    db = db.sync().await.expect("sync variable compact db");
+                    assert_eq!(
+                        (
+                            db.size(),
+                            db.root(),
+                            db.inactivity_floor_loc(),
+                            db.get_metadata(),
+                        ),
+                        expected,
+                        "sync should preserve variable compact immutable state"
+                    );
+                    commits.push(Commit {
+                        size: db.size().as_u64(),
+                        root: db.root(),
+                        metadata: db.get_metadata(),
+                    });
+                }
+                Operation::Rewind { index } => {
+                    let commit = commits[*index as usize % commits.len()].clone();
+                    db = db
+                        .rewind(Location::new(commit.size))
+                        .await
+                        .expect("rewind variable compact db");
+                    assert_eq!(db.root(), commit.root);
+                    assert_eq!(db.get_metadata(), commit.metadata);
+                    commits.retain(|candidate| candidate.size <= commit.size);
+                }
+                Operation::Prune { index } => {
+                    let boundary = commits[*index as usize % commits.len()].size;
+                    let expected = (db.size(), db.root(), db.get_metadata());
+                    db = db
+                        .prune(Location::new(boundary))
+                        .await
+                        .expect("prune variable compact db");
+                    assert_eq!(
+                        (db.size(), db.root(), db.get_metadata()),
+                        expected,
+                        "prune should preserve variable compact immutable state"
+                    );
+                    commits.retain(|candidate| candidate.size >= boundary);
+                }
+                Operation::ToBatch => {
+                    let snapshot = db.to_batch();
+                    assert_eq!(snapshot.root(), db.root());
+                    assert_eq!(snapshot.bounds().total_size, db.size().as_u64());
+                }
+                Operation::Target => {
+                    let target = db.target();
+                    assert!(target.validate().is_ok());
+                    assert_eq!(target.root, db.root());
+                }
+                Operation::CompactSync => {
+                    let target = db.target();
+                    let expected_size = db.size();
+                    let source = Arc::new(db);
+                    let client_config =
+                        variable_config(&format!("{name}-client-{sync_id}"), &context);
+                    let client: VariableDb<
+                        F,
+                        _,
+                        Digest,
+                        Vec<u8>,
+                        Sha256,
+                        VariableCodec,
+                        Sequential,
+                    > = compact::sync(compact::Config {
+                        context: context.child("client"),
+                        resolver: source.clone(),
+                        target: target.clone(),
+                        db_config: client_config,
+                        update_rx: None,
+                        finish_rx: None,
+                        reached_target_tx: None,
+                    })
+                    .await
+                    .expect("compact-sync variable immutable db");
+                    assert_eq!(client.root(), target.root);
+                    assert_eq!(client.size(), expected_size);
+                    assert_eq!(client.get_metadata(), source.get_metadata());
+                    client
+                        .destroy()
+                        .await
+                        .expect("destroy variable compact client");
+                    db = Arc::try_unwrap(source).unwrap_or_else(|_| panic!("source still shared"));
+                    sync_id += 1;
+                }
+                Operation::Root => assert_eq!(db.root(), db.to_batch().root()),
+                Operation::Metadata => {
+                    assert_eq!(db.get_metadata(), commits.last().unwrap().metadata)
+                }
+            }
+        }
+
+        db.destroy()
+            .await
+            .expect("destroy variable compact immutable db");
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz_fixed::<mmr::Family>(&input, "qmgb-immutable-compact-fixed-mmr");
+    fuzz_fixed::<mmb::Family>(&input, "qmgb-immutable-compact-fixed-mmb");
+    fuzz_variable::<mmr::Family>(&input, "qmgb-immutable-compact-variable-mmr");
+    fuzz_variable::<mmb::Family>(&input, "qmgb-immutable-compact-variable-mmb");
+});

--- a/storage/fuzz/fuzz_targets/qmgb_gen_immutable_fixed.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_immutable_fixed.rs
@@ -1,0 +1,362 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use commonware_cryptography::{Hasher, Sha256, sha256::Digest};
+use commonware_parallel::Sequential;
+use commonware_runtime::{BufferPooler, Runner, buffer::paged::CacheRef, deterministic};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{Family as MerkleFamily, Location, mmb, mmr},
+    mmr::full::Config as MerkleConfig,
+    qmdb::{
+        immutable::{Config, fixed::Db as Immutable},
+        verify_proof,
+    },
+    translator::TwoCap,
+};
+use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize};
+use libfuzzer_sys::fuzz_target;
+use rand::RngExt as _;
+use rand_core::CryptoRng;
+use std::{
+    collections::BTreeMap,
+    num::{NonZeroU16, NonZeroU64},
+};
+
+const MAX_OPERATIONS: usize = 50;
+const MAX_VALUE_SIZE: usize = 256;
+const MAX_PROOF_OPS: u64 = 100;
+const PAGE_SIZE: NonZeroU16 = NZU16!(77);
+const PAGE_CACHE_SIZE: usize = 9;
+const ITEMS_PER_SECTION: u64 = 5;
+const ITEMS_PER_BLOB: u64 = 11;
+
+#[derive(Arbitrary, Debug, Clone)]
+enum ImmutableOperation {
+    Set {
+        key_seed: u64,
+        value_size: usize,
+    },
+    Get {
+        key_seed: u64,
+    },
+    Commit {
+        has_metadata: bool,
+        metadata_size: usize,
+        advance_floor: bool,
+    },
+    Prune {
+        loc: u64,
+    },
+    Proof {
+        start_index: u64,
+        max_ops: u64,
+    },
+    HistoricalProof {
+        size: u64,
+        start_loc: u64,
+        max_ops: u64,
+    },
+    GetMetadata,
+    OpCount,
+    OldestRetainedLoc,
+    Root,
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    operations: Vec<ImmutableOperation>,
+    raw_bytes: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let mut operations = Vec::with_capacity(num_ops);
+
+        for _ in 0..num_ops {
+            operations.push(u.arbitrary()?);
+        }
+
+        Ok(FuzzInput {
+            operations,
+            raw_bytes,
+        })
+    }
+}
+
+fn generate_key(seed: u64) -> Digest {
+    Sha256::hash(&seed.to_be_bytes())
+}
+
+fn generate_value(rng: &mut impl CryptoRng, size: usize) -> Digest {
+    let actual_size = size.clamp(1, MAX_VALUE_SIZE);
+    let bytes = (0..actual_size).map(|_| rng.random()).collect::<Vec<u8>>();
+    Sha256::hash(&bytes)
+}
+
+#[allow(clippy::type_complexity)]
+fn db_config(suffix: &str, pooler: &impl BufferPooler) -> Config<TwoCap, FConfig, Sequential> {
+    let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE));
+    Config {
+        merkle_config: MerkleConfig {
+            journal_partition: format!("journal-{suffix}"),
+            metadata_partition: format!("metadata-{suffix}"),
+            items_per_blob: NZU64!(ITEMS_PER_BLOB),
+            write_buffer: NZUsize!(1024),
+            strategy: Sequential,
+            page_cache: page_cache.clone(),
+        },
+        log: FConfig {
+            partition: format!("log-{suffix}"),
+            items_per_blob: NZU64!(ITEMS_PER_SECTION),
+            write_buffer: NZUsize!(1024),
+            page_cache,
+        },
+        translator: TwoCap,
+        init_cache_size: Some(NZUsize!(3)),
+        init_buffer: NZUsize!(1 << 21),
+    }
+}
+
+/// Assign locations to pending keys based on sorted order (matching BTreeMap
+/// iteration in `merkleize()`).
+fn assign_pending_locations<F: MerkleFamily>(
+    pending: &[(Digest, Digest)],
+    base: Location<F>,
+    keys_set: &mut Vec<(Digest, Location<F>)>,
+    set_locations: &mut Vec<(Digest, Location<F>)>,
+) {
+    let mut sorted_keys: Vec<Digest> = pending.iter().map(|(k, _)| *k).collect();
+    sorted_keys.sort();
+    for (i, key) in sorted_keys.iter().enumerate() {
+        let loc = Location::new(base.as_u64() + i as u64);
+        keys_set.push((*key, loc));
+        set_locations.push((*key, loc));
+    }
+}
+
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
+    let cfg =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    let runner = deterministic::Runner::new(cfg);
+
+    runner.start(|context| {
+        let operations = input.operations.clone();
+        async move {
+            let mut rng = FuzzRng::new(input.raw_bytes.clone());
+
+            let cfg = db_config(suffix, &context);
+            let mut db =
+                Immutable::<F, _, Digest, Digest, Sha256, TwoCap, Sequential>::init(context, cfg)
+                    .await
+                    .unwrap();
+
+            let mut keys_set: Vec<(Digest, Location<F>)> = Vec::new();
+            let mut set_locations: Vec<(Digest, Location<F>)> = Vec::new();
+            let mut pending_sets: Vec<(Digest, Digest)> = Vec::new();
+            let mut committed_values = BTreeMap::<Digest, (Digest, Location<F>)>::new();
+            let mut expected_metadata = None;
+            let mut expected_root = db.root();
+            let mut expected_size = db.bounds().end;
+            let mut commits = vec![(expected_size, expected_root)];
+
+            for op in operations {
+                db = match op {
+                    ImmutableOperation::Set {
+                        key_seed,
+                        value_size,
+                    } => {
+                        let key = generate_key(key_seed);
+                        let value = generate_value(&mut rng, value_size);
+
+                        if !keys_set.iter().any(|(k, _)| k == &key)
+                            && !pending_sets.iter().any(|(k, _)| k == &key)
+                        {
+                            pending_sets.push((key, value));
+                        }
+                        db
+                    }
+
+                    ImmutableOperation::Get { key_seed } => {
+                        let key = generate_key(key_seed);
+                        let actual = db.get(&key).await.expect("get should not fail");
+                        let expected = committed_values
+                            .get(&key)
+                            .filter(|(_, loc)| *loc >= db.bounds().start)
+                            .map(|(value, _)| *value);
+                        assert_eq!(actual, expected);
+                        db
+                    }
+
+                    ImmutableOperation::Commit {
+                        has_metadata,
+                        metadata_size,
+                        advance_floor,
+                    } => {
+                        let metadata = if has_metadata {
+                            Some(generate_value(&mut rng, metadata_size))
+                        } else {
+                            None
+                        };
+
+                        let end = db.bounds().end;
+                        let pending_count = pending_sets.len() as u64;
+                        let mut committed = pending_sets.clone();
+                        committed.sort_by_key(|(key, _)| *key);
+                        assign_pending_locations(
+                            &pending_sets,
+                            end,
+                            &mut keys_set,
+                            &mut set_locations,
+                        );
+                        let mut batch = db.new_batch();
+                        for (k, v) in pending_sets.drain(..) {
+                            batch = batch.set(k, v);
+                        }
+                        let floor = if advance_floor {
+                            // Advance floor to the commit location (end of this batch).
+                            // total_size = end + pending_count + 1 (commit op).
+                            // Floor at the commit op is the maximum valid value.
+                            Location::new(*end + pending_count)
+                        } else {
+                            db.inactivity_floor_loc()
+                        };
+                        let merkleized = batch.merkleize(&db, metadata, floor).await;
+                        let expected_batch_root = merkleized.root();
+                        let (db, range) = db.apply_batch(merkleized).await.unwrap();
+                        assert_eq!(range.start, end);
+                        assert_eq!(range.end, db.bounds().end);
+                        assert_eq!(db.root(), expected_batch_root);
+                        let db = db.commit().await.unwrap();
+                        for ((key, value), (_, loc)) in committed.into_iter().zip(
+                            set_locations[set_locations.len() - pending_count as usize..]
+                                .iter()
+                                .copied(),
+                        ) {
+                            committed_values.insert(key, (value, loc));
+                        }
+                        expected_metadata = metadata;
+                        expected_root = expected_batch_root;
+                        expected_size = db.bounds().end;
+                        commits.push((expected_size, expected_root));
+                        db
+                    }
+
+                    ImmutableOperation::Prune { loc } => {
+                        let bounds = db.bounds();
+                        let floor = db.inactivity_floor_loc();
+                        let width = floor.as_u64().saturating_sub(bounds.start.as_u64()) + 1;
+                        let safe_loc = Location::new(bounds.start.as_u64() + loc % width);
+                        let root = db.root();
+                        let db = db.prune(safe_loc).await.expect("prune should not fail");
+                        assert_eq!(db.root(), root);
+                        assert_eq!(db.bounds().end, expected_size);
+                        committed_values
+                            .retain(|_, (_, value_loc)| *value_loc >= db.bounds().start);
+                        set_locations.retain(|(_, value_loc)| *value_loc >= db.bounds().start);
+                        keys_set.retain(|(_, value_loc)| *value_loc >= db.bounds().start);
+                        db
+                    }
+
+                    ImmutableOperation::Proof {
+                        start_index,
+                        max_ops,
+                    } => {
+                        let bounds = db.bounds();
+                        if bounds.start < bounds.end {
+                            let safe_start = Location::new(
+                                bounds.start.as_u64()
+                                    + start_index % (bounds.end - bounds.start).as_u64(),
+                            );
+                            let safe_max_ops =
+                                NonZeroU64::new((max_ops % MAX_PROOF_OPS).max(1)).unwrap();
+                            let (proof, ops) = db
+                                .proof(safe_start, safe_max_ops)
+                                .await
+                                .expect("proof should not fail for a retained location");
+                            assert!(verify_proof::<Sha256, _, _>(
+                                &proof,
+                                safe_start,
+                                &ops,
+                                &expected_root,
+                            ));
+                        }
+                        db
+                    }
+
+                    ImmutableOperation::HistoricalProof {
+                        size,
+                        start_loc,
+                        max_ops,
+                    } => {
+                        let retained = commits
+                            .iter()
+                            .filter(|(commit_size, _)| *commit_size > db.bounds().start)
+                            .copied()
+                            .collect::<Vec<_>>();
+                        if !retained.is_empty() {
+                            let (safe_size, historical_root) =
+                                retained[size as usize % retained.len()];
+                            let safe_start = Location::new(
+                                db.bounds().start.as_u64()
+                                    + start_loc % (safe_size - db.bounds().start).as_u64(),
+                            );
+                            let safe_max_ops =
+                                NonZeroU64::new((max_ops % MAX_PROOF_OPS).max(1)).unwrap();
+                            let (proof, ops) = db
+                                .historical_proof(safe_size, safe_start, safe_max_ops)
+                                .await
+                                .expect("historical proof should not fail at a retained commit");
+                            assert!(verify_proof::<Sha256, _, _>(
+                                &proof,
+                                safe_start,
+                                &ops,
+                                &historical_root,
+                            ));
+                        }
+                        db
+                    }
+
+                    ImmutableOperation::GetMetadata => {
+                        assert_eq!(
+                            db.get_metadata()
+                                .await
+                                .expect("metadata read should not fail"),
+                            expected_metadata
+                        );
+                        db
+                    }
+
+                    ImmutableOperation::OpCount => {
+                        assert_eq!(db.bounds().end, expected_size);
+                        db
+                    }
+
+                    ImmutableOperation::OldestRetainedLoc => {
+                        assert!(db.bounds().start <= db.inactivity_floor_loc());
+                        db
+                    }
+
+                    ImmutableOperation::Root => {
+                        assert_eq!(db.root(), expected_root);
+                        db
+                    }
+                };
+            }
+
+            db.destroy().await.unwrap();
+        }
+    });
+}
+
+fn fuzz(input: FuzzInput) {
+    fuzz_family::<mmr::Family>(&input, "fuzz-fixed-mmr");
+    fuzz_family::<mmb::Family>(&input, "fuzz-fixed-mmb");
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz(input);
+});

--- a/storage/fuzz/fuzz_targets/qmgb_gen_keyless_compact_fixed.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_keyless_compact_fixed.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_cryptography::Sha256;
+use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
 use commonware_parallel::{Rayon, Sequential, Strategy};
 use commonware_runtime::{
     BufferPooler, Runner, Strategizer, Supervisor as _, buffer::paged::CacheRef, deterministic,
@@ -11,7 +11,7 @@ use commonware_storage::{
     merkle::{Error as MerkleError, Family, Location, mmb, mmr},
     qmdb::{
         Error,
-        keyless::variable::{CompactConfig, CompactDb},
+        keyless::fixed::{CompactConfig, CompactDb},
         sync::compact as compact_sync,
     },
 };
@@ -22,7 +22,6 @@ use std::{num::NonZeroU16, sync::Arc};
 const MAX_OPERATIONS: usize = 50;
 const MAX_VALUE_LEN: usize = 10000;
 const MAX_METADATA_LEN: usize = 1000;
-type CodecConfig = (commonware_codec::RangeCfg<usize>, ());
 
 /// Which error variant a bad-floor commit should produce.
 #[derive(Debug, Clone, Copy)]
@@ -96,23 +95,19 @@ enum Operation {
     /// Drop the handle without syncing and reopen: state must match the last synced commit.
     Restart,
     Root,
-    LastCommitLoc,
     GetMetadata,
     Target,
-    ToBatch,
-    Strategy {
-        values: [u8; 4],
-    },
+    CompactSync,
 }
 
 impl<'a> Arbitrary<'a> for Operation {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice: u8 = u.arbitrary()?;
-        match choice % 16 {
+        match choice % 14 {
             0 => {
                 let value_len: u16 = u.arbitrary()?;
                 let actual_len = (((value_len as usize) % MAX_VALUE_LEN) + 1).min(u.len());
-                let value_bytes = u.bytes(actual_len.min(u.len()))?.to_vec();
+                let value_bytes = u.bytes(actual_len)?.to_vec();
                 Ok(Operation::Append { value_bytes })
             }
             1 => {
@@ -121,7 +116,7 @@ impl<'a> Arbitrary<'a> for Operation {
                     let metadata_len: u16 = u.arbitrary()?;
                     let actual_len =
                         (((metadata_len as usize) % MAX_METADATA_LEN) + 1).min(u.len());
-                    Some(u.bytes(actual_len.min(u.len()))?.to_vec())
+                    Some(u.bytes(actual_len)?.to_vec())
                 } else {
                     None
                 };
@@ -133,7 +128,7 @@ impl<'a> Arbitrary<'a> for Operation {
             }
             2 => Ok(Operation::ChainedCommit),
             3 => Ok(Operation::StaleBatch),
-            4 => Ok(Operation::Sync),
+            4 => Ok(Operation::Persist),
             5 => {
                 let idx = u.arbitrary()?;
                 Ok(Operation::Rewind { idx })
@@ -147,12 +142,8 @@ impl<'a> Arbitrary<'a> for Operation {
             9 => Ok(Operation::Root),
             10 => Ok(Operation::GetMetadata),
             11 => Ok(Operation::Target),
-            12 => Ok(Operation::Persist),
-            13 => Ok(Operation::LastCommitLoc),
-            14 => Ok(Operation::ToBatch),
-            15 => Ok(Operation::Strategy {
-                values: u.arbitrary()?,
-            }),
+            12 => Ok(Operation::CompactSync),
+            13 => Ok(Operation::Sync),
             _ => unreachable!(),
         }
     }
@@ -179,13 +170,13 @@ impl<'a> Arbitrary<'a> for FuzzInput {
 const PAGE_SIZE: NonZeroU16 = NZU16!(127);
 const PAGE_CACHE_SIZE: usize = 8;
 
-type Db<F, S> = CompactDb<F, deterministic::Context, Vec<u8>, Sha256, CodecConfig, S>;
+type Db<F, S> = CompactDb<F, deterministic::Context, Digest, Sha256, S>;
 
 fn test_config<S: Strategy>(
     test_name: &str,
     pooler: &impl BufferPooler,
     strategy: S,
-) -> CompactConfig<CodecConfig, S> {
+) -> CompactConfig<S> {
     CompactConfig {
         strategy,
         witness: JournalConfig {
@@ -196,7 +187,7 @@ fn test_config<S: Strategy>(
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE)),
             write_buffer: NZUsize!(1024),
         },
-        commit_codec_config: ((0..=10000).into(), ()),
+        commit_codec_config: (),
     }
 }
 
@@ -204,8 +195,7 @@ fn test_config<S: Strategy>(
 struct SyncedCommit<D> {
     size: u64,
     root: D,
-    metadata: Option<Vec<u8>>,
-    floor: u64,
+    metadata: Option<Digest>,
 }
 
 fn fuzz_family<F: Family, S: Strategy>(
@@ -213,7 +203,6 @@ fn fuzz_family<F: Family, S: Strategy>(
     suffix: &str,
     strategy: impl FnOnce(&deterministic::Context) -> S,
 ) {
-    deterministic::Runner::default();
     let cfg =
         deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
     let runner = deterministic::Runner::new(cfg);
@@ -226,20 +215,20 @@ fn fuzz_family<F: Family, S: Strategy>(
             .expect("Failed to init compact keyless db");
         let mut restarts = 0usize;
 
-        let mut pending_appends: Vec<Vec<u8>> = Vec::new();
+        let mut pending_appends: Vec<Digest> = Vec::new();
         let mut expected_metadata = db.get_metadata();
+        let mut syncs = 0usize;
         // The bootstrap commit is durable, so it is a valid rewind target.
         let mut synced = vec![SyncedCommit {
             size: db.size().as_u64(),
             root: db.root(),
             metadata: db.get_metadata(),
-            floor: db.inactivity_floor_loc().as_u64(),
         }];
 
         for op in &input.ops {
             match op {
                 Operation::Append { value_bytes } => {
-                    pending_appends.push(value_bytes.clone());
+                    pending_appends.push(Sha256::hash(value_bytes));
                 }
 
                 Operation::Commit {
@@ -267,26 +256,25 @@ fn fuzz_family<F: Family, S: Strategy>(
                         }
                     };
 
+                    let appends = std::mem::take(&mut pending_appends);
                     let mut batch = db.new_batch();
-                    for v in pending_appends.drain(..) {
-                        batch = batch.append(v);
+                    for v in &appends {
+                        batch = batch.append(*v);
                     }
-                    let merkleized = batch.merkleize(&db, metadata_bytes.clone(), floor).await;
+                    let metadata = metadata_bytes.as_deref().map(Sha256::hash);
+                    let merkleized = batch.merkleize(&db, metadata, floor).await;
 
                     match expect_err {
                         None => {
-                            assert_eq!(merkleized.bounds().base_size, db.size().as_u64());
-                            assert_eq!(
-                                merkleized.bounds().total_size,
-                                db.size().as_u64() + pending_count + 1
-                            );
-                            assert_eq!(merkleized.bounds().inactivity_floor, floor);
                             let expected_root = merkleized.root();
-                            (db, _) = db.apply_batch(merkleized).expect("Commit should not fail");
+                            let start = db.size();
+                            let range;
+                            (db, range) =
+                                db.apply_batch(merkleized).expect("Commit should not fail");
+                            assert_eq!(range.start, start);
+                            assert_eq!(range.end, db.size());
                             assert_eq!(db.root(), expected_root);
-                            assert_eq!(db.get_metadata(), metadata_bytes.clone());
-                            assert_eq!(db.inactivity_floor_loc(), floor);
-                            expected_metadata = metadata_bytes.clone();
+                            expected_metadata = metadata;
                         }
                         Some(kind) => {
                             // Snapshot state; the reject must not mutate. `apply_batch` consumes
@@ -301,59 +289,77 @@ fn fuzz_family<F: Family, S: Strategy>(
                             assert_eq!(db.size(), before_size);
                             assert_eq!(db.inactivity_floor_loc(), before_floor);
                             assert_eq!(db.root(), before_root);
+                            pending_appends = appends;
                         }
                     }
                 }
 
                 Operation::ChainedCommit => {
+                    if pending_appends.len() < 2 {
+                        continue;
+                    }
                     let floor = db.inactivity_floor_loc();
                     let parent = db
                         .new_batch()
-                        .append(vec![0u8; 1])
+                        .append(pending_appends[0])
                         .merkleize(&db, None, floor)
                         .await;
                     let child = parent
                         .new_batch::<Sha256>()
-                        .append(vec![1u8; 1])
+                        .append(pending_appends[1])
                         .merkleize(&db, None, floor)
                         .await;
                     let expected_root = child.root();
-                    (db, _) = db
+                    let start = db.size();
+                    let range;
+                    (db, range) = db
                         .apply_batch(child)
                         .expect("Chained commit should not fail");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, db.size());
                     assert_eq!(db.root(), expected_root);
-                    assert_eq!(db.get_metadata(), None);
                     expected_metadata = None;
                 }
 
                 Operation::StaleBatch => {
+                    if pending_appends.len() < 2 {
+                        continue;
+                    }
                     let floor = db.inactivity_floor_loc();
                     let batch_a = db
                         .new_batch()
-                        .append(vec![2u8; 1])
+                        .append(pending_appends[0])
                         .merkleize(&db, None, floor)
                         .await;
                     let batch_b = db
                         .new_batch()
-                        .append(vec![3u8; 1])
+                        .append(pending_appends[1])
                         .merkleize(&db, None, floor)
                         .await;
-                    (db, _) = db.apply_batch(batch_a).expect("Commit should not fail");
-                    expected_metadata = None;
+                    let start = db.size();
+                    let range;
+                    (db, range) = db.apply_batch(batch_a).expect("Commit should not fail");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, db.size());
                     assert!(
                         matches!(db.validate_batch(&batch_b), Err(Error::StaleBatch { .. })),
                         "second batch from the same state must be stale"
                     );
+                    expected_metadata = None;
                 }
 
-                Operation::Persist => {
+                Operation::Persist | Operation::Sync => {
                     let expected = (
                         db.size(),
                         db.root(),
                         db.inactivity_floor_loc(),
                         db.get_metadata(),
                     );
-                    db = db.commit().await.expect("Commit should not fail");
+                    db = if matches!(op, Operation::Persist) {
+                        db.commit().await.expect("Commit should not fail")
+                    } else {
+                        db.sync().await.expect("Sync should not fail")
+                    };
                     assert_eq!(
                         (
                             db.size(),
@@ -361,33 +367,16 @@ fn fuzz_family<F: Family, S: Strategy>(
                             db.inactivity_floor_loc(),
                             db.get_metadata(),
                         ),
-                        expected
+                        expected,
+                        "persistence should preserve compact keyless state"
                     );
-                    let state = SyncedCommit {
-                        size: db.size().as_u64(),
-                        root: db.root(),
-                        metadata: db.get_metadata(),
-                        floor: db.inactivity_floor_loc().as_u64(),
-                    };
-                    if synced.last().map(|commit| commit.size) == Some(state.size) {
-                        *synced.last_mut().unwrap() = state;
-                    } else {
-                        synced.push(state);
-                    }
-                }
-
-                Operation::Sync => {
-                    db = db.sync().await.expect("Sync should not fail");
-                    let state = SyncedCommit {
-                        size: db.size().as_u64(),
-                        root: db.root(),
-                        metadata: db.get_metadata(),
-                        floor: db.inactivity_floor_loc().as_u64(),
-                    };
-                    if synced.last().map(|commit| commit.size) == Some(state.size) {
-                        *synced.last_mut().unwrap() = state;
-                    } else {
-                        synced.push(state);
+                    let size = db.size().as_u64();
+                    if synced.last().map(|c| c.size) != Some(size) {
+                        synced.push(SyncedCommit {
+                            size,
+                            root: db.root(),
+                            metadata: db.get_metadata(),
+                        });
                     }
                 }
 
@@ -403,8 +392,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                     assert_eq!(db.size().as_u64(), tip.size);
                     assert_eq!(db.root(), tip.root);
                     assert_eq!(db.get_metadata(), tip.metadata);
-                    assert_eq!(db.inactivity_floor_loc().as_u64(), tip.floor);
-                    expected_metadata = tip.metadata.clone();
+                    expected_metadata = tip.metadata;
                 }
 
                 Operation::RewindUnsynced => {
@@ -433,8 +421,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                     assert_eq!(db.size().as_u64(), tip.size);
                     assert_eq!(db.root(), tip.root);
                     assert_eq!(db.get_metadata(), tip.metadata);
-                    assert_eq!(db.inactivity_floor_loc().as_u64(), tip.floor);
-                    expected_metadata = tip.metadata.clone();
+                    expected_metadata = tip.metadata;
                 }
 
                 Operation::Prune { idx } => {
@@ -464,16 +451,11 @@ fn fuzz_family<F: Family, S: Strategy>(
                     assert_eq!(db.size().as_u64(), tip.size);
                     assert_eq!(db.root(), tip.root);
                     assert_eq!(db.get_metadata(), tip.metadata);
-                    assert_eq!(db.inactivity_floor_loc().as_u64(), tip.floor);
-                    expected_metadata = tip.metadata.clone();
+                    expected_metadata = tip.metadata;
                 }
 
                 Operation::Root => {
                     assert_eq!(db.root(), db.to_batch().root());
-                }
-
-                Operation::LastCommitLoc => {
-                    assert_eq!(db.last_commit_loc() + 1, db.size());
                 }
 
                 Operation::GetMetadata => {
@@ -482,78 +464,54 @@ fn fuzz_family<F: Family, S: Strategy>(
 
                 Operation::Target => {
                     let target = db.target();
+                    assert!(target.validate().is_ok());
                     let expected = synced.last().unwrap();
                     assert_eq!(target.leaf_count.as_u64(), expected.size);
                     assert_eq!(target.root, expected.root);
                 }
 
-                Operation::ToBatch => {
-                    let batch = db.to_batch();
-                    assert_eq!(batch.root(), db.root());
-                    assert_eq!(batch.bounds().base_size, db.size().as_u64());
-                    assert_eq!(batch.bounds().total_size, db.size().as_u64());
-                    assert_eq!(batch.bounds().inactivity_floor, db.inactivity_floor_loc());
-                }
-
-                Operation::Strategy { values } => {
-                    let expected = values.iter().map(|value| u64::from(*value)).sum::<u64>();
-                    let actual = db.strategy().fold(
-                        values,
-                        || 0u64,
-                        |sum, value| sum + u64::from(*value),
-                        |left, right| left + right,
+                Operation::CompactSync => {
+                    let target = db.target();
+                    let expected = synced.last().unwrap();
+                    let expected_size = expected.size;
+                    let expected_metadata = expected.metadata;
+                    let source = Arc::new(db);
+                    let client_cfg = test_config(
+                        &format!("{suffix}-client-{syncs}"),
+                        &context,
+                        strategy.clone(),
                     );
-                    assert_eq!(actual, expected, "database strategy produced a wrong fold");
+                    let client: Db<F, S> = compact_sync::sync(compact_sync::Config {
+                        context: context.child("client").with_attribute("instance", syncs),
+                        resolver: source.clone(),
+                        target: target.clone(),
+                        db_config: client_cfg,
+                        update_rx: None,
+                        finish_rx: None,
+                        reached_target_tx: None,
+                    })
+                    .await
+                    .expect("Compact sync should not fail");
+                    assert_eq!(client.root(), target.root);
+                    assert_eq!(client.size().as_u64(), expected_size);
+                    assert_eq!(client.get_metadata(), expected_metadata);
+                    client.destroy().await.expect("Destroy should not fail");
+                    db = Arc::try_unwrap(source).unwrap_or_else(|_| panic!("single source ref"));
+                    syncs += 1;
                 }
             }
         }
-
-        // Compact-sync round-trip: rebuild a fresh db from the source's persisted compact witness,
-        // exercising compact_state, init_from_validated_state, and Store::from_import.
-        let db = db.sync().await.expect("Sync should not fail");
-        let target = db.target();
-        let source = Arc::new(db);
-        let client_cfg = test_config(&format!("{suffix}-client"), &context, strategy.clone());
-        let client: Db<F, S> = compact_sync::sync(compact_sync::Config {
-            context: context.child("client"),
-            resolver: source.clone(),
-            target: target.clone(),
-            db_config: client_cfg.clone(),
-            update_rx: None,
-            finish_rx: None,
-            reached_target_tx: None,
-        })
-        .await
-        .expect("Compact sync should not fail");
-        assert_eq!(client.root(), target.root);
-        assert_eq!(client.get_metadata(), source.get_metadata());
-        assert_eq!(client.inactivity_floor_loc(), source.inactivity_floor_loc());
-        drop(client);
-
-        // Reopen from disk: the imported witness must persist across a restart.
-        let reopened: Db<F, S> = Db::init(context.child("client_reopen"), client_cfg)
-            .await
-            .expect("Failed to reopen imported client");
-        assert_eq!(reopened.root(), target.root);
-        assert_eq!(reopened.get_metadata(), source.get_metadata());
-        assert_eq!(
-            reopened.inactivity_floor_loc(),
-            source.inactivity_floor_loc()
-        );
-        reopened.destroy().await.expect("Destroy should not fail");
-
-        let db = Arc::try_unwrap(source).unwrap_or_else(|_| panic!("single source ref"));
         db.destroy().await.expect("Destroy should not fail");
     });
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz_family::<mmr::Family, Sequential>(&input, "fuzz-mmr-sequential", |_| Sequential);
-    fuzz_family::<mmb::Family, Sequential>(&input, "fuzz-mmb-sequential", |_| Sequential);
-    fuzz_family::<mmr::Family, Rayon>(&input, "fuzz-mmr-rayon", |context| {
+    fuzz_family::<mmr::Family, Sequential>(&input, "fuzz-fixed-mmr-sequential", |_| Sequential);
+    fuzz_family::<mmb::Family, Sequential>(&input, "fuzz-fixed-mmb-sequential", |_| Sequential);
+    fuzz_family::<mmr::Family, Rayon>(&input, "fuzz-fixed-mmr-rayon", |context| {
         context.strategy(NZUsize!(2))
     });
-    fuzz_family::<mmb::Family, Rayon>(&input, "fuzz-mmb-rayon", |context| {
+    fuzz_family::<mmb::Family, Rayon>(&input, "fuzz-fixed-mmb-rayon", |context| {
         context.strategy(NZUsize!(2))
     });
 });

--- a/storage/fuzz/fuzz_targets/qmgb_gen_keyless_compact_fixed.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_keyless_compact_fixed.rs
@@ -47,9 +47,9 @@ enum FloorKind {
     Current,
     /// Advance to the commit location (the tight upper bound).
     AdvanceToCommit,
-    /// Floor one below the current floor — must be rejected as `FloorRegressed`.
+    /// Floor one below the current floor - must be rejected as `FloorRegressed`.
     BadRegression,
-    /// Floor one past the commit location — must be rejected as `FloorBeyondSize`.
+    /// Floor one past the commit location - must be rejected as `FloorBeyondSize`.
     BadBeyondCommit,
 }
 

--- a/storage/fuzz/fuzz_targets/qmgb_gen_keyless_fixed.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_keyless_fixed.rs
@@ -46,9 +46,9 @@ enum FloorKind {
     Current,
     /// Advance to the commit location (the tight upper bound).
     AdvanceToCommit,
-    /// Floor one below the current floor — must be rejected as `FloorRegressed`.
+    /// Floor one below the current floor - must be rejected as `FloorRegressed`.
     BadRegression,
-    /// Floor one past the commit location — must be rejected as `FloorBeyondSize`.
+    /// Floor one past the commit location - must be rejected as `FloorBeyondSize`.
     BadBeyondCommit,
 }
 
@@ -74,7 +74,7 @@ enum Operation {
         metadata_bytes: Option<Vec<u8>>,
         floor_kind: FloorKind,
     },
-    /// Build a two-level batch chain (parent → child) and apply the child directly. The
+    /// Build a two-level batch chain (parent -> child) and apply the child directly. The
     /// parent's floor is intentionally invalid (regressed or beyond its own commit location);
     /// this exercises the per-ancestor validation path in `apply_batch`.
     BadChainedCommit {
@@ -158,7 +158,7 @@ impl<'a> Arbitrary<'a> for Operation {
             }
             12 => Ok(Operation::SimulateFailure {}),
             13 => {
-                // Only Bad* kinds make sense here — the ancestor is guaranteed unapplied.
+                // Only Bad* kinds make sense here - the ancestor is guaranteed unapplied.
                 let ancestor_kind = match u.arbitrary::<bool>()? {
                     false => FloorKind::BadRegression,
                     true => FloorKind::BadBeyondCommit,
@@ -377,7 +377,7 @@ fn fuzz_family<F: Family, S: Strategy>(
                         .merkleize(&db, None, parent_floor)
                         .await;
                     // child: valid on its own; only the ancestor should trip the check.
-                    let child_floor = parent_floor; // stay ≥ parent_floor even if parent is bad
+                    let child_floor = parent_floor; // stay >= parent_floor even if parent is bad
                     let child = parent
                         .new_batch::<Sha256>()
                         .append(pending_appends[1])

--- a/storage/fuzz/fuzz_targets/qmgb_gen_keyless_fixed.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_keyless_fixed.rs
@@ -1,0 +1,558 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
+use commonware_parallel::{Rayon, Sequential, Strategy};
+use commonware_runtime::{
+    BufferPooler, Runner, Strategizer as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{Family, Location, full::Config as MerkleConfig, mmb, mmr},
+    qmdb::{
+        Error,
+        keyless::fixed::{Config, Db as Keyless},
+        verify_proof,
+    },
+};
+use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize};
+use libfuzzer_sys::fuzz_target;
+use std::{collections::BTreeMap, num::NonZeroU16};
+
+const MAX_OPERATIONS: usize = 50;
+const MAX_PROOF_OPS: u64 = 100;
+
+/// Which error variant a bad-floor commit should produce.
+#[derive(Debug, Clone, Copy)]
+enum BadFloorExpect {
+    Regression,
+    BeyondSize,
+}
+
+fn assert_bad_floor_error<F: Family>(err: &Error<F>, kind: BadFloorExpect) {
+    match (err, kind) {
+        (Error::FloorRegressed(_, _), BadFloorExpect::Regression) => {}
+        (Error::FloorBeyondSize(_, _), BadFloorExpect::BeyondSize) => {}
+        _ => panic!("unexpected error for {kind:?}: {err:?}"),
+    }
+}
+
+/// What floor value a fuzz-generated commit should carry. The `Bad*` variants intentionally
+/// produce floors that must be rejected; the handler asserts the expected error variant and
+/// that the DB state is untouched.
+#[derive(Debug, Clone, Copy)]
+enum FloorKind {
+    /// Keep the current floor (monotonicity trivially preserved).
+    Current,
+    /// Advance to the commit location (the tight upper bound).
+    AdvanceToCommit,
+    /// Floor one below the current floor — must be rejected as `FloorRegressed`.
+    BadRegression,
+    /// Floor one past the commit location — must be rejected as `FloorBeyondSize`.
+    BadBeyondCommit,
+}
+
+impl<'a> Arbitrary<'a> for FloorKind {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let choice: u8 = u.arbitrary()?;
+        Ok(match choice % 4 {
+            0 => FloorKind::Current,
+            1 => FloorKind::AdvanceToCommit,
+            2 => FloorKind::BadRegression,
+            3 => FloorKind::BadBeyondCommit,
+            _ => unreachable!(),
+        })
+    }
+}
+
+#[derive(Debug)]
+enum Operation {
+    Append {
+        value_bytes: Vec<u8>,
+    },
+    Commit {
+        metadata_bytes: Option<Vec<u8>>,
+        floor_kind: FloorKind,
+    },
+    /// Build a two-level batch chain (parent → child) and apply the child directly. The
+    /// parent's floor is intentionally invalid (regressed or beyond its own commit location);
+    /// this exercises the per-ancestor validation path in `apply_batch`.
+    BadChainedCommit {
+        ancestor_kind: FloorKind,
+    },
+    Get {
+        loc_offset: u32,
+    },
+    GetMetadata,
+    Prune,
+    Sync,
+    OpCount,
+    LastCommitLoc,
+    OldestRetainedLoc,
+    Root,
+    Proof {
+        start_offset: u32,
+        max_ops: u16,
+    },
+    HistoricalProof {
+        size_offset: u32,
+        start_offset: u32,
+        max_ops: u16,
+    },
+    SimulateFailure {},
+}
+
+impl<'a> Arbitrary<'a> for Operation {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let choice: u8 = u.arbitrary()?;
+        match choice % 14 {
+            0 => {
+                let value_len: u16 = u.arbitrary()?;
+                let actual_len = (((value_len as usize) % 10000) + 1).min(u.len());
+                let value_bytes = u.bytes(actual_len)?.to_vec();
+                Ok(Operation::Append { value_bytes })
+            }
+            1 => {
+                let has_metadata: bool = u.arbitrary()?;
+                let metadata_bytes = if has_metadata {
+                    let metadata_len: u16 = u.arbitrary()?;
+                    let actual_len = (((metadata_len as usize) % 1000) + 1).min(u.len());
+                    Some(u.bytes(actual_len)?.to_vec())
+                } else {
+                    None
+                };
+                let floor_kind = FloorKind::arbitrary(u)?;
+                Ok(Operation::Commit {
+                    metadata_bytes,
+                    floor_kind,
+                })
+            }
+            2 => {
+                let loc_offset = u.arbitrary()?;
+                Ok(Operation::Get { loc_offset })
+            }
+            3 => Ok(Operation::GetMetadata),
+            4 => Ok(Operation::Prune),
+            5 => Ok(Operation::Sync),
+            6 => Ok(Operation::OpCount),
+            7 => Ok(Operation::LastCommitLoc),
+            8 => Ok(Operation::OldestRetainedLoc),
+            9 => Ok(Operation::Root),
+            10 => {
+                let start_offset = u.arbitrary()?;
+                let max_ops = u.arbitrary()?;
+                Ok(Operation::Proof {
+                    start_offset,
+                    max_ops,
+                })
+            }
+            11 => {
+                let size_offset = u.arbitrary()?;
+                let start_offset = u.arbitrary()?;
+                let max_ops = u.arbitrary()?;
+                Ok(Operation::HistoricalProof {
+                    size_offset,
+                    start_offset,
+                    max_ops,
+                })
+            }
+            12 => Ok(Operation::SimulateFailure {}),
+            13 => {
+                // Only Bad* kinds make sense here — the ancestor is guaranteed unapplied.
+                let ancestor_kind = match u.arbitrary::<bool>()? {
+                    false => FloorKind::BadRegression,
+                    true => FloorKind::BadBeyondCommit,
+                };
+                Ok(Operation::BadChainedCommit { ancestor_kind })
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    ops: Vec<Operation>,
+    raw_bytes: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let ops = (0..num_ops)
+            .map(|_| Operation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(FuzzInput { ops, raw_bytes })
+    }
+}
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(127);
+const PAGE_CACHE_SIZE: usize = 8;
+
+type Db<F, S> = Keyless<F, deterministic::Context, Digest, Sha256, S>;
+
+fn test_config<S: Strategy>(test_name: &str, pooler: &impl BufferPooler, strategy: S) -> Config<S> {
+    let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(PAGE_CACHE_SIZE));
+    Config {
+        merkle: MerkleConfig {
+            journal_partition: format!("{test_name}-journal"),
+            metadata_partition: format!("{test_name}-meta"),
+            items_per_blob: NZU64!(3),
+            write_buffer: NZUsize!(1024),
+            strategy,
+            page_cache: page_cache.clone(),
+        },
+        log: FConfig {
+            partition: format!("{test_name}-log"),
+            write_buffer: NZUsize!(1024),
+            items_per_blob: NZU64!(7),
+            page_cache,
+        },
+    }
+}
+
+/// Reopen the database.
+async fn reopen<F: Family, S: Strategy>(
+    context: &deterministic::Context,
+    suffix: &str,
+    strategy: &S,
+    restarts: &mut usize,
+) -> Db<F, S> {
+    let cfg = test_config(suffix, context, strategy.clone());
+    let db = Db::init(
+        context.child("db").with_attribute("instance", *restarts),
+        cfg,
+    )
+    .await
+    .expect("Failed to init keyless db");
+    *restarts += 1;
+    db
+}
+
+fn fuzz_family<F: Family, S: Strategy>(
+    input: &FuzzInput,
+    suffix: &str,
+    strategy: impl FnOnce(&deterministic::Context) -> S,
+) {
+    let cfg =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    let runner = deterministic::Runner::new(cfg);
+
+    runner.start(|context| async move {
+        let strategy = strategy(&context);
+        let cfg = test_config(suffix, &context, strategy.clone());
+        let mut db: Db<F, S> = Db::init(context.child("storage"), cfg)
+            .await
+            .expect("Failed to init keyless db");
+        let mut restarts = 0usize;
+
+        let mut pending_appends: Vec<Digest> = Vec::new();
+        let mut expected_values = BTreeMap::<u64, Digest>::new();
+        let mut expected_metadata = None;
+        let mut expected_root = db.root();
+        let mut expected_size = db.bounds().end;
+        let mut commits = vec![(expected_size, expected_root)];
+
+        for op in &input.ops {
+            db = match op {
+                Operation::Append { value_bytes } => {
+                    pending_appends.push(Sha256::hash(value_bytes));
+                    db
+                }
+
+                Operation::Commit {
+                    metadata_bytes,
+                    floor_kind,
+                } => {
+                    let pending_count = pending_appends.len() as u64;
+                    let end = db.bounds().end;
+                    let commit_loc = end.as_u64() + pending_count;
+                    let current_floor = db.inactivity_floor_loc();
+
+                    // Pick the floor for this commit. `Bad*` kinds are guaranteed to trigger
+                    // the expected error; Valid kinds (Current/AdvanceToCommit) apply cleanly.
+                    let (floor, expect_err) = match floor_kind {
+                        FloorKind::Current => (current_floor, None),
+                        FloorKind::AdvanceToCommit => (Location::<F>::new(commit_loc), None),
+                        FloorKind::BadRegression => {
+                            // Only meaningful when current floor > 0; otherwise fall back to Current.
+                            if current_floor.as_u64() == 0 {
+                                (current_floor, None)
+                            } else {
+                                let bad = Location::<F>::new(current_floor.as_u64() - 1);
+                                (bad, Some(BadFloorExpect::Regression))
+                            }
+                        }
+                        FloorKind::BadBeyondCommit => {
+                            let bad = Location::<F>::new(commit_loc + 1);
+                            (bad, Some(BadFloorExpect::BeyondSize))
+                        }
+                    };
+
+                    let appends = std::mem::take(&mut pending_appends);
+                    let mut batch = db.new_batch();
+                    for v in &appends {
+                        batch = batch.append(*v);
+                    }
+                    let metadata = metadata_bytes.as_deref().map(Sha256::hash);
+                    let merkleized = batch.merkleize(&db, metadata, floor).await;
+
+                    match expect_err {
+                        None => {
+                            let batch_root = merkleized.root();
+                            let (db, range) = db
+                                .apply_batch(merkleized)
+                                .await
+                                .expect("Commit should not fail");
+                            assert_eq!(range.start, end);
+                            assert_eq!(range.end, db.bounds().end);
+                            assert_eq!(db.root(), batch_root);
+                            let db = db.commit().await.expect("Commit should not fail");
+                            for (offset, value) in appends.into_iter().enumerate() {
+                                expected_values.insert(end.as_u64() + offset as u64, value);
+                            }
+                            if let Some(metadata) = metadata {
+                                expected_values.insert(commit_loc, metadata);
+                            }
+                            expected_metadata = metadata;
+                            expected_root = batch_root;
+                            expected_size = db.bounds().end;
+                            commits.push((expected_size, expected_root));
+                            db
+                        }
+                        Some(kind) => {
+                            // Snapshot state; the reject must not mutate persisted state.
+                            let before_last_commit = db.last_commit_loc();
+                            let before_floor = db.inactivity_floor_loc();
+                            let before_root = db.root();
+                            let err = match db.apply_batch(merkleized).await {
+                                Ok(_) => panic!("bad floor must be rejected"),
+                                Err(err) => err,
+                            };
+                            assert_bad_floor_error(&err, kind);
+                            // Reopen and verify the reject persisted nothing.
+                            let db = reopen(&context, suffix, &strategy, &mut restarts).await;
+                            assert_eq!(db.last_commit_loc(), before_last_commit);
+                            assert_eq!(db.inactivity_floor_loc(), before_floor);
+                            assert_eq!(db.root(), before_root);
+                            pending_appends = appends;
+                            db
+                        }
+                    }
+                }
+
+                Operation::BadChainedCommit { ancestor_kind } => {
+                    let end = db.bounds().end;
+                    let current_floor = db.inactivity_floor_loc();
+
+                    // Parent batch: base = end, 1 append lands at `end`, commit lands at `end + 1`.
+                    // So parent's total_size = end + 2 and parent_commit_loc = end + 1.
+                    let parent_commit_loc = end.as_u64() + 1;
+                    let (parent_floor, kind) = match ancestor_kind {
+                        FloorKind::BadRegression => {
+                            if current_floor.as_u64() == 0 {
+                                // No regression possible; skip this op (no-op).
+                                continue;
+                            }
+                            (
+                                Location::<F>::new(current_floor.as_u64() - 1),
+                                BadFloorExpect::Regression,
+                            )
+                        }
+                        FloorKind::BadBeyondCommit => (
+                            Location::<F>::new(parent_commit_loc + 1),
+                            BadFloorExpect::BeyondSize,
+                        ),
+                        _ => continue, // only bad kinds are meaningful here
+                    };
+
+                    if pending_appends.len() < 2 {
+                        continue;
+                    }
+                    let parent = db
+                        .new_batch()
+                        .append(pending_appends[0])
+                        .merkleize(&db, None, parent_floor)
+                        .await;
+                    // child: valid on its own; only the ancestor should trip the check.
+                    let child_floor = parent_floor; // stay ≥ parent_floor even if parent is bad
+                    let child = parent
+                        .new_batch::<Sha256>()
+                        .append(pending_appends[1])
+                        .merkleize(&db, None, child_floor)
+                        .await;
+
+                    let before_last_commit = db.last_commit_loc();
+                    let before_floor = db.inactivity_floor_loc();
+                    let before_root = db.root();
+                    let err = match db.apply_batch(child).await {
+                        Ok(_) => panic!("bad ancestor floor must be rejected"),
+                        Err(err) => err,
+                    };
+                    assert_bad_floor_error(&err, kind);
+                    // Reopen and verify the reject persisted nothing.
+                    let db = reopen(&context, suffix, &strategy, &mut restarts).await;
+                    assert_eq!(db.last_commit_loc(), before_last_commit);
+                    assert_eq!(db.inactivity_floor_loc(), before_floor);
+                    assert_eq!(db.root(), before_root);
+                    db
+                }
+
+                Operation::Get { loc_offset } => {
+                    let bounds = db.bounds();
+                    if bounds.start < bounds.end {
+                        let loc = bounds.start.as_u64()
+                            + (*loc_offset as u64) % (bounds.end - bounds.start).as_u64();
+                        let actual = db
+                            .get(Location::new(loc))
+                            .await
+                            .expect("get should not fail");
+                        assert_eq!(actual, expected_values.get(&loc).copied());
+                    }
+                    db
+                }
+
+                Operation::GetMetadata => {
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("metadata read should not fail"),
+                        expected_metadata,
+                    );
+                    db
+                }
+
+                Operation::Prune => {
+                    let floor = db.inactivity_floor_loc();
+                    let root = db.root();
+                    let db = db.prune(floor).await.expect("Prune should not fail");
+                    assert_eq!(db.root(), root);
+                    assert_eq!(db.bounds().end, expected_size);
+                    expected_values.retain(|loc, _| *loc >= db.bounds().start.as_u64());
+                    db
+                }
+
+                Operation::Sync => {
+                    let expected = (
+                        db.bounds(),
+                        db.root(),
+                        db.inactivity_floor_loc(),
+                        db.get_metadata()
+                            .await
+                            .expect("metadata read should not fail"),
+                    );
+                    let db = db.sync().await.expect("Sync should not fail");
+                    assert_eq!(
+                        (
+                            db.bounds(),
+                            db.root(),
+                            db.inactivity_floor_loc(),
+                            db.get_metadata()
+                                .await
+                                .expect("metadata read should not fail"),
+                        ),
+                        expected,
+                        "sync should preserve keyless state"
+                    );
+                    db
+                }
+
+                Operation::OpCount => {
+                    assert_eq!(db.bounds().end, expected_size);
+                    db
+                }
+
+                Operation::LastCommitLoc => {
+                    assert_eq!(db.last_commit_loc() + 1, expected_size);
+                    db
+                }
+
+                Operation::OldestRetainedLoc => {
+                    assert!(db.bounds().start <= db.inactivity_floor_loc());
+                    db
+                }
+
+                Operation::Root => {
+                    assert_eq!(db.root(), expected_root);
+                    db
+                }
+
+                Operation::Proof {
+                    start_offset,
+                    max_ops,
+                } => {
+                    let bounds = db.bounds();
+                    let start_loc = bounds.start.as_u64()
+                        + (*start_offset as u64) % (bounds.end - bounds.start).as_u64();
+                    let max_ops_value = ((*max_ops as u64) % MAX_PROOF_OPS) + 1;
+                    let start_loc: Location<F> = Location::new(start_loc);
+                    let (proof, ops) = db
+                        .proof(start_loc, NZU64!(max_ops_value))
+                        .await
+                        .expect("proof should not fail for a retained location");
+                    assert!(verify_proof::<Sha256, _, _>(
+                        &proof,
+                        start_loc,
+                        &ops,
+                        &expected_root,
+                    ));
+                    db
+                }
+
+                Operation::HistoricalProof {
+                    size_offset,
+                    start_offset,
+                    max_ops,
+                } => {
+                    let retained = commits
+                        .iter()
+                        .filter(|(size, _)| *size > db.bounds().start)
+                        .copied()
+                        .collect::<Vec<_>>();
+                    let (size, root) = retained[*size_offset as usize % retained.len()];
+                    let start_loc = Location::new(
+                        db.bounds().start.as_u64()
+                            + (*start_offset as u64) % (size - db.bounds().start).as_u64(),
+                    );
+                    let max_ops_value = ((*max_ops as u64) % MAX_PROOF_OPS) + 1;
+                    let (proof, ops) = db
+                        .historical_proof(size, start_loc, NZU64!(max_ops_value))
+                        .await
+                        .expect("historical proof should not fail at a retained commit");
+                    assert!(verify_proof::<Sha256, _, _>(&proof, start_loc, &ops, &root,));
+                    db
+                }
+
+                Operation::SimulateFailure {} => {
+                    pending_appends.clear();
+                    drop(db);
+                    let db = reopen(&context, suffix, &strategy, &mut restarts).await;
+                    assert_eq!(db.bounds().end, expected_size);
+                    assert_eq!(db.root(), expected_root);
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("metadata read should not fail"),
+                        expected_metadata,
+                    );
+                    db
+                }
+            };
+        }
+
+        db.destroy().await.expect("Destroy should not fail");
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz_family::<mmr::Family, Sequential>(&input, "fuzz-fixed-mmr-sequential", |_| Sequential);
+    fuzz_family::<mmb::Family, Sequential>(&input, "fuzz-fixed-mmb-sequential", |_| Sequential);
+    fuzz_family::<mmr::Family, Rayon>(&input, "fuzz-fixed-mmr-rayon", |context| {
+        context.strategy(NZUsize!(2))
+    });
+    fuzz_family::<mmb::Family, Rayon>(&input, "fuzz-fixed-mmb-rayon", |context| {
+        context.strategy(NZUsize!(2))
+    });
+});

--- a/storage/fuzz/fuzz_targets/qmgb_gen_partitioned.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_partitioned.rs
@@ -1,0 +1,282 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use commonware_cryptography::{Sha256, sha256::Digest};
+use commonware_parallel::Sequential;
+use commonware_runtime::{
+    BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as JournalConfig,
+    merkle::{Graftable, full::Config as MerkleConfig, mmb, mmr},
+    qmdb::{
+        any::{
+            FixedConfig as AnyConfig, ordered::fixed::partitioned::Db as AnyOrdered,
+            unordered::fixed::partitioned::Db as AnyUnordered,
+        },
+        current::{
+            FixedConfig as CurrentConfig, ordered::fixed::partitioned::Db as CurrentOrdered,
+            unordered::fixed::partitioned::Db as CurrentUnordered,
+        },
+    },
+    translator::TwoCap,
+};
+use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize};
+use libfuzzer_sys::fuzz_target;
+use std::{collections::BTreeMap, num::NonZeroU16};
+
+const MAX_OPERATIONS: usize = 20;
+const PAGE_SIZE: NonZeroU16 = NZU16!(139);
+const PARTITION_BYTES: usize = 1;
+const BITMAP_CHUNK_BYTES: usize = 32;
+
+type AnyOrderedDb<F> = AnyOrdered<
+    F,
+    deterministic::Context,
+    Digest,
+    Digest,
+    Sha256,
+    TwoCap,
+    PARTITION_BYTES,
+    Sequential,
+>;
+type AnyUnorderedDb<F> = AnyUnordered<
+    F,
+    deterministic::Context,
+    Digest,
+    Digest,
+    Sha256,
+    TwoCap,
+    PARTITION_BYTES,
+    Sequential,
+>;
+type CurrentOrderedDb<F> = CurrentOrdered<
+    F,
+    deterministic::Context,
+    Digest,
+    Digest,
+    Sha256,
+    TwoCap,
+    PARTITION_BYTES,
+    BITMAP_CHUNK_BYTES,
+    Sequential,
+>;
+type CurrentUnorderedDb<F> = CurrentUnordered<
+    F,
+    deterministic::Context,
+    Digest,
+    Digest,
+    Sha256,
+    TwoCap,
+    PARTITION_BYTES,
+    BITMAP_CHUNK_BYTES,
+    Sequential,
+>;
+
+#[derive(Arbitrary, Clone, Debug)]
+enum Operation {
+    Update { key: [u8; 32], value: [u8; 32] },
+    Delete { key: [u8; 32] },
+    Commit,
+    Get { key: [u8; 32] },
+    Sync,
+    ToBatch,
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    raw_bytes: Vec<u8>,
+    operations: Vec<Operation>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let operation_count = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let operations = (0..operation_count)
+            .map(|_| Operation::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            raw_bytes,
+            operations,
+        })
+    }
+}
+
+fn journal_config(name: &str, pooler: &impl BufferPooler) -> JournalConfig {
+    JournalConfig {
+        partition: format!("{name}-log"),
+        items_per_blob: NZU64!(7),
+        write_buffer: NZUsize!(1024),
+        page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(8)),
+    }
+}
+
+fn any_config(
+    name: &str,
+    pooler: &impl BufferPooler,
+) -> AnyConfig<TwoCap, Sequential, std::num::NonZeroUsize> {
+    let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(8));
+    AnyConfig {
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{name}-merkle"),
+            metadata_partition: format!("{name}-metadata"),
+            items_per_blob: NZU64!(11),
+            write_buffer: NZUsize!(1024),
+            strategy: Sequential,
+            page_cache,
+        },
+        journal_config: journal_config(name, pooler),
+        translator: TwoCap,
+        init_cache_size: Some(NZUsize!(32)),
+        init_buffer: NZUsize!(1 << 16),
+        init_concurrency: NZUsize!(1),
+    }
+}
+
+fn current_config(
+    name: &str,
+    pooler: &impl BufferPooler,
+) -> CurrentConfig<TwoCap, Sequential, std::num::NonZeroUsize> {
+    let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(8));
+    CurrentConfig {
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{name}-merkle"),
+            metadata_partition: format!("{name}-metadata"),
+            items_per_blob: NZU64!(11),
+            write_buffer: NZUsize!(1024),
+            strategy: Sequential,
+            page_cache,
+        },
+        journal_config: journal_config(name, pooler),
+        grafted_metadata_partition: format!("{name}-grafted"),
+        translator: TwoCap,
+        init_cache_size: Some(NZUsize!(32)),
+        init_buffer: NZUsize!(1 << 16),
+        init_concurrency: NZUsize!(1),
+    }
+}
+
+macro_rules! exercise {
+    ($db:expr, $operations:expr) => {{
+        let mut db = $db;
+        let mut committed = BTreeMap::<Digest, Digest>::new();
+        let mut pending = BTreeMap::<Digest, Option<Digest>>::new();
+
+        for operation in $operations {
+            match operation {
+                Operation::Update { key, value } => {
+                    pending.insert(Digest::from(*key), Some(Digest::from(*value)));
+                }
+                Operation::Delete { key } => {
+                    let key = Digest::from(*key);
+                    if pending.get(&key).is_some_and(Option::is_some)
+                        || (!pending.contains_key(&key) && committed.contains_key(&key))
+                    {
+                        pending.insert(key, None);
+                    }
+                }
+                Operation::Commit => {
+                    let mut batch = db.new_batch();
+                    for (key, value) in &pending {
+                        batch = batch.write(*key, *value);
+                    }
+                    let batch = batch
+                        .merkleize(&db, None)
+                        .await
+                        .expect("merkleize partitioned batch");
+                    assert!(db.validate_batch(&batch).is_ok());
+                    let expected_root = batch.root();
+                    let start = db.bounds().end;
+                    let (next, range) = db
+                        .apply_batch(batch)
+                        .await
+                        .expect("apply partitioned batch");
+                    db = next.commit().await.expect("commit partitioned db");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, db.bounds().end);
+                    assert_eq!(db.root(), expected_root);
+                    for (key, value) in std::mem::take(&mut pending) {
+                        if let Some(value) = value {
+                            committed.insert(key, value);
+                        } else {
+                            committed.remove(&key);
+                        }
+                    }
+                }
+                Operation::Get { key } => {
+                    let key = Digest::from(*key);
+                    assert_eq!(
+                        db.get(&key).await.expect("read partitioned db"),
+                        committed.get(&key).copied()
+                    );
+                }
+                Operation::Sync => {
+                    let expected = (db.bounds(), db.root());
+                    db = db.sync().await.expect("sync partitioned db");
+                    assert_eq!(
+                        (db.bounds(), db.root()),
+                        expected,
+                        "sync should preserve partitioned database state"
+                    );
+                    for (key, expected) in &committed {
+                        assert_eq!(
+                            db.get(key).await.expect("read synced partitioned db"),
+                            Some(*expected)
+                        );
+                    }
+                }
+                Operation::ToBatch => {
+                    let snapshot = db.to_batch();
+                    assert_eq!(snapshot.root(), db.root());
+                }
+            }
+        }
+
+        db.destroy().await.expect("destroy partitioned db");
+    }};
+}
+
+fn fuzz_family<F: Graftable>(input: &FuzzInput, family: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let name = format!("qmgb-any-ordered-{family}");
+        let db: AnyOrderedDb<F> =
+            AnyOrderedDb::init(context.child("any_ordered"), any_config(&name, &context))
+                .await
+                .expect("init partitioned Any ordered db");
+        exercise!(db, &input.operations);
+
+        let name = format!("qmgb-any-unordered-{family}");
+        let db: AnyUnorderedDb<F> =
+            AnyUnorderedDb::init(context.child("any_unordered"), any_config(&name, &context))
+                .await
+                .expect("init partitioned Any unordered db");
+        exercise!(db, &input.operations);
+
+        let name = format!("qmgb-current-ordered-{family}");
+        let db: CurrentOrderedDb<F> = CurrentOrderedDb::init(
+            context.child("current_ordered"),
+            current_config(&name, &context),
+        )
+        .await
+        .expect("init partitioned Current ordered db");
+        exercise!(db, &input.operations);
+
+        let name = format!("qmgb-current-unordered-{family}");
+        let db: CurrentUnorderedDb<F> = CurrentUnorderedDb::init(
+            context.child("current_unordered"),
+            current_config(&name, &context),
+        )
+        .await
+        .expect("init partitioned Current unordered db");
+        exercise!(db, &input.operations);
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz_family::<mmr::Family>(&input, "mmr");
+    fuzz_family::<mmb::Family>(&input, "mmb");
+});

--- a/storage/fuzz/fuzz_targets/qmgb_gen_stream_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmgb_gen_stream_sync.rs
@@ -1,0 +1,516 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use commonware_cryptography::{Sha256, sha256::Digest};
+use commonware_parallel::Sequential;
+use commonware_runtime::{
+    BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::{
+    journal::contiguous::variable::Config as JournalConfig,
+    merkle::{Graftable, full::Config as MerkleConfig, mmb, mmr},
+    qmdb::{
+        any::{VariableConfig as AnyConfig, ordered::variable::Db as AnyDb},
+        current::{VariableConfig as CurrentConfig, ordered::variable::Db as CurrentDb},
+        immutable::variable::{Config as ImmutableConfig, Db as ImmutableDb},
+        keyless::variable::{Config as KeylessConfig, Db as KeylessDb},
+        sync,
+    },
+    translator::TwoCap,
+};
+use commonware_utils::{FuzzRng, NZU16, NZU64, NZUsize, non_empty_range};
+use libfuzzer_sys::fuzz_target;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU16,
+    sync::Arc,
+};
+
+const MAX_OPERATIONS: usize = 16;
+const PAGE_SIZE: NonZeroU16 = NZU16!(141);
+const BITMAP_CHUNK_BYTES: usize = 32;
+
+type Any<F> = AnyDb<F, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>;
+type Current<F> = CurrentDb<
+    F,
+    deterministic::Context,
+    Digest,
+    Digest,
+    Sha256,
+    TwoCap,
+    BITMAP_CHUNK_BYTES,
+    Sequential,
+>;
+type Immutable<F> =
+    ImmutableDb<F, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>;
+type Keyless<F> = KeylessDb<F, deterministic::Context, Digest, Sha256, Sequential>;
+
+#[derive(Arbitrary, Clone, Debug)]
+enum Operation {
+    Update { key: [u8; 32], value: [u8; 32] },
+    Delete { key: [u8; 32] },
+    Commit,
+    StreamSync,
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    raw_bytes: Vec<u8>,
+    operations: Vec<Operation>,
+    fetch_batch_size: u8,
+    apply_batch_size: u8,
+    max_outstanding: u8,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
+        let operation_count = u.int_in_range(1..=MAX_OPERATIONS)?;
+        let operations = (0..operation_count)
+            .map(|_| Operation::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+        Ok(Self {
+            raw_bytes,
+            operations,
+            fetch_batch_size: u.arbitrary()?,
+            apply_batch_size: u.arbitrary()?,
+            max_outstanding: u.arbitrary()?,
+        })
+    }
+}
+
+fn journal_config<C: Clone>(
+    name: &str,
+    pooler: &impl BufferPooler,
+    codec_config: C,
+) -> JournalConfig<C> {
+    JournalConfig {
+        partition: format!("{name}-log"),
+        items_per_section: NZU64!(7),
+        write_buffer: NZUsize!(1024),
+        compression: None,
+        codec_config,
+        page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(8)),
+    }
+}
+
+fn merkle_config(name: &str, pooler: &impl BufferPooler) -> MerkleConfig<Sequential> {
+    MerkleConfig {
+        journal_partition: format!("{name}-merkle"),
+        metadata_partition: format!("{name}-metadata"),
+        items_per_blob: NZU64!(11),
+        write_buffer: NZUsize!(1024),
+        strategy: Sequential,
+        page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(8)),
+    }
+}
+
+fn any_config(name: &str, pooler: &impl BufferPooler) -> AnyConfig<TwoCap, ((), ()), Sequential> {
+    AnyConfig {
+        merkle_config: merkle_config(name, pooler),
+        journal_config: journal_config(name, pooler, ((), ())),
+        translator: TwoCap,
+        init_cache_size: Some(NZUsize!(16)),
+        init_buffer: NZUsize!(1 << 16),
+        init_concurrency: (),
+    }
+}
+
+fn current_config(
+    name: &str,
+    pooler: &impl BufferPooler,
+) -> CurrentConfig<TwoCap, ((), ()), Sequential> {
+    CurrentConfig {
+        merkle_config: merkle_config(name, pooler),
+        journal_config: journal_config(name, pooler, ((), ())),
+        grafted_metadata_partition: format!("{name}-grafted"),
+        translator: TwoCap,
+        init_cache_size: Some(NZUsize!(16)),
+        init_buffer: NZUsize!(1 << 16),
+        init_concurrency: (),
+    }
+}
+
+fn immutable_config(
+    name: &str,
+    pooler: &impl BufferPooler,
+) -> ImmutableConfig<TwoCap, ((), ()), Sequential> {
+    ImmutableConfig {
+        merkle_config: merkle_config(name, pooler),
+        log: journal_config(name, pooler, ((), ())),
+        translator: TwoCap,
+        init_cache_size: Some(NZUsize!(16)),
+        init_buffer: NZUsize!(1 << 16),
+    }
+}
+
+fn keyless_config(name: &str, pooler: &impl BufferPooler) -> KeylessConfig<(), Sequential> {
+    KeylessConfig {
+        merkle: merkle_config(name, pooler),
+        log: journal_config(name, pooler, ()),
+    }
+}
+
+fn sync_sizes(input: &FuzzInput) -> (u64, usize, usize) {
+    (
+        u64::from(input.fetch_batch_size) + 1,
+        usize::from(input.apply_batch_size) + 1,
+        usize::from(input.max_outstanding) + 1,
+    )
+}
+
+fn fuzz_any<F: Graftable>(input: &FuzzInput, family: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let source_name = format!("qmgb-sync-any-source-{family}");
+        let mut source: Any<F> =
+            Any::init(context.child("source"), any_config(&source_name, &context))
+                .await
+                .expect("init Any sync source");
+        let mut mutations = BTreeMap::new();
+        let mut syncs = 0usize;
+        for operation in &input.operations {
+            match operation {
+                Operation::Update { key, value } => {
+                    mutations.insert(Digest::from(*key), Some(Digest::from(*value)));
+                }
+                Operation::Delete { key } => {
+                    mutations.insert(Digest::from(*key), None);
+                }
+                Operation::Commit => {
+                    let mut batch = source.new_batch();
+                    for (key, value) in std::mem::take(&mut mutations) {
+                        batch = batch.write(key, value);
+                    }
+                    let start = source.bounds().end;
+                    let batch = batch
+                        .merkleize(&source, None)
+                        .await
+                        .expect("merkleize Any source");
+                    let expected_root = batch.root();
+                    let range;
+                    (source, range) = source
+                        .apply_batch(batch)
+                        .await
+                        .expect("apply Any source batch");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, source.bounds().end);
+                    assert_eq!(source.root(), expected_root);
+                    source = source.commit().await.expect("commit Any source");
+                }
+                Operation::StreamSync => {
+                    let target = sync::Target::new(
+                        source.root(),
+                        non_empty_range!(source.sync_boundary(), source.bounds().end),
+                    );
+                    let expected_root = source.root();
+                    let expected_bounds = target.range.start()..target.range.end();
+                    let source_arc = Arc::new(source);
+                    let (fetch, apply, outstanding) = sync_sizes(input);
+                    let destination: Any<F> = sync::sync(sync::engine::Config {
+                        context: context
+                            .child("destination")
+                            .with_attribute("instance", syncs),
+                        resolver: source_arc.clone(),
+                        target,
+                        max_outstanding_requests: outstanding,
+                        fetch_batch_size: NZU64!(fetch),
+                        apply_batch_size: apply,
+                        db_config: any_config(
+                            &format!("qmgb-sync-any-dest-{family}-{syncs}"),
+                            &context,
+                        ),
+                        update_rx: None,
+                        finish_rx: None,
+                        reached_target_tx: None,
+                        max_retained_roots: 4,
+                    })
+                    .await
+                    .expect("sync Any variable db");
+                    assert_eq!(destination.root(), expected_root);
+                    assert_eq!(destination.bounds(), expected_bounds);
+                    destination
+                        .destroy()
+                        .await
+                        .expect("destroy Any destination");
+                    source = Arc::try_unwrap(source_arc)
+                        .unwrap_or_else(|_| panic!("Any source still shared"));
+                    syncs += 1;
+                }
+            }
+        }
+        source.destroy().await.expect("destroy Any source");
+    });
+}
+
+fn fuzz_current<F: Graftable>(input: &FuzzInput, family: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let source_name = format!("qmgb-sync-current-source-{family}");
+        let mut source: Current<F> = Current::init(
+            context.child("source"),
+            current_config(&source_name, &context),
+        )
+        .await
+        .expect("init Current sync source");
+        let mut mutations = BTreeMap::new();
+        let mut syncs = 0usize;
+        for operation in &input.operations {
+            match operation {
+                Operation::Update { key, value } => {
+                    mutations.insert(Digest::from(*key), Some(Digest::from(*value)));
+                }
+                Operation::Delete { key } => {
+                    mutations.insert(Digest::from(*key), None);
+                }
+                Operation::Commit => {
+                    let mut batch = source.new_batch();
+                    for (key, value) in std::mem::take(&mut mutations) {
+                        batch = batch.write(key, value);
+                    }
+                    let start = source.bounds().end;
+                    let batch = batch
+                        .merkleize(&source, None)
+                        .await
+                        .expect("merkleize Current source");
+                    let expected_root = batch.root();
+                    let range;
+                    (source, range) = source
+                        .apply_batch(batch)
+                        .await
+                        .expect("apply Current source batch");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, source.bounds().end);
+                    assert_eq!(source.root(), expected_root);
+                    source = source.commit().await.expect("commit Current source");
+                }
+                Operation::StreamSync => {
+                    let target = sync::Target::new(
+                        source.ops_root(),
+                        non_empty_range!(source.sync_boundary(), source.bounds().end),
+                    );
+                    let expected_root = source.root();
+                    let expected_ops_root = source.ops_root();
+                    let expected_bounds = target.range.start()..target.range.end();
+                    let source_arc = Arc::new(source);
+                    let (fetch, apply, outstanding) = sync_sizes(input);
+                    let destination: Current<F> = sync::sync(sync::engine::Config {
+                        context: context
+                            .child("destination")
+                            .with_attribute("instance", syncs),
+                        resolver: source_arc.clone(),
+                        target,
+                        max_outstanding_requests: outstanding,
+                        fetch_batch_size: NZU64!(fetch),
+                        apply_batch_size: apply,
+                        db_config: current_config(
+                            &format!("qmgb-sync-current-dest-{family}-{syncs}"),
+                            &context,
+                        ),
+                        update_rx: None,
+                        finish_rx: None,
+                        reached_target_tx: None,
+                        max_retained_roots: 4,
+                    })
+                    .await
+                    .expect("sync Current variable db");
+                    assert_eq!(destination.ops_root(), expected_ops_root);
+                    assert_eq!(destination.root(), expected_root);
+                    assert_eq!(destination.bounds(), expected_bounds);
+                    destination
+                        .destroy()
+                        .await
+                        .expect("destroy Current destination");
+                    source = Arc::try_unwrap(source_arc)
+                        .unwrap_or_else(|_| panic!("Current source still shared"));
+                    syncs += 1;
+                }
+            }
+        }
+        source.destroy().await.expect("destroy Current source");
+    });
+}
+
+fn fuzz_immutable<F: Graftable>(input: &FuzzInput, family: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let source_name = format!("qmgb-sync-immutable-source-{family}");
+        let mut source: Immutable<F> = Immutable::init(
+            context.child("source"),
+            immutable_config(&source_name, &context),
+        )
+        .await
+        .expect("init Immutable sync source");
+        let mut values = BTreeMap::new();
+        let mut seen = BTreeSet::new();
+        let mut syncs = 0usize;
+        for operation in &input.operations {
+            match operation {
+                Operation::Update { key, value } => {
+                    let key = Digest::from(*key);
+                    if seen.insert(key) {
+                        values.insert(key, Digest::from(*value));
+                    }
+                }
+                Operation::Delete { .. } => {}
+                Operation::Commit => {
+                    let mut batch = source.new_batch();
+                    for (key, value) in std::mem::take(&mut values) {
+                        batch = batch.set(key, value);
+                    }
+                    let start = source.bounds().end;
+                    let batch = batch
+                        .merkleize(&source, None, source.inactivity_floor_loc())
+                        .await;
+                    let expected_root = batch.root();
+                    let range;
+                    (source, range) = source
+                        .apply_batch(batch)
+                        .await
+                        .expect("apply Immutable source batch");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, source.bounds().end);
+                    assert_eq!(source.root(), expected_root);
+                    source = source.commit().await.expect("commit Immutable source");
+                }
+                Operation::StreamSync => {
+                    let target = sync::Target::new(
+                        source.root(),
+                        non_empty_range!(source.sync_boundary(), source.bounds().end),
+                    );
+                    let expected_root = source.root();
+                    let expected_bounds = target.range.start()..target.range.end();
+                    let source_arc = Arc::new(source);
+                    let (fetch, apply, outstanding) = sync_sizes(input);
+                    let destination: Immutable<F> = sync::sync(sync::engine::Config {
+                        context: context
+                            .child("destination")
+                            .with_attribute("instance", syncs),
+                        resolver: source_arc.clone(),
+                        target,
+                        max_outstanding_requests: outstanding,
+                        fetch_batch_size: NZU64!(fetch),
+                        apply_batch_size: apply,
+                        db_config: immutable_config(
+                            &format!("qmgb-sync-immutable-dest-{family}-{syncs}"),
+                            &context,
+                        ),
+                        update_rx: None,
+                        finish_rx: None,
+                        reached_target_tx: None,
+                        max_retained_roots: 4,
+                    })
+                    .await
+                    .expect("sync Immutable variable db");
+                    assert_eq!(destination.root(), expected_root);
+                    assert_eq!(destination.bounds(), expected_bounds);
+                    destination
+                        .destroy()
+                        .await
+                        .expect("destroy Immutable destination");
+                    source = Arc::try_unwrap(source_arc)
+                        .unwrap_or_else(|_| panic!("Immutable source still shared"));
+                    syncs += 1;
+                }
+            }
+        }
+        source.destroy().await.expect("destroy Immutable source");
+    });
+}
+
+fn fuzz_keyless<F: Graftable>(input: &FuzzInput, family: &str) {
+    let runtime =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
+    deterministic::Runner::new(runtime).start(|context| async move {
+        let source_name = format!("qmgb-sync-keyless-source-{family}");
+        let mut source: Keyless<F> = Keyless::init(
+            context.child("source"),
+            keyless_config(&source_name, &context),
+        )
+        .await
+        .expect("init Keyless sync source");
+        let mut values = Vec::new();
+        let mut syncs = 0usize;
+        for operation in &input.operations {
+            match operation {
+                Operation::Update { value, .. } => values.push(Digest::from(*value)),
+                Operation::Delete { key } => values.push(Digest::from(*key)),
+                Operation::Commit => {
+                    let mut batch = source.new_batch();
+                    for value in values.drain(..) {
+                        batch = batch.append(value);
+                    }
+                    let start = source.bounds().end;
+                    let batch = batch
+                        .merkleize(&source, None, source.inactivity_floor_loc())
+                        .await;
+                    let expected_root = batch.root();
+                    let range;
+                    (source, range) = source
+                        .apply_batch(batch)
+                        .await
+                        .expect("apply Keyless source batch");
+                    assert_eq!(range.start, start);
+                    assert_eq!(range.end, source.bounds().end);
+                    assert_eq!(source.root(), expected_root);
+                    source = source.commit().await.expect("commit Keyless source");
+                }
+                Operation::StreamSync => {
+                    let target = sync::Target::new(
+                        source.root(),
+                        non_empty_range!(source.sync_boundary(), source.bounds().end),
+                    );
+                    let expected_root = source.root();
+                    let expected_bounds = target.range.start()..target.range.end();
+                    let source_arc = Arc::new(source);
+                    let (fetch, apply, outstanding) = sync_sizes(input);
+                    let destination: Keyless<F> = sync::sync(sync::engine::Config {
+                        context: context
+                            .child("destination")
+                            .with_attribute("instance", syncs),
+                        resolver: source_arc.clone(),
+                        target,
+                        max_outstanding_requests: outstanding,
+                        fetch_batch_size: NZU64!(fetch),
+                        apply_batch_size: apply,
+                        db_config: keyless_config(
+                            &format!("qmgb-sync-keyless-dest-{family}-{syncs}"),
+                            &context,
+                        ),
+                        update_rx: None,
+                        finish_rx: None,
+                        reached_target_tx: None,
+                        max_retained_roots: 4,
+                    })
+                    .await
+                    .expect("sync Keyless variable db");
+                    assert_eq!(destination.root(), expected_root);
+                    assert_eq!(destination.bounds(), expected_bounds);
+                    destination
+                        .destroy()
+                        .await
+                        .expect("destroy Keyless destination");
+                    source = Arc::try_unwrap(source_arc)
+                        .unwrap_or_else(|_| panic!("Keyless source still shared"));
+                    syncs += 1;
+                }
+            }
+        }
+        source.destroy().await.expect("destroy Keyless source");
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz_any::<mmr::Family>(&input, "mmr");
+    fuzz_any::<mmb::Family>(&input, "mmb");
+    fuzz_current::<mmr::Family>(&input, "mmr");
+    fuzz_current::<mmb::Family>(&input, "mmb");
+    fuzz_immutable::<mmr::Family>(&input, "mmr");
+    fuzz_immutable::<mmb::Family>(&input, "mmb");
+    fuzz_keyless::<mmr::Family>(&input, "mmr");
+    fuzz_keyless::<mmb::Family>(&input, "mmb");
+});

--- a/storage/fuzz/fuzz_targets/store_operations.rs
+++ b/storage/fuzz/fuzz_targets/store_operations.rs
@@ -31,18 +31,19 @@ enum Operation {
     Prune,
     OpCount,
     InactivityFloorLoc,
+    IsEmpty,
     SimulateFailure,
 }
 
 impl<'a> Arbitrary<'a> for Operation {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let choice: u8 = u.arbitrary()?;
-        match choice % 10 {
+        match choice % 11 {
             0 => {
                 let key = u.arbitrary()?;
                 let value_len: u16 = u.arbitrary()?;
                 let actual_len = ((value_len as usize) % 10000) + 1;
-                let value_bytes = u.bytes(actual_len)?.to_vec();
+                let value_bytes = u.bytes(actual_len.min(u.len()))?.to_vec();
                 Ok(Operation::Update { key, value_bytes })
             }
             1 => {
@@ -54,7 +55,7 @@ impl<'a> Arbitrary<'a> for Operation {
                 let metadata_bytes = if has_metadata {
                     let metadata_len: u16 = u.arbitrary()?;
                     let actual_len = ((metadata_len as usize) % 1000) + 1;
-                    Some(u.bytes(actual_len)?.to_vec())
+                    Some(u.bytes(actual_len.min(u.len()))?.to_vec())
                 } else {
                     None
                 };
@@ -69,7 +70,8 @@ impl<'a> Arbitrary<'a> for Operation {
             6 => Ok(Operation::Prune),
             7 => Ok(Operation::OpCount),
             8 => Ok(Operation::InactivityFloorLoc),
-            9 => Ok(Operation::SimulateFailure),
+            9 => Ok(Operation::IsEmpty),
+            10 => Ok(Operation::SimulateFailure),
             _ => unreachable!(),
         }
     }
@@ -83,11 +85,12 @@ struct FuzzInput {
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let raw_len = u.len().min(8);
+        let raw_bytes = u.bytes(raw_len)?.to_vec();
         let num_ops = u.int_in_range(1..=MAX_OPERATIONS)?;
         let ops = (0..num_ops)
             .map(|_| Operation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
-        let raw_bytes = u.bytes(u.len())?.to_vec();
         Ok(FuzzInput { ops, raw_bytes })
     }
 }
@@ -115,7 +118,8 @@ fn test_config(
 }
 
 fn fuzz(input: FuzzInput) {
-    let cfg = deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes)));
+    let cfg =
+        deterministic::Config::new().with_rng(Box::new(FuzzRng::new(input.raw_bytes.clone())));
     let runner = deterministic::Runner::new(cfg);
 
     runner.start(|context| async move {
@@ -125,6 +129,9 @@ fn fuzz(input: FuzzInput) {
             .expect("Failed to init db");
         let mut restarts = 0usize;
         let mut pending: BTreeMap<Digest, Option<Vec<u8>>> = BTreeMap::new();
+        let mut committed: BTreeMap<Digest, Vec<u8>> = BTreeMap::new();
+        let mut committed_metadata = None;
+        let mut expected_size = db.size();
 
         for op in &input.ops {
             db = match op {
@@ -140,32 +147,71 @@ fn fuzz(input: FuzzInput) {
 
                 Operation::Commit { metadata_bytes } => {
                     let mut batch = db.new_batch();
-                    for (key, value) in std::mem::take(&mut pending) {
+                    let changes = std::mem::take(&mut pending);
+                    for (key, value) in &changes {
                         batch = match value {
-                            Some(v) => batch.update(key, v),
-                            None => batch.delete(key),
+                            Some(v) => batch.update(*key, v.clone()),
+                            None => batch.delete(*key),
                         };
                     }
                     let changeset = batch.finalize(metadata_bytes.clone());
-                    let (db, _) = db
+                    let (db, applied) = db
                         .apply_batch(changeset)
                         .await
                         .expect("Apply batch should not fail");
-                    db.commit().await.expect("Commit should not fail")
+                    assert_eq!(applied.start, expected_size);
+                    expected_size = applied.end;
+                    let db = db.commit().await.expect("Commit should not fail");
+                    for (key, value) in changes {
+                        match value {
+                            Some(value) => {
+                                committed.insert(key, value);
+                            }
+                            None => {
+                                committed.remove(&key);
+                            }
+                        }
+                    }
+                    committed_metadata = metadata_bytes.clone();
+                    db
                 }
 
                 Operation::Get { key } => {
                     let digest = Digest(*key);
-                    if let Some(value) = pending.get(&digest) {
-                        let _ = value.clone();
-                    } else {
-                        let _ = db.get(&digest).await;
+                    let committed_value = db.get(&digest).await.expect("Get should not fail");
+                    assert_eq!(
+                        committed_value,
+                        committed.get(&digest).cloned(),
+                        "Store get disagreed with committed model",
+                    );
+
+                    let mut batch = db.new_batch();
+                    for (key, value) in &pending {
+                        batch = match value {
+                            Some(value) => batch.update(*key, value.clone()),
+                            None => batch.delete(*key),
+                        };
                     }
+                    let expected = match pending.get(&digest) {
+                        Some(value) => value.clone(),
+                        None => committed.get(&digest).cloned(),
+                    };
+                    assert_eq!(
+                        batch.get(&digest).await.expect("Batch get should not fail"),
+                        expected,
+                        "Batch get disagreed with pending model",
+                    );
                     db
                 }
 
                 Operation::GetMetadata => {
-                    let _ = db.get_metadata().await;
+                    assert_eq!(
+                        db.get_metadata()
+                            .await
+                            .expect("Get metadata should not fail"),
+                        committed_metadata,
+                        "Store metadata disagreed with committed model",
+                    );
                     db
                 }
 
@@ -177,12 +223,33 @@ fn fuzz(input: FuzzInput) {
                 }
 
                 Operation::OpCount => {
-                    let _ = db.bounds().end;
+                    assert_eq!(
+                        db.bounds().end,
+                        expected_size,
+                        "Store bounds disagreed with the modeled operation log"
+                    );
+                    assert_eq!(
+                        db.size(),
+                        expected_size,
+                        "Store size disagreed with the model"
+                    );
                     db
                 }
 
                 Operation::InactivityFloorLoc => {
-                    let _ = db.inactivity_floor_loc();
+                    assert!(
+                        db.inactivity_floor_loc() <= db.size(),
+                        "Inactivity floor exceeded store size",
+                    );
+                    db
+                }
+
+                Operation::IsEmpty => {
+                    assert_eq!(
+                        db.is_empty(),
+                        committed.is_empty(),
+                        "Store emptiness disagreed with committed model",
+                    );
                     db
                 }
 
@@ -197,6 +264,7 @@ fn fuzz(input: FuzzInput) {
                     )
                     .await
                     .expect("Failed to init db");
+                    expected_size = db.size();
                     restarts += 1;
                     db
                 }

--- a/storage/fuzz/fuzz_targets/verify_proof.rs
+++ b/storage/fuzz/fuzz_targets/verify_proof.rs
@@ -12,11 +12,20 @@ const MAX_DIGESTS: usize = 128;
 const MAX_OPERATIONS: usize = 50;
 const MAX_OPERATION_BYTES: usize = 512;
 
-#[derive(Arbitrary, Debug)]
+#[derive(Debug)]
 struct OperationInput {
     // Raw `u64` so we also exercise the per-op `is_valid()` rejection path.
     location: u64,
     payload: Vec<u8>,
+}
+
+impl<'a> Arbitrary<'a> for OperationInput {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let location = u.arbitrary()?;
+        let payload_len = u.int_in_range(0..=MAX_OPERATION_BYTES)?;
+        let payload = u.bytes(payload_len.min(u.len()))?.to_vec();
+        Ok(Self { location, payload })
+    }
 }
 
 // `proof_leaves` is typed `Location<F>` so that `Arbitrary` bounds it to `F::MAX_LEAVES`;
@@ -32,12 +41,36 @@ struct FuzzInput<F: MerkleFamily> {
 
 impl<'a, F: MerkleFamily> Arbitrary<'a> for FuzzInput<F> {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let proof_leaves = u.arbitrary()?;
+        let inactive_peaks = u.arbitrary()?;
+        let root = u.arbitrary()?;
+
+        // Keep enough bytes for a non-empty operation list after fixed-size digests.
+        let max_digests = ((u.len().saturating_sub(12)) / 32).min(MAX_DIGESTS);
+        let num_digests = u.int_in_range(0..=max_digests)?;
+        let digests = (0..num_digests)
+            .map(|_| <[u8; 32]>::arbitrary(u))
+            .collect::<arbitrary::Result<Vec<_>>>()?;
+
+        // Partition the remaining input so one variable payload cannot starve later operations.
+        let max_operations = ((u.len().saturating_sub(1)) / 10).min(MAX_OPERATIONS);
+        if max_operations == 0 {
+            return Err(arbitrary::Error::NotEnoughData);
+        }
+        let num_operations = u.int_in_range(1..=max_operations)?;
+        let mut operations = Vec::with_capacity(num_operations);
+        for remaining in (1..=num_operations).rev() {
+            let chunk_len = u.len() / remaining;
+            let mut chunk = Unstructured::new(u.bytes(chunk_len)?);
+            operations.push(OperationInput::arbitrary(&mut chunk)?);
+        }
+
         Ok(Self {
-            proof_leaves: u.arbitrary()?,
-            inactive_peaks: u.arbitrary()?,
-            digests: u.arbitrary()?,
-            operations: u.arbitrary()?,
-            root: u.arbitrary()?,
+            proof_leaves,
+            inactive_peaks,
+            digests,
+            operations,
+            root,
         })
     }
 }
@@ -70,7 +103,24 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput<F>) {
     }
 
     let root = Digest::from(input.root);
-    let _ = verify_multi_proof::<Sha256, _, _>(&proof, operations.as_slice(), &root);
+    let verified = verify_multi_proof::<Sha256, _, _>(&proof, operations.as_slice(), &root);
+    if verified {
+        assert!(
+            operations.iter().all(|(loc, _)| *loc < proof.leaves),
+            "verified operation locations must be within the authenticated tree",
+        );
+
+        let mut tampered_root = input.root;
+        tampered_root[0] ^= 1;
+        assert!(
+            !verify_multi_proof::<Sha256, _, _>(
+                &proof,
+                operations.as_slice(),
+                &Digest::from(tampered_root),
+            ),
+            "a multi-proof must reject a different root",
+        );
+    }
 }
 
 fuzz_target!(|data: &[u8]| {

--- a/storage/fuzz/qmdb_fuzz_plan.md
+++ b/storage/fuzz/qmdb_fuzz_plan.md
@@ -1,0 +1,72 @@
+# QMDB fuzz coverage plan
+
+## Constraints
+
+- Keep existing targets structurally intact; add surgical operation arms and invariant assertions.
+- Keep every target input-driven. Do not embed unit-test scenarios or fixed expected values.
+- Generate at least one operation per input.
+- Reserve fuzz bytes before parsing operations and seed the deterministic runtime with
+  `commonware_utils::FuzzRng`.
+- Run targets from empty corpus directories and verify production-line coverage with LLVM coverage.
+
+## Generator work
+
+- Replace unconstrained derived operation vectors in `qmdb_unordered_operations`,
+  `qmdb_ordered_batching`, `qmdb_any_variable_sync`, `current_crash_recovery`, and
+  `verify_proof`.
+- Bound the digest and operation payload vectors in `verify_proof` so variable-length fields cannot
+  consume the bytes required to construct an input.
+- Reserve a short input prefix for `FuzzRng`, following `cache_operations.rs`, in targets that use
+  the deterministic runtime. `verify_proof` is a pure verification target and has no runtime RNG.
+
+## Missing concrete variants
+
+All generated targets use the `qmgb_gen_` prefix.
+
+- `qmgb_gen_any_ordered_variable`: Any ordered-variable, MMR and MMB.
+- `qmgb_gen_current_ordered_variable`: Current ordered-variable, MMR and MMB.
+- `qmgb_gen_immutable_fixed`: full immutable fixed, MMR and MMB.
+- `qmgb_gen_immutable_compact`: compact immutable fixed and variable, MMR and MMB.
+- `qmgb_gen_keyless_fixed`: full keyless fixed, MMR and MMB.
+- `qmgb_gen_keyless_compact_fixed`: compact keyless fixed, MMR and MMB.
+- `qmgb_gen_partitioned`: representative partitioned Any and Current variants.
+- `qmgb_gen_stream_sync`: streaming-sync adapters not covered by `qmdb_any_fixed_sync`.
+
+## Existing-target API additions
+
+### Any
+
+- Add `get_many`, a strategy-backed fold oracle, pinned-node proof verification, idempotent rewind,
+  sync/reopen, and empty-state invariants across the operation and variable-sync targets.
+- Add ordered `get_all`, `stream_range`, and `span_contains` invariants.
+- Exercise batch reads, staging/expansion, bounds, child batches, validation, and `to_batch` in the
+  existing batching targets.
+
+### Current
+
+- Add metadata, ops-root witness, historical proof, pinned nodes, rewind, sync/reopen, and batch
+  validation operations.
+- Cross-check lower-level proof verification against database verification wrappers.
+- Add ordered range streaming and batch read/staging/to-batch invariants.
+
+### Immutable and keyless
+
+- Add size/bounds, sync boundary, bulk reads, pinned-node proof verification, rewind, sync/reopen,
+  validation, `to_batch`, and batch-view operations.
+- Exercise operation accessors using operations returned by generated proofs.
+- Add compact last-commit, commit/reopen, bounds, and `to_batch` invariants.
+
+### Store and sync
+
+- Add store `is_empty`, `size`, and batch-read invariants.
+- Exercise streaming sync for variable Any, Current, immutable, and keyless databases using
+  input-driven commit/sync operations and root, bounds, metadata, and ops-root oracles.
+
+## Validation
+
+1. Build every changed and generated fuzz target.
+2. Run each target from an empty temporary corpus.
+3. Generate per-target LLVM coverage.
+4. Merge the profiles and inspect `storage/src/qmdb` with `llvm-cov show`.
+5. Iterate until each intended variant is instantiated and every public production method is
+   either directly fuzzed with an invariant or documented as transitive-only support code.


### PR DESCRIPTION
This PR contains several trivial improvements to the coverage and generated experimental fuzz targets for qmdb to run experiments in the fuzz cloud.