### PR TITLE
[deployer] Tag AWS resources with owner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1556,6 +1556,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-ec2",
  "aws-sdk-s3",
+ "aws-sdk-sts",
  "cfg-if",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ aws-sdk-s3 = { version = "1.138.0", default-features = false, features = [
 	"rt-tokio",
 	"sigv4a",
 ] }
+aws-sdk-sts = { version = "1.99.0", default-features = false, features = [
+	"default-https-client",
+	"rt-tokio",
+] }
 axum = "0.8.9"
 blake3 = { version = "1.8.5", default-features = false }
 blst = { version = "0.3.16", default-features = false }

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -19,6 +19,7 @@ aws = [
 	"aws-config",
 	"aws-sdk-ec2",
 	"aws-sdk-s3",
+	"aws-sdk-sts",
 	"chrono",
 	"clap",
 	"commonware-cryptography",
@@ -36,6 +37,7 @@ aws = [
 aws-config = { workspace = true, optional = true }
 aws-sdk-ec2 = { workspace = true, optional = true }
 aws-sdk-s3 = { workspace = true, optional = true }
+aws-sdk-sts = { workspace = true, optional = true }
 cfg-if.workspace = true
 chrono = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -96,7 +96,15 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
         serde_yaml::from_reader(config_file)?
     };
     let tag = &config.tag;
-    info!(tag = tag.as_str(), "loaded configuration");
+
+    // Resolve the AWS principal running this deploy so every created resource is
+    // tagged with an `owner`, enabling attribution and tag-based IAM guardrails.
+    let owner = ec2::get_owner().await?;
+    info!(
+        tag = tag.as_str(),
+        owner = owner.as_str(),
+        "loaded configuration"
+    );
 
     // Ensure no instance is duplicated or named MONITORING_NAME
     let mut instance_names = HashSet::new();
@@ -360,6 +368,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
         .map(|(idx, region)| {
             let region = region.clone();
             let tag = tag.clone();
+            let owner = owner.clone();
             let deployer_ip = deployer_ip.clone();
             let key_name = key_name.clone();
             let public_key = public_key.clone();
@@ -379,13 +388,13 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
 
                 // Create VPC, IGW, route table
                 let vpc_cidr = format!("10.{idx}.0.0/16");
-                let vpc_id = create_vpc(&ec2_client, &vpc_cidr, &tag).await?;
+                let vpc_id = create_vpc(&ec2_client, &vpc_cidr, &tag, &owner).await?;
                 info!(
                     vpc = vpc_id.as_str(),
                     region = region.as_str(),
                     "created VPC"
                 );
-                let igw_id = create_and_attach_igw(&ec2_client, &vpc_id, &tag).await?;
+                let igw_id = create_and_attach_igw(&ec2_client, &vpc_id, &tag, &owner).await?;
                 info!(
                     igw = igw_id.as_str(),
                     vpc = vpc_id.as_str(),
@@ -393,7 +402,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                     "created and attached IGW"
                 );
                 let route_table_id =
-                    create_route_table(&ec2_client, &vpc_id, &igw_id, &tag).await?;
+                    create_route_table(&ec2_client, &vpc_id, &igw_id, &tag, &owner).await?;
                 info!(
                     route_table = route_table_id.as_str(),
                     vpc = vpc_id.as_str(),
@@ -410,6 +419,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                         let vpc_id = vpc_id.clone();
                         let route_table_id = route_table_id.clone();
                         let tag = tag.clone();
+                        let owner = owner.clone();
                         let az = az.clone();
                         let region = region.clone();
                         async move {
@@ -421,6 +431,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                                 &subnet_cidr,
                                 &az,
                                 &tag,
+                                &owner,
                             )
                             .await?;
                             info!(
@@ -437,9 +448,14 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
 
                 // Create monitoring security group in monitoring region
                 let monitoring_sg_id = if region == MONITORING_REGION {
-                    let sg_id =
-                        create_security_group_monitoring(&ec2_client, &vpc_id, &deployer_ip, &tag)
-                            .await?;
+                    let sg_id = create_security_group_monitoring(
+                        &ec2_client,
+                        &vpc_id,
+                        &deployer_ip,
+                        &tag,
+                        &owner,
+                    )
+                    .await?;
                     info!(
                         sg = sg_id.as_str(),
                         vpc = vpc_id.as_str(),
@@ -452,7 +468,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                 };
 
                 // Import key pair
-                import_key_pair(&ec2_client, &key_name, &public_key).await?;
+                import_key_pair(&ec2_client, &key_name, &public_key, &tag, &owner).await?;
                 info!(
                     key = key_name.as_str(),
                     region = region.as_str(),
@@ -504,11 +520,18 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
             let vpc_id = resources.vpc_id.clone();
             let deployer_ip = deployer_ip.clone();
             let tag = tag.clone();
+            let owner = owner.clone();
             let ports = config.ports.clone();
             async move {
-                let binary_sg_id =
-                    create_security_group_binary(&ec2_client, &vpc_id, &deployer_ip, &tag, &ports)
-                        .await?;
+                let binary_sg_id = create_security_group_binary(
+                    &ec2_client,
+                    &vpc_id,
+                    &deployer_ip,
+                    &tag,
+                    &owner,
+                    &ports,
+                )
+                .await?;
                 info!(
                     sg = binary_sg_id.as_str(),
                     vpc = vpc_id.as_str(),
@@ -548,6 +571,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
             let binary_cidr = binary_resources.vpc_cidr.clone();
             let binary_route_table_id = binary_resources.route_table_id.clone();
             let tag = tag.clone();
+            let owner = owner.clone();
             async move {
                 let peer_id = create_vpc_peering_connection(
                     &monitoring_ec2_client,
@@ -555,6 +579,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                     &binary_vpc_id,
                     &region,
                     &tag,
+                    &owner,
                 )
                 .await?;
                 info!(
@@ -659,6 +684,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
     let monitoring_launch_future = {
         let key_name = key_name.clone();
         let tag = tag.clone();
+        let owner = owner.clone();
         let sg_id = monitoring_sg_id.clone();
         async move {
             let (mut ids, az) = launch_instances(
@@ -677,6 +703,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                 1,
                 MONITORING_NAME,
                 &tag,
+                &owner,
             )
             .await?;
             let instance_id = ids.remove(0);
@@ -699,6 +726,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                 InstanceType::try_parse(&instance.instance_type).expect("Invalid instance type");
             let binary_sg_id = resources.binary_sg_id.as_ref().unwrap();
             let tag = tag.clone();
+            let owner = owner.clone();
             let instance_name = instance.name.clone();
             let region = instance.region.clone();
             let subnets = grouped_subnets(instance, resources, &availability_zone_groups);
@@ -721,6 +749,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                     1,
                     &instance.name,
                     &tag,
+                    &owner,
                 )
                 .await?;
                 let instance_id = ids.remove(0);

--- a/deployer/src/aws/ec2.rs
+++ b/deployer/src/aws/ec2.rs
@@ -596,6 +596,18 @@ async fn try_launch_instances(
                 }))
                 .build(),
         )
+        .tag_specifications(
+            TagSpecification::builder()
+                .resource_type(ResourceType::Volume)
+                .set_tags(Some(deployer_tags(tag, owner)))
+                .build(),
+        )
+        .tag_specifications(
+            TagSpecification::builder()
+                .resource_type(ResourceType::NetworkInterface)
+                .set_tags(Some(deployer_tags(tag, owner)))
+                .build(),
+        )
         .block_device_mappings(
             BlockDeviceMapping::builder()
                 .device_name("/dev/sda1")

--- a/deployer/src/aws/ec2.rs
+++ b/deployer/src/aws/ec2.rs
@@ -43,17 +43,62 @@ pub async fn create_client(region: Region) -> Ec2Client {
     Ec2Client::new(&config)
 }
 
+/// Resolves an identifier for the AWS principal running the deployment, used to
+/// stamp an `owner` tag on every created resource. Derived from STS
+/// `GetCallerIdentity`: for an assumed role (e.g. AWS SSO) this is the role
+/// session name, and for an IAM user it is the user name. Falls back to the
+/// caller's unique id when the ARN cannot be parsed.
+pub async fn get_owner() -> Result<String, super::Error> {
+    let config = aws_config::defaults(BehaviorVersion::v2026_01_12())
+        .region(Region::new(super::MONITORING_REGION))
+        .load()
+        .await;
+    let client = aws_sdk_sts::Client::new(&config);
+    let identity = client
+        .get_caller_identity()
+        .send()
+        .await
+        .map_err(|e| Box::new(aws_sdk_sts::Error::from(e)))?;
+    let owner = identity
+        .arn()
+        .and_then(|arn| arn.rsplit('/').next())
+        .filter(|s| !s.is_empty())
+        .or_else(|| identity.user_id())
+        .unwrap_or("unknown")
+        .to_string();
+    Ok(owner)
+}
+
+/// Standard tags applied to every resource the deployer creates: the deployment
+/// `tag` and the `owner` (see [`get_owner`]). The `owner` tag enables per-user
+/// attribution and tag-based IAM policies that prevent deleting other users'
+/// deployments.
+fn deployer_tags(tag: &str, owner: &str) -> Vec<Tag> {
+    vec![
+        Tag::builder().key("deployer").value(tag).build(),
+        Tag::builder().key("owner").value(owner).build(),
+    ]
+}
+
 /// Imports an SSH public key into the specified region
 pub async fn import_key_pair(
     client: &Ec2Client,
     key_name: &str,
     public_key: &str,
+    tag: &str,
+    owner: &str,
 ) -> Result<(), Ec2Error> {
     let blob = Blob::new(public_key.as_bytes());
     client
         .import_key_pair()
         .key_name(key_name)
         .public_key_material(blob)
+        .tag_specifications(
+            TagSpecification::builder()
+                .resource_type(ResourceType::KeyPair)
+                .set_tags(Some(deployer_tags(tag, owner)))
+                .build(),
+        )
         .send()
         .await?;
     Ok(())
@@ -170,6 +215,7 @@ pub async fn create_vpc(
     client: &Ec2Client,
     cidr_block: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<String, Ec2Error> {
     let resp = client
         .create_vpc()
@@ -177,7 +223,7 @@ pub async fn create_vpc(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::Vpc)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()
@@ -190,13 +236,14 @@ pub async fn create_and_attach_igw(
     client: &Ec2Client,
     vpc_id: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<String, Ec2Error> {
     let igw_resp = client
         .create_internet_gateway()
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::InternetGateway)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()
@@ -221,6 +268,7 @@ pub async fn create_route_table(
     vpc_id: &str,
     igw_id: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<String, Ec2Error> {
     let rt_resp = client
         .create_route_table()
@@ -228,7 +276,7 @@ pub async fn create_route_table(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::RouteTable)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()
@@ -252,6 +300,7 @@ pub async fn create_subnet(
     subnet_cidr: &str,
     availability_zone: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<String, Ec2Error> {
     let subnet_resp = client
         .create_subnet()
@@ -261,7 +310,7 @@ pub async fn create_subnet(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::Subnet)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()
@@ -282,6 +331,7 @@ pub async fn create_security_group_monitoring(
     vpc_id: &str,
     deployer_ip: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<String, Ec2Error> {
     let sg_resp = client
         .create_security_group()
@@ -291,7 +341,7 @@ pub async fn create_security_group_monitoring(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::SecurityGroup)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()
@@ -320,6 +370,7 @@ pub async fn create_security_group_binary(
     vpc_id: &str,
     deployer_ip: &str,
     tag: &str,
+    owner: &str,
     ports: &[PortConfig],
 ) -> Result<String, Ec2Error> {
     let sg_resp = client
@@ -330,7 +381,7 @@ pub async fn create_security_group_binary(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::SecurityGroup)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()
@@ -506,6 +557,7 @@ async fn try_launch_instances(
     count: i32,
     name: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<Vec<String>, Ec2Error> {
     // Build the root EBS mapping with optional provisioned performance settings.
     let mut ebs = EbsBlockDevice::builder()
@@ -537,10 +589,11 @@ async fn try_launch_instances(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::Instance)
-                .set_tags(Some(vec![
-                    Tag::builder().key("deployer").value(tag).build(),
-                    Tag::builder().key("name").value(name).build(),
-                ]))
+                .set_tags(Some({
+                    let mut tags = deployer_tags(tag, owner);
+                    tags.push(Tag::builder().key("name").value(name).build());
+                    tags
+                }))
                 .build(),
         )
         .block_device_mappings(
@@ -600,6 +653,7 @@ pub async fn launch_instances(
     count: i32,
     name: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<(Vec<String>, String), super::Error> {
     validate_storage_options(
         name,
@@ -645,6 +699,7 @@ pub async fn launch_instances(
                 count,
                 name,
                 tag,
+                owner,
             )
             .await
             {
@@ -800,6 +855,7 @@ pub async fn create_vpc_peering_connection(
     peer_vpc_id: &str,
     peer_region: &str,
     tag: &str,
+    owner: &str,
 ) -> Result<String, Ec2Error> {
     let resp = client
         .create_vpc_peering_connection()
@@ -809,7 +865,7 @@ pub async fn create_vpc_peering_connection(
         .tag_specifications(
             TagSpecification::builder()
                 .resource_type(ResourceType::VpcPeeringConnection)
-                .tags(Tag::builder().key("deployer").value(tag).build())
+                .set_tags(Some(deployer_tags(tag, owner)))
                 .build(),
         )
         .send()

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -473,6 +473,8 @@ cfg_if::cfg_if! {
         pub enum Error {
             #[error("AWS EC2 error: {0}")]
             AwsEc2(#[from] aws_sdk_ec2::Error),
+            #[error("AWS STS error: {0}")]
+            AwsSts(#[from] Box<aws_sdk_sts::Error>),
             #[error("AWS security group ingress error: {0}")]
             AwsSecurityGroupIngress(#[from] aws_sdk_ec2::operation::authorize_security_group_ingress::AuthorizeSecurityGroupIngressError),
             #[error("AWS describe instances error: {0}")]


### PR DESCRIPTION
## Problem

Every resource the deployer creates is tagged only with `deployer=<uuid>` (plus `name` on instances). There is no attribution to the principal that created it. In a shared AWS account this means:

- You can't tell whose deployment is whose without CloudTrail archaeology.
- Nothing stops one user from accidentally tearing down another user's infrastructure via a manual sweep.

## Change

Stamp an additional `owner` tag on **every** created resource — VPC, internet gateway, route table, subnet, monitoring + binary security groups, VPC peering connections, instances, and the SSH key pair (previously identified only by name).

The owner is resolved once per `create` via STS `GetCallerIdentity`:
- assumed role (e.g. AWS SSO) → role session name
- IAM user → user name
- fallback → caller's unique id, else `"unknown"`

Implementation notes:
- New `ec2::get_owner()` + a shared `deployer_tags(tag, owner)` helper so all tag specs stay consistent.
- Adds `aws-sdk-sts` as an optional dep under the existing `aws` feature.
- New `Error::AwsSts` variant is boxed to keep `aws::Error` under clippy's `result_large_err` threshold.

## Why it matters

With resources carrying `owner`, a tag-based IAM policy on the shared permission set can **deny** `ec2:Terminate*` / `ec2:Delete*` when `ec2:ResourceTag/owner != aws:PrincipalTag/owner`, making accidental cross-owner deletion impossible rather than merely discouraged. (Requires a companion rule enforcing the `owner` tag on create so it can't be omitted/spoofed.)

## Testing

- `cargo check -p commonware-deployer --features aws` ✅
- `cargo test -p commonware-deployer --features aws` ✅ (34 passed)
- `cargo clippy`: introduces no new findings (the pre-existing lints are identical on `main`; they only surface on newer clippy toolchains).

Backwards compatible: no config schema change, existing `config.yaml` files work unchanged.
