### PR TITLE
[runtime] Track active paged checksums explicitly

### DIFF
--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -254,7 +254,7 @@ impl Slot {
     }
 }
 
-/// The checksum slot selected after validating a page footer.
+/// The checksum covering a page's logical bytes and the footer slot that holds it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct ActiveChecksum {
     slot: Slot,
@@ -273,7 +273,6 @@ impl ActiveChecksum {
 /// The CRC accompanied by the larger length is the one that should be treated as authoritative for
 /// the page. Two checksums are stored so that partial pages can be written without overwriting a
 /// valid checksum for a previously committed partial page.
-#[derive(Clone)]
 struct Checksum {
     len1: u16,
     crc1: u32,
@@ -285,24 +284,11 @@ impl Checksum {
     /// Create a new CRC record with the given length and CRC.
     /// The new CRC is stored in the first slot (len1/crc1), with the second slot zeroed.
     const fn new(len: u16, crc: u32) -> Self {
-        Self::in_slot(Slot::First, len, crc)
-    }
-
-    /// A record carrying `(len, crc)` in `slot`, with the other slot zeroed.
-    const fn in_slot(slot: Slot, len: u16, crc: u32) -> Self {
-        match slot {
-            Slot::First => Self {
-                len1: len,
-                crc1: crc,
-                len2: 0,
-                crc2: 0,
-            },
-            Slot::Second => Self {
-                len1: 0,
-                crc1: 0,
-                len2: len,
-                crc2: crc,
-            },
+        Self {
+            len1: len,
+            crc1: crc,
+            len2: 0,
+            crc2: 0,
         }
     }
 
@@ -353,8 +339,20 @@ impl Checksum {
     ) -> Option<ActiveChecksum> {
         let (len, crc) = self.get_slot(slot);
         let len_usize = len as usize;
-        if len_usize == 0 || len_usize > crc_start_idx || Crc32::checksum(&buf[..len_usize]) != crc
-        {
+
+        // A zero length marks an inactive checksum slot (committed pages are never empty).
+        // This also rejects zero-filled physical pages from unwritten storage.
+        if len_usize == 0 {
+            return None;
+        }
+
+        // The checksum must cover only logical page bytes, not the checksum footer itself.
+        if len_usize > crc_start_idx {
+            return None;
+        }
+
+        // The recorded checksum must match the claimed logical prefix.
+        if Crc32::checksum(&buf[..len_usize]) != crc {
             return None;
         }
         Some(ActiveChecksum::new(slot, len, crc))

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -317,11 +317,16 @@ impl Checksum {
         let crc_start_idx = (physical_page_size - CHECKSUM_SIZE) as usize;
         let mut crc_bytes = &buf[crc_start_idx..];
         let crc_record = Self::read(&mut crc_bytes).expect("CRC record read should not fail");
+
+        // Prefer the authoritative slot: when both slots are valid, it covers the most recently
+        // committed contents of the page.
         let authoritative = crc_record.authoritative();
         if let Some(checksum) = crc_record.validate_slot(authoritative, buf, crc_start_idx) {
             return Some(checksum);
         }
 
+        // An interrupted write can corrupt only the slot it was rewriting. The other slot still
+        // covers the page's previously committed contents.
         debug!("Invalid authoritative CRC, using fallback CRC");
         let checksum = crc_record.validate_slot(authoritative.other(), buf, crc_start_idx);
         if checksum.is_none() {

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -314,6 +314,8 @@ impl Checksum {
             return None;
         }
 
+        // Decode the CRC record from the page footer. The size guard above guarantees all of its
+        // bytes are present, and every bit pattern decodes, so the read cannot fail.
         let crc_start_idx = (physical_page_size - CHECKSUM_SIZE) as usize;
         let mut crc_bytes = &buf[crc_start_idx..];
         let crc_record = Self::read(&mut crc_bytes).expect("CRC record read should not fail");

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -204,12 +204,12 @@ async fn get_page_from_blob(
     Ok(page)
 }
 
-/// Read the designated page and return both its logical bytes and validated checksum record.
+/// Read the designated page and return both its logical bytes and validated checksum.
 async fn get_page_with_checksum_from_blob(
     blob: &impl Blob,
     page_num: u64,
     page_size: u64,
-) -> Result<(IoBuf, Checksum), Error> {
+) -> Result<(IoBuf, ActiveChecksum), Error> {
     let physical_page_size = page_size
         .checked_add(CHECKSUM_SIZE)
         .ok_or(Error::OffsetOverflow)?;
@@ -222,16 +222,15 @@ async fn get_page_with_checksum_from_blob(
         .await?
         .coalesce();
 
-    let Some(record) = Checksum::validate_page(page.as_ref()) else {
+    let Some(checksum) = Checksum::validate_page(page.as_ref()) else {
         return Err(Error::InvalidChecksum);
     };
-    let (len, _) = record.get_crc();
 
-    Ok((page.freeze().slice(..len as usize), record))
+    Ok((page.freeze().slice(..checksum.len as usize), checksum))
 }
 
 /// One of a page footer's two CRC slots, laid out back to back after the page data.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Slot {
     First,
     Second,
@@ -252,6 +251,20 @@ impl Slot {
             Self::First => Self::Second,
             Self::Second => Self::First,
         }
+    }
+}
+
+/// The checksum slot selected after validating a page footer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ActiveChecksum {
+    slot: Slot,
+    len: u16,
+    crc: u32,
+}
+
+impl ActiveChecksum {
+    const fn new(slot: Slot, len: u16, crc: u32) -> Self {
+        Self { slot, len, crc }
     }
 }
 
@@ -302,11 +315,9 @@ impl Checksum {
         }
     }
 
-    /// Return the CRC record for the page if it is valid. The provided slice is assumed to be
-    /// exactly the size of a physical page. The record may not precisely reflect the bytes written
-    /// if what should have been the most recent CRC doesn't validate, in which case it will be
-    /// zeroed and the other CRC used as a fallback.
-    fn validate_page(buf: &[u8]) -> Option<Self> {
+    /// Return the active checksum if the page is valid. The provided slice is assumed to be exactly
+    /// the size of a physical page.
+    fn validate_page(buf: &[u8]) -> Option<ActiveChecksum> {
         let physical_page_size = buf.len() as u64;
         if physical_page_size < CHECKSUM_SIZE {
             error!(
@@ -319,94 +330,41 @@ impl Checksum {
 
         let crc_start_idx = (physical_page_size - CHECKSUM_SIZE) as usize;
         let mut crc_bytes = &buf[crc_start_idx..];
-        let mut crc_record = Self::read(&mut crc_bytes).expect("CRC record read should not fail");
-        let (len, crc) = crc_record.get_crc();
-
-        // Validate that len is in the valid range [1, page_size].
-        // A page with len=0 is invalid (e.g., all-zero pages from unwritten data).
-        let len_usize = len as usize;
-        if len_usize == 0 {
-            // Both CRCs have 0 length, so there is no fallback possible.
-            debug!("Invalid CRC: len==0");
-            return None;
+        let crc_record = Self::read(&mut crc_bytes).expect("CRC record read should not fail");
+        let authoritative = crc_record.authoritative();
+        if let Some(checksum) = crc_record.validate_slot(authoritative, buf, crc_start_idx) {
+            return Some(checksum);
         }
 
-        if len_usize > crc_start_idx {
-            // len is too large so this CRC isn't valid. Fall back to the other CRC.
-            debug!("Invalid CRC: len too long. Using fallback CRC");
-            if crc_record.validate_fallback(buf, crc_start_idx) {
-                return Some(crc_record);
-            }
-            return None;
+        debug!("Invalid authoritative CRC, using fallback CRC");
+        let checksum = crc_record.validate_slot(authoritative.other(), buf, crc_start_idx);
+        if checksum.is_none() {
+            debug!("Invalid fallback CRC");
         }
-
-        let computed_crc = Crc32::checksum(&buf[..len_usize]);
-        if computed_crc != crc {
-            debug!("Invalid CRC: doesn't match page contents. Using fallback CRC");
-            if crc_record.validate_fallback(buf, crc_start_idx) {
-                return Some(crc_record);
-            }
-            return None;
-        }
-
-        Some(crc_record)
+        checksum
     }
 
-    /// Attempts to validate a CRC record based on its fallback CRC because the primary CRC failed
-    /// validation. The primary CRC is zeroed in the process. Returns false if the fallback CRC
-    /// fails validation.
-    fn validate_fallback(&mut self, buf: &[u8], crc_start_idx: usize) -> bool {
-        let (len, crc) = self.get_fallback_crc();
-        if len == 0 {
-            // No fallback available (only one CRC was ever written to this page).
-            debug!("Invalid fallback CRC: len==0");
-            return false;
-        }
-
+    /// Validate one slot independently of the footer's authority ordering.
+    fn validate_slot(
+        &self,
+        slot: Slot,
+        buf: &[u8],
+        crc_start_idx: usize,
+    ) -> Option<ActiveChecksum> {
+        let (len, crc) = self.get_slot(slot);
         let len_usize = len as usize;
-
-        if len_usize > crc_start_idx {
-            // len is too large so this CRC isn't valid.
-            debug!("Invalid fallback CRC: len too long.");
-            return false;
+        if len_usize == 0 || len_usize > crc_start_idx || Crc32::checksum(&buf[..len_usize]) != crc
+        {
+            return None;
         }
-
-        let computed_crc = Crc32::checksum(&buf[..len_usize]);
-        if computed_crc != crc {
-            debug!("Invalid fallback CRC: doesn't match page contents.");
-            return false;
-        }
-
-        true
+        Some(ActiveChecksum::new(slot, len, crc))
     }
 
-    /// Returns the CRC record with the longer (authoritative) length, without performing any
-    /// validation. If they both have the same length (which should only happen due to data
-    /// corruption) return the first.
-    const fn get_crc(&self) -> (u16, u32) {
-        match self.authoritative() {
+    /// Return one checksum slot without considering authority.
+    const fn get_slot(&self, slot: Slot) -> (u16, u32) {
+        match slot {
             Slot::First => (self.len1, self.crc1),
             Slot::Second => (self.len2, self.crc2),
-        }
-    }
-
-    /// Zeroes the primary CRC (because we assumed it failed validation) and returns the other. This
-    /// should only be called if the primary CRC failed validation. After this returns, get_crc will
-    /// no longer return the invalid primary CRC.
-    const fn get_fallback_crc(&mut self) -> (u16, u32) {
-        match self.authoritative() {
-            Slot::First => {
-                // First CRC was primary, and must have been invalid. Zero it and return the second.
-                self.len1 = 0;
-                self.crc1 = 0;
-                (self.len2, self.crc2)
-            }
-            Slot::Second => {
-                // Second CRC was primary, and must have been invalid. Zero it and return the first.
-                self.len2 = 0;
-                self.crc2 = 0;
-                (self.len1, self.crc1)
-            }
         }
     }
 
@@ -418,7 +376,7 @@ impl Checksum {
     /// Encode a whole checksum slot (`[len: u16][crc: u32]`) in its storage representation.
     ///
     /// A page footer holds two slots; recovery treats the one with the larger `len` as
-    /// authoritative (see [`Self::get_crc`]). A `len` of 0 is never authoritative.
+    /// authoritative. A `len` of 0 is never authoritative.
     fn slot_bytes(len: u16, crc: u32) -> [u8; CHECKSUM_SLOT_SIZE] {
         let mut bytes = [0; CHECKSUM_SLOT_SIZE];
         let mut buf = bytes.as_mut_slice();
@@ -582,7 +540,7 @@ mod tests {
     }
 
     #[test]
-    fn test_crc_record_get_crc_len1_larger() {
+    fn test_crc_record_authoritative_len1_larger() {
         let record = Checksum {
             len1: 200,
             crc1: 0xAAAAAAAA,
@@ -590,13 +548,11 @@ mod tests {
             crc2: 0xBBBBBBBB,
         };
 
-        let (len, crc) = record.get_crc();
-        assert_eq!(len, 200);
-        assert_eq!(crc, 0xAAAAAAAA);
+        assert_eq!(record.authoritative(), Slot::First);
     }
 
     #[test]
-    fn test_crc_record_get_crc_len2_larger() {
+    fn test_crc_record_authoritative_len2_larger() {
         let record = Checksum {
             len1: 100,
             crc1: 0xAAAAAAAA,
@@ -604,14 +560,12 @@ mod tests {
             crc2: 0xBBBBBBBB,
         };
 
-        let (len, crc) = record.get_crc();
-        assert_eq!(len, 200);
-        assert_eq!(crc, 0xBBBBBBBB);
+        assert_eq!(record.authoritative(), Slot::Second);
     }
 
     #[test]
-    fn test_crc_record_get_crc_equal_lengths() {
-        // When lengths are equal, len1/crc1 is returned (first slot wins ties).
+    fn test_crc_record_authoritative_equal_lengths() {
+        // The first slot wins ties.
         let record = Checksum {
             len1: 100,
             crc1: 0xAAAAAAAA,
@@ -619,9 +573,7 @@ mod tests {
             crc2: 0xBBBBBBBB,
         };
 
-        let (len, crc) = record.get_crc();
-        assert_eq!(len, 100);
-        assert_eq!(crc, 0xAAAAAAAA);
+        assert_eq!(record.authoritative(), Slot::First);
     }
 
     #[test]
@@ -642,11 +594,10 @@ mod tests {
         let crc_start = physical_page_size - Checksum::SIZE;
         page[crc_start..].copy_from_slice(&record.to_bytes());
 
-        // Validate - should return Some with the Checksum
+        // Validate - should return the active checksum
         let validated = Checksum::validate_page(&page);
         assert!(validated.is_some());
-        let (len, _) = validated.unwrap().get_crc();
-        assert_eq!(len as usize, data.len());
+        assert_eq!(validated.unwrap().len as usize, data.len());
     }
 
     #[test]
@@ -719,8 +670,7 @@ mod tests {
         // Should validate using len2/crc2 since len2 > len1
         let validated = Checksum::validate_page(&page);
         assert!(validated.is_some());
-        let (len, _) = validated.unwrap().get_crc();
-        assert_eq!(len as usize, data.len());
+        assert_eq!(validated.unwrap().len as usize, data.len());
     }
 
     #[test]
@@ -753,13 +703,10 @@ mod tests {
 
         assert!(validated.is_some(), "Should have validated using fallback");
         let validated = validated.unwrap();
-        let (len, crc) = validated.get_crc();
-        assert_eq!(len, valid_len);
-        assert_eq!(crc, valid_crc);
-
-        // Verify that the invalid primary was zeroed out
-        assert_eq!(validated.len1, 0);
-        assert_eq!(validated.crc1, 0);
+        assert_eq!(
+            validated,
+            ActiveChecksum::new(Slot::Second, valid_len, valid_crc)
+        );
     }
 
     #[test]

--- a/runtime/src/utils/buffer/paged/read.rs
+++ b/runtime/src/utils/buffer/paged/read.rs
@@ -131,12 +131,11 @@ impl<B: Blob> PageReader<B> {
             let page_start = page_idx * self.physical_page_size;
             let page_slice =
                 &physical_buf.as_ref()[page_start..page_start + self.physical_page_size];
-            let Some(record) = Checksum::validate_page(page_slice) else {
+            let Some(checksum) = Checksum::validate_page(page_slice) else {
                 error!(page = self.blob_page + page_idx as u64, "CRC mismatch");
                 return Err(Error::InvalidChecksum);
             };
-            let (len, _) = record.get_crc();
-            let len = len as usize;
+            let len = checksum.len as usize;
 
             // Only the final page in the blob may have partial length
             let is_last_page_in_blob = is_final_batch && page_idx + 1 == pages_to_read;

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -45,7 +45,7 @@ use crate::{
     Blob, Error, Handle, IoBuf, IoBufMut, IoBufs,
     buffer::{
         SyncState,
-        paged::{CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE, CacheRef, Checksum, Slot},
+        paged::{ActiveChecksum, CHECKSUM_SIZE, CHECKSUM_SLOT_SIZE, CacheRef, Checksum, Slot},
         tip::Buffer,
     },
 };
@@ -102,9 +102,8 @@ pub struct Writer<B: Blob> {
     /// The page where the next appended byte will be written to.
     current_page: u64,
 
-    /// The state of the partial page in the blob. If it was written due to a sync call, then this
-    /// will contain its CRC record.
-    partial_page_state: Option<Checksum>,
+    /// The active checksum of the partial page in the blob, if any.
+    partial_page_state: Option<ActiveChecksum>,
 
     /// Durability state for plain writes, resizes, and range-sync writes.
     sync_state: SyncState,
@@ -213,7 +212,8 @@ impl<B: Blob> Writer<B> {
     /// A tuple of `(partial_page, page_count, invalid_data_found)`:
     ///
     /// - `partial_page`: If the last valid page is partial (contains fewer than `page_size` logical
-    ///   bytes), returns `Some((data, crc_record))` containing the logical data and its CRC record.
+    ///   bytes), returns `Some((data, checksum))` containing the logical data and its active
+    ///   checksum.
     ///   Returns `None` if the last valid page is full or if no valid pages exist.
     ///
     /// - `page_count`: The number of pages in the blob up to and including the last valid page
@@ -227,7 +227,7 @@ impl<B: Blob> Writer<B> {
         blob: &B,
         blob_size: u64,
         page_size: u64,
-    ) -> Result<(Option<(IoBuf, Checksum)>, u64, bool), Error> {
+    ) -> Result<(Option<(IoBuf, ActiveChecksum)>, u64, bool), Error> {
         let physical_page_size = page_size + CHECKSUM_SIZE;
         let partial_bytes = blob_size % physical_page_size;
         let mut last_page_end = blob_size - partial_bytes;
@@ -246,15 +246,14 @@ impl<B: Blob> Writer<B> {
                 .freeze();
 
             match Checksum::validate_page(buf.as_ref()) {
-                Some(crc_record) => {
+                Some(checksum) => {
                     // Found a valid page.
-                    let (len, _) = crc_record.get_crc();
-                    let len = len as u64;
+                    let len = checksum.len as u64;
                     if len != page_size {
                         // The page is partial (logical data doesn't fill the page).
                         let logical_bytes = buf.slice(..len as usize);
                         return Ok((
-                            Some((logical_bytes, crc_record)),
+                            Some((logical_bytes, checksum)),
                             last_page_end / physical_page_size,
                             invalid_data_found,
                         ));
@@ -659,11 +658,11 @@ impl<B: Blob> Writer<B> {
     /// - `prefix_len`: bytes `[0, prefix_len)` are committed logical data already covered by the
     ///   protected CRC and do not need to be rewritten
     /// - `protected_crc`: which CRC slot must not be overwritten by the next flush
-    fn identify_protected_regions(partial_page_state: Option<&Checksum>) -> Option<(usize, Slot)> {
-        let crc_record = partial_page_state?;
-        let (old_len, _) = crc_record.get_crc();
-        // The protected CRC is the authoritative (longer) slot.
-        Some((old_len as usize, crc_record.authoritative()))
+    fn identify_protected_regions(
+        partial_page_state: Option<&ActiveChecksum>,
+    ) -> Option<(usize, Slot)> {
+        let checksum = partial_page_state?;
+        Some((checksum.len as usize, checksum.slot))
     }
 
     /// Prepare physical-page writes from buffered logical bytes.
@@ -675,15 +674,15 @@ impl<B: Blob> Writer<B> {
     ///
     /// * `buffer` - The buffer containing logical page data
     /// * `include_partial_page` - Whether to include a partial page if one exists
-    /// * `old_crc_record` - The CRC record from a previously committed partial page, if any.
-    ///   When present, the first page's CRC record will preserve the old CRC in its original slot
-    ///   and place the new CRC in the other slot.
+    /// * `old_checksum` - The active checksum from a previously committed partial page, if any.
+    ///   When present, the first page's CRC record will preserve it in its original slot and place
+    ///   the new checksum in the other slot.
     fn to_physical_pages(
         &self,
         buffer: &Buffer,
         include_partial_page: bool,
-        old_crc_record: Option<&Checksum>,
-    ) -> (IoBufs, Option<Checksum>) {
+        old_checksum: Option<&ActiveChecksum>,
+    ) -> (IoBufs, Option<ActiveChecksum>) {
         let page_size = self.cache_ref.page_size() as usize;
         let physical_page_size = page_size + CHECKSUM_SIZE as usize;
         let pages_to_write = buffer.len() / page_size;
@@ -693,7 +692,7 @@ impl<B: Blob> Writer<B> {
         if pages_to_write > 0 {
             self.append_full_pages(
                 &buffer.slice(..pages_to_write * page_size),
-                old_crc_record,
+                old_checksum,
                 &mut write_buffer,
             );
         }
@@ -711,23 +710,23 @@ impl<B: Blob> Writer<B> {
         // If there are no full pages and the partial page length matches what was already
         // written, there's nothing new to write.
         if pages_to_write == 0
-            && let Some(old_crc) = old_crc_record
+            && let Some(old_checksum) = old_checksum
+            && partial_page.len() == old_checksum.len as usize
         {
-            let (old_len, _) = old_crc.get_crc();
-            if partial_page.len() == old_len as usize {
-                return (write_buffer, None);
-            }
+            return (write_buffer, None);
         }
         let partial_len = partial_page.len();
         let crc = Crc32::checksum(partial_page);
 
         // For partial pages: if this is the first page and there's an old CRC, preserve it.
         // Otherwise just use the new CRC in slot 0.
-        let crc_record = if let (0, Some(old_crc)) = (pages_to_write, old_crc_record) {
-            Self::build_crc_record_preserving_old(partial_len as u16, crc, old_crc)
+        let old_checksum = if pages_to_write == 0 {
+            old_checksum
         } else {
-            Checksum::new(partial_len as u16, crc)
+            None
         };
+        let (crc_record, active_checksum) =
+            Self::build_crc_record(partial_len as u16, crc, old_checksum);
 
         // A persisted partial page still occupies one full physical page:
         // [partial logical bytes, zero padding, crc record].
@@ -740,20 +739,18 @@ impl<B: Blob> Writer<B> {
         padded.put_slice(&crc_record.to_bytes());
         write_buffer.append(padded.freeze());
 
-        // Return the CRC record that matches what we wrote to disk, so that future flushes
-        // correctly identify which slot is protected.
-        (write_buffer, Some(crc_record))
+        (write_buffer, Some(active_checksum))
     }
 
     /// Appends each page of `data` to `write_buffer` in on-disk format: its payload (a zero-copy
     /// slice of `data`) followed by a CRC record.
     ///
-    /// `data.len()` must be a non-zero multiple of the page size. When `old_crc_record` is present,
-    /// the first page's record preserves the old CRC in its original slot.
+    /// `data.len()` must be a non-zero multiple of the page size. When `old_checksum` is present,
+    /// the first page's record preserves it in its original slot.
     fn append_full_pages(
         &self,
         data: &IoBuf,
-        old_crc_record: Option<&Checksum>,
+        old_checksum: Option<&ActiveChecksum>,
         write_buffer: &mut IoBufs,
     ) {
         let page_size = self.cache_ref.page_size() as usize;
@@ -775,11 +772,8 @@ impl<B: Blob> Writer<B> {
 
             // For the first page, if there's an old partial page CRC, construct the record
             // to preserve the old CRC in its original slot.
-            let crc_record = if let (0, Some(old_crc)) = (page, old_crc_record) {
-                Self::build_crc_record_preserving_old(page_size_u16, crc, old_crc)
-            } else {
-                Checksum::new(page_size_u16, crc)
-            };
+            let old_checksum = if page == 0 { old_checksum } else { None };
+            let (crc_record, _) = Self::build_crc_record(page_size_u16, crc, old_checksum);
             crcs.put_slice(&crc_record.to_bytes());
         }
         let crc_blob = crcs.freeze();
@@ -795,32 +789,39 @@ impl<B: Blob> Writer<B> {
         }
     }
 
-    /// Build a CRC record that preserves the old CRC in its original slot and places the new CRC
-    /// in the other slot.
+    /// Build a CRC record and identify its active checksum. If an old checksum is provided, it is
+    /// preserved in its original slot and the new checksum is placed in the other slot.
     ///
     /// A subsequent flush writes around the preserved slot, so an interrupted rewrite can recover
     /// either the old partial page or the new one.
-    const fn build_crc_record_preserving_old(
+    const fn build_crc_record(
         new_len: u16,
         new_crc: u32,
-        old_crc: &Checksum,
-    ) -> Checksum {
-        let (old_len, old_crc_val) = old_crc.get_crc();
-        // Keep the old CRC in its slot and place the new CRC in the free one.
-        match old_crc.authoritative() {
+        old_checksum: Option<&ActiveChecksum>,
+    ) -> (Checksum, ActiveChecksum) {
+        let Some(old_checksum) = old_checksum else {
+            return (
+                Checksum::new(new_len, new_crc),
+                ActiveChecksum::new(Slot::First, new_len, new_crc),
+            );
+        };
+
+        let new_slot = old_checksum.slot.other();
+        let record = match old_checksum.slot {
             Slot::First => Checksum {
-                len1: old_len,
-                crc1: old_crc_val,
+                len1: old_checksum.len,
+                crc1: old_checksum.crc,
                 len2: new_len,
                 crc2: new_crc,
             },
             Slot::Second => Checksum {
                 len1: new_len,
                 crc1: new_crc,
-                len2: old_len,
-                crc2: old_crc_val,
+                len2: old_checksum.len,
+                crc2: old_checksum.crc,
             },
-        }
+        };
+        (record, ActiveChecksum::new(new_slot, new_len, new_crc))
     }
 
     /// Durably rewrite a committed page to a shorter partial length.
@@ -830,8 +831,8 @@ impl<B: Blob> Writer<B> {
         page_size: u64,
         new_len: u16,
         new_crc: u32,
-        old_crc: &Checksum,
-    ) -> Result<Checksum, Error> {
+        old_checksum: &ActiveChecksum,
+    ) -> Result<ActiveChecksum, Error> {
         // Recovery chooses the valid slot with the larger length. While shrinking, the new
         // checksum must be made durable without becoming authoritative until the old longer slot
         // can be disabled. The sequence below therefore lets recovery observe either the old page
@@ -843,7 +844,7 @@ impl<B: Blob> Writer<B> {
             .checked_mul(physical_page_size)
             .and_then(|start| start.checked_add(page_size))
             .ok_or(Error::OffsetOverflow)?;
-        let old_slot = old_crc.authoritative();
+        let old_slot = old_checksum.slot;
         let new_slot = old_slot.other();
 
         // Stage the new slot with a 0 length and the shrunken page CRC. A crash here leaves the
@@ -870,7 +871,7 @@ impl<B: Blob> Writer<B> {
         self.write_at_sync(old_slot_offset, Checksum::slot_len_bytes(0).to_vec())
             .await?;
 
-        Ok(Checksum::in_slot(new_slot, new_len, new_crc))
+        Ok(ActiveChecksum::new(new_slot, new_len, new_crc))
     }
 
     /// Flushes any buffered data, then returns a [Replay] for the underlying blob.
@@ -900,10 +901,9 @@ impl<B: Blob> Writer<B> {
                 let logical = page_size * self.current_page;
                 (physical, logical)
             },
-            |crc_record| {
+            |checksum| {
                 // There's a partial page with a checksum.
-                let (partial_len, _) = crc_record.get_crc();
-                let partial_len = partial_len as u64;
+                let partial_len = checksum.len as u64;
                 // Physical: all pages including the partial one (which is padded to full size).
                 let physical = physical_page_size * (self.current_page + 1);
                 // Logical: full pages before this + partial page's actual data length.
@@ -1106,7 +1106,7 @@ impl<B: Blob> Writer<B> {
         self.current_page = full_pages;
         self.buffer.offset = tail_offset;
 
-        let (page_data, old_crc) =
+        let (page_data, old_checksum) =
             super::get_page_with_checksum_from_blob(&self.blob, full_pages, page_size).await?;
 
         // Ensure the validated data covers what we need.
@@ -1125,7 +1125,7 @@ impl<B: Blob> Writer<B> {
                 page_size,
                 partial_bytes as u16,
                 Crc32::checksum(new_data),
-                &old_crc,
+                &old_checksum,
             )
             .await?;
         self.partial_page_state = Some(final_record);
@@ -3172,66 +3172,19 @@ mod tests {
     const DUMMY_MARKER: [u8; 6] = [0x00, 0x00, 0xDE, 0xAD, 0xBE, 0xEF];
 
     #[test]
-    fn test_identify_protected_regions_equal_lengths() {
-        // When lengths are equal, the first CRC should be protected (tie-breaking rule).
-        let record = Checksum {
-            len1: 50,
-            crc1: 0xAAAAAAAA,
-            len2: 50,
-            crc2: 0xBBBBBBBB,
-        };
-
+    fn test_identify_protected_regions_first_slot() {
+        let checksum = ActiveChecksum::new(Slot::First, 50, 0xAAAAAAAA);
         let result =
-            Writer::<crate::storage::memory::Blob>::identify_protected_regions(Some(&record));
-        assert!(result.is_some());
-        let (prefix_len, protected_crc) = result.unwrap();
-        assert_eq!(prefix_len, 50);
-        assert!(
-            matches!(protected_crc, Slot::First),
-            "First CRC should be protected when lengths are equal"
-        );
+            Writer::<crate::storage::memory::Blob>::identify_protected_regions(Some(&checksum));
+        assert_eq!(result, Some((checksum.len as usize, checksum.slot)));
     }
 
     #[test]
-    fn test_identify_protected_regions_len1_larger() {
-        // When len1 > len2, the first CRC should be protected.
-        let record = Checksum {
-            len1: 100,
-            crc1: 0xAAAAAAAA,
-            len2: 50,
-            crc2: 0xBBBBBBBB,
-        };
-
+    fn test_identify_protected_regions_second_slot() {
+        let checksum = ActiveChecksum::new(Slot::Second, 100, 0xBBBBBBBB);
         let result =
-            Writer::<crate::storage::memory::Blob>::identify_protected_regions(Some(&record));
-        assert!(result.is_some());
-        let (prefix_len, protected_crc) = result.unwrap();
-        assert_eq!(prefix_len, 100);
-        assert!(
-            matches!(protected_crc, Slot::First),
-            "First CRC should be protected when len1 > len2"
-        );
-    }
-
-    #[test]
-    fn test_identify_protected_regions_len2_larger() {
-        // When len2 > len1, the second CRC should be protected.
-        let record = Checksum {
-            len1: 50,
-            crc1: 0xAAAAAAAA,
-            len2: 100,
-            crc2: 0xBBBBBBBB,
-        };
-
-        let result =
-            Writer::<crate::storage::memory::Blob>::identify_protected_regions(Some(&record));
-        assert!(result.is_some());
-        let (prefix_len, protected_crc) = result.unwrap();
-        assert_eq!(prefix_len, 100);
-        assert!(
-            matches!(protected_crc, Slot::Second),
-            "Second CRC should be protected when len2 > len1"
-        );
+            Writer::<crate::storage::memory::Blob>::identify_protected_regions(Some(&checksum));
+        assert_eq!(result, Some((checksum.len as usize, checksum.slot)));
     }
 
     /// Test that `to_physical_pages` emits full pages zero-copy while still materializing the
@@ -3283,9 +3236,8 @@ mod tests {
             assert_eq!(physical_pages.chunk_count(), 5);
 
             // The returned partial-page CRC state must describe the exact trailing logical length.
-            let crc_record = partial_page_state.expect("partial page state must be returned");
-            let (len, _) = crc_record.get_crc();
-            assert_eq!(len as usize, partial_len);
+            let checksum = partial_page_state.expect("partial page state must be returned");
+            assert_eq!(checksum.len as usize, partial_len);
 
             // Coalesce for easier content inspection. The assembled bytes should still form three
             // full physical pages on disk.

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -677,6 +677,9 @@ impl<B: Blob> Writer<B> {
     /// * `old_checksum` - The active checksum from a previously committed partial page, if any.
     ///   When present, the first page's CRC record will preserve it in its original slot and place
     ///   the new checksum in the other slot.
+    ///
+    /// Returns the physical pages to write and, for any included partial page, the active
+    /// checksum future flushes must protect.
     fn to_physical_pages(
         &self,
         buffer: &Buffer,


### PR DESCRIPTION
## Summary
- distinguish the raw two-slot page footer from its validated active checksum
- retain the selected checksum slot directly in writer state
- simplify fallback validation without changing the on-disk format or durability protocol

## Testing
- just test -p commonware-runtime buffer::paged
- just clippy -p commonware-runtime