### PR TITLE
[glue] Wire Db::prefetch into the stateful Processor

### DIFF
--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -420,6 +420,19 @@ where
             }
         }
 
+        // Warm this block's access set into the page cache on a detached task, overlapping the
+        // rest of verification (prepare_batches + app.verify) so cold reads land off the critical
+        // path. Best-effort and drop-safe: prefetch never mutates durable state, so an abandoned
+        // task (e.g. a losing fork) is harmless. The app supplies the keys; the default is a no-op.
+        {
+            let app = self.app.clone();
+            let databases = self.databases.clone();
+            let block = block.clone();
+            let _ = context
+                .child("prefetch")
+                .spawn(move |_| async move { app.prefetch(&block, &databases).await });
+        }
+
         let round = consensus_context.round();
         let parent = match fetch_ancestor(&mut response, &mut ancestry).await {
             Some(Some(parent)) => parent,

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -283,4 +283,21 @@ where
     ) -> impl Future<Output = ()> + Send {
         async {}
     }
+
+    /// Warm the page cache for a block's access set before its state pipeline runs.
+    ///
+    /// Called best-effort by the wrapper on a detached task as soon as a candidate block is
+    /// known, so warming overlaps the rest of verification and stays off the block's critical
+    /// path. Implementations extract the block's touched keys and call `Db::prefetch` on the
+    /// relevant databases; the default does nothing.
+    ///
+    /// Must be safe to run speculatively and to drop mid-flight: a losing fork's task is simply
+    /// abandoned, and `Db::prefetch` never mutates durable state.
+    fn prefetch(
+        &self,
+        _block: &Self::Block,
+        _databases: &Self::Databases,
+    ) -> impl Future<Output = ()> + Send {
+        async {}
+    }
 }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -228,6 +228,36 @@ where
             .await
     }
 
+    /// Best-effort: warm the page cache for a block's access set so a later load hits cache
+    /// instead of disk.
+    ///
+    /// Resolves committed locations from the in-memory index and reads the covering value-log
+    /// pages, discarding the results. It never mutates the log, snapshot, or root, so it is safe
+    /// to run speculatively (e.g. during an inter-block gap) and safe to drop mid-flight — any
+    /// pages warmed so far persist. It only helps when the working set exceeds the page cache; in
+    /// cache it is equivalent to a no-op. Read failures are swallowed (a miss just means the later
+    /// read pays for the page). `write_keys` are warmed alongside `read_keys` because a superseded
+    /// key's current page is read by read-modify-write and by ordered predecessor resolution.
+    pub async fn prefetch(&self, read_keys: &[&U::Key], write_keys: &[&U::Key]) {
+        let _timer = self.metrics.prefetch_timer();
+        self.metrics.prefetch_calls.inc();
+        self.metrics
+            .prefetch_keys
+            .inc_by((read_keys.len() + write_keys.len()) as u64);
+        let mut candidates: Vec<(usize, u64)> =
+            Vec::with_capacity(read_keys.len() + write_keys.len());
+        self.snapshot
+            .get_many(read_keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
+        self.snapshot
+            .get_many(write_keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
+        if candidates.is_empty() {
+            return;
+        }
+        candidates.sort_unstable_by_key(|&(_, pos)| pos);
+        let positions = Self::dedup_positions(&candidates);
+        let _ = self.log.read_many(&positions).await;
+    }
+
     /// Like [`Self::get_many`] but maps each matched update through `map`, which also
     /// receives the committed location the update was read from.
     pub(crate) async fn get_many_map<T: Send>(

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -7,7 +7,7 @@
 //! any optimization must reproduce identical roots).
 //!
 //! Usage:
-//!   cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [reads] [read_chunks] [updates] [threads] [page_cache]
+//!   cargo bench -p commonware-storage --bench constantinople -- <db> [depth] [iters] [keys] [reads] [read_chunks] [updates] [threads] [page_cache] [mode]
 //!
 //! - db: one of "any::unordered::fixed::mmb", "any::ordered::fixed::mmb",
 //!   "any::unordered::variable::mmb", "current::unordered::fixed::mmb", or
@@ -23,6 +23,11 @@
 //! - threads: strategy pool threads (default 8)
 //! - page_cache: page cache capacity in 4096-byte pages (default 131,072 = 512MiB, enough
 //!   to hold the default working set; shrink it to measure miss-heavy regimes)
+//! - mode: cache regime for the timed load (default "warm"). "warm" = no cache drop (in-RAM
+//!   baseline); "cold" = drop the OS page cache before each timed load so app-cache misses hit
+//!   disk (pair with a small page_cache and large keys for a true out-of-RAM regime); "prefetch"
+//!   = drop, then warm the block's read set into the page cache before timing (models a gap-time
+//!   prefetch). The load_p50/load_mean columns of the cold vs prefetch runs bound the prefetch win.
 
 use commonware_cryptography::{DigestOf, Hasher as _, Sha256};
 use commonware_parallel::Rayon;
@@ -151,10 +156,36 @@ struct Args {
     num_updates: u64,
     num_reads: u64,
     read_chunks: usize,
+    // Cache regime for the timed load: "warm" (no drop, in-RAM baseline), "cold" (drop the OS
+    // page cache before each timed load so app-cache misses hit disk), or "prefetch" (drop, then
+    // warm the block's read set into the page cache before timing, modeling a gap-time prefetch).
+    mode: String,
 }
 
 fn key(i: u64) -> Digest {
     Sha256::hash(&i.to_be_bytes())
+}
+
+/// Drop the OS page cache (requires passwordless sudo), returning whether it succeeded. Combined
+/// with a page cache smaller than the state, this forces the timed load into the disk-bound
+/// (out-of-RAM) regime the prefetch optimization targets.
+fn drop_os_caches() -> bool {
+    #[cfg(target_os = "linux")]
+    let status = std::process::Command::new("sh")
+        .args([
+            "-c",
+            "sync && echo 3 | sudo -n tee /proc/sys/vm/drop_caches > /dev/null",
+        ])
+        .status();
+    #[cfg(target_os = "macos")]
+    let status = std::process::Command::new("sudo")
+        .args(["-n", "purge"])
+        .status();
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    let status = std::io::Result::<std::process::ExitStatus>::Err(std::io::Error::other(
+        "unsupported platform",
+    ));
+    matches!(status, Ok(s) if s.success())
 }
 
 fn gen_muts(rng: &mut TestRng, num_updates: u64, num_keys: u64) -> Vec<(Digest, Digest)> {
@@ -166,20 +197,23 @@ fn gen_muts(rng: &mut TestRng, num_updates: u64, num_keys: u64) -> Vec<(Digest, 
         .collect()
 }
 
-fn report(db: &str, args: &Args, mut times_ms: Vec<f64>) {
+fn report(db: &str, args: &Args, mut times_ms: Vec<f64>, mut load_ms: Vec<f64>) {
     times_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
-    let p = |q: f64| times_ms[((times_ms.len() - 1) as f64 * q) as usize];
-    let mean: f64 = times_ms.iter().sum::<f64>() / times_ms.len() as f64;
+    load_ms.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let pct = |v: &[f64], q: f64| v[((v.len() - 1) as f64 * q) as usize];
+    let mean = |v: &[f64]| v.iter().sum::<f64>() / v.len() as f64;
     println!(
-        "RESULT db={db} depth={} reads={} read_chunks={} updates={} p10={:.2} p50={:.2} mean={:.2} max={:.2}",
+        "RESULT db={db} mode={} depth={} reads={} read_chunks={} updates={} total_p50={:.2} total_mean={:.2} load_p50={:.2} load_mean={:.2} load_max={:.2}",
+        args.mode,
         args.depth,
         args.num_reads,
         args.read_chunks,
         args.num_updates,
-        p(0.1),
-        p(0.5),
-        mean,
-        times_ms[times_ms.len() - 1]
+        pct(&times_ms, 0.5),
+        mean(&times_ms),
+        pct(&load_ms, 0.5),
+        mean(&load_ms),
+        load_ms[load_ms.len() - 1]
     );
 }
 
@@ -216,6 +250,7 @@ macro_rules! run_pipeline {
 
         let mut rng = TestRng::new(99);
         let mut times_ms: Vec<f64> = Vec::with_capacity(args.iters);
+        let mut load_ms: Vec<f64> = Vec::with_capacity(args.iters);
         for iter in 0..args.iters {
             // Pending ancestors are rebuilt per iteration and never applied (untimed). The
             // whole chain is held alive: dropping an uncommitted ancestor before merkleize
@@ -248,6 +283,22 @@ macro_rules! run_pipeline {
                     .map_or_else(|| db.new_batch(), |p| p.new_batch::<Sha256>())
             };
 
+            // Out-of-RAM regime: drop the OS page cache so the timed load's app-cache misses hit
+            // disk (paired with a page cache smaller than the state).
+            if args.mode != "warm" && !drop_os_caches() {
+                eprintln!(
+                    "WARNING: drop_os_caches failed (need passwordless sudo); load is NOT cold"
+                );
+            }
+            // Gap prefetch: warm this block's access set (read set for the load, write set for
+            // the grafted-tree inputs) via the real fork-agnostic prefetch API, modeling a
+            // prefetch issued during the inter-block gap.
+            if args.mode == "prefetch" {
+                let write_keys: Vec<&Digest> =
+                    updates.iter().map(|&(idx, _)| &reads[idx].0).collect();
+                db.prefetch(keys.as_slice(), &write_keys).await;
+            }
+
             // Timed: load all touched keys, merkleize selected updates, read root. The
             // load returns a staged batch that consumes `(read_index, value)` pairs after the
             // caller has computed them.
@@ -273,6 +324,7 @@ macro_rules! run_pipeline {
             let elapsed = start.elapsed();
 
             times_ms.push(elapsed.as_secs_f64() * 1000.0);
+            load_ms.push(t_load.as_secs_f64() * 1000.0);
             println!(
                 "iter={iter} ms={:.2} load={:.2} merkleize={:.2} root={root}",
                 times_ms[iter],
@@ -281,7 +333,7 @@ macro_rules! run_pipeline {
             );
         }
 
-        report($label, &args, times_ms);
+        report($label, &args, times_ms, load_ms);
         db.destroy().await.unwrap();
     }};
 }
@@ -304,6 +356,7 @@ fn main() {
         num_reads: raw.get(5).and_then(|s| s.parse().ok()).unwrap_or(32_768),
         read_chunks: raw.get(6).and_then(|s| s.parse().ok()).unwrap_or(1),
         num_updates: raw.get(7).and_then(|s| s.parse().ok()).unwrap_or(32_768),
+        mode: raw.get(10).cloned().unwrap_or_else(|| "warm".to_string()),
     };
     let threads: NonZeroUsize = raw
         .get(8)
@@ -332,10 +385,20 @@ fn main() {
         "iters, keys, and updates must be non-zero, and reads must be >= updates"
     );
     assert!(args.read_chunks > 0, "read_chunks must be non-zero");
+    assert!(
+        matches!(args.mode.as_str(), "warm" | "cold" | "prefetch"),
+        "mode: warm|cold|prefetch"
+    );
 
     eprintln!(
-        "constantinople db={db_kind} depth={} iters={} keys={} reads={} read_chunks={} updates={} threads={threads} page_cache={page_cache}",
-        args.depth, args.iters, args.num_keys, args.num_reads, args.read_chunks, args.num_updates
+        "constantinople db={db_kind} depth={} iters={} keys={} reads={} read_chunks={} updates={} threads={threads} page_cache={page_cache} mode={}",
+        args.depth,
+        args.iters,
+        args.num_keys,
+        args.num_reads,
+        args.read_chunks,
+        args.num_updates,
+        args.mode
     );
 
     Runner::new(RConfig::default()).start(|ctx| async move {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -41,7 +41,7 @@ use commonware_utils::{
     sequence::prefixed_u64::U64,
 };
 use core::{num::NonZeroU64, ops::Range};
-use futures::future::try_join_all;
+use futures::future::{join_all, try_join_all};
 use std::{collections::BTreeMap, sync::Arc};
 use tracing::{error, warn};
 
@@ -69,6 +69,10 @@ pub(crate) struct Metrics<E: Context> {
     pub prune_calls: Counter,
     /// Duration of Current-layer prune calls.
     prune_duration: Timed,
+    /// Grafted-tree input nodes warmed by best-effort prefetch.
+    pub prefetch_graft_chunks: Counter,
+    /// Duration of the grafted-tree prefetch warm.
+    prefetch_graft_duration: Timed,
     /// Clock used by the duration timers.
     clock: Arc<E>,
 }
@@ -90,6 +94,15 @@ impl<E: Context> Metrics<E> {
             sync_duration: Timed::register(&context, "sync_duration", "Duration of sync calls"),
             prune_calls: context.counter("prune_calls", "Number of prune calls"),
             prune_duration: Timed::register(&context, "prune_duration", "Duration of prune calls"),
+            prefetch_graft_chunks: context.counter(
+                "prefetch_graft_chunks",
+                "Number of grafted-tree input nodes warmed by prefetch",
+            ),
+            prefetch_graft_duration: Timed::register(
+                &context,
+                "prefetch_graft_duration",
+                "Duration of the grafted-tree prefetch warm",
+            ),
             clock: Arc::new(context),
         }
     }
@@ -104,6 +117,10 @@ impl<E: Context> Metrics<E> {
 
     pub fn prune_timer(&self) -> ScopedTimer<E> {
         self.prune_duration.scoped(&self.clock)
+    }
+
+    pub fn prefetch_graft_timer(&self) -> ScopedTimer<E> {
+        self.prefetch_graft_duration.scoped(&self.clock)
     }
 
     /// Update Current-specific state gauges.
@@ -155,7 +172,7 @@ pub struct Db<
     pub(super) root: DigestOf<H>,
 
     /// Metrics for the Current layer.
-    pub(super) metrics: Metrics<E>,
+    pub(super) metrics: Box<Metrics<E>>,
 
     /// Test-only: park [Self::prune] after the pruning-metadata sync, before the log prune,
     /// so tests can drop the pending future at that exact point.
@@ -262,6 +279,55 @@ where
     /// Return a reference to the merkleization strategy.
     pub const fn strategy(&self) -> &S {
         &self.strategy
+    }
+
+    /// Best-effort: warm the page cache for a block's access set so a later block pipeline hits
+    /// cache instead of disk.
+    ///
+    /// Warms the value-log pages for the load (via the `any` layer) and, additionally, the
+    /// grafted-tree inputs this layer's merkleize reads: the ops-tree node covering each write
+    /// key's superseded (committed) location's chunk. Everything is read-only and root-neutral, so
+    /// it is safe to run speculatively during an inter-block gap and safe to drop mid-flight. It
+    /// only helps when the working set exceeds the page cache. Read failures are swallowed.
+    pub async fn prefetch(&self, read_keys: &[&U::Key], write_keys: &[&U::Key]) {
+        // Value-log warm (covers the load; the delegated call records prefetch metrics).
+        self.any.prefetch(read_keys, write_keys).await;
+        if write_keys.is_empty() {
+            return;
+        }
+
+        // Grafted-tree warm: merkleize re-binds each superseded chunk to its covering ops-tree
+        // node (`read_graft_inputs`). Resolve committed locations from the in-memory index, dedup
+        // to chunks, and warm those nodes. The chunk bytes are unused by the node read, so pass a
+        // placeholder; a missing/pruned node just leaves that chunk cold.
+        let _timer = self.metrics.prefetch_graft_timer();
+        let grafting_height = grafting::height::<N>();
+        let mut candidates: Vec<(usize, u64)> = Vec::with_capacity(write_keys.len());
+        self.any
+            .snapshot
+            .get_many(write_keys, |key_idx, &loc| candidates.push((key_idx, *loc)));
+        let mut chunks: Vec<usize> = candidates
+            .iter()
+            .map(|&(_, loc)| (loc >> grafting_height) as usize)
+            .collect();
+        chunks.sort_unstable();
+        chunks.dedup();
+
+        // For each chunk, warm the ops-tree node merkleize will read for it so that read
+        // hits cache. Resolve each with read_graft_input under join_all (concurrent, but each
+        // independent) rather than try_join_all: a write key can land in the newest chunk,
+        // which is still partial (or, under MMB, complete but not yet merged into the tree)
+        // and so has no such node yet, and try_join_all would let that one miss discard the
+        // reads for every other chunk. Count only the chunks that warmed.
+        let warmed =
+            join_all(chunks.into_iter().map(|idx| {
+                read_graft_input::<F, H::Digest, N>(&self.any.log.merkle, idx, [0u8; N])
+            }))
+            .await
+            .iter()
+            .filter(|result| result.is_ok())
+            .count();
+        self.metrics.prefetch_graft_chunks.inc_by(warmed as u64);
     }
 
     /// Returns the ops tree root.
@@ -1071,30 +1137,39 @@ pub(super) async fn compute_grafted_root<
     Ok(hasher.root(leaves, inactive_peaks, peaks.iter())?)
 }
 
-/// Resolve each bitmap chunk's covering ops-tree node, returning
-/// `(chunk_idx, chunk_ops_digest, chunk)` triples ready for
-/// [`grafting::graft_chunk_digests`].
+/// Resolve a single bitmap chunk's covering ops-tree node, returning a
+/// `(chunk_idx, chunk_ops_digest, chunk)` triple ready for [`grafting::graft_chunk_digests`].
 ///
-/// Callers must pass only **graftable** chunks (those whose h=G ancestor has already been born in
-/// the ops tree). Each graftable chunk has exactly one covering ops node at height G, looked up via
-/// [`merkle::Graftable::subtree_root_position`].
+/// The chunk must be **graftable** - its h=G ancestor already born in the ops tree, where it has a
+/// single covering ops node at the deterministic `subtree_root_position(chunk_idx << G, G)`. A
+/// non-graftable chunk (a partial or not-yet-merged chunk, whose node does not exist yet) errors
+/// with [`merkle::Error::MissingGraftedLeaf`].
+async fn read_graft_input<F: merkle::Graftable, D: Digest, const N: usize>(
+    ops_tree: &impl MerkleStorage<F, Digest = D>,
+    chunk_idx: usize,
+    chunk: [u8; N],
+) -> Result<(usize, D, [u8; N]), Error<F>> {
+    let grafting_height = grafting::height::<N>();
+    let leaf_start = Location::<F>::new((chunk_idx as u64) << grafting_height);
+    let pos = F::subtree_root_position(leaf_start, grafting_height);
+    let chunk_ops_digest = ops_tree
+        .get_node(pos)
+        .await?
+        .ok_or(merkle::Error::<F>::MissingGraftedLeaf(pos))?;
+    Ok((chunk_idx, chunk_ops_digest, chunk))
+}
+
+/// Resolve each bitmap chunk's covering ops-tree node (see [read_graft_input]), returning the
+/// triples ready for [`grafting::graft_chunk_digests`]. Fail-fast: every chunk must be graftable.
 pub(super) async fn read_graft_inputs<F: merkle::Graftable, D: Digest, const N: usize>(
     ops_tree: &impl MerkleStorage<F, Digest = D>,
     chunks: impl IntoIterator<Item = (usize, [u8; N])>,
 ) -> Result<Vec<(usize, D, [u8; N])>, Error<F>> {
-    let grafting_height = grafting::height::<N>();
-
-    // Each graftable chunk has a single h=G ancestor at the deterministic
-    // `subtree_root_position(chunk_idx << G, G)`. Look it up directly.
-    try_join_all(chunks.into_iter().map(|(chunk_idx, chunk)| async move {
-        let leaf_start = Location::<F>::new((chunk_idx as u64) << grafting_height);
-        let pos = F::subtree_root_position(leaf_start, grafting_height);
-        let chunk_ops_digest = ops_tree
-            .get_node(pos)
-            .await?
-            .ok_or(merkle::Error::<F>::MissingGraftedLeaf(pos))?;
-        Ok::<_, Error<F>>((chunk_idx, chunk_ops_digest, chunk))
-    }))
+    try_join_all(
+        chunks
+            .into_iter()
+            .map(|(chunk_idx, chunk)| read_graft_input(ops_tree, chunk_idx, chunk)),
+    )
     .await
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -487,7 +487,7 @@ where
     )
     .await?;
 
-    let metrics = Metrics::new(context);
+    let metrics = Box::new(Metrics::new(context));
     let db = db::Db {
         any,
         grafted_tree: Arc::new(grafted_tree),

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -228,7 +228,7 @@ where
         db::init_metadata::<F, E, DigestOf<H>>(context.child("metadata"), &metadata_partition)
             .await?;
 
-    let metrics = db::Metrics::new(context);
+    let metrics = Box::new(db::Metrics::new(context));
     let mut current_db = db::Db {
         any,
         grafted_tree: Arc::new(grafted_tree),

--- a/storage/src/qmdb/metrics.rs
+++ b/storage/src/qmdb/metrics.rs
@@ -40,6 +40,12 @@ pub(crate) struct Metrics<E: Clock> {
     get_many_duration: Timed,
     /// Lookups requested by read paths, whether or not they are found.
     pub lookups_requested: Counter,
+    /// Best-effort prefetch (cache-warming) calls.
+    pub prefetch_calls: Counter,
+    /// Duration of prefetch calls.
+    prefetch_duration: Timed,
+    /// Keys submitted to prefetch calls (read plus write).
+    pub prefetch_keys: Counter,
     /// Durable commit calls.
     pub commit_calls: Counter,
     /// Duration of commit calls.
@@ -91,6 +97,16 @@ impl<E: RuntimeMetrics + Clock> Metrics<E> {
                 "lookups_requested",
                 "Number of lookups requested by get/get-many calls, including misses",
             ),
+            prefetch_calls: context.counter("prefetch_calls", "Number of prefetch calls"),
+            prefetch_duration: Timed::register(
+                &context,
+                "prefetch_duration",
+                "Duration of prefetch calls",
+            ),
+            prefetch_keys: context.counter(
+                "prefetch_keys",
+                "Number of keys submitted to prefetch calls (read plus write)",
+            ),
             commit_calls: context.counter("commit_calls", "Number of commit calls"),
             commit_duration: Timed::register(
                 &context,
@@ -117,6 +133,10 @@ impl<E: Clock> Metrics<E> {
 
     pub(crate) fn get_many_timer(&self) -> ScopedTimer<E> {
         self.get_many_duration.scoped(&self.clock)
+    }
+
+    pub(crate) fn prefetch_timer(&self) -> ScopedTimer<E> {
+        self.prefetch_duration.scoped(&self.clock)
     }
 
     pub(crate) fn commit_timer(&self) -> ScopedTimer<E> {


### PR DESCRIPTION
## Summary

Wires the `Db::prefetch` primitive (#4305) into the `glue` stateful-execution layer so a
block's access set can be warmed into the page cache during the inter-block gap, off the
critical path.

**Stacked on #4305** — base is `constantinople-oom`, so this PR shows only the glue-seam
commit. Retarget to `main` once #4305 merges.

## What it adds

- **`Application::prefetch(&self, block, databases)`** — a default-no-op trait hook (mirrors
  `finalized`). `glue` stays fully generic (it never sees keys or the concrete `Db`); the
  application derives the access set from the block and calls `Db::prefetch` on its databases.
- **`Processor::verify`** spawns `app.prefetch(&block, &databases)` on a detached
  `context.child("prefetch")` task, after the short-circuit checks and before the state
  pipeline — so warming overlaps `prepare_batches` + `app.verify`.

Fire-and-forget and drop-safe: the runtime `Handle` has no `Drop`, so the task detaches and
self-terminates; `Db::prefetch` never mutates durable state, so an abandoned task (e.g. a
losing fork) is harmless. Existing applications inherit the no-op default and are unchanged.

## Note on the realized benefit

The `Processing` loop is serial, so this spawn overlaps *the rest of verify* rather than a
full pre-verify gap — the end-to-end benefit will sit between cold and the primitive's
bench-measured ideal (which prefetches fully ahead of the read). Capturing the full gap would
mean hooking an earlier consensus event; a reasonable follow-up.

## Testing

- `commonware-glue` builds clean.
- The consumer side (a real `Application::prefetch` impl deriving keys from block txs) is a
  separate change in the downstream application; this PR only provides the seam.

## Draft because

Depends on #4305, and the downstream consumer that exercises it end-to-end lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo
