### PR TITLE
[storage/journal] Add off-hot-path start_prune to contiguous journals

### DIFF
--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -953,6 +953,65 @@ impl<B: Blob> Blob for WriteFaultBlob<B> {
     }
 }
 
+/// Controls a [RemoveFaultContext]: while armed, every `remove` fails with an injected error.
+#[derive(Clone, Default)]
+pub struct RemoveFaults {
+    fail: Arc<Mutex<bool>>,
+}
+
+impl RemoveFaults {
+    /// Start failing removes.
+    pub fn arm(&self) {
+        *self.fail.lock() = true;
+    }
+
+    /// Stop failing removes.
+    pub fn disarm(&self) {
+        *self.fail.lock() = false;
+    }
+
+    fn check(&self) -> Result<(), Error> {
+        if *self.fail.lock() {
+            return Err(Error::Io(
+                std::io::Error::other("injected remove failure").into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Context wrapper whose `remove` fails while the shared [RemoveFaults] is armed. The switch
+/// propagates to `child(...)` contexts, so removals issued by a child context fail too.
+#[derive(Clone)]
+pub struct RemoveFaultContext<E> {
+    pub inner: E,
+    pub faults: RemoveFaults,
+}
+
+forward_context!(RemoveFaultContext, faults);
+
+impl<E: Storage> Storage for RemoveFaultContext<E> {
+    type Blob = E::Blob;
+
+    async fn open_versioned(
+        &self,
+        partition: &str,
+        name: &[u8],
+        versions: std::ops::RangeInclusive<u16>,
+    ) -> Result<(Self::Blob, u64, u16), Error> {
+        self.inner.open_versioned(partition, name, versions).await
+    }
+
+    async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
+        self.faults.check()?;
+        self.inner.remove(partition, name).await
+    }
+
+    async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
+        self.inner.scan(partition).await
+    }
+}
+
 /// Context wrapper whose blobs fail `sync` and `start_sync` for a single partition.
 #[derive(Clone)]
 pub struct SyncFaultContext<E> {

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -323,7 +323,7 @@ impl<E: Context> Writable<E> {
     ///
     /// - `oldest_blob_index < min_blob`
     /// - `min_blob <= tail_blob_index`
-    fn detach(&mut self, min_blob: u64) -> Range<u64> {
+    fn prune_mem(&mut self, min_blob: u64) -> Range<u64> {
         assert!(self.oldest_blob_index < min_blob);
         assert!(min_blob <= self.tail_blob_index());
         let drop_count = (min_blob - self.oldest_blob_index) as usize;
@@ -348,7 +348,7 @@ impl<E: Context> Writable<E> {
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
         self.drain_pending_prune().await;
-        let freed = self.detach(min_blob);
+        let freed = self.prune_mem(min_blob);
 
         #[cfg(test)]
         if self.halt_prune_unlinks {
@@ -369,13 +369,13 @@ impl<E: Context> Writable<E> {
     ///
     /// - `oldest_blob_index < min_blob <= tail_blob_index`
     /// - every blob in `oldest_blob_index..min_blob` is durable
-    pub(super) async fn start_prune(&mut self, min_blob: u64) -> Result<SyncCompletion, Error> {
+    pub(super) async fn start_prune(&mut self, min_blob: u64) -> SyncCompletion {
         // Drain any prior deferred unlink first, so at most one is in flight. Unlike `prune`, the
         // tail syncs are not drained: seals are eager and the sync that advances the durable
         // frontier joins the seal sync, so a blob with an in-flight seal sync is always at or above
         // the frontier and excluded by the `min_blob <= watermark_blob` clamp.
         self.drain_pending_prune().await;
-        let freed = self.detach(min_blob);
+        let freed = self.prune_mem(min_blob);
 
         // Deferred removal runs alongside continued appends and targets only blobs below the live
         // tail.
@@ -421,7 +421,7 @@ impl<E: Context> Writable<E> {
         .boxed()
         .shared();
         self.pending_prune = Some(removal.clone());
-        Ok(removal)
+        removal
     }
 
     /// Rewind the tail to `byte_offset`, shrinking it in place.

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -14,8 +14,8 @@ use futures::{
     FutureExt as _,
     future::{self, try_join_all},
 };
-use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
-use tracing::debug;
+use std::{collections::BTreeMap, num::NonZeroUsize, ops::Range, sync::Arc};
+use tracing::{debug, warn};
 
 /// Metrics for a journal's blobs.
 struct Metrics {
@@ -153,6 +153,10 @@ pub(super) struct Writable<E: Context> {
     /// Sync of the live tail. Kept on failure so later operations keep failing.
     tail_sync: Option<SyncCompletion>,
 
+    /// Deferred unlink from the most recent [Self::start_prune], kept so a reset or teardown can
+    /// fence it before the freed indices are reused, mirroring [Self::tail_sync].
+    pending_prune: Option<SyncCompletion>,
+
     /// Test-only: park [Self::seal_tail] at entry so tests can drop an append future at the
     /// roll-over await, leaving the logical end ahead of the physical tail.
     #[cfg(test)]
@@ -231,6 +235,7 @@ impl<E: Context> Writable<E> {
             sealed_snapshot: None,
             tail_predecessor_sync: None,
             tail_sync: None,
+            pending_prune: None,
             #[cfg(test)]
             halt_seal_tail: false,
             #[cfg(test)]
@@ -309,6 +314,25 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
+    /// Advance the in-memory pruning boundary to `min_blob`, returning the freed blob indices for
+    /// the caller to unlink (inline in [Self::prune], deferred in [Self::start_prune]). Metrics
+    /// reflect the logical prune immediately; the physical unlink follows.
+    ///
+    /// # Invariants
+    ///
+    /// - `oldest_blob_index < min_blob <= tail_blob_index`
+    fn detach(&mut self, min_blob: u64) -> Range<u64> {
+        assert!(self.oldest_blob_index < min_blob && min_blob <= self.tail_blob_index());
+        let drop_count = (min_blob - self.oldest_blob_index) as usize;
+        let freed = self.oldest_blob_index..min_blob;
+        self.sealed.drain(..drop_count);
+        self.sealed_snapshot = None;
+        self.oldest_blob_index = min_blob;
+        self.metrics.tracked.dec_by(drop_count as i64);
+        self.metrics.pruned.inc_by(drop_count as u64);
+        freed
+    }
+
     /// Drop and remove every blob below `min_blob`.
     ///
     /// Safe with live readers: snapshot readers keep their own handles, which the runtime's
@@ -318,15 +342,10 @@ impl<E: Context> Writable<E> {
     ///
     /// - `oldest_blob_index < min_blob <= tail_blob_index`
     pub(super) async fn prune(&mut self, min_blob: u64) -> Result<(), Error> {
-        assert!(self.oldest_blob_index < min_blob && min_blob <= self.tail_blob_index());
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
-
-        let drop_count = (min_blob - self.oldest_blob_index) as usize;
-        let prev_oldest_blob_index = self.oldest_blob_index;
-        self.sealed.drain(..drop_count);
-        self.sealed_snapshot = None;
-        self.oldest_blob_index = min_blob;
+        self.drain_pending_prune().await;
+        let freed = self.detach(min_blob);
 
         #[cfg(test)]
         if self.halt_prune_unlinks {
@@ -336,11 +355,74 @@ impl<E: Context> Writable<E> {
         // Remove blobs concurrently. (Some backends serialize removals internally, so concurrency
         // is an upper bound, not a guarantee.)
         let partition = &self.partition;
-        try_join_all((prev_oldest_blob_index..min_blob).map(|blob| partition.remove(blob))).await?;
-
-        self.metrics.tracked.dec_by(drop_count as i64);
-        self.metrics.pruned.inc_by(drop_count as u64);
+        try_join_all(freed.map(|blob| partition.remove(blob))).await?;
         Ok(())
+    }
+
+    /// Advance the pruning boundary to `min_blob` in memory and return a shared handle that unlinks
+    /// the freed blobs.
+    ///
+    /// Unlike [`Self::prune`], the unlink is deferred: the caller drives the returned handle off the
+    /// hot path, and a dropped or failed removal is completed by recovery from the durable boundary.
+    /// A clone is retained in [Self::pending_prune] so [Self::clear]/[Self::destroy]/[Self::prune]
+    /// can fence it before the freed indices are reused, and any prior deferred unlink is drained
+    /// first to keep at most one in flight. No tail sync is drained because every freed blob is
+    /// below the durable watermark (the caller clamps `min_blob` to it), so its sync is already
+    /// complete; only the tail and its predecessor can have a sync in flight, and both sit above the
+    /// removal range. The freed blobs are strictly older than the live tail, so the removal runs
+    /// safely alongside continued appends, and an already-unlinked blob is tolerated so overlapping
+    /// prunes and recovery-completed removals stay idempotent.
+    ///
+    /// # Invariants
+    ///
+    /// - `oldest_blob_index < min_blob <= tail_blob_index`
+    /// - every blob in `oldest_blob_index..min_blob` is durable
+    pub(super) async fn start_prune(&mut self, min_blob: u64) -> Result<SyncCompletion, Error> {
+        self.drain_pending_prune().await;
+        let freed = self.detach(min_blob);
+
+        // Take an owned context + name so the removal can outlive this borrow and run concurrently
+        // with continued appends (freed blobs are all below the live tail). The context isn't
+        // `Clone`, so use `child` (as init does) to get an owned handle to the same storage.
+        let context = self.partition.context.child("prune");
+        let name = self.partition.name.clone();
+        #[cfg(test)]
+        let halt_prune_unlinks = self.halt_prune_unlinks;
+        let removal = async move {
+            #[cfg(test)]
+            if halt_prune_unlinks {
+                std::future::pending::<()>().await;
+            }
+            let context = &context;
+            let name = name.as_str();
+            let result = try_join_all(freed.map(move |blob| async move {
+                match context.remove(name, Some(&blob.to_be_bytes())).await {
+                    // An already-removed blob (or partition) is a no-op: a missing blob surfaces as
+                    // `BlobMissing`, a missing partition as `PartitionMissing`. Tolerating both keeps
+                    // overlapping prunes and recovery-completed removals idempotent.
+                    Ok(()) | Err(RError::BlobMissing(..)) | Err(RError::PartitionMissing(_)) => {
+                        Ok(())
+                    }
+                    Err(err) => Err(err),
+                }
+            }))
+            .await
+            .map(|_| ());
+            // Log at the source so a failure is recorded exactly once regardless of who drives the
+            // removal (the caller's handle or a later drain); the error still propagates to the
+            // caller's handle.
+            if let Err(err) = &result {
+                warn!(
+                    ?err,
+                    "deferred prune unlink failed; leaving stray blobs for recovery"
+                );
+            }
+            result
+        }
+        .boxed()
+        .shared();
+        self.pending_prune = Some(removal.clone());
+        Ok(removal)
     }
 
     /// Rewind the tail to `byte_offset`, shrinking it in place.
@@ -414,6 +496,9 @@ impl<E: Context> Writable<E> {
     pub(super) async fn clear(&mut self, tail_blob: u64) -> Result<(), Error> {
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
+        // Fence any deferred unlink before reusing the freed indices: a live removal targeting an
+        // old index would otherwise unlink a blob this reset repopulates.
+        self.drain_pending_prune().await;
 
         // Remove the whole partition: a cancelled prune may leave untracked blob files
         // whose contents would become visible again after resetting the boundary.
@@ -447,6 +532,18 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
+    /// Await the deferred unlink from the most recent [Self::start_prune] so a reset or teardown
+    /// cannot reuse a freed index while it is still in flight. The unlink is best-effort: a failed
+    /// removal (logged at its source) leaves a stray blob below the durable boundary that recovery
+    /// or a later `remove_all` reclaims, so it is not propagated here (which would poison this and
+    /// every later prune, clear, or destroy). The caller's own handle still surfaces the error.
+    async fn drain_pending_prune(&mut self) {
+        let Some(pending) = self.pending_prune.take() else {
+            return;
+        };
+        let _ = pending.await;
+    }
+
     /// Start syncing the tail, returning a handle that completes once both the tail and its
     /// predecessor are durable.
     pub(super) async fn start_sync(&mut self) -> Handle<()> {
@@ -476,6 +573,7 @@ impl<E: Context> Writable<E> {
     pub(super) async fn destroy(mut self) -> Result<(), Error> {
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
+        self.drain_pending_prune().await;
 
         let tail_blob = self.tail_blob_index();
         drop(self.tail);

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -15,7 +15,7 @@ use futures::{
     future::{self, try_join_all},
 };
 use std::{collections::BTreeMap, num::NonZeroUsize, ops::Range, sync::Arc};
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 /// Metrics for a journal's blobs.
 struct Metrics {
@@ -315,14 +315,17 @@ impl<E: Context> Writable<E> {
     }
 
     /// Advance the in-memory pruning boundary to `min_blob`, returning the freed blob indices for
-    /// the caller to unlink (inline in [Self::prune], deferred in [Self::start_prune]). Metrics
-    /// reflect the logical prune immediately; the physical unlink follows.
+    /// the caller to unlink.
     ///
-    /// # Invariants
+    /// Metrics reflect the logical prune immediately even though the physical unlink follows.
     ///
-    /// - `oldest_blob_index < min_blob <= tail_blob_index`
+    /// # Preconditions
+    ///
+    /// - `oldest_blob_index < min_blob`
+    /// - `min_blob <= tail_blob_index`
     fn detach(&mut self, min_blob: u64) -> Range<u64> {
-        assert!(self.oldest_blob_index < min_blob && min_blob <= self.tail_blob_index());
+        assert!(self.oldest_blob_index < min_blob);
+        assert!(min_blob <= self.tail_blob_index());
         let drop_count = (min_blob - self.oldest_blob_index) as usize;
         let freed = self.oldest_blob_index..min_blob;
         self.sealed.drain(..drop_count);
@@ -338,7 +341,7 @@ impl<E: Context> Writable<E> {
     /// Safe with live readers: snapshot readers keep their own handles, which the runtime's
     /// read-after-remove contract keeps valid.
     ///
-    /// # Invariants
+    /// # Preconditions
     ///
     /// - `oldest_blob_index < min_blob <= tail_blob_index`
     pub(super) async fn prune(&mut self, min_blob: u64) -> Result<(), Error> {
@@ -359,35 +362,29 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
-    /// Advance the pruning boundary to `min_blob` in memory and return a shared handle that unlinks
-    /// the freed blobs.
+    /// Advance the pruning boundary to `min_blob` in memory and return a handle that unlinks the
+    /// freed blobs off the hot path.
     ///
-    /// Unlike [`Self::prune`], the unlink is deferred: the caller drives the returned handle off the
-    /// hot path, and a dropped or failed removal is completed by recovery from the durable boundary.
-    /// A clone is retained in [Self::pending_prune] so [Self::clear]/[Self::destroy]/[Self::prune]
-    /// can fence it before the freed indices are reused, and any prior deferred unlink is drained
-    /// first to keep at most one in flight. No tail sync is drained because every freed blob is
-    /// below the durable watermark (the caller clamps `min_blob` to it), so its sync is already
-    /// complete; only the tail and its predecessor can have a sync in flight, and both sit above the
-    /// removal range. The freed blobs are strictly older than the live tail, so the removal runs
-    /// safely alongside continued appends, and an already-unlinked blob is tolerated so overlapping
-    /// prunes and recovery-completed removals stay idempotent.
-    ///
-    /// # Invariants
+    /// # Preconditions
     ///
     /// - `oldest_blob_index < min_blob <= tail_blob_index`
     /// - every blob in `oldest_blob_index..min_blob` is durable
     pub(super) async fn start_prune(&mut self, min_blob: u64) -> Result<SyncCompletion, Error> {
+        // Drain any prior deferred unlink first, so at most one is in flight. Unlike `prune`, the
+        // tail syncs are not drained: seals are eager and the sync that advances the durable
+        // frontier joins the seal sync, so a blob with an in-flight seal sync is always at or above
+        // the frontier and excluded by the `min_blob <= watermark_blob` clamp.
         self.drain_pending_prune().await;
         let freed = self.detach(min_blob);
 
-        // Take an owned context + name so the removal can outlive this borrow and run concurrently
-        // with continued appends (freed blobs are all below the live tail). The context isn't
-        // `Clone`, so use `child` (as init does) to get an owned handle to the same storage.
+        // Deferred removal runs alongside continued appends and targets only blobs below the live
+        // tail.
         let context = self.partition.context.child("prune");
         let name = self.partition.name.clone();
+
         #[cfg(test)]
         let halt_prune_unlinks = self.halt_prune_unlinks;
+
         let removal = async move {
             #[cfg(test)]
             if halt_prune_unlinks {
@@ -395,29 +392,31 @@ impl<E: Context> Writable<E> {
             }
             let context = &context;
             let name = name.as_str();
-            let result = try_join_all(freed.map(move |blob| async move {
+            try_join_all(freed.map(move |blob| async move {
                 match context.remove(name, Some(&blob.to_be_bytes())).await {
-                    // An already-removed blob (or partition) is a no-op: a missing blob surfaces as
-                    // `BlobMissing`, a missing partition as `PartitionMissing`. Tolerating both keeps
-                    // overlapping prunes and recovery-completed removals idempotent.
-                    Ok(()) | Err(RError::BlobMissing(..)) | Err(RError::PartitionMissing(_)) => {
+                    Ok(()) => Ok(()),
+                    Err(err @ (RError::BlobMissing(..) | RError::PartitionMissing(_))) => {
+                        // A missing blob or partition is not expected in normal operation (the detached
+                        // blobs exist and nothing else removes them first), but it is not a true
+                        // failure either: the blob is already gone, which is the goal. Warn and treat
+                        // as done.
+                        warn!(blob, ?err, "deferred prune unlink: blob already absent");
                         Ok(())
                     }
-                    Err(err) => Err(err),
+                    Err(err) => {
+                        // Any other error means the blob may still be on disk. Not fatal (recovery
+                        // re-unlinks blobs below the boundary), but flag it loudly and propagate.
+                        error!(
+                            blob,
+                            ?err,
+                            "deferred prune unlink failed; leaving stray blob"
+                        );
+                        Err(err)
+                    }
                 }
             }))
             .await
-            .map(|_| ());
-            // Log at the source so a failure is recorded exactly once regardless of who drives the
-            // removal (the caller's handle or a later drain); the error still propagates to the
-            // caller's handle.
-            if let Err(err) = &result {
-                warn!(
-                    ?err,
-                    "deferred prune unlink failed; leaving stray blobs for recovery"
-                );
-            }
-            result
+            .map(|_| ())
         }
         .boxed()
         .shared();
@@ -427,10 +426,9 @@ impl<E: Context> Writable<E> {
 
     /// Rewind the tail to `byte_offset`, shrinking it in place.
     ///
-    /// # Invariants
+    /// # Preconditions
     ///
     /// - `byte_offset <= tail size`
-    ///
     pub(super) async fn rewind_tail(&mut self, byte_offset: u64) -> Result<(), Error> {
         let current_bytes = self.tail.size();
         assert!(byte_offset <= current_bytes);
@@ -445,7 +443,7 @@ impl<E: Context> Writable<E> {
     /// Rewind into a sealed blob: demote it to the writable tail, rewinding to `byte_offset`,
     /// and discarding every newer blob.
     ///
-    /// # Invariants
+    /// # Preconditions
     ///
     /// - `blob < tail_blob_index`
     pub(super) async fn rewind_into_sealed(
@@ -496,6 +494,7 @@ impl<E: Context> Writable<E> {
     pub(super) async fn clear(&mut self, tail_blob: u64) -> Result<(), Error> {
         self.drain_tail_predecessor_sync().await?;
         self.drain_tail_sync().await?;
+
         // Fence any deferred unlink before reusing the freed indices: a live removal targeting an
         // old index would otherwise unlink a blob this reset repopulates.
         self.drain_pending_prune().await;

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -146,32 +146,34 @@ impl<E: Context> Checkpoint<E> {
     }
 
     /// Begin recording `boundary` and raising the watermark to `watermark`, returning a completion
-    /// handle. If neither value advances, returns a resolved handle. The pipelined analogue of
-    /// [Self::persist].
+    /// handle. The boundary is always written. The watermark is written only if it is not already
+    /// current.
     ///
     /// # Preconditions
     ///
     /// - all items below `watermark` are durable
     /// - `boundary <= watermark`
+    /// - `boundary` advances past the recorded boundary
     pub(super) async fn start_persist(
         mut self,
         boundary: u64,
         watermark: u64,
     ) -> Result<(Self, Handle<()>), Error> {
         assert!(boundary <= watermark);
-        let advance_boundary =
-            !matches!(self.boundary_hint(), Some(current) if current >= boundary);
+
+        // Confirm the caller is advancing the boundary.
+        assert!(
+            !matches!(self.boundary_hint(), Some(current) if current >= boundary),
+            "start_persist requires an advancing boundary"
+        );
+
+        // Advance the watermark if it's not already current.
         let advance_watermark = !matches!(self.watermark(), Some(current) if current >= watermark);
-        if !advance_boundary && !advance_watermark {
-            return Ok((self, Handle::ready(Ok(()))));
-        }
 
         // Stage both entries before the single sync so a boundary advance and its covering
         // watermark land in one metadata version; a crash can never expose one advance without the
         // other.
-        if advance_boundary {
-            self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
-        }
+        self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
         if advance_watermark {
             self.metadata.put(RECOVERY_WATERMARK_KEY, watermark.into());
         }

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -24,11 +24,15 @@
 //! - The recovery watermark advances only after the blob state it describes is durable.
 //! - Except while a clear is staged or after adopting a legacy pruning boundary, the recovery
 //!   watermark never trails the pruning boundary (`boundary <= watermark <= size`). A prune records
-//!   the just-synced size as the watermark, so the watermark covers the retained items the boundary
-//!   exposes. Recovery relies on this: a durable watermark above the boundary proves those retained
-//!   items existed, so their loss is corruption rather than a completed prune. A staged clear may
-//!   temporarily lower the watermark below the old boundary; its clear target supersedes both.
-//!   A legacy checkpoint may also carry a sub-boundary watermark, which recovery treats as stale.
+//!   a proven-durable size as the watermark (the just-synced size for `prune`, or the already-proven
+//!   durable frontier for `start_prune`, which needs no fresh data sync), so the watermark covers
+//!   the retained items the boundary exposes. The boundary never advances in a metadata version
+//!   without a covering watermark in that same version, so a torn or partial write can never leave
+//!   the boundary ahead of the durable watermark. Recovery relies on this: a durable watermark above
+//!   the boundary proves those retained items existed, so their loss is corruption rather than a
+//!   completed prune. A staged clear may temporarily lower the watermark below the old boundary; its
+//!   clear target supersedes both. A legacy checkpoint may also carry a sub-boundary watermark,
+//!   which recovery treats as stale.
 //! - An entry is lowered before blob state moves backward (rewind, clear).
 //!
 //! Together they make backward operations recoverable without requiring blob presence alone to
@@ -135,6 +139,34 @@ impl<E: Context> Checkpoint<E> {
             return Ok((self, Handle::ready(Ok(()))));
         }
         self.metadata.put(RECOVERY_WATERMARK_KEY, watermark.into());
+        let (metadata, handle) = self.metadata.start_sync().await?;
+        self.metadata = metadata;
+        Ok((self, handle))
+    }
+
+    /// Begin recording `boundary` and raising the watermark to `watermark`, returning a completion
+    /// handle and writing only entries that advance. If neither advances, returns a resolved
+    /// handle. The pipelined analogue of [Self::persist].
+    /// Invariant: all items below `watermark` are durable, and `boundary <= watermark`.
+    pub(super) async fn start_persist(
+        mut self,
+        boundary: u64,
+        watermark: u64,
+    ) -> Result<(Self, Handle<()>), Error> {
+        let advance_boundary =
+            !matches!(self.boundary_hint(), Some(current) if current >= boundary);
+        let advance_watermark = !matches!(self.watermark(), Some(current) if current >= watermark);
+        if !advance_boundary && !advance_watermark {
+            return Ok((self, Handle::ready(Ok(()))));
+        }
+        // Stage both entries before the single sync so a boundary advance and its covering watermark
+        // land in one metadata version; a crash can never expose one advance without the other.
+        if advance_boundary {
+            self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
+        }
+        if advance_watermark {
+            self.metadata.put(RECOVERY_WATERMARK_KEY, watermark.into());
+        }
         let (metadata, handle) = self.metadata.start_sync().await?;
         self.metadata = metadata;
         Ok((self, handle))

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -24,15 +24,15 @@
 //! - The recovery watermark advances only after the blob state it describes is durable.
 //! - Except while a clear is staged or after adopting a legacy pruning boundary, the recovery
 //!   watermark never trails the pruning boundary (`boundary <= watermark <= size`). A prune records
-//!   a proven-durable size as the watermark (the just-synced size for `prune`, or the already-proven
-//!   durable frontier for `start_prune`, which needs no fresh data sync), so the watermark covers
-//!   the retained items the boundary exposes. The boundary never advances in a metadata version
-//!   without a covering watermark in that same version, so a torn or partial write can never leave
-//!   the boundary ahead of the durable watermark. Recovery relies on this: a durable watermark above
-//!   the boundary proves those retained items existed, so their loss is corruption rather than a
-//!   completed prune. A staged clear may temporarily lower the watermark below the old boundary; its
-//!   clear target supersedes both. A legacy checkpoint may also carry a sub-boundary watermark,
-//!   which recovery treats as stale.
+//!   a proven-durable size as the watermark (the just-synced size for `prune`, or the
+//!   already-proven durable frontier for `start_prune`, which needs no fresh data sync), so the
+//!   watermark covers the retained items the boundary exposes. The boundary never advances in a
+//!   metadata version without a covering watermark in that same version, so a torn or partial write
+//!   can never leave the boundary ahead of the durable watermark. Recovery relies on this: a
+//!   durable watermark above the boundary proves those retained items existed, so their loss is
+//!   corruption rather than a completed prune. A staged clear may temporarily lower the watermark
+//!   below the old boundary; its clear target supersedes both. A legacy checkpoint may also carry a
+//!   sub-boundary watermark, which recovery treats as stale.
 //! - An entry is lowered before blob state moves backward (rewind, clear).
 //!
 //! Together they make backward operations recoverable without requiring blob presence alone to
@@ -130,7 +130,8 @@ impl<E: Context> Checkpoint<E> {
     /// at or below the current one is ignored, returning a resolved handle.
     /// A started advance's failure leaves the raised value staged: later advances at or below
     /// it are ignored, and the next checkpoint write observes the failure and fails.
-    /// Invariant: all items below `watermark` are durable.
+    ///
+    /// Precondition: all items below `watermark` are durable.
     pub(super) async fn start_watermark_sync(
         mut self,
         watermark: u64,
@@ -145,22 +146,29 @@ impl<E: Context> Checkpoint<E> {
     }
 
     /// Begin recording `boundary` and raising the watermark to `watermark`, returning a completion
-    /// handle and writing only entries that advance. If neither advances, returns a resolved
-    /// handle. The pipelined analogue of [Self::persist].
-    /// Invariant: all items below `watermark` are durable, and `boundary <= watermark`.
+    /// handle. If neither value advances, returns a resolved handle. The pipelined analogue of
+    /// [Self::persist].
+    ///
+    /// # Preconditions
+    ///
+    /// - all items below `watermark` are durable
+    /// - `boundary <= watermark`
     pub(super) async fn start_persist(
         mut self,
         boundary: u64,
         watermark: u64,
     ) -> Result<(Self, Handle<()>), Error> {
+        assert!(boundary <= watermark);
         let advance_boundary =
             !matches!(self.boundary_hint(), Some(current) if current >= boundary);
         let advance_watermark = !matches!(self.watermark(), Some(current) if current >= watermark);
         if !advance_boundary && !advance_watermark {
             return Ok((self, Handle::ready(Ok(()))));
         }
-        // Stage both entries before the single sync so a boundary advance and its covering watermark
-        // land in one metadata version; a crash can never expose one advance without the other.
+
+        // Stage both entries before the single sync so a boundary advance and its covering
+        // watermark land in one metadata version; a crash can never expose one advance without the
+        // other.
         if advance_boundary {
             self.metadata.put(PRUNING_BOUNDARY_KEY, boundary.into());
         }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -131,6 +131,7 @@
 //! The `replay` method supports fast reading of all unpruned items into memory.
 
 use super::{
+    PruneHandle,
     blobs::{Blob, Blobs, Partition, Replay as BlobReplay, Writable},
     checkpoint::Checkpoint,
     durability::Barrier,
@@ -1156,6 +1157,77 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         Ok((self, true))
     }
 
+    /// See [Journal::start_prune]. `watermark` is the proven-durable frontier
+    /// ([`Barrier::size`](super::durability::Barrier::size)); the caller supplies it so the
+    /// variable journal can pass its joint frontier instead of the offsets sub-journal's own.
+    pub(crate) async fn start_prune(
+        mut self: Box<Self>,
+        min_item_pos: u64,
+        watermark: u64,
+    ) -> Result<(Box<Self>, PruneHandle), Error> {
+        let items_per_blob = self.items_per_blob.get();
+
+        // Clamp the target to the proven-durable frontier: `start_prune` reclaims only already-
+        // durable data, so it needs no data sync. Cap at the physical tail and never regress below
+        // the current boundary (as `prune` does).
+        let target_blob = super::position_to_blob(min_item_pos, items_per_blob);
+        let watermark_blob = super::position_to_blob(watermark, items_per_blob);
+        let min_blob = target_blob
+            .min(watermark_blob)
+            .min(self.blobs.tail_blob_index())
+            .max(super::position_to_blob(self.bounds.start, items_per_blob));
+
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start. With
+        // `min_blob <= watermark_blob` and the durable boundary never exceeding the frontier,
+        // `new_boundary <= watermark`, so the retained data below it is already durable and no data
+        // sync is needed. This is load-bearing: a boundary past the frontier would let a crash lose
+        // retained data that was recorded as pruned.
+        let new_boundary =
+            super::blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
+        assert!(new_boundary <= watermark);
+
+        if target_blob > watermark_blob {
+            warn!(
+                requested = min_item_pos,
+                frontier = watermark,
+                effective = new_boundary,
+                "start_prune target exceeds durable frontier; clamped (use prune)"
+            );
+        }
+
+        if min_blob <= self.blobs.oldest_blob_index() {
+            return Ok((self, PruneHandle::noop(new_boundary)));
+        }
+
+        // Adopt the boundary in memory. A dropped future consumes the journal, discarding this
+        // advance; the boundary the returned handle persists is what recovery completes on reopen.
+        self.bounds.start = new_boundary;
+
+        // Commit the boundary and raise the watermark to the proven frontier in one pipelined
+        // write. Every retained item is already durable (`new_boundary <= watermark`), so no data
+        // sync is needed, and recording the frontier advances the durable watermark for free. The
+        // write's durability is joined by the returned handle; recovery treats an ahead boundary as
+        // an interrupted prune and completes the removal, so the unlink is deferred below.
+        let (checkpoint, boundary) = self
+            .checkpoint
+            .start_persist(new_boundary, watermark)
+            .await?;
+        self.checkpoint = checkpoint;
+
+        // Advance the in-memory blob boundary and defer the unlink into the returned handle, gated
+        // on the boundary being durable. The blobs layer retains its own clone so a later reset or
+        // teardown can fence the unlink before reusing the freed indices.
+        let removal = self.blobs.start_prune(min_blob).await?;
+        self.metrics
+            .update(self.bounds.end, self.bounds.start, items_per_blob);
+
+        let handle = Handle::from_future(async move {
+            boundary.await?;
+            removal.await
+        });
+        Ok((self, PruneHandle::new(new_boundary, handle)))
+    }
+
     /// See [Journal::destroy].
     pub(crate) async fn destroy(self) -> Result<(), Error> {
         self.blobs.destroy().await?;
@@ -1407,6 +1479,29 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let (inner, pruned) = self.0.prune(min_item_pos).await?;
         self.0 = inner;
         Ok((self, pruned))
+    }
+
+    /// Begin pruning items older than `min_item_pos` off the hot path, without a data sync.
+    ///
+    /// `min_item_pos` is clamped down to the proven-durable frontier: only already-synced data is
+    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped (logging a
+    /// warning) rather than rejected; use [`Self::prune`] to prune data not yet synced. As with
+    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be pruned.
+    ///
+    /// The boundary is recorded by a pipelined checkpoint write (which also advances the recovery
+    /// watermark to the frontier) and the freed blobs are unlinked as the returned [PruneHandle]
+    /// completes. Like [`Self::start_sync`], recording the boundary waits for a prior in-flight
+    /// checkpoint sync before starting a new one. Await the handle to observe a durable boundary and
+    /// removed blobs, or drive it off the hot path. Cancelling this call (dropping its future before
+    /// it returns) consumes the journal and discards the in-memory boundary advance, as with any
+    /// mutating method; dropping the returned handle does neither. A dropped or crashed removal is
+    /// completed by recovery from the durable boundary, so the unlink never has to finish atomically
+    /// or in order.
+    pub async fn start_prune(mut self, min_item_pos: u64) -> Result<(Self, PruneHandle), Error> {
+        let watermark = self.0.barrier.size();
+        let (inner, handle) = self.0.start_prune(min_item_pos, watermark).await?;
+        self.0 = inner;
+        Ok((self, handle))
     }
 
     /// Remove any persisted data created by the journal.
@@ -1841,8 +1936,8 @@ mod tests {
         buffer::paged::Writer,
         deterministic::{self, Context},
         mocks::{
-            DelayedSyncContext, PendingSyncs, WriteFaultContext, WriteFaults, drive_pending_syncs,
-            fail_pending_syncs, release_pending_syncs,
+            DelayedSyncContext, PendingSyncs, RemoveFaultContext, RemoveFaults, WriteFaultContext,
+            WriteFaults, drive_pending_syncs, fail_pending_syncs, release_pending_syncs,
         },
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};
@@ -3383,6 +3478,315 @@ mod tests {
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `start_prune` below the durable watermark commits the boundary and frees the old blobs
+    /// without a data sync: the watermark is unchanged and the boundary survives a reopen.
+    #[test_traced]
+    fn test_fixed_start_prune_below_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let watermark = journal.0.recovery_watermark();
+
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+            assert!(handle.pruned());
+            assert_eq!(handle.boundary(), 10);
+            // No data sync; the persisted watermark already covers the frontier, so it does not move.
+            assert_eq!(journal.0.recovery_watermark(), watermark);
+            assert_eq!(journal.bounds(), 10..15);
+            handle.await.unwrap();
+
+            // Pruned items are gone; retained items remain.
+            assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(_))));
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+
+            // A request at or below the current boundary is a no-op handle.
+            let (journal, noop) = journal.start_prune(5).await.unwrap();
+            assert!(!noop.pruned());
+            assert_eq!(noop.boundary(), 10);
+            noop.await.unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            drop(journal);
+
+            // The committed boundary survives a reopen and the freed blobs stay pruned.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A `start_prune` target past the durable watermark is clamped to it: only already-synced
+    /// blobs are freed, the retained unsynced tail is untouched, and the watermark does not move.
+    #[test_traced]
+    fn test_fixed_start_prune_clamps_to_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+            // Append past the durable watermark without syncing.
+            for i in 15..20u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            assert_eq!(journal.0.recovery_watermark(), 15);
+
+            // Request pruning the whole journal; it clamps to the watermark's blob boundary.
+            let (journal, handle) = journal.start_prune(20).await.unwrap();
+            assert_eq!(journal.bounds(), 15..20);
+            assert_eq!(journal.0.recovery_watermark(), 15);
+            handle.await.unwrap();
+
+            // The retained (unsynced) tail above the boundary is still readable.
+            for i in 15..20u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A `start_prune` handle dropped at the parked unlink leaves the boundary durably committed
+    /// but the blobs unremoved. Recovery completes the interrupted prune from that boundary.
+    #[test_traced]
+    fn test_fixed_start_prune_interrupted_unlink_completed_by_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Park the deferred unlink: the handle makes the boundary durable, then parks before
+            // removing any blob.
+            journal.0.blobs.halt_prune_unlinks = true;
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+            {
+                futures::pin_mut!(handle);
+                assert!(
+                    futures::poll!(handle.as_mut()).is_pending(),
+                    "start_prune handle must park at the halted unlink"
+                );
+            }
+            // Crash: drop the parked handle and the journal without finishing the unlink.
+            drop(journal);
+
+            // Recovery completes the interrupted prune from the durable boundary.
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `clear_to_size` fences an in-flight deferred unlink before reusing the freed indices: a
+    /// stale unlink driven after the reset must not delete a blob the reset repopulated.
+    #[test_traced]
+    fn test_fixed_start_prune_fenced_by_clear_to_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Begin a deferred prune but do not drive the returned handle: the unlink of blobs 0
+            // and 1 is still pending when the reset runs.
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+
+            // The reset must drive the pending unlink to completion before reusing the low indices.
+            let mut journal = journal.clear_to_size(0).await.unwrap();
+            for i in 0..5u64 {
+                (journal, _) = journal.append(&test_digest(100 + i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Driving the stale handle now is a no-op: its unlink already completed during the
+            // reset, so the freshly written blob 0 survives.
+            handle.await.unwrap();
+            assert_eq!(journal.bounds(), 0..5);
+            for i in 0..5u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(100 + i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// Two `start_prune` calls in a row: the second drains the first's deferred unlink before
+    /// advancing further, so both handles resolve and the journal ends at the later boundary.
+    #[test_traced]
+    fn test_fixed_start_prune_consecutive_handles() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // First prune to boundary 5; do not drive its handle.
+            let (journal, first) = journal.start_prune(5).await.unwrap();
+            assert_eq!(first.boundary(), 5);
+
+            // Second prune to 10 drains the first unlink before detaching further.
+            let (journal, second) = journal.start_prune(10).await.unwrap();
+            assert_eq!(second.boundary(), 10);
+            assert_eq!(journal.bounds(), 10..15);
+
+            first.await.unwrap();
+            second.await.unwrap();
+
+            assert!(matches!(journal.read(7).await, Err(Error::ItemPruned(_))));
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A snapshot taken before `start_prune` keeps reading the pruned range through its own blob
+    /// handles while the deferred unlink removes those blobs (the read-after-remove contract).
+    #[test_traced]
+    fn test_fixed_start_prune_snapshot_reads_across_unlink() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Freeze a snapshot over the full range, then prune below it and finish the unlink.
+            let (journal, snapshot) = journal.snapshot().await.unwrap();
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+            handle.await.unwrap();
+
+            // The live snapshot still reads the unlinked range via its retained handles.
+            assert_eq!(snapshot.bounds(), 0..15);
+            for i in 0..15u64 {
+                assert_eq!(snapshot.read(i).await.unwrap(), test_digest(i));
+            }
+            // The journal itself reports the pruned prefix.
+            assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(_))));
+            drop(snapshot);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// After `commit` (data durable, watermark not yet persisted), `start_prune` reclaims up to the
+    /// proven-durable frontier, past the stale persisted watermark, and advances the recovery
+    /// watermark to that frontier, still without a data sync.
+    #[test_traced]
+    fn test_fixed_start_prune_uses_proven_frontier() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            // Persist a watermark at 5, then commit more data durable without advancing it.
+            for i in 0..5u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+            for i in 5..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.commit().await.unwrap();
+            assert_eq!(journal.0.recovery_watermark(), 5);
+
+            // The prune target (10) is past the persisted watermark (5) but within the proven
+            // frontier (15), so it prunes to 10 and advances the watermark to the frontier.
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+            assert!(handle.pruned());
+            assert_eq!(handle.boundary(), 10);
+            assert_eq!(journal.bounds(), 10..15);
+            assert_eq!(journal.0.recovery_watermark(), 15);
+            handle.await.unwrap();
+
+            assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(_))));
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A failed deferred unlink surfaces the error through the handle but does not poison the
+    /// journal: the boundary still commits, and a later prune (with removals working) succeeds.
+    #[test_traced]
+    fn test_fixed_start_prune_unlink_failure_does_not_poison() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let faults = RemoveFaults::default();
+            let cfg = test_cfg(&context, NZU64!(5));
+            let ctx = RemoveFaultContext {
+                inner: context.child("journal"),
+                faults: faults.clone(),
+            };
+            let mut journal = Journal::<_, Digest>::init(ctx, cfg.clone()).await.unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Arm the fault so the deferred unlink fails; the boundary still commits and the handle
+            // reports the error.
+            faults.arm();
+            let (journal, handle) = journal.start_prune(5).await.unwrap();
+            assert!(handle.pruned());
+            assert!(handle.await.is_err());
+
+            // The failure did not poison the journal: with removals working again, a later prune
+            // still succeeds and the retained items stay readable.
+            faults.disarm();
+            let (journal, pruned) = journal.prune(10).await.unwrap();
+            assert!(pruned);
             assert_eq!(journal.bounds(), 10..15);
             for i in 10..15u64 {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -160,7 +160,7 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-use tracing::warn;
+use tracing::{info, warn};
 
 // Reusable scratch for [`Reader::probe_items`], grown to the largest probe served on the
 // thread. Probes run per shard on the hot read path, where a fresh zeroed allocation per call
@@ -1181,12 +1181,15 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let new_boundary =
             super::blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
 
-        if target_blob > watermark_blob {
-            warn!(
+        if min_item_pos > watermark {
+            // Log any attempt to prune data that isn't already durable in case it's not the
+            // intent of the caller. We clamp the boundary to the durable frontier instead of
+            // returning an error since pruning is already best-effort by contract.
+            info!(
                 requested = min_item_pos,
                 frontier = watermark,
                 effective = new_boundary,
-                "start_prune target exceeds durable frontier; clamped (use prune)"
+                "clamping start_prune boundary to durable frontier"
             );
         }
 
@@ -1483,8 +1486,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Begin pruning items older than `min_item_pos` off the hot path, without a data sync.
     ///
     /// `min_item_pos` is clamped down to the proven-durable frontier: only already-synced data is
-    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped (logging a
-    /// warning) rather than rejected; use [`Self::prune`] to prune data not yet synced. As with
+    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped rather than
+    /// rejected; use [`Self::prune`] to prune data not yet synced. As with
     /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be
     /// pruned.
     ///

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1492,9 +1492,11 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// watermark to the frontier) and the freed blobs are unlinked as the returned [PruneHandle]
     /// completes. Like [`Self::start_sync`], recording the boundary waits for a prior in-flight
     /// checkpoint sync before starting a new one. Await the handle to observe a durable boundary
-    /// and removed blobs, or drive it off the hot path. A dropped or crashed removal is completed
-    /// by recovery from the durable boundary, so the unlink never has to finish atomically or in
-    /// order.
+    /// and removed blobs, or drive it off the hot path. Until the handle resolves `Ok` the boundary
+    /// advance is provisional: a failed metadata write or a crash reverts it, so drive it to `Ok`
+    /// before durably recording anything derived from the boundary. A dropped or crashed removal is
+    /// completed by recovery from the durable boundary, so the unlink never has to finish atomically
+    /// or in order.
     pub async fn start_prune(mut self, min_item_pos: u64) -> Result<(Self, PruneHandle), Error> {
         let watermark = self.0.barrier.size();
         let (inner, handle) = self.0.start_prune(min_item_pos, watermark).await?;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1157,9 +1157,9 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         Ok((self, true))
     }
 
-    /// See [Journal::start_prune]. `watermark` is the proven-durable frontier
-    /// ([`Barrier::size`](super::durability::Barrier::size)); the caller supplies it so the
-    /// variable journal can pass its joint frontier instead of the offsets sub-journal's own.
+    /// See [Journal::start_prune].
+    ///
+    /// `watermark` is the frontier below which all represented data is proven durable.
     pub(crate) async fn start_prune(
         mut self: Box<Self>,
         min_item_pos: u64,
@@ -1177,14 +1177,9 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             .min(self.blobs.tail_blob_index())
             .max(super::position_to_blob(self.bounds.start, items_per_blob));
 
-        // The max keeps a mid-blob adopted boundary from regressing to its blob's start. With
-        // `min_blob <= watermark_blob` and the durable boundary never exceeding the frontier,
-        // `new_boundary <= watermark`, so the retained data below it is already durable and no data
-        // sync is needed. This is load-bearing: a boundary past the frontier would let a crash lose
-        // retained data that was recorded as pruned.
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
         let new_boundary =
             super::blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
-        assert!(new_boundary <= watermark);
 
         if target_blob > watermark_blob {
             warn!(
@@ -1199,6 +1194,10 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             return Ok((self, PruneHandle::noop(new_boundary)));
         }
 
+        // Retained data below the boundary must be durable, or a crash could lose data recorded as
+        // pruned; the real-prune path (past the no-op above) guarantees `new_boundary <= watermark`.
+        assert!(new_boundary <= watermark);
+
         // Adopt the boundary in memory. A dropped future consumes the journal, discarding this
         // advance; the boundary the returned handle persists is what recovery completes on reopen.
         self.bounds.start = new_boundary;
@@ -1208,7 +1207,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         // sync is needed, and recording the frontier advances the durable watermark for free. The
         // write's durability is joined by the returned handle; recovery treats an ahead boundary as
         // an interrupted prune and completes the removal, so the unlink is deferred below.
-        let (checkpoint, boundary) = self
+        let (checkpoint, persist) = self
             .checkpoint
             .start_persist(new_boundary, watermark)
             .await?;
@@ -1222,7 +1221,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             .update(self.bounds.end, self.bounds.start, items_per_blob);
 
         let handle = Handle::from_future(async move {
-            boundary.await?;
+            persist.await?;
             removal.await
         });
         Ok((self, PruneHandle::new(new_boundary, handle)))
@@ -1486,17 +1485,16 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// `min_item_pos` is clamped down to the proven-durable frontier: only already-synced data is
     /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped (logging a
     /// warning) rather than rejected; use [`Self::prune`] to prune data not yet synced. As with
-    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be pruned.
+    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be
+    /// pruned.
     ///
     /// The boundary is recorded by a pipelined checkpoint write (which also advances the recovery
     /// watermark to the frontier) and the freed blobs are unlinked as the returned [PruneHandle]
     /// completes. Like [`Self::start_sync`], recording the boundary waits for a prior in-flight
-    /// checkpoint sync before starting a new one. Await the handle to observe a durable boundary and
-    /// removed blobs, or drive it off the hot path. Cancelling this call (dropping its future before
-    /// it returns) consumes the journal and discards the in-memory boundary advance, as with any
-    /// mutating method; dropping the returned handle does neither. A dropped or crashed removal is
-    /// completed by recovery from the durable boundary, so the unlink never has to finish atomically
-    /// or in order.
+    /// checkpoint sync before starting a new one. Await the handle to observe a durable boundary
+    /// and removed blobs, or drive it off the hot path. A dropped or crashed removal is completed
+    /// by recovery from the durable boundary, so the unlink never has to finish atomically or in
+    /// order.
     pub async fn start_prune(mut self, min_item_pos: u64) -> Result<(Self, PruneHandle), Error> {
         let watermark = self.0.barrier.size();
         let (inner, handle) = self.0.start_prune(min_item_pos, watermark).await?;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1198,8 +1198,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         // pruned; the real-prune path (past the no-op above) guarantees `new_boundary <= watermark`.
         assert!(new_boundary <= watermark);
 
-        // Adopt the boundary in memory. A dropped future consumes the journal, discarding this
-        // advance; the boundary the returned handle persists is what recovery completes on reopen.
+        // Adopt the boundary in memory.
         self.bounds.start = new_boundary;
 
         // Commit the boundary and raise the watermark to the proven frontier in one pipelined
@@ -1214,8 +1213,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         self.checkpoint = checkpoint;
 
         // Advance the in-memory blob boundary and defer the unlink into the returned handle, gated
-        // on the boundary being durable. The blobs layer retains its own clone so a later reset or
-        // teardown can fence the unlink before reusing the freed indices.
+        // on the boundary being durable.
         let removal = self.blobs.start_prune(min_blob).await?;
         self.metrics
             .update(self.bounds.end, self.bounds.start, items_per_blob);
@@ -1377,7 +1375,9 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Durably persist the current state of the structure, ensuring no recovery is required in the
     /// event of a crash following this call.
     ///
-    /// Advances the recovery watermark to the current size.
+    /// Advances the recovery watermark to the current size. Deferred prunes are the exception: if a
+    /// [`Self::start_prune`] handle was dropped instead of driven, its blobs are unlinked on the
+    /// next open rather than by this call.
     pub async fn sync(mut self) -> Result<Self, Error> {
         self.0 = self.0.sync().await?;
         Ok(self)

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1217,7 +1217,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
 
         // Advance the in-memory blob boundary and defer the unlink into the returned handle, gated
         // on the boundary being durable.
-        let removal = self.blobs.start_prune(min_blob).await?;
+        let removal = self.blobs.start_prune(min_blob).await;
         self.metrics
             .update(self.bounds.end, self.bounds.start, items_per_blob);
 

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -14,7 +14,13 @@
 use super::Error;
 use commonware_runtime::Handle;
 use futures::{Stream, StreamExt as _, stream};
-use std::{future::Future, num::NonZeroUsize, ops::Range};
+use std::{
+    future::Future,
+    num::NonZeroUsize,
+    ops::Range,
+    pin::Pin,
+    task::{Context, Poll},
+};
 use tracing::warn;
 
 mod blobs;
@@ -152,6 +158,63 @@ where
         ReplayStreamState::next,
     )
     .flat_map(stream::iter)
+}
+
+/// A deferred prune returned by `start_prune`.
+///
+/// Awaiting or spawning it drives the pruning boundary to durability and unlinks the freed blobs
+/// off the hot path; dropping it leaves the unlink for recovery or a later reset to complete. The
+/// output mirrors a durability [Handle]: `Ok(())` once the boundary is durable and the blobs are
+/// removed.
+///
+/// The handle unlinks blobs by index and borrows nothing, so it can outlive its journal. It
+/// reserves the journal's partition: before reopening that partition in the same process, drive or
+/// drop the handle, or a stale unlink could remove blobs the reopened journal relies on.
+#[must_use = "await or spawn the handle to observe completion and reclaim the pruned blobs"]
+pub struct PruneHandle {
+    boundary: u64,
+    pruned: bool,
+    inner: Handle<()>,
+}
+
+impl PruneHandle {
+    /// A prune that advanced the boundary; `inner` records it durable and unlinks the blobs.
+    pub(super) const fn new(boundary: u64, inner: Handle<()>) -> Self {
+        Self {
+            boundary,
+            pruned: true,
+            inner,
+        }
+    }
+
+    /// A no-op prune: the boundary was unchanged and nothing needs unlinking.
+    pub(super) fn noop(boundary: u64) -> Self {
+        Self {
+            boundary,
+            pruned: false,
+            inner: Handle::ready(Ok(())),
+        }
+    }
+
+    /// The effective pruning boundary after clamping to the blob and durability limits. All items
+    /// at positions below it are (being) pruned.
+    pub const fn boundary(&self) -> u64 {
+        self.boundary
+    }
+
+    /// Whether this call advanced the logical pruning boundary. `false` means the request was at or
+    /// below the existing boundary, so awaiting the handle is a resolved no-op.
+    pub const fn pruned(&self) -> bool {
+        self.pruned
+    }
+}
+
+impl Future for PruneHandle {
+    type Output = Result<(), commonware_runtime::Error>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.inner).poll(cx)
+    }
 }
 
 /// A read-only, position-based view of a contiguous journal.

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -167,9 +167,9 @@ where
 /// output mirrors a durability [Handle]: `Ok(())` once the boundary is durable and the blobs are
 /// removed.
 ///
-/// The handle unlinks blobs by index and borrows nothing, so it can outlive its journal. It
-/// reserves the journal's partition: before reopening that partition in the same process, drive or
-/// drop the handle, or a stale unlink could remove blobs the reopened journal relies on.
+/// The handle may remain active after its journal is dropped and reserves the journal's partition.
+/// Before reopening that partition in the same process, await or drop the handle; otherwise a stale
+/// unlink could remove blobs used by the reopened journal.
 #[must_use = "await or spawn the handle to observe completion and reclaim the pruned blobs"]
 pub struct PruneHandle {
     boundary: u64,
@@ -178,7 +178,9 @@ pub struct PruneHandle {
 }
 
 impl PruneHandle {
-    /// A prune that advanced the boundary; `inner` records it durable and unlinks the blobs.
+    /// A prune that advanced the boundary.
+    ///
+    /// `inner` durably records the pruning boundary and unlinks the blobs.
     pub(super) const fn new(boundary: u64, inner: Handle<()>) -> Self {
         Self {
             boundary,
@@ -202,8 +204,8 @@ impl PruneHandle {
         self.boundary
     }
 
-    /// Whether this call advanced the logical pruning boundary. `false` means the request was at or
-    /// below the existing boundary, so awaiting the handle is a resolved no-op.
+    /// Whether this call pruned anything (freed at least one whole blob). Awaiting the handle is a
+    /// resolved no-op when `false`.
     pub const fn pruned(&self) -> bool {
         self.pruned
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1591,13 +1591,8 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             .min(self.blobs.tail_blob_index())
             .max(position_to_blob(self.bounds.start, items_per_blob));
 
-        // The max keeps a mid-blob adopted boundary from regressing to its blob's start. With
-        // `min_blob <= watermark_blob` and the durable boundary never exceeding the frontier,
-        // `new_boundary <= watermark`, so the retained data below it is already durable and no data
-        // sync is needed. This is load-bearing: a boundary past the frontier would let a crash lose
-        // retained data that was recorded as pruned.
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
         let new_boundary = blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
-        assert!(new_boundary <= watermark);
 
         if target_blob > watermark_blob {
             warn!(
@@ -1611,6 +1606,10 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok((self, PruneHandle::noop(new_boundary)));
         }
+
+        // Retained data below the boundary must be durable, or a crash could lose data recorded as
+        // pruned; the real-prune path (past the no-op above) guarantees `new_boundary <= watermark`.
+        assert!(new_boundary <= watermark);
 
         // The offsets journal is the durable prune record. Its own `start_prune` commits the
         // boundary and raises the offsets watermark to the joint frontier (no data sync), deferring
@@ -2421,23 +2420,22 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok((self, pruned))
     }
 
-    /// Begin pruning items at positions strictly less than `min_position` off the hot path,
-    /// without a data sync.
+    /// Begin pruning items at positions strictly less than `min_position` off the hot path, without
+    /// a data sync.
     ///
     /// `min_position` is clamped down to the proven-durable frontier: only already-synced data is
     /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped (logging a
     /// warning) rather than rejected; use [`Self::prune`] to prune data not yet synced. As with
-    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be pruned.
+    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be
+    /// pruned.
     ///
-    /// The boundary is recorded by a pipelined write to the offsets journal's checkpoint (which also
-    /// advances the recovery watermark to the frontier), and the freed data and offsets blobs are
-    /// unlinked as the returned [PruneHandle] completes. Like [`Self::start_sync`], recording the
-    /// boundary waits for a prior in-flight checkpoint sync before starting a new one. Await the
-    /// handle to observe a durable boundary and removed blobs, or drive it off the hot path.
-    /// Cancelling this call (dropping its future before it returns) consumes the journal and discards
-    /// the in-memory boundary advance, as with any mutating method; dropping the returned handle does
-    /// neither. A dropped or crashed removal is completed by recovery from the durable boundary, so
-    /// the unlink never has to finish atomically or in order.
+    /// The boundary is recorded by a pipelined write to the offsets journal's checkpoint (which
+    /// also advances the recovery watermark to the frontier), and the freed data and offsets blobs
+    /// are unlinked as the returned [PruneHandle] completes. Like [`Self::start_sync`], recording
+    /// the boundary waits for a prior in-flight checkpoint sync before starting a new one. Await
+    /// the handle to observe a durable boundary and removed blobs, or drive it off the hot path.
+    /// A dropped or crashed removal is completed by recovery from the durable boundary, so the
+    /// unlink never has to finish atomically or in order.
     pub async fn start_prune(mut self, min_position: u64) -> Result<(Self, PruneHandle), Error> {
         let (inner, handle) = self.0.start_prune(min_position).await?;
         self.0 = inner;
@@ -4571,7 +4569,9 @@ mod tests {
             let (journal, handle) = journal.start_prune(10).await.unwrap();
             assert!(handle.pruned());
             assert_eq!(handle.boundary(), 10);
-            // No data sync; the persisted watermark already covers the frontier, so it does not move.
+
+            // No data sync; the persisted watermark already covers the frontier, so it does not
+            // move.
             assert_eq!(journal.0.offsets.recovery_watermark(), watermark);
             assert_eq!(journal.bounds(), 10..15);
             handle.await.unwrap();
@@ -4634,7 +4634,8 @@ mod tests {
     }
 
     /// A `start_prune` handle dropped at the parked data unlink leaves the offsets boundary durably
-    /// committed with data ahead of it. Recovery completes the interrupted prune from that boundary.
+    /// committed with data ahead of it. Recovery completes the interrupted prune from that
+    /// boundary.
     #[test_traced]
     fn test_variable_start_prune_interrupted_unlink_completed_by_recovery() {
         let executor = deterministic::Runner::default();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2426,10 +2426,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// a data sync.
     ///
     /// `min_position` is clamped down to the proven-durable frontier: only already-synced data is
-    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped rather than
-    /// rejected; use [`Self::prune`] to prune data not yet synced. As with
-    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be
-    /// pruned.
+    /// reclaimed, so no data fsync is needed. Data made durable only by [`Self::commit`] is not
+    /// reclaimable here: `commit` persists the data blobs but not the offsets journal, so the
+    /// proven-durable frontier does not advance until [`Self::sync`]. Use `sync` (or [`Self::prune`],
+    /// which syncs) to reclaim committed-but-unsynced data. A request beyond the frontier is clamped
+    /// rather than rejected. As with `prune`, blob boundaries are preserved, so slightly fewer items
+    /// than requested may be pruned.
     ///
     /// The boundary is recorded by a pipelined write to the offsets journal's checkpoint (which
     /// also advances the recovery watermark to the frontier), and the freed data and offsets blobs
@@ -4634,6 +4636,51 @@ mod tests {
 
             // The retained (unsynced) tail above the boundary is still readable.
             for i in 15..20u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `commit` alone does not let `start_prune` advance past the offsets (sync) frontier: `commit`
+    /// makes the data durable but not the offsets journal, so the proven-durable frontier does not
+    /// move, and committed-but-unsynced data stays reclaimable only after a `sync`.
+    #[test_traced]
+    fn test_variable_start_prune_does_not_reclaim_committed() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "variable-start-prune-committed".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..10u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+            assert_eq!(journal.0.offsets.recovery_watermark(), 10);
+
+            // Append past the synced frontier and commit (not sync): the data becomes durable but
+            // the offsets journal does not, so the proven-durable frontier stays at 10.
+            for i in 10..15u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            let journal = journal.commit().await.unwrap();
+            assert_eq!(journal.0.offsets.recovery_watermark(), 10);
+
+            // Pruning past the frontier clamps to the synced frontier (10), not the commit frontier
+            // (15): the committed-but-unsynced data is retained, not reclaimed.
+            let (journal, handle) = journal.start_prune(15).await.unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            assert_eq!(journal.0.offsets.recovery_watermark(), 10);
+            handle.await.unwrap();
+            for i in 10..15u64 {
                 assert_eq!(journal.read(i).await.unwrap(), i);
             }
             journal.destroy().await.unwrap();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -50,9 +50,9 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-use tracing::warn;
 #[commonware_macros::stability(ALPHA)]
-use tracing::{debug, info};
+use tracing::debug;
+use tracing::{info, warn};
 
 /// Items encoded for a deferred append, created by [`Journal::prepare_append`] and consumed by
 /// [`Journal::append_prepared`].
@@ -1625,7 +1625,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 
         // Defer the data unlink into the returned handle, gated on the offsets boundary being
         // durable so a crash never removes data ahead of an uncommitted boundary.
-        let data_removal = self.blobs.start_prune(min_blob).await?;
+        let data_removal = self.blobs.start_prune(min_blob).await;
         self.metrics.update(
             self.bounds.end,
             self.bounds.start,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1620,9 +1620,8 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         self.offsets = offsets;
         self.bounds.start = new_boundary;
 
-        // Defer the data unlink, fenced by the blobs layer like the offsets side. Gate it on the
-        // offsets boundary being durable so a crash never removes data ahead of an uncommitted
-        // boundary.
+        // Defer the data unlink into the returned handle, gated on the offsets boundary being
+        // durable so a crash never removes data ahead of an uncommitted boundary.
         let data_removal = self.blobs.start_prune(min_blob).await?;
         self.metrics.update(
             self.bounds.end,
@@ -2469,6 +2468,9 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     }
 
     /// Persist data blobs and all metadata for both the data and offsets journals.
+    ///
+    /// Deferred prunes are the exception: if a [`Self::start_prune`] handle was dropped instead of
+    /// driven, its blobs are unlinked on the next open rather than by this call.
     pub async fn sync(mut self) -> Result<Self, Error> {
         self.0 = self.0.sync().await?;
         Ok(self)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -12,7 +12,7 @@
 //! durable. See the [`fixed`] module docs for the full model.
 
 use super::{
-    Contiguous, Many, Mutable, blob_first_position,
+    Contiguous, Many, Mutable, PruneHandle, blob_first_position,
     blobs::{Blob, Blobs, Partition, Replay as BlobReplay, Writable},
     durability::Barrier,
     fixed,
@@ -1571,6 +1571,73 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         Ok((self, true))
     }
 
+    /// See [Journal::start_prune].
+    pub(crate) async fn start_prune(
+        mut self: Box<Self>,
+        min_position: u64,
+    ) -> Result<(Box<Self>, PruneHandle), Error> {
+        let items_per_blob = self.items_per_blob.get();
+        // The joint proven-durable frontier for both journals. It must never be the offsets
+        // sub-journal's own frontier, which can run ahead of the data after a one-sided sync.
+        let watermark = self.barrier.size();
+
+        // Clamp the target to the proven-durable frontier: `start_prune` reclaims only already-
+        // durable data, so it needs no data sync. Cap at the physical tail and never regress below
+        // the current boundary (as `prune` does).
+        let target_blob = position_to_blob(min_position, items_per_blob);
+        let watermark_blob = position_to_blob(watermark, items_per_blob);
+        let min_blob = target_blob
+            .min(watermark_blob)
+            .min(self.blobs.tail_blob_index())
+            .max(position_to_blob(self.bounds.start, items_per_blob));
+
+        // The max keeps a mid-blob adopted boundary from regressing to its blob's start. With
+        // `min_blob <= watermark_blob` and the durable boundary never exceeding the frontier,
+        // `new_boundary <= watermark`, so the retained data below it is already durable and no data
+        // sync is needed. This is load-bearing: a boundary past the frontier would let a crash lose
+        // retained data that was recorded as pruned.
+        let new_boundary = blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
+        assert!(new_boundary <= watermark);
+
+        if target_blob > watermark_blob {
+            warn!(
+                requested = min_position,
+                frontier = watermark,
+                effective = new_boundary,
+                "start_prune target exceeds durable frontier; clamped (use prune)"
+            );
+        }
+
+        if min_blob <= self.blobs.oldest_blob_index() {
+            return Ok((self, PruneHandle::noop(new_boundary)));
+        }
+
+        // The offsets journal is the durable prune record. Its own `start_prune` commits the
+        // boundary and raises the offsets watermark to the joint frontier (no data sync), deferring
+        // its stale-blob unlink; the returned handle joins that durability. Recovery completes an
+        // interrupted prune from the committed offsets boundary, so both unlinks are deferred into
+        // the handle below.
+        let (offsets, offsets_handle) = self.offsets.start_prune(new_boundary, watermark).await?;
+        self.offsets = offsets;
+        self.bounds.start = new_boundary;
+
+        // Defer the data unlink, fenced by the blobs layer like the offsets side. Gate it on the
+        // offsets boundary being durable so a crash never removes data ahead of an uncommitted
+        // boundary.
+        let data_removal = self.blobs.start_prune(min_blob).await?;
+        self.metrics.update(
+            self.bounds.end,
+            self.bounds.start,
+            self.items_per_blob.get(),
+        );
+
+        let handle = Handle::from_future(async move {
+            offsets_handle.await?;
+            data_removal.await
+        });
+        Ok((self, PruneHandle::new(new_boundary, handle)))
+    }
+
     /// See [Journal::start_sync].
     pub(crate) async fn start_sync(mut self: Box<Self>) -> Result<(Box<Self>, Handle<()>), Error> {
         self.metrics.start_sync_calls.inc();
@@ -2352,6 +2419,29 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         let (inner, pruned) = self.0.prune(min_position).await?;
         self.0 = inner;
         Ok((self, pruned))
+    }
+
+    /// Begin pruning items at positions strictly less than `min_position` off the hot path,
+    /// without a data sync.
+    ///
+    /// `min_position` is clamped down to the proven-durable frontier: only already-synced data is
+    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped (logging a
+    /// warning) rather than rejected; use [`Self::prune`] to prune data not yet synced. As with
+    /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be pruned.
+    ///
+    /// The boundary is recorded by a pipelined write to the offsets journal's checkpoint (which also
+    /// advances the recovery watermark to the frontier), and the freed data and offsets blobs are
+    /// unlinked as the returned [PruneHandle] completes. Like [`Self::start_sync`], recording the
+    /// boundary waits for a prior in-flight checkpoint sync before starting a new one. Await the
+    /// handle to observe a durable boundary and removed blobs, or drive it off the hot path.
+    /// Cancelling this call (dropping its future before it returns) consumes the journal and discards
+    /// the in-memory boundary advance, as with any mutating method; dropping the returned handle does
+    /// neither. A dropped or crashed removal is completed by recovery from the durable boundary, so
+    /// the unlink never has to finish atomically or in order.
+    pub async fn start_prune(mut self, min_position: u64) -> Result<(Self, PruneHandle), Error> {
+        let (inner, handle) = self.0.start_prune(min_position).await?;
+        self.0 = inner;
+        Ok((self, handle))
     }
 
     /// Persist data blobs so committed data survives a crash.
@@ -4450,6 +4540,187 @@ mod tests {
             let names = context.scan(&cfg.data_partition()).await.unwrap();
             assert!(!names.contains(&0u64.to_be_bytes().to_vec()));
             assert!(!names.contains(&1u64.to_be_bytes().to_vec()));
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `start_prune` below the durable watermark commits the boundary and frees the old data and
+    /// offsets blobs without a data sync: the watermark is unchanged and the boundary survives a
+    /// reopen.
+    #[test_traced]
+    fn test_variable_start_prune_below_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "variable-start-prune-below".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            let watermark = journal.0.offsets.recovery_watermark();
+
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+            assert!(handle.pruned());
+            assert_eq!(handle.boundary(), 10);
+            // No data sync; the persisted watermark already covers the frontier, so it does not move.
+            assert_eq!(journal.0.offsets.recovery_watermark(), watermark);
+            assert_eq!(journal.bounds(), 10..15);
+            handle.await.unwrap();
+
+            // Pruned items are gone; retained items remain.
+            assert!(matches!(journal.read(5).await, Err(Error::ItemPruned(_))));
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i);
+            }
+            drop(journal);
+
+            // The committed boundary survives a reopen and the freed blobs stay pruned.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 10..15);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A `start_prune` target past the durable watermark is clamped to it: only already-synced
+    /// blobs are freed, the retained unsynced tail is untouched, and the watermark does not move.
+    #[test_traced]
+    fn test_variable_start_prune_clamps_to_watermark() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "variable-start-prune-clamp".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+            // Append past the durable watermark without syncing.
+            for i in 15..20u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            assert_eq!(journal.0.offsets.recovery_watermark(), 15);
+
+            // Request pruning the whole journal; it clamps to the watermark's blob boundary.
+            let (journal, handle) = journal.start_prune(20).await.unwrap();
+            assert_eq!(journal.bounds(), 15..20);
+            assert_eq!(journal.0.offsets.recovery_watermark(), 15);
+            handle.await.unwrap();
+
+            // The retained (unsynced) tail above the boundary is still readable.
+            for i in 15..20u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A `start_prune` handle dropped at the parked data unlink leaves the offsets boundary durably
+    /// committed with data ahead of it. Recovery completes the interrupted prune from that boundary.
+    #[test_traced]
+    fn test_variable_start_prune_interrupted_unlink_completed_by_recovery() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "variable-start-prune-interrupted".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Park the deferred data unlink: the handle makes the offsets boundary durable and
+            // removes the offsets blobs, then parks before removing any data blob.
+            journal.0.blobs.halt_prune_unlinks = true;
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+            {
+                futures::pin_mut!(handle);
+                assert!(
+                    futures::poll!(handle.as_mut()).is_pending(),
+                    "start_prune handle must park at the halted data unlink"
+                );
+            }
+            // Crash: drop the parked handle and the journal without finishing the unlink.
+            drop(journal);
+
+            // Recovery completes the interrupted prune from the durable offsets boundary.
+            let journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("recovery must complete the interrupted prune");
+            assert_eq!(journal.bounds(), 10..15);
+            for i in 10..15u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i);
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `clear_to_size` fences an in-flight deferred unlink before reusing the freed indices: a
+    /// stale unlink driven after the reset must not delete a blob the reset repopulated.
+    #[test_traced]
+    fn test_variable_start_prune_fenced_by_clear_to_size() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "variable-start-prune-fence".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("journal"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&i).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Begin a deferred prune but do not drive the returned handle: the unlink of the old
+            // data and offsets blobs is still pending when the reset runs.
+            let (journal, handle) = journal.start_prune(10).await.unwrap();
+
+            // The reset must drive the pending unlink to completion before reusing the low indices.
+            let mut journal = journal.clear_to_size(0).await.unwrap();
+            for i in 0..5u64 {
+                (journal, _) = journal.append(&(100 + i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // Driving the stale handle now is a no-op: its unlinks already completed during the
+            // reset, so the freshly written blob 0 survives.
+            handle.await.unwrap();
+            assert_eq!(journal.bounds(), 0..5);
+            for i in 0..5u64 {
+                assert_eq!(journal.read(i).await.unwrap(), 100 + i);
+            }
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -50,9 +50,9 @@ use std::{
     ops::Range,
     sync::Arc,
 };
-#[commonware_macros::stability(ALPHA)]
-use tracing::debug;
 use tracing::warn;
+#[commonware_macros::stability(ALPHA)]
+use tracing::{debug, info};
 
 /// Items encoded for a deferred append, created by [`Journal::prepare_append`] and consumed by
 /// [`Journal::append_prepared`].
@@ -1594,12 +1594,15 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         // The max keeps a mid-blob adopted boundary from regressing to its blob's start.
         let new_boundary = blob_first_position(min_blob, items_per_blob)?.max(self.bounds.start);
 
-        if target_blob > watermark_blob {
-            warn!(
+        if min_position > watermark {
+            // Log any attempt to prune data that isn't already durable in case it's not the
+            // intent of the caller. We clamp the boundary to the durable frontier instead of
+            // returning an error since pruning is already best-effort by contract.
+            info!(
                 requested = min_position,
                 frontier = watermark,
                 effective = new_boundary,
-                "start_prune target exceeds durable frontier; clamped (use prune)"
+                "clamping start_prune boundary to durable frontier"
             );
         }
 
@@ -2423,8 +2426,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// a data sync.
     ///
     /// `min_position` is clamped down to the proven-durable frontier: only already-synced data is
-    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped (logging a
-    /// warning) rather than rejected; use [`Self::prune`] to prune data not yet synced. As with
+    /// reclaimed, so no data fsync is needed. A request beyond the frontier is clamped rather than
+    /// rejected; use [`Self::prune`] to prune data not yet synced. As with
     /// `prune`, blob boundaries are preserved, so slightly fewer items than requested may be
     /// pruned.
     ///
@@ -2433,8 +2436,10 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// are unlinked as the returned [PruneHandle] completes. Like [`Self::start_sync`], recording
     /// the boundary waits for a prior in-flight checkpoint sync before starting a new one. Await
     /// the handle to observe a durable boundary and removed blobs, or drive it off the hot path.
-    /// A dropped or crashed removal is completed by recovery from the durable boundary, so the
-    /// unlink never has to finish atomically or in order.
+    /// Until the handle resolves `Ok` the boundary advance is provisional: a failed metadata write
+    /// or a crash reverts it, so drive it to `Ok` before durably recording anything derived from
+    /// the boundary. A dropped or crashed removal is completed by recovery from the durable
+    /// boundary, so the unlink never has to finish atomically or in order.
     pub async fn start_prune(mut self, min_position: u64) -> Result<(Self, PruneHandle), Error> {
         let (inner, handle) = self.0.start_prune(min_position).await?;
         self.0 = inner;


### PR DESCRIPTION
Stacks on #4235 (base branch `journal-prune-boundary-wal`).

Adds `start_prune`, an fsync-free pruning variant for the fixed and variable contiguous journals — the async analogue of `prune`, mirroring `sync`/`start_sync`.

## What it does

For a boundary at or below the **proven-durable frontier** (`barrier.size()`), `start_prune`:
- records the boundary via a **pipelined** checkpoint write that also raises the recovery watermark to the frontier at no extra I/O cost (that data is already on disk, so no data fsync is needed);
- defers the blob unlink into the returned `PruneHandle` the caller drives off the hot path.

A request past the frontier is **clamped** to it (with a `warn!` logging `requested`, `frontier`, and `effective`) rather than rejected — an error would be fatal since the method consumes `self`. `prune` is left unchanged; use it to prune data not yet synced. No `Spawner` bound: the caller drives (or spawns) the returned handle.

`PruneHandle` is a `Future` (delegates to the inner durability handle) that also exposes `boundary()` and `pruned()` and is `#[must_use]`. It reserves its journal's partition: because it borrows nothing and can outlive the journal, drive or drop it before reopening that partition (documented on the type).

## Recovery & lifecycle safety

- The deferred unlink is retained as a shared handle (`pending_prune`) and drained by `clear`/`destroy`/`prune` before any freed blob index can be reused — mirroring the existing `tail_sync` fencing. Without this, a live unlink racing a `clear_to_size` + re-append would delete freshly-written blobs.
- The drain is **best-effort**: a failed unlink is logged at its source (exactly once) rather than propagated, so it cannot poison later operations; the error still surfaces through the caller's handle. An already-removed blob (`BlobMissing`/`PartitionMissing`) is tolerated for idempotence.
- An interrupted unlink is completed by recovery from the durable boundary (the state #4235 already handles), so it never has to finish atomically or in order.
- Every other concurrent blob create/delete is safe by construction: appends open `tail+1` (disjoint from the low removal range) and `rewind` is guarded by `size >= bounds.start`.
- `assert!(new_boundary <= watermark)` is a loud tripwire for the no-fsync durability invariant.

The variable journal inherits the fence on both blob sets for free (its data blobs and offsets journal are both built on the same `Writable`), and passes its **joint** `barrier.size()` to the offsets sub-journal so the recorded watermark never trusts one side's frontier running ahead of the other.

## Tests

12 new `start_prune` tests (8 fixed, 4 variable): below-frontier happy path + reopen, clamp-to-frontier, interrupted-unlink-completed-by-recovery, `clear_to_size` fence (verified load-bearing — fails `BlobMissing` without the drain), consecutive handles (drain-prior / at-most-one), a live snapshot reading across the deferred unlink (read-after-remove), `uses_proven_frontier` (prunes past a stale persisted watermark after `commit`), and unlink-failure-does-not-poison (a failed removal surfaces through the handle while a later prune still succeeds). Full `journal::contiguous` suite: 248 passing.

Adds a small `RemoveFaultContext` to `runtime` mocks (mirrors `WriteFaultContext`) to inject `remove` failures for the last test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSarn1C4iMrjHQHrVcanFo
