### PR TITLE
[storage] Add `start_sync` to the remaining QMDB databases

### DIFF
--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -1452,6 +1452,53 @@ async fn test_start_sync_overlaps_work<F, Fut, J>(
     journal.destroy().await.unwrap();
 }
 
+/// A new sync waits for the prior sync before starting: the second start_sync call itself
+/// (not its returned handle) stays pending, and no second backend sync starts, until the
+/// prior sync completes.
+#[boxed]
+async fn test_start_sync_waits_for_prior<F, Fut, J>(
+    context: deterministic::Context,
+    pending: PendingSyncs,
+    make: F,
+) where
+    F: Fn(DelayedSyncContext<deterministic::Context>) -> Fut,
+    Fut: Future<Output = Result<J, Error>>,
+    J: Mutable<Item = u64>,
+{
+    let mut journal = make(DelayedSyncContext {
+        inner: context.child("a"),
+        pending: pending.clone(),
+    })
+    .await
+    .unwrap();
+    for i in 0..4u64 {
+        (journal, _) = journal.append(&i).await.unwrap();
+    }
+
+    let first;
+    (journal, first) = journal.start_sync().await.unwrap();
+    let starts_before = pending.starts();
+    (journal, _) = journal.append(&999).await.unwrap();
+
+    let (journal, second) = {
+        let mut call = std::pin::pin!(journal.start_sync());
+        assert!(
+            call.as_mut().now_or_never().is_none(),
+            "start_sync proceeded while the prior sync was pending"
+        );
+        assert_eq!(
+            pending.starts(),
+            starts_before,
+            "a second backend sync started while the prior sync was pending"
+        );
+        pending.unblock();
+        call.await.unwrap()
+    };
+    first.await.unwrap();
+    second.await.unwrap();
+    journal.destroy().await.unwrap();
+}
+
 /// A sync handle completes only once both the tail sync and the predecessor's rollover sync
 /// are durable.
 #[boxed]
@@ -1630,6 +1677,34 @@ fn test_variable_start_sync_overlaps_work() {
         let pending = PendingSyncs::default();
         let cfg = variable_overlap_cfg(&context, "variable-start-sync-overlap");
         test_start_sync_overlaps_work(context, pending, move |ctx| {
+            let cfg = cfg.clone();
+            variable::Journal::<_, u64>::init(ctx, cfg)
+        })
+        .await;
+    });
+}
+
+#[test]
+fn test_fixed_start_sync_waits_for_prior() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let pending = PendingSyncs::default();
+        let cfg = fixed_overlap_cfg(&context, "fixed-start-sync-waits");
+        test_start_sync_waits_for_prior(context, pending, move |ctx| {
+            let cfg = cfg.clone();
+            fixed::Journal::<_, u64>::init(ctx, cfg)
+        })
+        .await;
+    });
+}
+
+#[test]
+fn test_variable_start_sync_waits_for_prior() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let pending = PendingSyncs::default();
+        let cfg = variable_overlap_cfg(&context, "variable-start-sync-waits");
+        test_start_sync_waits_for_prior(context, pending, move |ctx| {
             let cfg = cfg.clone();
             variable::Journal::<_, u64>::init(ctx, cfg)
         })

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2794,9 +2794,9 @@ where
     /// different fork returns [`crate::qmdb::Error::StaleBatch`] (see
     /// [`crate::qmdb::batch_chain`] for more details).
     ///
-    /// This publishes the batch to the in-memory database state and appends it to the
-    /// journal, but does not durably persist it. Call [`Db::commit`] or [`Db::sync`] to
-    /// guarantee durability.
+    /// This publishes the batch to the in-memory database state and appends it to the journal,
+    /// but does not durably persist it. Call [`Db::commit`] or [`Db::sync`], or await the handle
+    /// returned by [`Db::start_sync`], to guarantee durability.
     #[tracing::instrument(
         name = "qmdb.any.db.apply_batch",
         level = "info",

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -543,7 +543,8 @@ where
     /// from `rewind` and reopen from storage.
     ///
     /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
-    /// [`Db::sync`].
+    /// [`Db::sync`] completes, or until the handle returned by a subsequent [`Db::start_sync`]
+    /// completes.
     #[tracing::instrument(
         name = "qmdb.any.db.rewind",
         level = "info",

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -294,16 +294,31 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         H: Hasher<Digest = D>,
         S: Strategy,
     {
+        // Match the deferred-failure convention used by the journal: return a prior completion's
+        // error through a ready handle before a later completion can replace it. Errors while
+        // staging or initiating this sync continue to use the outer result.
+        if let Err(err) = self.wait_for_sync().await {
+            return Ok((self, Handle::ready(Err(err))));
+        }
+
+        // Decide whether the journal needs a new witness before starting this sync. During import,
+        // staging verifies the cached witness before clearing the journal it will replace.
         let verified;
         (self, verified) = self
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
+
         if let Some(verified) = verified {
+            // Publish the witness to the cache only after it has been appended. The cache may
+            // then match the Merkle before the append is durable, which `pending_sync` tracks.
             (self.journal, _) = self.journal.append(&verified.witness).await?;
             self.import_pending.store(false, Ordering::Relaxed);
             merkle.prune_to_frontier();
             self.replace(verified);
         }
+
+        // Share one completion between the caller and the store. Retaining a clone keeps a
+        // dropped handle's failure observable by the next durability operation.
         let handle;
         (self.journal, handle) = self.journal.start_sync().await?;
         let completion: SyncCompletion = handle.boxed().shared();

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -25,7 +25,7 @@ use crate::{
 use commonware_codec::{Decode as _, EncodeSize, Read, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
-use commonware_runtime::Handle;
+use commonware_runtime::{Error as RError, Handle};
 use commonware_utils::sync::RwLock;
 use futures::FutureExt as _;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -182,9 +182,10 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Persist the current compact state as a new witness journal entry, committing the journal
     /// so the entry survives a crash. Journal recovery may be required on reopen.
     ///
-    /// If the cached witness already matches the Merkle, this only awaits any sync still in
-    /// flight from [`Self::start_sync`]. Otherwise appends a witness built from the unpruned
-    /// Merkle, prunes the Merkle to its frontier, and refreshes the cache.
+    /// First waits for any sync pipelined by [`Self::start_sync`], surfacing its failure. If the
+    /// cached witness already matches the Merkle, nothing more is needed. Otherwise appends a
+    /// witness built from the unpruned Merkle, prunes the Merkle to its frontier, and refreshes
+    /// the cache.
     pub(crate) async fn commit<H, S>(
         self,
         merkle: &compact::Merkle<F, D, S>,
@@ -195,6 +196,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         H: Hasher<Digest = D>,
         S: Strategy,
     {
+        self.wait_for_sync().await?;
         self.persist::<H, S>(
             merkle,
             inactivity_floor_loc,
@@ -207,9 +209,10 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Persist the current compact state as a new witness journal entry, syncing the journal and
     /// all of its metadata to minimize recovery work on reopen.
     ///
-    /// If the cached witness already matches the Merkle, this only awaits any sync still in
-    /// flight from [`Self::start_sync`]. Otherwise appends a witness built from the unpruned
-    /// Merkle, prunes the Merkle to its frontier, and refreshes the cache.
+    /// If the cached witness already matches the Merkle, this only settles any sync pipelined
+    /// by [`Self::start_sync`], running a full journal sync when one is outstanding. Otherwise
+    /// appends a witness built from the unpruned Merkle, prunes the Merkle to its frontier, and
+    /// refreshes the cache.
     pub(crate) async fn sync<H, S>(
         self,
         merkle: &compact::Merkle<F, D, S>,
@@ -250,26 +253,16 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
         let Some(verified) = verified else {
-            // Nothing new to append, so only the sync pipelined by start_sync needs
-            // settling. Its success provides only commit-level durability, so a full
-            // sync still runs.
-            match durability {
-                Durability::Commit => {
-                    if let Some(pending) = self.pending_sync.clone()
-                        && pending.await.is_err()
-                    {
-                        self.journal = self.journal.commit().await?;
-                    }
-                }
-                Durability::Sync => {
-                    if self.pending_sync.take().is_some() {
-                        self.journal = self.journal.sync().await?;
-                    }
-                }
+            // A commit already waited for the pipelined sync. A full sync still runs because
+            // the pipelined sync made only a best-effort attempt to persist all metadata.
+            if matches!(durability, Durability::Sync) && self.pending_sync.take().is_some() {
+                self.journal = self.journal.sync().await?;
             }
             return Ok(self);
         };
         (self.journal, _) = self.journal.append(&verified.witness).await?;
+
+        // A commit leaves `pending_sync` set so the next full sync still persists all metadata.
         self.journal = match durability {
             Durability::Commit => self.journal.commit().await?,
             Durability::Sync => {
@@ -318,11 +311,15 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         Ok((self, Handle::from_future(completion)))
     }
 
-    /// Whether a sync pipelined by [`Self::start_sync`] is still pending.
-    pub(crate) fn has_pending_sync(&self) -> bool {
-        self.pending_sync
-            .as_ref()
-            .is_some_and(|pending| !matches!(pending.peek(), Some(Ok(()))))
+    /// Wait for any sync pipelined by [`Self::start_sync`], surfacing its failure.
+    ///
+    /// A successful completion remains recorded until the next full journal sync, which must
+    /// still guarantee that all metadata is current.
+    pub(crate) async fn wait_for_sync(&self) -> Result<(), RError> {
+        let Some(pending) = self.pending_sync.clone() else {
+            return Ok(());
+        };
+        pending.await
     }
 
     /// Decide what a persist must write, clearing the journal first when an import is pending.

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -253,10 +253,13 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
         let Some(verified) = verified else {
-            // A commit already waited for the pipelined sync. A full sync still runs because
-            // the pipelined sync made only a best-effort attempt to persist all metadata.
-            if matches!(durability, Durability::Sync) && self.pending_sync.take().is_some() {
+            // `commit` already waited for the pipelined sync. `sync` waits here and then runs a
+            // full journal sync because the pipelined sync made only a best-effort attempt to
+            // persist all metadata.
+            if matches!(durability, Durability::Sync) && self.pending_sync.is_some() {
+                self.wait_for_sync().await?;
                 self.journal = self.journal.sync().await?;
+                self.pending_sync = None;
             }
             return Ok(self);
         };

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -253,11 +253,10 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
         let Some(verified) = verified else {
-            // `commit` already waited for the pipelined sync. `sync` waits here and then runs a
-            // full journal sync because the pipelined sync made only a best-effort attempt to
-            // persist all metadata.
+            // `commit` already waited for the pipelined sync. `sync` delegates that drain to the
+            // full journal sync, which is still required because the pipelined sync made only a
+            // best-effort attempt to persist all metadata.
             if matches!(durability, Durability::Sync) && self.pending_sync.is_some() {
-                self.wait_for_sync().await?;
                 self.journal = self.journal.sync().await?;
                 self.pending_sync = None;
             }

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -15,7 +15,7 @@
 //! never pruned.
 
 use crate::{
-    Context,
+    Context, SyncCompletion,
     journal::contiguous::{Contiguous, variable},
     merkle::{
         self, Family, Location, MAX_PINNED_NODES, MAX_PROOF_DIGESTS_PER_ELEMENT, Proof, compact,
@@ -27,6 +27,7 @@ use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_runtime::Handle;
 use commonware_utils::sync::RwLock;
+use futures::FutureExt as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// A single durably persisted witness: a complete snapshot of one synced commit.
@@ -136,9 +137,9 @@ pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     /// serialized by ownership of the store, so `Relaxed` suffices.
     import_pending: AtomicBool,
 
-    /// Whether the journal may hold work from [`Self::start_sync`] not yet proven by a full
+    /// The sync pipelined by the last [`Self::start_sync`], cleared by the next full
     /// journal sync.
-    sync_started: bool,
+    pending_sync: Option<SyncCompletion>,
 }
 
 impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
@@ -148,7 +149,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             journal,
             tip_witness: RwLock::new(witness),
             import_pending: AtomicBool::new(false),
-            sync_started: false,
+            pending_sync: None,
         }
     }
 
@@ -164,7 +165,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             journal,
             tip_witness: RwLock::new(witness),
             import_pending: AtomicBool::new(true),
-            sync_started: false,
+            pending_sync: None,
         }
     }
 
@@ -249,15 +250,21 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
         let Some(verified) = verified else {
-            // Nothing new to append, but a sync started by start_sync may still be in
-            // flight: drain it before reporting the tip durable.
-            if self.sync_started {
-                self.journal = match durability {
-                    Durability::Commit => self.journal.commit().await?,
-                    Durability::Sync => self.journal.sync().await?,
-                };
-                if matches!(durability, Durability::Sync) {
-                    self.sync_started = false;
+            // Nothing new to append, so only the sync pipelined by start_sync needs
+            // settling. Its success provides only commit-level durability, so a full
+            // sync still runs.
+            match durability {
+                Durability::Commit => {
+                    if let Some(pending) = self.pending_sync.clone()
+                        && pending.await.is_err()
+                    {
+                        self.journal = self.journal.commit().await?;
+                    }
+                }
+                Durability::Sync => {
+                    if self.pending_sync.take().is_some() {
+                        self.journal = self.journal.sync().await?;
+                    }
                 }
             }
             return Ok(self);
@@ -265,11 +272,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         (self.journal, _) = self.journal.append(&verified.witness).await?;
         self.journal = match durability {
             Durability::Commit => self.journal.commit().await?,
-            Durability::Sync => self.journal.sync().await?,
+            Durability::Sync => {
+                let journal = self.journal.sync().await?;
+                self.pending_sync = None;
+                journal
+            }
         };
-        if matches!(durability, Durability::Sync) {
-            self.sync_started = false;
-        }
         self.import_pending.store(false, Ordering::Relaxed);
         merkle.prune_to_frontier();
         self.replace(verified);
@@ -305,14 +313,19 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         }
         let handle;
         (self.journal, handle) = self.journal.start_sync().await?;
-        self.sync_started = true;
-        Ok((self, handle))
+        let completion: SyncCompletion = handle.boxed().shared();
+        self.pending_sync = Some(completion.clone());
+        Ok((self, Handle::from_future(completion)))
     }
 
-    /// Whether a pipelined sync from [`Self::start_sync`] may still be in flight, leaving the
-    /// cached tip ahead of what a crash would recover.
-    pub(crate) const fn sync_started(&self) -> bool {
-        self.sync_started
+    /// Whether a sync pipelined by [`Self::start_sync`] is still pending, i.e. has not
+    /// provably succeeded.
+    ///
+    /// Peeks the completion without blocking, so an in-flight sync counts as pending.
+    pub(crate) fn has_pending_sync(&self) -> bool {
+        self.pending_sync
+            .as_ref()
+            .is_some_and(|pending| !matches!(pending.peek(), Some(Ok(()))))
     }
 
     /// Decide what a persist must write, clearing the journal first when an import is pending.
@@ -383,7 +396,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             last_commit_floor,
         )?;
         self.journal = self.journal.rewind(pos + 1).await?.sync().await?;
-        self.sync_started = false;
+        self.pending_sync = None;
         self.replace(witness);
         Ok((self, op))
     }
@@ -404,7 +417,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .min(bounds.end - 1);
         (self.journal, _) = self.journal.prune(pos).await?;
         self.journal = self.journal.sync().await?;
-        self.sync_started = false;
+        self.pending_sync = None;
         Ok(self)
     }
 

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -10,8 +10,9 @@
 //! Entries are strictly increasing in committed leaf count (`proof.leaves`), so a leaf count
 //! uniquely identifies a rewind or prune target. The journal `commit` or `sync` after an append
 //! is the commit point: a crash before it drops the unsynced tail on reopen, recovering the
-//! previous commit. [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip
-//! entry is never pruned.
+//! previous commit. For [`Store::start_sync`] the commit point is the completion of the returned
+//! handle. [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is
+//! never pruned.
 
 use crate::{
     Context,
@@ -24,6 +25,7 @@ use crate::{
 use commonware_codec::{Decode as _, EncodeSize, Read, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
+use commonware_runtime::Handle;
 use commonware_utils::sync::RwLock;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -133,6 +135,9 @@ pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     /// first persist replaces them with the cached witness and clears this flag. Mutations are
     /// serialized by ownership of the store, so `Relaxed` suffices.
     import_pending: AtomicBool,
+
+    /// Whether a pipelined journal sync from [`Self::start_sync`] may still be in flight.
+    sync_started: bool,
 }
 
 impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
@@ -142,6 +147,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             journal,
             tip_witness: RwLock::new(witness),
             import_pending: AtomicBool::new(false),
+            sync_started: false,
         }
     }
 
@@ -157,6 +163,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             journal,
             tip_witness: RwLock::new(witness),
             import_pending: AtomicBool::new(true),
+            sync_started: false,
         }
     }
 
@@ -173,9 +180,9 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Persist the current compact state as a new witness journal entry, committing the journal
     /// so the entry survives a crash. Journal recovery may be required on reopen.
     ///
-    /// No-op if the cached witness already matches the Merkle (the witness is already durable).
-    /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
-    /// frontier, and refreshes the cache.
+    /// If the cached witness already matches the Merkle, this only awaits any sync still in
+    /// flight from [`Self::start_sync`]. Otherwise appends a witness built from the unpruned
+    /// Merkle, prunes the Merkle to its frontier, and refreshes the cache.
     pub(crate) async fn commit<H, S>(
         self,
         merkle: &compact::Merkle<F, D, S>,
@@ -198,9 +205,9 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Persist the current compact state as a new witness journal entry, syncing the journal and
     /// all of its metadata to minimize recovery work on reopen.
     ///
-    /// No-op if the cached witness already matches the Merkle (the witness is already durable).
-    /// Otherwise appends a witness built from the unpruned Merkle, prunes the Merkle to its
-    /// frontier, and refreshes the cache.
+    /// If the cached witness already matches the Merkle, this only awaits any sync still in
+    /// flight from [`Self::start_sync`]. Otherwise appends a witness built from the unpruned
+    /// Merkle, prunes the Merkle to its frontier, and refreshes the cache.
     pub(crate) async fn sync<H, S>(
         self,
         merkle: &compact::Merkle<F, D, S>,
@@ -241,6 +248,15 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
         let Some(verified) = verified else {
+            // Nothing new to append, but a sync started by start_sync may still be in
+            // flight: drain it before reporting the tip durable.
+            if self.sync_started {
+                self.journal = match durability {
+                    Durability::Commit => self.journal.commit().await?,
+                    Durability::Sync => self.journal.sync().await?,
+                };
+                self.sync_started = false;
+            }
             return Ok(self);
         };
         (self.journal, _) = self.journal.append(&verified.witness).await?;
@@ -248,10 +264,50 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             Durability::Commit => self.journal.commit().await?,
             Durability::Sync => self.journal.sync().await?,
         };
+        self.sync_started = false;
         self.import_pending.store(false, Ordering::Relaxed);
         merkle.prune_to_frontier();
         self.replace(verified);
         Ok(self)
+    }
+
+    /// Persist the current compact state as a new witness journal entry, starting the journal
+    /// sync instead of awaiting it.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on reopen. When nothing new must
+    /// be appended, the handle still proves the current tip durable and resurfaces any retained
+    /// sync failure.
+    pub(crate) async fn start_sync<H, S>(
+        mut self,
+        merkle: &compact::Merkle<F, D, S>,
+        inactivity_floor_loc: Location<F>,
+        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
+    ) -> Result<(Self, Handle<()>), Error<F>>
+    where
+        H: Hasher<Digest = D>,
+        S: Strategy,
+    {
+        let verified;
+        (self, verified) = self
+            .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
+            .await?;
+        if let Some(verified) = verified {
+            (self.journal, _) = self.journal.append(&verified.witness).await?;
+            self.import_pending.store(false, Ordering::Relaxed);
+            merkle.prune_to_frontier();
+            self.replace(verified);
+        }
+        let handle;
+        (self.journal, handle) = self.journal.start_sync().await?;
+        self.sync_started = true;
+        Ok((self, handle))
+    }
+
+    /// Whether a pipelined sync from [`Self::start_sync`] may still be in flight, leaving the
+    /// cached tip ahead of what a crash would recover.
+    pub(crate) const fn sync_started(&self) -> bool {
+        self.sync_started
     }
 
     /// Decide what a persist must write, clearing the journal first when an import is pending.
@@ -322,6 +378,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             last_commit_floor,
         )?;
         self.journal = self.journal.rewind(pos + 1).await?.sync().await?;
+        self.sync_started = false;
         self.replace(witness);
         Ok((self, op))
     }
@@ -342,6 +399,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .min(bounds.end - 1);
         (self.journal, _) = self.journal.prune(pos).await?;
         self.journal = self.journal.sync().await?;
+        self.sync_started = false;
         Ok(self)
     }
 

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -136,7 +136,8 @@ pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     /// serialized by ownership of the store, so `Relaxed` suffices.
     import_pending: AtomicBool,
 
-    /// Whether a pipelined journal sync from [`Self::start_sync`] may still be in flight.
+    /// Whether the journal may hold work from [`Self::start_sync`] not yet proven by a full
+    /// journal sync.
     sync_started: bool,
 }
 
@@ -255,7 +256,9 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
                     Durability::Commit => self.journal.commit().await?,
                     Durability::Sync => self.journal.sync().await?,
                 };
-                self.sync_started = false;
+                if matches!(durability, Durability::Sync) {
+                    self.sync_started = false;
+                }
             }
             return Ok(self);
         };
@@ -264,7 +267,9 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             Durability::Commit => self.journal.commit().await?,
             Durability::Sync => self.journal.sync().await?,
         };
-        self.sync_started = false;
+        if matches!(durability, Durability::Sync) {
+            self.sync_started = false;
+        }
         self.import_pending.store(false, Ordering::Relaxed);
         merkle.prune_to_frontier();
         self.replace(verified);

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -318,10 +318,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         Ok((self, Handle::from_future(completion)))
     }
 
-    /// Whether a sync pipelined by [`Self::start_sync`] is still pending, i.e. has not
-    /// provably succeeded.
-    ///
-    /// Peeks the completion without blocking, so an in-flight sync counts as pending.
+    /// Whether a sync pipelined by [`Self::start_sync`] is still pending.
     pub(crate) fn has_pending_sync(&self) -> bool {
         self.pending_sync
             .as_ref()

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -1,18 +1,18 @@
 //! Shared machinery for the compact-db witness journal.
 //!
 //! The witness journal is the single durable source of truth for a compact database. Each
-//! [`Witness`] is a complete snapshot of one synced commit: the encoded commit operation,
+//! [`Witness`] is a complete snapshot of one published commit: the encoded commit operation,
 //! its single-leaf inclusion proof against the committed root, and the pinned frontier nodes of
 //! the compact Merkle. On open and rewind, the in-memory Merkle is rebuilt from an entry and the
 //! entry's proof is re-verified against the root recomputed from the rebuilt frontier; a
 //! mismatch fails with [`Error::DataCorrupted`].
 //!
 //! Entries are strictly increasing in committed leaf count (`proof.leaves`), so a leaf count
-//! uniquely identifies a rewind or prune target. The journal `commit` or `sync` after an append
-//! is the commit point: a crash before it drops the unsynced tail on reopen, recovering the
-//! previous commit. For [`Store::start_sync`] the commit point is the completion of the returned
-//! handle. [`Store::prune`] bounds how far back [`Store::rewind`] can reach; the tip entry is
-//! never pruned.
+//! uniquely identifies a rewind or prune target. An appended entry becomes durable when the
+//! journal `commit` or `sync` completes. For [`Store::start_sync`] it becomes durable when the
+//! returned handle completes. Before that point, the entry is not guaranteed durable and recovery
+//! may fall back to the previous commit. [`Store::prune`] bounds how far back [`Store::rewind`] can
+//! reach. The tip entry is never pruned.
 
 use crate::{
     Context, SyncCompletion,
@@ -30,7 +30,7 @@ use commonware_utils::sync::RwLock;
 use futures::FutureExt as _;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-/// A single durably persisted witness: a complete snapshot of one synced commit.
+/// A witness journal entry containing a complete snapshot of one published commit.
 ///
 /// The root is not stored: it is recomputed from the rebuilt frontier and authenticated against
 /// `proof`.
@@ -174,7 +174,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         f(&self.tip_witness.read())
     }
 
-    /// Replace the cached witness after the matching compact Merkle state is persisted or loaded.
+    /// Replace the cached witness after the matching compact Merkle state is staged or loaded.
     pub(crate) fn replace(&self, witness: VerifiedWitness<F, D>) {
         *self.tip_witness.write() = witness;
     }
@@ -324,7 +324,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 
     /// Decide what a persist must write, clearing the journal first when an import is pending.
     ///
-    /// Returns `None` if the durable tip already matches the in-memory Merkle and no import is
+    /// Returns `None` if the cached tip already matches the in-memory Merkle and no import is
     /// pending, otherwise the witness to append and install in the cache.
     async fn stage<H, S>(
         mut self,
@@ -337,9 +337,10 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         S: Strategy,
     {
         // An equal leaf count means no commit has been applied since the cache was set.
-        // Normally the cache mirrors the journal tip, so the state is already durable and there
-        // is nothing to do. During a pending import the cached witness is not in the journal
-        // yet, so it is exactly what must be persisted: replace the journal's contents with it.
+        // Normally the cache mirrors the journal tip, so there is no witness to append. A
+        // start_sync may still be proving that tip durable, which pending_sync tracks separately.
+        // During a pending import the cached witness is not in the journal yet, so it is exactly
+        // what must be persisted. Replace the journal's contents with it.
         let cached_leaves = self.with(|w| w.leaf_count());
         let verified = if cached_leaves == merkle.leaves() {
             if !self.import_pending.load(Ordering::Relaxed) {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -598,7 +598,8 @@ where
     /// this database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
-    /// [`Db::sync`].
+    /// [`Db::sync`] completes, or until the handle returned by a subsequent [`Db::start_sync`]
+    /// completes.
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
@@ -874,9 +875,9 @@ where
     /// different fork returns [`Error::StaleBatch`] (see [`crate::qmdb::batch_chain`] for
     /// more details).
     ///
-    /// This publishes the batch to the in-memory Current view and appends it to the journal,
-    /// but does not durably persist it. Call [`Db::commit`] or [`Db::sync`] to guarantee
-    /// durability.
+    /// This publishes the batch to the in-memory Current view and appends it to the journal, but
+    /// does not durably persist it. Call [`Db::commit`] or [`Db::sync`], or await the handle
+    /// returned by [`Db::start_sync`], to guarantee durability.
     #[tracing::instrument(name = "qmdb.current.db.apply_batch", level = "info", skip_all)]
     #[boxed]
     pub async fn apply_batch(

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -290,9 +290,10 @@ where
     /// Build a compact db handle from already-validated compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. The import lives only in memory until the first [`Self::commit`]
-    /// or [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
-    /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
+    /// supplied witness/root pair. The import lives only in memory until the first
+    /// [`Self::commit`], [`Self::sync`], or [`Self::start_sync`], which replaces the journal's
+    /// contents with it. Until then, dropping the handle leaves the previous on-disk state
+    /// untouched, and rewind/prune are rejected.
     pub(crate) fn init_from_validated_state(
         strategy: S,
         journal: witness::Journal<E, F, H::Digest>,
@@ -426,9 +427,10 @@ where
 
     /// Return the compact-sync target described by the current witness.
     ///
-    /// This reflects the last persisted commit, which may lag behind live in-memory mutations
-    /// until [`Self::commit`] or [`Self::sync`] is called, or a [`Self::start_sync`] handle
-    /// completes.
+    /// This reflects the last commit handed to the witness journal, which may lag behind live
+    /// in-memory mutations until [`Self::commit`], [`Self::sync`], or [`Self::start_sync`] is
+    /// called. A target published by [`Self::start_sync`] is proven durable only when its
+    /// handle completes.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }
@@ -549,8 +551,8 @@ where
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on reopen. Use [Self::sync] to
     /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
-    /// of the deferred work surface on the returned handle. A failed data sync also fails the
-    /// next durability operation.
+    /// of the deferred durability work surface on the returned handle and the next durability
+    /// operation.
     #[tracing::instrument(
         name = "qmdb.immutable.compact.db.start_sync",
         level = "info",
@@ -612,13 +614,13 @@ where
     where
         F: Family,
     {
-        // Fast path: already durably at `target` with no uncommitted state. A tip whose
-        // pipelined sync is still in flight is not yet proven durable and falls through.
+        // Fast path: already at `target` with no uncommitted state. Wait for any pipelined sync
+        // to prove the tip durable before returning.
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
-            && !self.witness.has_pending_sync()
         {
+            self.witness.wait_for_sync().await?;
             return Ok(self);
         }
 
@@ -649,8 +651,8 @@ where
     ///
     /// # Errors
     ///
-    /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
-    /// [`Self::sync`].
+    /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`],
+    /// [`Self::sync`], or [`Self::start_sync`].
     pub async fn prune(mut self, pruning_boundary: Location<F>) -> Result<Self, Error<F>> {
         self.witness = self.witness.prune(pruning_boundary).await?;
         Ok(self)
@@ -678,10 +680,11 @@ mod tests {
         BufferPooler, Runner as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic,
-        mocks::{DelayedSyncContext, PendingSyncs},
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};
     use core::future::Future;
+    use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
 
     type TestDb<F> =
@@ -810,11 +813,91 @@ mod tests {
                 handle.await.is_err(),
                 "the sync handle surfaces the failure"
             );
+            let starts_before = pending.starts();
+
             // The witness entry was already appended, so this commit has nothing to stage.
             // It must still observe the retained failure rather than no-op.
             assert!(
                 db.commit().await.is_err(),
                 "the next durability op surfaces the failed in-flight sync"
+            );
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the surfaced error is the retained failure, not a fresh sync's"
+            );
+        });
+    }
+
+    /// A rewind to the current size waits for the in-flight sync and adopts its proof of
+    /// durability instead of starting new journal work.
+    #[test_traced]
+    fn test_compact_start_sync_rewind_fast_path_drains() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "immutable-start-sync-rewind-drain";
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", partition, &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), Sha256::fill(9u8)).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            let root = db.root();
+            let size = db.size();
+
+            let starts_before = pending.starts();
+            let db = {
+                let mut rewind = std::pin::pin!(db.rewind(size));
+                assert!(
+                    rewind.as_mut().now_or_never().is_none(),
+                    "rewind proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                rewind.await.unwrap()
+            };
+            handle.await.unwrap();
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the fast path started journal work instead of adopting the proven sync"
+            );
+            assert_eq!(db.root(), root);
+            drop(db);
+
+            // The awaited pipelined sync made the witness entry durable.
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A rewind to the current size fails when the sync started for the tip witness has
+    /// already failed, rather than reporting the unproven tip as durable.
+    #[test_traced]
+    fn test_compact_start_sync_rewind_fast_path_fails() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(
+                &ctx,
+                "delayed",
+                "immutable-start-sync-rewind-fail",
+                &pending,
+            )
+            .await
+            .unwrap();
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), Sha256::fill(9u8)).await;
+
+            pending.arm_fail();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(handle.await.is_err());
+            let size = db.size();
+            assert!(
+                db.rewind(size).await.is_err(),
+                "rewind reported an unproven tip as durable"
             );
         });
     }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -617,7 +617,7 @@ where
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
-            && !self.witness.sync_started()
+            && !self.witness.has_pending_sync()
         {
             return Ok(self);
         }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -611,9 +611,8 @@ where
     where
         F: Family,
     {
-        // Fast path: already durably at `target` with no uncommitted state. A pipelined sync
-        // still in flight means the cached tip is not yet proven durable, so fall through to
-        // the store, which drains it.
+        // Fast path: already durably at `target` with no uncommitted state. A tip whose
+        // pipelined sync is still in flight is not yet proven durable and falls through.
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -426,8 +426,9 @@ where
 
     /// Return the compact-sync target described by the current witness.
     ///
-    /// This reflects the last durably persisted commit, which may lag behind live in-memory
-    /// mutations until [`Self::commit`], [`Self::sync`], or [`Self::start_sync`] is called.
+    /// This reflects the last persisted commit, which may lag behind live in-memory mutations
+    /// until [`Self::commit`] or [`Self::sync`] is called, or a [`Self::start_sync`] handle
+    /// completes.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -1,16 +1,16 @@
 //! An immutable authenticated db that discards historical operations, retaining only a witness
-//! for each synced commit.
+//! for each published commit.
 //!
 //! Mirrors the API of [`crate::qmdb::immutable::Immutable`] (`new_batch -> merkleize ->
-//! apply_batch -> sync`, pipelined batch chains, `StaleBatch` validation) but is backed by
-//! the peak-only [`crate::merkle::compact`]. Because history is discarded, there are no
-//! `get` / `proof` / `bounds` methods; use the full variant if you need them.
+//! apply_batch -> commit / sync / start_sync`, pipelined batch chains, `StaleBatch` validation)
+//! but is backed by the peak-only [`crate::merkle::compact`]. Because history is discarded,
+//! there are no `get` / `proof` / `bounds` methods. Use the full variant if you need them.
 //!
 //! # Witness journal
 //!
-//! The witness journal holds a complete snapshot of every synced commit, so [`Db::rewind`] can
-//! restore any commit still retained there (history is bounded only by [`Db::prune`]). Reopen
-//! and rewind re-verify the persisted snapshot; corruption surfaces as [`Error::DataCorrupted`].
+//! The witness journal holds a complete snapshot of every published commit, so [`Db::rewind`] can
+//! restore any commit still retained there. History is bounded only by [`Db::prune`]. Reopen and
+//! rewind re-verify the persisted snapshot. Corruption surfaces as [`Error::DataCorrupted`].
 //! The witness (the last-commit operation plus its inclusion proof) is also what lets compact
 //! nodes serve compact sync without retaining historical operations.
 //!
@@ -20,7 +20,7 @@
 //! [`crate::qmdb::immutable::Immutable`]: the root is computed over the encoded operation
 //! sequence, and that sequence must include the same floor to produce the same root as the
 //! full variant. The floor has no effect on pruning or snapshot rebuilding here; all
-//! historical in-memory state is discarded on every sync.
+//! historical in-memory state is discarded whenever a witness is published.
 
 use super::operation::Operation;
 use crate::{
@@ -64,7 +64,7 @@ pub struct Config<C, S: Strategy> {
 }
 
 /// An immutable authenticated db that discards historical operations, retaining only a witness
-/// for each synced commit.
+/// for each published commit.
 pub struct Db<F, E, K, V, H, C, S: Strategy>
 where
     F: Family,
@@ -516,8 +516,9 @@ where
 
     /// Apply a merkleized batch to the database.
     ///
-    /// Returns the range of locations written. The state is updated in memory only; call
-    /// [`Self::commit`] or [`Self::sync`] to persist.
+    /// Returns the range of locations written. The state is updated in memory only. Call
+    /// [`Self::commit`] or [`Self::sync`], or await the handle returned by [`Self::start_sync`],
+    /// to persist it.
     ///
     /// # Errors
     ///
@@ -601,14 +602,14 @@ where
         Ok(self)
     }
 
-    /// Rewind the db to the synced commit with exactly `target` operations, discarding any
+    /// Rewind the db to the published commit with exactly `target` operations, discarding any
     /// uncommitted batches and any later commits. The rewind is made durable before this
     /// method returns.
     ///
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
-    /// no retained commit has exactly `target` operations (never synced, or pruned).
+    /// no retained commit has exactly `target` operations (never published, or pruned).
     #[tracing::instrument(name = "qmdb.immutable.compact.db.rewind", level = "info", skip_all)]
     pub async fn rewind(mut self, target: Location<F>) -> Result<Self, Error<F>>
     where

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -43,6 +43,7 @@ use commonware_codec::{Decode as _, Encode, EncodeShared, Read};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Handle;
 use core::marker::PhantomData;
 use std::{
     collections::BTreeMap,
@@ -426,7 +427,7 @@ where
     /// Return the compact-sync target described by the current witness.
     ///
     /// This reflects the last durably persisted commit, which may lag behind live in-memory
-    /// mutations until [`Self::commit`] or [`Self::sync`] is called.
+    /// mutations until [`Self::commit`], [`Self::sync`], or [`Self::start_sync`] is called.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }
@@ -542,6 +543,31 @@ where
         Ok((self, start_loc..Location::new(batch.bounds.total_size)))
     }
 
+    /// Begin durably persisting the current db state to disk.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on reopen. Use [Self::sync] to
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// of the deferred work surface on the returned handle. A failed data sync also fails the
+    /// next durability operation.
+    #[tracing::instrument(
+        name = "qmdb.immutable.compact.db.start_sync",
+        level = "info",
+        skip_all
+    )]
+    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
+        let last_commit_metadata = self.last_commit_metadata.clone();
+        let inactivity_floor_loc = self.inactivity_floor_loc;
+        let handle;
+        (self.witness, handle) = self
+            .witness
+            .start_sync::<H, S>(&self.merkle, inactivity_floor_loc, || {
+                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
+            })
+            .await?;
+        Ok((self, handle))
+    }
+
     /// Durably persist the current db state to disk. This is faster than [`Self::sync`] but
     /// reopen may need to replay the witness journal's tail to recover.
     #[tracing::instrument(name = "qmdb.immutable.compact.db.commit", level = "info", skip_all)]
@@ -585,10 +611,13 @@ where
     where
         F: Family,
     {
-        // Fast path: already durably at `target` with no uncommitted state.
+        // Fast path: already durably at `target` with no uncommitted state. A pipelined sync
+        // still in flight means the cached tip is not yet proven durable, so fall through to
+        // the store, which drains it.
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
+            && !self.witness.sync_started()
         {
             return Ok(self);
         }
@@ -646,9 +675,13 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+        BufferPooler, Runner as _, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs},
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};
+    use core::future::Future;
     use std::num::{NonZeroU16, NonZeroUsize};
 
     type TestDb<F> =
@@ -683,6 +716,107 @@ mod tests {
     ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
         let cfg = witness_config(partition, &context);
         witness::Journal::init(context, cfg).await.unwrap()
+    }
+
+    /// A compact db over a delayed-sync storage backend.
+    type DelayedDb = Db<
+        mmr::Family,
+        DelayedSyncContext<deterministic::Context>,
+        Digest,
+        FixedEncoding<Digest>,
+        Sha256,
+        (),
+        Sequential,
+    >;
+
+    /// Open a [DelayedDb] whose blob syncs park on `pending`.
+    ///
+    /// Init durably persists the bootstrap witness, so while syncs park the returned future
+    /// must be driven with `drive_pending_syncs` (or the mock unblocked first).
+    fn open_delayed_db(
+        context: &deterministic::Context,
+        label: &'static str,
+        partition: &str,
+        pending: &PendingSyncs,
+    ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
+        let witness_cfg = witness_config(partition, context);
+        let merkle = crate::merkle::compact::Merkle::new(Sequential);
+        let context = DelayedSyncContext {
+            inner: context.child(label),
+            pending: pending.clone(),
+        };
+        DelayedDb::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+    }
+
+    /// Apply a single-key batch writing `key -> value` with `metadata`.
+    async fn apply_set(db: DelayedDb, key: Digest, value: Digest, metadata: Digest) -> DelayedDb {
+        let floor = db.inactivity_floor_loc();
+        let batch = db
+            .new_batch()
+            .set(key, value)
+            .merkleize(&db, Some(metadata), floor)
+            .await;
+        let (db, _) = db.apply_batch(batch).unwrap();
+        db
+    }
+
+    /// State persisted via an awaited start_sync handle is recovered on reopen.
+    #[test_traced]
+    fn test_compact_start_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "immutable-start-sync-recovery";
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", partition, &pending)
+                .await
+                .unwrap();
+            let metadata = Sha256::fill(9u8);
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), metadata).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get_metadata(), Some(metadata));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A sync begun by `start_sync` that fails in flight surfaces the error through both the
+    /// returned handle and the next durability operation, even when that operation has nothing
+    /// new to persist.
+    #[test_traced]
+    fn test_compact_start_sync_failure_propagates() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "immutable-start-sync-fail", &pending)
+                .await
+                .unwrap();
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), Sha256::fill(9u8)).await;
+
+            // Arm all future syncs to resolve to an injected error.
+            pending.arm_fail();
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(
+                handle.await.is_err(),
+                "the sync handle surfaces the failure"
+            );
+            // The witness entry was already appended, so this commit has nothing to stage.
+            // It must still observe the retained failure rather than no-op.
+            assert!(
+                db.commit().await.is_err(),
+                "the next durability op surfaces the failed in-flight sync"
+            );
+        });
     }
 
     #[test_traced("INFO")]

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -78,7 +78,7 @@ impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, S: Strategy>
 mod tests {
     use super::*;
     use crate::{
-        merkle::{full::Config as MmrConfig, mmb, mmr},
+        merkle::{Location, full::Config as MmrConfig, mmb, mmr},
         qmdb::immutable::test,
         translator::TwoCap,
     };
@@ -86,10 +86,15 @@ mod tests {
     use commonware_macros::{boxed, test_traced};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Metrics, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+        BufferPooler, Metrics, Runner as _, Spawner as _, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
+        reschedule,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};
     use core::{future::Future, pin::Pin};
+    use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(77);
@@ -143,6 +148,248 @@ mod tests {
         CompactDb::init(context, cfg).await.unwrap()
     }
 
+    /// An immutable db over a delayed-sync storage backend.
+    type DelayedDb = Db<
+        mmr::Family,
+        DelayedSyncContext<deterministic::Context>,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        Sequential,
+    >;
+
+    /// Open a [DelayedDb] whose blob syncs park on `pending`.
+    ///
+    /// Init durably persists the recovered database, so while syncs park the returned future
+    /// must be driven with [drive_pending_syncs] (or the mock unblocked first). The journal
+    /// uses large pages and blobs: an apply that fills the write buffer or rolls the blob over
+    /// waits for the in-flight sync, so mid-sync applies must stay clear of both.
+    fn open_delayed_db(
+        context: &deterministic::Context,
+        label: &'static str,
+        suffix: &str,
+        pending: &PendingSyncs,
+    ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
+        let mut cfg = config(suffix, context);
+        let page_cache = CacheRef::from_pooler(context, NZU16!(1024), NZUsize!(8));
+        cfg.log.items_per_blob = NZU64!(1000);
+        cfg.log.page_cache = page_cache.clone();
+        cfg.merkle_config.items_per_blob = NZU64!(1000);
+        cfg.merkle_config.page_cache = page_cache;
+        DelayedDb::init(
+            DelayedSyncContext {
+                inner: context.child(label),
+                pending: pending.clone(),
+            },
+            cfg,
+        )
+    }
+
+    /// Apply a single-key batch writing `key -> value` with inactivity floor `floor`.
+    async fn apply_set(
+        db: DelayedDb,
+        key: Digest,
+        value: Digest,
+        floor: Location<mmr::Family>,
+    ) -> DelayedDb {
+        let batch = db
+            .new_batch()
+            .set(key, value)
+            .merkleize(&db, None, floor)
+            .await;
+        let (db, _) = db.apply_batch(batch).await.unwrap();
+        db
+    }
+
+    /// A sync handle must not block database use while the backend sync is pending.
+    #[test_traced]
+    fn test_fixed_start_sync_overlaps_work() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "start-sync-overlap", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            let key0 = Sha256::fill(1u8);
+            let value0 = Sha256::fill(2u8);
+            let floor = db.inactivity_floor_loc();
+            db = apply_set(db, key0, value0, floor).await;
+
+            let starts_before = pending.starts();
+            let entered_before = pending.entered();
+            let completions_before = pending.completions();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+            assert_eq!(pending.completions(), completions_before);
+
+            // Observe the sync while the database keeps working.
+            let waiter = ctx
+                .child("await_sync")
+                .spawn(|_| async move { handle.await.unwrap() });
+            while pending.entered() == entered_before {
+                reschedule().await;
+            }
+
+            // Reads and applies complete before the sync does.
+            assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+            let key1 = Sha256::fill(3u8);
+            let value1 = Sha256::fill(4u8);
+            let floor = db.inactivity_floor_loc();
+            db = apply_set(db, key1, value1, floor).await;
+            assert_eq!(
+                pending.completions(),
+                completions_before,
+                "the database made progress while the sync was still in flight"
+            );
+
+            pending.unblock();
+            waiter.await.unwrap();
+
+            // The mid-sync batch is durable after the next start_sync completes.
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", "start-sync-overlap", &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A sync begun by `start_sync` that fails in flight surfaces the error through both the
+    /// returned handle and the next durability operation.
+    #[test_traced]
+    fn test_fixed_start_sync_failure_propagates() {
+        deterministic::Runner::default().start(|ctx| async move {
+            // Pass syncs through so opening the database doesn't park.
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "start-sync-fail", &pending)
+                .await
+                .unwrap();
+            let floor = db.inactivity_floor_loc();
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), floor).await;
+
+            // Arm all future syncs to resolve to an injected error.
+            pending.arm_fail();
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(
+                handle.await.is_err(),
+                "the sync handle surfaces the failure"
+            );
+            let starts_before = pending.starts();
+            // A failed mutable method consumes the database per the failures-are-fatal contract.
+            assert!(
+                db.commit().await.is_err(),
+                "the next durability op surfaces the failed in-flight sync"
+            );
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the surfaced error is the retained failure, not a fresh sync's"
+            );
+        });
+    }
+
+    /// State persisted via an awaited start_sync handle is recovered on reopen.
+    #[test_traced]
+    fn test_fixed_start_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "start-sync-recovery", &pending)
+                .await
+                .unwrap();
+            let key = Sha256::fill(1u8);
+            let value = Sha256::fill(2u8);
+            let floor = db.inactivity_floor_loc();
+            db = apply_set(db, key, value, floor).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", "start-sync-recovery", &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(&key).await.unwrap(), Some(value));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Pruning drains the in-flight sync before mutating storage.
+    #[test_traced]
+    fn test_fixed_start_sync_prune_waits() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "start-sync-prune", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            // Two batches: the second declares floor 2 so the prune below is non-trivial.
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), Location::new(0)).await;
+            db = apply_set(db, Sha256::fill(3u8), Sha256::fill(4u8), Location::new(2)).await;
+
+            let starts_before = pending.starts();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+
+            let floor = db.inactivity_floor_loc();
+            assert!(*floor > 0);
+            let db = {
+                let mut prune = std::pin::pin!(db.prune(floor));
+                assert!(
+                    prune.as_mut().now_or_never().is_none(),
+                    "prune proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                prune.await.unwrap()
+            };
+            handle.await.unwrap();
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Rewinding drains the in-flight sync before mutating storage.
+    #[test_traced]
+    fn test_fixed_start_sync_rewind_waits() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "start-sync-rewind", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_set(db, Sha256::fill(1u8), Sha256::fill(2u8), Location::new(0)).await;
+            db = drive_pending_syncs(&pending, db.commit()).await.unwrap();
+            let committed_root = db.root();
+            let committed_size = db.bounds().end;
+            db = apply_set(db, Sha256::fill(3u8), Sha256::fill(4u8), Location::new(0)).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+
+            let db = {
+                let mut rewind = std::pin::pin!(db.rewind(committed_size));
+                assert!(
+                    rewind.as_mut().now_or_never().is_none(),
+                    "rewind proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                rewind.await.unwrap()
+            };
+            handle.await.unwrap();
+            assert_eq!(db.root(), committed_root);
+            db.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced("INFO")]
     fn test_immutable_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {
@@ -160,6 +407,8 @@ mod tests {
             assert_eq!(db.get_many(&[&key]).await.unwrap(), vec![Some(value)]);
             let db = db.commit().await.unwrap();
             let db = db.sync().await.unwrap();
+            let (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
             let _db = db.prune(crate::merkle::Location::new(0)).await.unwrap();
 
             let metrics = ctx.encode();
@@ -176,6 +425,7 @@ mod tests {
                 "db_operations_applied_total 2",
                 "db_commit_calls_total 1",
                 "db_sync_calls_total 1",
+                "db_start_sync_calls_total 1",
                 "db_prune_calls_total 1",
                 "db_get_duration_count 1",
                 "db_get_many_duration_count 1",

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -542,7 +542,8 @@ where
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// A successful rewind is not restart-stable until a subsequent [`Immutable::commit`] or
-    /// [`Immutable::sync`].
+    /// [`Immutable::sync`] completes, or until the handle returned by a subsequent
+    /// [`Immutable::start_sync`] completes.
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
@@ -657,7 +658,11 @@ where
     ///
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
-    /// guarantee none is needed. A new sync waits for the prior sync before starting.
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// of the deferred durability work surface on the returned handle. A failed data sync also
+    /// fails the next durability operation. A failed recovery-watermark sync is not observed by
+    /// [Self::commit], and a failed merkle-node sync may not be. Both resurface on the next
+    /// [Self::sync].
     #[tracing::instrument(name = "qmdb.immutable.db.start_sync", level = "info", skip_all)]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
         self.metrics.start_sync_calls.inc();
@@ -728,9 +733,9 @@ where
     ///
     /// Returns the range of locations written.
     ///
-    /// This publishes the batch to the in-memory database state and appends it to the
-    /// journal, but does not durably commit it. Call [`Immutable::commit`] or
-    /// [`Immutable::sync`] to guarantee durability.
+    /// This publishes the batch to the in-memory database state and appends it to the journal,
+    /// but does not durably commit it. Call [`Immutable::commit`] or [`Immutable::sync`], or await
+    /// the handle returned by [`Immutable::start_sync`], to guarantee durability.
     #[tracing::instrument(name = "qmdb.immutable.db.apply_batch", level = "info", skip_all)]
     pub async fn apply_batch(
         mut self,

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -657,8 +657,7 @@ where
     ///
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
-    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
-    /// surface as described on [`any::Db::start_sync`](crate::qmdb::any::db::Db::start_sync).
+    /// guarantee none is needed. A new sync waits for the prior sync before starting.
     #[tracing::instrument(name = "qmdb.immutable.db.start_sync", level = "info", skip_all)]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
         self.metrics.start_sync_calls.inc();

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -90,6 +90,7 @@ use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Handle;
 use core::num::{NonZeroU64, NonZeroUsize};
 use std::{ops::Range, sync::Arc};
 use tracing::warn;
@@ -649,6 +650,21 @@ where
         self.metrics.sync_calls.inc();
         self.journal = self.journal.sync().await?;
         Ok(self)
+    }
+
+    /// Begin durably persisting the journal state published by prior [`Immutable::apply_batch`]
+    /// calls.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// surface as described on [`any::Db::start_sync`](crate::qmdb::any::db::Db::start_sync).
+    #[tracing::instrument(name = "qmdb.immutable.db.start_sync", level = "info", skip_all)]
+    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
+        self.metrics.start_sync_calls.inc();
+        let handle;
+        (self.journal, handle) = self.journal.start_sync().await?;
+        Ok((self, handle))
     }
 
     /// Durably commit the journal state published by prior [`Immutable::apply_batch`] calls.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -739,6 +739,25 @@ mod tests {
         db
     }
 
+    /// Leave a failed recovery-watermark sync retained after dropping its public handle.
+    async fn fail_dropped_watermark_sync(mut db: DelayedDb, pending: &PendingSyncs) -> DelayedDb {
+        // Prove the data durable so the next call only advances recovery metadata.
+        let first;
+        (db, first) = db.start_sync().await.unwrap();
+        drive_pending_syncs(pending, first).await.unwrap();
+
+        let dropped;
+        (db, dropped) = db.start_sync().await.unwrap();
+        assert_eq!(
+            pending.lock().len(),
+            1,
+            "expected only the recovery-watermark sync"
+        );
+        fail_pending_syncs(pending);
+        drop(dropped);
+        db
+    }
+
     /// A sync handle must not block database use while the witness sync is pending.
     #[test_traced]
     fn test_compact_start_sync_overlaps_work() {
@@ -898,6 +917,34 @@ mod tests {
                 .unwrap();
             assert_eq!(db.root(), root);
             db.destroy().await.unwrap();
+        });
+    }
+
+    /// A no-op `sync` returns a retained metadata failure before starting new journal work.
+    #[test_traced]
+    fn test_compact_start_sync_then_noop_sync_fails_without_new_work() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(
+                &ctx,
+                "delayed",
+                "keyless-start-sync-noop-sync-fail",
+                &pending,
+            );
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+            db = fail_dropped_watermark_sync(db, &pending).await;
+
+            let starts_before = pending.starts();
+            assert!(
+                drive_pending_syncs(&pending, db.sync()).await.is_err(),
+                "sync absorbed the retained metadata failure"
+            );
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "sync started new journal work before returning the retained failure"
+            );
         });
     }
 
@@ -1104,21 +1151,8 @@ mod tests {
             );
             let mut db = drive_pending_syncs(&pending, open).await.unwrap();
             db = apply_append(db, 1).await;
-
-            // Prove the data durable so the next call only advances recovery metadata.
-            let first;
-            (db, first) = db.start_sync().await.unwrap();
-            drive_pending_syncs(&pending, first).await.unwrap();
-
-            let dropped;
-            (db, dropped) = db.start_sync().await.unwrap();
-            assert_eq!(
-                pending.lock().len(),
-                1,
-                "expected only the recovery-watermark sync"
-            );
-            fail_pending_syncs(&pending);
-            drop(dropped);
+            // Leave only the failed recovery-watermark completion for the next call to observe.
+            db = fail_dropped_watermark_sync(db, &pending).await;
 
             // The store retains the dropped handle's completion. Deferred failures stay on the
             // handle channel, so this call succeeds but its handle must fail.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -411,8 +411,9 @@ where
 
     /// Return the compact-sync target described by the current witness.
     ///
-    /// This reflects the last durably persisted commit, which may lag behind live in-memory
-    /// mutations until [`Self::commit`], [`Self::sync`], or [`Self::start_sync`] is called.
+    /// This reflects the last persisted commit, which may lag behind live in-memory mutations
+    /// until [`Self::commit`] or [`Self::sync`] is called, or a [`Self::start_sync`] handle
+    /// completes.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -657,7 +657,7 @@ mod tests {
         BufferPooler, Runner as _, Spawner as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic,
-        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs, fail_pending_syncs},
         reschedule,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
@@ -1088,6 +1088,47 @@ mod tests {
                 db.commit().await.is_err(),
                 "commit absorbed the retained metadata failure"
             );
+        });
+    }
+
+    /// A later `start_sync` cannot replace an unobserved failure from the prior handle.
+    #[test_traced]
+    fn test_compact_start_sync_retains_dropped_metadata_failure() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(
+                &ctx,
+                "delayed",
+                "keyless-start-sync-dropped-meta-fail",
+                &pending,
+            );
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            // Prove the data durable so the next call only advances recovery metadata.
+            let first;
+            (db, first) = db.start_sync().await.unwrap();
+            drive_pending_syncs(&pending, first).await.unwrap();
+
+            let dropped;
+            (db, dropped) = db.start_sync().await.unwrap();
+            assert_eq!(
+                pending.lock().len(),
+                1,
+                "expected only the recovery-watermark sync"
+            );
+            fail_pending_syncs(&pending);
+            drop(dropped);
+
+            // The store retains the dropped handle's completion. Deferred failures stay on the
+            // handle channel, so this call succeeds but its handle must fail.
+            let next;
+            (db, next) = db.start_sync().await.unwrap();
+            assert!(
+                drive_pending_syncs(&pending, next).await.is_err(),
+                "a later start_sync masked the retained metadata failure"
+            );
+            drop(db);
         });
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -1,16 +1,16 @@
 //! A keyless authenticated db that discards historical operations, retaining only a witness
-//! for each synced commit.
+//! for each published commit.
 //!
 //! Mirrors the API of [`crate::qmdb::keyless::Keyless`] (`new_batch -> merkleize ->
-//! apply_batch -> sync`, pipelined batch chains, `StaleBatch` validation) but is backed by
-//! the peak-only [`crate::merkle::compact`]. Because history is discarded, there are no
-//! `get` / `proof` / `bounds` methods; use the full variant if you need them.
+//! apply_batch -> commit / sync / start_sync`, pipelined batch chains, `StaleBatch` validation)
+//! but is backed by the peak-only [`crate::merkle::compact`]. Because history is discarded,
+//! there are no `get` / `proof` / `bounds` methods. Use the full variant if you need them.
 //!
 //! # Witness journal
 //!
-//! The witness journal holds a complete snapshot of every synced commit, so [`Db::rewind`] can
-//! restore any commit still retained there (history is bounded only by [`Db::prune`]). Reopen
-//! and rewind re-verify the persisted snapshot; corruption surfaces as [`Error::DataCorrupted`].
+//! The witness journal holds a complete snapshot of every published commit, so [`Db::rewind`] can
+//! restore any commit still retained there. History is bounded only by [`Db::prune`]. Reopen and
+//! rewind re-verify the persisted snapshot. Corruption surfaces as [`Error::DataCorrupted`].
 //! The witness (the last-commit operation plus its inclusion proof) is also what lets compact
 //! nodes serve compact sync without retaining historical operations.
 //!
@@ -20,7 +20,7 @@
 //! [`crate::qmdb::keyless::Keyless`]: the root is computed over the encoded operation
 //! sequence, and that sequence must include the same floor to produce the same root as the
 //! full variant. The floor has no effect on pruning or snapshot rebuilding here; all
-//! historical in-memory state is discarded on every sync.
+//! historical in-memory state is discarded whenever a witness is published.
 
 use super::operation::Operation;
 use crate::{
@@ -59,7 +59,7 @@ pub struct Config<C, S: Strategy> {
 }
 
 /// A keyless authenticated db that discards historical operations, retaining only a witness
-/// for each synced commit.
+/// for each published commit.
 pub struct Db<F, E, V, H, C, S: Strategy>
 where
     F: Family,
@@ -500,8 +500,9 @@ where
 
     /// Apply a merkleized batch to the database.
     ///
-    /// Returns the range of locations written. The state is updated in memory only; call
-    /// [`Self::commit`] or [`Self::sync`] to persist.
+    /// Returns the range of locations written. The state is updated in memory only. Call
+    /// [`Self::commit`] or [`Self::sync`], or await the handle returned by [`Self::start_sync`],
+    /// to persist it.
     ///
     /// # Errors
     ///
@@ -577,14 +578,14 @@ where
         Ok(self)
     }
 
-    /// Rewind the db to the synced commit with exactly `target` operations, discarding any
+    /// Rewind the db to the published commit with exactly `target` operations, discarding any
     /// uncommitted batches and any later commits. The rewind is made durable before this
     /// method returns.
     ///
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::RewindBeyondHistory`] (wrapped as [`Error::Merkle`]) if
-    /// no retained commit has exactly `target` operations (never synced, or pruned).
+    /// no retained commit has exactly `target` operations (never published, or pruned).
     #[tracing::instrument(name = "qmdb.keyless.compact.db.rewind", level = "info", skip_all)]
     pub async fn rewind(mut self, target: Location<F>) -> Result<Self, Error<F>>
     where
@@ -653,10 +654,11 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Runner as _, Supervisor as _,
+        BufferPooler, Runner as _, Spawner as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
+        reschedule,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
     use core::future::Future;
@@ -735,6 +737,63 @@ mod tests {
             .await;
         let (db, _) = db.apply_batch(batch).unwrap();
         db
+    }
+
+    /// A sync handle must not block database use while the witness sync is pending.
+    #[test_traced]
+    fn test_compact_start_sync_overlaps_work() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "keyless-start-sync-overlap";
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", partition, &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            let starts_before = pending.starts();
+            let entered_before = pending.entered();
+            let completions_before = pending.completions();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+            assert_eq!(pending.completions(), completions_before);
+            let first_target = db.target();
+
+            let waiter = ctx
+                .child("await_sync")
+                .spawn(|_| async move { handle.await.unwrap() });
+            while pending.entered() == entered_before {
+                reschedule().await;
+            }
+
+            db = apply_append(db, 2).await;
+            assert_ne!(db.root(), first_target.root);
+            assert_eq!(db.target(), first_target);
+            assert_eq!(
+                pending.completions(),
+                completions_before,
+                "the database made progress while the sync was still in flight"
+            );
+
+            pending.unblock();
+            waiter.await.unwrap();
+
+            // The mid-sync batch becomes the servable durable state after the next start_sync
+            // handle completes.
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            let target = db.target();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.target(), target);
+            assert_eq!(db.get_metadata(), Some(U64::new(2)));
+            db.destroy().await.unwrap();
+        });
     }
 
     /// State persisted via an awaited start_sync handle is recovered on reopen.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -587,9 +587,8 @@ where
     where
         F: Family,
     {
-        // Fast path: already durably at `target` with no uncommitted state. A pipelined sync
-        // still in flight means the cached tip is not yet proven durable, so fall through to
-        // the store, which drains it.
+        // Fast path: already durably at `target` with no uncommitted state. A tip whose
+        // pipelined sync is still in flight is not yet proven durable and falls through.
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -277,9 +277,10 @@ where
     /// Build a compact db handle from already-validated compact state.
     ///
     /// The caller has reconstructed the compact Merkle in memory and already authenticated the
-    /// supplied witness/root pair. The import lives only in memory until the first [`Self::commit`]
-    /// or [`Self::sync`], which replaces the journal's contents with it. Until then, dropping the
-    /// handle leaves the previous on-disk state untouched, and rewind/prune are rejected.
+    /// supplied witness/root pair. The import lives only in memory until the first
+    /// [`Self::commit`], [`Self::sync`], or [`Self::start_sync`], which replaces the journal's
+    /// contents with it. Until then, dropping the handle leaves the previous on-disk state
+    /// untouched, and rewind/prune are rejected.
     pub(crate) fn init_from_validated_state(
         strategy: S,
         journal: witness::Journal<E, F, H::Digest>,
@@ -411,9 +412,10 @@ where
 
     /// Return the compact-sync target described by the current witness.
     ///
-    /// This reflects the last persisted commit, which may lag behind live in-memory mutations
-    /// until [`Self::commit`] or [`Self::sync`] is called, or a [`Self::start_sync`] handle
-    /// completes.
+    /// This reflects the last commit handed to the witness journal, which may lag behind live
+    /// in-memory mutations until [`Self::commit`], [`Self::sync`], or [`Self::start_sync`] is
+    /// called. A target published by [`Self::start_sync`] is proven durable only when its
+    /// handle completes.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }
@@ -529,8 +531,8 @@ where
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on reopen. Use [Self::sync] to
     /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
-    /// of the deferred work surface on the returned handle. A failed data sync also fails the
-    /// next durability operation.
+    /// of the deferred durability work surface on the returned handle and the next durability
+    /// operation.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.start_sync", level = "info", skip_all)]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
         let last_commit_metadata = self.last_commit_metadata.clone();
@@ -588,13 +590,13 @@ where
     where
         F: Family,
     {
-        // Fast path: already durably at `target` with no uncommitted state. A tip whose
-        // pipelined sync is still in flight is not yet proven durable and falls through.
+        // Fast path: already at `target` with no uncommitted state. Wait for any pipelined sync
+        // to prove the tip durable before returning.
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
-            && !self.witness.has_pending_sync()
         {
+            self.witness.wait_for_sync().await?;
             return Ok(self);
         }
 
@@ -625,8 +627,8 @@ where
     ///
     /// # Errors
     ///
-    /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`] or
-    /// [`Self::sync`].
+    /// Fails if a compact-sync import has not yet been persisted by [`Self::commit`],
+    /// [`Self::sync`], or [`Self::start_sync`].
     pub async fn prune(mut self, pruning_boundary: Location<F>) -> Result<Self, Error<F>> {
         self.witness = self.witness.prune(pruning_boundary).await?;
         Ok(self)
@@ -784,11 +786,18 @@ mod tests {
                 handle.await.is_err(),
                 "the sync handle surfaces the failure"
             );
+            let starts_before = pending.starts();
+
             // The witness entry was already appended, so this commit has nothing to stage.
             // It must still observe the retained failure rather than no-op.
             assert!(
                 db.commit().await.is_err(),
                 "the next durability op surfaces the failed in-flight sync"
+            );
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the surfaced error is the retained failure, not a fresh sync's"
             );
         });
     }
@@ -833,6 +842,40 @@ mod tests {
         });
     }
 
+    /// A `commit` with nothing new to persist still waits for the sync started by a prior
+    /// `start_sync` before reporting the tip durable, and starts no journal work when that
+    /// sync succeeds.
+    #[test_traced]
+    fn test_compact_start_sync_then_noop_commit_waits() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "keyless-start-sync-noop-commit", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            let starts_before = pending.starts();
+
+            let db = {
+                let mut commit = std::pin::pin!(db.commit());
+                assert!(
+                    commit.as_mut().now_or_never().is_none(),
+                    "commit proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                commit.await.unwrap()
+            };
+            handle.await.unwrap();
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "a successful pipelined sync still triggered journal work"
+            );
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// A `start_sync` with nothing new to persist returns a working handle and appends no
     /// duplicate witness entry.
     #[test_traced]
@@ -870,7 +913,8 @@ mod tests {
         });
     }
 
-    /// A rewind to the current size drains the in-flight sync instead of fast-pathing over it.
+    /// A rewind to the current size waits for the in-flight sync and adopts its proof of
+    /// durability instead of starting new journal work.
     #[test_traced]
     fn test_compact_start_sync_rewind_fast_path_drains() {
         deterministic::Runner::default().start(|ctx| async move {
@@ -885,20 +929,26 @@ mod tests {
             let root = db.root();
             let size = db.size();
 
+            let starts_before = pending.starts();
             let db = {
                 let mut rewind = std::pin::pin!(db.rewind(size));
                 assert!(
                     rewind.as_mut().now_or_never().is_none(),
-                    "rewind fast-pathed while the started sync was pending"
+                    "rewind proceeded while the started sync was pending"
                 );
                 pending.unblock();
                 rewind.await.unwrap()
             };
             handle.await.unwrap();
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the fast path started journal work instead of adopting the proven sync"
+            );
             assert_eq!(db.root(), root);
             drop(db);
 
-            // The rewind's drain made the witness entry durable.
+            // The awaited pipelined sync made the witness entry durable.
             let db = open_delayed_db(&ctx, "reopen", partition, &pending)
                 .await
                 .unwrap();
@@ -932,10 +982,10 @@ mod tests {
         });
     }
 
-    /// A metadata sync failure from `start_sync` that `commit` does not observe still
-    /// resurfaces on the next `sync`, even when that sync has nothing new to persist.
+    /// A metadata sync failure from `start_sync` resurfaces on the next `commit`, even when
+    /// that commit has new state to persist.
     #[test_traced]
-    fn test_compact_start_sync_metadata_failure_resurfaces_on_sync() {
+    fn test_compact_start_sync_metadata_failure_resurfaces_on_commit() {
         deterministic::Runner::default().start(|ctx| async move {
             let pending = PendingSyncs::default();
             let open = open_delayed_db(&ctx, "delayed", "keyless-start-sync-meta-fail", &pending);
@@ -946,7 +996,7 @@ mod tests {
             (db, handle) = db.start_sync().await.unwrap();
 
             // start_sync parks the data sync and then the offsets sync. Complete the data
-            // sync and fail the offsets sync: a failure commit() does not observe.
+            // sync and fail the offsets sync.
             {
                 let mut parked = pending.lock();
                 assert_eq!(
@@ -972,14 +1022,12 @@ mod tests {
             // Later syncs pass; only the retained offsets failure remains.
             pending.unblock();
 
-            // A data-only commit succeeds without observing the metadata failure.
-            let db = db.commit().await.unwrap();
-
-            // sync() has nothing new to persist but must still reach the journal and
-            // resurface the retained failure.
+            // Apply another batch to prove commit checks the prior sync before persisting a new
+            // witness.
+            let db = apply_append(db, 2).await;
             assert!(
-                db.sync().await.is_err(),
-                "sync absorbed the metadata failure after a commit-level drain"
+                db.commit().await.is_err(),
+                "commit absorbed the retained metadata failure"
             );
         });
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -932,6 +932,58 @@ mod tests {
         });
     }
 
+    /// A metadata sync failure from `start_sync` that `commit` does not observe still
+    /// resurfaces on the next `sync`, even when that sync has nothing new to persist.
+    #[test_traced]
+    fn test_compact_start_sync_metadata_failure_resurfaces_on_sync() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "keyless-start-sync-meta-fail", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+
+            // start_sync parks the data sync and then the offsets sync. Complete the data
+            // sync and fail the offsets sync: a failure commit() does not observe.
+            {
+                let mut parked = pending.lock();
+                assert_eq!(
+                    parked.len(),
+                    2,
+                    "expected the data and offsets syncs parked"
+                );
+                let offsets = parked.pop().unwrap();
+                let data = parked.pop().unwrap();
+                data.release.send(Ok(())).unwrap();
+                offsets
+                    .release
+                    .send(Err(commonware_runtime::Error::Io(
+                        std::io::Error::other("injected sync failure").into(),
+                    )))
+                    .unwrap();
+            }
+            assert!(
+                handle.await.is_err(),
+                "the sync handle surfaces the failure"
+            );
+
+            // Later syncs pass; only the retained offsets failure remains.
+            pending.unblock();
+
+            // A data-only commit succeeds without observing the metadata failure.
+            let db = db.commit().await.unwrap();
+
+            // sync() has nothing new to persist but must still reach the journal and
+            // resurface the retained failure.
+            assert!(
+                db.sync().await.is_err(),
+                "sync absorbed the metadata failure after a commit-level drain"
+            );
+        });
+    }
+
     /// The first persist after a compact-sync import can be pipelined: awaiting the handle
     /// makes the imported witness durable.
     #[test_traced("INFO")]

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -593,7 +593,7 @@ where
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
-            && !self.witness.sync_started()
+            && !self.witness.has_pending_sync()
         {
             return Ok(self);
         }
@@ -981,6 +981,35 @@ mod tests {
                 db.sync().await.is_err(),
                 "sync absorbed the metadata failure after a commit-level drain"
             );
+        });
+    }
+
+    /// Once a start_sync handle completes successfully, a commit and a rewind to the current
+    /// size have nothing left to prove and touch no storage.
+    #[test_traced]
+    fn test_compact_start_sync_proven_skips_journal() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "keyless-start-sync-proven", &pending)
+                .await
+                .unwrap();
+            db = apply_append(db, 1).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+
+            let starts_before = pending.starts();
+            let db = db.commit().await.unwrap();
+            let size = db.size();
+            let db = db.rewind(size).await.unwrap();
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "a proven pipelined sync still triggered journal work"
+            );
+            db.destroy().await.unwrap();
         });
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -42,6 +42,7 @@ use commonware_codec::{Decode as _, Encode, EncodeShared, Read};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Handle;
 use std::sync::{Arc, Weak};
 
 /// Configuration for a compact keyless authenticated db.
@@ -411,7 +412,7 @@ where
     /// Return the compact-sync target described by the current witness.
     ///
     /// This reflects the last durably persisted commit, which may lag behind live in-memory
-    /// mutations until [`Self::commit`] or [`Self::sync`] is called.
+    /// mutations until [`Self::commit`], [`Self::sync`], or [`Self::start_sync`] is called.
     pub fn target(&self) -> compact_sync::Target<F, H::Digest> {
         self.witness.with(VerifiedWitness::target)
     }
@@ -522,6 +523,27 @@ where
         Ok((self, start_loc..Location::new(batch.bounds.total_size)))
     }
 
+    /// Begin durably persisting the current db state to disk.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on reopen. Use [Self::sync] to
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// of the deferred work surface on the returned handle. A failed data sync also fails the
+    /// next durability operation.
+    #[tracing::instrument(name = "qmdb.keyless.compact.db.start_sync", level = "info", skip_all)]
+    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
+        let last_commit_metadata = self.last_commit_metadata.clone();
+        let inactivity_floor_loc = self.inactivity_floor_loc;
+        let handle;
+        (self.witness, handle) = self
+            .witness
+            .start_sync::<H, S>(&self.merkle, inactivity_floor_loc, || {
+                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
+            })
+            .await?;
+        Ok((self, handle))
+    }
+
     /// Durably persist the current db state to disk. This is faster than [`Self::sync`] but
     /// reopen may need to replay the witness journal's tail to recover.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.commit", level = "info", skip_all)]
@@ -565,10 +587,13 @@ where
     where
         F: Family,
     {
-        // Fast path: already durably at `target` with no uncommitted state.
+        // Fast path: already durably at `target` with no uncommitted state. A pipelined sync
+        // still in flight means the cached tip is not yet proven durable, so fall through to
+        // the store, which drains it.
         if self.size() == target
             && self.witness.with(|w| w.leaf_count()) == target
             && !self.witness.import_pending()
+            && !self.witness.sync_started()
         {
             return Ok(self);
         }
@@ -626,9 +651,14 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+        BufferPooler, Runner as _, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
+    use core::future::Future;
+    use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
 
     type TestDb<F> = Db<F, deterministic::Context, FixedEncoding<U64>, Sha256, (), Sequential>;
@@ -662,6 +692,317 @@ mod tests {
     ) -> witness::Journal<deterministic::Context, mmr::Family, Digest> {
         let cfg = witness_config(partition, &context);
         witness::Journal::init(context, cfg).await.unwrap()
+    }
+
+    /// A compact db over a delayed-sync storage backend.
+    type DelayedDb = Db<
+        mmr::Family,
+        DelayedSyncContext<deterministic::Context>,
+        FixedEncoding<U64>,
+        Sha256,
+        (),
+        Sequential,
+    >;
+
+    /// Open a [DelayedDb] whose blob syncs park on `pending`.
+    ///
+    /// Init durably persists the bootstrap witness, so while syncs park the returned future
+    /// must be driven with [drive_pending_syncs] (or the mock unblocked first).
+    fn open_delayed_db(
+        context: &deterministic::Context,
+        label: &'static str,
+        partition: &str,
+        pending: &PendingSyncs,
+    ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
+        let witness_cfg = witness_config(partition, context);
+        let merkle = crate::merkle::compact::Merkle::new(Sequential);
+        let context = DelayedSyncContext {
+            inner: context.child(label),
+            pending: pending.clone(),
+        };
+        DelayedDb::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+    }
+
+    /// Apply a single-append batch carrying `seed` as both value and metadata.
+    async fn apply_append(db: DelayedDb, seed: u64) -> DelayedDb {
+        let floor = db.inactivity_floor_loc();
+        let batch = db
+            .new_batch()
+            .append(U64::new(seed))
+            .merkleize(&db, Some(U64::new(seed)), floor)
+            .await;
+        let (db, _) = db.apply_batch(batch).unwrap();
+        db
+    }
+
+    /// State persisted via an awaited start_sync handle is recovered on reopen.
+    #[test_traced]
+    fn test_compact_start_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "keyless-start-sync-recovery";
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", partition, &pending)
+                .await
+                .unwrap();
+            db = apply_append(db, 1).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get_metadata(), Some(U64::new(1)));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A sync begun by `start_sync` that fails in flight surfaces the error through both the
+    /// returned handle and the next durability operation, even when that operation has nothing
+    /// new to persist.
+    #[test_traced]
+    fn test_compact_start_sync_failure_propagates() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "keyless-start-sync-fail", &pending)
+                .await
+                .unwrap();
+            db = apply_append(db, 1).await;
+
+            // Arm all future syncs to resolve to an injected error.
+            pending.arm_fail();
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(
+                handle.await.is_err(),
+                "the sync handle surfaces the failure"
+            );
+            // The witness entry was already appended, so this commit has nothing to stage.
+            // It must still observe the retained failure rather than no-op.
+            assert!(
+                db.commit().await.is_err(),
+                "the next durability op surfaces the failed in-flight sync"
+            );
+        });
+    }
+
+    /// A `sync` with nothing new to persist still drains (and proves) the sync started by a
+    /// prior `start_sync`.
+    #[test_traced]
+    fn test_compact_start_sync_then_noop_sync_drains() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "keyless-start-sync-noop-drain";
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", partition, &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            let starts_before = pending.starts();
+            let completions_before = pending.completions();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+            assert_eq!(pending.completions(), completions_before);
+            let root = db.root();
+
+            let db = {
+                let mut sync = std::pin::pin!(db.sync());
+                assert!(
+                    sync.as_mut().now_or_never().is_none(),
+                    "sync proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                sync.await.unwrap()
+            };
+            handle.await.unwrap();
+            assert!(pending.completions() > completions_before);
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A `start_sync` with nothing new to persist returns a working handle and appends no
+    /// duplicate witness entry.
+    #[test_traced]
+    fn test_compact_start_sync_noop_second_call() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "keyless-start-sync-noop-second";
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", partition, &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            let h1;
+            (db, h1) = db.start_sync().await.unwrap();
+            // Release the parked sync: a second start_sync waits for the prior sync before
+            // starting, so back-to-back calls under a parked mock would deadlock.
+            pending.unblock();
+            h1.await.unwrap();
+
+            let h2;
+            (db, h2) = db.start_sync().await.unwrap();
+            h2.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            // The journal holds exactly the bootstrap entry and the one committed witness.
+            let journal = open_witness_journal(ctx.child("probe"), partition).await;
+            assert_eq!(journal.size(), 2);
+            drop(journal);
+
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A rewind to the current size drains the in-flight sync instead of fast-pathing over it.
+    #[test_traced]
+    fn test_compact_start_sync_rewind_fast_path_drains() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let partition = "keyless-start-sync-rewind-drain";
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", partition, &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            db = apply_append(db, 1).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            let root = db.root();
+            let size = db.size();
+
+            let db = {
+                let mut rewind = std::pin::pin!(db.rewind(size));
+                assert!(
+                    rewind.as_mut().now_or_never().is_none(),
+                    "rewind fast-pathed while the started sync was pending"
+                );
+                pending.unblock();
+                rewind.await.unwrap()
+            };
+            handle.await.unwrap();
+            assert_eq!(db.root(), root);
+            drop(db);
+
+            // The rewind's drain made the witness entry durable.
+            let db = open_delayed_db(&ctx, "reopen", partition, &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A rewind to the current size fails when the sync started for the tip witness has
+    /// already failed, rather than reporting the unproven tip as durable.
+    #[test_traced]
+    fn test_compact_start_sync_rewind_fast_path_fails() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db =
+                open_delayed_db(&ctx, "delayed", "keyless-start-sync-rewind-fail", &pending)
+                    .await
+                    .unwrap();
+            db = apply_append(db, 1).await;
+
+            pending.arm_fail();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(handle.await.is_err());
+            let size = db.size();
+            assert!(
+                db.rewind(size).await.is_err(),
+                "rewind reported an unproven tip as durable"
+            );
+        });
+    }
+
+    /// The first persist after a compact-sync import can be pipelined: awaiting the handle
+    /// makes the imported witness durable.
+    #[test_traced("INFO")]
+    fn test_compact_start_sync_persists_import() {
+        deterministic::Runner::default().start(|context| async move {
+            let dst = "keyless-import-start-sync-dst";
+            let src = "keyless-import-start-sync-src";
+            let meta_a = U64::new(11);
+            let meta_b = U64::new(22);
+
+            // Build state B in a separate source partition and capture its validated state.
+            let target_b = {
+                let source = open_db::<mmr::Family>(context.child("src"), src).await;
+                let batch = source
+                    .new_batch()
+                    .append(U64::new(2))
+                    .merkleize(&source, Some(meta_b.clone()), Location::new(0))
+                    .await;
+                let (source, _) = source.apply_batch(batch).unwrap();
+                let source = source.sync().await.unwrap();
+                source.target()
+            };
+            let (_, proof_b, pinned_b) = {
+                let journal = open_witness_journal(context.child("src_tip"), src).await;
+                witness::tests::tip(&journal).await
+            };
+            let validated = compact_sync::ValidatedState {
+                state: compact_sync::State {
+                    leaf_count: target_b.leaf_count,
+                    pinned_nodes: pinned_b,
+                    last_commit_op: Operation::Commit(Some(meta_b.clone()), Location::new(0)),
+                    last_commit_proof: proof_b,
+                },
+                root: target_b.root,
+            };
+
+            // Seed the destination partition with a different committed state A.
+            {
+                let seeded = open_db::<mmr::Family>(context.child("seed"), dst).await;
+                let batch = seeded
+                    .new_batch()
+                    .append(U64::new(1))
+                    .merkleize(&seeded, Some(meta_a), Location::new(0))
+                    .await;
+                let (seeded, _) = seeded.apply_batch(batch).unwrap();
+                let seeded = seeded.sync().await.unwrap();
+                assert_ne!(seeded.target(), target_b);
+            }
+
+            // Import state B over the destination and make it durable through a pipelined sync.
+            {
+                let journal = open_witness_journal(context.child("import"), dst).await;
+                let imported = TestDb::<mmr::Family>::init_from_validated_state(
+                    Sequential,
+                    journal,
+                    (),
+                    validated,
+                )
+                .unwrap();
+                assert_eq!(imported.target(), target_b);
+                let (_imported, handle) = imported.start_sync().await.unwrap();
+                handle.await.unwrap();
+            }
+
+            // Reopen recovers the imported state, replacing state A.
+            let db = open_db::<mmr::Family>(context.child("reopen"), dst).await;
+            assert_eq!(db.target(), target_b);
+            assert_eq!(db.root(), target_b.root);
+            assert_eq!(db.get_metadata(), Some(meta_b));
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test_traced("INFO")]

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -66,17 +66,22 @@ impl<F: Family, E: Context, V: FixedValue, H: Hasher, S: Strategy> CompactDb<F, 
 mod test {
     use super::*;
     use crate::{
-        merkle::{mmb, mmr},
+        merkle::{Location, mmb, mmr},
         qmdb::keyless::tests,
     };
     use commonware_cryptography::Sha256;
     use commonware_macros::{boxed, test_traced};
     use commonware_parallel::{Rayon, Sequential, Strategy};
     use commonware_runtime::{
-        BufferPooler, Metrics as _, Runner as _, Strategizer as _, Supervisor as _,
-        buffer::paged::CacheRef, deterministic,
+        BufferPooler, Metrics as _, Runner as _, Spawner as _, Strategizer as _, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
+        reschedule,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize};
+    use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
+    use core::future::Future;
+    use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
@@ -149,6 +154,210 @@ mod test {
         Box::new(|ctx| Box::pin(open_db(ctx)))
     }
 
+    /// A keyless db over a delayed-sync storage backend.
+    type DelayedDb =
+        Db<mmr::Family, DelayedSyncContext<deterministic::Context>, U64, Sha256, Sequential>;
+
+    /// Open a [DelayedDb] whose blob syncs park on `pending`.
+    ///
+    /// Init durably persists the recovered database, so while syncs park the returned future
+    /// must be driven with [drive_pending_syncs] (or the mock unblocked first). The journal
+    /// uses large pages and blobs: an apply that fills the write buffer or rolls the blob over
+    /// waits for the in-flight sync, so mid-sync applies must stay clear of both.
+    fn open_delayed_db(
+        context: &deterministic::Context,
+        label: &'static str,
+        suffix: &str,
+        pending: &PendingSyncs,
+    ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
+        let mut cfg = db_config(suffix, context, Sequential);
+        let page_cache = CacheRef::from_pooler(context, NZU16!(1024), NZUsize!(8));
+        cfg.log.items_per_blob = NZU64!(1000);
+        cfg.log.page_cache = page_cache.clone();
+        cfg.merkle.items_per_blob = NZU64!(1000);
+        cfg.merkle.page_cache = page_cache;
+        DelayedDb::init(
+            DelayedSyncContext {
+                inner: context.child(label),
+                pending: pending.clone(),
+            },
+            cfg,
+        )
+    }
+
+    /// Apply a single-append batch with inactivity floor `floor`, returning the appended
+    /// value's location.
+    async fn apply_append(
+        db: DelayedDb,
+        value: U64,
+        floor: Location<mmr::Family>,
+    ) -> (DelayedDb, Location<mmr::Family>) {
+        let batch = db
+            .new_batch()
+            .append(value)
+            .merkleize(&db, None, floor)
+            .await;
+        let (db, range) = db.apply_batch(batch).await.unwrap();
+        (db, range.start)
+    }
+
+    /// A sync handle must not block database use while the backend sync is pending.
+    #[test_traced]
+    fn test_keyless_fixed_start_sync_overlaps_work() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "start-sync-overlap", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            let value0 = U64::new(1);
+            let loc0;
+            let floor = db.inactivity_floor_loc();
+            (db, loc0) = apply_append(db, value0.clone(), floor).await;
+
+            let starts_before = pending.starts();
+            let entered_before = pending.entered();
+            let completions_before = pending.completions();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+            assert_eq!(pending.completions(), completions_before);
+
+            // Observe the sync while the database keeps working.
+            let waiter = ctx
+                .child("await_sync")
+                .spawn(|_| async move { handle.await.unwrap() });
+            while pending.entered() == entered_before {
+                reschedule().await;
+            }
+
+            // Reads and applies complete before the sync does.
+            assert_eq!(db.get(loc0).await.unwrap(), Some(value0));
+            let value1 = U64::new(2);
+            let loc1;
+            let floor = db.inactivity_floor_loc();
+            (db, loc1) = apply_append(db, value1.clone(), floor).await;
+            assert_eq!(
+                pending.completions(),
+                completions_before,
+                "the database made progress while the sync was still in flight"
+            );
+
+            pending.unblock();
+            waiter.await.unwrap();
+
+            // The mid-sync batch is durable after the next start_sync completes.
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", "start-sync-overlap", &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(loc1).await.unwrap(), Some(value1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A sync begun by `start_sync` that fails in flight surfaces the error through both the
+    /// returned handle and the next durability operation.
+    #[test_traced]
+    fn test_keyless_fixed_start_sync_failure_propagates() {
+        deterministic::Runner::default().start(|ctx| async move {
+            // Pass syncs through so opening the database doesn't park.
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "start-sync-fail", &pending)
+                .await
+                .unwrap();
+            let floor = db.inactivity_floor_loc();
+            (db, _) = apply_append(db, U64::new(1), floor).await;
+
+            // Arm all future syncs to resolve to an injected error.
+            pending.arm_fail();
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(
+                handle.await.is_err(),
+                "the sync handle surfaces the failure"
+            );
+            let starts_before = pending.starts();
+            // A failed mutable method consumes the database per the failures-are-fatal contract.
+            assert!(
+                db.commit().await.is_err(),
+                "the next durability op surfaces the failed in-flight sync"
+            );
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the surfaced error is the retained failure, not a fresh sync's"
+            );
+        });
+    }
+
+    /// State persisted via an awaited start_sync handle is recovered on reopen.
+    #[test_traced]
+    fn test_keyless_fixed_start_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_db(&ctx, "delayed", "start-sync-recovery", &pending)
+                .await
+                .unwrap();
+            let value = U64::new(1);
+            let loc;
+            let floor = db.inactivity_floor_loc();
+            (db, loc) = apply_append(db, value.clone(), floor).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let root = db.root();
+            drop(db);
+
+            let db = open_delayed_db(&ctx, "reopen", "start-sync-recovery", &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(loc).await.unwrap(), Some(value));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Pruning drains the in-flight sync before mutating storage.
+    #[test_traced]
+    fn test_keyless_fixed_start_sync_prune_waits() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "start-sync-prune", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            // Two batches: the second declares floor 2 so the prune below is non-trivial.
+            (db, _) = apply_append(db, U64::new(1), Location::new(0)).await;
+            (db, _) = apply_append(db, U64::new(2), Location::new(2)).await;
+
+            let starts_before = pending.starts();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+
+            let floor = db.inactivity_floor_loc();
+            assert!(*floor > 0);
+            let db = {
+                let mut prune = std::pin::pin!(db.prune(floor));
+                assert!(
+                    prune.as_mut().now_or_never().is_none(),
+                    "prune proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                prune.await.unwrap()
+            };
+            handle.await.unwrap();
+            db.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced("INFO")]
     fn test_keyless_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {
@@ -168,6 +377,8 @@ mod test {
             );
             let db = db.commit().await.unwrap();
             let db = db.sync().await.unwrap();
+            let (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
             let _db = db.prune(crate::merkle::Location::new(0)).await.unwrap();
 
             let metrics = ctx.encode();
@@ -184,6 +395,7 @@ mod test {
                 "db_operations_applied_total 2",
                 "db_commit_calls_total 1",
                 "db_sync_calls_total 1",
+                "db_start_sync_calls_total 1",
                 "db_prune_calls_total 1",
                 "db_get_duration_count 1",
                 "db_get_many_duration_count 1",

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -358,6 +358,37 @@ mod test {
         });
     }
 
+    /// Rewinding drains the in-flight sync before mutating storage.
+    #[test_traced]
+    fn test_keyless_fixed_start_sync_rewind_waits() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_db(&ctx, "delayed", "start-sync-rewind", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            (db, _) = apply_append(db, U64::new(1), Location::new(0)).await;
+            db = drive_pending_syncs(&pending, db.commit()).await.unwrap();
+            let committed_root = db.root();
+            let committed_size = db.bounds().end;
+            (db, _) = apply_append(db, U64::new(2), Location::new(0)).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+
+            let db = {
+                let mut rewind = std::pin::pin!(db.rewind(committed_size));
+                assert!(
+                    rewind.as_mut().now_or_never().is_none(),
+                    "rewind proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                rewind.await.unwrap()
+            };
+            handle.await.unwrap();
+            assert_eq!(db.root(), committed_root);
+            db.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced("INFO")]
     fn test_keyless_fixed_metrics() {
         deterministic::Runner::default().start(|ctx| async move {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -480,8 +480,7 @@ where
     ///
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
-    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
-    /// surface as described on [`any::Db::start_sync`](crate::qmdb::any::db::Db::start_sync).
+    /// guarantee none is needed. A new sync waits for the prior sync before starting.
     #[tracing::instrument(name = "qmdb.keyless.db.start_sync", level = "info", skip_all)]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
         self.metrics.start_sync_calls.inc();

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -58,6 +58,7 @@ use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
+use commonware_runtime::Handle;
 use std::{num::NonZeroU64, sync::Arc};
 use tracing::{debug, warn};
 
@@ -472,6 +473,21 @@ where
         self.metrics.sync_calls.inc();
         self.journal = self.journal.sync().await?;
         Ok(self)
+    }
+
+    /// Begin durably persisting the journal state published by prior [`Keyless::apply_batch`]
+    /// calls.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// surface as described on [`any::Db::start_sync`](crate::qmdb::any::db::Db::start_sync).
+    #[tracing::instrument(name = "qmdb.keyless.db.start_sync", level = "info", skip_all)]
+    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
+        self.metrics.start_sync_calls.inc();
+        let handle;
+        (self.journal, handle) = self.journal.start_sync().await?;
+        Ok((self, handle))
     }
 
     /// Durably commit the journal state published by prior [`Keyless::apply_batch`] calls.

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -423,7 +423,8 @@ where
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// A successful rewind is not restart-stable until a subsequent [`Self::commit`] or
-    /// [`Self::sync`].
+    /// [`Self::sync`] completes, or until the handle returned by a subsequent
+    /// [`Self::start_sync`] completes.
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
@@ -480,7 +481,11 @@ where
     ///
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
-    /// guarantee none is needed. A new sync waits for the prior sync before starting.
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// of the deferred durability work surface on the returned handle. A failed data sync also
+    /// fails the next durability operation. A failed recovery-watermark sync is not observed by
+    /// [Self::commit], and a failed merkle-node sync may not be. Both resurface on the next
+    /// [Self::sync].
     #[tracing::instrument(name = "qmdb.keyless.db.start_sync", level = "info", skip_all)]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
         self.metrics.start_sync_calls.inc();
@@ -564,9 +569,9 @@ where
     ///
     /// Returns the range of locations written.
     ///
-    /// This publishes the batch to the in-memory database state and appends it to the
-    /// journal, but does not durably commit it. Call [`Keyless::commit`] or
-    /// [`Keyless::sync`] to guarantee durability.
+    /// This publishes the batch to the in-memory database state and appends it to the journal,
+    /// but does not durably commit it. Call [`Keyless::commit`] or [`Keyless::sync`], or await the
+    /// handle returned by [`Keyless::start_sync`], to guarantee durability.
     #[tracing::instrument(name = "qmdb.keyless.db.apply_batch", level = "info", skip_all)]
     pub async fn apply_batch(
         mut self,

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -450,8 +450,9 @@ where
     /// Applies a finalized batch to the in-memory database state and appends its operations to the
     /// journal, returning the range of written locations.
     ///
-    /// This publishes the batch to the in-memory database state and appends it to the journal, but
-    /// does not durably persist it. Call [`Db::commit`] or [`Db::sync`] to guarantee durability.
+    /// This publishes the batch to the in-memory database state and appends it to the journal,
+    /// but does not durably persist it. Call [`Db::commit`] or [`Db::sync`], or await the handle
+    /// returned by [`Db::start_sync`], to guarantee durability.
     #[boxed]
     pub async fn apply_batch(
         mut self,

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -536,8 +536,9 @@ where
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
     /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
     /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
-    /// of the deferred work surface on the returned handle. A failed data sync also fails the
-    /// next durability operation.
+    /// of the deferred durability work surface on the returned handle. A failed data sync also
+    /// fails the next durability operation. A failed offsets or recovery-watermark sync is not
+    /// observed by [Self::commit] and resurfaces on the next [Self::sync].
     #[boxed]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error> {
         let handle;

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -100,6 +100,7 @@ use crate::{
 };
 use commonware_codec::{CodecShared, Read};
 use commonware_macros::boxed;
+use commonware_runtime::Handle;
 use commonware_utils::Array;
 use core::{num::NonZeroUsize, ops::Range};
 use std::collections::BTreeMap;
@@ -530,6 +531,20 @@ where
         Ok((self, start_loc..end_loc))
     }
 
+    /// Begin durably persisting the journal state published by prior [`Db::apply_batch`] calls.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on startup. Use [Self::sync] to
+    /// guarantee none is needed. A new sync waits for the prior sync before starting. Failures
+    /// of the deferred work surface on the returned handle. A failed data sync also fails the
+    /// next durability operation.
+    #[boxed]
+    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error> {
+        let handle;
+        (self.log, handle) = self.log.start_sync().await?;
+        Ok((self, handle))
+    }
+
     /// Durably commit the journal state published by prior [`Db::apply_batch`] calls.
     #[boxed]
     pub async fn commit(mut self) -> Result<Self, Error> {
@@ -548,8 +563,16 @@ mod test {
     };
     use commonware_macros::test_traced;
     use commonware_math::algebra::Random;
-    use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
+    use commonware_runtime::{
+        Runner, Spawner as _, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
+        reschedule,
+    };
     use commonware_utils::{NZU16, NZU64, NZUsize};
+    use core::future::Future;
+    use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(77);
@@ -580,6 +603,202 @@ mod test {
         iter: impl IntoIterator<Item = (Digest, Option<Vec<u8>>)> + Send,
     ) -> (TestStore, Range<Location>) {
         db.apply_batch(iter.into_iter().collect()).await.unwrap()
+    }
+
+    /// A store over a delayed-sync storage backend.
+    type DelayedStore = Db<DelayedSyncContext<deterministic::Context>, Digest, Vec<u8>, TwoCap>;
+
+    /// Open a [DelayedStore] whose blob syncs park on `pending`.
+    ///
+    /// Init durably persists the recovered database, so while syncs park the returned future
+    /// must be driven with [drive_pending_syncs] (or the mock unblocked first). The journal
+    /// uses large pages and sections: an apply that fills the write buffer or rolls the blob
+    /// over waits for the in-flight sync, so mid-sync applies must stay clear of both.
+    fn open_delayed_store(
+        context: &deterministic::Context,
+        label: &'static str,
+        suffix: &str,
+        pending: &PendingSyncs,
+    ) -> impl Future<Output = Result<DelayedStore, Error>> {
+        let cfg = Config {
+            log: JournalConfig {
+                partition: format!("journal-{suffix}"),
+                write_buffer: NZUsize!(64 * 1024),
+                compression: None,
+                codec_config: ((), ((0..=10000).into(), ())),
+                items_per_section: NZU64!(1000),
+                page_cache: CacheRef::from_pooler(context, NZU16!(1024), NZUsize!(8)),
+            },
+            translator: TwoCap,
+            init_cache_size: Some(NZUsize!(1024)),
+            init_buffer: NZUsize!(1 << 21),
+        };
+        DelayedStore::init(
+            DelayedSyncContext {
+                inner: context.child(label),
+                pending: pending.clone(),
+            },
+            cfg,
+        )
+    }
+
+    /// Apply a single-key batch writing `key -> value`.
+    async fn apply_write(db: DelayedStore, key: Digest, value: Vec<u8>) -> DelayedStore {
+        let (db, _) = db.apply_batch([(key, Some(value))].into()).await.unwrap();
+        db
+    }
+
+    /// A sync handle must not block database use while the backend sync is pending.
+    #[test_traced]
+    fn test_store_start_sync_overlaps_work() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_store(&ctx, "delayed", "start-sync-overlap", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            let key0 = Blake3::hash(&[&0u64.to_be_bytes()]);
+            let value0 = vec![1u8; 8];
+            db = apply_write(db, key0, value0.clone()).await;
+
+            let starts_before = pending.starts();
+            let entered_before = pending.entered();
+            let completions_before = pending.completions();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+            assert_eq!(pending.completions(), completions_before);
+
+            // Observe the sync while the database keeps working.
+            let waiter = ctx
+                .child("await_sync")
+                .spawn(|_| async move { handle.await.unwrap() });
+            while pending.entered() == entered_before {
+                reschedule().await;
+            }
+
+            // Reads and applies complete before the sync does.
+            assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+            let key1 = Blake3::hash(&[&1u64.to_be_bytes()]);
+            let value1 = vec![2u8; 8];
+            db = apply_write(db, key1, value1.clone()).await;
+            assert_eq!(
+                pending.completions(),
+                completions_before,
+                "the database made progress while the sync was still in flight"
+            );
+
+            pending.unblock();
+            waiter.await.unwrap();
+
+            // The mid-sync batch is durable after the next start_sync completes.
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let size = db.size();
+            drop(db);
+
+            let db = open_delayed_store(&ctx, "reopen", "start-sync-overlap", &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.size(), size);
+            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A sync begun by `start_sync` that fails in flight surfaces the error through both the
+    /// returned handle and the next durability operation.
+    #[test_traced]
+    fn test_store_start_sync_failure_propagates() {
+        deterministic::Runner::default().start(|ctx| async move {
+            // Pass syncs through so opening the database doesn't park.
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_store(&ctx, "delayed", "start-sync-fail", &pending)
+                .await
+                .unwrap();
+            db = apply_write(db, Blake3::hash(&[&0u64.to_be_bytes()]), vec![1u8; 8]).await;
+
+            // Arm all future syncs to resolve to an injected error.
+            pending.arm_fail();
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(
+                handle.await.is_err(),
+                "the sync handle surfaces the failure"
+            );
+            let starts_before = pending.starts();
+            // A failed mutable method consumes the database per the failures-are-fatal contract.
+            assert!(
+                db.commit().await.is_err(),
+                "the next durability op surfaces the failed in-flight sync"
+            );
+            assert_eq!(
+                pending.starts(),
+                starts_before,
+                "the surfaced error is the retained failure, not a fresh sync's"
+            );
+        });
+    }
+
+    /// State persisted via an awaited start_sync handle is recovered on reopen.
+    #[test_traced]
+    fn test_store_start_sync_recovery() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let mut db = open_delayed_store(&ctx, "delayed", "start-sync-recovery", &pending)
+                .await
+                .unwrap();
+            let key = Blake3::hash(&[&0u64.to_be_bytes()]);
+            let value = vec![1u8; 8];
+            db = apply_write(db, key, value.clone()).await;
+
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            handle.await.unwrap();
+            let size = db.size();
+            drop(db);
+
+            let db = open_delayed_store(&ctx, "reopen", "start-sync-recovery", &pending)
+                .await
+                .unwrap();
+            assert_eq!(db.size(), size);
+            assert_eq!(db.get(&key).await.unwrap(), Some(value));
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Pruning drains the in-flight sync before mutating storage.
+    #[test_traced]
+    fn test_store_start_sync_prune_waits() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open_delayed_store(&ctx, "delayed", "start-sync-prune", &pending);
+            let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+            // Two batches so floor-raising steps leave a non-trivial prune target.
+            db = apply_write(db, Blake3::hash(&[&0u64.to_be_bytes()]), vec![1u8; 8]).await;
+            db = apply_write(db, Blake3::hash(&[&1u64.to_be_bytes()]), vec![2u8; 8]).await;
+
+            let starts_before = pending.starts();
+            let handle;
+            (db, handle) = db.start_sync().await.unwrap();
+            assert!(pending.starts() > starts_before);
+
+            let floor = db.inactivity_floor_loc();
+            assert!(*floor > 0);
+            let db = {
+                let mut prune = std::pin::pin!(db.prune(floor));
+                assert!(
+                    prune.as_mut().now_or_never().is_none(),
+                    "prune proceeded while the started sync was pending"
+                );
+                pending.unblock();
+                prune.await.unwrap()
+            };
+            handle.await.unwrap();
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test_traced("DEBUG")]

--- a/storage/src/qmdb/sync/compact.rs
+++ b/storage/src/qmdb/sync/compact.rs
@@ -19,16 +19,18 @@
 //!
 //! # When compact state changes
 //!
-//! The servable compact state advances only on durable persistence:
+//! The servable compact state advances only when a commit is persisted:
 //!
 //! - [`sync`] verifies the final commit proof and compact frontier before database construction.
 //! - [`Database::from_validated_state`] reconstructs the already-validated state without
 //!   persisting it.
-//! - Compact db-local commits append one witness entry during `sync`.
+//! - Compact db-local commits append one witness entry during `commit`, `sync`, or
+//!   `start_sync`. An entry appended by `start_sync` is servable when the call returns and is
+//!   proven durable only when its handle completes.
 //! - `rewind` restores the frontier and the witness from the target journal entry.
 //!
 //! Unsynced in-memory mutations are therefore intentionally not servable: `target()` and
-//! compact-state responses lag behind `apply_batch()` until the db's next sync.
+//! compact-state responses lag behind `apply_batch()` until the db's next persist.
 //!
 //! # Safety and invariants
 //!


### PR DESCRIPTION
#4310 introduced pipelined `start_sync` on `qmdb::any` and `qmdb::current`. This extends it to the rest of the QMDBs:

```rust
pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error>
```

on `immutable::Immutable`, `keyless::Keyless`, `store::Db`, and both `CompactDb`s. As on the existing databases, awaiting the handle gives the same durability guarantee as `commit()`, plus a best-effort advance of the recovery watermark; a new sync waits for the prior sync before starting, and failures surface on the handle and again on the next durability operation.

## Delegating databases

`immutable`, `keyless`, and `store` keep all durable state in a single journal that already has `start_sync`, so their methods are one-line delegations (with the existing `start_sync_calls` counter on the authenticated databases).

## Compact databases

The compact databases persist through `witness::Store`, whose `commit`/`sync` no-op when the cached tip witness already matches the in-memory Merkle. That no-op was justified by an invariant `start_sync` breaks: the cache is installed when the sync *starts*, not when it completes, so "cache matches Merkle" no longer implies "durable".

`Store` therefore tracks whether a pipelined sync may still be in flight (`sync_started`):

- `commit`/`sync` with nothing new to append drain the in-flight sync instead of no-op'ing, so they never report an unproven tip durable and a failed pipelined sync resurfaces as an error.
- The `CompactDb::rewind` fast path (`target == size`) requires the flag to be clear; otherwise it falls through to the store, which drains before returning. Without this, rewind would return `Ok` under its "made durable before returning" contract while the tip was unproven — or after its sync had already failed.
- `Store::start_sync` with nothing new to append still starts a journal sync: the handle proves the current tip durable and immediately resurfaces any retained failure.
- A pending compact-sync import is marked persisted when its replacement sync starts. Sync failures are fatal to the instance and a crash before completion leaves the journal unreopenable until re-syncing recovers it — the same shape as the existing `commit` replacement window.

## Tests

Each database gets a parked-sync suite on the mock backend: `start_sync` overlaps reads and applies while the fsync is in flight; an in-flight failure surfaces on the handle and the next durability op; an awaited handle alone guarantees recovery on reopen; prune (and rewind, for `immutable`) drains the in-flight sync before mutating storage. The compact suites additionally pin the drain semantics: a no-op `sync()` after `start_sync` drains, a no-op second `start_sync` appends no duplicate witness entry, the rewind fast path drains (and fails on a failed sync) instead of fast-pathing, and an import persists through a pipelined sync. The immutable/keyless metrics tests now assert `start_sync_calls`.