### PR TITLE
[storage/qmdb] Expose activity bitmap & grafted storage

### DIFF
--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -225,6 +225,11 @@ where
         self.any.bounds()
     }
 
+    /// Returns a read-only view of the activity bitmap.
+    pub fn bitmap(&self) -> &impl bitmap::Readable<N> {
+        self.any.bitmap.as_ref()
+    }
+
     /// Return true if the given sequence of `ops` were applied starting at location `start_loc`
     /// in the log with the provided `root`, having the activity status described by `chunks`.
     pub fn verify_range_proof(
@@ -253,7 +258,7 @@ where
     /// Returns a virtual [grafting::Storage] over the grafted tree and ops tree. For positions at
     /// or above the grafting height, returns the grafted node. For positions below the grafting
     /// height, the ops tree is used.
-    fn grafted_storage(&self) -> impl MerkleStorage<F, Digest = H::Digest> + '_ {
+    pub fn grafted_storage(&self) -> impl MerkleStorage<F, Digest = H::Digest> + '_ {
         grafting::Storage::<F, H, _, _>::new(
             &self.grafted_tree,
             grafting::height::<N>(),

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -226,6 +226,10 @@ where
     }
 
     /// Returns a read-only view of the activity bitmap.
+    ///
+    /// Pruning does not renumber the retained chunks. Only chunks at or after `pruned_chunks()`
+    /// that contain a bit below `len()` are readable. Calling `get_chunk()` or `get_bit()` for a
+    /// pruned or out-of-bounds location panics.
     pub fn bitmap(&self) -> &impl bitmap::Readable<N> {
         self.any.bitmap.as_ref()
     }
@@ -255,9 +259,11 @@ where
     S: Strategy,
     Operation<F, U>: Codec,
 {
-    /// Returns a virtual [grafting::Storage] over the grafted tree and ops tree. For positions at
-    /// or above the grafting height, returns the grafted node. For positions below the grafting
-    /// height, the ops tree is used.
+    /// Returns a virtual [`crate::merkle::storage::Storage`] view over the grafted tree and ops
+    /// tree.
+    ///
+    /// Positions and `size()` use ops-tree coordinates. Positions at or above the grafting height
+    /// return bitmap-authenticated grafted nodes, while positions below it use the ops tree.
     pub fn grafted_storage(&self) -> impl MerkleStorage<F, Digest = H::Digest> + '_ {
         grafting::Storage::<F, H, _, _>::new(
             &self.grafted_tree,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1645,6 +1645,8 @@ pub mod tests {
             let batch = batch.merkleize(&db, None).await.unwrap();
             let (db, _) = db.apply_batch(batch).await.unwrap();
 
+            // The exposed bitmap must describe the same operation boundary as the DB and surface
+            // both reconstruction chunks that remain outside the grafted tree.
             let end = db.bounds().end;
             let bitmap = db.bitmap();
             assert_eq!(bitmap.len(), *end);
@@ -1663,6 +1665,7 @@ pub mod tests {
             assert!(partial_bits > 0 && partial_bits < CHUNK_BYTES as u64 * 8);
             assert_ne!(partial, [0; CHUNK_BYTES]);
 
+            // Tie the extracted bytes to the digests authenticated by the existing root witness.
             let witness = db.ops_root_witness().await.unwrap();
             assert_eq!(
                 witness.pending_chunk_digest,
@@ -1673,6 +1676,8 @@ pub mod tests {
                 Some((partial_bits, Sha256::hash(&[partial.as_slice()])))
             );
 
+            // The virtual storage remains in ops-tree coordinates even where it substitutes
+            // bitmap-authenticated grafted nodes.
             let storage = db.grafted_storage();
             assert_eq!(
                 storage.size(),
@@ -1685,6 +1690,8 @@ pub mod tests {
             );
             assert!(storage.get_node(ops_pos).await.unwrap().is_some());
 
+            // Reconstruction frontiers use the raw ops-tree pin ordering. The virtual digest at
+            // the grafting boundary must differ because the corresponding bitmap chunk is nonzero.
             let pinned_positions =
                 <mmb::Family as merkle::Family>::nodes_to_pin(end).collect::<Vec<_>>();
             let raw_pinned = db.pinned_nodes_at(end).await.unwrap();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1623,8 +1623,6 @@ pub mod tests {
 
     #[test_traced]
     fn test_reconstruction_views_expose_all_chunk_states() {
-        const CHUNK_BYTES: usize = 32;
-
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let db = UnorderedFixedMmbDb::init(
@@ -1652,18 +1650,20 @@ pub mod tests {
             assert_eq!(bitmap.len(), *end);
             assert_eq!(bitmap.pruned_chunks(), 0);
 
-            let grafting_height = grafting::height::<CHUNK_BYTES>();
+            let first = bitmap.get_chunk(0);
+            let chunk_bits = first.len() as u64 * 8;
+            let grafting_height = chunk_bits.trailing_zeros();
             let complete = bitmap.complete_chunks() as u64;
             let graftable =
                 grafting::graftable_chunks::<mmb::Family>(*end, grafting_height).min(complete);
             assert_eq!(complete - graftable, 1, "expected one pending chunk");
-            assert_ne!(bitmap.get_chunk(0), [0; CHUNK_BYTES]);
+            assert!(first.iter().any(|byte| *byte != 0));
             let pending = bitmap.get_chunk(graftable as usize);
-            assert_ne!(pending, [0; CHUNK_BYTES]);
+            assert!(pending.iter().any(|byte| *byte != 0));
 
             let (partial, partial_bits) = bitmap.last_chunk();
-            assert!(partial_bits > 0 && partial_bits < CHUNK_BYTES as u64 * 8);
-            assert_ne!(partial, [0; CHUNK_BYTES]);
+            assert!(partial_bits > 0 && partial_bits < chunk_bits);
+            assert!(partial.iter().any(|byte| *byte != 0));
 
             // Tie the extracted bytes to the digests authenticated by the existing root witness.
             let witness = db.ops_root_witness().await.unwrap();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -520,9 +520,11 @@ pub mod tests {
     //! Shared test utilities for Current QMDB variants.
 
     pub use super::BitmapPrunedBits;
-    use super::{FConfig, FixedConfig, MerkleConfig, VConfig, VariableConfig, ordered, unordered};
+    use super::{
+        FConfig, FixedConfig, MerkleConfig, VConfig, VariableConfig, grafting, ordered, unordered,
+    };
     use crate::{
-        merkle::{self, mmb, mmr},
+        merkle::{self, mmb, mmr, storage::Storage as _},
         qmdb::{
             any::{
                 test::colliding_digest,
@@ -1618,6 +1620,89 @@ pub mod tests {
         32,
         Sequential,
     >;
+
+    #[test_traced]
+    fn test_reconstruction_views_expose_all_chunk_states() {
+        const CHUNK_BYTES: usize = 32;
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let db = UnorderedFixedMmbDb::init(
+                context.child("db"),
+                fixed_config::<OneCap>("reconstruction-views", &context),
+            )
+            .await
+            .unwrap();
+
+            // At this size, MMB has a grafted chunk, a complete pending chunk, and a trailing
+            // partial chunk.
+            let mut batch = db.new_batch();
+            for i in 0u64..512 {
+                let key = Sha256::hash(&[&i.to_be_bytes()]);
+                let value = Sha256::hash(&[&(i + 1_000).to_be_bytes()]);
+                batch = batch.write(key, Some(value));
+            }
+            let batch = batch.merkleize(&db, None).await.unwrap();
+            let (db, _) = db.apply_batch(batch).await.unwrap();
+
+            let end = db.bounds().end;
+            let bitmap = db.bitmap();
+            assert_eq!(bitmap.len(), *end);
+            assert_eq!(bitmap.pruned_chunks(), 0);
+
+            let grafting_height = grafting::height::<CHUNK_BYTES>();
+            let complete = bitmap.complete_chunks() as u64;
+            let graftable =
+                grafting::graftable_chunks::<mmb::Family>(*end, grafting_height).min(complete);
+            assert_eq!(complete - graftable, 1, "expected one pending chunk");
+            assert_ne!(bitmap.get_chunk(0), [0; CHUNK_BYTES]);
+            let pending = bitmap.get_chunk(graftable as usize);
+            assert_ne!(pending, [0; CHUNK_BYTES]);
+
+            let (partial, partial_bits) = bitmap.last_chunk();
+            assert!(partial_bits > 0 && partial_bits < CHUNK_BYTES as u64 * 8);
+            assert_ne!(partial, [0; CHUNK_BYTES]);
+
+            let witness = db.ops_root_witness().await.unwrap();
+            assert_eq!(
+                witness.pending_chunk_digest,
+                Some(Sha256::hash(&[pending.as_slice()]))
+            );
+            assert_eq!(
+                witness.partial_chunk,
+                Some((partial_bits, Sha256::hash(&[partial.as_slice()])))
+            );
+
+            let storage = db.grafted_storage();
+            assert_eq!(
+                storage.size(),
+                <mmb::Family as merkle::Family>::location_to_position(end)
+            );
+
+            let ops_pos = <mmb::Family as merkle::Graftable>::subtree_root_position(
+                Location::new(0),
+                grafting_height,
+            );
+            assert!(storage.get_node(ops_pos).await.unwrap().is_some());
+
+            let pinned_positions =
+                <mmb::Family as merkle::Family>::nodes_to_pin(end).collect::<Vec<_>>();
+            let raw_pinned = db.pinned_nodes_at(end).await.unwrap();
+            assert_eq!(pinned_positions.len(), raw_pinned.len());
+            let mut checked_grafted_node = false;
+            for (pos, raw_digest) in pinned_positions.into_iter().zip(raw_pinned) {
+                let digest = storage.get_node(pos).await.unwrap().unwrap();
+                if pos == ops_pos {
+                    assert_ne!(digest, raw_digest);
+                    checked_grafted_node = true;
+                }
+            }
+            assert!(checked_grafted_node);
+
+            drop(storage);
+            db.destroy().await.unwrap();
+        });
+    }
 
     // Regression test for a forged exclusion proof against the ordered partitioned index with
     // variable-length keys shorter than the partition prefix. The buggy router zero-padded a short


### PR DESCRIPTION
### Problem

Creating a stateless witness requires read access to the activity bitmap and grafted storage.

### Solution

Make them public.

closes #4351