### PR TITLE
[cryptography] bind verifier fault models and validate threshold polynomials

### DIFF
--- a/consensus/src/aggregation/mocks/scheme.rs
+++ b/consensus/src/aggregation/mocks/scheme.rs
@@ -2,5 +2,6 @@
 
 use crate::aggregation::types::{Item, Namespace};
 use commonware_cryptography::impl_certificate_mock;
+use commonware_utils::N3f1;
 
-impl_certificate_mock!(&'a Item<D>, Namespace);
+impl_certificate_mock!(&'a Item<D>, Namespace, N3f1);

--- a/consensus/src/aggregation/scheme.rs
+++ b/consensus/src/aggregation/scheme.rs
@@ -17,16 +17,22 @@
 
 use super::types::Item;
 use commonware_cryptography::{Digest, certificate};
+use commonware_utils::N3f1;
 
 /// Marker trait for signing schemes compatible with `aggregation`.
 ///
-/// This trait binds a [`certificate::Scheme`] to the [`Item`] subject type used
-/// by the aggregation protocol. It is automatically implemented for any scheme
-/// whose subject type matches `&'a Item<D>`.
-pub trait Scheme<D: Digest>: for<'a> certificate::Scheme<Subject<'a, D> = &'a Item<D>> {}
+/// This trait binds a [`certificate::Scheme`] to the [`Item`] subject type and
+/// [`N3f1`] fault model used by the aggregation protocol. It is automatically
+/// implemented for any compatible scheme.
+pub trait Scheme<D: Digest>:
+    for<'a> certificate::Scheme<Subject<'a, D> = &'a Item<D>, Faults = N3f1>
+{
+}
 
-impl<D: Digest, S> Scheme<D> for S where S: for<'a> certificate::Scheme<Subject<'a, D> = &'a Item<D>>
-{}
+impl<D: Digest, S> Scheme<D> for S where
+    S: for<'a> certificate::Scheme<Subject<'a, D> = &'a Item<D>, Faults = N3f1>
+{
+}
 
 pub mod bls12381_multisig {
     //! BLS12-381 multi-signature implementation of the

--- a/consensus/src/aggregation/scheme.rs
+++ b/consensus/src/aggregation/scheme.rs
@@ -37,8 +37,9 @@ pub mod bls12381_multisig {
 
     use crate::aggregation::types::{Item, Namespace};
     use commonware_cryptography::impl_certificate_bls12381_multisig;
+    use commonware_utils::N3f1;
 
-    impl_certificate_bls12381_multisig!(&'a Item<D>, Namespace);
+    impl_certificate_bls12381_multisig!(&'a Item<D>, Namespace, N3f1);
 }
 
 pub mod bls12381_threshold {
@@ -50,8 +51,9 @@ pub mod bls12381_threshold {
 
     use crate::aggregation::types::{Item, Namespace};
     use commonware_cryptography::impl_certificate_bls12381_threshold;
+    use commonware_utils::N3f1;
 
-    impl_certificate_bls12381_threshold!(&'a Item<D>, Namespace);
+    impl_certificate_bls12381_threshold!(&'a Item<D>, Namespace, N3f1);
 }
 
 pub mod ed25519 {
@@ -63,8 +65,9 @@ pub mod ed25519 {
 
     use crate::aggregation::types::{Item, Namespace};
     use commonware_cryptography::impl_certificate_ed25519;
+    use commonware_utils::N3f1;
 
-    impl_certificate_ed25519!(&'a Item<D>, Namespace);
+    impl_certificate_ed25519!(&'a Item<D>, Namespace, N3f1);
 }
 
 pub mod secp256r1 {
@@ -76,6 +79,7 @@ pub mod secp256r1 {
 
     use crate::aggregation::types::{Item, Namespace};
     use commonware_cryptography::impl_certificate_secp256r1;
+    use commonware_utils::N3f1;
 
-    impl_certificate_secp256r1!(&'a Item<D>, Namespace);
+    impl_certificate_secp256r1!(&'a Item<D>, Namespace, N3f1);
 }

--- a/consensus/src/aggregation/types.rs
+++ b/consensus/src/aggregation/types.rs
@@ -12,7 +12,7 @@ use commonware_cryptography::{
     certificate::{Attestation, Namespace as CertificateNamespace, Scheme, Subject},
 };
 use commonware_parallel::Strategy;
-use commonware_utils::{N3f1, channel::oneshot, union};
+use commonware_utils::{channel::oneshot, union};
 use rand_core::CryptoRng;
 use std::hash::Hash;
 
@@ -323,7 +323,7 @@ impl<S: Scheme, D: Digest> Certificate<S, D> {
         let attestations = iter
             .filter(|ack| ack.item == item)
             .map(|ack| ack.attestation.clone());
-        let certificate = scheme.assemble::<_, N3f1>(attestations, strategy)?;
+        let certificate = scheme.assemble(attestations, strategy)?;
 
         Some(Self { item, certificate })
     }
@@ -334,7 +334,7 @@ impl<S: Scheme, D: Digest> Certificate<S, D> {
         R: CryptoRng,
         S: scheme::Scheme<D>,
     {
-        scheme.verify_certificate::<_, D, N3f1>(rng, &self.item, &self.certificate, strategy)
+        scheme.verify_certificate::<_, D>(rng, &self.item, &self.certificate, strategy)
     }
 }
 

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1691,7 +1691,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor as _, deterministic};
     use commonware_utils::{
-        NZUsize, Participant, channel::oneshot::error::TryRecvError, ordered::Set,
+        N3f1, NZUsize, Participant, channel::oneshot::error::TryRecvError, ordered::Set,
     };
     use std::{
         future::Future,
@@ -1721,7 +1721,7 @@ mod tests {
         }
     }
 
-    impl_certificate_ed25519!(TestSubject, Vec<u8>);
+    impl_certificate_ed25519!(TestSubject, Vec<u8>, N3f1);
 
     const SCHEME_NAMESPACE: &[u8] = b"_COMMONWARE_SHARD_ENGINE_TEST";
 

--- a/consensus/src/ordered_broadcast/ack_manager.rs
+++ b/consensus/src/ordered_broadcast/ack_manager.rs
@@ -5,7 +5,6 @@ use commonware_cryptography::{
     certificate::{Attestation, Scheme},
 };
 use commonware_parallel::Strategy;
-use commonware_utils::N3f1;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 /// A struct representing a set of votes for a payload digest.
@@ -90,8 +89,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> AckManager<P, S, D> {
                 attestations.push(ack.attestation.clone());
 
                 // Try to assemble certificate
-                let certificate =
-                    scheme.assemble::<_, N3f1>(attestations.iter().cloned(), strategy)?;
+                let certificate = scheme.assemble(attestations.iter().cloned(), strategy)?;
 
                 // Take ownership of the votes, which must exist
                 p.attestations.remove(&ack.chunk.payload);

--- a/consensus/src/ordered_broadcast/mocks/scheme.rs
+++ b/consensus/src/ordered_broadcast/mocks/scheme.rs
@@ -2,5 +2,6 @@
 
 use crate::ordered_broadcast::types::{AckNamespace, AckSubject};
 use commonware_cryptography::impl_certificate_mock;
+use commonware_utils::N3f1;
 
-impl_certificate_mock!(AckSubject<'a, P, D>, AckNamespace);
+impl_certificate_mock!(AckSubject<'a, P, D>, AckNamespace, N3f1);

--- a/consensus/src/ordered_broadcast/scheme.rs
+++ b/consensus/src/ordered_broadcast/scheme.rs
@@ -43,8 +43,9 @@ pub mod bls12381_multisig {
 
     use crate::ordered_broadcast::types::{AckNamespace, AckSubject};
     use commonware_cryptography::impl_certificate_bls12381_multisig;
+    use commonware_utils::N3f1;
 
-    impl_certificate_bls12381_multisig!(AckSubject<'a, P, D>, AckNamespace);
+    impl_certificate_bls12381_multisig!(AckSubject<'a, P, D>, AckNamespace, N3f1);
 }
 
 pub mod bls12381_threshold {
@@ -58,8 +59,9 @@ pub mod bls12381_threshold {
 
     use crate::ordered_broadcast::types::{AckNamespace, AckSubject};
     use commonware_cryptography::impl_certificate_bls12381_threshold;
+    use commonware_utils::N3f1;
 
-    impl_certificate_bls12381_threshold!(AckSubject<'a, P, D>, AckNamespace);
+    impl_certificate_bls12381_threshold!(AckSubject<'a, P, D>, AckNamespace, N3f1);
 }
 
 pub mod ed25519 {
@@ -72,8 +74,9 @@ pub mod ed25519 {
 
     use crate::ordered_broadcast::types::{AckNamespace, AckSubject};
     use commonware_cryptography::{ed25519, impl_certificate_ed25519};
+    use commonware_utils::N3f1;
 
-    impl_certificate_ed25519!(AckSubject<'a, ed25519::PublicKey, D>, AckNamespace);
+    impl_certificate_ed25519!(AckSubject<'a, ed25519::PublicKey, D>, AckNamespace, N3f1);
 }
 
 pub mod secp256r1 {
@@ -86,6 +89,7 @@ pub mod secp256r1 {
 
     use crate::ordered_broadcast::types::{AckNamespace, AckSubject};
     use commonware_cryptography::impl_certificate_secp256r1;
+    use commonware_utils::N3f1;
 
-    impl_certificate_secp256r1!(AckSubject<'a, P, D>, AckNamespace);
+    impl_certificate_secp256r1!(AckSubject<'a, P, D>, AckNamespace, N3f1);
 }

--- a/consensus/src/ordered_broadcast/scheme.rs
+++ b/consensus/src/ordered_broadcast/scheme.rs
@@ -17,19 +17,24 @@
 
 use super::types::AckSubject;
 use commonware_cryptography::{Digest, PublicKey, certificate};
+use commonware_utils::N3f1;
 
 /// Marker trait for signing schemes compatible with `ordered_broadcast`.
 ///
 /// This trait binds a [`certificate::Scheme`] to the [`AckSubject`] subject
-/// type used by the ordered broadcast protocol. It is automatically implemented
-/// for any scheme whose subject type matches `AckSubject<'a, P, D>`.
+/// type and [`N3f1`] fault model used by the ordered broadcast protocol. It is
+/// automatically implemented for any compatible scheme.
 pub trait Scheme<P: PublicKey, D: Digest>:
-    for<'a> certificate::Scheme<Subject<'a, D> = AckSubject<'a, P, D>, PublicKey = P>
+    for<'a> certificate::Scheme<Subject<'a, D> = AckSubject<'a, P, D>, PublicKey = P, Faults = N3f1>
 {
 }
 
 impl<P: PublicKey, D: Digest, S> Scheme<P, D> for S where
-    S: for<'a> certificate::Scheme<Subject<'a, D> = AckSubject<'a, P, D>, PublicKey = P>
+    S: for<'a> certificate::Scheme<
+            Subject<'a, D> = AckSubject<'a, P, D>,
+            PublicKey = P,
+            Faults = N3f1,
+        >
 {
 }
 

--- a/consensus/src/ordered_broadcast/types.rs
+++ b/consensus/src/ordered_broadcast/types.rs
@@ -12,7 +12,7 @@ use commonware_cryptography::{
     certificate::{Attestation, Namespace, Provider, Scheme, Subject, Verifier},
 };
 use commonware_parallel::Strategy;
-use commonware_utils::{N3f1, channel::oneshot, ordered::Set, union};
+use commonware_utils::{channel::oneshot, ordered::Set, union};
 use rand_core::CryptoRng;
 use std::{
     hash::{Hash, Hasher},
@@ -636,7 +636,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Node<P, S, D> {
             chunk: &parent_chunk,
             epoch: parent.epoch,
         };
-        if !scoped.verify_certificate::<R, D, N3f1>(rng, ctx, &parent.certificate, strategy) {
+        if !scoped.verify_certificate::<R, D>(rng, ctx, &parent.certificate, strategy) {
             return Err(Error::InvalidCertificate);
         }
         Ok(Some(parent_chunk))
@@ -1047,7 +1047,7 @@ impl<P: PublicKey, S: Scheme, D: Digest> Lock<P, S, D> {
             chunk: &self.chunk,
             epoch: self.epoch,
         };
-        scheme.verify_certificate::<R, D, N3f1>(rng, ctx, &self.certificate, strategy)
+        scheme.verify_certificate::<R, D>(rng, ctx, &self.certificate, strategy)
     }
 }
 
@@ -1183,7 +1183,7 @@ mod tests {
 
         // Assemble certificate
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create and test parent
@@ -1244,7 +1244,7 @@ mod tests {
             .collect();
 
         let parent_certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(parent_attestations, &Sequential)
+            .assemble(parent_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create proper parent with valid certificate
@@ -1326,7 +1326,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(parent_ctx.clone()).unwrap())
             .collect();
         let parent_certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(parent_attestations, &Sequential)
+            .assemble(parent_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         let parent =
@@ -1468,7 +1468,7 @@ mod tests {
 
         // Assemble certificate
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create lock
@@ -1550,7 +1550,7 @@ mod tests {
 
         // Assemble certificate
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create lock, encode and decode
@@ -1612,7 +1612,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(parent_ctx.clone()).unwrap())
             .collect();
         let parent_certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(parent_attestations, &Sequential)
+            .assemble(parent_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         let parent = Some(Parent::<S, Sha256Digest>::new(
@@ -1687,7 +1687,7 @@ mod tests {
 
         // Assemble certificate
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create lock with certificate
@@ -1729,7 +1729,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
             .collect();
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create lock
@@ -1845,7 +1845,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(parent_ctx.clone()).unwrap())
             .collect();
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(parent_attestations, &Sequential)
+            .assemble(parent_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create parent with valid certificate
@@ -1880,7 +1880,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(wrong_ctx.clone()).unwrap())
             .collect();
         let wrong_certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(wrong_attestations, &Sequential)
+            .assemble(wrong_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create parent with certificate signed for wrong context (wrong epoch)
@@ -2015,7 +2015,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
             .collect();
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create lock
@@ -2030,7 +2030,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
             .collect();
         let wrong_certificate = wrong_fixture.schemes[0]
-            .assemble::<_, N3f1>(wrong_attestations, &Sequential)
+            .assemble(wrong_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         // Create lock with wrong signature
@@ -2119,7 +2119,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(ctx.clone()).unwrap())
             .collect();
         let certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("Should assemble certificate");
 
         let parent = Parent::<S, Sha256Digest>::new(sample_digest(0), Epoch::new(5), certificate);
@@ -2204,7 +2204,7 @@ mod tests {
             .map(|scheme| scheme.sign::<Sha256Digest>(parent_ctx.clone()).unwrap())
             .collect();
         let parent_certificate = fixture.schemes[0]
-            .assemble::<_, N3f1>(parent_attestations, &Sequential)
+            .assemble(parent_attestations, &Sequential)
             .expect("Should assemble certificate");
 
         let parent =

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -651,9 +651,7 @@ mod tests {
                     .unwrap()
             })
             .collect();
-        let cert1 = schemes[0]
-            .assemble::<_, N3f1>(attestations1, &Sequential)
-            .unwrap();
+        let cert1 = schemes[0].assemble(attestations1, &Sequential).unwrap();
 
         // Create certificate for round (1, 3) (different round -> different seed signature)
         let round2 = Round::new(Epoch::new(1), View::new(3));
@@ -665,9 +663,7 @@ mod tests {
                     .unwrap()
             })
             .collect();
-        let cert2 = schemes[0]
-            .assemble::<_, N3f1>(attestations2, &Sequential)
-            .unwrap();
+        let cert2 = schemes[0].assemble(attestations2, &Sequential).unwrap();
 
         // Same certificate always gives same leader
         let leader1a = elector.elect(round1, Some(&cert1));
@@ -774,9 +770,7 @@ mod tests {
                     .take(quorum)
                     .map(|s| s.sign::<Sha256Digest>(Subject::Nullify { round }).unwrap())
                     .collect();
-                let cert = schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap();
+                let cert = schemes[0].assemble(attestations, &Sequential).unwrap();
 
                 // Elect leader using the certificate
                 let leader = elector.elect(round, Some(&cert));

--- a/consensus/src/simplex/mocks/reporter.rs
+++ b/consensus/src/simplex/mocks/reporter.rs
@@ -20,7 +20,6 @@ use commonware_cryptography::{
 };
 use commonware_parallel::Sequential;
 use commonware_utils::{
-    N3f1,
     channel::{
         fallible::AsyncFallibleExt,
         mpsc::{Receiver, Sender},
@@ -190,7 +189,7 @@ where
             Activity::Notarization(notarization) | Activity::Certification(notarization) => {
                 // Verify notarization
                 let view = notarization.view();
-                if !self.scheme.verify_certificate::<_, D, N3f1>(
+                if !self.scheme.verify_certificate::<_, D>(
                     &mut *self.context.lock(),
                     Subject::Notarize {
                         proposal: &notarization.proposal,
@@ -228,7 +227,7 @@ where
             Activity::Nullification(nullification) => {
                 // Verify nullification
                 let view = nullification.view();
-                if !self.scheme.verify_certificate::<_, D, N3f1>(
+                if !self.scheme.verify_certificate::<_, D>(
                     &mut *self.context.lock(),
                     Subject::Nullify {
                         round: nullification.round,
@@ -272,7 +271,7 @@ where
             Activity::Finalization(finalization) => {
                 // Verify finalization
                 let view = finalization.view();
-                if !self.scheme.verify_certificate::<_, D, N3f1>(
+                if !self.scheme.verify_certificate::<_, D>(
                     &mut *self.context.lock(),
                     Subject::Finalize {
                         proposal: &finalization.proposal,

--- a/consensus/src/simplex/mocks/scheme.rs
+++ b/consensus/src/simplex/mocks/scheme.rs
@@ -2,5 +2,6 @@
 
 use crate::simplex::{scheme::Namespace, types::Subject};
 use commonware_cryptography::impl_certificate_mock;
+use commonware_utils::N3f1;
 
-impl_certificate_mock!(Subject<'a, D>, Namespace);
+impl_certificate_mock!(Subject<'a, D>, Namespace, N3f1);

--- a/consensus/src/simplex/mocks/wrapped.rs
+++ b/consensus/src/simplex/mocks/wrapped.rs
@@ -9,7 +9,7 @@ use commonware_cryptography::{
     sha256::Sha256,
 };
 use commonware_parallel::Sequential;
-use commonware_utils::{Faults, Participant, modulo, test_rng};
+use commonware_utils::{Participant, modulo, test_rng};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Behavior {
@@ -149,10 +149,11 @@ where
     S: CertificateScheme,
 {
     type Subject<'a, D: Digest> = S::Subject<'a, D>;
+    type Faults = S::Faults;
     type PublicKey = S::PublicKey;
     type Certificate = S::Certificate;
 
-    fn verify_certificate<R, D, M>(
+    fn verify_certificate<R, D>(
         &self,
         rng: &mut R,
         subject: Self::Subject<'_, D>,
@@ -162,10 +163,9 @@ where
     where
         R: rand_core::CryptoRng,
         D: Digest,
-        M: Faults,
     {
         self.inner
-            .verify_certificate::<_, _, M>(rng, subject, certificate, strategy)
+            .verify_certificate(rng, subject, certificate, strategy)
     }
 
     fn is_batchable() -> bool {
@@ -266,7 +266,7 @@ where
         )
     }
 
-    fn assemble<I, M>(
+    fn assemble<I>(
         &self,
         attestations: I,
         strategy: &impl commonware_parallel::Strategy,
@@ -274,9 +274,8 @@ where
     where
         I: IntoIterator<Item = Attestation<Self>>,
         I::IntoIter: Send,
-        M: Faults,
     {
-        self.inner.assemble::<_, M>(
+        self.inner.assemble(
             attestations.into_iter().map(|attestation| Attestation {
                 signer: attestation.signer,
                 signature: attestation.signature,

--- a/consensus/src/simplex/scheme/bls12381_multisig.rs
+++ b/consensus/src/simplex/scheme/bls12381_multisig.rs
@@ -7,5 +7,6 @@
 
 use crate::simplex::{scheme::Namespace, types::Subject};
 use commonware_cryptography::impl_certificate_bls12381_multisig;
+use commonware_utils::N3f1;
 
-impl_certificate_bls12381_multisig!(Subject<'a, D>, Namespace);
+impl_certificate_bls12381_multisig!(Subject<'a, D>, Namespace, N3f1);

--- a/consensus/src/simplex/scheme/bls12381_threshold/standard.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/standard.rs
@@ -12,5 +12,6 @@
 
 use crate::simplex::{scheme::Namespace, types::Subject};
 use commonware_cryptography::impl_certificate_bls12381_threshold;
+use commonware_utils::N3f1;
 
-impl_certificate_bls12381_threshold!(Subject<'a, D>, Namespace);
+impl_certificate_bls12381_threshold!(Subject<'a, D>, Namespace, N3f1);

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -76,7 +76,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::stability;
 use commonware_parallel::Strategy;
-use commonware_utils::{Faults, ordered::Set};
+use commonware_utils::{Faults, N3f1, ordered::Set};
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
 use std::{
@@ -320,7 +320,7 @@ where
     V: Variant,
     R: rand_core::CryptoRng,
 {
-    commonware_cryptography::bls12381::certificate::threshold::mocks::fixture::<_, V, _>(
+    commonware_cryptography::bls12381::certificate::threshold::mocks::fixture::<_, V, _, N3f1>(
         rng,
         namespace,
         n,
@@ -572,10 +572,11 @@ fn seed_message_from_subject<D: Digest>(subject: &Subject<'_, D>) -> bytes::Byte
 
 impl<P: PublicKey, V: Variant> certificate::Verifier for Scheme<P, V> {
     type Subject<'a, D: Digest> = Subject<'a, D>;
+    type Faults = N3f1;
     type PublicKey = P;
     type Certificate = Certificate<V>;
 
-    fn verify_certificate<R, D, M>(
+    fn verify_certificate<R, D>(
         &self,
         rng: &mut R,
         subject: Subject<'_, D>,
@@ -585,7 +586,6 @@ impl<P: PublicKey, V: Variant> certificate::Verifier for Scheme<P, V> {
     where
         R: CryptoRng,
         D: Digest,
-        M: Faults,
     {
         let Some(cert) = certificate.get() else {
             return false;
@@ -605,7 +605,7 @@ impl<P: PublicKey, V: Variant> certificate::Verifier for Scheme<P, V> {
         batch::verify_same_signer::<_, V, _>(rng, identity, entries, strategy).is_ok()
     }
 
-    fn verify_certificates<'a, R, D, I, M>(
+    fn verify_certificates<'a, R, D, I>(
         &self,
         rng: &mut R,
         certificates: I,
@@ -615,7 +615,6 @@ impl<P: PublicKey, V: Variant> certificate::Verifier for Scheme<P, V> {
         R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (Subject<'a, D>, &'a Self::Certificate)>,
-        M: Faults,
     {
         let identity = self.identity();
         let namespace = self.namespace();
@@ -839,11 +838,10 @@ impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
         Verification::new(verified, invalid.into_iter().collect())
     }
 
-    fn assemble<I, M>(&self, attestations: I, strategy: &impl Strategy) -> Option<Self::Certificate>
+    fn assemble<I>(&self, attestations: I, strategy: &impl Strategy) -> Option<Self::Certificate>
     where
         I: IntoIterator<Item = Attestation<Self>>,
         I::IntoIter: Send,
-        M: Faults,
     {
         let (partials, failures) =
             strategy.map_partition_collect_vec(attestations.into_iter(), |attestation| {
@@ -868,11 +866,11 @@ impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
         let (vote_partials, seed_partials): (Vec<_>, Vec<_>) = partials.into_iter().unzip();
 
         let quorum = self.polynomial();
-        if vote_partials.len() < quorum.required::<M>() as usize {
+        if vote_partials.len() < quorum.required::<Self::Faults>() as usize {
             return None;
         }
 
-        let (vote_signature, seed_signature) = threshold::recover_pair::<V, _, M>(
+        let (vote_signature, seed_signature) = threshold::recover_pair::<V, _, Self::Faults>(
             quorum,
             vote_partials.iter(),
             seed_partials.iter(),
@@ -1193,7 +1191,7 @@ mod tests {
             })
             .collect();
 
-        assert!(schemes[0].assemble::<_, N3f1>(votes, &Sequential).is_none());
+        assert!(schemes[0].assemble(votes, &Sequential).is_none());
     }
 
     #[test]
@@ -1220,10 +1218,10 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut test_rng(),
             Subject::Finalize {
                 proposal: &proposal,
@@ -1258,10 +1256,10 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             Subject::Notarize {
                 proposal: &proposal,
@@ -1276,7 +1274,7 @@ mod tests {
             seed_signature: cert.seed_signature,
         }
         .into();
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             Subject::Notarize {
                 proposal: &proposal,
@@ -1310,7 +1308,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
         let encoded = certificate.encode();
@@ -1342,7 +1340,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
         let cert = certificate.get().unwrap();
 
@@ -1377,7 +1375,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
         let cert = certificate.get().unwrap();
 
@@ -1481,7 +1479,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
         let certificate_verifier =
@@ -1494,16 +1492,14 @@ mod tests {
                 .is_none(),
             "certificate verifier should not produce votes"
         );
-        assert!(
-            certificate_verifier.verify_certificate::<_, Sha256Digest, N3f1>(
-                &mut test_rng(),
-                Subject::Finalize {
-                    proposal: &proposal,
-                },
-                &certificate,
-                &Sequential,
-            )
-        );
+        assert!(certificate_verifier.verify_certificate::<_, Sha256Digest>(
+            &mut test_rng(),
+            Subject::Finalize {
+                proposal: &proposal,
+            },
+            &certificate,
+            &Sequential,
+        ));
     }
 
     #[test]
@@ -1563,7 +1559,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
         let cert = certificate.get().unwrap();
 
@@ -1595,7 +1591,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
         let mut encoded = certificate.encode();
@@ -1667,10 +1663,10 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             Subject::Nullify {
                 round: proposal.round,
@@ -1685,7 +1681,7 @@ mod tests {
             seed_signature: cert.vote_signature,
         }
         .into();
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             Subject::Nullify {
                 round: proposal.round,
@@ -1896,10 +1892,10 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble certificate");
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             Subject::Notarize {
                 proposal: &proposal,
@@ -1923,7 +1919,7 @@ mod tests {
         assert_eq!(forged_sum, valid_sum, "signature sums should be equal");
 
         assert!(
-            !verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+            !verifier.verify_certificate::<_, Sha256Digest>(
                 &mut rng,
                 Subject::Notarize {
                     proposal: &proposal,
@@ -1972,14 +1968,14 @@ mod tests {
             .collect();
 
         let certificate1 = schemes[0]
-            .assemble::<_, N3f1>(votes1, &Sequential)
+            .assemble(votes1, &Sequential)
             .expect("assemble certificate1");
         let certificate2 = schemes[0]
-            .assemble::<_, N3f1>(votes2, &Sequential)
+            .assemble(votes2, &Sequential)
             .expect("assemble certificate2");
 
         assert!(
-            verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+            verifier.verify_certificates::<_, Sha256Digest, _>(
                 &mut rng,
                 [
                     (
@@ -2025,7 +2021,7 @@ mod tests {
         );
 
         assert!(
-            !verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+            !verifier.verify_certificates::<_, Sha256Digest, _>(
                 &mut rng,
                 [
                     (
@@ -2066,7 +2062,7 @@ mod tests {
             .collect();
 
         schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble notarization certificate")
     }
 
@@ -2082,7 +2078,7 @@ mod tests {
             .collect();
 
         schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("assemble finalization certificate")
     }
 
@@ -2094,7 +2090,7 @@ mod tests {
         let finalization_certificate = assemble_finalization_certificate(&schemes, &proposal);
 
         assert!(
-            verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+            verifier.verify_certificates::<_, Sha256Digest, _>(
                 &mut rng,
                 [
                     (
@@ -2132,7 +2128,7 @@ mod tests {
         let certificate2 = assemble_notarization_certificate(&schemes, &proposal2);
 
         assert!(
-            verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+            verifier.verify_certificates::<_, Sha256Digest, _>(
                 &mut rng,
                 [
                     (
@@ -2161,7 +2157,7 @@ mod tests {
         }
         .into();
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             Subject::Notarize {
                 proposal: &proposal2,
@@ -2185,17 +2181,13 @@ mod tests {
             ),
         ];
 
-        assert!(!verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(!verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             batch.iter().copied(),
             &Sequential,
         ));
         assert_eq!(
-            verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-                &mut rng,
-                &batch,
-                &Sequential,
-            ),
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &batch, &Sequential,),
             vec![true, false],
         );
     }

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -76,7 +76,10 @@ use commonware_cryptography::{
 };
 use commonware_macros::stability;
 use commonware_parallel::Strategy;
-use commonware_utils::{N3f1, ordered::Set};
+use commonware_utils::{
+    N3f1,
+    ordered::{Quorum, Set},
+};
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
 use std::{
@@ -156,9 +159,9 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
             "polynomial total must equal participant len"
         );
         assert_eq!(
-            polynomial.degree_exact(),
-            polynomial.required::<N3f1>().saturating_sub(1),
-            "polynomial degree must equal quorum minus one"
+            polynomial.required(),
+            participants.quorum::<N3f1>(),
+            "polynomial threshold must equal quorum"
         );
         polynomial.precompute_partial_publics();
         let partial_public = polynomial
@@ -199,9 +202,9 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
             "polynomial total must equal participant len"
         );
         assert_eq!(
-            polynomial.degree_exact(),
-            polynomial.required::<N3f1>().saturating_sub(1),
-            "polynomial degree must equal quorum minus one"
+            polynomial.required(),
+            participants.quorum::<N3f1>(),
+            "polynomial threshold must equal quorum"
         );
         polynomial.precompute_partial_publics();
 
@@ -886,11 +889,11 @@ impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
         let (vote_partials, seed_partials): (Vec<_>, Vec<_>) = partials.into_iter().unzip();
 
         let quorum = self.polynomial();
-        if vote_partials.len() < quorum.required::<Self::Faults>() as usize {
+        if vote_partials.len() < quorum.required() as usize {
             return None;
         }
 
-        let (vote_signature, seed_signature) = threshold::recover_pair::<V, _, Self::Faults>(
+        let (vote_signature, seed_signature) = threshold::recover_pair(
             quorum,
             vote_partials.iter(),
             seed_partials.iter(),
@@ -1053,13 +1056,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_signer_validates_polynomial_degree_min_pk() {
         signer_validates_polynomial_degree::<MinPk>();
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_signer_validates_polynomial_degree_min_sig() {
         signer_validates_polynomial_degree::<MinSig>();
     }
@@ -1077,13 +1080,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_verifier_validates_polynomial_degree_min_pk() {
         verifier_validates_polynomial_degree::<MinPk>();
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_verifier_validates_polynomial_degree_min_sig() {
         verifier_validates_polynomial_degree::<MinSig>();
     }

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -76,7 +76,7 @@ use commonware_cryptography::{
 };
 use commonware_macros::stability;
 use commonware_parallel::Strategy;
-use commonware_utils::{Faults, N3f1, ordered::Set};
+use commonware_utils::{N3f1, ordered::Set};
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
 use std::{
@@ -157,7 +157,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
         );
         assert_eq!(
             polynomial.degree_exact(),
-            N3f1::quorum(participants.len()) - 1,
+            polynomial.required::<N3f1>().saturating_sub(1),
             "polynomial degree must equal quorum minus one"
         );
         polynomial.precompute_partial_publics();
@@ -200,7 +200,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
         );
         assert_eq!(
             polynomial.degree_exact(),
-            N3f1::quorum(participants.len()) - 1,
+            polynomial.required::<N3f1>().saturating_sub(1),
             "polynomial degree must equal quorum minus one"
         );
         polynomial.precompute_partial_publics();

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -893,13 +893,9 @@ impl<P: PublicKey, V: Variant> certificate::Scheme for Scheme<P, V> {
             return None;
         }
 
-        let (vote_signature, seed_signature) = threshold::recover_pair(
-            quorum,
-            vote_partials.iter(),
-            seed_partials.iter(),
-            strategy,
-        )
-        .ok()?;
+        let (vote_signature, seed_signature) =
+            threshold::recover_pair(quorum, vote_partials.iter(), seed_partials.iter(), strategy)
+                .ok()?;
 
         Some(
             Signature {

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -135,6 +135,11 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
     ///
     /// Returns `None` if the share's public key does not match any participant.
     ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial's participant count or degree does not match the
+    /// committee, or if the share index does not identify a committee participant.
+    ///
     /// * `namespace` - base namespace for domain separation
     /// * `participants` - ordered set of participant identity keys
     /// * `polynomial` - public polynomial for threshold verification
@@ -149,6 +154,11 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
             polynomial.total().get() as usize,
             participants.len(),
             "polynomial total must equal participant len"
+        );
+        assert_eq!(
+            polynomial.degree_exact(),
+            N3f1::quorum(participants.len()) - 1,
+            "polynomial degree must equal quorum minus one"
         );
         polynomial.precompute_partial_publics();
         let partial_public = polynomial
@@ -174,6 +184,11 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
     /// The polynomial can be evaluated to obtain public verification keys for partial
     /// signatures produced by committee members.
     ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial's participant count or degree does not match the
+    /// committee.
+    ///
     /// * `namespace` - base namespace for domain separation
     /// * `participants` - ordered set of participant identity keys
     /// * `polynomial` - public polynomial for threshold verification
@@ -182,6 +197,11 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
             polynomial.total().get() as usize,
             participants.len(),
             "polynomial total must equal participant len"
+        );
+        assert_eq!(
+            polynomial.degree_exact(),
+            N3f1::quorum(participants.len()) - 1,
+            "polynomial degree must equal quorum minus one"
         );
         polynomial.precompute_partial_publics();
 
@@ -920,7 +940,7 @@ mod tests {
     };
     use commonware_math::algebra::{CryptoGroup, Random};
     use commonware_parallel::Sequential;
-    use commonware_utils::{Faults, N3f1, NZU32, test_rng};
+    use commonware_utils::{Faults, N3f1, N5f1, NZU32, test_rng};
     use rand::{SeedableRng, rngs::StdRng};
 
     const NAMESPACE: &[u8] = b"bls-threshold-signing-scheme";
@@ -1013,6 +1033,59 @@ mod tests {
     #[should_panic(expected = "polynomial total must equal participant len")]
     fn test_verifier_polynomial_threshold_must_equal_quorum_min_sig() {
         verifier_polynomial_threshold_must_equal_quorum::<MinSig>();
+    }
+
+    fn signer_validates_polynomial_degree<V: Variant>() {
+        let mut rng = test_rng();
+        let participants = ed25519_participants(&mut rng, 4);
+
+        // For four participants, N5f1 produces a degree 3 polynomial while this
+        // N3f1 scheme requires degree 2.
+        let (polynomial, shares) =
+            dkg::deal_anonymous::<V, N5f1>(&mut rng, Default::default(), NZU32!(4));
+
+        Scheme::<V>::signer(
+            NAMESPACE,
+            participants.keys().clone(),
+            polynomial,
+            shares[0].clone(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_signer_validates_polynomial_degree_min_pk() {
+        signer_validates_polynomial_degree::<MinPk>();
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_signer_validates_polynomial_degree_min_sig() {
+        signer_validates_polynomial_degree::<MinSig>();
+    }
+
+    fn verifier_validates_polynomial_degree<V: Variant>() {
+        let mut rng = test_rng();
+        let participants = ed25519_participants(&mut rng, 4);
+
+        // For four participants, N5f1 produces a degree 3 polynomial while this
+        // N3f1 scheme requires degree 2.
+        let (polynomial, _) =
+            dkg::deal_anonymous::<V, N5f1>(&mut rng, Default::default(), NZU32!(4));
+
+        Scheme::<V>::verifier(NAMESPACE, participants.keys().clone(), polynomial);
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_verifier_validates_polynomial_degree_min_pk() {
+        verifier_validates_polynomial_degree::<MinPk>();
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_verifier_validates_polynomial_degree_min_sig() {
+        verifier_validates_polynomial_degree::<MinSig>();
     }
 
     #[test]

--- a/consensus/src/simplex/scheme/ed25519.rs
+++ b/consensus/src/simplex/scheme/ed25519.rs
@@ -7,5 +7,6 @@
 
 use crate::simplex::{scheme::Namespace, types::Subject};
 use commonware_cryptography::impl_certificate_ed25519;
+use commonware_utils::N3f1;
 
-impl_certificate_ed25519!(Subject<'a, D>, Namespace);
+impl_certificate_ed25519!(Subject<'a, D>, Namespace, N3f1);

--- a/consensus/src/simplex/scheme/mod.rs
+++ b/consensus/src/simplex/scheme/mod.rs
@@ -52,7 +52,7 @@ use commonware_cryptography::{
         Subject as CertificateSubject, Verifier,
     },
 };
-use commonware_utils::union;
+use commonware_utils::{N3f1, union};
 
 pub mod bls12381_multisig;
 pub mod bls12381_threshold;
@@ -117,31 +117,31 @@ impl<'a, D: Digest> CertificateSubject for Subject<'a, D> {
 
 /// Marker trait for certificate verifiers compatible with `simplex`.
 ///
-/// This trait binds a [`Verifier`] to the [`Subject`] subject type
-/// used by the simplex protocol. It is automatically implemented for any verifier whose subject
-/// type matches `Subject<'a, D>`.
+/// This trait binds a [`Verifier`] to the [`Subject`] subject type and [`N3f1`]
+/// fault model used by the simplex protocol. It is automatically implemented
+/// for any compatible verifier.
 pub trait CertificateVerifier<D: Digest>:
-    for<'a> Verifier<Subject<'a, D> = Subject<'a, D>>
+    for<'a> Verifier<Subject<'a, D> = Subject<'a, D>, Faults = N3f1>
 {
 }
 
 impl<D: Digest, S> CertificateVerifier<D> for S where
-    S: for<'a> Verifier<Subject<'a, D> = Subject<'a, D>>
+    S: for<'a> Verifier<Subject<'a, D> = Subject<'a, D>, Faults = N3f1>
 {
 }
 
 /// Marker trait for signing schemes compatible with `simplex`.
 ///
-/// This trait binds a [`CertificateScheme`] to the [`Subject`] subject type
-/// used by the simplex protocol. It is automatically implemented for any scheme
-/// whose subject type matches `Subject<'a, D>`.
+/// This trait binds a [`CertificateScheme`] to the [`Subject`] subject type and
+/// [`N3f1`] fault model used by the simplex protocol. It is automatically
+/// implemented for any compatible scheme.
 pub trait Scheme<D: Digest>:
     CertificateVerifier<D> + for<'a> CertificateScheme<Subject<'a, D> = Subject<'a, D>>
 {
 }
 
 impl<D: Digest, S> Scheme<D> for S where
-    S: for<'a> CertificateScheme<Subject<'a, D> = Subject<'a, D>>
+    S: CertificateVerifier<D> + for<'a> CertificateScheme<Subject<'a, D> = Subject<'a, D>>
 {
 }
 

--- a/consensus/src/simplex/scheme/reporter.rs
+++ b/consensus/src/simplex/scheme/reporter.rs
@@ -155,7 +155,7 @@ mod tests {
         sha256::Digest as Sha256Digest,
     };
     use commonware_parallel::Sequential;
-    use commonware_utils::{N3f1, sync::Mutex, test_rng};
+    use commonware_utils::{sync::Mutex, test_rng};
     use std::sync::Arc;
 
     const NAMESPACE: &[u8] = b"test-reporter";
@@ -314,7 +314,7 @@ mod tests {
             .collect();
 
         let certificate = schemes[0]
-            .assemble::<_, N3f1>(votes, &Sequential)
+            .assemble(votes, &Sequential)
             .expect("failed to assemble certificate");
 
         let notarization = Notarization {

--- a/consensus/src/simplex/scheme/secp256r1.rs
+++ b/consensus/src/simplex/scheme/secp256r1.rs
@@ -11,5 +11,6 @@
 
 use crate::simplex::{scheme::Namespace, types::Subject};
 use commonware_cryptography::impl_certificate_secp256r1;
+use commonware_utils::N3f1;
 
-impl_certificate_secp256r1!(Subject<'a, D>, Namespace);
+impl_certificate_secp256r1!(Subject<'a, D>, Namespace, N3f1);

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -12,7 +12,6 @@ use commonware_cryptography::{
     certificate::{Attestation, Scheme},
 };
 use commonware_parallel::Strategy;
-use commonware_utils::N3f1;
 use rand_core::CryptoRng;
 use std::{collections::HashSet, fmt::Debug, hash::Hash, iter::once};
 
@@ -981,7 +980,7 @@ where
     S: CertificateVerifier<D>,
     D: Digest,
 {
-    scheme.verify_certificates_bisect::<_, D, N3f1>(rng, certificates, strategy)
+    scheme.verify_certificates_bisect::<_, D>(rng, certificates, strategy)
 }
 
 /// Aggregated notarization certificate recovered from notarize votes.
@@ -1016,7 +1015,7 @@ impl<S: Scheme, D: Digest> Notarization<S, D> {
             attestation,
         } = notarizes.next()?;
         let attestations = once(attestation).chain(notarizes.map(|n| n.attestation));
-        let certificate = scheme.assemble::<_, N3f1>(attestations, strategy)?;
+        let certificate = scheme.assemble(attestations, strategy)?;
 
         Some(Self {
             proposal,
@@ -1042,7 +1041,7 @@ impl<S: Scheme, D: Digest> Notarization<S, D> {
         scheme: &impl CertificateVerifier<D, Certificate = S::Certificate>,
         strategy: &impl Strategy,
     ) -> bool {
-        scheme.verify_certificate::<_, D, N3f1>(
+        scheme.verify_certificate::<_, D>(
             rng,
             Subject::Notarize {
                 proposal: &self.proposal,
@@ -1267,7 +1266,7 @@ impl<S: Scheme> Nullification<S> {
         let mut nullifies = nullifies.into_iter();
         let Nullify { round, attestation } = nullifies.next()?;
         let attestations = once(attestation).chain(nullifies.map(|n| n.attestation));
-        let certificate = scheme.assemble::<_, N3f1>(attestations, strategy)?;
+        let certificate = scheme.assemble(attestations, strategy)?;
 
         Some(Self { round, certificate })
     }
@@ -1290,7 +1289,7 @@ impl<S: Scheme> Nullification<S> {
         scheme: &impl CertificateVerifier<D, Certificate = S::Certificate>,
         strategy: &impl Strategy,
     ) -> bool {
-        scheme.verify_certificate::<_, D, N3f1>(
+        scheme.verify_certificate::<_, D>(
             rng,
             Subject::Nullify { round: self.round },
             &self.certificate,
@@ -1526,7 +1525,7 @@ impl<S: Scheme, D: Digest> Finalization<S, D> {
             attestation,
         } = finalizes.next()?;
         let attestations = once(attestation).chain(finalizes.map(|f| f.attestation));
-        let certificate = scheme.assemble::<_, N3f1>(attestations, strategy)?;
+        let certificate = scheme.assemble(attestations, strategy)?;
 
         Some(Self {
             proposal,
@@ -1552,7 +1551,7 @@ impl<S: Scheme, D: Digest> Finalization<S, D> {
         scheme: &impl CertificateVerifier<D, Certificate = S::Certificate>,
         strategy: &impl Strategy,
     ) -> bool {
-        scheme.verify_certificate::<_, D, N3f1>(
+        scheme.verify_certificate::<_, D>(
             rng,
             Subject::Finalize {
                 proposal: &self.proposal,
@@ -1843,11 +1842,7 @@ impl<S: Scheme, D: Digest> Response<S, D> {
             (context, &nullification.certificate)
         });
 
-        scheme.verify_certificates::<_, D, _, N3f1>(
-            rng,
-            notarizations.chain(nullifications),
-            strategy,
-        )
+        scheme.verify_certificates::<_, D, _>(rng, notarizations.chain(nullifications), strategy)
     }
 }
 

--- a/cryptography/fuzz/fuzz_targets/bls12381_threshold_operations.rs
+++ b/cryptography/fuzz/fuzz_targets/bls12381_threshold_operations.rs
@@ -9,7 +9,7 @@ use commonware_cryptography::bls12381::primitives::{
     variant::{MinPk, MinSig, PartialSignature},
 };
 use commonware_parallel::{Rayon, Sequential};
-use commonware_utils::{N3f1, Participant, test_rng};
+use commonware_utils::{Participant, test_rng};
 use libfuzzer_sys::fuzz_target;
 use std::num::NonZeroUsize;
 
@@ -235,7 +235,7 @@ fn fuzz(op: FuzzOperation) {
             share,
             namespace,
         } => {
-            if share.index.get() <= public.required::<N3f1>() {
+            if share.index.get() <= public.required() {
                 let _ = threshold::sign_proof_of_possession::<MinPk>(&public, &share, &namespace);
             }
         }
@@ -245,7 +245,7 @@ fn fuzz(op: FuzzOperation) {
             share,
             namespace,
         } => {
-            if share.index.get() <= public.required::<N3f1>() {
+            if share.index.get() <= public.required() {
                 let _ = threshold::sign_proof_of_possession::<MinSig>(&public, &share, &namespace);
             }
         }
@@ -255,7 +255,7 @@ fn fuzz(op: FuzzOperation) {
             namespace,
             partial,
         } => {
-            if partial.index.get() <= public.required::<N3f1>() {
+            if partial.index.get() <= public.required() {
                 let _ =
                     threshold::verify_proof_of_possession::<MinPk>(&public, &namespace, &partial);
             }
@@ -266,7 +266,7 @@ fn fuzz(op: FuzzOperation) {
             namespace,
             partial,
         } => {
-            if partial.index.get() <= public.required::<N3f1>() {
+            if partial.index.get() <= public.required() {
                 let _ =
                     threshold::verify_proof_of_possession::<MinSig>(&public, &namespace, &partial);
             }
@@ -277,7 +277,7 @@ fn fuzz(op: FuzzOperation) {
             index,
             entries,
         } => {
-            if index.get() <= public.required::<N3f1>() && !entries.is_empty() {
+            if index.get() <= public.required() && !entries.is_empty() {
                 let entries_refs: Vec<(&[u8], &[u8], PartialSignature<MinPk>)> = entries
                     .iter()
                     .enumerate()
@@ -307,7 +307,7 @@ fn fuzz(op: FuzzOperation) {
             index,
             entries,
         } => {
-            if index.get() <= public.required::<N3f1>() && !entries.is_empty() {
+            if index.get() <= public.required() && !entries.is_empty() {
                 let entries_refs: Vec<(&[u8], &[u8], PartialSignature<MinSig>)> = entries
                     .iter()
                     .enumerate()
@@ -338,7 +338,7 @@ fn fuzz(op: FuzzOperation) {
             message,
             partials,
         } => {
-            if public.required::<N3f1>() as usize == partials.len() {
+            if public.required() as usize == partials.len() {
                 let partials_evals: Vec<PartialSignature<MinPk>> = partials
                     .into_iter()
                     .map(|(idx, sig)| PartialSignature {
@@ -363,7 +363,7 @@ fn fuzz(op: FuzzOperation) {
             message,
             partials,
         } => {
-            if public.required::<N3f1>() as usize == partials.len() {
+            if public.required() as usize == partials.len() {
                 let partials_evals: Vec<PartialSignature<MinSig>> = partials
                     .into_iter()
                     .map(|(idx, sig)| PartialSignature {
@@ -383,11 +383,11 @@ fn fuzz(op: FuzzOperation) {
         }
 
         FuzzOperation::RecoverMinPk { sharing, partials } => {
-            let _ = threshold::recover::<MinPk, _, N3f1>(&sharing, &partials, &Sequential);
+            let _ = threshold::recover(&sharing, &partials, &Sequential);
         }
 
         FuzzOperation::RecoverMinSig { sharing, partials } => {
-            let _ = threshold::recover::<MinSig, _, N3f1>(&sharing, &partials, &Sequential);
+            let _ = threshold::recover(&sharing, &partials, &Sequential);
         }
 
         FuzzOperation::RecoverMultipleMinPk {
@@ -401,8 +401,7 @@ fn fuzz(op: FuzzOperation) {
                     .map(|group| group.iter().collect())
                     .collect();
                 let strategy = Rayon::new(NonZeroUsize::new(concurrency).unwrap()).unwrap();
-                let _ =
-                    threshold::recover_multiple::<MinPk, _, N3f1>(&sharing, groups_refs, &strategy);
+                let _ = threshold::recover_multiple(&sharing, groups_refs, &strategy);
             }
         }
 
@@ -417,11 +416,7 @@ fn fuzz(op: FuzzOperation) {
                     .map(|group| group.iter().collect())
                     .collect();
                 let strategy = Rayon::new(NonZeroUsize::new(concurrency).unwrap()).unwrap();
-                let _ = threshold::recover_multiple::<MinSig, _, N3f1>(
-                    &sharing,
-                    groups_refs,
-                    &strategy,
-                );
+                let _ = threshold::recover_multiple(&sharing, groups_refs, &strategy);
             }
         }
 
@@ -430,12 +425,7 @@ fn fuzz(op: FuzzOperation) {
             partials_1,
             partials_2,
         } => {
-            let _ = threshold::recover_pair::<MinPk, _, N3f1>(
-                &sharing,
-                &partials_1,
-                &partials_2,
-                &Sequential,
-            );
+            let _ = threshold::recover_pair(&sharing, &partials_1, &partials_2, &Sequential);
         }
 
         FuzzOperation::RecoverPairMinSig {
@@ -443,12 +433,7 @@ fn fuzz(op: FuzzOperation) {
             partials_1,
             partials_2,
         } => {
-            let _ = threshold::recover_pair::<MinSig, _, N3f1>(
-                &sharing,
-                &partials_1,
-                &partials_2,
-                &Sequential,
-            );
+            let _ = threshold::recover_pair(&sharing, &partials_1, &partials_2, &Sequential);
         }
 
         FuzzOperation::SignMessageMinPk {

--- a/cryptography/src/bls12381/benches/threshold_recover.rs
+++ b/cryptography/src/bls12381/benches/threshold_recover.rs
@@ -44,7 +44,7 @@ fn bench_threshold_recover(c: &mut Criterion) {
                         },
                         |(public, partials)| {
                             black_box(
-                                primitives::ops::threshold::recover::<MinSig, _, N3f1>(
+                                primitives::ops::threshold::recover(
                                     public.public(),
                                     &partials,
                                     &Sequential,

--- a/cryptography/src/bls12381/certificate/multisig/mod.rs
+++ b/cryptography/src/bls12381/certificate/multisig/mod.rs
@@ -21,7 +21,7 @@ use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error, Read, ReadExt, Write, types::lazy::Lazy};
 use commonware_parallel::Strategy;
 use commonware_utils::{
-    Faults, Participant,
+    Participant,
     ordered::{BiMap, Quorum, Set},
 };
 use rand_core::CryptoRng;
@@ -208,11 +208,10 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     }
 
     /// Assembles a certificate from a collection of attestations.
-    pub fn assemble<S, I, M>(&self, attestations: I) -> Option<Certificate<V>>
+    pub fn assemble<S, I>(&self, attestations: I) -> Option<Certificate<V>>
     where
         S: Scheme<Signature = V::Signature>,
         I: IntoIterator<Item = Attestation<S>>,
-        M: Faults,
     {
         // Collect the signers and signatures.
         let mut entries = Vec::new();
@@ -223,7 +222,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
             let signature = signature.get().cloned()?;
             entries.push((signer, signature));
         }
-        if entries.len() < self.participants.quorum::<M>() as usize {
+        if entries.len() < self.participants.quorum::<S::Faults>() as usize {
             return None;
         }
 
@@ -239,7 +238,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     }
 
     /// Verifies a certificate.
-    pub fn verify_certificate<'a, S, R, D, M>(
+    pub fn verify_certificate<'a, S, R, D>(
         &self,
         _rng: &mut R,
         subject: S::Subject<'a, D>,
@@ -250,7 +249,6 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: CryptoRng,
         D: Digest,
-        M: Faults,
     {
         // If the certificate signers length does not match the participant set, return false.
         if certificate.signers.len() != self.participants.len() {
@@ -258,7 +256,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         }
 
         // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum::<M>() as usize {
+        if certificate.signers.count() < self.participants.quorum::<S::Faults>() as usize {
             return false;
         }
 
@@ -287,17 +285,16 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     }
 
     /// Verifies multiple certificates (no batch optimization for BLS multisig).
-    pub fn verify_certificates<'a, S, R, D, I, M>(&self, rng: &mut R, certificates: I) -> bool
+    pub fn verify_certificates<'a, S, R, D, I>(&self, rng: &mut R, certificates: I) -> bool
     where
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate<V>)>,
-        M: Faults,
     {
         for (subject, certificate) in certificates {
-            if !self.verify_certificate::<S, _, _, M>(rng, subject, certificate) {
+            if !self.verify_certificate::<S, _, _>(rng, subject, certificate) {
                 return false;
             }
         }
@@ -394,17 +391,23 @@ where
 ///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
 ///   For protocols with multiple message types, a custom struct can pre-compute all variants.
 ///
+/// - `$faults`: The `commonware_utils::Faults` implementation used to compute certificate quorums.
+///
 /// # Example
 /// ```ignore
 /// // For non-generic subject types with a single namespace:
-/// impl_certificate_bls12381_multisig!(MySubject, Vec<u8>);
+/// impl_certificate_bls12381_multisig!(MySubject, Vec<u8>, commonware_utils::N3f1);
 ///
 /// // For protocols with generic subject types:
-/// impl_certificate_bls12381_multisig!(Subject<'a, D>, Namespace);
+/// impl_certificate_bls12381_multisig!(
+///     Subject<'a, D>,
+///     Namespace,
+///     commonware_utils::N3f1,
+/// );
 /// ```
 #[macro_export]
 macro_rules! impl_certificate_bls12381_multisig {
-    ($subject:ty, $namespace:ty) => {
+    ($subject:ty, $namespace:ty, $faults:ty) => {
         /// Generates a test fixture with Ed25519 identities and BLS12-381 multisig schemes.
         ///
         /// Returns a [`commonware_cryptography::certificate::mocks::Fixture`] whose keys and
@@ -476,10 +479,11 @@ macro_rules! impl_certificate_bls12381_multisig {
             V: $crate::bls12381::primitives::variant::Variant,
         > $crate::certificate::Verifier for Scheme<P, V> {
             type Subject<'a, D: $crate::Digest> = $subject;
+            type Faults = $faults;
             type PublicKey = P;
             type Certificate = $crate::bls12381::certificate::multisig::Certificate<V>;
 
-            fn verify_certificate<R, D, M>(
+            fn verify_certificate<R, D>(
                 &self,
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
@@ -489,13 +493,12 @@ macro_rules! impl_certificate_bls12381_multisig {
             where
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificate::<Self, _, D, M>(rng, subject, certificate)
+                    .verify_certificate::<Self, _, D>(rng, subject, certificate)
             }
 
-            fn verify_certificates<'a, R, D, I, M>(
+            fn verify_certificates<'a, R, D, I>(
                 &self,
                 rng: &mut R,
                 certificates: I,
@@ -505,10 +508,9 @@ macro_rules! impl_certificate_bls12381_multisig {
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificates::<Self, _, D, _, M>(rng, certificates)
+                    .verify_certificates::<Self, _, D, _>(rng, certificates)
             }
 
             fn is_batchable() -> bool {
@@ -579,16 +581,15 @@ macro_rules! impl_certificate_bls12381_multisig {
                     .verify_attestations::<_, _, D, _, _>(rng, subject, attestations, strategy)
             }
 
-            fn assemble<I, M>(
+            fn assemble<I>(
                 &self,
                 attestations: I,
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> Option<Self::Certificate>
             where
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
-                M: commonware_utils::Faults,
             {
-                self.generic.assemble::<Self, _, M>(attestations)
+                self.generic.assemble::<Self, _>(attestations)
             }
 
             fn is_attributable() -> bool {
@@ -640,7 +641,7 @@ mod tests {
     }
 
     // Use the macro to generate the test scheme
-    impl_certificate_bls12381_multisig!(TestSubject, Vec<u8>);
+    impl_certificate_bls12381_multisig!(TestSubject, Vec<u8>, N3f1);
 
     fn setup_signers<V: Variant>(
         rng: &mut impl CryptoRng,
@@ -811,9 +812,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
         assert_eq!(certificate.signers.count(), quorum);
     }
 
@@ -850,9 +849,7 @@ mod tests {
                 .unwrap(),
         ];
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Verify signers are sorted by signer index
         let expected: Vec<_> = indexed.iter().map(|(idx, _)| *idx).collect();
@@ -881,11 +878,9 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE)
@@ -917,12 +912,10 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Valid certificate passes
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -934,7 +927,7 @@ mod tests {
         // Corrupted certificate fails
         let mut corrupted = certificate;
         corrupted.signature = Lazy::from(aggregate::Signature::zero());
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -966,9 +959,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
         let encoded = certificate.encode();
         let decoded =
             Certificate::<V>::decode_cfg(encoded, &schemes.len()).expect("decode certificate");
@@ -997,11 +988,7 @@ mod tests {
             })
             .collect();
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -1029,11 +1016,7 @@ mod tests {
         // Corrupt signer index to be out of range
         attestations[0].signer = Participant::new(999);
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -1058,16 +1041,14 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Artificially truncate to below quorum
         let mut signers: Vec<Participant> = certificate.signers.iter().collect();
         signers.pop();
         certificate.signers = Signers::from(participants_len, signers);
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1099,15 +1080,13 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Make the signers bitmap size larger than participants
         let signers: Vec<Participant> = certificate.signers.iter().collect();
         certificate.signers = Signers::from(participants_len + 1, signers);
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1145,11 +1124,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         let certs_iter = messages.iter().zip(&certificates).map(|(msg, cert)| {
@@ -1161,7 +1136,7 @@ mod tests {
             )
         });
 
-        assert!(verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1196,11 +1171,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         // Corrupt second certificate
@@ -1215,7 +1186,7 @@ mod tests {
             )
         });
 
-        assert!(!verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(!verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1247,7 +1218,7 @@ mod tests {
         attestations.push(attestations.last().unwrap().clone());
 
         // This should panic due to duplicate signer
-        schemes[0].assemble::<_, N3f1>(attestations, &Sequential);
+        schemes[0].assemble(attestations, &Sequential);
     }
 
     #[test]
@@ -1310,9 +1281,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Well-formed certificate decodes successfully
         let encoded = certificate.encode();
@@ -1359,16 +1328,14 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Add an unknown signer (out of range)
         let mut signers: Vec<Participant> = certificate.signers.iter().collect();
         signers.push(Participant::from_usize(participants_len));
         certificate.signers = Signers::from(participants_len + 1, signers);
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),

--- a/cryptography/src/bls12381/certificate/multisig/mod.rs
+++ b/cryptography/src/bls12381/certificate/multisig/mod.rs
@@ -391,7 +391,8 @@ where
 ///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
 ///   For protocols with multiple message types, a custom struct can pre-compute all variants.
 ///
-/// - `$faults`: The `commonware_utils::Faults` implementation used to compute certificate quorums.
+/// - `$faults`: The [`Faults`](commonware_utils::Faults) implementation used to compute certificate
+///   quorums.
 ///
 /// # Example
 /// ```ignore

--- a/cryptography/src/bls12381/certificate/threshold/mocks.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mocks.rs
@@ -8,11 +8,11 @@ use crate::{
     certificate::{Scheme, mocks::Fixture},
     ed25519,
 };
-use commonware_utils::{N3f1, ordered::Set};
+use commonware_utils::{Faults, ordered::Set};
 use rand_core::CryptoRng;
 
 /// Builds ed25519 identities and matching BLS12-381 threshold schemes.
-pub fn fixture<S, V, R>(
+pub fn fixture<S, V, R, M>(
     rng: &mut R,
     namespace: &[u8],
     n: u32,
@@ -22,7 +22,8 @@ pub fn fixture<S, V, R>(
 where
     V: Variant,
     R: CryptoRng,
-    S: Scheme<PublicKey = ed25519::PublicKey>,
+    M: Faults,
+    S: Scheme<Faults = M, PublicKey = ed25519::PublicKey>,
 {
     assert!(n > 0);
 
@@ -39,7 +40,7 @@ where
         })
         .collect();
 
-    let (output, shares) = deal::<V, _, N3f1>(rng, Default::default(), participants.clone())
+    let (output, shares) = deal::<V, _, M>(rng, Default::default(), participants.clone())
         .expect("deal should succeed");
     let polynomial = output.public().clone();
 

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -102,7 +102,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         );
         assert_eq!(
             polynomial.degree_exact(),
-            polynomial.required::<M>() - 1,
+            polynomial.required::<M>().saturating_sub(1),
             "polynomial degree must equal quorum minus one"
         );
         #[cfg(feature = "std")]
@@ -149,7 +149,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         );
         assert_eq!(
             polynomial.degree_exact(),
-            polynomial.required::<M>() - 1,
+            polynomial.required::<M>().saturating_sub(1),
             "polynomial degree must equal quorum minus one"
         );
         #[cfg(feature = "std")]

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -26,7 +26,10 @@ use alloc::{collections::BTreeSet, vec::Vec};
 use bytes::{Buf, BufMut};
 use commonware_codec::{Error, FixedSize, Read, ReadExt, Write, types::lazy::Lazy};
 use commonware_parallel::Strategy;
-use commonware_utils::{Faults, Participant, ordered::Set};
+use commonware_utils::{
+    Faults, Participant,
+    ordered::{Quorum, Set},
+};
 use core::fmt::Debug;
 use rand_core::CryptoRng;
 #[cfg(feature = "std")]
@@ -101,9 +104,9 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
             "polynomial total must equal participant len"
         );
         assert_eq!(
-            polynomial.degree_exact(),
-            polynomial.required::<M>().saturating_sub(1),
-            "polynomial degree must equal quorum minus one"
+            polynomial.required(),
+            participants.quorum::<M>(),
+            "polynomial threshold must equal quorum"
         );
         #[cfg(feature = "std")]
         polynomial.precompute_partial_publics();
@@ -148,9 +151,9 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
             "polynomial total must equal participant len"
         );
         assert_eq!(
-            polynomial.degree_exact(),
-            polynomial.required::<M>().saturating_sub(1),
-            "polynomial degree must equal quorum minus one"
+            polynomial.required(),
+            participants.quorum::<M>(),
+            "polynomial threshold must equal quorum"
         );
         #[cfg(feature = "std")]
         polynomial.precompute_partial_publics();
@@ -352,11 +355,11 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         }
 
         let quorum = self.polynomial();
-        if partials.len() < quorum.required::<S::Faults>() as usize {
+        if partials.len() < quorum.required() as usize {
             return None;
         }
 
-        threshold::recover::<V, _, S::Faults>(quorum, partials.iter(), strategy)
+        threshold::recover(quorum, partials.iter(), strategy)
             .ok()
             .map(Certificate::new)
     }
@@ -1417,13 +1420,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_signer_validates_polynomial_degree_min_pk() {
         signer_validates_polynomial_degree::<MinPk>();
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_signer_validates_polynomial_degree_min_sig() {
         signer_validates_polynomial_degree::<MinSig>();
     }
@@ -1441,13 +1444,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_verifier_validates_polynomial_degree_min_pk() {
         verifier_validates_polynomial_degree::<MinPk>();
     }
 
     #[test]
-    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    #[should_panic(expected = "polynomial threshold must equal quorum")]
     fn test_verifier_validates_polynomial_degree_min_sig() {
         verifier_validates_polynomial_degree::<MinSig>();
     }

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -70,7 +70,8 @@ pub enum Generic<P: PublicKey, V: Variant, N: Namespace> {
 }
 
 impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
-    /// Constructs a signer instance with a private share and evaluated public polynomial.
+    /// Constructs a signer instance with a private share and evaluated public polynomial
+    /// compatible with the specified fault model.
     ///
     /// The participant identity keys are used for committee ordering and indexing.
     /// The polynomial can be evaluated to obtain public verification keys for partial
@@ -78,11 +79,17 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     ///
     /// Returns `None` if the share's public key does not match any participant.
     ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial's participant count or degree does not match the
+    /// committee and fault model, or if the share index does not identify a committee
+    /// participant.
+    ///
     /// * `namespace` - base namespace for domain separation
     /// * `participants` - ordered set of participant identity keys
     /// * `polynomial` - public polynomial for threshold verification
     /// * `share` - local threshold share for signing
-    pub fn signer(
+    pub fn signer<M: Faults>(
         namespace: &[u8],
         participants: Set<P>,
         polynomial: Sharing<V>,
@@ -92,6 +99,11 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
             polynomial.total().get() as usize,
             participants.len(),
             "polynomial total must equal participant len"
+        );
+        assert_eq!(
+            polynomial.degree_exact(),
+            polynomial.required::<M>() - 1,
+            "polynomial degree must equal quorum minus one"
         );
         #[cfg(feature = "std")]
         polynomial.precompute_partial_publics();
@@ -110,20 +122,35 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         }
     }
 
-    /// Produces a verifier that can authenticate signatures but does not hold signing state.
+    /// Produces a verifier for the specified fault model that can authenticate signatures
+    /// but does not hold signing state.
     ///
     /// The participant identity keys are used for committee ordering and indexing.
     /// The polynomial can be evaluated to obtain public verification keys for partial
     /// signatures produced by committee members.
     ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial's participant count or degree does not match the committee
+    /// and fault model.
+    ///
     /// * `namespace` - base namespace for domain separation
     /// * `participants` - ordered set of participant identity keys
     /// * `polynomial` - public polynomial for threshold verification
-    pub fn verifier(namespace: &[u8], participants: Set<P>, polynomial: Sharing<V>) -> Self {
+    pub fn verifier<M: Faults>(
+        namespace: &[u8],
+        participants: Set<P>,
+        polynomial: Sharing<V>,
+    ) -> Self {
         assert_eq!(
             polynomial.total().get() as usize,
             participants.len(),
             "polynomial total must equal participant len"
+        );
+        assert_eq!(
+            polynomial.degree_exact(),
+            polynomial.required::<M>() - 1,
+            "polynomial degree must equal quorum minus one"
         );
         #[cfg(feature = "std")]
         polynomial.precompute_partial_publics();
@@ -516,7 +543,7 @@ macro_rules! impl_certificate_bls12381_threshold {
             V: $crate::bls12381::primitives::variant::Variant,
             R: rand_core::CryptoRng,
         {
-            $crate::bls12381::certificate::threshold::mocks::fixture::<_, V, _>(
+            $crate::bls12381::certificate::threshold::mocks::fixture::<_, V, _, $faults>(
                 rng,
                 namespace,
                 n,
@@ -538,7 +565,8 @@ macro_rules! impl_certificate_bls12381_threshold {
             P: $crate::PublicKey,
             V: $crate::bls12381::primitives::variant::Variant,
         > Scheme<P, V> {
-            /// Creates a new signer instance with a private share and evaluated public polynomial.
+            /// Creates a new signer instance with a private share and evaluated public polynomial
+            /// compatible with the configured fault model.
             pub fn signer(
                 namespace: &[u8],
                 participants: commonware_utils::ordered::Set<P>,
@@ -546,7 +574,7 @@ macro_rules! impl_certificate_bls12381_threshold {
                 share: $crate::bls12381::primitives::group::Share,
             ) -> Option<Self> {
                 Some(Self {
-                    generic: $crate::bls12381::certificate::threshold::Generic::signer(
+                    generic: $crate::bls12381::certificate::threshold::Generic::signer::<$faults>(
                         namespace,
                         participants,
                         polynomial,
@@ -555,14 +583,15 @@ macro_rules! impl_certificate_bls12381_threshold {
                 })
             }
 
-            /// Creates a verifier that can authenticate partial signatures.
+            /// Creates a verifier for the configured fault model that can authenticate partial
+            /// signatures.
             pub fn verifier(
                 namespace: &[u8],
                 participants: commonware_utils::ordered::Set<P>,
                 polynomial: $crate::bls12381::primitives::sharing::Sharing<V>,
             ) -> Self {
                 Self {
-                    generic: $crate::bls12381::certificate::threshold::Generic::verifier(
+                    generic: $crate::bls12381::certificate::threshold::Generic::verifier::<$faults>(
                         namespace,
                         participants,
                         polynomial,
@@ -738,7 +767,7 @@ mod tests {
     use commonware_codec::{DecodeExt, Encode};
     use commonware_math::algebra::{Additive, Random};
     use commonware_parallel::Sequential;
-    use commonware_utils::{Faults, N3f1, NZU32, TryCollect, ordered::Set, test_rng};
+    use commonware_utils::{Faults, N3f1, N5f1, NZU32, TryCollect, ordered::Set, test_rng};
 
     const NAMESPACE: &[u8] = b"test-bls12381-threshold";
     const MESSAGE: &[u8] = b"test message";
@@ -1368,6 +1397,59 @@ mod tests {
             .map(|_| Ed25519PrivateKey::random(&mut *rng).public_key())
             .try_collect()
             .expect("participants are unique")
+    }
+
+    fn signer_validates_polynomial_degree<V: Variant>() {
+        let mut rng = test_rng();
+        let participants = make_participants(&mut rng, 4);
+
+        // For four participants, N5f1 produces a degree 3 polynomial while this
+        // N3f1 scheme requires degree 2.
+        let (polynomial, shares) =
+            dkg::deal_anonymous::<V, N5f1>(&mut rng, Default::default(), NZU32!(4));
+
+        Scheme::<ed25519::PublicKey, V>::signer(
+            NAMESPACE,
+            participants,
+            polynomial,
+            shares[0].clone(),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_signer_validates_polynomial_degree_min_pk() {
+        signer_validates_polynomial_degree::<MinPk>();
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_signer_validates_polynomial_degree_min_sig() {
+        signer_validates_polynomial_degree::<MinSig>();
+    }
+
+    fn verifier_validates_polynomial_degree<V: Variant>() {
+        let mut rng = test_rng();
+        let participants = make_participants(&mut rng, 4);
+
+        // For four participants, N5f1 produces a degree 3 polynomial while this
+        // N3f1 scheme requires degree 2.
+        let (polynomial, _) =
+            dkg::deal_anonymous::<V, N5f1>(&mut rng, Default::default(), NZU32!(4));
+
+        Scheme::<ed25519::PublicKey, V>::verifier(NAMESPACE, participants, polynomial);
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_verifier_validates_polynomial_degree_min_pk() {
+        verifier_validates_polynomial_degree::<MinPk>();
+    }
+
+    #[test]
+    #[should_panic(expected = "polynomial degree must equal quorum minus one")]
+    fn test_verifier_validates_polynomial_degree_min_sig() {
+        verifier_validates_polynomial_degree::<MinSig>();
     }
 
     fn signer_polynomial_threshold_must_equal_quorum<V: Variant>() {

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -304,13 +304,12 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     }
 
     /// Assembles a certificate from a collection of attestations.
-    pub fn assemble<S, I, T, M>(&self, attestations: I, strategy: &T) -> Option<Certificate<V>>
+    pub fn assemble<S, I, T>(&self, attestations: I, strategy: &T) -> Option<Certificate<V>>
     where
         S: Scheme<Signature = V::Signature>,
         I: IntoIterator<Item = Attestation<S>>,
         I::IntoIter: Send,
         T: Strategy,
-        M: Faults,
     {
         let (partials, failures) =
             strategy.map_partition_collect_vec(attestations.into_iter(), |attestation| {
@@ -326,17 +325,17 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         }
 
         let quorum = self.polynomial();
-        if partials.len() < quorum.required::<M>() as usize {
+        if partials.len() < quorum.required::<S::Faults>() as usize {
             return None;
         }
 
-        threshold::recover::<V, _, M>(quorum, partials.iter(), strategy)
+        threshold::recover::<V, _, S::Faults>(quorum, partials.iter(), strategy)
             .ok()
             .map(Certificate::new)
     }
 
     /// Verifies a certificate.
-    pub fn verify_certificate<'a, S, R, D, M>(
+    pub fn verify_certificate<'a, S, R, D>(
         &self,
         _rng: &mut R,
         subject: S::Subject<'a, D>,
@@ -347,7 +346,6 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: CryptoRng,
         D: Digest,
-        M: Faults,
     {
         let Some(signature) = certificate.get() else {
             return false;
@@ -362,7 +360,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
     }
 
     /// Verifies multiple certificates in a batch.
-    pub fn verify_certificates<'a, S, R, D, I, T, M>(
+    pub fn verify_certificates<'a, S, R, D, I, T>(
         &self,
         rng: &mut R,
         certificates: I,
@@ -375,7 +373,6 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate<V>)>,
         T: Strategy,
-        M: Faults,
     {
         let mut entries: Vec<_> = Vec::new();
 
@@ -487,17 +484,23 @@ where
 ///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
 ///   For protocols with multiple message types, a custom struct can pre-compute all variants.
 ///
+/// - `$faults`: The [`Faults`] implementation used to compute certificate quorums.
+///
 /// # Example
 /// ```ignore
 /// // For non-generic subject types with a single namespace:
-/// impl_certificate_bls12381_threshold!(MySubject, Vec<u8>);
+/// impl_certificate_bls12381_threshold!(MySubject, Vec<u8>, commonware_utils::N3f1);
 ///
 /// // For protocols with generic subject types:
-/// impl_certificate_bls12381_threshold!(Subject<'a, D>, Namespace);
+/// impl_certificate_bls12381_threshold!(
+///     Subject<'a, D>,
+///     Namespace,
+///     commonware_utils::N3f1,
+/// );
 /// ```
 #[macro_export]
 macro_rules! impl_certificate_bls12381_threshold {
-    ($subject:ty, $namespace:ty) => {
+    ($subject:ty, $namespace:ty, $faults:ty) => {
         /// Generates a test fixture with Ed25519 identities and BLS12-381 threshold schemes.
         ///
         /// Returns a [`commonware_cryptography::certificate::mocks::Fixture`] whose keys and
@@ -593,10 +596,11 @@ macro_rules! impl_certificate_bls12381_threshold {
             V: $crate::bls12381::primitives::variant::Variant,
         > $crate::certificate::Verifier for Scheme<P, V> {
             type Subject<'a, D: $crate::Digest> = $subject;
+            type Faults = $faults;
             type PublicKey = P;
             type Certificate = $crate::bls12381::certificate::threshold::Certificate<V>;
 
-            fn verify_certificate<R, D, M>(
+            fn verify_certificate<R, D>(
                 &self,
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
@@ -606,13 +610,12 @@ macro_rules! impl_certificate_bls12381_threshold {
             where
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificate::<Self, _, D, M>(rng, subject, certificate)
+                    .verify_certificate::<Self, _, D>(rng, subject, certificate)
             }
 
-            fn verify_certificates<'a, R, D, I, M>(
+            fn verify_certificates<'a, R, D, I>(
                 &self,
                 rng: &mut R,
                 certificates: I,
@@ -622,10 +625,9 @@ macro_rules! impl_certificate_bls12381_threshold {
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificates::<Self, _, D, _, _, M>(rng, certificates, strategy)
+                    .verify_certificates::<Self, _, D, _, _>(rng, certificates, strategy)
             }
 
             fn is_batchable() -> bool {
@@ -697,7 +699,7 @@ macro_rules! impl_certificate_bls12381_threshold {
                     .verify_attestations::<_, _, D, _, _>(rng, subject, attestations, strategy)
             }
 
-            fn assemble<I, M>(
+            fn assemble<I>(
                 &self,
                 attestations: I,
                 strategy: &impl commonware_parallel::Strategy,
@@ -705,9 +707,8 @@ macro_rules! impl_certificate_bls12381_threshold {
             where
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
                 I::IntoIter: Send,
-                M: commonware_utils::Faults,
             {
-                self.generic.assemble::<Self, _, _, M>(attestations, strategy)
+                self.generic.assemble::<Self, _, _>(attestations, strategy)
             }
 
             fn is_attributable() -> bool {
@@ -761,7 +762,7 @@ mod tests {
     }
 
     // Use the macro to generate the test scheme
-    impl_certificate_bls12381_threshold!(TestSubject, Vec<u8>);
+    impl_certificate_bls12381_threshold!(TestSubject, Vec<u8>, N3f1);
 
     #[allow(clippy::type_complexity)]
     fn setup_signers<V: Variant>(
@@ -920,12 +921,10 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Verify the assembled certificate
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -957,11 +956,9 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -993,12 +990,10 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Valid certificate passes
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1009,7 +1004,7 @@ mod tests {
 
         // Corrupted certificate fails
         let corrupted = Certificate::new(V::Signature::zero());
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1041,9 +1036,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
         let encoded = certificate.encode();
         let decoded = Certificate::<V>::decode(encoded).expect("decode certificate");
         assert_eq!(decoded, certificate);
@@ -1071,11 +1064,7 @@ mod tests {
             })
             .collect();
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -1107,11 +1096,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         let certs_iter = messages.iter().zip(&certificates).map(|(msg, cert)| {
@@ -1123,7 +1108,7 @@ mod tests {
             )
         });
 
-        assert!(verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1155,11 +1140,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         // Corrupt second certificate
@@ -1174,7 +1155,7 @@ mod tests {
             )
         });
 
-        assert!(!verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(!verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1203,9 +1184,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Create a certificate-only verifier using the identity from the polynomial
         let identity = polynomial.public();
@@ -1213,7 +1192,7 @@ mod tests {
             Scheme::<ed25519::PublicKey, V>::certificate_verifier(NAMESPACE, *identity);
 
         // Should be able to verify certificates
-        assert!(cert_verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(cert_verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1457,9 +1436,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
         let mut encoded = certificate.encode();
         encoded.truncate(encoded.len() - 1);
         assert!(V::Signature::decode(encoded).is_err());

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -2851,7 +2851,7 @@ mod test_plan {
                 }
 
                 let threshold = observer_output.quorum::<N3f1>();
-                let threshold_sig = threshold::recover::<V, _, N3f1>(
+                let threshold_sig = threshold::recover(
                     &observer_output.public,
                     &partial_sigs[0..threshold as usize],
                     &Sequential,

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -39,7 +39,7 @@
 //! }
 //!
 //! // Aggregate partial signatures
-//! let threshold_sig = threshold::recover::<MinSig, _, N3f1>(&sharing, &partials, &commonware_parallel::Sequential).unwrap();
+//! let threshold_sig = threshold::recover(&sharing, &partials, &commonware_parallel::Sequential).unwrap();
 //!
 //! // Verify threshold signature
 //! let threshold_pub = sharing.public();

--- a/cryptography/src/bls12381/primitives/ops/threshold.rs
+++ b/cryptography/src/bls12381/primitives/ops/threshold.rs
@@ -21,7 +21,7 @@ use super::{
 use alloc::{vec, vec::Vec};
 use commonware_codec::Encode;
 use commonware_parallel::Strategy;
-use commonware_utils::{Faults, Participant, ordered::Map, union_unique};
+use commonware_utils::{Participant, ordered::Map, union_unique};
 use rand_core::CryptoRng;
 
 /// Prepares partial signature evaluations for threshold recovery.
@@ -253,7 +253,7 @@ where
 /// # Warning
 ///
 /// This function assumes that each partial signature is unique.
-pub fn recover<'a, V, I, M>(
+pub fn recover<'a, V, I>(
     sharing: &Sharing<V>,
     partials: I,
     strategy: &impl Strategy,
@@ -262,9 +262,8 @@ where
     V: Variant,
     I: IntoIterator<Item = &'a PartialSignature<V>>,
     V::Signature: 'a,
-    M: Faults,
 {
-    let evals = prepare_evaluations::<V>(sharing.required::<M>(), partials)?;
+    let evals = prepare_evaluations::<V>(sharing.required(), partials)?;
     sharing
         .interpolator(evals.keys())?
         .interpolate(&evals, strategy)
@@ -283,7 +282,7 @@ where
 ///
 /// This function assumes that each partial signature is unique and that
 /// each set of partial signatures has the same indices.
-pub fn recover_multiple<'a, V, I, M>(
+pub fn recover_multiple<'a, V, I>(
     sharing: &Sharing<V>,
     many_evals: Vec<I>,
     strategy: &impl Strategy,
@@ -292,11 +291,10 @@ where
     V: Variant,
     I: IntoIterator<Item = &'a PartialSignature<V>>,
     V::Signature: 'a,
-    M: Faults,
 {
     let prepared_evals = many_evals
         .into_iter()
-        .map(|evals| prepare_evaluations::<V>(sharing.required::<M>(), evals))
+        .map(|evals| prepare_evaluations::<V>(sharing.required(), evals))
         .collect::<Result<Vec<_>, _>>()?;
     let Some(first_eval) = prepared_evals.first() else {
         return Ok(Vec::new());
@@ -325,7 +323,7 @@ where
 /// Recovers a pair of signatures from two sets of at least `threshold` partial signatures.
 ///
 /// This is just a wrapper around `recover_multiple`.
-pub fn recover_pair<'a, V, I, M>(
+pub fn recover_pair<'a, V, I>(
     sharing: &Sharing<V>,
     first: I,
     second: I,
@@ -335,9 +333,8 @@ where
     V: Variant,
     I: IntoIterator<Item = &'a PartialSignature<V>>,
     V::Signature: 'a,
-    M: Faults,
 {
-    let mut sigs = recover_multiple::<V, _, M>(sharing, vec![first, second], strategy)?;
+    let mut sigs = recover_multiple(sharing, vec![first, second], strategy)?;
     let second_sig = sigs.pop().unwrap();
     let first_sig = sigs.pop().unwrap();
     Ok((first_sig, second_sig))
@@ -401,7 +398,7 @@ mod tests {
             verify_proof_of_possession::<V>(&sharing, namespace, p)
                 .expect("signature should be valid");
         }
-        let threshold_sig = recover::<V, _, N3f1>(&sharing, &partials, &Sequential).unwrap();
+        let threshold_sig = recover(&sharing, &partials, &Sequential).unwrap();
         let threshold_pub = sharing.public();
 
         ops::verify_proof_of_possession::<V>(threshold_pub, namespace, &threshold_sig)
@@ -457,7 +454,7 @@ mod tests {
         for p in &partials {
             verify_message::<V>(&sharing, namespace, msg, p).expect("signature should be valid");
         }
-        let threshold_sig = recover::<V, _, N3f1>(&sharing, &partials, &Sequential).unwrap();
+        let threshold_sig = recover(&sharing, &partials, &Sequential).unwrap();
         let threshold_pub = sharing.public();
 
         ops::verify_message::<V>(threshold_pub, namespace, msg, &threshold_sig)
@@ -585,7 +582,7 @@ mod tests {
             .map(|s| sign_message::<V>(s, b"test", b"payload"))
             .collect();
 
-        let sig1 = recover::<V, _, N3f1>(&sharing, &partials, &Sequential).unwrap();
+        let sig1 = recover(&sharing, &partials, &Sequential).unwrap();
 
         ops::verify_message::<V>(sharing.public(), b"test", b"payload", &sig1).unwrap();
     }
@@ -613,15 +610,14 @@ mod tests {
             .map(|s| sign_message::<V>(s, b"test", b"payload2"))
             .collect();
 
-        let (sig_1, sig_2) =
-            recover_pair::<V, _, N3f1>(&sharing, &partials_1, &partials_2, &Sequential).unwrap();
+        let (sig_1, sig_2) = recover_pair(&sharing, &partials_1, &partials_2, &Sequential).unwrap();
 
         ops::verify_message::<V>(sharing.public(), b"test", b"payload1", &sig_1).unwrap();
         ops::verify_message::<V>(sharing.public(), b"test", b"payload2", &sig_2).unwrap();
 
         let parallel = Rayon::new(NZUsize!(4)).unwrap();
         let (sig_1_par, sig_2_par) =
-            recover_pair::<V, _, N3f1>(&sharing, &partials_1, &partials_2, &parallel).unwrap();
+            recover_pair(&sharing, &partials_1, &partials_2, &parallel).unwrap();
 
         assert_eq!(sig_1, sig_1_par);
         assert_eq!(sig_2, sig_2_par);
@@ -651,7 +647,7 @@ mod tests {
             verify_message::<V>(&sharing, namespace, msg, partial).unwrap();
         });
 
-        let threshold_sig = recover::<V, _, N3f1>(&sharing, &partials, &Sequential).unwrap();
+        let threshold_sig = recover(&sharing, &partials, &Sequential).unwrap();
         ops::verify_message::<V>(sharing.public(), namespace, msg, &threshold_sig).unwrap();
     }
 
@@ -683,7 +679,7 @@ mod tests {
             ));
         });
 
-        let threshold_sig = recover::<V, _, N3f1>(&sharing, &partials, &Sequential).unwrap();
+        let threshold_sig = recover(&sharing, &partials, &Sequential).unwrap();
         assert!(matches!(
             ops::verify_message::<V>(sharing.public(), namespace, msg, &threshold_sig).unwrap_err(),
             Error::InvalidSignature
@@ -717,7 +713,7 @@ mod tests {
         });
 
         assert!(matches!(
-            recover::<V, _, N3f1>(&group, &partials, &Sequential).unwrap_err(),
+            recover(&group, &partials, &Sequential).unwrap_err(),
             Error::NotEnoughPartialSignatures(4, 3)
         ));
     }
@@ -749,7 +745,7 @@ mod tests {
             verify_message::<V>(&sharing, namespace, msg, partial).unwrap();
         });
 
-        let threshold_sig = recover::<V, _, N3f1>(&sharing, &partials, &Sequential).unwrap();
+        let threshold_sig = recover(&sharing, &partials, &Sequential).unwrap();
         ops::verify_message::<V>(sharing.public(), namespace, msg, &threshold_sig).unwrap();
     }
 

--- a/cryptography/src/bls12381/primitives/sharing.rs
+++ b/cryptography/src/bls12381/primitives/sharing.rs
@@ -10,7 +10,7 @@ use commonware_macros::stability;
 use commonware_math::algebra::{FieldNTT, Ring};
 use commonware_math::poly::{Interpolator, Poly};
 use commonware_parallel::Sequential;
-use commonware_utils::{Faults, NZU32, Participant, ordered::Set};
+use commonware_utils::{NZU32, Participant, ordered::Set};
 #[stability(ALPHA)]
 use commonware_utils::{TryFromIterator, ordered::BiMap};
 #[cfg(feature = "std")]
@@ -326,17 +326,13 @@ impl<V: Variant> Sharing<V> {
         self.mode.all_scalars(self.total)
     }
 
-    /// Return the number of participants required to recover the secret
-    /// using the given fault model.
-    pub fn required<M: Faults>(&self) -> u32 {
-        M::quorum(self.total.get())
-    }
-
-    /// Return the exact degree of the public polynomial.
+    /// Return the number of participants required to recover the secret.
     ///
-    /// See [`Poly::degree_exact`] for details.
-    pub fn degree_exact(&self) -> u32 {
-        self.poly.degree_exact()
+    /// This is one more than the polynomial's [`Poly::degree_exact`].
+    pub fn required(&self) -> u32 {
+        // A polynomial has at most u32::MAX coefficients, so its exact degree
+        // is at most u32::MAX - 1.
+        self.poly.degree_exact() + 1
     }
 
     /// Return the total number of participants in this sharing.
@@ -448,6 +444,7 @@ impl<V: Variant> Read for Sharing<V> {
 #[cfg(all(test, feature = "std"))]
 mod tests {
     use super::*;
+    use crate::bls12381::primitives::variant::MinSig;
     use commonware_invariants::minifuzz;
     use commonware_utils::{TestRng, ordered::Map};
 
@@ -489,6 +486,21 @@ mod tests {
             );
             Ok(())
         });
+    }
+
+    #[test]
+    fn test_required_uses_exact_degree() {
+        // Subtraction preserves the three coefficient slots while setting every
+        // coefficient to zero.
+        let polynomial = Poly::<Scalar>::new(TestRng::new(0), 2);
+        let padded_zero = polynomial.clone() - &polynomial;
+        assert_eq!(padded_zero.required().get(), 3);
+
+        // The padded zero polynomial has exact degree zero, so recovering its
+        // secret requires only one share.
+        let sharing =
+            Sharing::<MinSig>::new(Mode::NonZeroCounter, NZU32!(4), Poly::commit(padded_zero));
+        assert_eq!(sharing.required(), 1);
     }
 
     #[test]
@@ -552,7 +564,7 @@ mod tests {
 mod fuzz {
     use super::*;
     use arbitrary::Arbitrary;
-    use commonware_utils::{N3f1, NZU32, TestRng};
+    use commonware_utils::{Faults, N3f1, NZU32, TestRng};
 
     impl<'a> Arbitrary<'a> for Mode {
         fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {

--- a/cryptography/src/bls12381/primitives/sharing.rs
+++ b/cryptography/src/bls12381/primitives/sharing.rs
@@ -332,6 +332,13 @@ impl<V: Variant> Sharing<V> {
         M::quorum(self.total.get())
     }
 
+    /// Return the exact degree of the public polynomial.
+    ///
+    /// See [`Poly::degree_exact`] for details.
+    pub fn degree_exact(&self) -> u32 {
+        self.poly.degree_exact()
+    }
+
     /// Return the total number of participants in this sharing.
     pub const fn total(&self) -> NonZeroU32 {
         self.total

--- a/cryptography/src/certificate.rs
+++ b/cryptography/src/certificate.rs
@@ -193,13 +193,17 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
     /// Subject type for certificate verification.
     type Subject<'a, D: Digest>: Subject;
 
+    /// Fault model used to compute certificate quorums.
+    type Faults: Faults;
+
     /// Public key type for participant identity used to order and index the participant set.
     type PublicKey: PublicKey;
+
     /// Certificate assembled from a set of attestations.
     type Certificate: Clone + Debug + PartialEq + Eq + Hash + Send + Sync + Codec;
 
     /// Verifies a certificate that was recovered or received from the network.
-    fn verify_certificate<R, D, M>(
+    fn verify_certificate<R, D>(
         &self,
         rng: &mut R,
         subject: Self::Subject<'_, D>,
@@ -208,11 +212,10 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
     ) -> bool
     where
         R: CryptoRng,
-        D: Digest,
-        M: Faults;
+        D: Digest;
 
     /// Verifies a stream of certificates, returning `false` at the first failure.
-    fn verify_certificates<'a, R, D, I, M>(
+    fn verify_certificates<'a, R, D, I>(
         &self,
         rng: &mut R,
         certificates: I,
@@ -222,10 +225,9 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-        M: Faults,
     {
         for (subject, certificate) in certificates {
-            if !self.verify_certificate::<_, _, M>(rng, subject, certificate, strategy) {
+            if !self.verify_certificate(rng, subject, certificate, strategy) {
                 return false;
             }
         }
@@ -238,7 +240,7 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
     /// For batchable schemes, attempts batch verification first and bisects
     /// on failure to efficiently identify invalid certificates. For
     /// non-batchable schemes, verifies each certificate individually.
-    fn verify_certificates_bisect<'a, R, D, M>(
+    fn verify_certificates_bisect<'a, R, D>(
         &self,
         rng: &mut R,
         certificates: &[(Self::Subject<'a, D>, &'a Self::Certificate)],
@@ -249,7 +251,6 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         D: Digest,
         Self::Subject<'a, D>: Copy,
         Self::Certificate: 'a,
-        M: Faults,
     {
         let len = certificates.len();
         let mut verified = vec![false; len];
@@ -261,8 +262,7 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         // since verify_certificates already checks one-by-one.
         if !Self::is_batchable() {
             for (i, (subject, certificate)) in certificates.iter().enumerate() {
-                verified[i] =
-                    self.verify_certificate::<_, _, M>(rng, *subject, certificate, strategy);
+                verified[i] = self.verify_certificate(rng, *subject, certificate, strategy);
             }
             return verified;
         }
@@ -280,11 +280,7 @@ pub trait Verifier: Clone + Debug + Send + Sync + 'static {
         //                    [6..7) pass  [7..8) fail
         let mut stack = vec![(0, len)];
         while let Some((start, end)) = stack.pop() {
-            if self.verify_certificates::<_, D, _, M>(
-                rng,
-                certificates[start..end].iter().copied(),
-                strategy,
-            ) {
+            if self.verify_certificates(rng, certificates[start..end].iter().copied(), strategy) {
                 verified[start..end].fill(true);
             } else if end - start > 1 {
                 let mid = start + (end - start) / 2;
@@ -383,15 +379,10 @@ pub trait Scheme: Verifier {
     ///
     /// Callers must not include duplicate attestations from the same signer. Passing duplicates
     /// is undefined behavior, implementations may panic or produce incorrect results.
-    fn assemble<I, M>(
-        &self,
-        attestations: I,
-        strategy: &impl Strategy,
-    ) -> Option<Self::Certificate>
+    fn assemble<I>(&self, attestations: I, strategy: &impl Strategy) -> Option<Self::Certificate>
     where
         I: IntoIterator<Item = Attestation<Self>>,
-        I::IntoIter: Send,
-        M: Faults;
+        I::IntoIter: Send;
 
     /// Returns whether per-participant fault evidence can be safely exposed.
     ///
@@ -436,10 +427,11 @@ impl<S: Scheme> Scoped<S> {
 
 impl<S: Scheme> Verifier for Scoped<S> {
     type Subject<'a, D: Digest> = S::Subject<'a, D>;
+    type Faults = S::Faults;
     type PublicKey = S::PublicKey;
     type Certificate = S::Certificate;
 
-    fn verify_certificate<R, D, M>(
+    fn verify_certificate<R, D>(
         &self,
         rng: &mut R,
         subject: Self::Subject<'_, D>,
@@ -449,13 +441,12 @@ impl<S: Scheme> Verifier for Scoped<S> {
     where
         R: CryptoRng,
         D: Digest,
-        M: Faults,
     {
         self.scheme
-            .verify_certificate::<_, D, M>(rng, subject, certificate, strategy)
+            .verify_certificate(rng, subject, certificate, strategy)
     }
 
-    fn verify_certificates<'a, R, D, I, M>(
+    fn verify_certificates<'a, R, D, I>(
         &self,
         rng: &mut R,
         certificates: I,
@@ -465,10 +456,8 @@ impl<S: Scheme> Verifier for Scoped<S> {
         R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-        M: Faults,
     {
-        self.scheme
-            .verify_certificates::<_, D, _, M>(rng, certificates, strategy)
+        self.scheme.verify_certificates(rng, certificates, strategy)
     }
 
     fn is_batchable() -> bool {
@@ -640,7 +629,7 @@ mod tests {
     use commonware_codec::{Decode, Encode};
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
-    use commonware_utils::{N3f1, TryCollect, ordered::Set, test_rng};
+    use commonware_utils::{TryCollect, ordered::Set, test_rng};
     use ed25519_fixture::{Scheme as Ed25519Scheme, TestSubject};
 
     #[test]
@@ -696,6 +685,7 @@ mod tests {
 
     mod ed25519_fixture {
         use crate::{certificate::Subject, impl_certificate_ed25519};
+        use commonware_utils::N3f1;
 
         /// Test subject for certificate verification tests.
         #[derive(Copy, Clone, Debug)]
@@ -716,7 +706,7 @@ mod tests {
         }
 
         // Use the macro to generate the test scheme
-        impl_certificate_ed25519!(TestSubject, Vec<u8>);
+        impl_certificate_ed25519!(TestSubject, Vec<u8>, N3f1);
     }
 
     const NAMESPACE: &[u8] = b"test-bisect";
@@ -732,7 +722,7 @@ mod tests {
             .filter_map(|s| s.sign::<Sha256Digest>(TestSubject { message }))
             .collect();
         schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .expect("assembly failed")
     }
 
@@ -756,11 +746,8 @@ mod tests {
     fn test_bisect_empty() {
         let mut rng = test_rng();
         let (_, verifier) = setup_ed25519(4);
-        let result = verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-            &mut rng,
-            &[],
-            &Sequential,
-        );
+        let result =
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &[], &Sequential);
         assert!(result.is_empty());
     }
 
@@ -771,11 +758,8 @@ mod tests {
         let cert = make_certificate(&schemes, MESSAGE);
         let good = TestSubject { message: MESSAGE };
         let pairs: Vec<_> = (0..5).map(|_| (good, &cert)).collect();
-        let result = verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-            &mut rng,
-            &pairs,
-            &Sequential,
-        );
+        let result =
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &pairs, &Sequential);
         assert_eq!(result, vec![true; 5]);
     }
 
@@ -799,11 +783,8 @@ mod tests {
             (bad, &cert),
         ];
         let expected = vec![true, false, true, false, true, true, false, false];
-        let result = verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-            &mut rng,
-            &pairs,
-            &Sequential,
-        );
+        let result =
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &pairs, &Sequential);
         assert_eq!(result, expected);
     }
 
@@ -816,11 +797,8 @@ mod tests {
             message: BAD_MESSAGE,
         };
         let pairs: Vec<_> = (0..4).map(|_| (bad, &cert)).collect();
-        let result = verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-            &mut rng,
-            &pairs,
-            &Sequential,
-        );
+        let result =
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &pairs, &Sequential);
         assert_eq!(result, vec![false; 4]);
     }
 
@@ -830,11 +808,8 @@ mod tests {
         let (schemes, verifier) = setup_ed25519(4);
         let cert = make_certificate(&schemes, MESSAGE);
         let pairs = vec![(TestSubject { message: MESSAGE }, &cert)];
-        let result = verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-            &mut rng,
-            &pairs,
-            &Sequential,
-        );
+        let result =
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &pairs, &Sequential);
         assert_eq!(result, vec![true]);
     }
 
@@ -849,11 +824,8 @@ mod tests {
             },
             &cert,
         )];
-        let result = verifier.verify_certificates_bisect::<_, Sha256Digest, N3f1>(
-            &mut rng,
-            &pairs,
-            &Sequential,
-        );
+        let result =
+            verifier.verify_certificates_bisect::<_, Sha256Digest>(&mut rng, &pairs, &Sequential);
         assert_eq!(result, vec![false]);
     }
 
@@ -868,20 +840,20 @@ mod tests {
         let as_scheme = Scoped::scheme(Arc::new(schemes[0].clone()));
 
         // Both scopes verify a valid certificate through the `Verifier` impl.
-        assert!(as_verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(as_verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             subject,
             &cert,
             &Sequential,
         ));
-        assert!(as_scheme.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(as_scheme.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             subject,
             &cert,
             &Sequential,
         ));
         let pairs = [(subject, &cert)];
-        assert!(as_verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(as_verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             pairs.iter().copied(),
             &Sequential,

--- a/cryptography/src/certificate/mocks.rs
+++ b/cryptography/src/certificate/mocks.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use bytes::Bytes;
 use commonware_utils::{
-    Faults, Participant,
+    Participant,
     ordered::{Quorum, Set},
     sequence::U64,
     sync::Mutex,
@@ -289,11 +289,10 @@ where
     }
 
     /// Assembles attestations into a mock certificate.
-    pub fn assemble<S, I, M>(&self, attestations: I) -> Option<U64>
+    pub fn assemble<S, I>(&self, attestations: I) -> Option<U64>
     where
         S: Scheme<Signature = U64>,
         I: IntoIterator<Item = Attestation<S>>,
-        M: Faults,
     {
         let mut unique_signers = HashSet::new();
         let mut signers = Vec::new();
@@ -334,7 +333,7 @@ where
             signers.push(attestation.signer);
         }
 
-        if signers.len() < self.participants.quorum::<M>() as usize {
+        if signers.len() < self.participants.quorum::<S::Faults>() as usize {
             return None;
         }
 
@@ -358,7 +357,7 @@ where
     }
 
     /// Verifies a mock certificate.
-    pub fn verify_certificate<'a, S, R, D, M>(
+    pub fn verify_certificate<'a, S, R, D>(
         &self,
         _rng: &mut R,
         subject: S::Subject<'a, D>,
@@ -369,7 +368,6 @@ where
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: CryptoRng,
         D: Digest,
-        M: Faults,
     {
         let expected_subject = SignedSubject::new(subject, &self.namespace);
         let certificate = u64::from(certificate);
@@ -383,17 +381,16 @@ where
     }
 
     /// Verifies a batch of certificates one-by-one.
-    pub fn verify_certificates<'a, S, R, D, I, M>(&self, rng: &mut R, mut certificates: I) -> bool
+    pub fn verify_certificates<'a, S, R, D, I>(&self, rng: &mut R, mut certificates: I) -> bool
     where
         S: Scheme<Certificate = U64>,
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: rand_core::CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a U64)>,
-        M: Faults,
     {
         certificates.all(|(subject, certificate)| {
-            self.verify_certificate::<S, _, D, M>(rng, subject, certificate)
+            self.verify_certificate::<S, _, D>(rng, subject, certificate)
         })
     }
 
@@ -417,18 +414,19 @@ where
 /// Implements a mock mock certificate scheme for a concrete subject and namespace.
 ///
 /// This follows the same binding pattern as the other certificate macros: the protocol
-/// supplies the subject type and namespace type, and the macro emits a local `Scheme`
-/// wrapper plus a `fixture(...)` helper for tests.
+/// supplies the subject type, namespace type, and fault model, and the macro emits a
+/// local `Scheme` wrapper plus a `fixture(...)` helper for tests.
 ///
 /// # Example
 /// ```ignore
 /// use commonware_cryptography::impl_certificate_mock;
+/// use commonware_utils::N3f1;
 ///
-/// impl_certificate_mock!(Subject<'a, D>, Namespace);
+/// impl_certificate_mock!(Subject<'a, D>, Namespace, N3f1);
 /// ```
 #[macro_export]
 macro_rules! impl_certificate_mock {
-    ($subject:ty, $namespace:ty) => {
+    ($subject:ty, $namespace:ty, $faults:ty) => {
         /// Generates a test fixture with Ed25519 identities and a mock mock scheme.
         #[cfg(feature = "mocks")]
         #[allow(dead_code)]
@@ -563,10 +561,11 @@ macro_rules! impl_certificate_mock {
         > $crate::certificate::Verifier for Scheme<P, ATTRIBUTABLE, BATCHABLE, ALLOW_INVALID>
         {
             type Subject<'a, D: $crate::Digest> = $subject;
+            type Faults = $faults;
             type PublicKey = P;
             type Certificate = commonware_utils::sequence::U64;
 
-            fn verify_certificate<R, D, M>(
+            fn verify_certificate<R, D>(
                 &self,
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
@@ -576,13 +575,12 @@ macro_rules! impl_certificate_mock {
             where
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificate::<Self, _, D, M>(rng, subject, certificate)
+                    .verify_certificate::<Self, _, D>(rng, subject, certificate)
             }
 
-            fn verify_certificates<'a, R, D, I, M>(
+            fn verify_certificates<'a, R, D, I>(
                 &self,
                 rng: &mut R,
                 certificates: I,
@@ -592,10 +590,9 @@ macro_rules! impl_certificate_mock {
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificates::<Self, _, D, _, M>(rng, certificates)
+                    .verify_certificates::<Self, _, D, _>(rng, certificates)
             }
 
             fn is_batchable() -> bool {
@@ -681,16 +678,15 @@ macro_rules! impl_certificate_mock {
                     .verify_attestations::<Self, _, D, _>(rng, subject, attestations)
             }
 
-            fn assemble<I, M>(
+            fn assemble<I>(
                 &self,
                 attestations: I,
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> Option<Self::Certificate>
             where
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
-                M: commonware_utils::Faults,
             {
-                self.generic.assemble::<Self, _, M>(attestations)
+                self.generic.assemble::<Self, _>(attestations)
             }
 
             fn is_attributable() -> bool {
@@ -736,7 +732,7 @@ mod tests {
         }
     }
 
-    impl_certificate_mock!(TestSubject<'a>, Vec<u8>);
+    impl_certificate_mock!(TestSubject<'a>, Vec<u8>, N3f1);
 
     #[test]
     fn attestation_round_trip_verifies() {
@@ -971,34 +967,26 @@ mod tests {
             .collect();
         let certificate = fixture
             .verifier
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .unwrap();
         let encoded = certificate.encode();
         let decoded =
             U64::decode_cfg(encoded, &fixture.verifier.certificate_codec_config()).unwrap();
 
-        assert!(
-            fixture
-                .verifier
-                .verify_certificate::<_, Sha256Digest, N3f1>(
-                    &mut rng,
-                    subject,
-                    &decoded,
-                    &Sequential,
-                )
-        );
-        assert!(
-            !fixture
-                .verifier
-                .verify_certificate::<_, Sha256Digest, N3f1>(
-                    &mut rng,
-                    TestSubject {
-                        message: b"other-subject",
-                    },
-                    &decoded,
-                    &Sequential,
-                )
-        );
+        assert!(fixture.verifier.verify_certificate::<_, Sha256Digest>(
+            &mut rng,
+            subject,
+            &decoded,
+            &Sequential,
+        ));
+        assert!(!fixture.verifier.verify_certificate::<_, Sha256Digest>(
+            &mut rng,
+            TestSubject {
+                message: b"other-subject",
+            },
+            &decoded,
+            &Sequential,
+        ));
     }
 
     #[test]
@@ -1015,11 +1003,11 @@ mod tests {
 
         let first = fixture
             .verifier
-            .assemble::<_, N3f1>(attestations.clone(), &Sequential)
+            .assemble(attestations.clone(), &Sequential)
             .unwrap();
         let second = fixture
             .verifier
-            .assemble::<_, N3f1>(
+            .assemble(
                 attestations.iter().cloned().rev().collect::<Vec<_>>(),
                 &Sequential,
             )
@@ -1039,7 +1027,7 @@ mod tests {
             .collect();
         let certificate = fixture
             .verifier
-            .assemble::<_, N3f1>(attestations, &Sequential)
+            .assemble(attestations, &Sequential)
             .unwrap();
         let encoded = certificate.encode();
 
@@ -1058,7 +1046,7 @@ mod tests {
         assert!(
             fixture
                 .verifier
-                .assemble::<_, N3f1>(
+                .assemble(
                     [
                         fixture.schemes[0].sign::<Sha256Digest>(subject).unwrap(),
                         fixture.schemes[1].sign::<Sha256Digest>(subject).unwrap(),
@@ -1071,7 +1059,7 @@ mod tests {
         assert!(
             fixture
                 .verifier
-                .assemble::<_, N3f1>(
+                .assemble(
                     [
                         fixture.schemes[0].sign::<Sha256Digest>(subject).unwrap(),
                         fixture.schemes[1].sign::<Sha256Digest>(subject).unwrap(),
@@ -1096,7 +1084,7 @@ mod tests {
             .sign::<Sha256Digest>(subject)
             .expect("signer must produce an attestation");
 
-        let certificate = fixture.verifier.assemble::<_, N3f1>(
+        let certificate = fixture.verifier.assemble(
             [
                 attestation.clone(),
                 attestation,
@@ -1127,52 +1115,36 @@ mod tests {
             .collect();
         let certificate_a = fixture
             .verifier
-            .assemble::<_, N3f1>(attestations_a, &Sequential)
+            .assemble(attestations_a, &Sequential)
             .unwrap();
         let certificate_b = fixture
             .verifier
-            .assemble::<_, N3f1>(attestations_b, &Sequential)
+            .assemble(attestations_b, &Sequential)
             .unwrap();
         let missing = U64::new(u64::MAX);
 
-        assert!(
-            !fixture
-                .verifier
-                .verify_certificate::<_, Sha256Digest, N3f1>(
-                    &mut rng,
-                    subject_a,
-                    &certificate_b,
-                    &Sequential,
-                )
-        );
-        assert!(
-            !fixture
-                .verifier
-                .verify_certificate::<_, Sha256Digest, N3f1>(
-                    &mut rng,
-                    subject_b,
-                    &missing,
-                    &Sequential,
-                )
-        );
-        assert!(
-            fixture
-                .verifier
-                .verify_certificates::<_, Sha256Digest, _, N3f1>(
-                    &mut rng,
-                    [(subject_a, &certificate_a), (subject_b, &certificate_b)].into_iter(),
-                    &Sequential,
-                )
-        );
-        assert!(
-            !fixture
-                .verifier
-                .verify_certificates::<_, Sha256Digest, _, N3f1>(
-                    &mut rng,
-                    [(subject_a, &certificate_a), (subject_b, &missing)].into_iter(),
-                    &Sequential,
-                )
-        );
+        assert!(!fixture.verifier.verify_certificate::<_, Sha256Digest>(
+            &mut rng,
+            subject_a,
+            &certificate_b,
+            &Sequential,
+        ));
+        assert!(!fixture.verifier.verify_certificate::<_, Sha256Digest>(
+            &mut rng,
+            subject_b,
+            &missing,
+            &Sequential,
+        ));
+        assert!(fixture.verifier.verify_certificates::<_, Sha256Digest, _>(
+            &mut rng,
+            [(subject_a, &certificate_a), (subject_b, &certificate_b)].into_iter(),
+            &Sequential,
+        ));
+        assert!(!fixture.verifier.verify_certificates::<_, Sha256Digest, _>(
+            &mut rng,
+            [(subject_a, &certificate_a), (subject_b, &missing)].into_iter(),
+            &Sequential,
+        ));
     }
 
     #[test]
@@ -1200,7 +1172,7 @@ mod tests {
         let fixture = fixture_with::<true, true, false, _>(&mut rng, b"mock-scheme", 4);
         let subject = TestSubject { message: b"vote-1" };
 
-        let _ = fixture.verifier.assemble::<_, N3f1>(
+        let _ = fixture.verifier.assemble(
             [
                 fixture.schemes[0].sign::<Sha256Digest>(subject).unwrap(),
                 fixture.schemes[1]

--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -399,7 +399,8 @@ impl Read for Certificate {
 ///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
 ///   For protocols with multiple message types, a custom struct can pre-compute all variants.
 ///
-/// - `$faults`: The `commonware_utils::Faults` implementation used to compute certificate quorums.
+/// - `$faults`: The [`Faults`](commonware_utils::Faults) implementation used to compute certificate
+///   quorums.
 ///
 /// # Example
 /// ```ignore

--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -17,7 +17,7 @@ use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error, Read, ReadRangeExt, Write, types::lazy::Lazy};
 use commonware_parallel::Strategy;
 use commonware_utils::{
-    Faults, Participant,
+    Participant,
     ordered::{Quorum, Set},
 };
 use rand_core::CryptoRng;
@@ -178,11 +178,10 @@ impl<N: Namespace> Generic<N> {
     }
 
     /// Assembles a certificate from a collection of attestations.
-    pub fn assemble<S, I, M>(&self, attestations: I) -> Option<Certificate>
+    pub fn assemble<S, I>(&self, attestations: I) -> Option<Certificate>
     where
         S: Scheme<Signature = Ed25519Signature>,
         I: IntoIterator<Item = Attestation<S>>,
-        M: Faults,
     {
         // Collect the signers and signatures.
         let mut entries = Vec::new();
@@ -193,7 +192,7 @@ impl<N: Namespace> Generic<N> {
             let signature = signature.get().cloned()?;
             entries.push((signer, signature));
         }
-        if entries.len() < self.participants.quorum::<M>() as usize {
+        if entries.len() < self.participants.quorum::<S::Faults>() as usize {
             return None;
         }
 
@@ -212,7 +211,7 @@ impl<N: Namespace> Generic<N> {
     /// Stages a certificate for batch verification.
     ///
     /// Returns false if the certificate structure is invalid.
-    fn batch_verify_certificate<'a, S, D, M>(
+    fn batch_verify_certificate<'a, S, D>(
         &self,
         batch: &mut Batch,
         subject: S::Subject<'a, D>,
@@ -222,7 +221,6 @@ impl<N: Namespace> Generic<N> {
         S: Scheme,
         S::Subject<'a, D>: Subject<Namespace = N>,
         D: Digest,
-        M: Faults,
     {
         // If the certificate signers length does not match the participant set, return false.
         if certificate.signers.len() != self.participants.len() {
@@ -235,7 +233,7 @@ impl<N: Namespace> Generic<N> {
         }
 
         // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum::<M>() as usize {
+        if certificate.signers.count() < self.participants.quorum::<S::Faults>() as usize {
             return false;
         }
 
@@ -257,7 +255,7 @@ impl<N: Namespace> Generic<N> {
     }
 
     /// Verifies a certificate using batch verification.
-    pub fn verify_certificate<'a, S, R, D, M>(
+    pub fn verify_certificate<'a, S, R, D>(
         &self,
         rng: &mut R,
         subject: S::Subject<'a, D>,
@@ -269,10 +267,9 @@ impl<N: Namespace> Generic<N> {
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: CryptoRng,
         D: Digest,
-        M: Faults,
     {
         let mut batch = Batch::new(certificate.signatures.len());
-        if !self.batch_verify_certificate::<S, D, M>(&mut batch, subject, certificate) {
+        if !self.batch_verify_certificate::<S, D>(&mut batch, subject, certificate) {
             return false;
         }
 
@@ -280,7 +277,7 @@ impl<N: Namespace> Generic<N> {
     }
 
     /// Verifies multiple certificates in a batch.
-    pub fn verify_certificates<'a, S, R, D, I, M>(
+    pub fn verify_certificates<'a, S, R, D, I>(
         &self,
         rng: &mut R,
         certificates: I,
@@ -292,13 +289,12 @@ impl<N: Namespace> Generic<N> {
         R: CryptoRng,
         D: Digest,
         I: Iterator<Item = (S::Subject<'a, D>, &'a Certificate)>,
-        M: Faults,
     {
         // Each certificate stages at most one signature per participant.
         let per_certificate = self.participants.len();
         let mut batch = Batch::new(certificates.size_hint().0.saturating_mul(per_certificate));
         for (subject, certificate) in certificates {
-            if !self.batch_verify_certificate::<S, D, M>(&mut batch, subject, certificate) {
+            if !self.batch_verify_certificate::<S, D>(&mut batch, subject, certificate) {
                 return false;
             }
         }
@@ -403,17 +399,19 @@ impl Read for Certificate {
 ///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
 ///   For protocols with multiple message types, a custom struct can pre-compute all variants.
 ///
+/// - `$faults`: The `commonware_utils::Faults` implementation used to compute certificate quorums.
+///
 /// # Example
 /// ```ignore
 /// // For non-generic subject types with a single namespace:
-/// impl_certificate_ed25519!(MySubject, Vec<u8>);
+/// impl_certificate_ed25519!(MySubject, Vec<u8>, commonware_utils::N3f1);
 ///
 /// // For protocols with generic subject types:
-/// impl_certificate_ed25519!(Subject<'a, D>, Namespace);
+/// impl_certificate_ed25519!(Subject<'a, D>, Namespace, commonware_utils::N3f1);
 /// ```
 #[macro_export]
 macro_rules! impl_certificate_ed25519 {
-    ($subject:ty, $namespace:ty) => {
+    ($subject:ty, $namespace:ty, $faults:ty) => {
         /// Generates a test fixture with Ed25519 identities and signing schemes.
         ///
         /// Returns a [`commonware_cryptography::certificate::mocks::Fixture`] whose keys and
@@ -485,10 +483,11 @@ macro_rules! impl_certificate_ed25519 {
 
         impl $crate::certificate::Verifier for Scheme {
             type Subject<'a, D: $crate::Digest> = $subject;
+            type Faults = $faults;
             type PublicKey = $crate::ed25519::PublicKey;
             type Certificate = $crate::ed25519::certificate::Certificate;
 
-            fn verify_certificate<R, D, M>(
+            fn verify_certificate<R, D>(
                 &self,
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
@@ -498,13 +497,12 @@ macro_rules! impl_certificate_ed25519 {
             where
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificate::<Self, _, D, M>(rng, subject, certificate, strategy)
+                    .verify_certificate::<Self, _, D>(rng, subject, certificate, strategy)
             }
 
-            fn verify_certificates<'a, R, D, I, M>(
+            fn verify_certificates<'a, R, D, I>(
                 &self,
                 rng: &mut R,
                 certificates: I,
@@ -514,10 +512,9 @@ macro_rules! impl_certificate_ed25519 {
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-                M: commonware_utils::Faults,
             {
                 self.generic
-                    .verify_certificates::<Self, _, D, _, M>(rng, certificates, strategy)
+                    .verify_certificates::<Self, _, D, _>(rng, certificates, strategy)
             }
 
             fn is_batchable() -> bool {
@@ -585,16 +582,15 @@ macro_rules! impl_certificate_ed25519 {
                     .verify_attestations::<_, _, D, _>(rng, subject, attestations, strategy)
             }
 
-            fn assemble<I, M>(
+            fn assemble<I>(
                 &self,
                 attestations: I,
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> Option<Self::Certificate>
             where
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
-                M: commonware_utils::Faults,
             {
-                self.generic.assemble::<Self, _, M>(attestations)
+                self.generic.assemble::<Self, _>(attestations)
             }
 
             fn is_attributable() -> bool {
@@ -639,7 +635,7 @@ mod tests {
     }
 
     // Use the macro to generate the test scheme
-    impl_certificate_ed25519!(TestSubject, Vec<u8>);
+    impl_certificate_ed25519!(TestSubject, Vec<u8>, N3f1);
 
     fn setup_signers(rng: &mut impl CryptoRng, n: u32) -> (Vec<Scheme>, Scheme) {
         let private_keys: Vec<_> = (0..n).map(|_| PrivateKey::random(&mut *rng)).collect();
@@ -780,9 +776,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Verify certificate has correct number of signers
         assert_eq!(certificate.signers.count(), quorum);
@@ -817,9 +811,7 @@ mod tests {
                 .unwrap(),
         ];
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Verify signers are sorted by signer index
         let expected: Vec<_> = indexed.iter().map(|(idx, _)| *idx).collect();
@@ -843,11 +835,9 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE)
@@ -874,12 +864,10 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Valid certificate passes
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -891,7 +879,7 @@ mod tests {
         // Corrupted certificate fails
         let mut corrupted = certificate;
         corrupted.signatures[0] = corrupted.signatures[1].clone();
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -918,9 +906,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
         let encoded = certificate.encode();
         let decoded = Certificate::decode_cfg(encoded, &schemes.len()).expect("decode certificate");
         assert_eq!(decoded, certificate);
@@ -943,11 +929,7 @@ mod tests {
             })
             .collect();
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -970,11 +952,7 @@ mod tests {
         // Corrupt signer index to be out of range
         attestations[0].signer = Participant::new(999);
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -994,9 +972,7 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Artificially truncate to below quorum
         let mut signers: Vec<Participant> = certificate.signers.iter().collect();
@@ -1004,7 +980,7 @@ mod tests {
         certificate.signers = Signers::from(participants_len, signers);
         certificate.signatures.pop();
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1030,14 +1006,12 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Remove one signature but keep signers bitmap unchanged
         certificate.signatures.pop();
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1070,11 +1044,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         let certs_iter = messages.iter().zip(&certificates).map(|(msg, cert)| {
@@ -1086,7 +1056,7 @@ mod tests {
             )
         });
 
-        assert!(verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1116,11 +1086,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         // Corrupt second certificate
@@ -1135,7 +1101,7 @@ mod tests {
             )
         });
 
-        assert!(!verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(!verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1163,7 +1129,7 @@ mod tests {
         attestations.push(attestations.last().unwrap().clone());
 
         // This should panic due to duplicate signer
-        schemes[0].assemble::<_, N3f1>(attestations, &Sequential);
+        schemes[0].assemble(attestations, &Sequential);
     }
 
     #[test]
@@ -1212,9 +1178,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Well-formed certificate decodes successfully
         let encoded = certificate.encode();
@@ -1265,9 +1229,7 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Add an unknown signer (out of range)
         let mut signers: Vec<Participant> = certificate.signers.iter().collect();
@@ -1277,7 +1239,7 @@ mod tests {
             .signatures
             .push(certificate.signatures[0].clone());
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1304,12 +1266,10 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Valid certificate passes
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1323,7 +1283,7 @@ mod tests {
         certificate.signers = Signers::from(participants_len + 1, signers);
 
         // Certificate verification should fail due to size mismatch
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1350,9 +1310,7 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Make the signers bitmap size larger than participants
         let signers: Vec<Participant> = certificate.signers.iter().collect();
@@ -1361,7 +1319,7 @@ mod tests {
             .signatures
             .push(certificate.signatures[0].clone());
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),

--- a/cryptography/src/secp256r1/certificate/mod.rs
+++ b/cryptography/src/secp256r1/certificate/mod.rs
@@ -344,7 +344,8 @@ impl Read for Certificate {
 ///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
 ///   For protocols with multiple message types, a custom struct can pre-compute all variants.
 ///
-/// - `$faults`: The `commonware_utils::Faults` implementation used to compute certificate quorums.
+/// - `$faults`: The [`Faults`](commonware_utils::Faults) implementation used to compute certificate
+///   quorums.
 ///
 /// # Example
 /// ```ignore

--- a/cryptography/src/secp256r1/certificate/mod.rs
+++ b/cryptography/src/secp256r1/certificate/mod.rs
@@ -16,7 +16,7 @@ use alloc::{collections::BTreeSet, vec::Vec};
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Error, Read, ReadRangeExt, Write, types::lazy::Lazy};
 use commonware_utils::{
-    Faults, Participant,
+    Participant,
     ordered::{BiMap, Quorum, Set},
 };
 use rand_core::{CryptoRng, Rng};
@@ -172,11 +172,10 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
     }
 
     /// Assembles a certificate from a collection of attestations.
-    pub fn assemble<S, I, M>(&self, attestations: I) -> Option<Certificate>
+    pub fn assemble<S, I>(&self, attestations: I) -> Option<Certificate>
     where
         S: Scheme<Signature = Secp256r1Signature>,
         I: IntoIterator<Item = Attestation<S>>,
-        M: Faults,
     {
         // Collect the signers and signatures.
         let mut entries = Vec::new();
@@ -187,7 +186,7 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
             let signature = signature.get().cloned()?;
             entries.push((signer, signature));
         }
-        if entries.len() < self.participants.quorum::<M>() as usize {
+        if entries.len() < self.participants.quorum::<S::Faults>() as usize {
             return None;
         }
 
@@ -204,7 +203,7 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
     }
 
     /// Verifies a certificate by checking each signature individually.
-    pub fn verify_certificate<'a, S, R, D, M>(
+    pub fn verify_certificate<'a, S, R, D>(
         &self,
         _rng: &mut R,
         subject: S::Subject<'a, D>,
@@ -215,7 +214,6 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
         S::Subject<'a, D>: Subject<Namespace = N>,
         R: Rng + CryptoRng,
         D: Digest,
-        M: Faults,
     {
         // If the certificate signers length does not match the participant set, return false.
         if certificate.signers.len() != self.participants.len() {
@@ -228,7 +226,7 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
         }
 
         // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum::<M>() as usize {
+        if certificate.signers.count() < self.participants.quorum::<S::Faults>() as usize {
             return false;
         }
 
@@ -331,17 +329,21 @@ impl Read for Certificate {
 
 /// Generates a Secp256r1 signing scheme wrapper for a specific protocol.
 ///
-/// This macro creates a complete wrapper struct with constructors, `Scheme` trait
-/// implementation, and a `fixture` function for testing.
-/// The only required parameter is the `Subject` type, which varies per protocol.
+/// This macro creates a complete wrapper struct with constructors, `Scheme`
+/// trait implementation, and a `fixture` function for testing. The protocol
+/// supplies its subject type, namespace type, and fault model.
 ///
 /// # Example
 /// ```ignore
-/// impl_certificate_secp256r1!(VoteSubject<'a, D>);
+/// impl_certificate_secp256r1!(
+///     VoteSubject<'a, D>,
+///     Namespace,
+///     commonware_utils::N3f1,
+/// );
 /// ```
 #[macro_export]
 macro_rules! impl_certificate_secp256r1 {
-    ($subject:ty, $namespace:ty) => {
+    ($subject:ty, $namespace:ty, $faults:ty) => {
         /// Generates a test fixture with Ed25519 identities and Secp256r1 signing schemes.
         ///
         /// Returns a [`commonware_cryptography::certificate::mocks::Fixture`] whose keys and
@@ -403,10 +405,11 @@ macro_rules! impl_certificate_secp256r1 {
 
         impl<P: $crate::PublicKey> $crate::certificate::Verifier for Scheme<P> {
             type Subject<'a, D: $crate::Digest> = $subject;
+            type Faults = $faults;
             type PublicKey = P;
             type Certificate = $crate::secp256r1::certificate::Certificate;
 
-            fn verify_certificate<R, D, M>(
+            fn verify_certificate<R, D>(
                 &self,
                 rng: &mut R,
                 subject: Self::Subject<'_, D>,
@@ -416,16 +419,15 @@ macro_rules! impl_certificate_secp256r1 {
             where
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
-                M: commonware_utils::Faults,
             {
-                self.generic.verify_certificate::<Self, _, D, M>(
+                self.generic.verify_certificate::<Self, _, D>(
                     rng,
                     subject,
                     certificate,
                 )
             }
 
-            fn verify_certificates<'a, R, D, I, M>(
+            fn verify_certificates<'a, R, D, I>(
                 &self,
                 rng: &mut R,
                 certificates: I,
@@ -435,10 +437,9 @@ macro_rules! impl_certificate_secp256r1 {
                 R: rand_core::CryptoRng,
                 D: $crate::Digest,
                 I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-                M: commonware_utils::Faults,
             {
                 for (subject, certificate) in certificates {
-                    if !self.generic.verify_certificate::<Self, _, D, M>(rng, subject, certificate) {
+                    if !self.generic.verify_certificate::<Self, _, D>(rng, subject, certificate) {
                         return false;
                     }
                 }
@@ -512,16 +513,15 @@ macro_rules! impl_certificate_secp256r1 {
                 )
             }
 
-            fn assemble<I, M>(
+            fn assemble<I>(
                 &self,
                 attestations: I,
                 _strategy: &impl commonware_parallel::Strategy,
             ) -> Option<Self::Certificate>
             where
                 I: IntoIterator<Item = $crate::certificate::Attestation<Self>>,
-                M: commonware_utils::Faults,
             {
-                self.generic.assemble::<Self, _, M>(attestations)
+                self.generic.assemble::<Self, _>(attestations)
             }
 
             fn is_attributable() -> bool {
@@ -567,7 +567,7 @@ mod tests {
     }
 
     // Use the macro to generate the test scheme
-    impl_certificate_secp256r1!(TestSubject, Vec<u8>);
+    impl_certificate_secp256r1!(TestSubject, Vec<u8>, N3f1);
 
     fn setup_signers(
         rng: &mut impl CryptoRng,
@@ -717,9 +717,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Verify certificate has correct number of signers
         assert_eq!(certificate.signers.count(), quorum);
@@ -754,9 +752,7 @@ mod tests {
                 .unwrap(),
         ];
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Verify signers are sorted by signer index
         let expected: Vec<_> = indexed.iter().map(|(idx, _)| *idx).collect();
@@ -780,11 +776,9 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -811,12 +805,10 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Valid certificate passes
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -828,7 +820,7 @@ mod tests {
         // Corrupted certificate fails
         let mut corrupted = certificate;
         corrupted.signatures[0] = corrupted.signatures[1].clone();
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -855,9 +847,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
         let encoded = certificate.encode();
         let decoded = Certificate::decode_cfg(encoded, &schemes.len()).expect("decode certificate");
         assert_eq!(decoded, certificate);
@@ -880,11 +870,7 @@ mod tests {
             })
             .collect();
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -907,11 +893,7 @@ mod tests {
         // Corrupt signer index to be out of range
         attestations[0].signer = Participant::new(999);
 
-        assert!(
-            schemes[0]
-                .assemble::<_, N3f1>(attestations, &Sequential)
-                .is_none()
-        );
+        assert!(schemes[0].assemble(attestations, &Sequential).is_none());
     }
 
     #[test]
@@ -931,9 +913,7 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Artificially truncate to below quorum
         let mut signers: Vec<Participant> = certificate.signers.iter().collect();
@@ -941,7 +921,7 @@ mod tests {
         certificate.signers = Signers::from(participants_len, signers);
         certificate.signatures.pop();
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -967,14 +947,12 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Remove one signature but keep signers bitmap unchanged
         certificate.signatures.pop();
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1007,11 +985,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         let certs_iter = messages.iter().zip(&certificates).map(|(msg, cert)| {
@@ -1023,7 +997,7 @@ mod tests {
             )
         });
 
-        assert!(verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1053,11 +1027,7 @@ mod tests {
                     .unwrap()
                 })
                 .collect();
-            certificates.push(
-                schemes[0]
-                    .assemble::<_, N3f1>(attestations, &Sequential)
-                    .unwrap(),
-            );
+            certificates.push(schemes[0].assemble(attestations, &Sequential).unwrap());
         }
 
         // Corrupt second certificate
@@ -1072,7 +1042,7 @@ mod tests {
             )
         });
 
-        assert!(!verifier.verify_certificates::<_, Sha256Digest, _, N3f1>(
+        assert!(!verifier.verify_certificates::<_, Sha256Digest, _>(
             &mut rng,
             certs_iter,
             &Sequential
@@ -1100,7 +1070,7 @@ mod tests {
         attestations.push(attestations.last().unwrap().clone());
 
         // This should panic due to duplicate signer
-        schemes[0].assemble::<_, N3f1>(attestations, &Sequential);
+        schemes[0].assemble(attestations, &Sequential);
     }
 
     #[test]
@@ -1149,9 +1119,7 @@ mod tests {
             })
             .collect();
 
-        let certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Well-formed certificate decodes successfully
         let encoded = certificate.encode();
@@ -1202,9 +1170,7 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Add an unknown signer (out of range)
         let mut signers: Vec<Participant> = certificate.signers.iter().collect();
@@ -1214,7 +1180,7 @@ mod tests {
             .signatures
             .push(certificate.signatures[0].clone());
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1241,12 +1207,10 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Valid certificate passes
-        assert!(verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1260,7 +1224,7 @@ mod tests {
         certificate.signers = Signers::from(participants_len + 1, signers);
 
         // Certificate verification should fail due to size mismatch
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),
@@ -1287,9 +1251,7 @@ mod tests {
             })
             .collect();
 
-        let mut certificate = schemes[0]
-            .assemble::<_, N3f1>(attestations, &Sequential)
-            .unwrap();
+        let mut certificate = schemes[0].assemble(attestations, &Sequential).unwrap();
 
         // Make the signers bitmap size larger than participants
         let signers: Vec<Participant> = certificate.signers.iter().collect();
@@ -1298,7 +1260,7 @@ mod tests {
             .signatures
             .push(certificate.signatures[0].clone());
 
-        assert!(!verifier.verify_certificate::<_, Sha256Digest, N3f1>(
+        assert!(!verifier.verify_certificate::<_, Sha256Digest>(
             &mut rng,
             TestSubject {
                 message: Bytes::from_static(MESSAGE),

--- a/cryptography/src/secp256r1/certificate/mod.rs
+++ b/cryptography/src/secp256r1/certificate/mod.rs
@@ -329,14 +329,31 @@ impl Read for Certificate {
 
 /// Generates a Secp256r1 signing scheme wrapper for a specific protocol.
 ///
-/// This macro creates a complete wrapper struct with constructors, `Scheme`
-/// trait implementation, and a `fixture` function for testing. The protocol
-/// supplies its subject type, namespace type, and fault model.
+/// This macro creates a complete wrapper struct with constructors, `Scheme` trait
+/// implementation, and a `fixture` function for testing.
+///
+/// # Parameters
+///
+/// - `$subject`: The subject type used as `Scheme::Subject<'a, D>`. Use `'a` and `D`
+///   in the subject type to bind to the GAT lifetime and digest type parameters.
+///
+/// - `$namespace`: The namespace type that implements [`Namespace`].
+///   This type pre-computes and stores any protocol-specific namespace bytes derived from
+///   a base namespace. The scheme calls `$namespace::derive(base)` at construction time
+///   to create the namespace, then passes it to `Subject::namespace()` during signing
+///   and verification. For simple protocols with only a base namespace, `Vec<u8>` can be used directly.
+///   For protocols with multiple message types, a custom struct can pre-compute all variants.
+///
+/// - `$faults`: The `commonware_utils::Faults` implementation used to compute certificate quorums.
 ///
 /// # Example
 /// ```ignore
+/// // For non-generic subject types with a single namespace:
+/// impl_certificate_secp256r1!(MySubject, Vec<u8>, commonware_utils::N3f1);
+///
+/// // For protocols with generic subject types:
 /// impl_certificate_secp256r1!(
-///     VoteSubject<'a, D>,
+///     Subject<'a, D>,
 ///     Namespace,
 ///     commonware_utils::N3f1,
 /// );

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -340,10 +340,11 @@ mod test {
     impl Verifier for MaybeEnumerableScheme {
         type Subject<'a, D: commonware_cryptography::Digest> =
             commonware_consensus::simplex::types::Subject<'a, D>;
+        type Faults = <Scheme as Verifier>::Faults;
         type PublicKey = ed25519::PublicKey;
         type Certificate = <Scheme as Verifier>::Certificate;
 
-        fn verify_certificate<R, D, M>(
+        fn verify_certificate<R, D>(
             &self,
             rng: &mut R,
             subject: Self::Subject<'_, D>,
@@ -353,13 +354,12 @@ mod test {
         where
             R: rand_core::CryptoRng,
             D: commonware_cryptography::Digest,
-            M: commonware_utils::Faults,
         {
             self.inner
-                .verify_certificate::<_, D, M>(rng, subject, certificate, strategy)
+                .verify_certificate(rng, subject, certificate, strategy)
         }
 
-        fn verify_certificates<'a, R, D, I, M>(
+        fn verify_certificates<'a, R, D, I>(
             &self,
             rng: &mut R,
             certificates: I,
@@ -369,10 +369,8 @@ mod test {
             R: rand_core::CryptoRng,
             D: commonware_cryptography::Digest,
             I: Iterator<Item = (Self::Subject<'a, D>, &'a Self::Certificate)>,
-            M: commonware_utils::Faults,
         {
-            self.inner
-                .verify_certificates::<_, D, _, M>(rng, certificates, strategy)
+            self.inner.verify_certificates(rng, certificates, strategy)
         }
 
         fn is_batchable() -> bool {
@@ -459,7 +457,7 @@ mod test {
             )
         }
 
-        fn assemble<I, M>(
+        fn assemble<I>(
             &self,
             attestations: I,
             strategy: &impl ParallelStrategy,
@@ -467,9 +465,8 @@ mod test {
         where
             I: IntoIterator<Item = Attestation<Self>>,
             I::IntoIter: Send,
-            M: commonware_utils::Faults,
         {
-            self.inner.assemble::<_, M>(
+            self.inner.assemble(
                 attestations.into_iter().map(Self::unwrap_attestation),
                 strategy,
             )


### PR DESCRIPTION
This PR adds a `Faults` associated type to the certificate `Verifier` trait and removes fault-model parameters from verification and assembly methods. Certificate macros now bind generated schemes to an explicit fault model, making quorum behavior a property of the scheme rather than a caller choice.

BLS threshold signer and verifier construction now validates that the public polynomial degree equals the quorum required by the configured fault model minus one. The same invariant is enforced by the simplex threshold VRF scheme.

Replaces https://github.com/commonwarexyz/monorepo/pull/3894.