### PR TITLE
[storage/journal] Nits on Sealing

### DIFF
--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -4,7 +4,7 @@
 //! # Sealing
 //!
 //! [`super::Writer::seal`] returns a [`Sealed`] read handle and starts an fsync. Reads observe
-//! flushed bytes immediately; durability waits for the sync handle.
+//! flushed bytes immediately, while durability waits for the sync handle.
 //!
 //! # Cheap sharing
 //!

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -971,6 +971,9 @@ impl<B: Blob> Writer<B> {
     /// [`Self::new`] sizes a blob by scanning backward to its last valid page, which cannot
     /// detect an earlier page that was lost or corrupted. This scans forward instead, stopping
     /// at the first invalid or short page.
+    ///
+    /// Expects all appended bytes to have reached the blob (as after recovery): a partial page
+    /// still buffered in this writer is unreadable from the blob and fails the scan.
     pub async fn recoverable_prefix_len(&self) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size();
         let total_pages = self.current_page + u64::from(self.partial_page_state.is_some());
@@ -981,7 +984,7 @@ impl<B: Blob> Writer<B> {
                 Ok((logical, _)) => {
                     let len = logical.len() as u64;
                     valid_len += len;
-                    // A partial page can only legitimately be the last one; stop here.
+                    // A partial page can only legitimately be the last one, so stop here.
                     if len < logical_page_size {
                         break;
                     }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -12,7 +12,7 @@ use commonware_runtime::{
 };
 use futures::{
     FutureExt as _,
-    future::{self, BoxFuture, Shared},
+    future::{self, BoxFuture, Shared, try_join_all},
 };
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 use tracing::debug;
@@ -180,6 +180,7 @@ impl<E: Context> Writable<E> {
         }
         let oldest = pending.keys().next().copied();
         let mut sealed = Vec::with_capacity(pending.len());
+        let mut syncs = Vec::with_capacity(pending.len());
         let mut tail: Option<Writer<E::Blob>> = None;
         let mut expected = oldest;
         for (blob, writer) in pending {
@@ -193,10 +194,11 @@ impl<E: Context> Writable<E> {
                 tail = Some(writer);
             } else {
                 let (sealed_blob, sync) = writer.seal().await?;
-                sync.await?;
+                syncs.push(sync);
                 sealed.push(sealed_blob);
             }
         }
+        try_join_all(syncs).await?;
         let tail = match tail {
             Some(writer) => writer,
             None => partition.open(tail_blob).await?,
@@ -424,7 +426,8 @@ impl<E: Context> Writable<E> {
     /// Start syncing the tail, returning a handle that completes once both the tail and its
     /// predecessor are durable.
     pub(super) async fn start_sync(&mut self) -> Handle<()> {
-        // Keep one tail sync in flight.
+        // Keep at most one tail sync in flight. A pending predecessor sync is not awaited here:
+        // the returned handle joins it, so handles from consecutive calls can be pending at once.
         if let Some(prior) = self.tail_sync.clone()
             && let Err(err) = prior.await
         {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -73,7 +73,9 @@
 //! A crash while one of those fsyncs is in flight can persist the blob's pages out of order: an
 //! earlier page may be lost while later pages, including a valid last page, survive. Sizing a
 //! blob by its last valid page cannot detect such a hole, so recovery re-reads the two newest
-//! blobs from the front and truncates each at the first missing or corrupt page.
+//! blobs from the front and truncates each at the first missing or corrupt page. A hole in a
+//! blob fully below the recovery watermark is external corruption, and recovery fails without
+//! truncating it.
 //!
 //! The recovered size is the logical end of this contiguous prefix. If the persisted watermark
 //! exceeds the recovered size, recovery returns a corruption error. Both the pruning boundary
@@ -431,24 +433,38 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 
         // Check the two newest blobs for interior holes. Only they can hold non-durable data, and
         // a crash during an in-flight fsync can lose an interior page while later pages survive.
-        // `Writer::new` sizes a blob by its last valid page, so it cannot see such a hole. Re-read
-        // each blob from the front and truncate at the first bad page (rounded down to whole
-        // items) so `recover_bounds` sees only intact data.
+        // `Writer::new` sizes a blob by its last valid page, so it cannot see such a hole. Above
+        // the watermark, truncate at the first bad page (rounded down to whole items) so
+        // `recover_bounds` sees only intact data. In a blob fully below the watermark the
+        // covering fsync completed, so a hole is external corruption: fail and preserve the
+        // evidence (`recover_bounds` would reject the truncated result anyway).
+        let floor_blob = super::position_to_blob(
+            checkpoint.watermark().unwrap_or(0),
+            cfg.items_per_blob.get(),
+        );
         let suspects: Vec<u64> = pending.keys().rev().take(2).copied().collect();
         for blob in suspects {
             let writer = pending.get_mut(&blob).expect("suspect blob is present");
             let valid = writer.recoverable_prefix_len().await?;
             let valid = Self::items_to_bytes(valid / Self::CHUNK_SIZE_U64)?;
-            if valid < writer.size() {
-                warn!(
-                    blob,
-                    valid,
-                    size = writer.size(),
-                    "truncating to last well-formed page"
-                );
-                writer.resize(valid).await?;
-                writer.sync().await?;
+            if valid == writer.size() {
+                continue;
             }
+            if blob < floor_blob {
+                return Err(Error::Corruption(format!(
+                    "blob {blob} no longer backs acknowledged items: well-formed prefix {valid} \
+                     of size {}",
+                    writer.size()
+                )));
+            }
+            warn!(
+                blob,
+                valid,
+                size = writer.size(),
+                "truncating to last well-formed page"
+            );
+            writer.resize(valid).await?;
+            writer.sync().await?;
         }
 
         let RecoveredBounds {
@@ -3540,7 +3556,8 @@ mod tests {
 
     /// A torn page beneath the recovery watermark is external corruption, not a crash artifact:
     /// the watermark only advances after the covering fsync completes. Recovery must fail rather
-    /// than silently adopt a shortened prefix.
+    /// than silently adopt a shortened prefix, and it must preserve the evidence so a retry
+    /// fails identically.
     #[test_traced]
     fn test_fixed_recovery_rejects_torn_page_below_watermark() {
         let executor = deterministic::Runner::default();
@@ -3562,8 +3579,24 @@ mod tests {
                 PAGE_SIZE.get() as u64,
             )
             .await;
+            let (_, size_before) = context
+                .open(&blob_partition(&cfg), &0u64.to_be_bytes())
+                .await
+                .unwrap();
 
-            let result = Journal::<_, Digest>::init(context.child("second"), cfg).await;
+            let result = Journal::<_, Digest>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The rejection must not truncate the torn blob, and a retry must fail identically.
+            let (_, size_after) = context
+                .open(&blob_partition(&cfg), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(
+                size_after, size_before,
+                "rejection must preserve the evidence"
+            );
+            let result = Journal::<_, Digest>::init(context.child("third"), cfg).await;
             assert!(matches!(result, Err(Error::Corruption(_))));
         });
     }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -34,7 +34,7 @@
 //!   and byte offset.
 //!
 //! - `Writable` owns the files: the contiguous sealed blobs plus the one writable tail. When the
-//!   tail fills, it is sealed and an fsync of it begins; `Writable` tracks that in-flight sync
+//!   tail fills, it is sealed and an fsync of it begins. `Writable` tracks that in-flight sync
 //!   along with any started sync of the new tail.
 //!
 //! - `Checkpoint` owns the durable recovery hints (mid-blob pruning boundary, recovery
@@ -68,7 +68,7 @@
 //! When an append fills the tail blob, the journal rolls over: it seals the full blob, starts an
 //! fsync of it, and opens the next blob as the new tail. Each rollover first waits for the
 //! previous rollover's fsync, so only the tail and its predecessor (the blob sealed by the last
-//! rollover) can ever hold non-durable data; every older blob is fully durable.
+//! rollover) can ever hold non-durable data. Every older blob is fully durable.
 //!
 //! A crash while one of those fsyncs is in flight can persist the blob's pages out of order: an
 //! earlier page may be lost while later pages, including a valid last page, survive. Sizing a
@@ -1152,9 +1152,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// beyond the previous `sync()`. Use `sync()` to advance the watermark and to ensure that a
     /// crash after this call doesn't require any recovery.
     ///
-    /// At most one commit is in flight at a time: if a prior commit's sync is still pending, this
-    /// call waits for it before starting a new one. Appends and reads proceed while the returned
-    /// handle is pending, and dropping the handle does not cancel the sync.
+    /// At most one tail fsync is in flight at a time: if a prior commit's fsync is still pending,
+    /// this call waits for it before starting a new one. It does not wait for a pending rollover
+    /// fsync: the returned handle joins it, so an earlier commit's handle may still be pending
+    /// when this call returns. Reads always proceed while the returned handle is pending, and
+    /// appends proceed while they fit in the write buffer (a buffer flush or rollover waits for
+    /// the in-flight fsync). Dropping the handle does not cancel the sync.
     pub async fn start_commit(mut self) -> (Self, Handle<()>) {
         let handle = self.0.start_commit().await;
         (self, handle)
@@ -3707,7 +3710,7 @@ mod tests {
     }
 
     /// A crash right after pruning must not lose retained items that were appended but never
-    /// synced. Blob removal is durable, so prune flushes every dirty blob first: otherwise the
+    /// synced. Blob removal is durable, so prune makes all data durable first: otherwise the
     /// unsynced tail would vanish with the crash and recovery would truncate the journal to
     /// empty even though the removal survived.
     #[test_traced]

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -444,7 +444,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
                     blob,
                     valid,
                     size = writer.size(),
-                    "interior hole detected: truncating to last well-formed page"
+                    "truncating to last well-formed page"
                 );
                 writer.resize(valid).await?;
                 writer.sync().await?;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1110,7 +1110,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
                 blob,
                 valid,
                 size = writer.size(),
-                "interior hole detected: truncating to last well-formed page"
+                "truncating to last well-formed page"
             );
             writer.resize(valid).await?;
             writer.sync().await?;

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -9,7 +9,7 @@
 //! and starts its fsync after awaiting the previous rollover's fsync, so only the tail and its
 //! predecessor can ever hold non-durable data. Recovery forward-validates those two blobs for
 //! interior fsync holes, and the offsets journal only advances after the data it indexes is
-//! durable. See the [`fixed`](super::fixed) module docs for the full model.
+//! durable. See the [`fixed`] module docs for the full model.
 
 use super::{
     Contiguous, Many, Mutable, blob_first_position,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1061,56 +1061,59 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         );
         let mut pending = partition.open_all().await?;
 
+        // Acknowledged floor: every position below it was covered by a completed data fsync
+        // (the pruning boundary covers a watermark gone stale after a prune).
+        let floor = offsets.recovery_watermark().max(offsets.pruning_boundary());
+        let floor_blob = position_to_blob(floor, items_per_blob);
+
+        // Every fully acknowledged blob must be large enough to back its last item (the fixed
+        // journal checks this by walking blob lengths). Positions below the offsets pruning
+        // boundary have nothing to validate: they were pruned, or `align` rejects the state as
+        // corruption. Torn pages in these blobs are left to page CRCs at read time.
+        for (&blob, writer) in pending.range(..floor_blob) {
+            let last_position = super::blob_end_position(blob, items_per_blob, u64::MAX) - 1;
+            if last_position < offsets.pruning_boundary() {
+                continue;
+            }
+            let offset = offsets.read(last_position).await?;
+            if offset >= writer.size() {
+                return Err(Error::Corruption(format!(
+                    "blob {blob} no longer backs acknowledged items: last item at offset \
+                     {offset} exceeds size {}",
+                    writer.size()
+                )));
+            }
+        }
+
         // Check the two newest blobs for interior holes. Only they can hold non-durable data
         // (each rollover fsyncs the just-sealed blob and awaits the previous rollover's fsync),
         // and a crash during an in-flight fsync can lose an interior page while later pages
         // survive. `Writer::new` sizes a blob by its last valid page, so it cannot see such a
-        // hole.
-        //
-        // How damage is handled depends on the acknowledged floor: the offsets recovery
-        // watermark, or the offsets pruning boundary when the watermark is stale. At or above
-        // the floor's blob, a hole is a crash artifact: truncate to the last well-formed page,
-        // and replay in `align` repairs a mid-frame cut like torn trailing junk. Below the
-        // floor's blob, every item is acknowledged and its covering fsync completed, so a hole
-        // or shortened extent is external corruption: fail without truncating, so the on-disk
-        // evidence survives and a retry fails identically. The extent check catches a blob
-        // shortened without leaving a torn page, which the forward scan cannot see.
-        let floor = offsets.recovery_watermark().max(offsets.pruning_boundary());
-        let floor_blob = position_to_blob(floor, items_per_blob);
+        // hole. Above the floor, truncate to the last well-formed page (replay in `align`
+        // repairs a mid-frame cut like torn trailing junk). Below the floor, the covering
+        // fsync completed, so a hole is external corruption: fail and preserve the evidence.
         let suspects: Vec<u64> = pending.keys().rev().take(2).copied().collect();
         for blob in suspects {
             let writer = pending.get_mut(&blob).expect("suspect blob is present");
             let valid = writer.recoverable_prefix_len().await?;
-            if blob < floor_blob {
-                let last_position = super::blob_end_position(blob, items_per_blob, u64::MAX) - 1;
-                // A pruning boundary past this blob's positions puts the offsets start in a
-                // strictly newer blob than this retained one, so it is also ahead of the oldest
-                // retained blob: `align` rejects that as corruption whenever any item survives,
-                // and in an all-empty journal every position here was deliberately pruned,
-                // leaving nothing to validate.
-                if last_position < offsets.pruning_boundary() {
-                    continue;
-                }
-                let offset = offsets.read(last_position).await?;
-                if valid < writer.size() || offset >= writer.size() {
-                    return Err(Error::Corruption(format!(
-                        "blob {blob} no longer backs acknowledged items: well-formed prefix \
-                         {valid} of size {}, last item at offset {offset}",
-                        writer.size()
-                    )));
-                }
+            if valid == writer.size() {
                 continue;
             }
-            if valid < writer.size() {
-                warn!(
-                    blob,
-                    valid,
-                    size = writer.size(),
-                    "interior hole detected: truncating to last well-formed page"
-                );
-                writer.resize(valid).await?;
-                writer.sync().await?;
+            if blob < floor_blob {
+                return Err(Error::Corruption(format!(
+                    "blob {blob} no longer backs acknowledged items: well-formed prefix {valid} \
+                     of size {}",
+                    writer.size()
+                )));
             }
+            warn!(
+                blob,
+                valid,
+                size = writer.size(),
+                "interior hole detected: truncating to last well-formed page"
+            );
+            writer.resize(valid).await?;
+            writer.sync().await?;
         }
 
         // Validate and align the offsets journal to match the data blobs.
@@ -4422,6 +4425,45 @@ mod tests {
         });
     }
 
+    /// An externally shortened blob below the watermark is rejected even when it is older than
+    /// the two blobs the interior-hole scan reads.
+    #[test_traced]
+    fn test_variable_recovery_rejects_shortened_old_blob_below_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config::<()> {
+                partition: "variable-short-old-below-watermark".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(10)),
+                write_buffer: NZUsize!(2048),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..25u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // Blob 0 holds 10 9-byte frames (90 bytes) across 2 pages, and is older than both
+            // scan suspects (blobs 1 and 2). Cut it to one whole physical page (64 logical
+            // bytes = 7 whole frames), leaving the surviving page well-formed.
+            let physical_page_size = 64 + 12;
+            let (blob, size) = context
+                .open(&cfg.data_partition(), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert!(size > physical_page_size);
+            blob.resize(physical_page_size).await.unwrap();
+            blob.sync().await.unwrap();
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+        });
+    }
+
     /// Test that a durable data blob above the sync watermark, sitting beyond an empty
     /// intermediate blob, is rolled back to the contiguous boundary during recovery.
     ///
@@ -5114,8 +5156,8 @@ mod tests {
                 match Journal::<_, u64>::init(context.child(child), cfg.clone()).await {
                     Err(Error::Corruption(message)) => assert_eq!(
                         message,
-                        "blob 1 no longer backs acknowledged items: well-formed prefix 0 of \
-                         size 0, last item at offset 81"
+                        "blob 1 no longer backs acknowledged items: last item at offset 81 \
+                         exceeds size 0"
                     ),
                     Err(error) => panic!("unexpected error: {error}"),
                     Ok(_) => panic!("missing acknowledged data was accepted"),

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2,6 +2,14 @@
 //!
 //! The data blobs are the source of truth. The offsets journal provides indexed access and records
 //! the preferred recovery point for replaying data to rebuild offset entries.
+//!
+//! # Durability
+//!
+//! Data blobs follow the same rollover pipeline as the fixed journal: filling the tail seals it
+//! and starts its fsync after awaiting the previous rollover's fsync, so only the tail and its
+//! predecessor can ever hold non-durable data. Recovery forward-validates those two blobs for
+//! interior fsync holes, and the offsets journal only advances after the data it indexes is
+//! durable. See the [`fixed`](super::fixed) module docs for the full model.
 
 use super::{
     Contiguous, Many, Mutable, blob_first_position,
@@ -1057,12 +1065,42 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         // (each rollover fsyncs the just-sealed blob and awaits the previous rollover's fsync),
         // and a crash during an in-flight fsync can lose an interior page while later pages
         // survive. `Writer::new` sizes a blob by its last valid page, so it cannot see such a
-        // hole. Re-read each blob from the front and truncate at the first bad page; if that
-        // cuts an item mid-frame, replay below repairs the torn frame like any trailing junk.
+        // hole.
+        //
+        // How damage is handled depends on the acknowledged floor: the offsets recovery
+        // watermark, or the offsets pruning boundary when the watermark is stale. At or above
+        // the floor's blob, a hole is a crash artifact: truncate to the last well-formed page,
+        // and replay in `align` repairs a mid-frame cut like torn trailing junk. Below the
+        // floor's blob, every item is acknowledged and its covering fsync completed, so a hole
+        // or shortened extent is external corruption: fail without truncating, so the on-disk
+        // evidence survives and a retry fails identically. The extent check catches a blob
+        // shortened without leaving a torn page, which the forward scan cannot see.
+        let floor = offsets.recovery_watermark().max(offsets.pruning_boundary());
+        let floor_blob = position_to_blob(floor, items_per_blob);
         let suspects: Vec<u64> = pending.keys().rev().take(2).copied().collect();
         for blob in suspects {
             let writer = pending.get_mut(&blob).expect("suspect blob is present");
             let valid = writer.recoverable_prefix_len().await?;
+            if blob < floor_blob {
+                let last_position = super::blob_end_position(blob, items_per_blob, u64::MAX) - 1;
+                // A pruning boundary past this blob's positions puts the offsets start in a
+                // strictly newer blob than this retained one, so it is also ahead of the oldest
+                // retained blob: `align` rejects that as corruption whenever any item survives,
+                // and in an all-empty journal every position here was deliberately pruned,
+                // leaving nothing to validate.
+                if last_position < offsets.pruning_boundary() {
+                    continue;
+                }
+                let offset = offsets.read(last_position).await?;
+                if valid < writer.size() || offset >= writer.size() {
+                    return Err(Error::Corruption(format!(
+                        "blob {blob} no longer backs acknowledged items: well-formed prefix \
+                         {valid} of size {}, last item at offset {offset}",
+                        writer.size()
+                    )));
+                }
+                continue;
+            }
             if valid < writer.size() {
                 warn!(
                     blob,
@@ -1090,9 +1128,9 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let tail_blob = position_to_blob(bounds.end, items_per_blob);
         let blobs = Writable::recover(partition, pending, tail_blob).await?;
 
-        // `align` synced any repaired or adopted data before `offsets.sync()`.
-        // `Writable::recover` only seals already-recovered writers; sealing an unchanged recovered
-        // partial page emits no new write, so init has no dirty data to carry forward.
+        // `align` synced any repaired or adopted data before `offsets.sync()`, and
+        // `Writable::recover` awaited an fsync of every blob it sealed, so init leaves no
+        // pending durability work.
 
         let metrics = Metrics::new(context);
         metrics.update(bounds.end, bounds.start, items_per_blob);
@@ -2225,9 +2263,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// Does not advance the recovery watermark, so reopen may need to replay entries beyond
     /// the previous `sync()`.
     ///
-    /// At most one commit is in flight at a time: if a prior commit's sync is still pending, this
-    /// call waits for it before starting a new one. Appends and reads proceed while the returned
-    /// handle is pending, and dropping the handle does not cancel the sync.
+    /// At most one tail fsync is in flight at a time: if a prior commit's fsync is still pending,
+    /// this call waits for it before starting a new one. It does not wait for a pending rollover
+    /// fsync: the returned handle joins it, so an earlier commit's handle may still be pending
+    /// when this call returns. Reads always proceed while the returned handle is pending, and
+    /// appends proceed while they fit in the write buffer (a buffer flush or rollover waits for
+    /// the in-flight fsync). Dropping the handle does not cancel the sync.
     pub async fn start_commit(mut self) -> (Self, Handle<()>) {
         let handle = self.0.start_commit().await;
         (self, handle)
@@ -4290,6 +4331,97 @@ mod tests {
         });
     }
 
+    /// A torn page beneath the offsets recovery watermark is external corruption, not a crash
+    /// artifact: the watermark only advances after the covering data fsync completes. Recovery
+    /// must fail rather than adopt bounds whose acknowledged items are unreadable, and it must
+    /// preserve the evidence so a retry fails identically.
+    #[test_traced]
+    fn test_variable_recovery_rejects_torn_page_below_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config::<()> {
+                partition: "variable-torn-below-watermark".into(),
+                items_per_section: NZU64!(30),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(10)),
+                write_buffer: NZUsize!(2048),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..33u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            // Unlike the torn-interior tests above, advance the offsets watermark past blob 0.
+            journal.sync().await.unwrap();
+
+            // Data blob 0 holds 30 9-byte frames (270 bytes) across 5 pages; tear page 2.
+            corrupt_page(&context, &cfg.data_partition(), 0, 2, 64).await;
+            let (_, size_before) = context
+                .open(&cfg.data_partition(), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+
+            // The watermark (33) anchors recovery in blob 1, so replay alone never revisits
+            // blob 0. Recovery must still reject the journal: positions 14..30 are acknowledged
+            // but no longer data-backed.
+            let result = Journal::<_, u64>::init(context.child("second"), cfg.clone()).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+
+            // The rejection must not truncate the torn blob, and a retry must fail identically.
+            let (_, size_after) = context
+                .open(&cfg.data_partition(), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(
+                size_after, size_before,
+                "rejection must preserve the evidence"
+            );
+            let result = Journal::<_, u64>::init(context.child("third"), cfg).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+        });
+    }
+
+    /// A blob cleanly shortened beneath the watermark leaves no torn page for the forward scan
+    /// to find, but its acknowledged items no longer fit its physical extent. Recovery must
+    /// reject it rather than adopt bounds pointing past the end of the blob.
+    #[test_traced]
+    fn test_variable_recovery_rejects_shortened_blob_below_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config::<()> {
+                partition: "variable-short-below-watermark".into(),
+                items_per_section: NZU64!(30),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(10)),
+                write_buffer: NZUsize!(2048),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..33u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            journal.sync().await.unwrap();
+
+            // Cut blob 0 to two whole physical pages (128 logical bytes = 14 whole frames), so
+            // every surviving page stays well-formed.
+            let physical_page_size = 64 + 12;
+            let (blob, size) = context
+                .open(&cfg.data_partition(), &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert!(size > 2 * physical_page_size);
+            blob.resize(2 * physical_page_size).await.unwrap();
+            blob.sync().await.unwrap();
+
+            let result = Journal::<_, u64>::init(context.child("second"), cfg).await;
+            assert!(matches!(result, Err(Error::Corruption(_))));
+        });
+    }
+
     /// Test that a durable data blob above the sync watermark, sitting beyond an empty
     /// intermediate blob, is rolled back to the contiguous boundary during recovery.
     ///
@@ -4977,12 +5109,13 @@ mod tests {
 
             // The watermark proves positions through 20 were acknowledged. Losing the second
             // blob is corruption, including when the surviving data ends exactly at a boundary.
+            // The acknowledged-floor check in init rejects it before `recovery_anchor` would.
             for child in ["second", "retry"] {
                 match Journal::<_, u64>::init(context.child(child), cfg.clone()).await {
                     Err(Error::Corruption(message)) => assert_eq!(
                         message,
-                        "offsets recovery watermark 20 exceeds retained data end 10 \
-                         (offsets bounds 0..20)"
+                        "blob 1 no longer backs acknowledged items: well-formed prefix 0 of \
+                         size 0, last item at offset 81"
                     ),
                     Err(error) => panic!("unexpected error: {error}"),
                     Ok(_) => panic!("missing acknowledged data was accepted"),

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -4464,6 +4464,40 @@ mod tests {
         });
     }
 
+    /// A torn page below a mid-blob watermark takes the truncate path (the floor is
+    /// blob-granular), but recovery still fails: `align` finds the acknowledged data missing.
+    /// Retries fail identically.
+    #[test_traced]
+    fn test_variable_recovery_rejects_torn_page_below_mid_blob_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config::<()> {
+                partition: "variable-torn-mid-blob-watermark".into(),
+                items_per_section: NZU64!(30),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(10)),
+                write_buffer: NZUsize!(2048),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..20u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            // The watermark (20) sits mid-blob: blob 0 holds 20 9-byte frames across 3 pages.
+            journal.sync().await.unwrap();
+
+            // Tear page 1 (bytes 64..128), beneath the acknowledged frames ending at byte 180.
+            corrupt_page(&context, &cfg.data_partition(), 0, 1, 64).await;
+
+            for child in ["second", "retry"] {
+                let result = Journal::<_, u64>::init(context.child(child), cfg.clone()).await;
+                assert!(matches!(result, Err(Error::Corruption(_))));
+            }
+        });
+    }
+
     /// Test that a durable data blob above the sync watermark, sitting beyond an empty
     /// intermediate blob, is rolled back to the contiguous boundary during recovery.
     ///


### PR DESCRIPTION
Review fixes on top of #4116.

## Recovery must not adopt damage below the offsets watermark

The interior-hole scan truncated a suspect blob without consulting the watermark. When the watermark anchors recovery in a newer blob, replay never revisits the truncated blob, so init returned `Ok` with bounds whose acknowledged positions are permanently unreadable — and the truncation itself durably destroyed the intact pages above the hole. The fixed journal rejects the identical state through its blob-length walk and watermark check.

Recovery now derives an acknowledged floor (the offsets recovery watermark, or the pruning boundary when the watermark is stale):

- A hole beneath the floor — in a fully acknowledged suspect blob, or in the acknowledged prefix of the blob containing the floor — fails with `Corruption` instead of being truncated. The evidence survives and a retry fails identically. Above the floor, holes remain crash artifacts and are repaired as before.
- Every fully acknowledged blob must still physically back its last item (one offsets read per blob). This matches the check the fixed journal gets for free by walking blob lengths, and catches an externally shortened or emptied blob even when it is older than the two blobs the scan reads.

The fixed journal's scan applies the same gate against its recovery watermark, so both journals preserve the evidence. New tests pin these behaviors in both journals (torn page below the watermark, torn page below a mid-blob watermark, shortened suspect blob, shortened old blob), plus evidence preservation and retry consistency. Torn pages in blobs older than the two suspects remain read-time CRC territory on both journals: a crash cannot tear a blob whose covering fsync completed.

## Parallel recovery fsyncs

`Writable::recover` awaited one fsync per retained blob sequentially on every init. It now collects the seal handles and joins them, so reopen pays roughly the slowest fsync instead of the sum. The durability barrier is unchanged: `recover` still returns only once every sealed blob is durable.

## Docs

- `start_commit`: at most one commit's sync is in flight, but the call does not wait for a pending rollover fsync — the returned handle joins it, so an earlier commit's handle may still be pending. Appends overlap only while they fit in the write buffer (a flush or rollover waits for the in-flight fsync).
- The variable module documents the rollover durability model (previously only fixed did).
- `recoverable_prefix_len` notes it scans only bytes that reached the blob.
- Removed stale references to the deleted dirty-blob tracking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
