### PR TITLE
[consensus/simplex] Track the batcher proposal's source

### DIFF
--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -483,74 +483,42 @@ where
                 );
                 let _guard = span.entered();
 
-                match message {
-                    Certificate::Notarization(notarization) => {
-                        // Verify the certificate
-                        if !notarization.verify(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid notarization");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        let proposal_changed = work
-                            .entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_notarization(&notarization.proposal);
-                        voter.recovered(Certificate::Notarization(notarization));
-
-                        // Reprocess buffered votes only if the notarization changed the
-                        // proposal filter.
-                        if !proposal_changed {
-                            continue;
-                        }
-
-                        updated_view = view;
-                    }
-                    Certificate::Nullification(nullification) => {
-                        // Verify the certificate
-                        if !nullification.verify::<_, D>(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid nullification");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_nullification();
-                        voter.recovered(Certificate::Nullification(nullification));
-
-                        // Certificates are already forwarded to voter, no need for construction.
-                        continue;
-                    }
-                    Certificate::Finalization(finalization) => {
-                        // Verify the certificate
-                        if !finalization.verify(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid finalization");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_finalization();
-                        voter.recovered(Certificate::Finalization(finalization));
-
-                        // Certificates are already forwarded to voter, no need for construction.
-                        continue;
-                    }
+                // Verify the certificate
+                let valid = match &message {
+                    Certificate::Notarization(notarization) => notarization.verify(
+                        self.context.as_mut(),
+                        self.scheme.as_ref(),
+                        &self.strategy,
+                    ),
+                    Certificate::Nullification(nullification) => nullification.verify::<_, D>(
+                        self.context.as_mut(),
+                        self.scheme.as_ref(),
+                        &self.strategy,
+                    ),
+                    Certificate::Finalization(finalization) => finalization.verify(
+                        self.context.as_mut(),
+                        self.scheme.as_ref(),
+                        &self.strategy,
+                    ),
+                };
+                if !valid {
+                    commonware_p2p::block!(self.blocker, sender, %view, %kind, "invalid certificate");
+                    continue;
                 }
+
+                // Store and forward to voter
+                let proposal_changed = work
+                    .entry(view)
+                    .or_insert_with(|| self.new_round(view))
+                    .record_certificate(&message);
+                voter.recovered(message);
+
+                // Reprocess buffered votes only if the notarization changed the
+                // round's proposal.
+                if !proposal_changed {
+                    continue;
+                }
+                updated_view = view;
             },
             // Handle votes from the network
             Ok((sender, message)) = vote_receiver.recv() else break => {

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -438,7 +438,8 @@ mod tests {
 
         // A verified notarization establishes the proposal and drops the
         // verifier's notarize buffers
-        assert!(round.record_notarization(&proposal));
+        let notarization = build_notarization(&schemes, &proposal, quorum(5) as usize);
+        assert!(round.record_certificate(&Certificate::Notarization(notarization)));
         assert!(round.has_certificate(Kind::Notarization));
 
         // The proposal can be forwarded before the leader is known
@@ -473,7 +474,8 @@ mod tests {
         assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
 
         // A finalization does not establish the proposal
-        round.record_finalization();
+        let finalization = build_finalization(&schemes, &proposal, quorum(5) as usize);
+        assert!(!round.record_certificate(&Certificate::Finalization(finalization)));
         assert!(round.has_certificate(Kind::Finalization));
 
         // Setting the leader discovers the proposal from its buffered vote

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -1,4 +1,4 @@
-use super::Verifier;
+use super::{Verifier, verifier::ProposalSource};
 use crate::{
     Reporter,
     simplex::{
@@ -95,30 +95,20 @@ impl<
         self.verifier.has_certificate(kind)
     }
 
-    /// Records that a certificate of `kind` exists, dropping its buffered votes.
-    fn record_certificate(&mut self, kind: Kind) {
-        self.verifier.record_certificate(kind);
-    }
-
-    /// Records a verified notarization, dropping its buffered votes and
-    /// adopting its authoritative proposal, which replaces any conflicting
-    /// proposal learned from the leader's vote.
-    ///
-    /// Returns whether the proposal changed.
-    pub fn record_notarization(&mut self, proposal: &Proposal<D>) -> bool {
-        let changed = self.verifier.set_proposal(proposal.clone());
-        self.record_certificate(Kind::Notarization);
-        changed
-    }
-
-    /// Records a verified nullification, dropping its buffered votes.
-    pub fn record_nullification(&mut self) {
-        self.record_certificate(Kind::Nullification);
-    }
-
-    /// Records a verified finalization, dropping its buffered votes.
-    pub fn record_finalization(&mut self) {
-        self.record_certificate(Kind::Finalization);
+    /// Records a verified certificate and returns whether the round's
+    /// proposal changed.
+    pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
+        let proposal_changed = match certificate {
+            Certificate::Notarization(notarization) => {
+                // Adopt the notarization's proposal, replacing any conflicting proposal learned
+                // from the leader's vote.
+                self.verifier
+                    .set_proposal(ProposalSource::Notarization(notarization.proposal.clone()))
+            }
+            Certificate::Nullification(_) | Certificate::Finalization(_) => false,
+        };
+        self.verifier.record_certificate(certificate.kind());
+        proposal_changed
     }
 
     /// Adds a vote from the network to this round's verifier.

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -1,4 +1,4 @@
-use super::{Verifier, verifier::ProposalSource};
+use super::{Verifier, verifier::ProposalState};
 use crate::{
     Reporter,
     simplex::{
@@ -97,14 +97,15 @@ impl<
 
     /// Records a verified certificate and returns whether the round's
     /// proposal changed.
+    ///
+    /// Only a notarization can change the proposal. Its proposal is authoritative and replaces any
+    /// conflicting proposal learned from the leader's vote. Nullifications and finalizations leave
+    /// the proposal unchanged.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
         let proposal_changed = match certificate {
-            Certificate::Notarization(notarization) => {
-                // Adopt the notarization's proposal, replacing any conflicting proposal learned
-                // from the leader's vote.
-                self.verifier
-                    .set_proposal(ProposalSource::Notarization(notarization.proposal.clone()))
-            }
+            Certificate::Notarization(notarization) => self
+                .verifier
+                .set_proposal(ProposalState::Notarization(notarization.proposal.clone())),
             Certificate::Nullification(_) | Certificate::Finalization(_) => false,
         };
         self.verifier.record_certificate(certificate.kind());

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -154,19 +154,22 @@ impl<V> Certification<V> {
     }
 }
 
-/// The round's proposal and how it was learned.
-pub(super) enum ProposalSource<D: Digest> {
-    /// The leader's notarize vote. May be replaced by a notarization.
+/// What the round knows about its proposal, and how it was learned.
+pub(super) enum ProposalState<D: Digest> {
+    /// No proposal is known.
+    Unknown,
+    /// Learned from the leader's notarize vote. May be replaced by a notarization.
     Leader(Proposal<D>),
-    /// A verified notarization. Never replaced.
+    /// Learned from a verified notarization. Never replaced.
     Notarization(Proposal<D>),
 }
 
-impl<D: Digest> ProposalSource<D> {
-    /// Returns the proposal.
-    const fn proposal(&self) -> &Proposal<D> {
+impl<D: Digest> ProposalState<D> {
+    /// Returns the proposal, if known.
+    const fn proposal(&self) -> Option<&Proposal<D>> {
         match self {
-            Self::Leader(proposal) | Self::Notarization(proposal) => proposal,
+            Self::Unknown => None,
+            Self::Leader(proposal) | Self::Notarization(proposal) => Some(proposal),
         }
     }
 }
@@ -204,7 +207,7 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
     /// A known leader's notarize vote may supply the initial proposal. A
     /// verified notarization is authoritative and may replace it, or establish
     /// the proposal before the leader is identified.
-    proposal: Option<ProposalSource<D>>,
+    proposal: ProposalState<D>,
 
     /// Notarize certification progress.
     notarize: Certification<Notarize<S, D>>,
@@ -232,7 +235,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             round,
 
             leader: None,
-            proposal: None,
+            proposal: ProposalState::Unknown,
 
             notarize: Certification::new(quorum, batchable),
             nullify: Certification::new(quorum, batchable),
@@ -251,8 +254,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     }
 
     /// Returns the round's proposal, once known.
-    pub fn proposal(&self) -> Option<&Proposal<D>> {
-        self.proposal.as_ref().map(ProposalSource::proposal)
+    pub const fn proposal(&self) -> Option<&Proposal<D>> {
+        self.proposal.proposal()
     }
 
     /// Attempts to construct a certificate from verified votes: the first kind
@@ -338,10 +341,10 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Does nothing if the leader is unknown, `notarize` is not from the
     /// leader, or a proposal is already set.
     fn try_set_proposal_from_leader(&mut self, notarize: &Notarize<S, D>) {
-        if self.proposal.is_some() || self.leader != Some(notarize.signer()) {
+        if self.proposal().is_some() || self.leader != Some(notarize.signer()) {
             return;
         }
-        self.set_proposal(ProposalSource::Leader(notarize.proposal.clone()));
+        self.set_proposal(ProposalState::Leader(notarize.proposal.clone()));
     }
 
     /// Adopts the proposal to which notarize and finalize votes are filtered,
@@ -349,14 +352,13 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// other proposal.
     ///
     /// Returns whether the proposal changed.
-    pub(super) fn set_proposal(&mut self, proposal: ProposalSource<D>) -> bool {
-        let new = proposal.proposal();
-        let changed = self.proposal() != Some(new);
-        if changed {
+    pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> bool {
+        let changed = self.proposal() != proposal.proposal();
+        if changed && let Some(new) = proposal.proposal() {
             self.notarize.retain(|n| &n.proposal == new);
             self.finalize.retain(|f| &f.proposal == new);
         }
-        self.proposal = Some(proposal);
+        self.proposal = proposal;
         changed
     }
 
@@ -444,7 +446,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ) -> Option<(usize, Vec<Participant>)> {
         // Until the proposal is known, notarizes may reference many different
         // proposals.
-        self.proposal.as_ref()?;
+        if matches!(self.proposal, ProposalState::Unknown) {
+            return None;
+        }
         self.notarize
             .try_verify(|notarizes, mut verified_notarizes| {
                 let span = info_span!(
@@ -554,7 +558,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ) -> Option<(usize, Vec<Participant>)> {
         // Until the proposal is known, finalizes may reference many different
         // proposals.
-        self.proposal.as_ref()?;
+        if matches!(self.proposal, ProposalState::Unknown) {
+            return None;
+        }
         self.finalize
             .try_verify(|finalizes, mut verified_finalizes| {
                 let span = info_span!(
@@ -781,11 +787,11 @@ mod tests {
         // from the leader's vote.
         let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
         assert_ne!(notarized_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(ProposalSource::Notarization(notarized_proposal.clone())));
+        assert!(verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // Re-adopting the same proposal reports no change.
-        assert!(!verifier2.set_proposal(ProposalSource::Notarization(notarized_proposal.clone())));
+        assert!(!verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
 
         // If the notarization arrives first, setting the leader cannot replace
         // its proposal with a conflicting buffered leader vote.
@@ -794,7 +800,7 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(ProposalSource::Notarization(notarized_proposal.clone())));
+        assert!(verifier3.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
         assert!(verifier3.leader().is_none());
         assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));
@@ -1398,7 +1404,7 @@ mod tests {
 
         let (mut verifier, finalize) = test_verifier_finalize();
 
-        verifier.set_proposal(ProposalSource::Notarization(finalize.proposal.clone()));
+        verifier.set_proposal(ProposalState::Notarization(finalize.proposal.clone()));
         assert!(verifier.leader.is_none());
         assert!(
             verifier

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -154,6 +154,23 @@ impl<V> Certification<V> {
     }
 }
 
+/// The round's proposal and how it was learned.
+pub(super) enum ProposalSource<D: Digest> {
+    /// The leader's notarize vote. May be replaced by a notarization.
+    Leader(Proposal<D>),
+    /// A verified notarization. Never replaced.
+    Notarization(Proposal<D>),
+}
+
+impl<D: Digest> ProposalSource<D> {
+    /// Returns the proposal.
+    const fn proposal(&self) -> &Proposal<D> {
+        match self {
+            Self::Leader(proposal) | Self::Notarization(proposal) => proposal,
+        }
+    }
+}
+
 /// `Verifier` is a utility for tracking and verifying consensus messages.
 ///
 /// For schemes where [`Verifier::is_batchable()`](commonware_cryptography::certificate::Verifier::is_batchable)
@@ -187,7 +204,7 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
     /// A known leader's notarize vote may supply the initial proposal. A
     /// verified notarization is authoritative and may replace it, or establish
     /// the proposal before the leader is identified.
-    proposal: Option<Proposal<D>>,
+    proposal: Option<ProposalSource<D>>,
 
     /// Notarize certification progress.
     notarize: Certification<Notarize<S, D>>,
@@ -234,8 +251,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     }
 
     /// Returns the round's proposal, once known.
-    pub const fn proposal(&self) -> Option<&Proposal<D>> {
-        self.proposal.as_ref()
+    pub fn proposal(&self) -> Option<&Proposal<D>> {
+        self.proposal.as_ref().map(ProposalSource::proposal)
     }
 
     /// Attempts to construct a certificate from verified votes: the first kind
@@ -324,7 +341,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         if self.proposal.is_some() || self.leader != Some(notarize.signer()) {
             return;
         }
-        self.set_proposal(notarize.proposal.clone());
+        self.set_proposal(ProposalSource::Leader(notarize.proposal.clone()));
     }
 
     /// Adopts the proposal to which notarize and finalize votes are filtered,
@@ -332,19 +349,15 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// other proposal.
     ///
     /// Returns whether the proposal changed.
-    pub(super) fn set_proposal(&mut self, proposal: Proposal<D>) -> bool {
-        if self.proposal.as_ref() == Some(&proposal) {
-            return false;
+    pub(super) fn set_proposal(&mut self, proposal: ProposalSource<D>) -> bool {
+        let new = proposal.proposal();
+        let changed = self.proposal() != Some(new);
+        if changed {
+            self.notarize.retain(|n| &n.proposal == new);
+            self.finalize.retain(|f| &f.proposal == new);
         }
-
-        // The leader-vote path calls this only while the proposal is unknown.
-        // The verified-notarization path may replace a conflicting proposal
-        // because its certificate is authoritative.
-        self.notarize.retain(|n| n.proposal == proposal);
-        self.finalize.retain(|f| f.proposal == proposal);
         self.proposal = Some(proposal);
-
-        true
+        changed
     }
 
     /// Adds a [Vote] message to the batch for later verification.
@@ -367,7 +380,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 self.try_set_proposal_from_leader(&notarize);
 
                 // If the proposal is known and the message is not for it, drop it
-                if let Some(proposal) = &self.proposal
+                if let Some(proposal) = self.proposal()
                     && proposal != &notarize.proposal
                 {
                     return;
@@ -379,7 +392,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             }
             Vote::Finalize(finalize) => {
                 // If the proposal is known and the message is not for it, drop it
-                if let Some(proposal) = &self.proposal
+                if let Some(proposal) = self.proposal()
                     && proposal != &finalize.proposal
                 {
                     return;
@@ -763,14 +776,16 @@ mod tests {
         verifier2.set_leader(leader, Some(&leader_notarize));
         assert_eq!(verifier2.leader(), Some(leader));
         assert_eq!(verifier2.proposal(), Some(&leader_notarize.proposal));
-        assert!(!verifier2.set_proposal(leader_notarize.proposal.clone()));
 
         // A verified notarization supersedes a conflicting proposal learned
         // from the leader's vote.
-        let certified_proposal = Proposal::new(round, View::new(0), sample_digest(2));
-        assert_ne!(certified_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(certified_proposal.clone()));
-        assert_eq!(verifier2.proposal(), Some(&certified_proposal));
+        let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
+        assert_ne!(notarized_proposal, leader_notarize.proposal);
+        assert!(verifier2.set_proposal(ProposalSource::Notarization(notarized_proposal.clone())));
+        assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
+
+        // Re-adopting the same proposal reports no change.
+        assert!(!verifier2.set_proposal(ProposalSource::Notarization(notarized_proposal.clone())));
 
         // If the notarization arrives first, setting the leader cannot replace
         // its proposal with a conflicting buffered leader vote.
@@ -779,12 +794,12 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(certified_proposal.clone()));
+        assert!(verifier3.set_proposal(ProposalSource::Notarization(notarized_proposal.clone())));
         assert!(verifier3.leader().is_none());
-        assert_eq!(verifier3.proposal(), Some(&certified_proposal));
+        assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));
         assert_eq!(verifier3.leader(), Some(leader));
-        assert_eq!(verifier3.proposal(), Some(&certified_proposal));
+        assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
     }
 
     #[test]
@@ -1383,7 +1398,7 @@ mod tests {
 
         let (mut verifier, finalize) = test_verifier_finalize();
 
-        verifier.set_proposal(finalize.proposal.clone());
+        verifier.set_proposal(ProposalSource::Notarization(finalize.proposal.clone()));
         assert!(verifier.leader.is_none());
         assert!(
             verifier


### PR DESCRIPTION
The verifier now tracks the round's proposal as `ProposalSource::Leader(proposal)` or `ProposalSource::Notarization(proposal)` instead of bare `Option<Proposal>`.

`Round` records all certificates through one method again. `record_certificate(&Certificate)` adopts the proposal from a notarization internally and returns whether it changed, which keeps the actor's three certificate arms identical after verification: record, forward to the voter, and reprocess buffered votes only if the proposal changed. Invalid certificates block with one reason ("invalid certificate" with the kind as a field) instead of three.