### PR TITLE
[marshal/applications] Harden Equivocation Handling

### DIFF
--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -246,6 +246,7 @@ mod tests {
     use crate::types::{Epoch, View};
     use commonware_cryptography::{Hasher, Sha256, sha256::Digest as Sha256Digest};
     use commonware_runtime::{Runner, Spawner, deterministic};
+    use std::future::ready;
 
     type D = Sha256Digest;
     type TestGates = Gates<D, u64>;
@@ -257,6 +258,10 @@ mod tests {
     fn pending_task() -> oneshot::Receiver<GateOutcome> {
         let (_tx, rx) = oneshot::channel();
         rx
+    }
+
+    fn no_fallback() -> std::future::Ready<oneshot::Receiver<bool>> {
+        unreachable!("certification must not fall back")
     }
 
     #[test]
@@ -374,10 +379,7 @@ mod tests {
                 let (task_tx, task_rx) = oneshot::channel();
                 let (tx, rx) = oneshot::channel();
                 task_tx.send_lossy(GateOutcome::Ready(verdict));
-                drive(tx, task_rx, round(1), digest, || async {
-                    unreachable!("a ready gate must not fall back")
-                })
-                .await;
+                drive(tx, task_rx, round(1), digest, no_fallback).await;
                 assert_eq!(rx.await.expect("verdict published"), verdict);
             }
         });
@@ -391,12 +393,9 @@ mod tests {
             let (task_tx, task_rx) = oneshot::channel();
             let (tx, rx) = oneshot::channel();
             task_tx.send_lossy(GateOutcome::Recover);
-            drive(tx, task_rx, round(1), digest, || async {
-                let (fallback_tx, fallback_rx) = oneshot::channel();
-                fallback_tx.send_lossy(true);
-                fallback_rx
-            })
-            .await;
+            let (fallback_tx, fallback_rx) = oneshot::channel();
+            fallback_tx.send_lossy(true);
+            drive(tx, task_rx, round(1), digest, || ready(fallback_rx)).await;
             assert!(rx.await.expect("fallback verdict published"));
         });
     }
@@ -409,12 +408,9 @@ mod tests {
             let (task_tx, task_rx) = oneshot::channel();
             let (tx, rx) = oneshot::channel();
             drop(task_tx);
-            drive(tx, task_rx, round(1), digest, || async {
-                let (fallback_tx, fallback_rx) = oneshot::channel();
-                fallback_tx.send_lossy(false);
-                fallback_rx
-            })
-            .await;
+            let (fallback_tx, fallback_rx) = oneshot::channel();
+            fallback_tx.send_lossy(false);
+            drive(tx, task_rx, round(1), digest, || ready(fallback_rx)).await;
             assert!(!rx.await.expect("fallback verdict published"));
         });
     }
@@ -427,10 +423,7 @@ mod tests {
             let (_task_tx, task_rx) = oneshot::channel();
             let (tx, rx) = oneshot::channel();
             drop(rx);
-            drive(tx, task_rx, round(1), digest, || async {
-                unreachable!("abandoned certification must not fall back")
-            })
-            .await;
+            drive(tx, task_rx, round(1), digest, no_fallback).await;
         });
     }
 

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -40,7 +40,7 @@ struct Inner<D: Digest, B> {
 /// Each entry is keyed by `(Round, D)` where `D` is a commitment or digest
 /// identifying the block. The gate task's [`oneshot::Receiver`] is consumed by
 /// certification. [`GateOutcome::Ready`] carries a verdict that applies to the
-/// notarized proposal; [`GateOutcome::Recover`] means the completed work does
+/// notarized proposal. [`GateOutcome::Recover`] means the completed work does
 /// not apply, so certification must use its recovery path. A dropped sender
 /// also triggers recovery because the task did not complete.
 /// Storage sync failures are fatal to the local marshal state and must panic
@@ -75,12 +75,7 @@ impl<D: Digest, B> Gates<D, B> {
     }
 
     /// Registers a certification gate task for the block identified by `(round, digest)`.
-    pub(crate) fn insert(
-        &self,
-        round: Round,
-        digest: D,
-        task: oneshot::Receiver<GateOutcome>,
-    ) {
+    pub(crate) fn insert(&self, round: Round, digest: D, task: oneshot::Receiver<GateOutcome>) {
         self.inner
             .lock()
             .certifications
@@ -88,11 +83,7 @@ impl<D: Digest, B> Gates<D, B> {
     }
 
     /// Removes and returns the certification gate task for `(round, digest)`, if present.
-    pub(crate) fn take(
-        &self,
-        round: Round,
-        digest: D,
-    ) -> Option<oneshot::Receiver<GateOutcome>> {
+    pub(crate) fn take(&self, round: Round, digest: D) -> Option<oneshot::Receiver<GateOutcome>> {
         self.inner.lock().certifications.remove(&(round, digest))
     }
 
@@ -375,6 +366,75 @@ mod tests {
     }
 
     #[test]
+    fn test_drive_adopts_ready_verdict_without_fallback() {
+        let runner = deterministic::Runner::default();
+        runner.start(|_| async move {
+            for verdict in [true, false] {
+                let digest = Sha256::hash(&[b"block"]);
+                let (task_tx, task_rx) = oneshot::channel();
+                let (tx, rx) = oneshot::channel();
+                task_tx.send_lossy(GateOutcome::Ready(verdict));
+                drive(tx, task_rx, round(1), digest, || async {
+                    unreachable!("a ready gate must not fall back")
+                })
+                .await;
+                assert_eq!(rx.await.expect("verdict published"), verdict);
+            }
+        });
+    }
+
+    #[test]
+    fn test_drive_recover_publishes_fallback_verdict() {
+        let runner = deterministic::Runner::default();
+        runner.start(|_| async move {
+            let digest = Sha256::hash(&[b"block"]);
+            let (task_tx, task_rx) = oneshot::channel();
+            let (tx, rx) = oneshot::channel();
+            task_tx.send_lossy(GateOutcome::Recover);
+            drive(tx, task_rx, round(1), digest, || async {
+                let (fallback_tx, fallback_rx) = oneshot::channel();
+                fallback_tx.send_lossy(true);
+                fallback_rx
+            })
+            .await;
+            assert!(rx.await.expect("fallback verdict published"));
+        });
+    }
+
+    #[test]
+    fn test_drive_dropped_sender_publishes_fallback_verdict() {
+        let runner = deterministic::Runner::default();
+        runner.start(|_| async move {
+            let digest = Sha256::hash(&[b"block"]);
+            let (task_tx, task_rx) = oneshot::channel();
+            let (tx, rx) = oneshot::channel();
+            drop(task_tx);
+            drive(tx, task_rx, round(1), digest, || async {
+                let (fallback_tx, fallback_rx) = oneshot::channel();
+                fallback_tx.send_lossy(false);
+                fallback_rx
+            })
+            .await;
+            assert!(!rx.await.expect("fallback verdict published"));
+        });
+    }
+
+    #[test]
+    fn test_drive_abandons_when_consensus_receiver_dropped() {
+        let runner = deterministic::Runner::default();
+        runner.start(|_| async move {
+            let digest = Sha256::hash(&[b"block"]);
+            let (_task_tx, task_rx) = oneshot::channel();
+            let (tx, rx) = oneshot::channel();
+            drop(rx);
+            drive(tx, task_rx, round(1), digest, || async {
+                unreachable!("abandoned certification must not fall back")
+            })
+            .await;
+        });
+    }
+
+    #[test]
     fn test_stage_handshake() {
         let runner = deterministic::Runner::default();
         runner.start(|context| async move {
@@ -401,10 +461,7 @@ mod tests {
 
             // Delivering a durable handle resolves the gate.
             ack.send_lossy(Handle::ready(Ok(())));
-            assert_eq!(
-                gate.await.expect("gate resolved"),
-                GateOutcome::Ready(true)
-            );
+            assert_eq!(gate.await.expect("gate resolved"), GateOutcome::Ready(true));
         });
     }
 

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -16,10 +16,19 @@ use tracing::debug;
 /// delivers its durable-sync handle once marshal persists it.
 type Staged<B> = (Arc<B>, oneshot::Sender<Handle<()>>);
 
+/// Result of an in-flight certification gate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum GateOutcome {
+    /// The gate produced a verdict that applies to the notarized proposal.
+    Ready(bool),
+    /// The gate's result does not apply to the notarized proposal.
+    Recover,
+}
+
 /// The registries behind [`Gates`], sharing one lock.
 struct Inner<D: Digest, B> {
     /// In-flight certification gate tasks, consumed by certification.
-    certifications: HashMap<(Round, D), oneshot::Receiver<bool>>,
+    certifications: HashMap<(Round, D), oneshot::Receiver<GateOutcome>>,
     /// Proposals staged for their relay broadcast, consumed by the relay (or
     /// by certification when no broadcast was requested).
     proposals: HashMap<(Round, D), Staged<B>>,
@@ -29,12 +38,11 @@ struct Inner<D: Digest, B> {
 /// staged proposals.
 ///
 /// Each entry is keyed by `(Round, D)` where `D` is a commitment or digest
-/// identifying the block. The gate task's [`oneshot::Receiver<bool>`] is
-/// consumed by certification and resolves to `true` only when that path may cast
-/// a finalize vote: local proposal durability has completed, or verification
-/// accepted the block and completed the required durable store. A resolved
-/// `false` records a live local rejection. A dropped sender means the task did
-/// not complete, so certification may fall back to its recovery fetch path.
+/// identifying the block. The gate task's [`oneshot::Receiver`] is consumed by
+/// certification. [`GateOutcome::Ready`] carries a verdict that applies to the
+/// notarized proposal; [`GateOutcome::Recover`] means the completed work does
+/// not apply, so certification must use its recovery path. A dropped sender
+/// also triggers recovery because the task did not complete.
 /// Storage sync failures are fatal to the local marshal state and must panic
 /// before resolving the task.
 ///
@@ -67,7 +75,12 @@ impl<D: Digest, B> Gates<D, B> {
     }
 
     /// Registers a certification gate task for the block identified by `(round, digest)`.
-    pub(crate) fn insert(&self, round: Round, digest: D, task: oneshot::Receiver<bool>) {
+    pub(crate) fn insert(
+        &self,
+        round: Round,
+        digest: D,
+        task: oneshot::Receiver<GateOutcome>,
+    ) {
         self.inner
             .lock()
             .certifications
@@ -75,7 +88,11 @@ impl<D: Digest, B> Gates<D, B> {
     }
 
     /// Removes and returns the certification gate task for `(round, digest)`, if present.
-    pub(crate) fn take(&self, round: Round, digest: D) -> Option<oneshot::Receiver<bool>> {
+    pub(crate) fn take(
+        &self,
+        round: Round,
+        digest: D,
+    ) -> Option<oneshot::Receiver<GateOutcome>> {
         self.inner.lock().certifications.remove(&(round, digest))
     }
 
@@ -157,7 +174,7 @@ impl<D: Digest, B> Gates<D, B> {
         if !handle.durable(round, name).await {
             return;
         }
-        durable_tx.send_lossy(true);
+        durable_tx.send_lossy(GateOutcome::Ready(true));
         debug!(?round, ?id, name, "block durable");
     }
 }
@@ -177,15 +194,15 @@ pub(crate) const fn resolve(verdict: Option<bool>, durable: bool) -> Option<bool
     }
 }
 
-/// Drives a certification gate `task` to a certify verdict, recovering through `fallback` after an
-/// unclean restart.
+/// Drives a certification gate `task` to a certify verdict, recovering through `fallback` when the
+/// gate cannot speak for the notarized proposal.
 ///
-/// A resolved verdict is published on `tx`. A dropped sender (the in-memory task is gone after
-/// restart) triggers `fallback`, whose receiver is awaited and published instead. A
-/// consensus-dropped receiver (`tx.closed()`) abandons the work.
+/// A ready verdict is published on `tx`. [`GateOutcome::Recover`] or a dropped sender triggers
+/// `fallback`, whose receiver is awaited and published instead. A consensus-dropped receiver
+/// (`tx.closed()`) abandons the work.
 pub(crate) async fn drive<D, F, Fut>(
     mut tx: oneshot::Sender<bool>,
-    task: oneshot::Receiver<bool>,
+    task: oneshot::Receiver<GateOutcome>,
     round: Round,
     id: D,
     fallback: F,
@@ -205,14 +222,14 @@ pub(crate) async fn drive<D, F, Fut>(
         result = task => result,
     };
     match result {
-        Ok(result) => {
+        Ok(GateOutcome::Ready(result)) => {
             tx.send_lossy(result);
         }
-        Err(_) => {
+        Ok(GateOutcome::Recover) | Err(_) => {
             debug!(
                 ?round,
                 ?id,
-                "certification gate task closed before certification, falling back to embedded context"
+                "certification gate requires recovery, falling back to embedded context"
             );
             let fallback = fallback().await;
             let result = select! {
@@ -246,7 +263,7 @@ mod tests {
         Round::new(Epoch::zero(), View::new(view))
     }
 
-    fn pending_task() -> oneshot::Receiver<bool> {
+    fn pending_task() -> oneshot::Receiver<GateOutcome> {
         let (_tx, rx) = oneshot::channel();
         rx
     }
@@ -384,7 +401,10 @@ mod tests {
 
             // Delivering a durable handle resolves the gate.
             ack.send_lossy(Handle::ready(Ok(())));
-            assert!(gate.await.expect("gate resolved"));
+            assert_eq!(
+                gate.await.expect("gate resolved"),
+                GateOutcome::Ready(true)
+            );
         });
     }
 

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -995,6 +995,12 @@ where
                         },
                     };
 
+                    // A rejection here is safe to publish as a gate verdict because
+                    // the boundary check is intrinsic to `(round, commitment)`: it
+                    // reads only the block's height and the round's epoch. The
+                    // commitment also binds the original proposal context, so no
+                    // honest notarization can form for this key under a conflicting
+                    // header.
                     if !is_valid_reproposal_at_verify(&epocher, block.height(), round.epoch()) {
                         debug!(
                             height = %block.height(),

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -84,7 +84,7 @@ use crate::{
     marshal::{
         Update,
         application::{
-            gates::{self, Gates},
+            gates::{self, GateOutcome, Gates},
             validation::{Stage, is_inferred_reproposal_at_certify, is_valid_reproposal_at_verify},
         },
         coding::{
@@ -320,7 +320,7 @@ where
         commitment: Commitment,
         prefetched_block: Option<Arc<CodedBlock<B, C, H>>>,
         stage: Stage,
-    ) -> oneshot::Receiver<bool> {
+    ) -> oneshot::Receiver<GateOutcome> {
         let marshal = self.marshal.clone();
         let mut application = self.application.clone();
         let epocher = self.epocher.clone();
@@ -473,7 +473,7 @@ where
                 // candidates may already be in the cache from the concurrent store above,
                 // so the gate verdict is the authority for consensus progress.
                 if let Some(application_valid) = gates::resolve(verdict, durable) {
-                    tx.send_lossy(application_valid);
+                    tx.send_lossy(GateOutcome::Ready(application_valid));
                 }
             }
             .instrument(span)
@@ -585,7 +585,7 @@ where
                 let verify_rx = marshaled
                     .deferred_verify(embedded_context, payload, Some(block), Stage::Certified)
                     .await;
-                if let Ok(result) = verify_rx.await {
+                if let Ok(GateOutcome::Ready(result)) = verify_rx.await {
                     tx.send_lossy(result);
                 }
             }
@@ -603,7 +603,7 @@ where
         &mut self,
         round: Round,
         payload: Commitment,
-        task: oneshot::Receiver<bool>,
+        task: oneshot::Receiver<GateOutcome>,
     ) -> oneshot::Receiver<bool> {
         // `verify()` intentionally waits only for local candidate data. Once
         // certification starts, a notarization exists and the same pending
@@ -612,8 +612,9 @@ where
         self.shards.notarized(payload, round);
         self.marshal.hint_notarized(round, payload);
 
-        // A completed gate is a live local verdict. After an unclean restart the
-        // in-memory task is gone, so recover via the embedded-context fetch path.
+        // A completed gate either carries an applicable local verdict or requests
+        // recovery. After an unclean restart the in-memory task is gone, which also
+        // recovers via the embedded-context fetch path.
         let mut marshaled = self.clone();
         let (tx, rx) = oneshot::channel();
         let context = self
@@ -999,7 +1000,7 @@ where
                             height = %block.height(),
                             "re-proposal is not at epoch boundary"
                         );
-                        task_tx.send_lossy(false);
+                        task_tx.send_lossy(GateOutcome::Ready(false));
                         tx.send_lossy(false);
                         return;
                     }
@@ -1010,7 +1011,7 @@ where
                     if !durable {
                         return;
                     }
-                    task_tx.send_lossy(true);
+                    task_tx.send_lossy(GateOutcome::Ready(true));
                     tx.send_lossy(true);
                 }
                 .instrument(info_span!(

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1434,6 +1434,35 @@ mod tests {
                 "Valid re-proposal at epoch boundary should be accepted"
             );
 
+            // The same boundary commitment may be re-proposed again after the
+            // first re-proposal certifies. Its parent view advances while its
+            // parent payload remains the boundary commitment. Re-proposal
+            // validation is intrinsic to the committed block and must return
+            // the same result under both headers.
+            let repeated_reproposal_round =
+                Round::new(Epoch::new(0), View::new(boundary_height.get() + 2));
+            let repeated_reproposal_context = CodingCtx {
+                round: repeated_reproposal_round,
+                leader: me.clone(),
+                parent: (reproposal_round.view(), boundary_commitment),
+            };
+            let repeated_verify = marshaled
+                .verify(repeated_reproposal_context, boundary_commitment)
+                .await
+                .await;
+            assert!(
+                repeated_verify.unwrap(),
+                "Repeated re-proposal should remain valid as the parent view advances"
+            );
+            let repeated_certify = marshaled
+                .certify(repeated_reproposal_round, boundary_commitment)
+                .await
+                .await;
+            assert!(
+                repeated_certify.unwrap(),
+                "Repeated re-proposal certification should remain valid"
+            );
+
             // Test 2: Invalid re-proposal (not at epoch boundary) should be rejected
             // Create a block at height 10 (not at epoch boundary)
             let non_boundary_height = Height::new(10);

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1363,6 +1363,12 @@ mod tests {
             let mut parent = genesis.digest();
             let mut last_view = View::zero();
             let mut last_commitment = genesis_commitment();
+
+            // Capture a genuinely-chained non-boundary block (height 10) so Test 2
+            // can re-propose one that validates cleanly under its own embedded
+            // context. Without this, a certify rejection there could come from an
+            // ancestry error rather than the re-proposal boundary gate under test.
+            let mut non_boundary = None;
             for i in 1..BLOCKS_PER_EPOCH.get() - 1 {
                 let round = Round::new(Epoch::new(0), View::new(i));
                 let ctx = CodingCtx {
@@ -1373,10 +1379,15 @@ mod tests {
                 let block = make_coding_block(ctx.clone(), parent, Height::new(i), i * 100);
                 let coded_block = CodedBlock::new(block.clone(), coding_config, &Sequential);
                 last_commitment = coded_block.commitment();
+                if i == 10 {
+                    non_boundary = Some((View::new(i), last_commitment));
+                }
                 shards.proposed(round, coded_block);
                 parent = block.digest();
                 last_view = View::new(i);
             }
+            let (non_boundary_view, non_boundary_commitment) =
+                non_boundary.expect("chain includes a non-boundary block");
 
             // Create the epoch boundary block (height 19, last block in epoch 0)
             let boundary_height = Height::new(BLOCKS_PER_EPOCH.get() - 1);
@@ -1464,37 +1475,16 @@ mod tests {
                 "Repeated re-proposal certification should remain valid"
             );
 
-            // Test 2: Invalid re-proposal (not at epoch boundary) should be rejected
-            // Create a block at height 10 (not at epoch boundary)
-            let non_boundary_height = Height::new(10);
-            let non_boundary_round = Round::new(Epoch::new(0), View::new(10));
-            // For simplicity, we'll create a fresh non-boundary block and test re-proposal
-            let non_boundary_context = CodingCtx {
-                round: non_boundary_round,
-                leader: me.clone(),
-                parent: (View::new(9), last_commitment), // Use a prior commitment
-            };
-            let non_boundary_block = make_coding_block(
-                non_boundary_context.clone(),
-                parent,
-                non_boundary_height,
-                1000,
-            );
-            let coded_non_boundary =
-                CodedBlock::new(non_boundary_block.clone(), coding_config, &Sequential);
-            let non_boundary_commitment = coded_non_boundary.commitment();
-
-            // Make the non-boundary block available
-            shards.proposed(non_boundary_round, coded_non_boundary);
-
-            context.sleep(Duration::from_millis(10)).await;
-
-            // Attempt to re-propose the non-boundary block
+            // Test 2: Invalid re-proposal (not at epoch boundary) should be
+            // rejected. Re-propose the genuinely-chained height-10 block at view
+            // 15. Because that block validates cleanly under its embedded context,
+            // a certify rejection can only come from the re-proposal boundary gate,
+            // not from an ancestry error.
             let invalid_reproposal_round = Round::new(Epoch::new(0), View::new(15));
             let invalid_reproposal_context = CodingCtx {
                 round: invalid_reproposal_round,
                 leader: me.clone(),
-                parent: (View::new(10), non_boundary_commitment),
+                parent: (non_boundary_view, non_boundary_commitment),
             };
 
             // Call verify to kick off deferred verification.

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -100,7 +100,7 @@ mod tests {
         sha256::Sha256,
     };
     use commonware_macros::{select, test_group, test_traced};
-    use commonware_p2p::Recipients;
+    use commonware_p2p::{Recipients, Sender as _};
     use commonware_parallel::Sequential;
     use commonware_resolver::{Delivery, Fetch, Resolver, TargetedResolver};
     use commonware_runtime::{
@@ -1357,12 +1357,13 @@ mod tests {
             };
             let genesis = make_coding_block(genesis_ctx, Sha256::hash(&[b""]), Height::zero(), 0);
 
-            // Build a chain up to the epoch boundary (height 19 is the last block in epoch 0
-            // with BLOCKS_PER_EPOCH=20, since epoch 0 covers heights 0-19)
+            // Build a chain up to just below the epoch boundary (height 19 is the last
+            // block in epoch 0 with BLOCKS_PER_EPOCH=20, since epoch 0 covers heights
+            // 0-19), so the boundary block below chains onto height 18.
             let mut parent = genesis.digest();
             let mut last_view = View::zero();
             let mut last_commitment = genesis_commitment();
-            for i in 1..BLOCKS_PER_EPOCH.get() {
+            for i in 1..BLOCKS_PER_EPOCH.get() - 1 {
                 let round = Round::new(Epoch::new(0), View::new(i));
                 let ctx = CodingCtx {
                     round,
@@ -2293,6 +2294,124 @@ mod tests {
                 },
                 _ = context.sleep(Duration::from_secs(5)) => {
                     panic!("certify should complete within timeout");
+                },
+            }
+        })
+    }
+
+    /// A Byzantine leader can deliver assigned shards to only f+1 honest
+    /// validators and form a notarization with its own vote, leaving no peer
+    /// able to serve a full-block fetch. A validator that never saw the
+    /// proposal then holds only buffered sender-indexed gossip shards, and
+    /// draining them requires the reconstruction interest that `certify`
+    /// registers with the shard engine (`shards.notarized`).
+    #[test_traced("WARN")]
+    fn test_certify_reconstructs_from_buffered_gossip_shards() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            // Register the peers' shard-channel senders and link the network.
+            // No peer runs a marshal actor, so round-bound block fetches go
+            // unanswered.
+            let mut peer_senders = Vec::new();
+            for peer in participants.iter().skip(1) {
+                let (sender, _receiver) = oracle
+                    .control(peer.clone())
+                    .register(2, TEST_QUOTA)
+                    .await
+                    .unwrap();
+                peer_senders.push(sender);
+            }
+            setup_network_links(&mut oracle, &participants, LINK).await;
+
+            let genesis_ctx = CodingCtx {
+                round: Round::zero(),
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let genesis = make_coding_block(genesis_ctx, Sha256::hash(&[b""]), Height::zero(), 0);
+
+            let mock_app: MockVerifyingApp<CodingB, S> = MockVerifyingApp::new();
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            // The parent is available locally. The notarized candidate is not:
+            // this validator never saw its proposal.
+            let parent_round = Round::new(Epoch::zero(), View::new(1));
+            let parent_ctx = CodingCtx {
+                round: parent_round,
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let parent = make_coding_block(parent_ctx, genesis.digest(), Height::new(1), 100);
+            let coded_parent = CodedBlock::new(parent.clone(), coding_config, &Sequential);
+            let parent_commitment = coded_parent.commitment();
+            shards.proposed(parent_round, coded_parent);
+
+            let child_round = Round::new(Epoch::zero(), View::new(2));
+            let child_ctx = CodingCtx {
+                round: child_round,
+                leader: participants[1].clone(),
+                parent: (View::new(1), parent_commitment),
+            };
+            let child = make_coding_block(child_ctx, parent.digest(), Height::new(2), 200);
+            let coded_child: TestCodedBlock = CodedBlock::new(child, coding_config, &Sequential);
+            let child_commitment = coded_child.commitment();
+
+            // Deliver each peer's sender-indexed gossip shard. Without leader
+            // discovery or reconstruction interest, the shard engine only
+            // buffers them.
+            for (i, sender) in peer_senders.iter_mut().enumerate() {
+                let index = u16::try_from(i + 1).expect("peer index fits in u16");
+                let shard = coded_child.shard(index).expect("missing shard").encode();
+                sender.send(Recipients::One(me.clone()), shard, true);
+            }
+            context.sleep(Duration::from_millis(250)).await;
+
+            // Certify must register reconstruction interest with the shard
+            // engine, drain the buffered shards, and verify the reconstructed
+            // block through its embedded context.
+            let certify_rx = marshaled.certify(child_round, child_commitment).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "certify must reconstruct the candidate from buffered gossip shards"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify did not reconstruct from buffered gossip shards");
                 },
             }
         })

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -2393,6 +2393,139 @@ mod tests {
         })
     }
 
+    /// Coding analog of the standard equivocation tests. The commitment binds
+    /// the proposal context, so a proposal that names a different parent for
+    /// the same commitment fails `validate_proposal` before any certification
+    /// gate is registered. Certification of the notarized commitment then
+    /// recovers through the block's embedded context.
+    #[test_traced("WARN")]
+    fn test_certify_not_poisoned_by_equivocating_parent_verify() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let genesis_ctx = CodingCtx {
+                round: Round::zero(),
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let genesis = make_coding_block(genesis_ctx, Sha256::hash(&[b""]), Height::zero(), 0);
+
+            let mock_app: MockVerifyingApp<CodingB, S> = MockVerifyingApp::new();
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            // The view-1 block: the parent this validator last certified.
+            let certified_round = Round::new(Epoch::zero(), View::new(1));
+            let certified_ctx = CodingCtx {
+                round: certified_round,
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let certified = make_coding_block(certified_ctx, genesis.digest(), Height::new(1), 100);
+            let certified_digest = certified.digest();
+            let coded_certified = CodedBlock::new(certified, coding_config, &Sequential);
+            let certified_commitment = coded_certified.commitment();
+            shards.proposed(certified_round, coded_certified);
+
+            // The view-2 block: notarized by the network but only nullified
+            // here, so this validator never certified it.
+            let notarized_round = Round::new(Epoch::zero(), View::new(2));
+            let notarized_ctx = CodingCtx {
+                round: notarized_round,
+                leader: me.clone(),
+                parent: (View::new(1), certified_commitment),
+            };
+            let notarized = make_coding_block(notarized_ctx, certified_digest, Height::new(2), 200);
+            let notarized_digest = notarized.digest();
+            let coded_notarized = CodedBlock::new(notarized, coding_config, &Sequential);
+            let notarized_commitment = coded_notarized.commitment();
+            shards.proposed(notarized_round, coded_notarized);
+
+            // The view-3 block builds on the view-2 block.
+            let round = Round::new(Epoch::zero(), View::new(3));
+            let block_ctx = CodingCtx {
+                round,
+                leader: me.clone(),
+                parent: (View::new(2), notarized_commitment),
+            };
+            let block = make_coding_block(block_ctx, notarized_digest, Height::new(3), 300);
+            let coded_block = CodedBlock::new(block, coding_config, &Sequential);
+            let commitment = coded_block.commitment();
+            shards.proposed(round, coded_block);
+
+            context.sleep(Duration::from_millis(10)).await;
+
+            // The equivocating proposal names the certified view-1 block as
+            // parent, which this validator's parent selection accepts
+            // (view 1 certified, view 2 nullified). The commitment's context
+            // digest exposes the mismatch, so verify rejects it without
+            // registering a certification gate.
+            let equivocating_ctx = CodingCtx {
+                round,
+                leader: me.clone(),
+                parent: (View::new(1), certified_commitment),
+            };
+            let verify_rx = marshaled.verify(equivocating_ctx, commitment).await;
+            select! {
+                result = verify_rx => {
+                    assert!(
+                        !result.expect("verify result missing"),
+                        "the equivocating proposal must not be notarized"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("verify should reject the equivocating proposal promptly");
+                },
+            }
+
+            // The honest notarization for the same `(round, commitment)`
+            // arrives. Certification recovers through the embedded context.
+            let certify_rx = marshaled.certify(round, commitment).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "certify of the notarized commitment must succeed via the embedded context"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
+                },
+            }
+        })
+    }
+
     #[test_traced("WARN")]
     fn test_backfill_block_mismatched_commitment() {
         // Regression: when backfilling by Key::Block(commitment), a peer may return

--- a/consensus/src/marshal/coding/validation.rs
+++ b/consensus/src/marshal/coding/validation.rs
@@ -493,7 +493,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reproposal_context_exception_does_not_validate_later_normal_context() {
+    fn test_validate_proposal_reproposal_exception_not_valid_in_later_context() {
         let fixture = baseline_fixture();
         let later_context = Round::new(Epoch::new(0), View::new(8));
 

--- a/consensus/src/marshal/coding/validation.rs
+++ b/consensus/src/marshal/coding/validation.rs
@@ -493,18 +493,27 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_proposal_none_context_skips_context_digest_check() {
+    fn test_reproposal_context_exception_does_not_validate_later_normal_context() {
         let fixture = baseline_fixture();
-        let wrong_context = Round::new(Epoch::new(0), View::new(8));
-        let payload_with_wrong_context = commitment_for(
-            fixture.block.digest(),
-            wrong_context,
-            fixture.config,
-            b"block_root",
-        );
+        let later_context = Round::new(Epoch::new(0), View::new(8));
+
+        // Re-proposals deliberately skip the context-digest check because the
+        // commitment retains the original proposal context.
         assert_eq!(
-            validate_proposal::<Sha256, Round>(payload_with_wrong_context, fixture.config, None),
+            validate_proposal::<Sha256, Round>(fixture.commitment, fixture.config, None),
             Ok(())
+        );
+
+        // The same commitment cannot also be accepted as a normal proposal in
+        // a later context. This prevents the re-proposal exception from
+        // aliasing a distinct context-dependent certification outcome.
+        assert_eq!(
+            validate_proposal::<Sha256, _>(
+                fixture.commitment,
+                fixture.config,
+                Some(&later_context)
+            ),
+            Err(ProposalError::ContextDigest)
         );
     }
 

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -75,7 +75,7 @@ use crate::{
     marshal::{
         Update,
         application::{
-            gates::{self, Gates},
+            gates::{self, GateOutcome, Gates},
             validation::{Stage, is_inferred_reproposal_at_certify},
         },
         core::{CommitmentFallback, DigestFallback, Mailbox},
@@ -247,7 +247,7 @@ where
         block: Arc<B>,
         parent_request: oneshot::Receiver<Arc<B>>,
         stage: Stage,
-    ) -> oneshot::Receiver<bool> {
+    ) -> oneshot::Receiver<GateOutcome> {
         let marshal = self.marshal.clone();
         let mut application = self.application.clone();
         let (mut tx, rx) = oneshot::channel();
@@ -305,7 +305,7 @@ where
                 // candidates may already be in the cache from the concurrent store above,
                 // so the gate verdict is the authority for consensus progress.
                 if let Some(application_valid) = gates::resolve(verdict, durable) {
-                    tx.send_lossy(application_valid);
+                    tx.send_lossy(GateOutcome::Ready(application_valid));
                 }
             }
             .instrument(span)
@@ -415,7 +415,7 @@ where
                 let verify_rx = marshaled
                     .deferred_verify(embedded_context, block, parent_request, Stage::Certified)
                     .await;
-                if let Ok(result) = verify_rx.await {
+                if let Ok(GateOutcome::Ready(result)) = verify_rx.await {
                     tx.send_lossy(result);
                 }
             }
@@ -433,7 +433,7 @@ where
         &mut self,
         round: Round,
         digest: B::Digest,
-        task: oneshot::Receiver<bool>,
+        task: oneshot::Receiver<GateOutcome>,
     ) -> oneshot::Receiver<bool> {
         // `verify()` waits only on local broadcast delivery, so nudge a
         // round-bound notarized fetch that can unblock the existing waiter
@@ -441,8 +441,9 @@ where
         // digest is also the variant commitment.
         self.marshal.hint_notarized(round, digest);
 
-        // A completed gate is a live local verdict. After an unclean restart the
-        // in-memory task is gone, so recover via the embedded-context fetch path.
+        // A completed gate either carries an applicable local verdict or requests
+        // recovery. After an unclean restart the in-memory task is gone, which also
+        // recovers via the embedded-context fetch path.
         let mut marshaled = self.clone();
         let (tx, rx) = oneshot::channel();
         let context = self
@@ -771,7 +772,7 @@ where
                     Decision::Complete(valid) => {
                         // `Complete` means either immediate rejection or successful
                         // re-proposal handling with no further ancestry validation.
-                        task_tx.send_lossy(valid);
+                        task_tx.send_lossy(GateOutcome::Ready(valid));
                         tx.send_lossy(valid);
                         return;
                     }
@@ -797,7 +798,7 @@ where
                         block_context = ?block.context(),
                         "block-embedded context does not match consensus context during optimistic verification"
                     );
-                    task_tx.send_lossy(false);
+                    task_tx.send_lossy(GateOutcome::Recover);
                     tx.send_lossy(false);
                     return;
                 }

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -1689,4 +1689,202 @@ mod tests {
             );
         });
     }
+
+    /// Shared scenario for the proposal-parent equivocation tests.
+    ///
+    /// The local validator certified the view-1 block but only nullified view 2,
+    /// while the rest of the network notarized and certified the view-2 block.
+    /// The view-3 leader builds on the view-2 block and broadcasts it, so the
+    /// block is buffered locally but was never verified here. The equivocating
+    /// context names the certified view-1 block as parent, which this
+    /// validator's parent selection accepts (view 1 certified, view 2 nullified).
+    struct EquivocationFixture {
+        marshaled: Deferred<deterministic::Context, S, MockVerifyingApp<B, S>, B, FixedEpocher>,
+        round: Round,
+        digest: <B as Digestible>::Digest,
+        embedded_ctx: Ctx,
+        equivocating_ctx: Ctx,
+        _extra: <StandardHarness as TestHarness>::ValidatorExtra,
+    }
+
+    async fn equivocation_fixture(
+        context: &mut deterministic::Context,
+        app: MockVerifyingApp<B, S>,
+    ) -> EquivocationFixture {
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = bls12381_threshold_vrf::fixture::<V, _>(context, NAMESPACE, NUM_VALIDATORS);
+        let mut oracle = setup_network_with_participants(
+            context.child("network"),
+            NZUsize!(1),
+            participants.clone(),
+        )
+        .await;
+
+        let me = participants[0].clone();
+        let setup = StandardHarness::setup_validator(
+            context.child("validator").with_attribute("index", 0),
+            &mut oracle,
+            me,
+            ConstantProvider::new(schemes[0].clone()),
+        )
+        .await;
+        let marshal = setup.mailbox;
+        let buffer = setup.extra;
+
+        let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
+        let leader = participants[1].clone();
+
+        // The view-1 block: the parent this validator last certified.
+        let certified_round = Round::new(Epoch::zero(), View::new(1));
+        let certified_ctx = Ctx {
+            round: certified_round,
+            leader: default_leader(),
+            parent: (View::zero(), genesis.digest()),
+        };
+        let certified = B::new::<Sha256>(certified_ctx, genesis.digest(), Height::new(1), 100);
+        let certified_digest = certified.digest();
+        assert!(marshal.verified(certified_round, certified).await);
+
+        // The view-2 block: notarized by the network but only nullified here,
+        // so this validator never certified it.
+        let notarized_round = Round::new(Epoch::zero(), View::new(2));
+        let notarized_ctx = Ctx {
+            round: notarized_round,
+            leader: leader.clone(),
+            parent: (View::new(1), certified_digest),
+        };
+        let notarized = B::new::<Sha256>(notarized_ctx, certified_digest, Height::new(2), 200);
+        let notarized_digest = notarized.digest();
+        assert!(marshal.verified(notarized_round, notarized).await);
+
+        // The view-3 block builds on the view-2 block. The leader's broadcast
+        // delivered it into the local buffer without a local verification.
+        let round = Round::new(Epoch::zero(), View::new(3));
+        let embedded_ctx = Ctx {
+            round,
+            leader: leader.clone(),
+            parent: (View::new(2), notarized_digest),
+        };
+        let block = B::new::<Sha256>(embedded_ctx.clone(), notarized_digest, Height::new(3), 300);
+        let digest = block.digest();
+        assert!(
+            buffer
+                .broadcast(commonware_p2p::Recipients::Some(vec![]), block)
+                .accepted(),
+            "buffer broadcast for the candidate should be accepted"
+        );
+
+        let equivocating_ctx = Ctx {
+            round,
+            leader,
+            parent: (View::new(1), certified_digest),
+        };
+
+        let marshaled = Deferred::new(
+            context.child("deferred"),
+            app,
+            marshal,
+            FixedEpocher::new(BLOCKS_PER_EPOCH),
+        );
+        context.sleep(Duration::from_millis(10)).await;
+
+        EquivocationFixture {
+            marshaled,
+            round,
+            digest,
+            embedded_ctx,
+            equivocating_ctx,
+            _extra: buffer,
+        }
+    }
+
+    /// A leader can equivocate at the proposal layer: sign one proposal for a
+    /// digest declaring the notarized view-2 parent (sent to the validators
+    /// that certified view 2) and another declaring the certified view-1
+    /// parent (sent to a validator that only nullified view 2). Both pass
+    /// their recipients' parent selection and carry the same digest because
+    /// they name the same block.
+    ///
+    /// Refusing to notarize the mismatched proposal is correct. That refusal
+    /// must not outlive the proposal: once the honest notarization for
+    /// `(round, digest)` arrives, certification must judge the block against
+    /// its embedded context (defended by the notarizing quorum) and succeed.
+    /// Adopting the verdict computed under the equivocating context wedges
+    /// this validator in the view: the other honest validators have certified
+    /// and advanced, leaving too few validators to form either a nullification
+    /// or a finalization after the Byzantine validator stops participating.
+    #[test_traced("WARN")]
+    fn test_certify_not_poisoned_by_equivocating_parent_verify() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let mut fixture = equivocation_fixture(&mut context, MockVerifyingApp::new()).await;
+
+            let verify_rx = fixture
+                .marshaled
+                .verify(fixture.equivocating_ctx.clone(), fixture.digest)
+                .await;
+            assert!(
+                !verify_rx.await.expect("verify result missing"),
+                "the equivocating proposal must not be notarized"
+            );
+
+            let certify_rx = fixture
+                .marshaled
+                .certify(fixture.round, fixture.digest)
+                .await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "certify of the notarized digest must not adopt the verdict computed under the equivocating context"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
+                },
+            }
+        });
+    }
+
+    /// Control for the equivocation tests: a live application rejection under
+    /// the matching context is a real verdict. Certification must keep
+    /// honoring it, because deferred voting means a notarization can exist
+    /// for an application-invalid block.
+    #[test_traced("WARN")]
+    fn test_certify_honors_application_rejection() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let mut fixture =
+                equivocation_fixture(&mut context, MockVerifyingApp::with_verify_result(false))
+                    .await;
+
+            let verify_rx = fixture
+                .marshaled
+                .verify(fixture.embedded_ctx.clone(), fixture.digest)
+                .await;
+            assert!(
+                verify_rx.await.expect("verify result missing"),
+                "optimistic verify accepts an available block with a matching context"
+            );
+
+            let certify_rx = fixture
+                .marshaled
+                .certify(fixture.round, fixture.digest)
+                .await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        !result.expect("certify result missing"),
+                        "certify must propagate the application rejection"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
+                },
+            }
+        });
+    }
 }

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -772,6 +772,14 @@ where
                     Decision::Complete(valid) => {
                         // `Complete` means either immediate rejection or successful
                         // re-proposal handling with no further ancestry validation.
+                        //
+                        // A rejection is safe to publish as a gate verdict because the
+                        // precheck depends only on the block's height and the gate key's
+                        // epoch, never on the declared parent. A conflicting header for
+                        // the same `(round, digest)` cannot produce an honest
+                        // notarization: reading the digest as a re-proposal requires it
+                        // to be the recorded payload of an earlier view, so its embedded
+                        // context fails the mismatch check under any normal header.
                         task_tx.send_lossy(GateOutcome::Ready(valid));
                         tx.send_lossy(valid);
                         return;

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -1462,4 +1462,121 @@ mod tests {
             );
         });
     }
+
+    /// Inline analog of the deferred equivocation test. A proposal that names
+    /// the certified view-1 parent for a block built on the view-2 block
+    /// fails structural parent validation, which resolves the certification
+    /// gate to false. Certification of the honest notarization for the same
+    /// `(round, digest)` must not adopt that verdict: the no-gate fallback
+    /// already certifies any notarized block it can fetch.
+    #[test_traced("WARN")]
+    fn test_certify_not_poisoned_by_equivocating_parent_verify() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let setup = StandardHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me,
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let buffer = setup.extra;
+
+            let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
+            let mock_app: MockVerifyingApp<B, S> = MockVerifyingApp::new();
+            let mut inline = Inline::new(
+                context.child("inline"),
+                mock_app,
+                marshal.clone(),
+                FixedEpocher::new(BLOCKS_PER_EPOCH),
+            );
+
+            let leader = participants[1].clone();
+
+            // The view-1 block: the parent this validator last certified.
+            let certified_round = Round::new(Epoch::zero(), View::new(1));
+            let certified_ctx = Ctx {
+                round: certified_round,
+                leader: default_leader(),
+                parent: (View::zero(), genesis.digest()),
+            };
+            let certified = B::new::<Sha256>(certified_ctx, genesis.digest(), Height::new(1), 100);
+            let certified_digest = certified.digest();
+            assert!(marshal.verified(certified_round, certified).await);
+
+            // The view-2 block: notarized by the network but only nullified
+            // here, so this validator never certified it.
+            let notarized_round = Round::new(Epoch::zero(), View::new(2));
+            let notarized_ctx = Ctx {
+                round: notarized_round,
+                leader: leader.clone(),
+                parent: (View::new(1), certified_digest),
+            };
+            let notarized = B::new::<Sha256>(notarized_ctx, certified_digest, Height::new(2), 200);
+            let notarized_digest = notarized.digest();
+            assert!(marshal.verified(notarized_round, notarized).await);
+
+            // The view-3 block builds on the view-2 block. The leader's
+            // broadcast delivered it into the local buffer without a local
+            // verification.
+            let round = Round::new(Epoch::zero(), View::new(3));
+            let block_ctx = Ctx {
+                round,
+                leader: leader.clone(),
+                parent: (View::new(2), notarized_digest),
+            };
+            let block = B::new::<Sha256>(block_ctx, notarized_digest, Height::new(3), 300);
+            let digest = block.digest();
+            assert!(
+                buffer
+                    .broadcast(commonware_p2p::Recipients::Some(vec![]), block)
+                    .accepted(),
+                "buffer broadcast for the candidate should be accepted"
+            );
+            context.sleep(Duration::from_millis(10)).await;
+
+            // The equivocating proposal names the certified view-1 block as
+            // parent, which this validator's parent selection accepts
+            // (view 1 certified, view 2 nullified). Refusing to notarize it
+            // is correct.
+            let equivocating_ctx = Ctx {
+                round,
+                leader,
+                parent: (View::new(1), certified_digest),
+            };
+            let verify_rx = inline.verify(equivocating_ctx, digest).await;
+            assert!(
+                !verify_rx.await.expect("verify result missing"),
+                "the equivocating proposal must not be notarized"
+            );
+
+            // The honest notarization for the same `(round, digest)` arrives.
+            let certify_rx = inline.certify(round, digest).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "certify of the notarized digest must not adopt the verdict computed under the equivocating context"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
+                },
+            }
+        });
+    }
 }

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -490,9 +490,10 @@ where
                 };
                 let block = match decision {
                     Decision::Complete(valid) => {
-                        // Re-proposal: precheck already persisted the block (durable) when
-                        // valid; epoch-reject when invalid. An invalid precheck is not a
-                        // certification verdict for a potentially conflicting header.
+                        // Re-proposal: a valid precheck already persisted the block
+                        // (durable), an invalid one is an epoch rejection. An invalid
+                        // precheck is not a certification verdict for a potentially
+                        // conflicting header.
                         tx.send_lossy(valid);
                         durable_tx.send_lossy(if valid {
                             GateOutcome::Ready(true)
@@ -570,7 +571,8 @@ where
 }
 
 /// Inline certification consumes a registered certification gate when present, and
-/// falls back to a round-bound fetch/persist path after restart.
+/// falls back to a round-bound fetch/persist path when the gate is missing (after
+/// an unclean restart) or cannot speak for the notarized proposal.
 impl<E, S, A, B, ES> CertifiableAutomaton for Inline<E, S, A, B, ES>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -983,6 +985,92 @@ mod tests {
                 },
                 _ = context.sleep(Duration::from_secs(5)) => {
                     panic!("certify should not depend on marshal after verify cached a re-proposal");
+                },
+            }
+        });
+    }
+
+    /// A header can only read as a re-proposal under its declared parent, so an
+    /// invalid-precheck rejection (non-boundary block) is scoped to that header,
+    /// not to the notarized `(round, digest)`. Certification must route through
+    /// recovery instead of adopting the rejection as its verdict.
+    #[test_traced("WARN")]
+    fn test_certify_recovers_from_invalid_reproposal_precheck() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let setup = StandardHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+
+            let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
+            let mock_app: MockVerifyingApp<B, S> = MockVerifyingApp::new();
+            let mut inline = Inline::new(
+                context.child("inline"),
+                mock_app,
+                marshal.clone(),
+                FixedEpocher::new(BLOCKS_PER_EPOCH),
+            );
+
+            // A non-boundary block notarized at view 2 and available locally.
+            let block_round = Round::new(Epoch::zero(), View::new(2));
+            let block = B::new::<Sha256>(
+                Ctx {
+                    round: block_round,
+                    leader: default_leader(),
+                    parent: (View::zero(), genesis.digest()),
+                },
+                genesis.digest(),
+                Height::new(2),
+                200,
+            );
+            let digest = block.digest();
+            assert!(marshal.verified(block_round, block).await);
+
+            // The view-3 header names the block as its own parent, so the
+            // precheck reads it as a re-proposal and rejects it (not at the
+            // epoch boundary).
+            let round = Round::new(Epoch::zero(), View::new(3));
+            let reproposal_context = Ctx {
+                round,
+                leader: me,
+                parent: (View::new(2), digest),
+            };
+            let verify_rx = inline.verify(reproposal_context, digest).await;
+            assert!(
+                !verify_rx.await.expect("verify result missing"),
+                "a non-boundary re-proposal must be rejected"
+            );
+
+            // The header-scoped rejection must not become the certification
+            // verdict for the notarized digest.
+            let certify_rx = inline.certify(round, digest).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "certify must recover instead of adopting the precheck rejection"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
                 },
             }
         });

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -429,6 +429,10 @@ where
         // while the block subscription / durable sync is still in flight. Inline verification
         // verdicts are scoped to the proposal context, while certification receives only a
         // notarized `(round, digest)`, so this gate records durability rather than validity.
+        // Unlike deferred, inline blocks do not embed their context, so no local check can
+        // rule out an honest notarization forming under a different header for this key. A
+        // notarization also implies f+1 honest validators already ran application
+        // verification, so durability is the only local fact certification still needs.
         let round = context.round;
         let (durable_tx, durable_rx) = oneshot::channel();
         self.gates.insert(round, digest, durable_rx);
@@ -491,9 +495,11 @@ where
                 let block = match decision {
                     Decision::Complete(valid) => {
                         // Re-proposal: a valid precheck already persisted the block
-                        // (durable), an invalid one is an epoch rejection. An invalid
-                        // precheck is not a certification verdict for a potentially
-                        // conflicting header.
+                        // (durable), an invalid one is an epoch rejection. The rejection
+                        // only speaks for this header: without an embedded context an
+                        // honest notarization may still form for the same
+                        // `(round, digest)` under another header, so certification must
+                        // recover rather than adopt it.
                         tx.send_lossy(valid);
                         durable_tx.send_lossy(if valid {
                             GateOutcome::Ready(true)

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -495,11 +495,12 @@ where
                 let block = match decision {
                     Decision::Complete(valid) => {
                         // Re-proposal: a valid precheck already persisted the block
-                        // (durable), an invalid one is an epoch rejection. The rejection
-                        // only speaks for this header: without an embedded context an
-                        // honest notarization may still form for the same
-                        // `(round, digest)` under another header, so certification must
-                        // recover rather than adopt it.
+                        // (durable), an invalid one is an epoch rejection. The re-proposal
+                        // reading is an artifact of this header's declared parent: a
+                        // conflicting header naming the block's real parent lets honest
+                        // validators verify the same block as a normal proposal and
+                        // notarize `(round, digest)`, so certification must recover
+                        // rather than adopt the rejection.
                         tx.send_lossy(valid);
                         durable_tx.send_lossy(if valid {
                             GateOutcome::Ready(true)

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -46,7 +46,7 @@ use crate::{
     Application, Automaton, Block, CertifiableAutomaton, Epochable, Relay, Reporter,
     marshal::{
         Update,
-        application::gates::{self, Gates},
+        application::gates::{GateOutcome, Gates},
         core::{CommitmentFallback, DigestFallback, Mailbox},
         standard::{
             Standard, relay,
@@ -426,9 +426,9 @@ where
         digest: Self::Digest,
     ) -> oneshot::Receiver<bool> {
         // Register the certification gate synchronously so `certify` always finds it, even
-        // while the block subscription / durable sync is still in flight. A `true` result means
-        // the block is durably persisted; a `false` result is a live local verdict; a dropped
-        // sender means verification did not complete and certification should use recovery fetch.
+        // while the block subscription / durable sync is still in flight. Inline verification
+        // verdicts are scoped to the proposal context, while certification receives only a
+        // notarized `(round, digest)`, so this gate records durability rather than validity.
         let round = context.round;
         let (durable_tx, durable_rx) = oneshot::channel();
         self.gates.insert(round, digest, durable_rx);
@@ -491,9 +491,14 @@ where
                 let block = match decision {
                     Decision::Complete(valid) => {
                         // Re-proposal: precheck already persisted the block (durable) when
-                        // valid; epoch-reject when invalid. Hand the verdict to certify.
+                        // valid; epoch-reject when invalid. An invalid precheck is not a
+                        // certification verdict for a potentially conflicting header.
                         tx.send_lossy(valid);
-                        durable_tx.send_lossy(valid);
+                        durable_tx.send_lossy(if valid {
+                            GateOutcome::Ready(true)
+                        } else {
+                            GateOutcome::Recover
+                        });
                         return;
                     }
                     Decision::Continue(block) => block,
@@ -508,18 +513,20 @@ where
                 // parent fetch (which may hit the network) nor the verdict below.
                 // Storing before validation is intentional: these caches provide
                 // candidate availability/recovery, not a validity decision. The
-                // notarize vote follows the app verdict, while certify awaits the
-                // registered gate that resolves true only after both app
-                // verification succeeds and the store is durable.
+                // notarize vote follows the app verdict, while certify independently
+                // awaits the registered durability gate.
                 //
                 // The verify future below aborts when consensus drops its receiver
                 // (the view exited via nullification or finalization), even though
                 // certification can still fire for a nullified view. That is
-                // deliberate: inline's certify fallback does not need the app
+                // deliberate: inline certification does not need the local app
                 // verdict (a notarization implies f+1 honest validators already
-                // verified), and the store still completes through the join, so
-                // the fallback rides the verified write instead of re-persisting.
-                let store = marshal.verified(round, Arc::clone(&block));
+                // verified), and the store still completes through the join.
+                let store = async {
+                    if marshal.verified(round, Arc::clone(&block)).await {
+                        durable_tx.send_lossy(GateOutcome::Ready(true));
+                    }
+                };
                 let verify_then_vote = async {
                     // Non-reproposal path: validate the parent we already started
                     // fetching.
@@ -554,10 +561,7 @@ where
                     }
                     valid
                 };
-                let (verdict, durable) = futures::join!(verify_then_vote, store);
-                if let Some(valid) = gates::resolve(verdict, durable) {
-                    durable_tx.send_lossy(valid);
-                }
+                futures::join!(verify_then_vote, store);
             }
             .instrument(span)
         });
@@ -609,8 +613,8 @@ where
             .with_attribute("round", round);
         context.spawn(move |_| {
             async move {
-                // Preserve a live local verdict. Missing local state after an unclean restart
-                // has no task and falls through to the round-bound fetch path below.
+                // A ready gate proves the notarized block is durable. A gate that
+                // cannot speak for the notarized proposal falls through to recovery.
                 if let Some(task) = task {
                     let result = select! {
                         _ = tx.closed() => {
@@ -622,9 +626,12 @@ where
                         },
                         result = task => result,
                     };
-                    if let Ok(verdict) = result {
-                        tx.send_lossy(verdict);
-                        return;
+                    match result {
+                        Ok(GateOutcome::Ready(verdict)) => {
+                            tx.send_lossy(verdict);
+                            return;
+                        }
+                        Ok(GateOutcome::Recover) | Err(_) => {}
                     }
                 }
 

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -1472,10 +1472,10 @@ mod tests {
 
     /// Inline analog of the deferred equivocation test. A proposal that names
     /// the certified view-1 parent for a block built on the view-2 block
-    /// fails structural parent validation, which resolves the certification
-    /// gate to false. Certification of the honest notarization for the same
-    /// `(round, digest)` must not adopt that verdict: the no-gate fallback
-    /// already certifies any notarized block it can fetch.
+    /// fails structural parent validation and is rejected for voting. The
+    /// candidate is nevertheless stored durably, and certification of the
+    /// honest notarization for the same `(round, digest)` must use that
+    /// durability result rather than the context-scoped verification verdict.
     #[test_traced("WARN")]
     fn test_certify_not_poisoned_by_equivocating_parent_verify() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -43,7 +43,7 @@ pub use variant::Standard;
 mod tests {
     use super::{Deferred, Inline, Standard, relay};
     use crate::{
-        Automaton, CertifiableAutomaton, Heightable, Reporter,
+        Automaton, CertifiableAutomaton, Heightable, Relay, Reporter,
         marshal::{
             Identifier, Update,
             ancestry::BlockProvider,
@@ -68,7 +68,7 @@ mod tests {
         simplex::{
             self, Plan,
             config::ForwardingPolicy,
-            elector::RoundRobin,
+            elector::{Config as _, Elector as _, RoundRobin},
             scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
             types::{
                 Certificate, Finalization, Notarization, Notarize, Nullification, Nullify,
@@ -107,7 +107,7 @@ mod tests {
         Acknowledgement as _, NZU16, NZU64, NZUsize,
         acknowledgement::Exact,
         channel::{fallible::OneshotExt, oneshot, oneshot::error::TryRecvError},
-        ordered::Set,
+        ordered::{Quorum as _, Set},
         sequence::U64,
         sync::Mutex,
         vec::NonEmptyVec,
@@ -1742,18 +1742,10 @@ mod tests {
     type InlineWrapper = Inline<Runtime, S, App, B, FixedEpocher>;
     type DeferredWrapper = Deferred<Runtime, S, App, B, FixedEpocher>;
 
+    #[derive(Clone)]
     enum Wrapper {
         Inline(InlineWrapper),
         Deferred(DeferredWrapper),
-    }
-
-    impl Clone for Wrapper {
-        fn clone(&self) -> Self {
-            match self {
-                Self::Inline(inline) => Self::Inline(inline.clone()),
-                Self::Deferred(deferred) => Self::Deferred(deferred.clone()),
-            }
-        }
     }
 
     impl Wrapper {
@@ -1826,16 +1818,12 @@ mod tests {
     }
 
     impl CertifiableAutomaton for Wrapper {
-        async fn certify(
-            &mut self,
-            round: Round,
-            digest: Self::Digest,
-        ) -> oneshot::Receiver<bool> {
+        async fn certify(&mut self, round: Round, digest: Self::Digest) -> oneshot::Receiver<bool> {
             Self::certify(self, round, digest).await
         }
     }
 
-    impl crate::Relay for Wrapper {
+    impl Relay for Wrapper {
         type Digest = D;
         type PublicKey = PublicKey;
         type Plan = Plan<PublicKey>;
@@ -1989,10 +1977,20 @@ mod tests {
                 NAMESPACE,
                 NUM_VALIDATORS,
             );
-            // At epoch 0, round-robin elects participant 3 for view 3.
+            // At epoch 0, round-robin elects participant 3 for view 3. Pin the
+            // mapping: with a different leader the scripted proposal never
+            // reaches verify, and certification would pass through the no-gate
+            // recovery path with or without a poisoned gate.
             let byzantine = participants[3].clone();
             let victim = participants[1].clone();
             let observer = participants[0].clone();
+            let elector = RoundRobin::<Sha256>::default().build(schemes[1].participants());
+            assert_eq!(
+                schemes[1]
+                    .participants()
+                    .key(elector.elect(Round::new(Epoch::zero(), View::new(3)), None)),
+                Some(&byzantine),
+            );
 
             let mut oracle = setup_network_with_participants(
                 context.child("network"),
@@ -2069,8 +2067,8 @@ mod tests {
             );
 
             // Channels 1 and 2 are owned by marshal. Keep the three Simplex
-            // channels separate and register the Byzantine peer as the
-            // scripted sender and observer.
+            // channels separate, register the Byzantine peer as the scripted
+            // sender, and tap the observer's vote receiver.
             let victim_control = oracle.control(victim.clone());
             let vote_network = victim_control.register(3, TEST_QUOTA).await.unwrap();
             let certificate_network = victim_control.register(4, TEST_QUOTA).await.unwrap();

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -57,8 +57,8 @@ mod tests {
                 harness::{
                     self, B, BLOCKS_PER_EPOCH, Ctx, D, DeferredHarness, EmptyProvider,
                     InlineHarness, LINK, NAMESPACE, NUM_VALIDATORS, PAGE_CACHE_SIZE, PAGE_SIZE,
-                    QUORUM, S, StandardHarness, TestHarness, UNRELIABLE_LINK, V, ValidatorHandle,
-                    default_leader, make_raw_block, setup_network_links,
+                    QUORUM, S, StandardHarness, TEST_QUOTA, TestHarness, UNRELIABLE_LINK, V,
+                    ValidatorHandle, default_leader, make_raw_block, setup_network_links,
                     setup_network_with_participants,
                 },
                 verifying::MockVerifyingApp,
@@ -66,16 +66,21 @@ mod tests {
             resolver::handler,
         },
         simplex::{
-            Plan,
+            self, Plan,
+            config::ForwardingPolicy,
+            elector::RoundRobin,
             scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
-            types::{Finalization, Proposal},
+            types::{
+                Certificate, Finalization, Notarization, Notarize, Nullification, Nullify,
+                Proposal, Vote,
+            },
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta},
     };
     use bytes::Bytes;
     use commonware_actor::{Feedback, mailbox};
     use commonware_broadcast::{Broadcaster as _, buffered};
-    use commonware_codec::Encode;
+    use commonware_codec::{DecodeExt as _, Encode};
     use commonware_cryptography::{
         Digestible, Hasher as _,
         certificate::{ConstantProvider, Provider, Scoped, Verifier as _, mocks::Fixture},
@@ -84,7 +89,7 @@ mod tests {
     };
     use commonware_macros::{select, test_group, test_traced};
     use commonware_p2p::{
-        Manager as _, Recipients,
+        Manager as _, Receiver as _, Recipients, Sender as _,
         simulated::{self, Network},
     };
     use commonware_parallel::Sequential;
@@ -108,6 +113,7 @@ mod tests {
         vec::NonEmptyVec,
     };
     use std::{
+        future::Future,
         num::{NonZeroU32, NonZeroU64, NonZeroUsize},
         sync::Arc,
         time::Duration,
@@ -1742,6 +1748,15 @@ mod tests {
         Deferred(DeferredWrapper),
     }
 
+    impl Clone for Wrapper {
+        fn clone(&self) -> Self {
+            match self {
+                Self::Inline(inline) => Self::Inline(inline.clone()),
+                Self::Deferred(deferred) => Self::Deferred(deferred.clone()),
+            }
+        }
+    }
+
     impl Wrapper {
         fn new(
             kind: WrapperKind,
@@ -1792,6 +1807,415 @@ mod tests {
                 Self::Deferred(deferred) => deferred.certify(round, digest).await,
             }
         }
+    }
+
+    impl Automaton for Wrapper {
+        type Context = Ctx;
+        type Digest = D;
+
+        fn propose(
+            &mut self,
+            context: Self::Context,
+        ) -> impl Future<Output = oneshot::Receiver<Self::Digest>> + Send {
+            async move { Wrapper::propose(self, context).await }
+        }
+
+        fn verify(
+            &mut self,
+            context: Self::Context,
+            digest: Self::Digest,
+        ) -> impl Future<Output = oneshot::Receiver<bool>> + Send {
+            async move { Wrapper::verify(self, context, digest).await }
+        }
+    }
+
+    impl CertifiableAutomaton for Wrapper {
+        fn certify(
+            &mut self,
+            round: Round,
+            digest: Self::Digest,
+        ) -> impl Future<Output = oneshot::Receiver<bool>> + Send {
+            async move { Wrapper::certify(self, round, digest).await }
+        }
+    }
+
+    impl crate::Relay for Wrapper {
+        type Digest = D;
+        type PublicKey = PublicKey;
+        type Plan = Plan<PublicKey>;
+
+        fn broadcast(&mut self, digest: Self::Digest, plan: Self::Plan) -> Feedback {
+            match self {
+                Self::Inline(inline) => inline.broadcast(digest, plan),
+                Self::Deferred(deferred) => deferred.broadcast(digest, plan),
+            }
+        }
+    }
+
+    fn pending_conflicting_verify_does_not_poison_certification(kind: WrapperKind) {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(
+                &mut context,
+                NAMESPACE,
+                NUM_VALIDATORS,
+            );
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+            let setup = StandardHarness::setup_validator(
+                context.child("validator"),
+                &mut oracle,
+                participants[0].clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let buffer = setup.extra;
+
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let certified_round = Round::new(Epoch::zero(), View::new(1));
+            let certified_block = B::new::<Sha256>(
+                Ctx {
+                    round: certified_round,
+                    leader: participants[0].clone(),
+                    parent: (View::zero(), genesis.digest()),
+                },
+                genesis.digest(),
+                Height::new(1),
+                100,
+            );
+            let certified_digest = certified_block.digest();
+            assert!(marshal.verified(certified_round, certified_block).await);
+
+            let skipped_round = Round::new(Epoch::zero(), View::new(2));
+            let skipped_block = B::new::<Sha256>(
+                Ctx {
+                    round: skipped_round,
+                    leader: participants[1].clone(),
+                    parent: (View::new(1), certified_digest),
+                },
+                certified_digest,
+                Height::new(2),
+                200,
+            );
+            let skipped_digest = skipped_block.digest();
+            assert!(marshal.verified(skipped_round, skipped_block).await);
+
+            let round = Round::new(Epoch::zero(), View::new(3));
+            let block = B::new::<Sha256>(
+                Ctx {
+                    round,
+                    leader: participants[1].clone(),
+                    parent: (View::new(2), skipped_digest),
+                },
+                skipped_digest,
+                Height::new(3),
+                300,
+            );
+            let digest = block.digest();
+            let conflicting_context = Ctx {
+                round,
+                leader: participants[1].clone(),
+                parent: (View::new(1), certified_digest),
+            };
+            let mut wrapper = Wrapper::new(
+                kind,
+                context.child("wrapper"),
+                MockVerifyingApp::new(),
+                marshal,
+            );
+
+            // `verify` registers the gate synchronously but cannot resolve it
+            // until the leader's block arrives. A notarization can arrive in
+            // this window, causing Simplex's sole `certify` request to consume
+            // and await that still-pending gate.
+            let verify_rx = wrapper.verify(conflicting_context, digest).await;
+            let certify_rx = wrapper.certify(round, digest).await;
+            assert!(
+                buffer
+                    .broadcast(Recipients::Some(vec![]), block)
+                    .accepted(),
+                "candidate broadcast should be accepted"
+            );
+
+            select! {
+                result = verify_rx => {
+                    assert!(
+                        !result.expect("verify result missing"),
+                        "{kind:?}: the conflicting proposal must be rejected"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("{kind:?}: conflicting verification did not resolve");
+                },
+            }
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "{kind:?}: pending certification must not adopt the conflicting verification verdict"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("{kind:?}: pending certification did not resolve");
+                },
+            }
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_inline_pending_conflicting_verify_does_not_poison_certification() {
+        pending_conflicting_verify_does_not_poison_certification(WrapperKind::Inline);
+    }
+
+    #[test_traced("WARN")]
+    fn test_deferred_pending_conflicting_verify_does_not_poison_certification() {
+        pending_conflicting_verify_does_not_poison_certification(WrapperKind::Deferred);
+    }
+
+    fn scripted_byzantine_parent_equivocation(kind: WrapperKind) {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(
+                &mut context,
+                NAMESPACE,
+                NUM_VALIDATORS,
+            );
+            // At epoch 0, round-robin elects participant 3 for view 3.
+            let byzantine = participants[3].clone();
+            let victim = participants[1].clone();
+            let observer = participants[0].clone();
+
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+            let setup = StandardHarness::setup_validator(
+                context.child("marshal"),
+                &mut oracle,
+                victim.clone(),
+                ConstantProvider::new(schemes[1].clone()),
+            )
+            .await;
+            let mut marshal = setup.mailbox;
+            let buffer = setup.extra;
+
+            // Start Simplex from a finalized view 1, then skip view 2. The
+            // victim may therefore accept a view-3 proposal naming view 1,
+            // while validators that certified view 2 build on view 2.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let floor_round = Round::new(Epoch::zero(), View::new(1));
+            let floor_block = B::new::<Sha256>(
+                Ctx {
+                    round: floor_round,
+                    leader: byzantine.clone(),
+                    parent: (View::zero(), genesis.digest()),
+                },
+                genesis.digest(),
+                Height::new(1),
+                100,
+            );
+            let floor_digest = floor_block.digest();
+            assert!(marshal.verified(floor_round, floor_block).await);
+            let floor_finalization = StandardHarness::make_finalization(
+                Proposal::new(floor_round, View::zero(), floor_digest),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut marshal, floor_finalization.clone()).await;
+
+            let skipped_round = Round::new(Epoch::zero(), View::new(2));
+            let skipped_block = B::new::<Sha256>(
+                Ctx {
+                    round: skipped_round,
+                    leader: participants[3].clone(),
+                    parent: (View::new(1), floor_digest),
+                },
+                floor_digest,
+                Height::new(2),
+                200,
+            );
+            let skipped_digest = skipped_block.digest();
+            assert!(marshal.verified(skipped_round, skipped_block).await);
+
+            let round = Round::new(Epoch::zero(), View::new(3));
+            let embedded_context = Ctx {
+                round,
+                leader: byzantine.clone(),
+                parent: (View::new(2), skipped_digest),
+            };
+            let block = B::new::<Sha256>(
+                embedded_context,
+                skipped_digest,
+                Height::new(3),
+                300,
+            );
+            let digest = block.digest();
+            assert!(
+                buffer
+                    .broadcast(Recipients::Some(vec![]), block)
+                    .accepted(),
+                "candidate broadcast should be accepted"
+            );
+
+            // Channels 1 and 2 are owned by marshal. Keep the three Simplex
+            // channels separate and register the Byzantine peer as the
+            // scripted sender and observer.
+            let victim_control = oracle.control(victim.clone());
+            let vote_network = victim_control.register(3, TEST_QUOTA).await.unwrap();
+            let certificate_network = victim_control.register(4, TEST_QUOTA).await.unwrap();
+            let resolver_network = victim_control.register(5, TEST_QUOTA).await.unwrap();
+            let byzantine_control = oracle.control(byzantine.clone());
+            let (mut byzantine_vote_sender, _byzantine_vote_receiver) =
+                byzantine_control.register(3, TEST_QUOTA).await.unwrap();
+            let (mut byzantine_certificate_sender, _byzantine_certificate_receiver) =
+                byzantine_control.register(4, TEST_QUOTA).await.unwrap();
+            let _byzantine_resolver = byzantine_control.register(5, TEST_QUOTA).await.unwrap();
+            let (_observer_vote_sender, mut observer_vote_receiver) = oracle
+                .control(observer)
+                .register(3, TEST_QUOTA)
+                .await
+                .unwrap();
+            setup_network_links(&mut oracle, &participants, LINK).await;
+
+            let wrapper = Wrapper::new(
+                kind,
+                context.child("wrapper"),
+                MockVerifyingApp::new(),
+                marshal.clone(),
+            );
+            let engine = simplex::Engine::new(
+                context.child("simplex"),
+                simplex::config::Config {
+                    scheme: schemes[1].clone(),
+                    elector: RoundRobin::<Sha256>::default(),
+                    blocker: oracle.control(victim.clone()),
+                    automaton: wrapper.clone(),
+                    relay: wrapper,
+                    reporter: marshal,
+                    strategy: Sequential,
+                    partition: format!("scripted-equivocation-{kind:?}"),
+                    mailbox_size: NZUsize!(128),
+                    epoch: Epoch::zero(),
+                    floor: simplex::config::Floor::Finalized(floor_finalization),
+                    replay_buffer: NZUsize!(1024),
+                    write_buffer: NZUsize!(1024),
+                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                    leader_timeout: Duration::from_secs(2),
+                    certification_timeout: Duration::from_secs(4),
+                    timeout_retry: Duration::from_secs(3),
+                    view_retention: ViewDelta::new(10),
+                    skip_timeout: Duration::from_secs(6),
+                    fetch_timeout: Duration::from_secs(1),
+                    fetch_concurrent: NZUsize!(3),
+                    forwarding: ForwardingPolicy::Disabled,
+                },
+            );
+            let _engine = engine.start(vote_network, certificate_network, resolver_network);
+
+            let nullifies: Vec<_> = [0usize, 2, 3]
+                .into_iter()
+                .map(|index| Nullify::sign::<D>(&schemes[index], skipped_round).unwrap())
+                .collect();
+            let nullification =
+                Nullification::from_nullifies(&schemes[0], &nullifies, &Sequential).unwrap();
+            byzantine_certificate_sender.send(
+                Recipients::One(victim.clone()),
+                Certificate::<S, D>::Nullification(nullification).encode(),
+                true,
+            );
+            context.sleep(Duration::from_millis(250)).await;
+
+            // The Byzantine leader reuses the honest block commitment in a
+            // conflicting header that declares the older certified parent.
+            let bad_proposal = Proposal::new(round, View::new(1), digest);
+            let good_proposal = Proposal::new(round, View::new(2), digest);
+            assert_eq!(bad_proposal.payload, good_proposal.payload);
+            assert_ne!(bad_proposal, good_proposal);
+            let bad_vote = Notarize::sign(&schemes[3], bad_proposal).unwrap();
+            byzantine_vote_sender.send(
+                Recipients::One(victim.clone()),
+                Vote::<S, D>::Notarize(bad_vote).encode(),
+                true,
+            );
+
+            // InvalidProposal is the deterministic barrier proving that the
+            // conflicting header reached verify and was rejected before the
+            // honest notarization arrives.
+            select! {
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("{kind:?}: victim did not reject the conflicting proposal");
+                },
+                result = async {
+                    loop {
+                        let (_, message) = observer_vote_receiver.recv().await.unwrap();
+                        let vote = Vote::<S, D>::decode(message).unwrap();
+                        if matches!(vote, Vote::Nullify(ref nullify) if nullify.round == round) {
+                            break;
+                        }
+                    }
+                } => result,
+            }
+            context.sleep(Duration::from_millis(250)).await;
+
+            // The Byzantine validator and the other two honest validators
+            // notarize the header naming view 2 without the victim's vote.
+            let good_votes: Vec<_> = [0usize, 2, 3]
+                .into_iter()
+                .map(|index| Notarize::sign(&schemes[index], good_proposal.clone()).unwrap())
+                .collect();
+            let notarization =
+                Notarization::from_notarizes(&schemes[0], &good_votes, &Sequential).unwrap();
+            byzantine_certificate_sender.send(
+                Recipients::One(victim),
+                Certificate::<S, D>::Notarization(notarization).encode(),
+                true,
+            );
+
+            // Certification is single-shot. The victim already nullified view
+            // 3, so same-term vote safety correctly prevents a finalize vote.
+            // Successful certification must instead advance it to view 4,
+            // where the silent leader eventually causes a new nullify vote.
+            let next_round = Round::new(Epoch::zero(), View::new(4));
+            select! {
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("{kind:?}: victim did not advance after certification");
+                },
+                result = async {
+                    loop {
+                        let (_, message) = observer_vote_receiver.recv().await.unwrap();
+                        let vote = Vote::<S, D>::decode(message).unwrap();
+                        if matches!(vote, Vote::Nullify(ref nullify) if nullify.round == next_round) {
+                            break;
+                        }
+                    }
+                } => result,
+            }
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_inline_scripted_byzantine_parent_equivocation() {
+        scripted_byzantine_parent_equivocation(WrapperKind::Inline);
+    }
+
+    #[test_traced("WARN")]
+    fn test_deferred_scripted_byzantine_parent_equivocation() {
+        scripted_byzantine_parent_equivocation(WrapperKind::Deferred);
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -113,7 +113,6 @@ mod tests {
         vec::NonEmptyVec,
     };
     use std::{
-        future::Future,
         num::{NonZeroU32, NonZeroU64, NonZeroUsize},
         sync::Arc,
         time::Duration,
@@ -1813,29 +1812,26 @@ mod tests {
         type Context = Ctx;
         type Digest = D;
 
-        fn propose(
-            &mut self,
-            context: Self::Context,
-        ) -> impl Future<Output = oneshot::Receiver<Self::Digest>> + Send {
-            async move { Wrapper::propose(self, context).await }
+        async fn propose(&mut self, context: Self::Context) -> oneshot::Receiver<Self::Digest> {
+            Self::propose(self, context).await
         }
 
-        fn verify(
+        async fn verify(
             &mut self,
             context: Self::Context,
             digest: Self::Digest,
-        ) -> impl Future<Output = oneshot::Receiver<bool>> + Send {
-            async move { Wrapper::verify(self, context, digest).await }
+        ) -> oneshot::Receiver<bool> {
+            Self::verify(self, context, digest).await
         }
     }
 
     impl CertifiableAutomaton for Wrapper {
-        fn certify(
+        async fn certify(
             &mut self,
             round: Round,
             digest: Self::Digest,
-        ) -> impl Future<Output = oneshot::Receiver<bool>> + Send {
-            async move { Wrapper::certify(self, round, digest).await }
+        ) -> oneshot::Receiver<bool> {
+            Self::certify(self, round, digest).await
         }
     }
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -68,7 +68,7 @@ mod tests {
         simplex::{
             self, Plan,
             config::ForwardingPolicy,
-            elector::{Config as _, Elector as _, RoundRobin},
+            elector::{Config as _, Elector as _, RoundRobin, RoundRobinElector},
             scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
             types::{
                 Certificate, Finalization, Notarization, Notarize, Nullification, Nullify,
@@ -1984,7 +1984,8 @@ mod tests {
             let byzantine = participants[3].clone();
             let victim = participants[1].clone();
             let observer = participants[0].clone();
-            let elector = RoundRobin::<Sha256>::default().build(schemes[1].participants());
+            let elector: RoundRobinElector<S> =
+                RoundRobin::<Sha256>::default().build(schemes[1].participants());
             assert_eq!(
                 schemes[1]
                     .participants()

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -47,7 +47,7 @@ mod tests {
         marshal::{
             Identifier, Update,
             ancestry::BlockProvider,
-            application::gates::Gates,
+            application::gates::{GateOutcome, Gates},
             config::{Config, Start},
             core::{
                 Actor, CommitmentFallback, DigestFallback, Mailbox, cache, durability::Durable as _,
@@ -7753,9 +7753,10 @@ mod tests {
             assert_eq!(rx.await.expect("id published"), digest);
             let gate = gates.take(round, digest).expect("gate registered");
             gates.flush_unrelayed(&mailbox, round, digest);
-            assert!(
+            assert_eq!(
                 gate.await.expect("gate resolved"),
-                "certify flush must resolve the gate durably"
+                GateOutcome::Ready(true),
+                "certify flush must resolve the gate durably",
             );
 
             // The relay finds nothing staged and must forward the persisted
@@ -7839,9 +7840,10 @@ mod tests {
 
             // The relayed proposal is persisted through the staged ack, so
             // the certification gate resolves durably.
-            assert!(
+            assert_eq!(
                 gate.await.expect("gate resolved"),
-                "relay handshake must resolve the gate durably"
+                GateOutcome::Ready(true),
+                "relay handshake must resolve the gate durably",
             );
         });
     }

--- a/consensus/src/marshal/standard/validation.rs
+++ b/consensus/src/marshal/standard/validation.rs
@@ -130,11 +130,11 @@ pub(super) enum ParentCheck<B> {
 ///
 /// Returns `None` when work should stop early (receiver dropped or parent unavailable).
 #[inline]
-pub(super) async fn await_and_validate_parent<B>(
+pub(super) async fn await_and_validate_parent<B, T>(
     parent_commitment: B::Digest,
     block: &B,
     parent_request: oneshot::Receiver<Arc<B>>,
-    tx: &mut oneshot::Sender<bool>,
+    tx: &mut oneshot::Sender<T>,
 ) -> Option<ParentCheck<Arc<B>>>
 where
     B: Block,
@@ -184,14 +184,14 @@ where
 /// can run it concurrently with this verification (durability is independent of validity).
 #[inline]
 #[allow(clippy::too_many_arguments)]
-pub(super) async fn run_app_verify<E, S, A, B>(
+pub(super) async fn run_app_verify<E, S, A, B, T>(
     runtime_context: E,
     context: Context<B::Digest, S::PublicKey>,
     block: Arc<B>,
     parent: Arc<B>,
     application: &mut A,
     marshal: &Mailbox<S, Standard<B>>,
-    tx: &mut oneshot::Sender<bool>,
+    tx: &mut oneshot::Sender<T>,
     ancestor_fetch_duration: Timed,
 ) -> Option<bool>
 where

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -3227,11 +3227,8 @@ mod tests {
             let mut pool = AbortablePool::<()>::default();
             let handle = pool.push(futures::future::pending());
             state.set_certify_handle(nullified_view, handle);
-            let nullification = build_nullification(
-                &verifier,
-                &schemes,
-                Rnd::new(Epoch::new(1), nullified_view),
-            );
+            let nullification =
+                build_nullification(&verifier, &schemes, Rnd::new(Epoch::new(1), nullified_view));
             assert!(state.add_nullification(nullification));
 
             // The view-3 leader signs a header that reuses the honest block's
@@ -3249,16 +3246,24 @@ mod tests {
             assert!(Notarize::sign(&schemes[0], bad_proposal.clone()).is_some());
 
             assert!(state.set_proposal(view, bad_proposal.clone()));
-            let (verify_context, verify_proposal) =
-                state.try_verify().expect("bad header should reach verification");
+            let (verify_context, verify_proposal) = state
+                .try_verify()
+                .expect("bad header should reach verification");
             assert_eq!(verify_proposal, bad_proposal);
-            assert_eq!(
-                verify_context.parent,
-                (certified_view, certified_payload)
-            );
+            assert_eq!(verify_context.parent, (certified_view, certified_payload));
+
+            // The rejected header times out the view, so this validator
+            // nullifies view 3 before the honest notarization arrives.
+            state.trigger_timeout(view, TimeoutReason::InvalidProposal);
+            let (retry, _) = state
+                .construct_nullify(view, TimeoutReason::InvalidProposal)
+                .expect("nullify");
+            assert!(!retry);
 
             // The Byzantine leader and the other two honest validators form a
-            // notarization for the header naming view 2, without H2's vote.
+            // notarization for the header naming view 2, without this
+            // validator's vote. A local nullify must not suppress the
+            // certification dispatch.
             let good_votes: Vec<_> = [0usize, 2, 3]
                 .into_iter()
                 .map(|index| {

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -3189,6 +3189,93 @@ mod tests {
     }
 
     #[test]
+    fn conflicting_parent_headers_share_payload_but_certify_notarized_proposal() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state(&mut context, 4, 1, 10, 1);
+
+            // Certify view 1 so it remains an eligible parent.
+            let certified_view = View::new(1);
+            let certified_payload = Sha256Digest::from([31u8; 32]);
+            let certified_proposal = Proposal::new(
+                Rnd::new(Epoch::new(1), certified_view),
+                GENESIS_VIEW,
+                certified_payload,
+            );
+            let certified_notarization =
+                build_notarization(&verifier, &schemes, &certified_proposal);
+            assert!(state.add_notarization(certified_notarization).0);
+            assert!(state.certified(certified_view, true).is_some());
+
+            // Start certification for view 2, then nullify it before completion.
+            let nullified_view = View::new(2);
+            let nullified_payload = Sha256Digest::from([32u8; 32]);
+            let nullified_proposal = Proposal::new(
+                Rnd::new(Epoch::new(1), nullified_view),
+                certified_view,
+                nullified_payload,
+            );
+            let nullified_notarization =
+                build_notarization(&verifier, &schemes, &nullified_proposal);
+            assert!(state.add_notarization(nullified_notarization).0);
+            assert_eq!(state.certify_candidates(), vec![nullified_proposal]);
+            let mut pool = AbortablePool::<()>::default();
+            let handle = pool.push(futures::future::pending());
+            state.set_certify_handle(nullified_view, handle);
+            let nullification = build_nullification(
+                &verifier,
+                &schemes,
+                Rnd::new(Epoch::new(1), nullified_view),
+            );
+            assert!(state.add_nullification(nullification));
+
+            // The view-3 leader signs a header that reuses the honest block's
+            // payload but declares the older certified parent.
+            let view = View::new(3);
+            assert_eq!(state.current_view(), view);
+            assert_eq!(state.leader_index(view), Some(Participant::new(0)));
+            let payload = Sha256Digest::from([33u8; 32]);
+            let bad_proposal =
+                Proposal::new(Rnd::new(Epoch::new(1), view), certified_view, payload);
+            let good_proposal =
+                Proposal::new(Rnd::new(Epoch::new(1), view), nullified_view, payload);
+            assert_ne!(bad_proposal, good_proposal);
+            assert_eq!(bad_proposal.payload, good_proposal.payload);
+            assert!(Notarize::sign(&schemes[0], bad_proposal.clone()).is_some());
+
+            assert!(state.set_proposal(view, bad_proposal.clone()));
+            let (verify_context, verify_proposal) =
+                state.try_verify().expect("bad header should reach verification");
+            assert_eq!(verify_proposal, bad_proposal);
+            assert_eq!(
+                verify_context.parent,
+                (certified_view, certified_payload)
+            );
+
+            // The Byzantine leader and the other two honest validators form a
+            // notarization for the header naming view 2, without H2's vote.
+            let good_votes: Vec<_> = [0usize, 2, 3]
+                .into_iter()
+                .map(|index| {
+                    Notarize::sign(&schemes[index], good_proposal.clone()).expect("notarize")
+                })
+                .collect();
+            let good_notarization =
+                Notarization::from_notarizes(&verifier, good_votes.iter(), &Sequential)
+                    .expect("notarization");
+            let (added, equivocator) = state.add_notarization(good_notarization);
+            assert!(added);
+            assert!(equivocator.is_some());
+            assert_eq!(state.certify_candidates(), vec![good_proposal]);
+        });
+    }
+
+    #[test]
     fn nullification_then_late_certification_allows_child_to_build_on_parent() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -3192,12 +3192,26 @@ mod tests {
     fn conflicting_parent_headers_share_payload_but_certify_notarized_proposal() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
-            let (
-                Fixture {
-                    schemes, verifier, ..
+            let namespace = b"ns".to_vec();
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, &namespace, 4);
+
+            // The state signs its own view-3 nullify below, so it needs a
+            // signing scheme rather than setup_state's verifier.
+            let mut state = State::new(
+                context,
+                Config {
+                    scheme: schemes[1].clone(),
+                    elector: round_robin(&verifier),
+                    epoch: Epoch::new(1),
+                    view_retention: ViewDelta::new(10),
+                    leader_timeout: Duration::from_secs(1),
+                    certification_timeout: Duration::from_secs(2),
+                    timeout_retry: Duration::from_secs(3),
                 },
-                mut state,
-            ) = setup_state(&mut context, 4, 1, 10, 1);
+            );
+            state.set_genesis(test_genesis());
 
             // Certify view 1 so it remains an eligible parent.
             let certified_view = View::new(1);


### PR DESCRIPTION
## Problem

Certification gates are keyed by `(round, payload)`, but `verify()` could resolve them with verdicts scoped to the proposal header it ran under. Consensus signs the declared parent separately from the payload, so an equivocating leader can show conflicting headers for the same payload to different validators. A validator that correctly rejected one header cached `false` in the gate, and certification of the honest notarization for the same `(round, payload)` then adopted that cached verdict. Because a view only exits on successful certification, a nullification certificate, or finalization, the validator could wedge permanently while the rest of the network advanced.

## Fix

Gates now resolve to `GateOutcome`, separating verdicts that hold for the notarized `(round, payload)` (`Ready`) from work that only applies to the header verification ran under (`Recover`). `Recover`, like a missing gate after restart, routes certification through the embedded-context recovery path, whose result is defended by the notarizing quorum. The inline gate records durability only. Notarize votes still follow the application verdict everywhere, and deferred certification still propagates a context-matched application rejection.

## Testing

Per-variant poison tests (deferred, inline, coding), pending-gate variants, and scripted end-to-end tests that drive a real engine through the split-header attack and assert the victim certifies and advances. All poison tests fail with the fix reverted. Controls pin that application rejections and coding's pre-gate header validation are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)