### PR TITLE
[consensus/simplex] Name the voter's verify methods for what they return

### DIFF
--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -128,16 +128,18 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         Some(leader)
     }
 
-    /// Returns the leader key and proposal when the view is ready for verification.
+    /// Returns the leader key and proposal ready for verification, without
+    /// recording the request. Resolve ancestry before calling
+    /// [`Self::request_verify`], which retires the round from later offers.
     #[allow(clippy::type_complexity)]
-    pub fn should_verify(&self) -> Option<(Leader<S::PublicKey>, Proposal<D>)> {
+    pub fn pending_verification(&self) -> Option<(Leader<S::PublicKey>, Proposal<D>)> {
         let leader = self.verify_ready()?;
         let proposal = self.proposal.proposal().cloned()?;
         Some((leader.clone(), proposal))
     }
 
     /// Marks that verification is in-flight; returns `false` to avoid duplicate requests.
-    pub fn try_verify(&mut self) -> bool {
+    pub fn request_verify(&mut self) -> bool {
         if self.verify_ready().is_none() {
             return false;
         }
@@ -1108,7 +1110,7 @@ mod tests {
 
         // No verification request should be emitted.
         assert!(
-            !round.try_verify(),
+            !round.request_verify(),
             "leader-owned replay should not request verification again"
         );
 

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -729,7 +729,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     #[allow(clippy::type_complexity)]
     pub fn try_verify(&mut self) -> Option<(Context<D, S::PublicKey>, Proposal<D>)> {
         let view = self.view;
-        let (leader, proposal) = self.views.get(&view)?.should_verify()?;
+        let (leader, proposal) = self.views.get(&view)?.pending_verification()?;
         let parent_payload = match self.parent_payload(&proposal) {
             Ok(parent_payload) => parent_payload,
             Err(err) => {
@@ -747,7 +747,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                 return None;
             }
         };
-        if !self.views.get_mut(&view)?.try_verify() {
+        if !self.views.get_mut(&view)?.request_verify() {
             return None;
         }
         let context = Context {


### PR DESCRIPTION
Two methods on the voter's `Round` are named in a way that misleads.

`should_verify` reads as a predicate but returns `Option<(Leader, Proposal)>`, and `try_verify` returns `bool`. Elsewhere in the crate the opposite holds, so a reader cannot carry one rule across:

| | `should_*` | `try_*` |
|---|---|---|
| `Certification` (batcher) | `bool` | `Option<(usize, Vec<Participant>)>` |
| `Slot` | `bool` | — |
| `Round` propose | `bool` | `Option<Leader>` |
| **`Round` verify** | **`Option<(Leader, Proposal)>`** | **`bool`** |

There is also a name collision waiting. #3416 adds `Slot::should_verify() -> bool`, and `Round::verify_ready` already calls it. That leaves one identifier meaning two different return types in a single call chain, with the `Option` one delegating to the `bool` one. Renaming here removes that, so #3416 needs no change.

**The shapes are correct and stay as they are.** `State::try_verify` has to hold the proposal before committing, because `request_verify` latches the slot and retires the round from later verification offers. Resolving ancestry first is what lets a proposal whose parent is not yet certified be retried instead of dropped. So the read genuinely returns data and the commit genuinely has nothing left to return. Forcing the pair into `should_*`/`try_*` would mean fetching the proposal twice and adding an invariant to hold them together.

Only the names change:

- `should_verify` -> `pending_verification`, a noun phrase that returns data rather than posing as a predicate
- `try_verify` -> `request_verify`, mirroring the `Slot::request_verify` it delegates to

Five sites: two definitions, one test, two call sites in `State::try_verify`. `State::try_verify` itself keeps its name.

The propose pair keeps `should_propose`/`try_propose`. Making it match would mean restructuring where `State::try_propose` reads the leader and commits, which is more churn than the inconsistency costs.

Ordering: #3416 touches `voter/round.rs` heavily, so merging it first and rebasing this one is cheaper than the reverse.
