### PR TITLE
[cryptography] Scale Message Hashes on `G1` in `MinSig`

### DIFF
--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -108,7 +108,8 @@ impl Variant for MinPk {
     /// of its respective `r_i`, equals one:
     /// `prod_i((e(hm_i,pk_i) * e(sig_i,-G1::one()))^{r_i}) == 1`
     ///
-    /// Using the bilinearity of pairings, this can be rewritten (by moving `r_i` inside the pairings):
+    /// Using the bilinearity of pairings, this can be rewritten (by moving `r_i` inside the pairings,
+    /// onto `pk_i` rather than `hm_i` because G1 multiplication is cheaper):
     /// `prod_i(e(hm_i,r_i * pk_i) * e(r_i * sig_i,-G1::one())) == 1`
     ///
     /// The second term `e(r_i * sig_i,-G1::one())` can be computed efficiently with Multi-Scalar Multiplication:
@@ -210,13 +211,14 @@ impl Variant for MinSig {
     /// raised to the power of its respective `r_i`, equals one:
     /// `prod_i((e(pk_i,hm_i) * e(-G2::one(),sig_i))^{r_i}) == 1`
     ///
-    /// Using the bilinearity of pairings, this can be rewritten (by moving `r_i` inside the pairings):
-    /// `prod_i(e(r_i * pk_i,hm_i) * e(-G2::one(),r_i * sig_i)) == 1`
+    /// Using the bilinearity of pairings, this can be rewritten (by moving `r_i` inside the pairings,
+    /// onto `hm_i` rather than `pk_i` because G1 multiplication is cheaper):
+    /// `prod_i(e(pk_i,r_i * hm_i) * e(-G2::one(),r_i * sig_i)) == 1`
     ///
     /// The second term `e(-G2::one(),r_i * sig_i)` can be computed efficiently with Multi-Scalar Multiplication:
     /// `e(-G2::one(),sum_i(r_i * sig_i))`
     ///
-    /// Finally, we aggregate all pairings `e(r_i * pk_i,hm_i)` (`n`) and `e(-G2::one(),sum_i(r_i * sig_i))` (`1`)
+    /// Finally, we aggregate all pairings `e(pk_i,r_i * hm_i)` (`n`) and `e(-G2::one(),sum_i(r_i * sig_i))` (`1`)
     /// into a single product in the target group `G_T`. If the result is the identity element in `G_T`,
     /// the batch verification succeeds.
     ///
@@ -240,11 +242,11 @@ impl Variant for MinSig {
             .map(|_| SmallScalar::random(&mut *rng))
             .collect();
 
-        let (s_agg, scaled_pks) = par.join(
+        let (s_agg, scaled_hms) = par.join(
             || G1::msm(signatures, &scalars, par),
-            || par.map_collect_vec(publics.iter().zip(scalars.iter()), |(&pk, s)| pk * s),
+            || par.map_collect_vec(hms.iter().zip(scalars.iter()), |(&hm, s)| hm * s),
         );
-        if !G1::multi_pairing_check(hms, &scaled_pks, &s_agg, &-G2::generator()) {
+        if !G1::multi_pairing_check(&scaled_hms, publics, &s_agg, &-G2::generator()) {
             return Err(Error::InvalidSignature);
         }
         Ok(())


### PR DESCRIPTION
`MinSig::batch_verify` applied the random batch-verification scalars to the public keys on G2. By bilinearity, `e(hm_i, r_i * pk_i) = e(r_i * hm_i, pk_i)`, so the scalars can instead be applied to the message hashes on G1, where a 128-bit multiplication is ~2.3x cheaper (32us vs 74us per point). `MinPk` already scales its G1 side (the public keys), so this makes the rule uniform across variants: the scalar always lands on the G1 side of the pairing. blst makes the same choice in both variants, and the [batch-verification construction](https://ethresear.ch/t/security-of-bls-batch-verification/10748) cited in the docs also weighs the message hashes. The doc comments on both variants now record the rationale.

The two placements accept and reject identical inputs for subgroup-checked points (which decode enforces), so there is no behavioral or security change.

Measured on `MinSig::batch_verify` with distinct signers and messages (Apple M-series, `Sequential`, 6 interleaved rounds):

| n | scale `pks` (G2) | scale `hms` (G1) | speedup |
|---|---|---|---|
| 8 | 1.67 ms | 1.34 ms | 20% |
| 64 | 10.9 ms | 8.2 ms | 25% |
| 512 | 83.9 ms | 62.3 ms | 26% |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
