### PR TITLE
[storage/bmt] Tighten MAX_LEVELS from 255 to 32

### DIFF
--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -53,9 +53,10 @@ use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::{non_empty_vec, vec::NonEmptyVec};
 use thiserror::Error;
 
-/// There should never be more than 255 levels in a proof (would mean the Binary Merkle Tree
-/// has more than 2^255 leaves).
-pub const MAX_LEVELS: usize = u8::MAX as usize;
+/// There should never be more than 32 sibling levels in a proof. Because
+/// [Proof::leaf_count] is a `u32`, a tree can have at most `u32::MAX` leaves,
+/// which requires at most `u32::BITS` sibling hashes per proven item.
+pub const MAX_LEVELS: usize = u32::BITS as usize;
 
 /// Errors that can occur when working with a Binary Merkle Tree (BMT).
 #[derive(Error, Debug)]

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -89,8 +89,16 @@ impl<H: Hasher> Builder<H> {
     /// Adds a leaf to the Binary Merkle Tree.
     ///
     /// When added, the leaf is hashed with its position.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the tree already has `u32::MAX` leaves.
     pub fn add(&mut self, leaf: &H::Digest) -> u32 {
+        // The count after this add must fit in Proof::leaf_count, a u32, so the
+        // maximum position is u32::MAX - 1.
         let position: u32 = self.leaves.len().try_into().expect("too many leaves");
+        assert!(position < u32::MAX, "too many leaves");
+
         let digest = H::hash(&[&position.to_be_bytes(), leaf.as_ref()]);
         self.leaves.push(digest);
         position


### PR DESCRIPTION
## Summary

- Lower `MAX_LEVELS` in `storage/src/bmt` from `u8::MAX` (255) to `u32::BITS` (32).
- `Proof::read_cfg` allocates up to `max_items * MAX_LEVELS` sibling digests before cryptographic verification; the old bound allowed far more allocation than any valid proof can contain.
- Because `Proof::leaf_count` is a `u32`, a tree can have at most `u32::MAX` leaves. `levels_in_tree(u32::MAX)` is 33, and `siblings_required_for_multi_proof` iterates `0..levels_count - 1`, so 32 sibling levels is the tight maximum per proven item.
- For ZODA's `StrongShard`, this tightens inclusion proof pre-allocation and reduces the risk of memory exhaustion from adversarial shards.

Fixes #3174

## Test plan

- [x] `cargo test -p commonware-storage bmt`
- [x] `cargo test -p commonware-coding zoda`
- [x] `cargo test -p commonware-coding reed_solomon`