### PR TITLE
[runtime] Blob Page Alignment Nits

### DIFF
--- a/consensus/conformance.toml
+++ b/consensus/conformance.toml
@@ -24,11 +24,11 @@ hash = "e53b4b684f0344590427aae976d298e3b6fd2b08ef46ff2cad5def04b4f7690b"
 
 ["commonware_consensus::marshal::conformance::CodingStorageConformance"]
 n_cases = 32
-hash = "3d1bd4dcd285b7e0ae0d959f5bc357d13939bf71cc7483478a613c45f5d14525"
+hash = "8335cf7b198c4889b83633b066ec23aeecd67ce9c568d4741640beb39a024d8a"
 
 ["commonware_consensus::marshal::conformance::StandardStorageConformance"]
 n_cases = 32
-hash = "8eeab335160ac77f581a5593eb3df9da798a0836cbb91bd0d530fec97a6574bb"
+hash = "5a263f4dbf20f9ebc64a81bc0dfbf487055b136074809d8c01aa725e28b86f17"
 
 ["commonware_consensus::marshal::resolver::handler::tests::conformance::CodecConformance<Key<D>>"]
 n_cases = 65536

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -78,56 +78,6 @@ stability_scope!(BETA {
     /// Default [`Blob`] version used when no version is specified via [`Storage::open`].
     pub const DEFAULT_BLOB_VERSION: u16 = 0;
 
-    /// Version of a [`Blob`]'s on-disk header layout.
-    ///
-    /// This versions the runtime's on-disk container (where data begins), not the blob's
-    /// contents: the application-owned blob version passed to [`Storage::open_versioned`] is a
-    /// separate field and is unaffected by the layout.
-    ///
-    /// New blobs are always created with the latest layout. Reopening an existing blob honors
-    /// the layout recorded in its header.
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-    pub(crate) enum BlobHeaderLayout {
-        /// An 8-byte header, with data beginning immediately after it.
-        V0,
-        /// A header padded to one 4096-byte page, so data begins on an aligned boundary.
-        V1,
-    }
-
-    impl BlobHeaderLayout {
-        /// The runtime version recorded in a header of this layout.
-        pub(crate) const fn runtime_version(self) -> u16 {
-            match self {
-                Self::V0 => 0,
-                Self::V1 => 1,
-            }
-        }
-
-        /// The magic bytes recorded in a header of this layout: a fixed 3-byte brand (`CWI`,
-        /// "is this file ours?") followed by a 1-byte layout tag ("which container layout?").
-        ///
-        /// The layout tag lives in the magic rather than the runtime version field because V0
-        /// stamped that field as zero, and zeros are exactly what a torn header write leaves
-        /// behind. Tags are nonzero and distinct, so no layout's magic can be turned into
-        /// another's by zeroing bytes, and a torn write can never be misread as a complete
-        /// header of a different layout.
-        pub(crate) const fn magic(self) -> [u8; 4] {
-            match self {
-                Self::V0 => *b"CWIC", // Commonware Is CWIC
-                Self::V1 => *b"CWI1",
-            }
-        }
-
-        /// The layout recorded by a header with the given magic bytes, if supported.
-        pub(crate) const fn from_magic(magic: &[u8; 4]) -> Option<Self> {
-            match magic {
-                b"CWIC" => Some(Self::V0),
-                b"CWI1" => Some(Self::V1),
-                _ => None,
-            }
-        }
-    }
-
     /// Errors that can occur when interacting with the runtime.
     #[derive(Error, Debug, Clone)]
     pub enum Error {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -84,11 +84,11 @@ stability_scope!(BETA {
     /// contents: the application-owned blob version passed to [`Storage::open_versioned`] is a
     /// separate field and is unaffected by the layout.
     ///
-    /// New blobs are always created with the latest layout; reopening an existing blob honors
+    /// New blobs are always created with the latest layout. Reopening an existing blob honors
     /// the layout recorded in its header.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub(crate) enum BlobHeaderLayout {
-        /// An 8-byte header; data begins immediately after it.
+        /// An 8-byte header, with data beginning immediately after it.
         V0,
         /// A header padded to one 4096-byte page, so data begins on an aligned boundary.
         V1,
@@ -679,7 +679,9 @@ stability_scope!(BETA {
         /// Multiple instances of the same blob can be opened concurrently, however,
         /// writing to the same blob concurrently may lead to undefined behavior.
         ///
-        /// An Ok result indicates the blob is durably created (or already exists).
+        /// An Ok result indicates the blob is durably created (or already exists). On
+        /// platforms without directory sync (e.g. Windows), the durability of the blob's
+        /// name is best-effort.
         ///
         /// # Versions
         ///
@@ -688,17 +690,8 @@ stability_scope!(BETA {
         ///
         /// # Layout
         ///
-        /// New blobs are created with the latest header layout; reopening an existing blob
+        /// New blobs are created with the latest header layout. Reopening an existing blob
         /// honors the layout recorded in its header.
-        ///
-        /// # Recovery
-        ///
-        /// Files shorter than the 8-byte header prelude are treated as new. Otherwise, a
-        /// blob whose contents match the signature of a creation interrupted before its
-        /// header became durable (a crash can tear the header write at any point) is detected
-        /// on reopen and recreated as new: a V1 blob in that state holds no synced data, and
-        /// a legacy V0 blob rotted into the same signature holds at most all-zero payload
-        /// bytes. Contents that do not match fail with [Error::BlobCorrupt] instead.
         ///
         /// # Returns
         ///

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -45,7 +45,7 @@ fn resolve_header(
     partition: &str,
     name: &[u8],
 ) -> Result<Option<(u64, u16, u64)>, Error> {
-    let mut raw = vec![0u8; raw_len.min(Header::V1_DATA_OFFSET) as usize];
+    let mut raw = vec![0u8; Header::resolve_len(raw_len)];
     file.seek(SeekFrom::Start(0))
         .map_err(|_| Error::ReadFailed)?;
     file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -428,8 +428,10 @@ impl crate::Blob for Blob {
 mod tests {
     use super::{Header, *};
     use crate::{
-        Blob as _, BlobHeaderLayout, BufferPool, BufferPoolConfig, IoBuf, IoBufMut, Storage as _,
-        storage::tests::run_storage_tests, telemetry::metrics::Registry, utils::thread,
+        Blob as _, BufferPool, BufferPoolConfig, IoBuf, IoBufMut, Storage as _,
+        storage::{BlobHeaderLayout, tests::run_storage_tests},
+        telemetry::metrics::Registry,
+        utils::thread,
     };
     use std::{
         env,

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -37,9 +37,7 @@ use std::{
     sync::Arc,
 };
 
-/// Parses an existing blob's header, returning `None` if the blob is new or its contents are
-/// those of a creation that was interrupted before its header became durable (the caller
-/// recreates the blob), and an error if the header is corrupt or unacceptable.
+/// Reads a blob's leading bytes and resolves its header (see [super::resolve_header]).
 fn resolve_header(
     file: &mut File,
     raw_len: u64,
@@ -47,24 +45,11 @@ fn resolve_header(
     partition: &str,
     name: &[u8],
 ) -> Result<Option<(u64, u16, u64)>, Error> {
-    if Header::missing(raw_len) {
-        return Ok(None);
-    }
     let mut raw = vec![0u8; raw_len.min(Header::V1_DATA_OFFSET) as usize];
     file.seek(SeekFrom::Start(0))
         .map_err(|_| Error::ReadFailed)?;
     file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;
-    let err = match Header::parse(&raw, raw_len, versions) {
-        Ok(resolved) => return Ok(Some(resolved)),
-        Err(err) => err,
-    };
-
-    // The header failed to parse: files longer than the creation region hold data and are
-    // never torn creations. Shorter files are already fully represented in `raw`.
-    if !err.may_be_torn_creation() || raw_len > Header::V1_DATA_OFFSET {
-        return Err(err.into_error(partition, name));
-    }
-    super::resolve_unparseable(err, &raw, partition, name)
+    super::resolve_header(&raw, raw_len, versions, partition, name)
 }
 
 /// Syncs a directory to ensure directory entry changes are durable.
@@ -154,9 +139,6 @@ impl crate::Storage for Storage {
             .parent()
             .ok_or_else(|| Error::PartitionMissing(partition.into()))?;
 
-        // Check if partition exists before creating
-        let parent_existed = parent.exists();
-
         // Create the partition directory if it does not exist
         fs::create_dir_all(parent).map_err(|_| Error::PartitionCreationFailed(partition.into()))?;
 
@@ -177,6 +159,14 @@ impl crate::Storage for Storage {
         let (logical_len, blob_version, data_offset) = match existing {
             Some(resolved) => resolved,
             None => {
+                // Sync the directories before writing the header so a parseable header
+                // always implies durable directory entries (an open that parses a header
+                // never re-runs these). The storage directory is synced unconditionally:
+                // the partition directory existing in the namespace does not imply its
+                // entry is durable.
+                sync_dir(parent)?;
+                sync_dir(&self.storage_directory)?;
+
                 // Truncate to zero before writing, per the [Header::create] contract.
                 let (region, blob_version) = Header::create(&versions);
                 let data_offset = region.len() as u64;
@@ -187,14 +177,6 @@ impl crate::Storage for Storage {
                 file.write_all(&region).map_err(|_| Error::WriteFailed)?;
                 file.sync_all()
                     .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
-
-                // Sync the directories to ensure the directory entry is durable. This must also
-                // run when recreating a torn blob: the creation it is recovering from may have
-                // crashed before its own directory syncs completed.
-                sync_dir(parent)?;
-                if !parent_existed {
-                    sync_dir(&self.storage_directory)?;
-                }
 
                 (0, blob_version, data_offset)
             }

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -11,7 +11,7 @@ fn resolve_header(
     partition: &str,
     name: &[u8],
 ) -> Result<Option<(u64, u16, u64)>, crate::Error> {
-    let raw = &content[..content.len().min(Header::V1_DATA_OFFSET_USIZE)];
+    let raw = &content[..Header::resolve_len(content.len() as u64)];
     super::resolve_header(raw, content.len() as u64, versions, partition, name)
 }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -4,24 +4,15 @@ use commonware_formatting::hex;
 use commonware_utils::sync::{Mutex, RwLock};
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
-/// Parses an existing blob's header, returning `None` if the blob is new or its contents are
-/// those of a creation that was interrupted before its header became durable (the caller
-/// recreates the blob), and an error if the header is corrupt or unacceptable.
+/// Resolves a blob's header from its full contents (see [super::resolve_header]).
 fn resolve_header(
     content: &[u8],
     versions: &RangeInclusive<u16>,
     partition: &str,
     name: &[u8],
 ) -> Result<Option<(u64, u16, u64)>, crate::Error> {
-    let raw_len = content.len() as u64;
-    if Header::missing(raw_len) {
-        return Ok(None);
-    }
     let raw = &content[..content.len().min(Header::V1_DATA_OFFSET_USIZE)];
-    match Header::parse(raw, raw_len, versions) {
-        Ok(resolved) => Ok(Some(resolved)),
-        Err(err) => super::resolve_unparseable(err, content, partition, name),
-    }
+    super::resolve_header(raw, content.len() as u64, versions, partition, name)
 }
 
 /// In-memory storage implementation for the commonware runtime.

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -269,7 +269,8 @@ impl crate::Blob for Blob {
 mod tests {
     use super::{Header, *};
     use crate::{
-        Blob, BlobHeaderLayout, BufferPoolConfig, Storage as _, storage::tests::run_storage_tests,
+        Blob, BufferPoolConfig, Storage as _,
+        storage::{BlobHeaderLayout, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
 

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -195,7 +195,7 @@ stability_scope!(BETA {
 
     /// Fixed-size header prelude at the start of each [crate::Blob].
     ///
-    /// On-disk layout (big-endian). The prelude is 8 bytes; a V1 header extends it:
+    /// On-disk layout (big-endian). The prelude is 8 bytes and a V1 header extends it:
     ///
     /// | bytes    | field                        | owner       | question it answers                              |
     /// |----------|------------------------------|-------------|--------------------------------------------------|
@@ -235,7 +235,7 @@ stability_scope!(BETA {
         pub(crate) const PARSE_LEN: usize = Self::PRELUDE_SIZE + Self::EXTENSION_SIZE;
 
         /// The data offset of every [BlobHeaderLayout::V1] blob: the header region occupies
-        /// exactly one 4096-byte page. Not stored on disk; the layout's magic implies it.
+        /// exactly one 4096-byte page. Not stored on disk (the layout's magic implies it).
         ///
         /// Frozen for the lifetime of the V1 layout: torn-creation recovery relies on every
         /// V1 creation producing this exact region, so a different offset requires a new
@@ -403,7 +403,7 @@ stability_scope!(BETA {
         /// Validates the magic bytes and runtime version, returning the layout the magic
         /// identifies.
         ///
-        /// The magic alone selects the layout; the runtime version must agree with it. Requiring
+        /// The magic alone selects the layout, and the runtime version must agree with it. Requiring
         /// agreement (rather than deriving the layout from the runtime version) means a header
         /// with any layout-identifying bytes zeroed by a torn write fails validation instead
         /// of parsing as a different layout.
@@ -452,25 +452,53 @@ stability_scope!(BETA {
         }
     }
 
-    /// Resolves a header that failed to parse: `Ok(None)` if the blob's raw contents are those
-    /// of a creation that was interrupted before its header became durable (the caller
-    /// recreates the blob), and the original parse error otherwise.
-    pub(crate) fn resolve_unparseable(
-        err: HeaderError,
+    /// Resolves a blob's header from its leading bytes.
+    ///
+    /// Returns `Some((logical_size, blob_version, data_offset))` for a valid header and
+    /// `None` when the caller should (re)create the blob: the file is too short to hold a
+    /// header, or its contents are those of a [BlobHeaderLayout::V1] creation interrupted
+    /// before its header became durable. Anything else fails as corrupt or unacceptable.
+    ///
+    /// `raw` must hold the blob's first `min(raw_len, V1_DATA_OFFSET)` bytes, where
+    /// `raw_len` is the blob's raw on-disk length.
+    pub(crate) fn resolve_header(
         raw: &[u8],
+        raw_len: u64,
+        versions: &RangeInclusive<u16>,
         partition: &str,
         name: &[u8],
     ) -> Result<Option<(u64, u16, u64)>, crate::Error> {
-        if err.may_be_torn_creation() && Header::interrupted_creation(raw) {
+        assert!(
+            raw.len() as u64 >= raw_len.min(Header::V1_DATA_OFFSET),
+            "caller must provide enough bytes to resolve the header region"
+        );
+
+        // Too short to hold any header: treat as new.
+        if Header::missing(raw_len) {
+            return Ok(None);
+        }
+
+        let err = match Header::parse(raw, raw_len, versions) {
+            Ok(resolved) => return Ok(Some(resolved)),
+            Err(err) => err,
+        };
+
+        // Heal a V1 creation interrupted before its header became durable: the failure
+        // must be one a torn write can produce, and the contents must match the canonical
+        // creation prefix. Files longer than the creation region hold data and never heal.
+        if raw_len <= Header::V1_DATA_OFFSET
+            && err.may_be_torn_creation()
+            && Header::interrupted_creation(raw)
+        {
             warn!(
                 partition,
                 name = %hex(name),
                 "recreating blob left torn by an interrupted creation"
             );
-            Ok(None)
-        } else {
-            Err(err.into_error(partition, name))
+            return Ok(None);
         }
+
+        Err(err.into_error(partition, name))
     }
 
     /// Validate that a partition name contains only allowed characters.
@@ -691,7 +719,7 @@ pub(crate) mod tests {
         ));
     }
 
-    /// Classification only triggers for parse failures a torn write can produce; a version
+    /// Classification only triggers for parse failures a torn write can produce. A version
     /// mismatch requires a validated CRC over a complete header region and stays loud.
     #[test]
     fn test_header_error_torn_creation_candidates() {

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -301,6 +301,16 @@ stability_scope!(BETA {
             raw_len < Self::PRELUDE_SIZE_U64
         }
 
+        /// Number of leading bytes [resolve_header] needs for a blob of raw on-disk length
+        /// `raw_len`: the full header region, capped by the file itself.
+        pub(crate) const fn resolve_len(raw_len: u64) -> usize {
+            if raw_len < Self::V1_DATA_OFFSET {
+                raw_len as usize
+            } else {
+                Self::V1_DATA_OFFSET_USIZE
+            }
+        }
+
         /// Returns true if a blob's raw contents are consistent with the creation of a
         /// [BlobHeaderLayout::V1] blob that was interrupted before its header became durable.
         ///
@@ -512,7 +522,7 @@ stability_scope!(BETA {
         name: &[u8],
     ) -> Result<Option<(u64, u16, u64)>, crate::Error> {
         assert!(
-            raw.len() as u64 >= raw_len.min(Header::V1_DATA_OFFSET),
+            raw.len() >= Header::resolve_len(raw_len),
             "caller must provide enough bytes to resolve the header region"
         );
 

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -226,8 +226,8 @@ stability_scope!(BETA {
         /// header of a different layout.
         pub(crate) const fn magic(self) -> [u8; 4] {
             match self {
-                Self::V0 => *b"CWIC", // Commonware Is CWIC
-                Self::V1 => *b"CWI1",
+                Self::V0 => *b"CWIC",
+                Self::V1 => *b"CWIK",
             }
         }
 
@@ -235,7 +235,7 @@ stability_scope!(BETA {
         pub(crate) const fn from_magic(magic: &[u8; 4]) -> Option<Self> {
             match magic {
                 b"CWIC" => Some(Self::V0),
-                b"CWI1" => Some(Self::V1),
+                b"CWIK" => Some(Self::V1),
                 _ => None,
             }
         }
@@ -649,7 +649,7 @@ pub(crate) mod tests {
     fn test_header_v1_fixture_bytes() {
         let (region, _) = Header::create(&(3..=3));
         let expected = [
-            b'C', b'W', b'I', b'1', // V1 magic
+            b'C', b'W', b'I', b'K', // V1 magic
             0x00, 0x01, // runtime version 1
             0x00, 0x03, // blob version 3
         ];

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -1,7 +1,5 @@
 //! Implementations of the `Storage` trait that can be used by the runtime.
 
-#[commonware_macros::stability(BETA)]
-use crate::BlobHeaderLayout;
 use commonware_macros::stability_scope;
 
 stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
@@ -193,6 +191,56 @@ stability_scope!(BETA {
         }
     }
 
+    /// Version of a [crate::Blob]'s on-disk header layout.
+    ///
+    /// This versions the runtime's on-disk container (where data begins), not the blob's
+    /// contents: the application-owned blob version passed to
+    /// [crate::Storage::open_versioned] is a separate field and is unaffected by the layout.
+    ///
+    /// New blobs are always created with the latest layout. Reopening an existing blob honors
+    /// the layout recorded in its header.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    pub(crate) enum BlobHeaderLayout {
+        /// An 8-byte header, with data beginning immediately after it.
+        V0,
+        /// A header padded to one 4096-byte page, so data begins on an aligned boundary.
+        V1,
+    }
+
+    impl BlobHeaderLayout {
+        /// The runtime version recorded in a header of this layout.
+        pub(crate) const fn runtime_version(self) -> u16 {
+            match self {
+                Self::V0 => 0,
+                Self::V1 => 1,
+            }
+        }
+
+        /// The magic bytes recorded in a header of this layout: a fixed 3-byte brand (`CWI`,
+        /// "is this file ours?") followed by a 1-byte layout tag ("which container layout?").
+        ///
+        /// The layout tag lives in the magic rather than the runtime version field because V0
+        /// stamped that field as zero, and zeros are exactly what a torn header write leaves
+        /// behind. Tags are nonzero and distinct, so no layout's magic can be turned into
+        /// another's by zeroing bytes, and a torn write can never be misread as a complete
+        /// header of a different layout.
+        pub(crate) const fn magic(self) -> [u8; 4] {
+            match self {
+                Self::V0 => *b"CWIC", // Commonware Is CWIC
+                Self::V1 => *b"CWI1",
+            }
+        }
+
+        /// The layout recorded by a header with the given magic bytes, if supported.
+        pub(crate) const fn from_magic(magic: &[u8; 4]) -> Option<Self> {
+            match magic {
+                b"CWIC" => Some(Self::V0),
+                b"CWI1" => Some(Self::V1),
+                _ => None,
+            }
+        }
+    }
+
     /// Fixed-size header prelude at the start of each [crate::Blob].
     ///
     /// On-disk layout (big-endian). The prelude is 8 bytes and a V1 header extends it:
@@ -342,11 +390,6 @@ stability_scope!(BETA {
             raw_len: u64,
             versions: &RangeInclusive<u16>,
         ) -> Result<(u64, u16, u64), HeaderError> {
-            debug_assert!(
-                raw.len() >= raw_len.min(Self::V1_DATA_OFFSET) as usize,
-                "caller must provide enough bytes to validate the header region"
-            );
-
             let header: Self = Self::decode(&raw[..Self::PRELUDE_SIZE])
                 .expect("header decode should never fail for correct size input");
             let layout = header.validate()?;
@@ -531,8 +574,8 @@ impl arbitrary::Arbitrary<'_> for Header {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use super::{Header, HeaderError};
-    use crate::{Blob, BlobHeaderLayout, Buf, IoBuf, IoBufMut, IoBufs, IoBufsMut, Storage};
+    use super::{BlobHeaderLayout, Header, HeaderError};
+    use crate::{Blob, Buf, IoBuf, IoBufMut, IoBufs, IoBufsMut, Storage};
     use commonware_codec::{DecodeExt, Encode};
     use futures::FutureExt;
 

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -178,8 +178,6 @@ impl crate::Storage for Storage {
                 });
                 match creation.await {
                     Ok(result) => result?,
-                    // Nothing aborts the creation task, so a join error is a panic (or a
-                    // runtime shutdown, which cancels the task).
                     Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
                     Err(_) => return Err(Error::Closed),
                 }

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -67,9 +67,7 @@ impl Storage {
         }
     }
 
-    /// Parses an existing blob's header, returning `None` if the blob is new or its contents
-    /// are those of a creation that was interrupted before its header became durable (the
-    /// caller recreates the blob), and an error if the header is corrupt or unacceptable.
+    /// Reads a blob's leading bytes and resolves its header (see [super::resolve_header]).
     async fn resolve_header(
         file: &mut fs::File,
         len: u64,
@@ -77,24 +75,11 @@ impl Storage {
         partition: &str,
         name: &[u8],
     ) -> Result<Option<(u64, u16, u64)>, Error> {
-        if Header::missing(len) {
-            return Ok(None);
-        }
         let mut raw = vec![0u8; len.min(Header::V1_DATA_OFFSET) as usize];
         file.read_exact(&mut raw)
             .await
             .map_err(|_| Error::ReadFailed)?;
-        let err = match Header::parse(&raw, len, versions) {
-            Ok(resolved) => return Ok(Some(resolved)),
-            Err(err) => err,
-        };
-
-        // The header failed to parse: files longer than the creation region hold data and are
-        // never torn creations. Shorter files are already fully represented in `raw`.
-        if !err.may_be_torn_creation() || len > Header::V1_DATA_OFFSET {
-            return Err(err.into_error(partition, name));
-        }
-        super::resolve_unparseable(err, &raw, partition, name)
+        super::resolve_header(&raw, len, versions, partition, name)
     }
 }
 
@@ -112,8 +97,9 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, u16), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        // Acquire the filesystem lock. The guard is owned so the creation path can move it
+        // into a task that outlives a dropped open future.
+        let guard = self.lock.clone().lock_owned().await;
 
         // Construct the full path
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
@@ -121,10 +107,6 @@ impl crate::Storage for Storage {
             Some(parent) => parent,
             None => return Err(Error::PartitionCreationFailed(partition.into())),
         };
-
-        // Check if partition exists before creating
-        #[cfg(unix)]
-        let parent_existed = parent.exists();
 
         // Create the partition directory, if it does not exist
         fs::create_dir_all(parent)
@@ -149,37 +131,61 @@ impl crate::Storage for Storage {
         // Handle header: existing blobs have their header read; new blobs and blobs left torn
         // by an interrupted creation get a fresh header written.
         let existing = Self::resolve_header(&mut file, len, &versions, partition, name).await?;
-        let (logical_size, blob_version, data_offset) = match existing {
-            Some(resolved) => resolved,
+        let (file, logical_size, blob_version, data_offset) = match existing {
+            Some((logical_size, blob_version, data_offset)) => {
+                (file, logical_size, blob_version, data_offset)
+            }
             None => {
-                // Truncate to zero before writing, per the [Header::create] contract.
-                let (region, blob_version) = Header::create(&versions);
-                let data_offset = region.len() as u64;
-                file.set_len(0)
-                    .await
-                    .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;
-                file.rewind().await.map_err(|_| Error::WriteFailed)?;
-                file.write_all(&region)
-                    .await
-                    .map_err(|_| Error::WriteFailed)?;
-                file.sync_all()
-                    .await
-                    .map_err(|e| Error::BlobSyncFailed(partition.into(), hex(name), e.into()))?;
+                // Run creation to completion on a task that owns the filesystem lock:
+                // dropping the open future must not abandon the sequence half-done (a
+                // straggling truncate could clobber a successor's blob) or leave a later
+                // open trusting a header whose syncs never ran.
+                let parent = parent.to_path_buf();
+                let storage_directory = self.cfg.storage_directory.clone();
+                let err_partition = partition.to_string();
+                let err_name = hex(name);
+                let creation = tokio::task::spawn(async move {
+                    let _guard = guard;
 
-                // Sync the directories to ensure the directory entry is durable. This must
-                // also run when recreating a torn blob: the creation it is recovering from
-                // may have crashed before its own directory syncs completed. (Windows has
-                // no notion of syncing a directory entry; see
-                // https://github.com/commonwarexyz/monorepo/issues/2026.)
-                #[cfg(unix)]
-                {
-                    sync_dir(parent).await?;
-                    if !parent_existed {
-                        sync_dir(&self.cfg.storage_directory).await?;
+                    // Sync the directories before writing the header so a parseable
+                    // header always implies durable directory entries (an open that
+                    // parses a header never re-runs these). The storage directory is
+                    // synced unconditionally: the partition directory existing in the
+                    // namespace does not imply its entry is durable. (Windows has no
+                    // notion of syncing a directory entry; see
+                    // https://github.com/commonwarexyz/monorepo/issues/2026.)
+                    #[cfg(unix)]
+                    {
+                        sync_dir(&parent).await?;
+                        sync_dir(&storage_directory).await?;
                     }
-                }
+                    #[cfg(not(unix))]
+                    let _ = (parent, storage_directory);
 
-                (0, blob_version, data_offset)
+                    // Truncate to zero before writing, per the [Header::create] contract.
+                    let (region, blob_version) = Header::create(&versions);
+                    let data_offset = region.len() as u64;
+                    file.set_len(0).await.map_err(|e| {
+                        Error::BlobResizeFailed(err_partition.clone(), err_name.clone(), e.into())
+                    })?;
+                    file.rewind().await.map_err(|_| Error::WriteFailed)?;
+                    file.write_all(&region)
+                        .await
+                        .map_err(|_| Error::WriteFailed)?;
+                    file.sync_all()
+                        .await
+                        .map_err(|e| Error::BlobSyncFailed(err_partition, err_name, e.into()))?;
+
+                    Ok::<_, Error>((file, blob_version, data_offset))
+                });
+                let (file, blob_version, data_offset) = match creation.await {
+                    Ok(result) => result?,
+                    // Nothing aborts the creation task, so a join error is a panic (or a
+                    // runtime shutdown, which cancels the task).
+                    Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+                    Err(_) => return Err(Error::Closed),
+                };
+                (file, 0, blob_version, data_offset)
             }
         };
 
@@ -539,6 +545,82 @@ mod tests {
         assert!(matches!(result, Err(crate::Error::BlobCorrupt(_, _, _))));
 
         let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    /// Dropping an open future at any await point must leave the blob openable: creation
+    /// runs to completion on a task that owns the filesystem lock, so a retry serializes
+    /// behind it and never observes (or clobbers) a half-created blob.
+    #[tokio::test]
+    async fn test_open_dropped_mid_creation() {
+        use futures::FutureExt;
+        use std::{
+            future::Future,
+            pin::Pin,
+            task::{Context, Poll},
+        };
+
+        /// Polls the wrapped future normally, but drops it after a fixed number of polls.
+        struct DropAfter<F: Future + Unpin> {
+            inner: Option<F>,
+            remaining: usize,
+        }
+
+        impl<F: Future + Unpin> Future for DropAfter<F> {
+            type Output = Option<F::Output>;
+
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+                if self.remaining == 0 {
+                    self.inner = None;
+                    return Poll::Ready(None);
+                }
+                self.remaining -= 1;
+                match self.inner.as_mut().unwrap().poll_unpin(cx) {
+                    Poll::Ready(output) => Poll::Ready(Some(output)),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+        }
+
+        let storage_directory =
+            env::temp_dir().join(format!("test_dropped_open_{}", random_suffix()));
+        let storage = Storage::new(
+            Config {
+                storage_directory: storage_directory.clone(),
+                maximum_buffer_size: 1024 * 1024,
+            },
+            test_pool(),
+        );
+
+        for depth in 0..64 {
+            let name = format!("blob{depth}");
+            let name = name.as_bytes();
+            let dropped = DropAfter {
+                inner: Some(Box::pin(storage.open("partition", name))),
+                remaining: depth,
+            }
+            .await;
+            let completed = dropped.is_some();
+            drop(dropped);
+
+            // Retry, write data, and confirm it survives reopen.
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 0);
+            blob.write_at(0, b"data".to_vec()).await.unwrap();
+            blob.sync().await.unwrap();
+            drop(blob);
+            let (blob, size) = storage.open("partition", name).await.unwrap();
+            assert_eq!(size, 4);
+            let read = blob.read_at(0, 4).await.unwrap();
+            assert_eq!(read.coalesce(), b"data");
+            drop(blob);
+
+            // Once the first open completes within the poll budget, deeper drops add nothing.
+            if completed {
+                let _ = std::fs::remove_dir_all(&storage_directory);
+                return;
+            }
+        }
+        panic!("open never completed within the poll budget");
     }
 
     #[tokio::test]

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -131,20 +131,20 @@ impl crate::Storage for Storage {
         // Handle header: existing blobs have their header read; new blobs and blobs left torn
         // by an interrupted creation get a fresh header written.
         let existing = Self::resolve_header(&mut file, len, &versions, partition, name).await?;
-        let (file, (logical_size, blob_version, data_offset)) = match existing {
-            Some(resolved) => (file, resolved),
+        let (file, guard, (logical_size, blob_version, data_offset)) = match existing {
+            Some(resolved) => (file, guard, resolved),
             None => {
                 // Run creation to completion on a task that owns the filesystem lock:
                 // dropping the open future must not abandon the sequence half-done (a
                 // straggling truncate could clobber a successor's blob) or leave a later
-                // open trusting a header whose syncs never ran.
+                // open trusting a header whose syncs never ran. The task hands the lock
+                // back so the open holds it until the blob is returned, like the reopen
+                // path.
                 let parent = parent.to_path_buf();
                 let storage_directory = self.cfg.storage_directory.clone();
                 let err_partition = partition.to_string();
                 let err_name = hex(name);
                 let creation = tokio::task::spawn(async move {
-                    let _guard = guard;
-
                     // Sync the directories before writing the header so a parseable
                     // header always implies durable directory entries (an open that
                     // parses a header never re-runs these). The storage directory is
@@ -174,7 +174,7 @@ impl crate::Storage for Storage {
                         .await
                         .map_err(|e| Error::BlobSyncFailed(err_partition, err_name, e.into()))?;
 
-                    Ok::<_, Error>((file, (0, blob_version, data_offset)))
+                    Ok::<_, Error>((file, guard, (0, blob_version, data_offset)))
                 });
                 match creation.await {
                     Ok(result) => result?,
@@ -184,27 +184,14 @@ impl crate::Storage for Storage {
             }
         };
 
+        // Convert to a blocking std::fs::File
         #[cfg(unix)]
-        {
-            // Convert to a blocking std::fs::File
-            let file = file.into_std().await;
+        let file = file.into_std().await;
 
-            // Construct the blob
-            Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset),
-                logical_size,
-                blob_version,
-            ))
-        }
-        #[cfg(not(unix))]
-        {
-            // Construct the blob
-            Ok((
-                Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset),
-                logical_size,
-                blob_version,
-            ))
-        }
+        // Construct the blob while still holding the filesystem lock.
+        let blob = Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset);
+        drop(guard);
+        Ok((blob, logical_size, blob_version))
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -75,7 +75,7 @@ impl Storage {
         partition: &str,
         name: &[u8],
     ) -> Result<Option<(u64, u16, u64)>, Error> {
-        let mut raw = vec![0u8; len.min(Header::V1_DATA_OFFSET) as usize];
+        let mut raw = vec![0u8; Header::resolve_len(len)];
         file.read_exact(&mut raw)
             .await
             .map_err(|_| Error::ReadFailed)?;

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -131,10 +131,8 @@ impl crate::Storage for Storage {
         // Handle header: existing blobs have their header read; new blobs and blobs left torn
         // by an interrupted creation get a fresh header written.
         let existing = Self::resolve_header(&mut file, len, &versions, partition, name).await?;
-        let (file, logical_size, blob_version, data_offset) = match existing {
-            Some((logical_size, blob_version, data_offset)) => {
-                (file, logical_size, blob_version, data_offset)
-            }
+        let (file, (logical_size, blob_version, data_offset)) = match existing {
+            Some(resolved) => (file, resolved),
             None => {
                 // Run creation to completion on a task that owns the filesystem lock:
                 // dropping the open future must not abandon the sequence half-done (a
@@ -176,16 +174,15 @@ impl crate::Storage for Storage {
                         .await
                         .map_err(|e| Error::BlobSyncFailed(err_partition, err_name, e.into()))?;
 
-                    Ok::<_, Error>((file, blob_version, data_offset))
+                    Ok::<_, Error>((file, (0, blob_version, data_offset)))
                 });
-                let (file, blob_version, data_offset) = match creation.await {
+                match creation.await {
                     Ok(result) => result?,
                     // Nothing aborts the creation task, so a join error is a panic (or a
                     // runtime shutdown, which cancels the task).
                     Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
                     Err(_) => return Err(Error::Closed),
-                };
-                (file, 0, blob_version, data_offset)
+                }
             }
         };
 
@@ -282,7 +279,8 @@ impl crate::Storage for Storage {
 mod tests {
     use super::{Header, *};
     use crate::{
-        Blob, BlobHeaderLayout, BufferPoolConfig, Storage as _, storage::tests::run_storage_tests,
+        Blob, BufferPoolConfig, Storage as _,
+        storage::{BlobHeaderLayout, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
     use commonware_utils::sys_rng;

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -178,7 +178,8 @@ impl CacheRef {
                 page_size = page_size.get(),
                 physical_page_size,
                 "page size produces physical pages that do not align with storage pages; pick a \
-                 page size via paged::page_size to avoid amplifying cold random reads"
+                 page size via paged::page_size to avoid amplifying cold random reads (changing \
+                 an existing store's page size is a destructive format migration)"
             );
         }
 

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -17,10 +17,11 @@
 //! # Storage-page alignment
 //!
 //! Physical page `p` begins at blob offset `p * physical_page_size`, and a newly created blob
-//! begins its data on a 4096-byte boundary. Choosing a logical page size
-//! such that the physical page size is a power of two (see [page_size]) therefore keeps
-//! every physical page from crossing a 4096-byte storage-page boundary (and starts every physical
-//! page of at least 4096 bytes exactly on one).
+//! begins its data on a 4096-byte boundary. Choosing a logical page size such that the physical
+//! page size is a power of two (see [page_size]) therefore makes every physical page either fit
+//! within a single 4096-byte storage page or start on a 4096-byte boundary and span whole
+//! storage pages. Blobs created before the aligned layout begin their data at offset 8 and never
+//! align, regardless of the page size chosen.
 //!
 //! Alignment is a performance property, not a correctness requirement: any page size works, but
 //! physical pages that straddle storage-page boundaries amplify cold random reads, so
@@ -60,16 +61,20 @@ const CHECKSUM_SIZE: u64 = Checksum::SIZE as u64;
 
 /// The storage-page granularity physical pages should align to (see the module docs).
 pub(crate) const STORAGE_PAGE_SIZE: u64 = 4096;
+// The alignment reasoning above assumes newly created blobs place their data on a
+// storage-page boundary.
+const _: () = assert!(crate::storage::Header::V1_DATA_OFFSET.is_multiple_of(STORAGE_PAGE_SIZE));
+
 const CHECKSUM_SLOT_LEN_SIZE: usize = u16::SIZE;
 const CHECKSUM_SLOT_SIZE: usize = CHECKSUM_SLOT_LEN_SIZE + crc32::Digest::SIZE;
 
 /// The logical page size whose physical page occupies exactly `physical_page_size` bytes on disk
 /// (see the module docs on storage-page alignment).
 ///
-/// This selects a page size for a store; it is not a migration path. A store that already holds
-/// data cannot be reopened under a different page size: the mismatched pages fail their integrity
-/// check, and reopening for writing silently truncates them. Changing page size is a destructive
-/// format migration.
+/// This selects a page size for a store. It is not a migration path: a store that already holds
+/// data cannot be reopened under a different page size, as the mismatched pages fail their
+/// integrity check and reopening for writing silently truncates them. Changing page size is a
+/// destructive format migration.
 ///
 /// # Panics
 ///

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -3312,6 +3312,7 @@ mod tests {
                     .iter()
                     .all(|byte| *byte == 0)
             );
+
             // Each assembled physical page must carry a valid CRC record.
             assert!(Checksum::validate_page(&coalesced.as_ref()[..physical_page_size]).is_some());
             assert!(

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -1,10 +1,10 @@
 ["commonware_storage::archive::conformance::StorageConformance<ArchiveImmutableWorkload>"]
 n_cases = 128
-hash = "d350580e22e6983572a08dfbb885b808f90ff88377c567e4489be29c9fbfb916"
+hash = "836f71ea345dc8707105fee756c04b1f2edb8a5e54c38b23282b53998244dd12"
 
 ["commonware_storage::archive::conformance::StorageConformance<ArchivePrunableWorkload>"]
 n_cases = 128
-hash = "65bfc888c5f3dbd56d0ed237645a43496a851a469848998556d8a95ad1b9d64f"
+hash = "c42202186ded174cd23871b6728b23a2284f7146c7acdaf1dbff61fa9bd666ea"
 
 ["commonware_storage::archive::immutable::storage::conformance::CodecConformance<Record>"]
 n_cases = 65536
@@ -24,7 +24,7 @@ hash = "18b1108f18520078e2eb5bb29c6a4cdf3bded6b52d8efda19d45c0f10be27207"
 
 ["commonware_storage::cache::conformance::StorageConformance<CacheWorkload>"]
 n_cases = 256
-hash = "1dc93a7225b6aa403866b3ad2a7b62a78466cd15264f05424652a4c6107d9497"
+hash = "e584dceea1d6b77fdec6c2ef5cb246ea5ace375904eed5b3cb5abebe75e34fde"
 
 ["commonware_storage::cache::storage::conformance::CodecConformance<Record<u64>>"]
 n_cases = 65536
@@ -32,7 +32,7 @@ hash = "9add8634d4f06c3fb7f6dfd80630f38013ecb20849c18accd0579d7eb2ca11d5"
 
 ["commonware_storage::freezer::conformance::StorageConformance<FreezerWorkload>"]
 n_cases = 512
-hash = "ec3e98bdeb3bc6766d5897ca25b1485b2361d1db10766c5dfeba633099c6f3f5"
+hash = "d01a45c01ea5b03f36007b83ed4a331ac1e711ba20605211f1dd378c7d76342c"
 
 ["commonware_storage::freezer::storage::conformance::CodecConformance<Checkpoint>"]
 n_cases = 65536
@@ -52,35 +52,35 @@ hash = "13b3e99a8c74b50dc18150194a92306de670b94e6642758feb6d9b6e9881f827"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmbWorkload>"]
 n_cases = 256
-hash = "9720314eb63cc8f92c9f259631317a7ae07890684d522e3ea5307962b6c1bf0d"
+hash = "74d03c4e36ba59834df32aa131bc6ad659dc55b1dab5e5926b9aa033d0ed821f"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmrWorkload>"]
 n_cases = 256
-hash = "f66f22fbed7b9d738144259685c6d4d5b8953de2c148dcb730e554cb77e7ef1a"
+hash = "9eec5df6e9016f6d3fb2317bc0d1e0a969ee3ef6efa4ee6a04770a1e533116b8"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousFixedWorkload>"]
 n_cases = 512
-hash = "1f048d31bd0667329fae2eade9224ae4075f6ddb0852f2a443c19a1153588c95"
+hash = "627ba252d6f69ef04e74cc493024712e8701ffc3fc27576858eb67995532e5a9"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousVariableWorkload>"]
 n_cases = 512
-hash = "0e3ec4688c1012de20415064a54a210ac6fe46f0dfe82092e397a3ea691c30b6"
+hash = "595d3b70ca5c4482669d6d1356b63870f319a78b9365211517b03b526eb25f64"
 
 ["commonware_storage::journal::conformance::StorageConformance<SegmentedFixedWorkload>"]
 n_cases = 512
-hash = "bc68e124cabb2a28ba9305f8e1b4ba772e812b6885d73876db29c2519e0cc88d"
+hash = "2af7164a4dea99e678e70c4700ec0dafd57477b318cb7b7c0ce30a1464c19a8f"
 
 ["commonware_storage::journal::conformance::StorageConformance<SegmentedGlobWorkload>"]
 n_cases = 512
-hash = "4d12cc6c8feb6c459c794fdbaa17026239c53c6220c4284eff213a332c071a0c"
+hash = "4c936d130e6fe7eea71ccfc237f0d93186321ad17e0ea7d52485779326ddd654"
 
 ["commonware_storage::journal::conformance::StorageConformance<SegmentedOversizedWorkload>"]
 n_cases = 512
-hash = "47ba5a5ec01e18b27c611279a68e651dadd0d9652b2b44ca8dc811221a94c496"
+hash = "e8eab39bfc0d5284d617f832f513c895c28771d80b2554f20611f39edce9c8c9"
 
 ["commonware_storage::journal::conformance::StorageConformance<SegmentedVariableWorkload>"]
 n_cases = 512
-hash = "ddb2ff82bd746a29ff13276062140407d465f4fd92a884b26c3c7e78f790a566"
+hash = "a9656e53e1f4682a218c715f6c5fb665452d0d06f634254fce44a0a11472e7c4"
 
 ["commonware_storage::merkle::conformance::tests::MmbRootStability"]
 n_cases = 200
@@ -92,11 +92,11 @@ hash = "4078ce1f5e242f8edb1d41575d51e166af620404036124f8094fc74d4b401047"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmbFullWorkload>"]
 n_cases = 256
-hash = "ca209d7835fa3c20a9c4f362c19071d5a867365188cdc235445192c78ab05d30"
+hash = "e1bb3e91b15311352a0696ab40600747292876fcaf3f8e1188d071d603761b7d"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmrFullWorkload>"]
 n_cases = 256
-hash = "a02df04da1eff67770c8f21a6bd9a3ffdab5a0a20cb4d0bc3af9e360b8e1576a"
+hash = "a6e586229899a2361b90cb2a208953ecaec6b23c98ec356d4a50c57be5eeb645"
 
 ["commonware_storage::merkle::mmr::proof::tests::conformance::CodecConformance<Proof<Family,Sha256Digest>>"]
 n_cases = 65536
@@ -104,11 +104,11 @@ hash = "f6c441a49ff8828cd4f3f41d44e5575267754b6d358faab14ff2cefd6b7808ec"
 
 ["commonware_storage::metadata::conformance::StorageConformance<MetadataWorkload>"]
 n_cases = 256
-hash = "0aaf7305ab31f65099def11146369dd056fb6c86ee9e12ae07edecc59260932b"
+hash = "2d5d43b6e04546db2791a4c966cf0d108ad24df6381b58d8f1449ede3d92a3e5"
 
 ["commonware_storage::ordinal::conformance::StorageConformance<OrdinalWorkload>"]
 n_cases = 256
-hash = "7df4046bad912ce0f6d6d86e9a59963756e008ff9189ef55c9d29881ff1cfa04"
+hash = "0195103818ed5e65d6c8faa170614a27bf80a92b993c57cbe613e96cb7aefcd2"
 
 ["commonware_storage::ordinal::storage::conformance::CodecConformance<Record<u32>>"]
 n_cases = 65536
@@ -300,131 +300,131 @@ hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "a919d639f6132e782f23b201c4bd1377d3a25d7cd979a552a5ca4d460595f7c1"
+hash = "8865dbff79b343e15be6248f7c9b9ecbcee4ce62fc6ce6ad74a10aeba0b037ca"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "56332f49a104d4ea78d986ee5ab0cb1c686d19d90903857fbeccd23a8910173b"
+hash = "08fa4a62f53a26a2bdebd93302dcf961aab3f50b11a576239b9e65cfb135a7e0"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "c0ed29e49c74542b121ab96fefe234e89e574c7a7a605a26ee786e068bbb95ff"
+hash = "e27ea4efaa3ca3fb1a9bda6e1e4989f6636f9b064aabbbca70dbaab906f0bc01"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "67cb2eb7f4ce4065bed7fb2049dadb122378b95fff367090af4ca5c774f56646"
+hash = "4bcfc84a06a52c0a27de3d1bf87ffce490a0fe2150bd5350908c49020c5e820d"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "49cf413d5a7954ab43ef9275773d01710e1e4faff3d0b0f0b2cef392b327449c"
+hash = "2c31e793a22f349c713cbe43fae4494ee39b9eb91e7085ee1ba9add1509c1b6b"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "d652a2d4123776f0d9822cf1f2502753db411b487756c90b0de00283e5e4e364"
+hash = "45cb75ee32c6455b2cbefbc9e6c791f782f1992e39713b548c7d61894597a4d8"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "332a868d45772fc1c302aa179fd9976123598dae647eb7550f67946da6d8d205"
+hash = "6ec3a1e38743976cf2132583e80dce3429ea8cc59b8a765a7eb293eaeddb3055"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "803cfc70d11ff7c8c049293834e2309c56bf76b4e58d16682759b62c1395d75c"
+hash = "3025d50d87c472227cc38a59c939454f2c9ca07d5c4b8fe614a9a54d961c3f45"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "8de7760b30f71c49e778457ac269c2878014d41bec4fb0aea302a6544427380c"
+hash = "52203c4160810631e6f8f02697970ed2db6a15be433be848eeb3de311a5ca1ac"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "b3220967a7b49fe9b08c4d1a9773c825567bdda9b8083252c5bc219a2f4353d5"
+hash = "9b859e3d42869a0305e538584d914b691fc7a236de01ce3da68093eb26111aba"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "14eabf1bbc7a159808d677882a6a67a9bd2bec265e8dac047281026ecdda309d"
+hash = "a33d79be75ae3db4f7c8f706cbb9707326adf070cb67ddf673fabcd17afab6eb"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "9dcc9d617e923aaad102895ed2f0e36351a666b9a74ba74ce4fb849cdf4b65f1"
+hash = "244811c362aa673e3f573f233b58c379671c64c26784acbb49343a3144fb90b0"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "1c548d4464d15d764de4a01a8fea0e29fd238bf68e477e41d2b90d4ab132fa93"
+hash = "abb6e4b1281d59e7fb5a223bc906c1989b3fd652533c2f94bea14c1b8cf4de08"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "889be8ea776725412621eb5345ae2e46dfd4fe117be3e2924b0cd0d7057036be"
+hash = "f2f7bd0129408519e54778487759de2e8ea7dedc239229cf389529f5e1621179"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "8c45c42669b767e6526628ca3ccfdc6e71f046e5037fe5a37af48bf54973cc54"
+hash = "7bf844eb896054ec13e2912e53c26f464fa56ac7431e1f7200cd6a8a4dcec944"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "cbabbdf48dcfd51dd3f53fe8a745d3bd4cb1e729ed822cf63e68b906de807cb4"
+hash = "02d3fa9305fed943c9ade46fe6c6e9eba9c06621aa120f02bbd79b3f81589540"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactFixedStorage>"]
 n_cases = 64
-hash = "ea0bd0e93ed2a5a8952b9da5c7715c18d54330c225fe4cff84bfffec093878cf"
+hash = "a0c9acaef2b9fada1d623fb9bae7f7835539aebe408fdd0d801986c86eddd125"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactVariableStorage>"]
 n_cases = 64
-hash = "169ef3cafa0afe99e9f082b908e37f9f6b4b20eb9a866ca95899ed97bf1cc526"
+hash = "15bb7b90c800f1c8d27f9bec2ca765c9f14782a341bdcb9144e09d836c7cc8ca"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbFixedStorage>"]
 n_cases = 64
-hash = "2a18fb1157d213477e658683eb69339224e8e055aaaac603d6ccc7b6eb4d2383"
+hash = "312105a085f950c933da73418c5bb1e7595247d27e52a2c3c7589ac4db75cdeb"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbVariableStorage>"]
 n_cases = 64
-hash = "4a3985420b67eb910e33ef394fc4f7753013a683716518a74b3bd6e41c41a1de"
+hash = "83a12aee531340131135b182651b53de86325e71122796be29b6b9708acfdaa9"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactFixedStorage>"]
 n_cases = 64
-hash = "0561de3030c37de94d4befec5a5cb47bb371c9e152b4318d0f186b4d9979f2dd"
+hash = "767a38711571e2893ff641f8ffce454b3dc890c4c848e711902b4c90a320646b"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactVariableStorage>"]
 n_cases = 64
-hash = "f7d9ca822a7f109fe2739c980c0a6db7533eac797ff5dd2b4478d5f0b1cfb575"
+hash = "5d82b14cbc49e2cd878d0c683ea88219b04c20d90d76ddeae8793b6bae797f7a"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrFixedStorage>"]
 n_cases = 64
-hash = "9561fd6a6928b353487ce1a2b567f4f10a5df35979c0ff132045a5e7ced1b638"
+hash = "3cf7ae2e5798fc7c78699f59c835552b49ee8b4355f4e8d49cd9659ba20bfd21"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrVariableStorage>"]
 n_cases = 64
-hash = "80adfbd5e630907a55c02d0d88c591c069867290bd95c49eaf98e25f9bb61de7"
+hash = "9f48c1fa5f420774726c6271f3f1180ab293c5fdb39cfd3e7e1c3be3551d57fe"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactFixedStorage>"]
 n_cases = 64
-hash = "195212b007a7e486c1bb3f7aebd1a2641a5baee2eb4ebfdb7fe8f8d84c188843"
+hash = "6a0b77ab225335c548d5c8e49cf41361c8900a116ddb5a2e68f581bd13cdf1cd"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactVariableStorage>"]
 n_cases = 64
-hash = "1d8fa93eb1a7ff08211a5f63102263598af8462599110c6cb65498a44b19bfcb"
+hash = "418eec9ff6e231951bc5c9f0e6021f5af643bfed7859eb4695af403344eb6fcb"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbFixedStorage>"]
 n_cases = 64
-hash = "631fc0032902b1c468e1e8dfe637b5a4bafd480c20ed4cadf22a770c593860e2"
+hash = "46bb0f05abd856a34be672ee5ef1a319a1fc4bc724d9f45439b4490d43e071b8"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbVariableStorage>"]
 n_cases = 64
-hash = "a8654a8350e97a6ce0245f1e981e23e1a725e0e04b2fefaa8eee0b6bceec92e1"
+hash = "98f24f75150d38e7c7151887dc0deb4ad5eb1190d1790ba304aaf78141e970f8"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactFixedStorage>"]
 n_cases = 64
-hash = "447071203c5209bbf2caf0856fc20215b3f2be336b12ad1ac2aaec803faecbdb"
+hash = "ee43661be83069608fe7b4c9956480efb6925ea1b51af1c2b1e71bbabfb0a9c1"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactVariableStorage>"]
 n_cases = 64
-hash = "0ea715bf2155afa4d2189e5ef6847e624ab5a3ad5c2a73018ae8817c8ba48730"
+hash = "3945b645594d6f803b7dc4279b8bb17e92ce23bbb30dae2e98646ceaa0f6425d"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrFixedStorage>"]
 n_cases = 64
-hash = "0f16b53da59ca915ced2a865977e1b9f9d12a873a60a5b28e1d0ea0444362840"
+hash = "182b01f2749b189e6a4c14c3a5c10e1c06600c6aedf01496c119cd01fbd5ba0e"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrVariableStorage>"]
 n_cases = 64
-hash = "cafd5e810df31be5cb31bb9a22e18ef066aa0d83d8940377ef71e526d15f67f3"
+hash = "a023b1399b8656e8e113787f935d10013606440d43c8cb7c818749f6f09fc2fd"
 
 ["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
 n_cases = 65536
@@ -508,4 +508,4 @@ hash = "f742d92a0af0af78a9519bf637bc52ea869965a85a84101a4c53f53eb39325ca"
 
 ["commonware_storage::queue::conformance::StorageConformance<QueueWorkload>"]
 n_cases = 512
-hash = "68de192def29f1827783905d1c11edbebba8fc9076404cab7b7b87184d03760a"
+hash = "af39c4e1fccf63cac68a7866703d7764c3baf3be3e3906460dc4fab9c7ffd19d"


### PR DESCRIPTION
Merges into #4184 (`blob-page-alignment`).

## Summary

Review fixes for the V1 blob layout: three durability holes in `open_versioned` creation, a consolidation of header resolution into one decision table, and doc corrections.

## Durability

Directory syncs ran after the header write and fsync. A creation that stopped between the two (a dropped future, a process crash, or a transient `sync_dir` error) left a fully parseable header, so a later open took the existing-blob path and returned Ok without ever making the directory entries durable. Directory syncs now run before any header byte is written, restoring the invariant that a parseable header implies durable directory entries.

The `parent_existed` probe skipped the storage-directory sync based on namespace existence, which does not imply the partition's own directory entry is durable. An interrupted first open in a partition permanently poisoned the gate for every later creation, and the torn-recreation path never synced the storage directory at all. The probe is gone and the creation path syncs the storage directory unconditionally. Creation gains one directory fsync, every open drops one `exists()` stat, and reopens are untouched.

In the tokio backend, dropping an `open_versioned` future mid-creation could leave a straggling `set_len(0)` that truncates a successor's durably-created blob (tokio file operations complete detached on the blocking pool), and a retry could trust a header whose syncs never ran. Creation now runs to completion on a spawned task that owns the filesystem lock and hands it back to the caller, so a dropped open cannot abandon creation half-done while the open still holds the lock end-to-end, like the reopen path. `test_open_dropped_mid_creation` pins this by dropping an open at every poll depth and verifying a retry always yields a healthy blob.

The io_uring backend runs creation synchronously within a single poll, so only the first two changes apply there. Crash-restart states are covered by the startup filesystem sync.

## Header resolution

Header resolution is one decision table in `storage::header::resolve` -- too short to hold a header (new), valid header, torn V1 creation (heal), anything else (corrupt) -- and the backend helpers read the leading bytes and delegate. The separate unparseable-header classifier folded into it, and its longer-than-creation-region guard (previously duplicated in two backends) is now enforced once. `Header::resolve_len` owns the read-window sizing so callers ask instead of recomputing it. The header apparatus (the layout enum, now `header::Layout`, plus `Header` and resolution) lives in its own `storage/header.rs`, with the `CodecConformance<Header>` fixture re-keyed to the new module path (same hash).

The V1 magic is now `CWIK` (from `CWI1`). V1 is unreleased, so this is a free rename, but it changes stored bytes: the storage and consensus conformance fixtures that hash storage audits are regenerated (49 + 2 entries). The `CodecConformance<Header>` fixture is untouched because it covers the V0 prelude, which is frozen on disk.

## Docs

- Removed the `# Recovery` section from the `Storage` trait docs.
- Qualified the durably-created claim: platforms without directory sync (Windows) get best-effort name durability.
- The storage-page alignment doc states the actual guarantee: physical pages either fit within a single 4096-byte storage page or start on a boundary and span whole pages. Legacy V0 blobs (data offset 8) never align.
- The misaligned-page-size warning and the `paged::page_size` docs note that changing an existing store's page size is a destructive format migration.
- A const assertion ties `Header::V1_DATA_OFFSET` to `paged::STORAGE_PAGE_SIZE` instead of prose.

## Validation

- `just test -p commonware-runtime storage`
- `just clippy -p commonware-runtime`
- `just check-fmt`
- `just test-conformance -p commonware-storage -p commonware-consensus`
- io_uring build/tests on Linux via Docker (kernel 6.12, `--security-opt seccomp=unconfined` since the default profile blocks `io_uring_*`): 93 storage tests pass, including the io_uring backend suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
