### PR TITLE
[consensus/simplex] let batcher adopt proposals from notarizations

### DIFF
--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -496,10 +496,19 @@ where
                         }
 
                         // Store and forward to voter
-                        work.entry(view)
+                        let proposal_changed = work
+                            .entry(view)
                             .or_insert_with(|| self.new_round(view))
-                            .record_certificate(kind);
+                            .record_notarization(&notarization.proposal);
                         voter.recovered(Certificate::Notarization(notarization));
+
+                        // Reprocess buffered votes only if the notarization changed the
+                        // proposal filter.
+                        if !proposal_changed {
+                            continue;
+                        }
+
+                        updated_view = view;
                     }
                     Certificate::Nullification(nullification) => {
                         // Verify the certificate
@@ -515,8 +524,11 @@ where
                         // Store and forward to voter
                         work.entry(view)
                             .or_insert_with(|| self.new_round(view))
-                            .record_certificate(kind);
+                            .record_nullification();
                         voter.recovered(Certificate::Nullification(nullification));
+
+                        // Certificates are already forwarded to voter, no need for construction.
+                        continue;
                     }
                     Certificate::Finalization(finalization) => {
                         // Verify the certificate
@@ -532,13 +544,13 @@ where
                         // Store and forward to voter
                         work.entry(view)
                             .or_insert_with(|| self.new_round(view))
-                            .record_certificate(kind);
+                            .record_finalization();
                         voter.recovered(Certificate::Finalization(finalization));
+
+                        // Certificates are already forwarded to voter, no need for construction.
+                        continue;
                     }
                 }
-
-                // Certificates are already forwarded to voter, no need for construction
-                continue;
             },
             // Handle votes from the network
             Ok((sender, message)) = vote_receiver.recv() else break => {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -507,7 +507,7 @@ where
                 }
 
                 // Store and forward to voter
-                let proposal_changed = work
+                let reprocess_votes = work
                     .entry(view)
                     .or_insert_with(|| self.new_round(view))
                     .record_certificate(&message);
@@ -515,7 +515,7 @@ where
 
                 // Reprocess buffered votes only if the notarization changed the
                 // round's proposal.
-                if !proposal_changed {
+                if !reprocess_votes {
                     // Otherwise, certificates are already forwarded to voter,
                     // no need for construction.
                     continue;
@@ -590,7 +590,8 @@ where
                     "updated view must be greater than zero"
                 );
 
-                // Forward leader's proposal to voter (if we're not the leader and haven't already)
+                // Forward the selected proposal to voter if we are not the
+                // leader and have not already forwarded it.
                 if let Some(round) = work.get_mut(&current.view)
                     && let Some(me) = self.scheme.me()
                     && let Some(proposal) = round.try_forward_proposal(me)

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -513,8 +513,8 @@ where
                     .record_certificate(&message);
                 voter.recovered(message);
 
-                // Reprocess buffered votes only if the notarization changed the
-                // round's proposal.
+                // A notarization may make buffered finalize votes newly eligible,
+                // requiring another verification and construction pass.
                 if !reprocess_votes {
                     // Otherwise, certificates are already forwarded to voter,
                     // no need for construction.

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -516,6 +516,8 @@ where
                 // Reprocess buffered votes only if the notarization changed the
                 // round's proposal.
                 if !proposal_changed {
+                    // Otherwise, certificates are already forwarded to voter,
+                    // no need for construction.
                     continue;
                 }
                 updated_view = view;

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -483,74 +483,42 @@ where
                 );
                 let _guard = span.entered();
 
-                match message {
-                    Certificate::Notarization(notarization) => {
-                        // Verify the certificate
-                        if !notarization.verify(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid notarization");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        let proposal_changed = work
-                            .entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_notarization(&notarization.proposal);
-                        voter.recovered(Certificate::Notarization(notarization));
-
-                        // Reprocess buffered votes only if the notarization changed the
-                        // proposal filter.
-                        if !proposal_changed {
-                            continue;
-                        }
-
-                        updated_view = view;
-                    }
-                    Certificate::Nullification(nullification) => {
-                        // Verify the certificate
-                        if !nullification.verify::<_, D>(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid nullification");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_nullification();
-                        voter.recovered(Certificate::Nullification(nullification));
-
-                        // Certificates are already forwarded to voter, no need for construction.
-                        continue;
-                    }
-                    Certificate::Finalization(finalization) => {
-                        // Verify the certificate
-                        if !finalization.verify(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid finalization");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_finalization();
-                        voter.recovered(Certificate::Finalization(finalization));
-
-                        // Certificates are already forwarded to voter, no need for construction.
-                        continue;
-                    }
+                // Verify the certificate
+                let valid = match &message {
+                    Certificate::Notarization(notarization) => notarization.verify(
+                        self.context.as_mut(),
+                        self.scheme.as_ref(),
+                        &self.strategy,
+                    ),
+                    Certificate::Nullification(nullification) => nullification.verify::<_, D>(
+                        self.context.as_mut(),
+                        self.scheme.as_ref(),
+                        &self.strategy,
+                    ),
+                    Certificate::Finalization(finalization) => finalization.verify(
+                        self.context.as_mut(),
+                        self.scheme.as_ref(),
+                        &self.strategy,
+                    ),
+                };
+                if !valid {
+                    commonware_p2p::block!(self.blocker, sender, %view, %kind, "invalid certificate");
+                    continue;
                 }
+
+                // Store and forward to voter
+                let proposal_changed = work
+                    .entry(view)
+                    .or_insert_with(|| self.new_round(view))
+                    .record_certificate(&message);
+                voter.recovered(message);
+
+                // Reprocess buffered votes only if the notarization changed the
+                // round's proposal.
+                if !proposal_changed {
+                    continue;
+                }
+                updated_view = view;
             },
             // Handle votes from the network
             Ok((sender, message)) = vote_receiver.recv() else break => {

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -438,7 +438,8 @@ mod tests {
 
         // A verified notarization establishes the proposal and drops the
         // verifier's notarize buffers
-        assert!(round.record_notarization(&proposal));
+        let notarization = build_notarization(&schemes, &proposal, quorum(5) as usize);
+        assert!(round.record_certificate(&Certificate::Notarization(notarization)));
         assert!(round.has_certificate(Kind::Notarization));
 
         // The proposal can be forwarded before the leader is known
@@ -473,7 +474,8 @@ mod tests {
         assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
 
         // A finalization does not establish the proposal
-        round.record_finalization();
+        let finalization = build_finalization(&schemes, &proposal, quorum(5) as usize);
+        assert!(!round.record_certificate(&Certificate::Finalization(finalization)));
         assert!(round.has_certificate(Kind::Finalization));
 
         // Setting the leader discovers the proposal from its buffered vote

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -569,6 +569,7 @@ mod tests {
                 );
             let voter_mailbox = voter::Mailbox::new(voter_sender);
 
+            // Register the batcher's vote and certificate channels.
             let (_vote_sender, vote_receiver) = oracle
                 .control(me.clone())
                 .register(0, TEST_QUOTA)
@@ -680,6 +681,187 @@ mod tests {
         certificate_forwarding_from_network(bls12381_multisig::fixture::<MinSig, _>);
         certificate_forwarding_from_network(ed25519::fixture);
         certificate_forwarding_from_network(secp256r1::fixture);
+    }
+
+    /// Regression: a notarization for a future view must unlock already-buffered
+    /// finalize votes even though that view's leader is not yet known.
+    fn notarization_unlocks_future_finalizes<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum_size = quorum(n) as usize;
+        let namespace = b"batcher_notarization_unlocks_future_finalizes".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            // Get participants.
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            // Create simulated network
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            // Setup reporter mock.
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            // Initialize batcher actor.
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter,
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            // Create voter mailbox for batcher to send to.
+            let (voter_sender, mut voter_receiver) =
+                mailbox::new::<voter::Message<S, Sha256Digest>>(
+                    context.child("mailbox"),
+                    NZUsize!(1024),
+                );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            // Register finalize-vote senders and link them to the batcher.
+            let link = Link {
+                latency: Duration::from_millis(1),
+                jitter: Duration::from_millis(0),
+                success_rate: 1.0,
+            };
+            let mut finalize_senders = Vec::new();
+            for (i, participant) in participants
+                .iter()
+                .enumerate()
+                .skip(1)
+                .take(quorum_size - 1)
+            {
+                let (sender, _receiver) = oracle
+                    .control(participant.clone())
+                    .register(0, TEST_QUOTA)
+                    .await
+                    .unwrap();
+                oracle
+                    .add_link(participant.clone(), me.clone(), link.clone())
+                    .await
+                    .unwrap();
+                finalize_senders.push((i, sender));
+            }
+
+            // Register a sender for the notarization certificate.
+            let (mut notarization_sender, _receiver) = oracle
+                .control(participants[1].clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            // Start the batcher.
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            // Initialize the batcher. The future view's leader remains unknown.
+            let current = View::new(1);
+            batcher_mailbox.update(
+                Span::none(),
+                current,
+                Participant::new(0),
+                View::zero(),
+                None,
+            );
+
+            // Build a proposal for the future view.
+            let future = current.next();
+            let proposal = Proposal::new(
+                Round::new(epoch, future),
+                current,
+                Sha256::hash(&[b"future_payload"]),
+            );
+
+            // Buffer a finalize quorum before the notarization. The future
+            // round has no leader yet, so these votes cannot be verified.
+            let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+            batcher_mailbox.constructed(Vote::Finalize(finalize));
+            for (i, mut sender) in finalize_senders {
+                let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+                sender
+                    .send(
+                        Recipients::One(me.clone()),
+                        Vote::Finalize(finalize).encode(),
+                        true,
+                    );
+            }
+
+            // Allow all finalize votes to arrive before the notarization.
+            context.sleep(Duration::from_millis(50)).await;
+
+            // The notarization authenticates the proposal without announcing
+            // the future round's leader.
+            let notarization = build_notarization(&schemes, &proposal, quorum_size);
+            notarization_sender
+                .send(
+                    Recipients::One(me),
+                    Certificate::Notarization(notarization).encode(),
+                    true,
+                );
+
+            // The notarization is forwarded before the recovered finalization.
+            let mut saw_notarization = false;
+            loop {
+                let message = select! {
+                    message = voter_receiver.recv() => message,
+                    _ = context.sleep(Duration::from_millis(100)) => {
+                        panic!("timed out waiting for finalization");
+                    },
+                };
+                match message.unwrap() {
+                    voter::Message::Verified {
+                        certificate: Certificate::Notarization(notarization),
+                        ..
+                    } => {
+                        assert_eq!(notarization.proposal, proposal);
+                        saw_notarization = true;
+                    }
+                    voter::Message::Verified {
+                        certificate: Certificate::Finalization(finalization),
+                        ..
+                    } => {
+                        assert!(saw_notarization);
+                        assert_eq!(finalization.proposal, proposal);
+                        break;
+                    },
+                    _ => {}
+                }
+            };
+        });
+    }
+
+    #[test_traced]
+    fn test_notarization_unlocks_future_finalizes() {
+        notarization_unlocks_future_finalizes(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        notarization_unlocks_future_finalizes(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        notarization_unlocks_future_finalizes(bls12381_threshold_std::fixture::<MinPk, _>);
+        notarization_unlocks_future_finalizes(bls12381_threshold_std::fixture::<MinSig, _>);
+        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinPk, _>);
+        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinSig, _>);
+        notarization_unlocks_future_finalizes(ed25519::fixture);
+        notarization_unlocks_future_finalizes(secp256r1::fixture);
     }
 
     /// Regression: an old notarization for view `V` is still forwarded to voter even

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -449,11 +449,10 @@ mod tests {
         );
     }
 
-    /// A finalization observed before the leader is known does not establish
-    /// the proposal. Setting the leader still discovers it from the leader's
-    /// buffered notarize vote.
+    /// A finalization replaces a conflicting leader-selected proposal and
+    /// makes its proposal authoritative.
     #[test]
-    fn test_set_leader_after_finalization() {
+    fn test_finalization_establishes_proposal() {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -468,21 +467,167 @@ mod tests {
             NoopReporter(PhantomData),
         );
 
-        // The leader's notarize arrives before the leader is known
-        let proposal = Proposal::new(round_id, View::new(0), Sha256::hash(&[b"payload"]));
-        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
+        // The leader's notarize arrives before the leader is known.
+        let leader_proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"leader"]));
+        let notarize = Notarize::sign(&schemes[0], leader_proposal).unwrap();
         assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
 
-        // A finalization does not establish the proposal
+        // Setting the leader selects its buffered proposal.
+        round.set_leader(Participant::from_usize(0));
+
+        // The finalization replaces the leader-selected proposal.
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"finalized"]));
         let finalization = build_finalization(&schemes, &proposal, quorum(5) as usize);
         assert!(!round.record_certificate(&Certificate::Finalization(finalization)));
         assert!(round.has_certificate(Kind::Finalization));
 
-        // Setting the leader discovers the proposal from its buffered vote
-        round.set_leader(Participant::from_usize(0));
+        // The finalization's proposal remains selected.
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(1)),
             Some(proposal)
+        );
+    }
+
+    /// A locally constructed finalize establishes the proposal without a known
+    /// leader.
+    #[test]
+    fn test_constructed_finalize_establishes_proposal() {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(
+            round_id,
+            View::zero(),
+            Sha256::hash(&[b"notarized_payload"]),
+        );
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+
+        // The constructed finalize establishes the proposal without relying
+        // on a leader vote.
+        let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+        round.add_constructed(Vote::Finalize(finalize));
+        assert_eq!(
+            round.try_forward_proposal(Participant::from_usize(0)),
+            Some(proposal)
+        );
+    }
+
+    /// A constructed finalize is added as verified while restoring only
+    /// matching network votes after replacing a conflicting leader proposal.
+    #[test_async]
+    async fn test_constructed_finalize_restores_only_network_votes() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            verifier,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let quorum_size = quorum(5) as usize;
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(verifier),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"notarized"]));
+
+        // Select a conflicting proposal from the leader's buffered vote.
+        let leader = Participant::from_usize(quorum_size);
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+        let notarize = Notarize::sign(&schemes[quorum_size], conflicting).unwrap();
+        assert!(round.add_network(participants[quorum_size].clone(), Vote::Notarize(notarize)));
+        round.set_leader(leader);
+
+        // These votes are retained by the tracker but filtered from the verifier.
+        for i in 1..quorum_size {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+
+        // The constructed finalize replaces the proposal and restores the
+        // matching network votes before it enters the tracker itself.
+        let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+        round.add_constructed(Vote::Finalize(finalize));
+
+        // Only the network votes require verification.
+        let (batch, invalid) = round
+            .try_verify(&mut rng, &Sequential)
+            .await
+            .expect("restored finalize quorum must be ready");
+        assert_eq!(batch, quorum_size - 1);
+        assert!(invalid.is_empty());
+        let certificate = round
+            .try_construct_certificate(&Sequential)
+            .await
+            .expect("restored finalize quorum must construct a certificate");
+        assert!(
+            matches!(certificate, Certificate::Finalization(finalization) if finalization.proposal == proposal)
+        );
+    }
+
+    /// A notarization restores matching finalize votes that were filtered when
+    /// a conflicting leader proposal was selected.
+    #[test_async]
+    async fn test_notarization_restores_filtered_finalizes() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            verifier,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let quorum_size = quorum(5) as usize;
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(verifier),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"notarized"]));
+
+        // Buffer some matching finalizes before selecting a proposal.
+        for i in 0..quorum_size / 2 {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+
+        // Selecting a conflicting leader proposal filters the buffered votes.
+        let leader = Participant::from_usize(quorum_size);
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+        let notarize = Notarize::sign(&schemes[quorum_size], conflicting).unwrap();
+        assert!(round.add_network(participants[quorum_size].clone(), Vote::Notarize(notarize)));
+        round.set_leader(leader);
+
+        // Matching finalizes received afterward are retained only by the vote
+        // tracker because they do not match the selected proposal.
+        for i in quorum_size / 2..quorum_size {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+
+        // The authoritative notarization restores both sets of votes.
+        let notarization = build_notarization(&schemes, &proposal, quorum_size);
+        assert!(round.record_certificate(&Certificate::Notarization(notarization)));
+        let (batch, invalid) = round
+            .try_verify(&mut rng, &Sequential)
+            .await
+            .expect("restored finalize quorum must be ready");
+        assert_eq!(batch, quorum_size);
+        assert!(invalid.is_empty());
+        let certificate = round
+            .try_construct_certificate(&Sequential)
+            .await
+            .expect("restored finalize quorum must construct a certificate");
+        assert!(
+            matches!(certificate, Certificate::Finalization(finalization) if finalization.proposal == proposal)
         );
     }
 
@@ -796,10 +941,8 @@ mod tests {
                 Sha256::hash(&[b"future_payload"]),
             );
 
-            // Buffer a finalize quorum before the notarization. The future
-            // round has no leader yet, so these votes cannot be verified.
-            let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-            batcher_mailbox.constructed(Vote::Finalize(finalize));
+            // Buffer the network finalize votes before the notarization. The
+            // future round has no leader yet, so they cannot be verified.
             for (i, mut sender) in finalize_senders {
                 let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
                 sender
@@ -838,6 +981,11 @@ mod tests {
                         ..
                     } => {
                         assert_eq!(notarization.proposal, proposal);
+
+                        // Complete the quorum only after the notarization has
+                        // restored the network votes.
+                        let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+                        batcher_mailbox.constructed(Vote::Finalize(finalize));
                         saw_notarization = true;
                     }
                     voter::Message::Verified {

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -413,11 +413,10 @@ mod tests {
         });
     }
 
-    /// A certificate observed before the leader is known must not lose the
-    /// leader's buffered vote: the round discovers the proposal from its vote
-    /// tracker even after certification drops the verifier's buffers.
+    /// A notarization observed before the leader is known establishes a
+    /// proposal that can be forwarded immediately.
     #[test]
-    fn test_set_leader_after_certification() {
+    fn test_forward_proposal_from_notarization_without_leader() {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -437,11 +436,47 @@ mod tests {
         let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
         assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
 
-        // A notarization certificate drops the verifier's notarize buffers
-        round.record_certificate(Kind::Notarization);
+        // A verified notarization establishes the proposal and drops the
+        // verifier's notarize buffers
+        assert!(round.record_notarization(&proposal));
         assert!(round.has_certificate(Kind::Notarization));
 
-        // The leader's proposal is still discovered when the leader is set
+        // The proposal can be forwarded before the leader is known
+        assert_eq!(
+            round.try_forward_proposal(Participant::from_usize(1)),
+            Some(proposal)
+        );
+    }
+
+    /// A finalization observed before the leader is known does not establish
+    /// the proposal. Setting the leader still discovers it from the leader's
+    /// buffered notarize vote.
+    #[test]
+    fn test_set_leader_after_finalization() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[1].clone()),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+
+        // The leader's notarize arrives before the leader is known
+        let proposal = Proposal::new(round_id, View::new(0), Sha256::hash(&[b"payload"]));
+        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
+        assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
+
+        // A finalization does not establish the proposal
+        round.record_finalization();
+        assert!(round.has_certificate(Kind::Finalization));
+
+        // Setting the leader discovers the proposal from its buffered vote
         round.set_leader(Participant::from_usize(0));
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(1)),

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -982,8 +982,8 @@ mod tests {
                     } => {
                         assert_eq!(notarization.proposal, proposal);
 
-                        // Complete the quorum only after the notarization has
-                        // restored the network votes.
+                        // Complete the quorum only after the notarization has made
+                        // the buffered network votes eligible.
                         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
                         batcher_mailbox.constructed(Vote::Finalize(finalize));
                         saw_notarization = true;

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -28,9 +28,13 @@ pub struct Round<
 > {
     blocker: B,
     reporter: R,
-    /// Verifier only attempts to recover a certificate from votes for the first proposal
-    /// we see from a leader. If we are on the wrong side of an equivocation, the verifier
-    /// will not produce anything of value (and we'll only participate by forwarding certificates).
+    /// The verifier attempts to recover notarizations and finalizations only
+    /// from votes for one proposal. It initially filters to the first proposal
+    /// observed from the known leader. If the leader equivocates, a node that
+    /// observed the losing proposal cannot recover a proposal certificate
+    /// locally, but can still forward certificates recovered elsewhere. A
+    /// verified notarization is authoritative and switches the filter to its
+    /// proposal.
     verifier: Verifier<S, D>,
     /// Votes received from network (may not be verified yet).
     /// Used for duplicate detection and conflict reporting.
@@ -92,8 +96,29 @@ impl<
     }
 
     /// Records that a certificate of `kind` exists, dropping its buffered votes.
-    pub fn record_certificate(&mut self, kind: Kind) {
+    fn record_certificate(&mut self, kind: Kind) {
         self.verifier.record_certificate(kind);
+    }
+
+    /// Records a verified notarization, dropping its buffered votes and
+    /// adopting its authoritative proposal, which replaces any conflicting
+    /// proposal learned from the leader's vote.
+    ///
+    /// Returns whether the proposal changed.
+    pub fn record_notarization(&mut self, proposal: &Proposal<D>) -> bool {
+        let changed = self.verifier.set_proposal(proposal.clone());
+        self.record_certificate(Kind::Notarization);
+        changed
+    }
+
+    /// Records a verified nullification, dropping its buffered votes.
+    pub fn record_nullification(&mut self) {
+        self.record_certificate(Kind::Nullification);
+    }
+
+    /// Records a verified finalization, dropping its buffered votes.
+    pub fn record_finalization(&mut self) {
+        self.record_certificate(Kind::Finalization);
     }
 
     /// Adds a vote from the network to this round's verifier.
@@ -261,16 +286,15 @@ impl<
             .set_leader(leader, self.votes.notarize(leader));
     }
 
-    /// Returns the leader's proposal to forward to the voter, marking it sent
-    /// (at most once per round). Returns `None` if we already forwarded one,
-    /// the leader's proposal is unknown, or we are the leader (leaders don't
-    /// need to forward their own proposal).
+    /// Returns the proposal to forward to the voter, marking it sent (at most
+    /// once per round). Returns `None` if we already forwarded one, the
+    /// proposal is unknown, or the known leader is us.
     pub fn try_forward_proposal(&mut self, me: Participant) -> Option<Proposal<D>> {
         if self.proposal_sent {
             return None;
         }
-        let (leader, proposal) = self.verifier.get_leader_proposal()?;
-        if leader == me {
+        let proposal = self.verifier.proposal()?;
+        if self.verifier.leader() == Some(me) {
             return None;
         }
         let proposal = proposal.clone();

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -95,12 +95,12 @@ impl<
         self.verifier.has_certificate(kind)
     }
 
-    /// Records a verified certificate and returns whether the round's
-    /// proposal changed.
+    /// Records a verified certificate and returns whether the round's proposal
+    /// changed.
     ///
-    /// Only a notarization can change the proposal. Its proposal is authoritative and replaces any
-    /// conflicting proposal learned from the leader's vote. Nullifications and finalizations leave
-    /// the proposal unchanged.
+    /// Only a notarization can change the proposal. Its proposal is
+    /// authoritative and replaces any conflicting proposal learned from the
+    /// leader's vote.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
         let proposal_changed = match certificate {
             Certificate::Notarization(notarization) => self

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -30,17 +30,17 @@ pub struct Round<
     reporter: R,
     /// The verifier attempts to recover notarizations and finalizations only
     /// from votes for one proposal. It initially filters to the first proposal
-    /// observed from the known leader. If the leader equivocates, a node that
-    /// observed the losing proposal cannot recover a proposal certificate
-    /// locally, but can still forward certificates recovered elsewhere. A
-    /// verified notarization is authoritative and switches the filter to its
-    /// proposal.
+    /// observed from the known leader. Independently authenticated proposal
+    /// evidence is authoritative and switches the filter.
     verifier: Verifier<S, D>,
-    /// Votes received from network (may not be verified yet).
-    /// Used for duplicate detection and conflict reporting.
+    /// At most one vote of each kind per signer.
+    ///
+    /// Includes locally constructed votes and network votes that may not be
+    /// verified. Used for duplicate detection, conflict reporting, and
+    /// proposal-switch recovery.
     votes: VoteTracker<S, D>,
 
-    /// Whether we've already sent the leader's proposal to the voter.
+    /// Whether we've already sent the selected proposal to the voter.
     proposal_sent: bool,
 
     /// Root span of the view, shared with the voter's round.
@@ -95,21 +95,51 @@ impl<
         self.verifier.has_certificate(kind)
     }
 
-    /// Records a verified certificate and returns whether the round's proposal
-    /// changed.
+    /// Records a verified certificate.
     ///
-    /// Only a notarization can change the proposal. Its proposal is
-    /// authoritative and replaces any conflicting proposal learned from the
-    /// leader's vote.
+    /// The first notarization or finalization establishes an authoritative
+    /// proposal and may replace one learned from the leader's vote. Returns
+    /// `true` when a notarization selects a new proposal, making its buffered
+    /// finalize votes eligible for processing.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
-        let proposal_changed = match certificate {
-            Certificate::Notarization(notarization) => self
-                .verifier
-                .set_proposal(ProposalState::Notarization(notarization.proposal.clone())),
-            Certificate::Nullification(_) | Certificate::Finalization(_) => false,
+        let process_votes = match certificate {
+            Certificate::Notarization(notarization) => {
+                self.set_authoritative_proposal(&notarization.proposal)
+            }
+            Certificate::Finalization(finalization) => {
+                // A finalization may replace the leader-selected proposal, but its
+                // certificate makes reprocessing buffered finalize votes unnecessary.
+                self.verifier
+                    .set_proposal(ProposalState::Certificate(finalization.proposal.clone()));
+                false
+            }
+            Certificate::Nullification(_) => false,
         };
         self.verifier.record_certificate(certificate.kind());
-        proposal_changed
+        process_votes
+    }
+
+    /// Makes an independently authenticated proposal authoritative, restoring
+    /// finalize votes filtered by a conflicting leader proposal.
+    ///
+    /// Returns whether the selected proposal changed.
+    fn set_authoritative_proposal(&mut self, proposal: &Proposal<D>) -> bool {
+        let update = self
+            .verifier
+            .set_proposal(ProposalState::Certificate(proposal.clone()));
+        if update.replaced {
+            // Matching tracked finalizes are unverified network votes: the conflicting
+            // leader proposal filtered them, while constructed finalizes establish the
+            // proposal before entering the tracker.
+            for finalize in self
+                .votes
+                .iter_finalizes()
+                .filter(|finalize| &finalize.proposal == proposal)
+            {
+                self.verifier.add(Vote::Finalize(finalize.clone()), false);
+            }
+        }
+        update.changed
     }
 
     /// Adds a vote from the network to this round's verifier.
@@ -252,7 +282,9 @@ impl<
                 self.reporter.report(Activity::Nullify(nullify.clone()));
             }
             Vote::Finalize(finalize) => {
-                // Our own votes are already verified
+                // The voter only constructs a finalize after independently
+                // authenticating the proposal.
+                self.set_authoritative_proposal(&finalize.proposal);
                 assert!(
                     self.votes.insert_finalize(finalize.clone()),
                     "duplicate finalize"
@@ -263,7 +295,7 @@ impl<
             }
         }
 
-        // The verifier drops votes for a different proposal than the leader's.
+        // The verifier drops votes for a different proposal than the selected one.
         self.verifier.add(message, true);
     }
 

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -1,4 +1,4 @@
-use super::Verifier;
+use super::{Verifier, verifier::ProposalState};
 use crate::{
     Reporter,
     simplex::{
@@ -95,30 +95,21 @@ impl<
         self.verifier.has_certificate(kind)
     }
 
-    /// Records that a certificate of `kind` exists, dropping its buffered votes.
-    fn record_certificate(&mut self, kind: Kind) {
-        self.verifier.record_certificate(kind);
-    }
-
-    /// Records a verified notarization, dropping its buffered votes and
-    /// adopting its authoritative proposal, which replaces any conflicting
-    /// proposal learned from the leader's vote.
+    /// Records a verified certificate and returns whether the round's
+    /// proposal changed.
     ///
-    /// Returns whether the proposal changed.
-    pub fn record_notarization(&mut self, proposal: &Proposal<D>) -> bool {
-        let changed = self.verifier.set_proposal(proposal.clone());
-        self.record_certificate(Kind::Notarization);
-        changed
-    }
-
-    /// Records a verified nullification, dropping its buffered votes.
-    pub fn record_nullification(&mut self) {
-        self.record_certificate(Kind::Nullification);
-    }
-
-    /// Records a verified finalization, dropping its buffered votes.
-    pub fn record_finalization(&mut self) {
-        self.record_certificate(Kind::Finalization);
+    /// Only a notarization can change the proposal. Its proposal is authoritative and replaces any
+    /// conflicting proposal learned from the leader's vote. Nullifications and finalizations leave
+    /// the proposal unchanged.
+    pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
+        let proposal_changed = match certificate {
+            Certificate::Notarization(notarization) => self
+                .verifier
+                .set_proposal(ProposalState::Notarization(notarization.proposal.clone())),
+            Certificate::Nullification(_) | Certificate::Finalization(_) => false,
+        };
+        self.verifier.record_certificate(certificate.kind());
+        proposal_changed
     }
 
     /// Adds a vote from the network to this round's verifier.

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -154,6 +154,26 @@ impl<V> Certification<V> {
     }
 }
 
+/// What the round knows about its proposal, and how it was learned.
+pub(super) enum ProposalState<D: Digest> {
+    /// No proposal is known.
+    Unknown,
+    /// Learned from the leader's notarize vote. May be replaced by a notarization.
+    Leader(Proposal<D>),
+    /// Learned from a verified notarization. Never replaced.
+    Notarization(Proposal<D>),
+}
+
+impl<D: Digest> ProposalState<D> {
+    /// Returns the proposal, if known.
+    const fn proposal(&self) -> Option<&Proposal<D>> {
+        match self {
+            Self::Unknown => None,
+            Self::Leader(proposal) | Self::Notarization(proposal) => Some(proposal),
+        }
+    }
+}
+
 /// `Verifier` is a utility for tracking and verifying consensus messages.
 ///
 /// For schemes where [`Verifier::is_batchable()`](commonware_cryptography::certificate::Verifier::is_batchable)
@@ -187,7 +207,7 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
     /// A known leader's notarize vote may supply the initial proposal. A
     /// verified notarization is authoritative and may replace it, or establish
     /// the proposal before the leader is identified.
-    proposal: Option<Proposal<D>>,
+    proposal: ProposalState<D>,
 
     /// Notarize certification progress.
     notarize: Certification<Notarize<S, D>>,
@@ -215,7 +235,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             round,
 
             leader: None,
-            proposal: None,
+            proposal: ProposalState::Unknown,
 
             notarize: Certification::new(quorum, batchable),
             nullify: Certification::new(quorum, batchable),
@@ -235,7 +255,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
 
     /// Returns the round's proposal, once known.
     pub const fn proposal(&self) -> Option<&Proposal<D>> {
-        self.proposal.as_ref()
+        self.proposal.proposal()
     }
 
     /// Attempts to construct a certificate from verified votes: the first kind
@@ -321,10 +341,10 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Does nothing if the leader is unknown, `notarize` is not from the
     /// leader, or a proposal is already set.
     fn try_set_proposal_from_leader(&mut self, notarize: &Notarize<S, D>) {
-        if self.proposal.is_some() || self.leader != Some(notarize.signer()) {
+        if self.proposal().is_some() || self.leader != Some(notarize.signer()) {
             return;
         }
-        self.set_proposal(notarize.proposal.clone());
+        self.set_proposal(ProposalState::Leader(notarize.proposal.clone()));
     }
 
     /// Adopts the proposal to which notarize and finalize votes are filtered,
@@ -332,19 +352,14 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// other proposal.
     ///
     /// Returns whether the proposal changed.
-    pub(super) fn set_proposal(&mut self, proposal: Proposal<D>) -> bool {
-        if self.proposal.as_ref() == Some(&proposal) {
-            return false;
+    pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> bool {
+        let changed = self.proposal() != proposal.proposal();
+        if changed && let Some(new) = proposal.proposal() {
+            self.notarize.retain(|n| &n.proposal == new);
+            self.finalize.retain(|f| &f.proposal == new);
         }
-
-        // The leader-vote path calls this only while the proposal is unknown.
-        // The verified-notarization path may replace a conflicting proposal
-        // because its certificate is authoritative.
-        self.notarize.retain(|n| n.proposal == proposal);
-        self.finalize.retain(|f| f.proposal == proposal);
-        self.proposal = Some(proposal);
-
-        true
+        self.proposal = proposal;
+        changed
     }
 
     /// Adds a [Vote] message to the batch for later verification.
@@ -367,7 +382,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 self.try_set_proposal_from_leader(&notarize);
 
                 // If the proposal is known and the message is not for it, drop it
-                if let Some(proposal) = &self.proposal
+                if let Some(proposal) = self.proposal()
                     && proposal != &notarize.proposal
                 {
                     return;
@@ -379,7 +394,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             }
             Vote::Finalize(finalize) => {
                 // If the proposal is known and the message is not for it, drop it
-                if let Some(proposal) = &self.proposal
+                if let Some(proposal) = self.proposal()
                     && proposal != &finalize.proposal
                 {
                     return;
@@ -431,7 +446,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ) -> Option<(usize, Vec<Participant>)> {
         // Until the proposal is known, notarizes may reference many different
         // proposals.
-        self.proposal.as_ref()?;
+        if matches!(self.proposal, ProposalState::Unknown) {
+            return None;
+        }
         self.notarize
             .try_verify(|notarizes, mut verified_notarizes| {
                 let span = info_span!(
@@ -541,7 +558,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ) -> Option<(usize, Vec<Participant>)> {
         // Until the proposal is known, finalizes may reference many different
         // proposals.
-        self.proposal.as_ref()?;
+        if matches!(self.proposal, ProposalState::Unknown) {
+            return None;
+        }
         self.finalize
             .try_verify(|finalizes, mut verified_finalizes| {
                 let span = info_span!(
@@ -763,14 +782,16 @@ mod tests {
         verifier2.set_leader(leader, Some(&leader_notarize));
         assert_eq!(verifier2.leader(), Some(leader));
         assert_eq!(verifier2.proposal(), Some(&leader_notarize.proposal));
-        assert!(!verifier2.set_proposal(leader_notarize.proposal.clone()));
 
         // A verified notarization supersedes a conflicting proposal learned
         // from the leader's vote.
-        let certified_proposal = Proposal::new(round, View::new(0), sample_digest(2));
-        assert_ne!(certified_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(certified_proposal.clone()));
-        assert_eq!(verifier2.proposal(), Some(&certified_proposal));
+        let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
+        assert_ne!(notarized_proposal, leader_notarize.proposal);
+        assert!(verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
+
+        // Re-adopting the same proposal reports no change.
+        assert!(!verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
 
         // If the notarization arrives first, setting the leader cannot replace
         // its proposal with a conflicting buffered leader vote.
@@ -779,12 +800,12 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(certified_proposal.clone()));
+        assert!(verifier3.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
         assert!(verifier3.leader().is_none());
-        assert_eq!(verifier3.proposal(), Some(&certified_proposal));
+        assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));
         assert_eq!(verifier3.leader(), Some(leader));
-        assert_eq!(verifier3.proposal(), Some(&certified_proposal));
+        assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
     }
 
     #[test]
@@ -1383,7 +1404,7 @@ mod tests {
 
         let (mut verifier, finalize) = test_verifier_finalize();
 
-        verifier.set_proposal(finalize.proposal.clone());
+        verifier.set_proposal(ProposalState::Notarization(finalize.proposal.clone()));
         assert!(verifier.leader.is_none());
         assert!(
             verifier

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -154,14 +154,24 @@ impl<V> Certification<V> {
     }
 }
 
+/// How the selected proposal changed after an update.
+pub(super) struct ProposalUpdate {
+    /// Whether the selected proposal changed.
+    pub(super) changed: bool,
+    /// Whether an existing proposal was replaced with a different one.
+    pub(super) replaced: bool,
+}
+
 /// What the round knows about its proposal, and how it was learned.
 pub(super) enum ProposalState<D: Digest> {
     /// No proposal is known.
     Unknown,
-    /// Learned from the leader's notarize vote. May be replaced by a notarization.
+    /// Learned from the leader's notarize vote. An authoritative proposal may
+    /// replace it.
     Leader(Proposal<D>),
-    /// Learned from a verified notarization. Never replaced.
-    Notarization(Proposal<D>),
+    /// Learned from a verified certificate or locally constructed finalize.
+    /// Never replaced.
+    Certificate(Proposal<D>),
 }
 
 impl<D: Digest> ProposalState<D> {
@@ -169,23 +179,21 @@ impl<D: Digest> ProposalState<D> {
     const fn proposal(&self) -> Option<&Proposal<D>> {
         match self {
             Self::Unknown => None,
-            Self::Leader(proposal) | Self::Notarization(proposal) => Some(proposal),
+            Self::Leader(proposal) | Self::Certificate(proposal) => Some(proposal),
         }
     }
 
-    /// Updates the proposal from a leader vote or notarization.
+    /// Updates the proposal from a leader vote or authoritative evidence.
     ///
-    /// An unknown proposal accepts either source, while a proposal from a
-    /// leader vote may be superseded by the first notarization. All other
-    /// transitions are ignored.
+    /// An unknown proposal accepts either source. An authoritative proposal
+    /// may supersede a leader vote. All other transitions are ignored.
     ///
-    /// Returns the selected proposal if its value changed. A provenance-only
-    /// change from a leader vote to a notarization of the same proposal returns
-    /// `None`.
+    /// Returns the selected proposal if its value changed. Certifying the
+    /// leader-selected proposal returns `None`.
     fn update(&mut self, next: Self) -> Option<&Proposal<D>> {
         match (&*self, &next) {
-            (Self::Unknown, Self::Leader(_) | Self::Notarization(_)) => {}
-            (Self::Leader(_), Self::Notarization(_)) => {}
+            (Self::Unknown, Self::Leader(_) | Self::Certificate(_)) => {}
+            (Self::Leader(_), Self::Certificate(_)) => {}
             _ => return None,
         }
 
@@ -225,9 +233,9 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
 
     /// The round's proposal, once known.
     ///
-    /// A known leader's notarize vote may supply the initial proposal. A
-    /// verified notarization is authoritative and may replace it, or establish
-    /// the proposal before the leader is identified.
+    /// A known leader's notarize vote may supply the initial proposal. An
+    /// independently authenticated proposal is authoritative and may replace
+    /// it, or be established before the leader is identified.
     proposal: ProposalState<D>,
 
     /// Notarize certification progress.
@@ -371,16 +379,23 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Updates the proposal state and, if the selected proposal changes, drops
     /// buffered notarize and finalize votes for any other proposal.
     ///
-    /// Returns `true` only if the selected proposal changed. Rejected
-    /// transitions and a provenance-only change from a leader vote to a
-    /// notarization of the same proposal return `false`.
-    pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> bool {
+    /// Returns whether the selected proposal changed and whether the accepted
+    /// change replaced an existing proposal. Rejected transitions and a
+    /// provenance-only change return `false` for both.
+    pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> ProposalUpdate {
+        let replaced = self.proposal.proposal().is_some();
         let Some(proposal) = self.proposal.update(proposal) else {
-            return false;
+            return ProposalUpdate {
+                changed: false,
+                replaced: false,
+            };
         };
         self.notarize.retain(|n| &n.proposal == proposal);
         self.finalize.retain(|f| &f.proposal == proposal);
-        true
+        ProposalUpdate {
+            changed: true,
+            replaced,
+        }
     }
 
     /// Adds a [Vote] message to the batch for later verification.
@@ -428,8 +443,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Sets the leader for the current consensus view.
     ///
     /// `notarize` carries the leader's already-received vote, if any. Its
-    /// proposal is learned when none is known. A proposal already established
-    /// by a verified notarization remains authoritative.
+    /// proposal is learned when none is known. An authoritative proposal is
+    /// never replaced.
     ///
     /// # Panics
     ///
@@ -485,7 +500,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                         .map(|n| (n.proposal, n.attestation))
                         .unzip();
                     // All proposals here are equal: pending votes are filtered to the
-                    // leader's proposal before verification becomes ready.
+                    // selected proposal before verification becomes ready.
                     let proposal = &proposals[0];
 
                     let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
@@ -808,16 +823,26 @@ mod tests {
         // from the leader's vote.
         let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
         assert_ne!(notarized_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert!(
+            verifier2
+                .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
+                .changed
+        );
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // Re-adopting the same proposal reports no change.
-        assert!(!verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert!(
+            !verifier2
+                .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
+                .changed
+        );
 
         // The first notarization remains authoritative.
         let conflicting_notarized_proposal = Proposal::new(round, View::new(0), sample_digest(3));
         assert!(
-            !verifier2.set_proposal(ProposalState::Notarization(conflicting_notarized_proposal))
+            !verifier2
+                .set_proposal(ProposalState::Certificate(conflicting_notarized_proposal))
+                .changed
         );
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
@@ -828,7 +853,11 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert!(
+            verifier3
+                .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
+                .changed
+        );
         assert!(verifier3.leader().is_none());
         assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));
@@ -1432,7 +1461,7 @@ mod tests {
 
         let (mut verifier, finalize) = test_verifier_finalize();
 
-        verifier.set_proposal(ProposalState::Notarization(finalize.proposal.clone()));
+        verifier.set_proposal(ProposalState::Certificate(finalize.proposal.clone()));
         assert!(verifier.leader.is_none());
         assert!(
             verifier

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -172,6 +172,27 @@ impl<D: Digest> ProposalState<D> {
             Self::Leader(proposal) | Self::Notarization(proposal) => Some(proposal),
         }
     }
+
+    /// Updates the proposal from a leader vote or notarization.
+    ///
+    /// An unknown proposal accepts either source, while a proposal from a
+    /// leader vote may be superseded by the first notarization. All other
+    /// transitions are ignored.
+    ///
+    /// Returns the selected proposal if its value changed. A provenance-only
+    /// change from a leader vote to a notarization of the same proposal returns
+    /// `None`.
+    fn update(&mut self, next: Self) -> Option<&Proposal<D>> {
+        match (&*self, &next) {
+            (Self::Unknown, Self::Leader(_) | Self::Notarization(_)) => {}
+            (Self::Leader(_), Self::Notarization(_)) => {}
+            _ => return None,
+        }
+
+        let changed = self.proposal() != next.proposal();
+        *self = next;
+        changed.then(|| self.proposal().expect("updated proposal must be known"))
+    }
 }
 
 /// `Verifier` is a utility for tracking and verifying consensus messages.
@@ -339,27 +360,27 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// certificate).
     ///
     /// Does nothing if the leader is unknown, `notarize` is not from the
-    /// leader, or a proposal is already set.
+    /// leader, or the proposal state rejects the transition.
     fn try_set_proposal_from_leader(&mut self, notarize: &Notarize<S, D>) {
-        if self.proposal().is_some() || self.leader != Some(notarize.signer()) {
+        if self.leader != Some(notarize.signer()) {
             return;
         }
         self.set_proposal(ProposalState::Leader(notarize.proposal.clone()));
     }
 
-    /// Adopts the proposal to which notarize and finalize votes are filtered,
-    /// replacing any previous proposal and dropping buffered votes for any
-    /// other proposal.
+    /// Updates the proposal state and, if the selected proposal changes, drops
+    /// buffered notarize and finalize votes for any other proposal.
     ///
-    /// Returns whether the proposal changed.
+    /// Returns `true` only if the selected proposal changed. Rejected
+    /// transitions and a provenance-only change from a leader vote to a
+    /// notarization of the same proposal return `false`.
     pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> bool {
-        let changed = self.proposal() != proposal.proposal();
-        if changed && let Some(new) = proposal.proposal() {
-            self.notarize.retain(|n| &n.proposal == new);
-            self.finalize.retain(|f| &f.proposal == new);
-        }
-        self.proposal = proposal;
-        changed
+        let Some(proposal) = self.proposal.update(proposal) else {
+            return false;
+        };
+        self.notarize.retain(|n| &n.proposal == proposal);
+        self.finalize.retain(|f| &f.proposal == proposal);
+        true
     }
 
     /// Adds a [Vote] message to the batch for later verification.
@@ -792,6 +813,13 @@ mod tests {
 
         // Re-adopting the same proposal reports no change.
         assert!(!verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+
+        // The first notarization remains authoritative.
+        let conflicting_notarized_proposal = Proposal::new(round, View::new(0), sample_digest(3));
+        assert!(
+            !verifier2.set_proposal(ProposalState::Notarization(conflicting_notarized_proposal))
+        );
+        assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // If the notarization arrives first, setting the leader cannot replace
         // its proposal with a conflicting buffered leader vote.

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -154,19 +154,6 @@ impl<V> Certification<V> {
     }
 }
 
-/// The leader lifecycle for one view.
-enum Leader<D: Digest> {
-    /// Not yet announced by the voter.
-    Unknown,
-    /// Announced, but their proposal is not yet known.
-    Known(Participant),
-    /// Their proposal is known. Notarize and finalize votes filter to it.
-    Proposed {
-        leader: Participant,
-        proposal: Proposal<D>,
-    },
-}
-
 /// `Verifier` is a utility for tracking and verifying consensus messages.
 ///
 /// For schemes where [`Verifier::is_batchable()`](commonware_cryptography::certificate::Verifier::is_batchable)
@@ -192,8 +179,15 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
     /// The round being certified.
     round: Rnd,
 
-    /// The leader lifecycle.
-    leader: Leader<D>,
+    /// The round's leader, once identified.
+    leader: Option<Participant>,
+
+    /// The round's proposal, once known.
+    ///
+    /// A known leader's notarize vote may supply the initial proposal. A
+    /// verified notarization is authoritative and may replace it, or establish
+    /// the proposal before the leader is identified.
+    proposal: Option<Proposal<D>>,
 
     /// Notarize certification progress.
     notarize: Certification<Notarize<S, D>>,
@@ -220,7 +214,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
 
             round,
 
-            leader: Leader::Unknown,
+            leader: None,
+            proposal: None,
 
             notarize: Certification::new(quorum, batchable),
             nullify: Certification::new(quorum, batchable),
@@ -231,6 +226,16 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Returns the ordered participant set.
     pub(super) fn participants(&self) -> &Set<S::PublicKey> {
         self.scheme.participants()
+    }
+
+    /// Returns the round's leader, once known.
+    pub const fn leader(&self) -> Option<Participant> {
+        self.leader
+    }
+
+    /// Returns the round's proposal, once known.
+    pub const fn proposal(&self) -> Option<&Proposal<D>> {
+        self.proposal.as_ref()
     }
 
     /// Attempts to construct a certificate from verified votes: the first kind
@@ -309,29 +314,37 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         }
     }
 
-    /// Learns the leader's proposal from `notarize`, dropping buffered votes
-    /// for any other proposal (they cannot contribute to a certificate).
-    /// Does nothing unless the leader is [Leader::Known] and the vote is theirs.
-    fn try_learn_proposal(&mut self, notarize: &Notarize<S, D>) {
-        let Leader::Known(leader) = &self.leader else {
-            return;
-        };
-        let leader = *leader;
-        if leader != notarize.signer() {
+    /// Tries to set the proposal from the known leader's notarize, dropping
+    /// buffered votes for any other proposal (they cannot contribute to a
+    /// certificate).
+    ///
+    /// Does nothing if the leader is unknown, `notarize` is not from the
+    /// leader, or a proposal is already set.
+    fn try_set_proposal_from_leader(&mut self, notarize: &Notarize<S, D>) {
+        if self.proposal.is_some() || self.leader != Some(notarize.signer()) {
             return;
         }
-        let proposal = notarize.proposal.clone();
-        self.notarize.retain(|n| n.proposal == proposal);
-        self.finalize.retain(|f| f.proposal == proposal);
-        self.leader = Leader::Proposed { leader, proposal };
+        self.set_proposal(notarize.proposal.clone());
     }
 
-    /// Returns the leader and their proposal, once known.
-    pub const fn get_leader_proposal(&self) -> Option<(Participant, &Proposal<D>)> {
-        match &self.leader {
-            Leader::Proposed { leader, proposal } => Some((*leader, proposal)),
-            _ => None,
+    /// Adopts the proposal to which notarize and finalize votes are filtered,
+    /// replacing any previous proposal and dropping buffered votes for any
+    /// other proposal.
+    ///
+    /// Returns whether the proposal changed.
+    pub(super) fn set_proposal(&mut self, proposal: Proposal<D>) -> bool {
+        if self.proposal.as_ref() == Some(&proposal) {
+            return false;
         }
+
+        // The leader-vote path calls this only while the proposal is unknown.
+        // The verified-notarization path may replace a conflicting proposal
+        // because its certificate is authoritative.
+        self.notarize.retain(|n| n.proposal == proposal);
+        self.finalize.retain(|f| f.proposal == proposal);
+        self.proposal = Some(proposal);
+
+        true
     }
 
     /// Adds a [Vote] message to the batch for later verification.
@@ -339,7 +352,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// If the message has already been verified (e.g., we built it), it is stored
     /// directly for certificate recovery. Otherwise, it is added to the appropriate
     /// pending queue. Notarize and finalize votes for a proposal other than the
-    /// known leader's are dropped since they cannot contribute to a certificate.
+    /// known proposal are dropped since they cannot contribute to a certificate.
     ///
     /// If a leader is known and the message is a [Vote::Notarize] from that leader,
     /// this method may reveal the leader proposal.
@@ -351,10 +364,10 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     pub fn add(&mut self, msg: Vote<S, D>, verified: bool) {
         match msg {
             Vote::Notarize(notarize) => {
-                self.try_learn_proposal(&notarize);
+                self.try_set_proposal_from_leader(&notarize);
 
-                // If the leader's proposal is known and the message is not for it, drop it
-                if let Leader::Proposed { proposal, .. } = &self.leader
+                // If the proposal is known and the message is not for it, drop it
+                if let Some(proposal) = &self.proposal
                     && proposal != &notarize.proposal
                 {
                     return;
@@ -365,8 +378,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 self.nullify.add(nullify, verified);
             }
             Vote::Finalize(finalize) => {
-                // If the leader's proposal is known and the message is not for it, drop it
-                if let Leader::Proposed { proposal, .. } = &self.leader
+                // If the proposal is known and the message is not for it, drop it
+                if let Some(proposal) = &self.proposal
                     && proposal != &finalize.proposal
                 {
                     return;
@@ -378,25 +391,26 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
 
     /// Sets the leader for the current consensus view.
     ///
-    /// `notarize` carries the leader's already-received vote, if any. Their
-    /// proposal is learned from it and votes for other proposals are dropped.
+    /// `notarize` carries the leader's already-received vote, if any. Its
+    /// proposal is learned when none is known. A proposal already established
+    /// by a verified notarization remains authoritative.
     ///
     /// # Panics
     ///
     /// Panics if a leader was already set or if `notarize` is not from
     /// `leader`.
     pub fn set_leader(&mut self, leader: Participant, notarize: Option<&Notarize<S, D>>) {
-        assert!(matches!(self.leader, Leader::Unknown));
-        self.leader = Leader::Known(leader);
+        assert!(self.leader.is_none(), "leader already set");
+        self.leader = Some(leader);
         if let Some(notarize) = notarize {
             assert_eq!(notarize.signer(), leader, "notarize must be from leader");
-            self.try_learn_proposal(notarize);
+            self.try_set_proposal_from_leader(notarize);
         }
     }
 
     /// Batch verifies pending [Vote::Notarize] messages, if worthwhile: the
-    /// leader's proposal is known (notarizes reference one proposal) and the
-    /// buffers warrant a batch (see [Certification::should_verify]).
+    /// proposal is known (notarizes reference one proposal) and the buffers
+    /// warrant a batch (see [Certification::should_verify]).
     ///
     /// It uses `S::verify_attestations` for efficient batch verification, run as one CPU-bound job
     /// submitted through [Strategy::spawn] so a parallel strategy hosts it on its own pool
@@ -415,11 +429,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        // Until the leader's proposal is known, notarizes may reference many
-        // different proposals.
-        if !matches!(self.leader, Leader::Proposed { .. }) {
-            return None;
-        }
+        // Until the proposal is known, notarizes may reference many different
+        // proposals.
+        self.proposal.as_ref()?;
         self.notarize
             .try_verify(|notarizes, mut verified_notarizes| {
                 let span = info_span!(
@@ -507,8 +519,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     }
 
     /// Batch verifies pending [Vote::Finalize] messages, if worthwhile: the
-    /// leader's proposal is known (finalizes reference one proposal) and the
-    /// buffers warrant a batch (see [Certification::should_verify]).
+    /// proposal is known (finalizes reference one proposal) and the buffers
+    /// warrant a batch (see [Certification::should_verify]).
     ///
     /// It uses `S::verify_attestations` for efficient batch verification, run as one CPU-bound job
     /// submitted through [Strategy::spawn] so a parallel strategy hosts it on its own pool
@@ -527,11 +539,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        // Until the leader's proposal is known, finalizes may reference many
-        // different proposals.
-        if !matches!(self.leader, Leader::Proposed { .. }) {
-            return None;
-        }
+        // Until the proposal is known, finalizes may reference many different
+        // proposals.
+        self.proposal.as_ref()?;
         self.finalize
             .try_verify(|finalizes, mut verified_finalizes| {
                 let span = info_span!(
@@ -671,10 +681,8 @@ mod tests {
         assert_eq!(verifier.notarize.verified().len(), 1);
 
         verifier.set_leader(notarize1.signer(), Some(&notarize1));
-        assert_eq!(
-            verifier.get_leader_proposal(),
-            Some((notarize1.signer(), &notarize1.proposal))
-        );
+        assert_eq!(verifier.leader(), Some(notarize1.signer()));
+        assert_eq!(verifier.proposal(), Some(&notarize1.proposal));
         assert_eq!(verifier.notarize.pending().len(), 1);
 
         verifier.add(Vote::Notarize(notarize2), false);
@@ -694,14 +702,12 @@ mod tests {
 
         verifier2.set_leader(notarize_leader.signer(), None);
         verifier2.add(Vote::Notarize(notarize_non_leader), false);
-        assert!(verifier2.get_leader_proposal().is_none());
+        assert_eq!(verifier2.leader(), Some(notarize_leader.signer()));
+        assert!(verifier2.proposal().is_none());
         assert_eq!(verifier2.notarize.pending().len(), 1);
 
         verifier2.add(Vote::Notarize(notarize_leader.clone()), false);
-        assert_eq!(
-            verifier2.get_leader_proposal(),
-            Some((notarize_leader.signer(), &notarize_leader.proposal))
-        );
+        assert_eq!(verifier2.proposal(), Some(&notarize_leader.proposal));
         assert_eq!(verifier2.notarize.pending().len(), 2);
     }
 
@@ -740,15 +746,12 @@ mod tests {
 
         let leader = leader_notarize.signer();
         verifier.set_leader(leader, None);
-        assert!(matches!(verifier.leader, Leader::Known(l) if l == leader));
-        assert!(verifier.get_leader_proposal().is_none());
+        assert_eq!(verifier.leader(), Some(leader));
+        assert!(verifier.proposal().is_none());
         assert_eq!(verifier.notarize.pending().len(), 1);
 
         verifier.add(Vote::Notarize(leader_notarize.clone()), false);
-        assert_eq!(
-            verifier.get_leader_proposal(),
-            Some((leader, &leader_notarize.proposal))
-        );
+        assert_eq!(verifier.proposal(), Some(&leader_notarize.proposal));
         assert_eq!(verifier.notarize.pending().len(), 2);
 
         let mut verifier2 = Verifier::<S, Sha256>::new(
@@ -758,10 +761,30 @@ mod tests {
         );
         verifier2.add(Vote::Notarize(leader_notarize.clone()), true);
         verifier2.set_leader(leader, Some(&leader_notarize));
-        assert_eq!(
-            verifier2.get_leader_proposal(),
-            Some((leader, &leader_notarize.proposal))
+        assert_eq!(verifier2.leader(), Some(leader));
+        assert_eq!(verifier2.proposal(), Some(&leader_notarize.proposal));
+        assert!(!verifier2.set_proposal(leader_notarize.proposal.clone()));
+
+        // A verified notarization supersedes a conflicting proposal learned
+        // from the leader's vote.
+        let certified_proposal = Proposal::new(round, View::new(0), sample_digest(2));
+        assert_ne!(certified_proposal, leader_notarize.proposal);
+        assert!(verifier2.set_proposal(certified_proposal.clone()));
+        assert_eq!(verifier2.proposal(), Some(&certified_proposal));
+
+        // If the notarization arrives first, setting the leader cannot replace
+        // its proposal with a conflicting buffered leader vote.
+        let mut verifier3 = Verifier::<S, Sha256>::new(
+            Round::new(Epoch::new(0), View::new(1)),
+            schemes[0].clone(),
+            quorum,
         );
+        assert!(verifier3.set_proposal(certified_proposal.clone()));
+        assert!(verifier3.leader().is_none());
+        assert_eq!(verifier3.proposal(), Some(&certified_proposal));
+        verifier3.set_leader(leader, Some(&leader_notarize));
+        assert_eq!(verifier3.leader(), Some(leader));
+        assert_eq!(verifier3.proposal(), Some(&certified_proposal));
     }
 
     #[test]
@@ -985,9 +1008,9 @@ mod tests {
         assert_eq!(verifier.finalize.pending().len(), 2);
 
         verifier.set_leader(finalize_a.signer(), None);
-        assert!(verifier.get_leader_proposal().is_none());
+        assert!(verifier.proposal().is_none());
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
-        verifier.try_learn_proposal(&leader_notarize);
+        verifier.try_set_proposal_from_leader(&leader_notarize);
         assert_eq!(verifier.finalize.pending().len(), 1);
         assert_eq!(verifier.finalize.pending()[0], finalize_a);
         assert_eq!(verifier.finalize.verified().len(), 0);
@@ -1149,49 +1172,49 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_bls_threshold_minsig() {
         set_leader_twice_panics(bls12381_threshold_vrf::fixture::<MinSig, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_bls_threshold_minpk() {
         set_leader_twice_panics(bls12381_threshold_vrf::fixture::<MinPk, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_bls_threshold_std_minsig() {
         set_leader_twice_panics(bls12381_threshold_std::fixture::<MinSig, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_bls_threshold_std_minpk() {
         set_leader_twice_panics(bls12381_threshold_std::fixture::<MinPk, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_bls_multisig_minsig() {
         set_leader_twice_panics(bls12381_multisig::fixture::<MinSig, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_bls_multisig_minpk() {
         set_leader_twice_panics(bls12381_multisig::fixture::<MinPk, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_ed() {
         set_leader_twice_panics(ed25519::fixture);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
+    #[should_panic(expected = "leader already set")]
     fn test_set_leader_twice_panics_secp() {
         set_leader_twice_panics(secp256r1::fixture);
     }
@@ -1318,21 +1341,27 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
         let quorum = N3f1::quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
-        let round = Round::new(Epoch::new(0), View::new(1));
-        let finalizes: Vec<_> = schemes
-            .iter()
-            .take(quorum as usize)
-            .map(|scheme| create_finalize(scheme, round, View::new(0), 1))
-            .collect();
+        let test_verifier_finalize = || {
+            let mut verifier = Verifier::<S, Sha256>::new(
+                Round::new(Epoch::new(0), View::new(1)),
+                schemes[0].clone(),
+                quorum,
+            );
+            let round = Round::new(Epoch::new(0), View::new(1));
+            let finalizes: Vec<_> = schemes
+                .iter()
+                .take(quorum as usize)
+                .map(|scheme| create_finalize(scheme, round, View::new(0), 1))
+                .collect();
 
-        for finalize in finalizes.iter() {
-            verifier.add(Vote::Finalize(finalize.clone()), false);
-        }
+            for finalize in finalizes.iter() {
+                verifier.add(Vote::Finalize(finalize.clone()), false);
+            }
+
+            (verifier, finalizes[0].clone())
+        };
+
+        let (mut verifier, finalize) = test_verifier_finalize();
 
         assert!(
             verifier
@@ -1342,15 +1371,27 @@ mod tests {
             "Should not verify without leader/proposal set"
         );
 
-        verifier.set_leader(finalizes[0].signer(), None);
+        verifier.set_leader(finalize.signer(), None);
         assert!(
             verifier
                 .try_verify_finalizes(&mut rng, &Sequential)
                 .await
                 .is_none(),
-            "Should not verify without leader_proposal set"
+            "Should not verify with a leader but no proposal"
         );
         assert_eq!(verifier.finalize.pending().len(), quorum as usize);
+
+        let (mut verifier, finalize) = test_verifier_finalize();
+
+        verifier.set_proposal(finalize.proposal.clone());
+        assert!(verifier.leader.is_none());
+        assert!(
+            verifier
+                .try_verify_finalizes(&mut rng, &Sequential)
+                .await
+                .is_some(),
+            "Should verify with a proposal and no leader"
+        );
     }
 
     #[test_async]
@@ -1882,15 +1923,13 @@ mod tests {
 
         verifier.record_certificate(Kind::Notarization);
         verifier.set_leader(Participant::new(0), None);
-        assert!(verifier.get_leader_proposal().is_none());
+        assert_eq!(verifier.leader(), Some(Participant::new(0)));
+        assert!(verifier.proposal().is_none());
 
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
         let proposal = leader_notarize.proposal.clone();
         verifier.add(Vote::Notarize(leader_notarize), false);
-        assert_eq!(
-            verifier.get_leader_proposal(),
-            Some((Participant::new(0), &proposal))
-        );
+        assert_eq!(verifier.proposal(), Some(&proposal));
         assert!(verifier.notarize.pending().is_empty());
 
         // Certifying one kind leaves the others accumulating


### PR DESCRIPTION
The batcher previously verified notarize and finalize votes only after learning the leader's proposal from the leader's notarize vote. If that vote was missed but a valid notarization was received, an already-buffered finalize quorum could remain unverified.

This PR updates the batcher to track the leader and proposal independently. A verified notarization now establishes the authoritative proposal and causes buffered votes for that proposal to be reconsidered, even when the round's leader is not yet known. Finalizations retain their existing behavior.