### PR TITLE
[consensus/simplex] Overlap batcher crypto via dispatch pool instead of inline awaits

### DIFF
--- a/consensus/fuzz/fuzz_targets/simplex_elector.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_elector.rs
@@ -6,7 +6,7 @@ use commonware_consensus::{
         elector::{self, Elector, Random, RoundRobin},
         scheme::{bls12381_threshold::vrf as bls12381_threshold_vrf, ed25519},
     },
-    types::{Round, TermLength, View},
+    types::{Round, TermLength, View, ViewDelta},
 };
 use commonware_cryptography::{
     Sha256, Signer,
@@ -72,17 +72,22 @@ fuzz_target!(|input: FuzzInput| {
         FuzzElector::RoundRobin(term_length) => {
             let elector = match term_length.get() {
                 1 => RoundRobin::<Sha256>::default(),
-                _ => {
-                    RoundRobin::<Sha256>::default().with_term(*term_length, Duration::from_secs(12))
-                }
+                _ => RoundRobin::<Sha256>::default().with_term(
+                    *term_length,
+                    Duration::from_secs(12),
+                    ViewDelta::new(0),
+                ),
             };
             fuzz::<ed25519::Scheme, _>(&input, elector, None);
         }
         FuzzElector::RoundRobinShuffled(seed, term_length) => {
             let elector = match term_length.get() {
                 1 => RoundRobin::<Sha256>::shuffled(seed),
-                _ => RoundRobin::<Sha256>::shuffled(seed)
-                    .with_term(*term_length, Duration::from_secs(12)),
+                _ => RoundRobin::<Sha256>::shuffled(seed).with_term(
+                    *term_length,
+                    Duration::from_secs(12),
+                    ViewDelta::new(0),
+                ),
             };
             fuzz::<ed25519::Scheme, _>(&input, elector, None);
         }

--- a/consensus/fuzz/src/invariants.rs
+++ b/consensus/fuzz/src/invariants.rs
@@ -1,5 +1,5 @@
 use crate::{
-    bounds,
+    Configuration, bounds,
     simplex::Simplex,
     types::{Finalization, Notarization, Nullification, ReplicaState},
 };
@@ -13,7 +13,7 @@ use commonware_cryptography::{
     sha256::Digest as Sha256Digest,
 };
 use rand_core::CryptoRng;
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 // Intentionally restates View::covers with independent integer arithmetic:
 // the fuzz oracle must not delegate to the production term predicates
@@ -35,29 +35,117 @@ fn nullification_conflicts(
     (nullified_view - 1) / term_length == (finalized_view - 1) / term_length
 }
 
-pub fn check<P: Simplex>(n: u32, term_length: TermLength, replicas: Vec<ReplicaState>) {
-    let threshold = bounds::quorum(n) as usize;
+// Term index and term-start test derived from the same boundaries, kept
+// independent of the production predicates for the same reason. Genesis is its
+// own term, so term indices start at 1 for view 1.
+fn term_of(view: u64, term_length: TermLength) -> u64 {
+    match view {
+        0 => 0,
+        view => 1 + (view - 1) / term_length.get(),
+    }
+}
+
+fn is_term_start(view: u64, term_length: TermLength) -> bool {
+    view == 0 || (view - 1).is_multiple_of(term_length.get())
+}
+
+pub fn check<P: Simplex>(
+    configuration: Configuration,
+    term_length: TermLength,
+    replicas: Vec<ReplicaState>,
+) {
+    let threshold = bounds::quorum(configuration.n) as usize;
 
     // Invariant: agreement
-    // All replicas that finalized a given view must have the same digest for that view.
+    // All replicas that finalized a given view must have the same digest for
+    // that view. The parent is only compared when an honest quorum exists
+    // (can_finalize): a Byzantine quorum can jointly mint a certificate with
+    // a mutated parent view alongside the honest one, which would trip the
+    // parent comparison without a real safety violation.
     let all_views: HashSet<u64> = replicas
         .iter()
         .flat_map(|(_, _, finalizations)| finalizations.keys().cloned())
         .collect();
     for view in all_views {
-        let finalizations_for_view: Vec<(usize, Sha256Digest)> = replicas
+        let finalizations_for_view: Vec<(usize, (Sha256Digest, u64))> = replicas
             .iter()
             .enumerate()
             .filter_map(|(idx, (_, _, finalizations))| {
-                finalizations.get(&view).map(|d| (idx, d.payload))
+                finalizations
+                    .get(&view)
+                    .map(|d| (idx, (d.payload, d.parent)))
             })
             .collect();
 
-        if let Some((first_idx, first_digest)) = finalizations_for_view.first() {
-            for (idx, digest) in &finalizations_for_view[1..] {
+        if let Some((first_idx, first_record)) = finalizations_for_view.first() {
+            for (idx, record) in &finalizations_for_view[1..] {
                 assert_eq!(
-                    digest, first_digest,
-                    "Invariant violation: finalized digest mismatch in view {view}: replica {idx} has {digest:?} but replica {first_idx} has {first_digest:?}",
+                    record.0, first_record.0,
+                    "Invariant violation: finalized digest mismatch in view {view}: replica {idx} has {record:?} but replica {first_idx} has {first_record:?}",
+                );
+                if configuration.can_finalize() {
+                    assert_eq!(
+                        record.1, first_record.1,
+                        "Invariant violation: finalized parent mismatch in view {view}: replica {idx} has {record:?} but replica {first_idx} has {first_record:?}",
+                    );
+                }
+            }
+        }
+    }
+
+    // Invariant: finalization_ancestry
+    // A finalized view's parent must be an earlier view, and no view may
+    // finalize strictly between a parent and its child (such a block would be
+    // forked around). A parent may also only skip views the protocol allows to
+    // be skipped. Gated on `can_finalize` for the reason given above.
+    if configuration.can_finalize() {
+        let finalized_parents: BTreeMap<u64, u64> = replicas
+            .iter()
+            .flat_map(|(_, _, finalizations)| {
+                finalizations.iter().map(|(&view, d)| (view, d.parent))
+            })
+            .collect();
+        // Terms any replica nullified. Taking the union across replicas is
+        // deliberately permissive: a skip is accepted when the nullification
+        // that justifies it was observed anywhere, not necessarily by the
+        // replica that finalized. That can only weaken the check below.
+        let nullified_terms: HashSet<u64> = replicas
+            .iter()
+            .flat_map(|(_, nullifications, _)| nullifications.keys())
+            .map(|&view| term_of(view, term_length))
+            .collect();
+
+        // In ascending view order, each parent must be strictly below its
+        // child and at or above the previous finalized view (otherwise that
+        // predecessor was forked around).
+        let mut previous: Option<u64> = None;
+        for (&view, &parent) in &finalized_parents {
+            assert!(
+                parent < view,
+                "Invariant violation: view {view} finalized with parent {parent} not strictly below it",
+            );
+            if let Some(previous) = previous {
+                assert!(
+                    parent >= previous,
+                    "Invariant violation: view {previous} finalized strictly between parent {parent} and finalized child {view}",
+                );
+            }
+            previous = Some(view);
+
+            // Only a term start may skip views, and then only over terms the
+            // network agreed to abandon.
+            if !is_term_start(view, term_length) {
+                assert_eq!(
+                    parent + 1,
+                    view,
+                    "Invariant violation: intra-term view {view} finalized with non-immediate parent {parent}",
+                );
+                continue;
+            }
+            for term in term_of(parent + 1, term_length)..=term_of(view - 1, term_length) {
+                assert!(
+                    nullified_terms.contains(&term),
+                    "Invariant violation: view {view} finalized over term {term} (parent {parent}) with no nullification",
                 );
             }
         }
@@ -264,6 +352,7 @@ where
                         view.get(),
                         Finalization {
                             payload: cert.proposal.payload,
+                            parent: cert.proposal.parent.get(),
                             signature_count: get_signature_count::<S>(
                                 &cert.certificate,
                                 max_participants,
@@ -281,7 +370,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::simplex::SimplexEd25519;
+    use crate::{N4F1C3, N4F3C1, simplex::SimplexEd25519};
     use commonware_utils::NZU32;
     use std::{collections::HashMap, panic};
 
@@ -308,17 +397,183 @@ mod tests {
             3,
             Finalization {
                 payload,
+                parent: 0,
                 signature_count: Some(3),
             },
         );
 
         let result = panic::catch_unwind(|| {
             check::<SimplexEd25519>(
-                4,
+                N4F1C3,
                 TermLength::new(NZU32!(5)),
                 vec![(notarizations, nullifications, finalizations)],
             );
         });
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn parent_mismatch_requires_honest_quorum() {
+        let payload = Sha256Digest::from([9u8; 32]);
+        let replica = |parent| {
+            let mut notarizations = HashMap::new();
+            notarizations.insert(
+                3,
+                Notarization {
+                    payload,
+                    signature_count: Some(3),
+                },
+            );
+            let mut finalizations = HashMap::new();
+            finalizations.insert(
+                3,
+                Finalization {
+                    payload,
+                    parent,
+                    signature_count: Some(3),
+                },
+            );
+            (notarizations, HashMap::new(), finalizations)
+        };
+
+        // A Byzantine quorum can mint a certificate with a mutated parent
+        // alongside the honest one, so a parent mismatch must not fire
+        // without an honest quorum.
+        check::<SimplexEd25519>(
+            N4F3C1,
+            TermLength::new(NZU32!(5)),
+            vec![replica(1), replica(2)],
+        );
+
+        // With an honest quorum, a parent mismatch is a real violation.
+        let result = panic::catch_unwind(|| {
+            check::<SimplexEd25519>(
+                N4F1C3,
+                TermLength::new(NZU32!(5)),
+                vec![replica(1), replica(2)],
+            );
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn finalization_between_parent_and_child_fires() {
+        let mut notarizations = HashMap::new();
+        let mut finalizations = HashMap::new();
+        for (view, byte, parent) in [(2u64, 2u8, 1u64), (5, 5, 1)] {
+            let payload = Sha256Digest::from([byte; 32]);
+            notarizations.insert(
+                view,
+                Notarization {
+                    payload,
+                    signature_count: Some(3),
+                },
+            );
+            finalizations.insert(
+                view,
+                Finalization {
+                    payload,
+                    parent,
+                    signature_count: Some(3),
+                },
+            );
+        }
+
+        // View 5 finalized with parent 1, but view 2 is also finalized: view 2
+        // is forked around, so the ancestry invariant must fire.
+        let result = panic::catch_unwind(|| {
+            check::<SimplexEd25519>(
+                N4F1C3,
+                TermLength::ONE,
+                vec![(notarizations, HashMap::new(), finalizations)],
+            );
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn intra_term_parent_skip_fires() {
+        let payload = Sha256Digest::from([4u8; 32]);
+        let state = || {
+            let mut notarizations = HashMap::new();
+            notarizations.insert(
+                4,
+                Notarization {
+                    payload,
+                    signature_count: Some(3),
+                },
+            );
+            let mut finalizations = HashMap::new();
+            finalizations.insert(
+                4,
+                Finalization {
+                    payload,
+                    parent: 2,
+                    signature_count: Some(3),
+                },
+            );
+            vec![(notarizations, HashMap::new(), finalizations)]
+        };
+
+        // View 4 is not a term start, so it must build on view 3.
+        let result = panic::catch_unwind(|| {
+            check::<SimplexEd25519>(N4F1C3, TermLength::new(NZU32!(5)), state());
+        });
+        assert!(result.is_err());
+
+        // Without an honest quorum the parent is not trustworthy, so the rule
+        // must not fire (see `parent_mismatch_requires_honest_quorum`).
+        check::<SimplexEd25519>(N4F3C1, TermLength::new(NZU32!(5)), state());
+    }
+
+    #[test]
+    fn term_start_skip_requires_nullification() {
+        let payload = Sha256Digest::from([6u8; 32]);
+        // View 11 starts a term under term_length 5, so it may skip back to
+        // view 3 only if the terms it skips (containing views 4 and 6) were
+        // nullified.
+        let state = |nullified: &[u64]| {
+            let mut notarizations = HashMap::new();
+            notarizations.insert(
+                11,
+                Notarization {
+                    payload,
+                    signature_count: Some(3),
+                },
+            );
+            let mut nullifications = HashMap::new();
+            for &view in nullified {
+                nullifications.insert(
+                    view,
+                    Nullification {
+                        signature_count: Some(3),
+                    },
+                );
+            }
+            let mut finalizations = HashMap::new();
+            finalizations.insert(
+                11,
+                Finalization {
+                    payload,
+                    parent: 3,
+                    signature_count: Some(3),
+                },
+            );
+            vec![(notarizations, nullifications, finalizations)]
+        };
+
+        let result = panic::catch_unwind(|| {
+            check::<SimplexEd25519>(N4F1C3, TermLength::new(NZU32!(5)), state(&[]));
+        });
+        assert!(result.is_err(), "skip over an unnullified term must fire");
+
+        // Nullifying only the first skipped term leaves the second uncovered.
+        let result = panic::catch_unwind(|| {
+            check::<SimplexEd25519>(N4F1C3, TermLength::new(NZU32!(5)), state(&[4]));
+        });
+        assert!(result.is_err(), "partial coverage must fire");
+
+        // Both skipped terms nullified: the skip is legal.
+        check::<SimplexEd25519>(N4F1C3, TermLength::new(NZU32!(5)), state(&[4, 6]));
     }
 }

--- a/consensus/fuzz/src/invariants.rs
+++ b/consensus/fuzz/src/invariants.rs
@@ -77,16 +77,16 @@ pub fn check<P: Simplex>(
             })
             .collect();
 
-        if let Some((first_idx, first_record)) = finalizations_for_view.first() {
-            for (idx, record) in &finalizations_for_view[1..] {
+        if let Some((first_idx, (first_payload, first_parent))) = finalizations_for_view.first() {
+            for (idx, (payload, parent)) in &finalizations_for_view[1..] {
                 assert_eq!(
-                    record.0, first_record.0,
-                    "Invariant violation: finalized digest mismatch in view {view}: replica {idx} has {record:?} but replica {first_idx} has {first_record:?}",
+                    payload, first_payload,
+                    "Invariant violation: finalized digest mismatch in view {view}: replica {idx} has ({payload:?}, {parent}) but replica {first_idx} has ({first_payload:?}, {first_parent})",
                 );
                 if configuration.can_finalize() {
                     assert_eq!(
-                        record.1, first_record.1,
-                        "Invariant violation: finalized parent mismatch in view {view}: replica {idx} has {record:?} but replica {first_idx} has {first_record:?}",
+                        parent, first_parent,
+                        "Invariant violation: finalized parent mismatch in view {view}: replica {idx} has ({payload:?}, {parent}) but replica {first_idx} has ({first_payload:?}, {first_parent})",
                     );
                 }
             }

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -156,7 +156,7 @@ impl Arbitrary<'_> for FuzzInput {
             u.int_in_range(MIN_REQUIRED_CONTAINERS..=MAX_REQUIRED_CONTAINERS)?;
         let term_length = TermLength::new(NZU32!(u.int_in_range(1..=5)?));
         let optimistic_views =
-            ViewDelta::new(u.int_in_range(0..=optimistic_views_domain(term_length) - 1)?);
+            ViewDelta::new(u.int_in_range(0..=max_optimistic_views(term_length))?);
 
         // SmallScope mutations with round-based injections - 80%,
         // AnyScope mutations - 10%,
@@ -202,15 +202,15 @@ impl Arbitrary<'_> for FuzzInput {
 fn validator_optimistic_views(input: &FuzzInput, validator: usize) -> ViewDelta {
     ViewDelta::new(
         (input.optimistic_views.get() + validator as u64)
-            % optimistic_views_domain(input.term_length),
+            % (max_optimistic_views(input.term_length) + 1),
     )
 }
 
-/// Size of the optimistic-view domain `[0, term_length + 2]`: covers 0
-/// (optimistic validation disabled), the term-length boundary, and values
-/// beyond the term length, which production accepts but caps.
-fn optimistic_views_domain(term_length: TermLength) -> u64 {
-    term_length.get() + 3
+/// Largest fuzzed optimistic-view value: the domain `[0, term_length + 2]`
+/// covers 0 (optimistic validation disabled), the term-length boundary, and
+/// values beyond the term length, which production accepts but caps.
+fn max_optimistic_views(term_length: TermLength) -> u64 {
+    term_length.get() + 2
 }
 
 type NetworkChannels = (

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -20,7 +20,7 @@ use commonware_consensus::{
         mocks::{application, relay, reporter, twins},
         types::{Certificate, Vote},
     },
-    types::{Delta, Epoch, TermLength, View},
+    types::{Delta, Epoch, TermLength, View, ViewDelta},
 };
 use commonware_cryptography::{
     Sha256,
@@ -124,6 +124,7 @@ pub struct FuzzInput {
     pub raw_bytes: Vec<u8>,
     pub required_containers: u64,
     pub term_length: TermLength,
+    pub optimistic_views: ViewDelta,
     pub degraded_network: bool,
     pub configuration: Configuration,
     pub partition: Partition,
@@ -154,6 +155,8 @@ impl Arbitrary<'_> for FuzzInput {
         let required_containers =
             u.int_in_range(MIN_REQUIRED_CONTAINERS..=MAX_REQUIRED_CONTAINERS)?;
         let term_length = TermLength::new(NZU32!(u.int_in_range(1..=5)?));
+        let optimistic_views =
+            ViewDelta::new(u.int_in_range(0..=optimistic_views_domain(term_length) - 1)?);
 
         // SmallScope mutations with round-based injections - 80%,
         // AnyScope mutations - 10%,
@@ -185,9 +188,29 @@ impl Arbitrary<'_> for FuzzInput {
             degraded_network,
             required_containers,
             term_length,
+            optimistic_views,
             strategy,
         })
     }
+}
+
+/// Derive a per-validator optimistic-view budget from the fuzzed base value.
+///
+/// Mismatched values across validators are safe (see
+/// [`commonware_consensus::simplex::elector::Terms::stable`]), so varying them
+/// deterministically exercises heterogeneous deployments.
+fn validator_optimistic_views(input: &FuzzInput, validator: usize) -> ViewDelta {
+    ViewDelta::new(
+        (input.optimistic_views.get() + validator as u64)
+            % optimistic_views_domain(input.term_length),
+    )
+}
+
+/// Size of the optimistic-view domain `[0, term_length + 2]`: covers 0
+/// (optimistic validation disabled), the term-length boundary, and values
+/// beyond the term length, which production accepts but caps.
+fn optimistic_views_domain(term_length: TermLength) -> u64 {
+    term_length.get() + 3
 }
 
 type NetworkChannels = (
@@ -344,6 +367,7 @@ fn spawn_honest_validator<
     oracle: &Oracle<Ed25519PublicKey, deterministic::Context>,
     participants: &[Ed25519PublicKey],
     term_length: TermLength,
+    optimistic_views: ViewDelta,
     scheme: P::Scheme,
     validator: Ed25519PublicKey,
     relay: Arc<relay::Relay<Sha256Digest, Ed25519PublicKey>>,
@@ -362,7 +386,7 @@ where
     ResolverSender: commonware_p2p::Sender<PublicKey = Ed25519PublicKey>,
     ResolverReceiver: commonware_p2p::Receiver<PublicKey = Ed25519PublicKey>,
 {
-    let elector = P::elector(term_length);
+    let elector = P::elector(term_length, optimistic_views);
     let reporter_cfg = reporter::Config {
         participants: participants.try_into().expect("public keys are unique"),
         scheme: scheme.clone(),
@@ -447,6 +471,7 @@ fn run<P: simplex::Simplex>(input: FuzzInput) {
                 &oracle,
                 &participants,
                 input.term_length,
+                validator_optimistic_views(&input, i),
                 schemes[i].clone(),
                 validator.clone(),
                 relay.clone(),
@@ -488,7 +513,7 @@ fn run<P: simplex::Simplex>(input: FuzzInput) {
                 .collect(),
             config.n as usize,
         );
-        invariants::check::<P>(config.n, input.term_length, states);
+        invariants::check::<P>(config, input.term_length, states);
     });
 }
 
@@ -603,7 +628,8 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
 
             // Primary: legitimate engine
             let primary_context = context.child("primary");
-            let primary_elector = P::elector(input.term_length);
+            let primary_elector =
+                P::elector(input.term_length, validator_optimistic_views(&input, idx));
             let reporter_cfg = reporter::Config {
                 participants: participants
                     .as_ref()
@@ -682,6 +708,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 &oracle,
                 participants.as_ref(),
                 input.term_length,
+                validator_optimistic_views(&input, idx),
                 schemes[idx].clone(),
                 validator.clone(),
                 relay.clone(),
@@ -723,7 +750,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 .collect(),
             config.n as usize,
         );
-        invariants::check::<P>(config.n, input.term_length, states);
+        invariants::check::<P>(config, input.term_length, states);
     });
 }
 

--- a/consensus/fuzz/src/simplex.rs
+++ b/consensus/fuzz/src/simplex.rs
@@ -7,7 +7,7 @@ use commonware_consensus::{
             secp256r1,
         },
     },
-    types::TermLength,
+    types::{TermLength, ViewDelta},
 };
 use commonware_cryptography::{
     bls12381::primitives::variant::{MinPk, MinSig},
@@ -18,12 +18,13 @@ use commonware_cryptography::{
 use commonware_runtime::deterministic;
 use std::time::Duration;
 
-/// Returns a round-robin elector config for the fuzzed term length.
-fn round_robin(term_length: TermLength) -> RoundRobin {
+/// Returns a round-robin elector config for the fuzzed term length and
+/// optimistic lookahead (ignored for single-view terms, where it is a no-op).
+fn round_robin(term_length: TermLength, optimistic_views: ViewDelta) -> RoundRobin {
     if term_length.get() == 1 {
         RoundRobin::default()
     } else {
-        RoundRobin::default().with_term(term_length, Duration::from_secs(12))
+        RoundRobin::default().with_term(term_length, Duration::from_secs(12), optimistic_views)
     }
 }
 
@@ -33,7 +34,7 @@ where
 {
     type Scheme: Scheme<Sha256Digest, PublicKey = Ed25519PublicKey>;
     type Elector: elector::Config<Self::Scheme>;
-    fn elector(term_length: TermLength) -> Self::Elector;
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector;
     fn fixture(
         context: &mut deterministic::Context,
         namespace: &[u8],
@@ -47,8 +48,8 @@ impl Simplex for SimplexEd25519 {
     type Scheme = ed25519::Scheme;
     type Elector = RoundRobin;
 
-    fn elector(term_length: TermLength) -> Self::Elector {
-        round_robin(term_length)
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector {
+        round_robin(term_length, optimistic_views)
     }
 
     fn fixture(
@@ -66,8 +67,8 @@ impl Simplex for SimplexBls12381MultisigMinPk {
     type Scheme = bls12381_multisig::Scheme<Ed25519PublicKey, MinPk>;
     type Elector = RoundRobin;
 
-    fn elector(term_length: TermLength) -> Self::Elector {
-        round_robin(term_length)
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector {
+        round_robin(term_length, optimistic_views)
     }
 
     fn fixture(
@@ -85,8 +86,8 @@ impl Simplex for SimplexBls12381MultisigMinSig {
     type Scheme = bls12381_multisig::Scheme<Ed25519PublicKey, MinSig>;
     type Elector = RoundRobin;
 
-    fn elector(term_length: TermLength) -> Self::Elector {
-        round_robin(term_length)
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector {
+        round_robin(term_length, optimistic_views)
     }
 
     fn fixture(
@@ -104,8 +105,8 @@ impl Simplex for SimplexBls12381MinPk {
     type Scheme = bls12381_threshold_vrf::Scheme<Ed25519PublicKey, MinPk>;
     type Elector = RoundRobin;
 
-    fn elector(term_length: TermLength) -> Self::Elector {
-        round_robin(term_length)
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector {
+        round_robin(term_length, optimistic_views)
     }
 
     fn fixture(
@@ -123,8 +124,8 @@ impl Simplex for SimplexBls12381MinSig {
     type Scheme = bls12381_threshold_vrf::Scheme<Ed25519PublicKey, MinSig>;
     type Elector = RoundRobin;
 
-    fn elector(term_length: TermLength) -> Self::Elector {
-        round_robin(term_length)
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector {
+        round_robin(term_length, optimistic_views)
     }
 
     fn fixture(
@@ -142,8 +143,8 @@ impl Simplex for SimplexSecp256r1 {
     type Scheme = secp256r1::Scheme<Ed25519PublicKey>;
     type Elector = RoundRobin;
 
-    fn elector(term_length: TermLength) -> Self::Elector {
-        round_robin(term_length)
+    fn elector(term_length: TermLength, optimistic_views: ViewDelta) -> Self::Elector {
+        round_robin(term_length, optimistic_views)
     }
 
     fn fixture(
@@ -159,7 +160,7 @@ impl Simplex for SimplexSecp256r1 {
 mod tests {
     use super::*;
     use crate::{FuzzInput, N4F1C3, Standard, fuzz, strategy::StrategyChoice, utils::Partition};
-    use commonware_consensus::types::TermLength;
+    use commonware_consensus::types::{TermLength, ViewDelta};
     use commonware_macros::{test_group, test_traced};
     use commonware_utils::NZU32;
     use proptest::prelude::*;
@@ -176,6 +177,7 @@ mod tests {
             configuration: N4F1C3,
             required_containers: containers,
             term_length,
+            optimistic_views: ViewDelta::new(term_length.get()),
             degraded_network: false,
             strategy: StrategyChoice::AnyScope,
         }
@@ -185,6 +187,18 @@ mod tests {
     #[test_traced]
     fn test_ed25519_connected() {
         fuzz::<SimplexEd25519, Standard>(test_input(SEED, TEST_CONTAINERS, TermLength::ONE));
+    }
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_ed25519_stable_leader_connected() {
+        // Multi-view terms with a small optimistic-view budget exercise the
+        // stable-leader path, unlike the TermLength::ONE tests above.
+        let input = FuzzInput {
+            optimistic_views: ViewDelta::new(2),
+            ..test_input(SEED, TEST_CONTAINERS, TermLength::new(NZU32!(5)))
+        };
+        fuzz::<SimplexEd25519, Standard>(input);
     }
 
     #[test_group("slow")]

--- a/consensus/fuzz/src/types.rs
+++ b/consensus/fuzz/src/types.rs
@@ -25,6 +25,8 @@ pub struct Nullification {
 
 pub struct Finalization {
     pub payload: Sha256Digest,
+    /// View of the finalized proposal's parent.
+    pub parent: u64,
     /// None for threshold schemes where count is not exposed.
     pub signature_count: Option<usize>,
 }

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -119,6 +119,14 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// For [`CertifiableAutomaton`] implementations, returning a payload from
         /// `propose` also commits the local proposer to certifying that same
         /// `(round, payload)` if it later becomes notarized.
+        ///
+        /// The parent named in the context is not guaranteed to be settled.
+        /// Implementations that run ahead optimistically (see [`simplex`]) may
+        /// request a payload while the parent is only notarized, or only
+        /// locally voted for, and may do so before consensus has entered the
+        /// context's own view. Build on the named parent regardless of how far
+        /// it has progressed; if the parent is later abandoned, so is this
+        /// proposal.
         fn propose(
             &mut self,
             context: Self::Context,
@@ -140,6 +148,12 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// Closing the channel is also terminal for this request and should be reserved for cases
         /// where verification cannot ever produce a verdict anymore (for example, shutdown), not
         /// for temporary inability to decide.
+        ///
+        /// The parent settlement caveat on [`Self::propose`] applies here too,
+        /// and makes the guidance above load-bearing. A `false` verdict (or a
+        /// closed channel) for a future view is retained and acted upon as
+        /// soon as that view is entered, so declining because the payload
+        /// cannot be validated *yet* converts the optimization into a stall.
         fn verify(
             &mut self,
             context: Self::Context,

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -2,14 +2,14 @@ use super::{Config, Mailbox, Message, Round};
 use crate::{
     Epochable, Relay, Reporter, Viewable,
     simplex::{
-        Plan, Viewport,
+        Lookahead, Plan, Viewport,
         actors::voter,
         config::ForwardingPolicy,
         metrics::{Inbound, Peer, TimeoutReason},
         scheme::Scheme,
         types::{Activity, Certificate, Proposal, Vote},
     },
-    types::{Epoch, Participant, Round as Rnd, TermLength, View, ViewDelta},
+    types::{Epoch, Participant, Round as Rnd, View, ViewDelta},
 };
 use commonware_actor::mailbox;
 use commonware_cryptography::Digest;
@@ -35,12 +35,16 @@ use std::{
 };
 use tracing::{Instrument as _, Span, debug, info_span, trace};
 
-/// Tracks the current view, its leader, and whether the voter has
-/// already been told to timeout this view.
+/// Tracks the current view, its leader, and whether the voter has already been
+/// sent the leader-nullify hint for it.
+///
+/// The hint is tracked on its own rather than alongside other timeout reasons
+/// because the voter may ignore an inactivity hint (a buffered proposal
+/// disproves it) but must always act on the leader's own nullify.
 struct Current {
     view: View,
     leader: Option<Participant>,
-    timed_out: bool,
+    leader_nullify_hinted: bool,
 }
 
 pub struct Actor<E, S, B, D, Re, Rl, T>
@@ -66,7 +70,7 @@ where
     skip_timeout: Duration,
     forwarding: ForwardingPolicy,
     epoch: Epoch,
-    term_length: TermLength,
+    lookahead: Lookahead,
     floor: View,
 
     /// Tracks the last activity time for each participant, indexed by
@@ -151,7 +155,7 @@ where
                 skip_timeout: cfg.skip_timeout,
                 forwarding: cfg.forwarding,
                 epoch: cfg.epoch,
-                term_length: cfg.term_length,
+                lookahead: cfg.lookahead,
                 floor: cfg.floor,
 
                 mailbox_receiver: receiver,
@@ -223,7 +227,7 @@ where
             finalized,
             current,
             view_retention: self.view_retention,
-            term_length: self.term_length,
+            lookahead: self.lookahead,
         }
     }
 
@@ -237,7 +241,7 @@ where
             .collect()
     }
 
-    /// Selects forwarding targets for a certified proposal under the active policy.
+    /// Selects forwarding targets for a forwardable proposal under the active policy.
     fn forward_targets(
         &self,
         round: &Round<S, B, D, Re>,
@@ -273,7 +277,7 @@ where
     /// Returns true if the leader has nullified the current view
     /// and we have not yet notified the voter.
     fn leader_nullified(current: &Current, work: &BTreeMap<View, Round<S, B, D, Re>>) -> bool {
-        if current.timed_out {
+        if current.leader_nullify_hinted {
             return false;
         }
         let Some(leader) = current.leader else {
@@ -281,6 +285,77 @@ where
         };
         work.get(&current.view)
             .is_some_and(|round| round.has_nullify(leader))
+    }
+
+    /// Returns the round for `view`, creating it if needed and stamping the
+    /// stable leader when the view is within the admission window.
+    fn round_for_view<'a>(
+        &self,
+        current: &Current,
+        work: &'a mut BTreeMap<View, Round<S, B, D, Re>>,
+        view: View,
+    ) -> &'a mut Round<S, B, D, Re> {
+        let round = work.entry(view).or_insert_with(|| self.new_round(view));
+        self.stamp_leader(current, view, round);
+        round
+    }
+
+    /// Stamps the current term's stable leader on `view`'s round when the
+    /// view is current or inside the admission window.
+    fn stamp_leader(&self, current: &Current, view: View, round: &mut Round<S, B, D, Re>) {
+        let Some(leader) = current.leader else {
+            return;
+        };
+
+        if view == current.view || self.lookahead.in_admission_window(current.view, view) {
+            round.set_leader(leader);
+        }
+    }
+
+    /// Batch-verifies any ready votes for `view` and forwards newly
+    /// constructible certificates to the voter.
+    async fn process_view(
+        &mut self,
+        voter: &mut voter::Mailbox<S, D>,
+        view: View,
+        round: &mut Round<S, B, D, Re>,
+    ) {
+        loop {
+            let timer = self.verify_latency.timer(self.context.as_ref());
+            let Some((batch, failed)) = round
+                .try_verify(self.context.as_mut(), &self.strategy)
+                .await
+            else {
+                trace!(%view, "no verifier ready");
+                break;
+            };
+
+            timer.observe(self.context.as_ref());
+
+            trace!(%view, batch, "batch verified votes");
+            self.verified.inc_by(batch as u64);
+            self.batch_size.observe(batch as f64);
+
+            for invalid in failed {
+                if let Some(signer) = self.scheme.participants().key(invalid) {
+                    commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
+                }
+            }
+        }
+
+        // Construct and forward every certificate with a verified quorum
+        while let Some(certificate) = self
+            .recover_latency
+            .time_some(
+                self.context.as_ref(),
+                round.try_construct_certificate(&self.strategy),
+            )
+            .await
+        {
+            let kind = certificate.kind();
+            debug!(%view, %kind, "constructed certificate, forwarding to voter");
+            voter.recovered(certificate);
+        }
     }
 
     pub fn start(
@@ -311,15 +386,19 @@ where
         let mut current = Current {
             view: View::zero(),
             leader: None,
-            timed_out: false,
+            leader_nullify_hinted: false,
         };
         let mut finalized = self.floor;
         let mut work: BTreeMap<View, Round<S, B, D, Re>> = BTreeMap::new();
+        // Views needing (re)processing this iteration, in ascending order.
+        // Reused across iterations to keep the per-vote path allocation-free.
+        // Reprocessing a view is a no-op, so a duplicate entry costs only a
+        // wasted pass.
+        let mut dirty_views: Vec<View> = Vec::new();
         select_loop! {
             self.context,
             on_start => {
-                // Track which view was modified (if any) for certificate construction
-                let updated_view;
+                dirty_views.clear();
             },
             on_stopped => {
                 debug!("context shutdown, stopping batcher");
@@ -343,7 +422,7 @@ where
                         current: new_current,
                         leader,
                         finalized: new_finalized,
-                        certified_proposal,
+                        forwardable_proposal,
                     } => {
                         let process = process_span(span.clone());
                         let _guard = process.entered();
@@ -352,7 +431,7 @@ where
                         current = Current {
                             view: new_current,
                             leader: Some(leader),
-                            timed_out: false,
+                            leader_nullify_hinted: false,
                         };
                         finalized = new_finalized;
 
@@ -363,11 +442,20 @@ where
 
                         // Track the new current view, adopting the voter's view
                         // span so all of its work shares one trace
-                        let round = work
-                            .entry(current.view)
-                            .or_insert_with(|| self.new_round(current.view));
+                        let round = self.round_for_view(&current, &mut work, current.view);
                         round.set_span(span);
-                        round.set_leader(leader);
+                        dirty_views.push(current.view);
+
+                        // Revisit rounds in the admission window now that the
+                        // current view advanced: rounds already visited are
+                        // cheap no-ops to reprocess.
+                        let limit = self.lookahead.admission_limit(current.view);
+                        if current.view < limit {
+                            for (&view, round) in work.range_mut(current.view.next()..=limit) {
+                                self.stamp_leader(&current, view, round);
+                                dirty_views.push(view);
+                            }
+                        }
 
                         // If the leader nullified this view or has not been active
                         // recently, tell the voter to reduce the leader timeout to now.
@@ -392,12 +480,13 @@ where
                             },
                         };
                         if let Some(timeout_reason) = timeout_reason {
-                            current.timed_out = true;
+                            current.leader_nullify_hinted =
+                                matches!(timeout_reason, TimeoutReason::LeaderNullify);
                             voter.timeout(Rnd::new(self.epoch, current.view), timeout_reason);
                         }
 
                         // Forward the proposal, if enabled and we have something to forward
-                        if let Some((proposal, round)) = certified_proposal
+                        if let Some((proposal, round)) = forwardable_proposal
                             .filter(|_| self.forwarding.is_enabled())
                             .and_then(|proposal| {
                                 work.get(&proposal.view()).map(|round| (proposal, round))
@@ -407,8 +496,6 @@ where
                             self.forward_proposal(proposal, participants);
                         }
 
-                        // Setting leader may enable batch verification
-                        updated_view = current.view;
                     }
                     Message::Constructed(message) => {
                         // Skip votes below the viewport floor. Our own votes
@@ -421,13 +508,15 @@ where
                             continue;
                         }
 
-                        // Add the message to the verifier
-                        let round = work.entry(view).or_insert_with(|| self.new_round(view));
+                        // Add the message to the verifier. Since these are our own
+                        // votes, we can safely add the message even if the view is
+                        // arbitrarily far in the future.
+                        let round = self.round_for_view(&current, &mut work, view);
                         let process = process_span(round.span());
                         let _guard = process.entered();
                         round.add_constructed(message);
                         self.added.inc();
-                        updated_view = view;
+                        dirty_views.push(view);
                     }
                 }
             },
@@ -465,8 +554,7 @@ where
                 // Skip certificates we already have for the view
                 let kind = message.kind();
                 let round = work.get(&view);
-                let duplicate = round.is_some_and(|round| round.has_certificate(kind));
-                if duplicate {
+                if round.is_some_and(|round| round.has_certificate(kind)) {
                     trace!(%view, %kind, "skipping duplicate certificate");
                     continue;
                 }
@@ -483,62 +571,19 @@ where
                 );
                 let _guard = span.entered();
 
-                match message {
-                    Certificate::Notarization(notarization) => {
-                        // Verify the certificate
-                        if !notarization.verify(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid notarization");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_certificate(kind);
-                        voter.recovered(Certificate::Notarization(notarization));
-                    }
-                    Certificate::Nullification(nullification) => {
-                        // Verify the certificate
-                        if !nullification.verify::<_, D>(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid nullification");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_certificate(kind);
-                        voter.recovered(Certificate::Nullification(nullification));
-                    }
-                    Certificate::Finalization(finalization) => {
-                        // Verify the certificate
-                        if !finalization.verify(
-                            self.context.as_mut(),
-                            self.scheme.as_ref(),
-                            &self.strategy,
-                        ) {
-                            commonware_p2p::block!(self.blocker, sender, %view, "invalid finalization");
-                            continue;
-                        }
-
-                        // Store and forward to voter
-                        work.entry(view)
-                            .or_insert_with(|| self.new_round(view))
-                            .record_certificate(kind);
-                        voter.recovered(Certificate::Finalization(finalization));
-                    }
+                // Verify the certificate.
+                if !message.verify(self.context.as_mut(), self.scheme.as_ref(), &self.strategy) {
+                    commonware_p2p::block!(self.blocker, sender, %view, %kind, "invalid certificate");
+                    continue;
                 }
 
-                // Certificates are already forwarded to voter, no need for construction
-                continue;
+                // Store and forward to voter, revisiting the round when the
+                // certificate may have unlocked already-buffered votes.
+                let round = self.round_for_view(&current, &mut work, view);
+                if round.set_certificate(&message) {
+                    dirty_views.push(view);
+                }
+                voter.recovered(message);
             },
             // Handle votes from the network
             Ok((sender, message)) = vote_receiver.recv() else break => {
@@ -573,11 +618,8 @@ where
                 }
 
                 // Add the vote to the verifier
-                if work
-                    .entry(view)
-                    .or_insert_with(|| self.new_round(view))
-                    .add_network(sender.clone(), message)
-                {
+                let round = self.round_for_view(&current, &mut work, view);
+                if round.add_network(sender.clone(), message) {
                     self.added.inc();
 
                     // Update per-peer latest vote metric (only if higher than current)
@@ -590,7 +632,7 @@ where
                     // the voter so it can fast-path timeout without waiting for its local
                     // timer. We check after adding because duplicate votes are rejected.
                     if Self::leader_nullified(&current, &work) {
-                        current.timed_out = true;
+                        current.leader_nullify_hinted = true;
                         let round = Rnd::new(self.epoch, current.view);
                         let _guard = work
                             .get(&current.view)
@@ -599,90 +641,51 @@ where
                             .entered();
                         voter.timeout(round, TimeoutReason::LeaderNullify);
                     }
+                    dirty_views.push(view);
                 }
-                updated_view = view;
             },
             on_end => {
-                assert!(
-                    updated_view != View::zero(),
-                    "updated view must be greater than zero"
-                );
-
-                // Forward leader's proposal to voter (if we're not the leader and haven't already)
-                if let Some(round) = work.get_mut(&current.view)
-                    && let Some(me) = self.scheme.me()
-                    && let Some(proposal) = round.try_forward_proposal(me)
-                {
-                    round.span().in_scope(|| voter.proposal(proposal));
-                }
-
-                // Skip verification and construction for views at or below finalized.
-                //
-                // We still admit votes at or below finalized (see
-                // [Viewport::retains]) because we want to notify the reporter of
-                // all votes within the activity timeout (even if we don't need
-                // them in the voter).
-                if updated_view <= finalized {
+                if dirty_views.is_empty() {
                     continue;
                 }
 
-                // Process the updated view (if any)
-                let Some(round) = work.get_mut(&updated_view) else {
-                    continue;
-                };
-                let span = round.span();
-                async {
-                    // Batch verify votes if ready
-                    let timer = self.verify_latency.timer(self.context.as_ref());
-                    if let Some((batch, failed)) = round
-                        .try_verify(self.context.as_mut(), &self.strategy)
-                        .await
+                let me = self.scheme.me();
+
+                for view in dirty_views.drain(..) {
+                    // Skip verification and construction for views at or below
+                    // finalized. We still admit votes there (see
+                    // [Viewport::retains]) to notify the reporter of all votes
+                    // within the retained window (even if we don't need them
+                    // in the voter).
+                    if view <= finalized {
+                        continue;
+                    }
+                    let Some(round) = work.get_mut(&view) else {
+                        continue;
+                    };
+
+                    // Forward the round's leader proposal once known, keeping
+                    // optimistic followers fed. No window check needed: this
+                    // requires a stamped leader, and stamping is already
+                    // window-gated.
+                    if let Some(me) = me
+                        && let Some(proposal) = round.try_forward_proposal(me)
                     {
-                        timer.observe(self.context.as_ref());
-
-                        // Process verified votes.
-                        trace!(%updated_view, batch, "batch verified votes");
-                        self.verified.inc_by(batch as u64);
-                        self.batch_size.observe(batch as f64);
-
-                        // Block invalid signers
-                        for invalid in failed {
-                            if let Some(signer) = self.scheme.participants().key(invalid) {
-                                commonware_p2p::block!(
-                                    self.blocker,
-                                    signer.clone(),
-                                    "invalid signature"
-                                );
-                            }
-                        }
-                    } else {
-                        trace!(
-                            current = %current.view,
-                            %finalized,
-                            "no verifier ready"
-                        );
+                        round.span().in_scope(|| voter.proposal(proposal));
                     }
 
-                    // Construct and forward every certificate with a verified quorum
-                    while let Some(certificate) = self
-                        .recover_latency
-                        .time_some(
-                            self.context.as_ref(),
-                            round.try_construct_certificate(&self.strategy),
-                        )
-                        .await
-                    {
-                        let kind = certificate.kind();
-                        debug!(
-                            %updated_view,
-                            %kind,
-                            "constructed certificate, forwarding to voter"
-                        );
-                        voter.recovered(certificate);
+                    // We only process bounded future work. This keeps memory and
+                    // verification bounded while still enabling optimistic lookahead.
+                    if !self.lookahead.admits(current.view, view) {
+                        trace!(current = %current.view, %view, "skipping out-of-window round processing");
+                        continue;
                     }
+
+                    let span = round.span();
+                    self.process_view(&mut voter, view, round)
+                        .instrument(span)
+                        .await;
                 }
-                .instrument(span)
-                .await;
 
                 // Drop any rounds that are no longer retained
                 let viewport = self.viewport(finalized, current.view);

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -1,4 +1,4 @@
-use super::{Config, Mailbox, Message, Round};
+use super::{Config, Mailbox, Message, Round, VerifiedVotes};
 use crate::{
     Epochable, Relay, Reporter, Viewable,
     simplex::{
@@ -26,14 +26,14 @@ use commonware_runtime::{
         traces::TracedExt as _,
     },
 };
-use commonware_utils::{N3f1, ordered::Quorum};
+use commonware_utils::{N3f1, futures::Pool, ordered::Quorum};
 use rand_core::CryptoRng;
 use std::{
     collections::BTreeMap,
     sync::Arc,
     time::{Duration, SystemTime},
 };
-use tracing::{Instrument as _, Span, debug, info_span, trace};
+use tracing::{Span, debug, info_span, trace};
 
 /// Tracks the current view, its leader, and whether the voter has already been
 /// sent the leader-nullify hint for it.
@@ -45,6 +45,27 @@ struct Current {
     view: View,
     leader: Option<Participant>,
     leader_nullify_hinted: bool,
+}
+
+/// A completed crypto job from the actor's dispatch pool.
+enum Done<S: Scheme<D>, D: Digest> {
+    /// A verification batch completed: its verified votes must be
+    /// reintegrated into the view's round (see [Round::finish_verify]) and
+    /// invalid signers blocked.
+    Verified {
+        view: View,
+        batch: usize,
+        timer: histogram::Timer,
+        votes: VerifiedVotes<S, D>,
+        invalid: Vec<Participant>,
+    },
+    /// A certificate was recovered from a verified quorum and must be
+    /// forwarded to the voter.
+    Recovered {
+        view: View,
+        timer: histogram::Timer,
+        certificate: Certificate<S, D>,
+    },
 }
 
 pub struct Actor<E, S, B, D, Re, Rl, T>
@@ -312,49 +333,46 @@ where
         }
     }
 
-    /// Batch-verifies any ready votes for `view` and forwards newly
-    /// constructible certificates to the voter.
-    async fn process_view(
+    /// Dispatches any ready crypto work for `view` into `pool` without
+    /// blocking the event loop: one verification batch per vote kind (each
+    /// kind independently tracks an in-flight batch) plus recovery of every
+    /// certificate with a verified quorum.
+    ///
+    /// Results arrive through the pool's completion branch, which reintegrates
+    /// them and marks the view dirty so this dispatch runs again (e.g. to
+    /// recover a certificate from a quorum a batch just completed).
+    fn dispatch_view(
         &mut self,
-        voter: &mut voter::Mailbox<S, D>,
+        pool: &mut Pool<Done<S, D>>,
         view: View,
         round: &mut Round<S, B, D, Re>,
     ) {
-        loop {
+        // Begin a verification batch for every vote kind with work worth
+        // verifying.
+        while let Some((batch, job)) = round.begin_verify(self.context.as_mut(), &self.strategy) {
             let timer = self.verify_latency.timer(self.context.as_ref());
-            let Some((batch, failed)) = round
-                .try_verify(self.context.as_mut(), &self.strategy)
-                .await
-            else {
-                trace!(%view, "no verifier ready");
-                break;
-            };
-
-            timer.observe(self.context.as_ref());
-
-            trace!(%view, batch, "batch verified votes");
-            self.verified.inc_by(batch as u64);
-            self.batch_size.observe(batch as f64);
-
-            for invalid in failed {
-                if let Some(signer) = self.scheme.participants().key(invalid) {
-                    commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
+            pool.push(async move {
+                let (votes, invalid) = job.await;
+                Done::Verified {
+                    view,
+                    batch,
+                    timer,
+                    votes,
+                    invalid,
                 }
-            }
+            });
         }
 
-        // Construct and forward every certificate with a verified quorum
-        while let Some(certificate) = self
-            .recover_latency
-            .time_some(
-                self.context.as_ref(),
-                round.try_construct_certificate(&self.strategy),
-            )
-            .await
-        {
-            let kind = certificate.kind();
-            debug!(%view, %kind, "constructed certificate, forwarding to voter");
-            voter.recovered(certificate);
+        // Begin recovery of every certificate with a verified quorum.
+        while let Some(job) = round.begin_construct_certificate(&self.strategy) {
+            let timer = self.recover_latency.timer(self.context.as_ref());
+            pool.push(async move {
+                Done::Recovered {
+                    view,
+                    timer,
+                    certificate: job.await,
+                }
+            });
         }
     }
 
@@ -393,6 +411,11 @@ where
         // Views to (re)process this iteration. Reused to keep the per-vote
         // path allocation-free; a duplicate entry only costs a no-op pass.
         let mut dirty_views: Vec<View> = Vec::new();
+        // In-flight crypto (verification batches and certificate recoveries).
+        // Dispatching instead of awaiting keeps the event loop free to ingest
+        // votes while the strategy's workers verify, so multiple batches (and
+        // views) make progress concurrently.
+        let mut crypto_pool: Pool<Done<S, D>> = Pool::default();
         select_loop! {
             self.context,
             on_start => {
@@ -515,6 +538,48 @@ where
                         round.add_constructed(message);
                         self.added.inc();
                         dirty_views.push(view);
+                    }
+                }
+            },
+            // Handle completed crypto work (verification batches and
+            // certificate recoveries)
+            done = crypto_pool.next_completed() => {
+                match done {
+                    Done::Verified { view, batch, timer, votes, invalid } => {
+                        timer.observe(self.context.as_ref());
+                        self.verified.inc_by(batch as u64);
+                        self.batch_size.observe(batch as f64);
+
+                        for signer in invalid {
+                            if let Some(signer) = self.scheme.participants().key(signer) {
+                                commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
+                            }
+                        }
+
+                        // The round may have been pruned while the batch was in
+                        // flight; its votes are no longer needed.
+                        let Some(round) = work.get_mut(&view) else {
+                            continue;
+                        };
+                        let _guard = round.span().entered();
+                        trace!(%view, batch, "batch verified votes");
+                        round.finish_verify(votes);
+
+                        // Revisit the view: the batch may have completed a
+                        // quorum (certificate recovery) or more votes may have
+                        // buffered while it was in flight (another batch).
+                        dirty_views.push(view);
+                    }
+                    Done::Recovered { view, timer, certificate } => {
+                        timer.observe(self.context.as_ref());
+                        let kind = certificate.kind();
+                        let _guard = work
+                            .get(&view)
+                            .map(|round| round.span())
+                            .unwrap_or_else(Span::none)
+                            .entered();
+                        debug!(%view, %kind, "constructed certificate, forwarding to voter");
+                        voter.recovered(certificate);
                     }
                 }
             },
@@ -680,9 +745,7 @@ where
                     }
 
                     let span = round.span();
-                    self.process_view(&mut voter, view, round)
-                        .instrument(span)
-                        .await;
+                    span.in_scope(|| self.dispatch_view(&mut crypto_pool, view, round));
                 }
 
                 // Drop any rounds that are no longer retained

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -390,10 +390,8 @@ where
         };
         let mut finalized = self.floor;
         let mut work: BTreeMap<View, Round<S, B, D, Re>> = BTreeMap::new();
-        // Views needing (re)processing this iteration, in ascending order.
-        // Reused across iterations to keep the per-vote path allocation-free.
-        // Reprocessing a view is a no-op, so a duplicate entry costs only a
-        // wasted pass.
+        // Views to (re)process this iteration. Reused to keep the per-vote
+        // path allocation-free; a duplicate entry only costs a no-op pass.
         let mut dirty_views: Vec<View> = Vec::new();
         select_loop! {
             self.context,

--- a/consensus/src/simplex/actors/batcher/ingress.rs
+++ b/consensus/src/simplex/actors/batcher/ingress.rs
@@ -16,7 +16,7 @@ pub enum Message<S: Scheme, D: Digest> {
         current: View,
         leader: Participant,
         finalized: View,
-        certified_proposal: Option<Proposal<D>>,
+        forwardable_proposal: Option<Proposal<D>>,
     },
     /// A constructed vote (needed for quorum).
     Constructed(Vote<S, D>),
@@ -177,14 +177,14 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
         current: View,
         leader: Participant,
         finalized: View,
-        certified_proposal: Option<Proposal<D>>,
+        forwardable_proposal: Option<Proposal<D>>,
     ) {
         let _ = self.sender.enqueue(Message::Update {
             span,
             current,
             leader,
             finalized,
-            certified_proposal,
+            forwardable_proposal,
         });
     }
 
@@ -246,7 +246,7 @@ mod tests {
             current,
             leader: Participant::new(0),
             finalized,
-            certified_proposal: None,
+            forwardable_proposal: None,
         }
     }
 

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -15,7 +15,7 @@ use commonware_parallel::Strategy;
 pub use ingress::{Mailbox, Message};
 pub use round::Round;
 use std::{num::NonZeroUsize, time::Duration};
-pub use verifier::Verifier;
+pub use verifier::{VerifiedVotes, Verifier, VerifyJob};
 
 pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
     pub scheme: S,

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -591,298 +591,232 @@ mod tests {
         });
     }
 
-    /// Finalize votes buffer unverifiable while the leader's proposal is
-    /// unknown. The leader's notarize vote arrives last, after a full
-    /// finalize quorum is already buffered, so setting the proposal must
-    /// drain the ready finalize batch in the same pass, yielding both
-    /// certificates. (The notarize loop starts at signer 2 to keep the
-    /// leader's vote, which reveals the proposal, for the end.)
-    #[test_traced]
-    fn test_local_notarization_drains_ready_finalization() {
+    /// Harness for the buffered-finalization tests: a started batcher for
+    /// participant 0 (leader 1, view 1) with a finalize quorum for `proposal`
+    /// buffered unverifiable, since the leader's proposal is not yet known.
+    struct BufferedFinalization {
+        oracle: Oracle<PublicKey, deterministic::Context>,
+        participants: Vec<PublicKey>,
+        schemes: Vec<ed25519::Scheme>,
+        /// Vote-channel senders per participant (`None` for the local node).
+        participant_senders: Vec<Option<Sender<PublicKey, deterministic::Context>>>,
+        me: PublicKey,
+        proposal: Proposal<Sha256Digest>,
+        quorum: usize,
+        voter_receiver: mailbox::Receiver<voter::Message<ed25519::Scheme, Sha256Digest>>,
+        /// Keeps the batcher's mailbox open for the life of the test.
+        _batcher_mailbox: Mailbox<ed25519::Scheme, Sha256Digest>,
+        /// Keeps the local node's registered channels open.
+        _local_senders: (
+            Sender<PublicKey, deterministic::Context>,
+            Sender<PublicKey, deterministic::Context>,
+        ),
+    }
+
+    /// Builds a [`BufferedFinalization`]: finalize votes buffer unverifiable
+    /// while the leader's proposal is unknown, so each test reveals the
+    /// proposal its own way and expects the buffered quorum to drain.
+    async fn buffered_finalization_setup(
+        context: &mut deterministic::Context,
+    ) -> BufferedFinalization {
         let n = 5;
         let quorum = quorum(n) as usize;
         let namespace = b"batcher_test".to_vec();
         let epoch = Epoch::new(333);
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(context, &namespace, n);
+        let oracle =
+            start_test_network_with_peers(context.child("network"), participants.clone()).await;
+        let reporter = test_reporter(context, &schemes[0]);
+
+        let me = participants[0].clone();
+        let batcher_cfg = test_config(
+            schemes[0].clone(),
+            oracle.control(me.clone()),
+            reporter,
+            MockRelay::new(),
+            epoch,
+            BatcherOptions::default(),
+        );
+        let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+        let (voter_sender, voter_receiver) = mailbox::new::<
+            voter::Message<ed25519::Scheme, Sha256Digest>,
+        >(context.child("mailbox"), NZUsize!(1024));
+        let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+        let (vote_sender, vote_receiver) = oracle
+            .control(me.clone())
+            .register(0, TEST_QUOTA)
+            .await
+            .unwrap();
+        let (certificate_sender, certificate_receiver) = oracle
+            .control(me.clone())
+            .register(1, TEST_QUOTA)
+            .await
+            .unwrap();
+
+        let mut participant_senders = Vec::new();
+        for (i, pk) in participants.iter().enumerate() {
+            if i == 0 {
+                participant_senders.push(None);
+                continue;
+            }
+            let sender = register_and_link_peer(
+                &oracle,
+                pk.clone(),
+                me.clone(),
+                0,
+                Duration::from_millis(1),
+            )
+            .await;
+            participant_senders.push(Some(sender));
+        }
+        track_test_peers(context, &oracle, 1, &participants, &[]).await;
+
+        batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+        let view = View::new(1);
+        let leader = Participant::new(1);
+        batcher_mailbox.update(Span::none(), view, leader, View::zero(), None);
+        context.sleep(Duration::from_millis(5)).await;
+
+        let round = Round::new(epoch, view);
+        let proposal = Proposal::new(round, View::zero(), Sha256::hash(&[b"test_payload"]));
+
+        for i in 1..=quorum {
+            let vote = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            participant_senders[i]
+                .as_mut()
+                .expect("participant sender")
+                .send(
+                    Recipients::One(me.clone()),
+                    Vote::Finalize(vote).encode(),
+                    true,
+                );
+        }
+        context.sleep(Duration::from_millis(10)).await;
+
+        BufferedFinalization {
+            oracle,
+            participants,
+            schemes,
+            participant_senders,
+            me,
+            proposal,
+            quorum,
+            voter_receiver,
+            _batcher_mailbox: batcher_mailbox,
+            _local_senders: (vote_sender, certificate_sender),
+        }
+    }
+
+    /// Drains voter messages until both a notarization and a finalization for
+    /// `proposal` arrive, panicking on anything else or on timeout.
+    async fn expect_notarization_and_finalization<S: Scheme<Sha256Digest>>(
+        context: &mut deterministic::Context,
+        voter_receiver: &mut mailbox::Receiver<voter::Message<S, Sha256Digest>>,
+        proposal: &Proposal<Sha256Digest>,
+    ) {
+        let mut saw_notarization = false;
+        let mut saw_finalization = false;
+        while !(saw_notarization && saw_finalization) {
+            select! {
+                output = voter_receiver.recv() => match output {
+                    Some(voter::Message::Proposal { proposal: p, .. }) => {
+                        assert_eq!(&p, proposal);
+                    }
+                    Some(voter::Message::Verified {
+                        certificate: Certificate::Notarization(n),
+                        ..
+                    }) => {
+                        assert_eq!(&n.proposal, proposal);
+                        saw_notarization = true;
+                    }
+                    Some(voter::Message::Verified {
+                        certificate: Certificate::Finalization(f),
+                        ..
+                    }) => {
+                        assert_eq!(&f.proposal, proposal);
+                        saw_finalization = true;
+                    }
+                    Some(_) => panic!("unexpected batcher output"),
+                    None => panic!("voter receiver closed"),
+                },
+                _ = context.sleep(Duration::from_secs(2)) => {
+                    panic!("timed out waiting for notarization and finalization");
+                },
+            }
+        }
+    }
+
+    /// The leader's notarize vote arrives last, after a full finalize quorum
+    /// is already buffered, so setting the proposal must drain the ready
+    /// finalize batch in the same pass, yielding both certificates. (The
+    /// notarize loop starts at signer 2 to keep the leader's vote, which
+    /// reveals the proposal, for the end.)
+    #[test_traced]
+    fn test_local_notarization_drains_ready_finalization() {
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|mut context| async move {
-            let Fixture {
-                participants,
-                schemes,
-                ..
-            } = ed25519::fixture(&mut context, &namespace, n);
-            let oracle =
-                start_test_network_with_peers(context.child("network"), participants.clone()).await;
-            let reporter = test_reporter(&mut context, &schemes[0]);
+            let mut s = buffered_finalization_setup(&mut context).await;
 
-            let me = participants[0].clone();
-            let batcher_cfg = test_config(
-                schemes[0].clone(),
-                oracle.control(me.clone()),
-                reporter,
-                MockRelay::new(),
-                epoch,
-                BatcherOptions::default(),
-            );
-            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
-            let (voter_sender, mut voter_receiver) = mailbox::new::<
-                voter::Message<ed25519::Scheme, Sha256Digest>,
-            >(
-                context.child("mailbox"), NZUsize!(1024)
-            );
-            let voter_mailbox = voter::Mailbox::new(voter_sender);
-
-            let (_vote_sender, vote_receiver) = oracle
-                .control(me.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            let (_certificate_sender, certificate_receiver) = oracle
-                .control(me.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            let mut participant_senders = Vec::new();
-            for (i, pk) in participants.iter().enumerate() {
-                if i == 0 {
-                    participant_senders.push(None);
-                    continue;
-                }
-                let sender = register_and_link_peer(
-                    &oracle,
-                    pk.clone(),
-                    me.clone(),
-                    0,
-                    Duration::from_millis(1),
-                )
-                .await;
-                participant_senders.push(Some(sender));
-            }
-            track_test_peers(&mut context, &oracle, 1, &participants, &[]).await;
-
-            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
-
-            let view = View::new(1);
-            let leader = Participant::new(1);
-            batcher_mailbox.update(Span::none(), view, leader, View::zero(), None);
-            context.sleep(Duration::from_millis(5)).await;
-
-            let round = Round::new(epoch, view);
-            let proposal = Proposal::new(round, View::zero(), Sha256::hash(&[b"test_payload"]));
-
-            for i in 1..=quorum {
-                let vote = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
-                participant_senders[i]
+            for i in 2..=s.quorum {
+                let vote = Notarize::sign(&s.schemes[i], s.proposal.clone()).unwrap();
+                s.participant_senders[i]
                     .as_mut()
                     .expect("participant sender")
                     .send(
-                        Recipients::One(me.clone()),
-                        Vote::Finalize(vote).encode(),
-                        true,
-                    );
-            }
-            context.sleep(Duration::from_millis(10)).await;
-
-            for i in 2..=quorum {
-                let vote = Notarize::sign(&schemes[i], proposal.clone()).unwrap();
-                participant_senders[i]
-                    .as_mut()
-                    .expect("participant sender")
-                    .send(
-                        Recipients::One(me.clone()),
+                        Recipients::One(s.me.clone()),
                         Vote::Notarize(vote).encode(),
                         true,
                     );
             }
             context.sleep(Duration::from_millis(10)).await;
 
-            let leader_vote = Notarize::sign(&schemes[1], proposal.clone()).unwrap();
-            participant_senders[1]
+            let leader_vote = Notarize::sign(&s.schemes[1], s.proposal.clone()).unwrap();
+            s.participant_senders[1]
                 .as_mut()
                 .expect("leader sender")
                 .send(
-                    Recipients::One(me.clone()),
+                    Recipients::One(s.me.clone()),
                     Vote::Notarize(leader_vote).encode(),
                     true,
                 );
 
-            let mut saw_notarization = false;
-            let mut saw_finalization = false;
-            loop {
-                select! {
-                    output = voter_receiver.recv() => match output {
-                        Some(voter::Message::Proposal { proposal: p, .. }) => {
-                            assert_eq!(p, proposal);
-                        }
-                        Some(voter::Message::Verified {
-                            certificate: Certificate::Notarization(n),
-                            ..
-                        }) => {
-                            assert_eq!(n.proposal, proposal);
-                            saw_notarization = true;
-                        }
-                        Some(voter::Message::Verified {
-                            certificate: Certificate::Finalization(f),
-                            ..
-                        }) => {
-                            assert_eq!(f.proposal, proposal);
-                            saw_finalization = true;
-                        }
-                        Some(_) => panic!("unexpected batcher output"),
-                        None => panic!("voter receiver closed"),
-                    },
-                    _ = context.sleep(Duration::from_secs(2)) => {
-                        panic!("timed out waiting for recovered notarization and finalization");
-                    },
-                }
-                if saw_notarization && saw_finalization {
-                    break;
-                }
-            }
+            expect_notarization_and_finalization(&mut context, &mut s.voter_receiver, &s.proposal)
+                .await;
         });
     }
 
-    /// Finalize votes buffer unverifiable while the leader's proposal is
-    /// unknown. A notarization certificate received from the network reveals
-    /// the proposal, so the actor must revisit the round and construct a
-    /// finalization from the votes the certificate unlocked.
+    /// A notarization certificate received from the network reveals the
+    /// proposal, so the actor must revisit the round, forward the
+    /// certificate, and construct a finalization from the votes it unlocked.
     #[test_traced]
     fn test_network_notarization_unlocks_buffered_finalization() {
-        let n = 5;
-        let quorum = quorum(n) as usize;
-        let namespace = b"batcher_test".to_vec();
-        let epoch = Epoch::new(333);
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|mut context| async move {
-            let Fixture {
-                participants,
-                schemes,
-                ..
-            } = ed25519::fixture(&mut context, &namespace, n);
-            let oracle =
-                start_test_network_with_peers(context.child("network"), participants.clone()).await;
-            let reporter = test_reporter(&mut context, &schemes[0]);
+            let mut s = buffered_finalization_setup(&mut context).await;
 
-            let me = participants[0].clone();
-            let batcher_cfg = test_config(
-                schemes[0].clone(),
-                oracle.control(me.clone()),
-                reporter,
-                MockRelay::new(),
-                epoch,
-                BatcherOptions::default(),
-            );
-            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
-            let (voter_sender, mut voter_receiver) = mailbox::new::<
-                voter::Message<ed25519::Scheme, Sha256Digest>,
-            >(
-                context.child("mailbox"), NZUsize!(1024)
-            );
-            let voter_mailbox = voter::Mailbox::new(voter_sender);
-
-            let (_vote_sender, vote_receiver) = oracle
-                .control(me.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            let (_certificate_sender, certificate_receiver) = oracle
-                .control(me.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            let mut participant_senders = Vec::new();
-            for (i, pk) in participants.iter().enumerate() {
-                if i == 0 {
-                    participant_senders.push(None);
-                    continue;
-                }
-                let sender = register_and_link_peer(
-                    &oracle,
-                    pk.clone(),
-                    me.clone(),
-                    0,
-                    Duration::from_millis(1),
-                )
-                .await;
-                participant_senders.push(Some(sender));
-            }
             // Certificate channel for participant 1 (the vote link already exists).
-            let (mut certificate_injector, _receiver) = oracle
-                .control(participants[1].clone())
+            let (mut certificate_injector, _receiver) = s
+                .oracle
+                .control(s.participants[1].clone())
                 .register(1, TEST_QUOTA)
                 .await
                 .unwrap();
-            track_test_peers(&mut context, &oracle, 1, &participants, &[]).await;
 
-            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
-
-            let view = View::new(1);
-            let leader = Participant::new(1);
-            batcher_mailbox.update(Span::none(), view, leader, View::zero(), None);
-            context.sleep(Duration::from_millis(5)).await;
-
-            let round = Round::new(epoch, view);
-            let proposal = Proposal::new(round, View::zero(), Sha256::hash(&[b"test_payload"]));
-
-            // Buffer a finalize quorum. The proposal stays unknown (the
-            // leader's notarize never arrives), so none of them can verify.
-            for i in 1..=quorum {
-                let vote = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
-                participant_senders[i]
-                    .as_mut()
-                    .expect("participant sender")
-                    .send(
-                        Recipients::One(me.clone()),
-                        Vote::Finalize(vote).encode(),
-                        true,
-                    );
-            }
-            context.sleep(Duration::from_millis(10)).await;
-
-            // A network notarization certificate reveals the proposal.
-            let notarization = build_notarization(&schemes, &proposal, quorum);
+            let notarization = build_notarization(&s.schemes, &s.proposal, s.quorum);
             certificate_injector.send(
-                Recipients::One(me.clone()),
+                Recipients::One(s.me.clone()),
                 Certificate::<ed25519::Scheme, Sha256Digest>::Notarization(notarization).encode(),
                 true,
             );
 
-            // The certificate is forwarded and the finalizes it unlocked must
-            // yield a finalization certificate.
-            let mut saw_notarization = false;
-            let mut saw_finalization = false;
-            loop {
-                select! {
-                    output = voter_receiver.recv() => match output {
-                        Some(voter::Message::Proposal { proposal: p, .. }) => {
-                            assert_eq!(p, proposal);
-                        }
-                        Some(voter::Message::Verified {
-                            certificate: Certificate::Notarization(n),
-                            ..
-                        }) => {
-                            assert_eq!(n.proposal, proposal);
-                            saw_notarization = true;
-                        }
-                        Some(voter::Message::Verified {
-                            certificate: Certificate::Finalization(f),
-                            ..
-                        }) => {
-                            assert_eq!(f.proposal, proposal);
-                            saw_finalization = true;
-                        }
-                        Some(_) => panic!("unexpected batcher output"),
-                        None => panic!("voter receiver closed"),
-                    },
-                    _ = context.sleep(Duration::from_secs(2)) => {
-                        panic!("timed out waiting for forwarded notarization and unlocked finalization");
-                    },
-                }
-                if saw_notarization && saw_finalization {
-                    break;
-                }
-            }
+            expect_notarization_and_finalization(&mut context, &mut s.voter_receiver, &s.proposal)
+                .await;
         });
     }
 
@@ -3750,16 +3684,11 @@ mod tests {
         });
     }
 
+    /// Admission-window forwarding does not touch signature handling, so one
+    /// scheme is enough.
     #[test_traced]
     fn test_optimistic_future_proposal_forwarded() {
-        optimistic_future_proposal_forwarded(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        optimistic_future_proposal_forwarded(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        optimistic_future_proposal_forwarded(bls12381_threshold_std::fixture::<MinPk, _>);
-        optimistic_future_proposal_forwarded(bls12381_threshold_std::fixture::<MinSig, _>);
-        optimistic_future_proposal_forwarded(bls12381_multisig::fixture::<MinPk, _>);
-        optimistic_future_proposal_forwarded(bls12381_multisig::fixture::<MinSig, _>);
         optimistic_future_proposal_forwarded(ed25519::fixture);
-        optimistic_future_proposal_forwarded(secp256r1::fixture);
     }
 
     /// Test that leader activity detection works correctly:
@@ -3945,22 +3874,16 @@ mod tests {
                 .await
                 .unwrap();
 
-            let link = Link {
-                latency: Duration::from_millis(1),
-                jitter: Duration::from_millis(0),
-                success_rate: 1.0,
-            };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate().skip(2) {
-                let (sender, _receiver) = oracle
-                    .control(pk.clone())
-                    .register(0, TEST_QUOTA)
-                    .await
-                    .unwrap();
-                oracle
-                    .add_link(pk.clone(), me.clone(), link.clone())
-                    .await
-                    .unwrap();
+                let sender = register_and_link_peer(
+                    &oracle,
+                    pk.clone(),
+                    me.clone(),
+                    0,
+                    Duration::from_millis(1),
+                )
+                .await;
                 participant_senders.push((i, sender));
             }
 
@@ -4924,44 +4847,21 @@ mod tests {
         });
     }
 
+    /// Admission-window bookkeeping does not touch signature handling, so one
+    /// scheme is enough.
     #[test_traced]
     fn test_same_term_optimistic_future_votes_are_admitted() {
-        same_term_optimistic_future_votes_are_admitted(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        same_term_optimistic_future_votes_are_admitted(
-            bls12381_threshold_vrf::fixture::<MinSig, _>,
-        );
-        same_term_optimistic_future_votes_are_admitted(bls12381_threshold_std::fixture::<MinPk, _>);
-        same_term_optimistic_future_votes_are_admitted(
-            bls12381_threshold_std::fixture::<MinSig, _>,
-        );
-        same_term_optimistic_future_votes_are_admitted(bls12381_multisig::fixture::<MinPk, _>);
-        same_term_optimistic_future_votes_are_admitted(bls12381_multisig::fixture::<MinSig, _>);
         same_term_optimistic_future_votes_are_admitted(ed25519::fixture);
-        same_term_optimistic_future_votes_are_admitted(secp256r1::fixture);
     }
 
+    /// Certificate construction is scheme-dependent, so cover one
+    /// threshold-recovered scheme and one individual-signature scheme.
     #[test_traced]
     fn test_same_term_optimistic_future_votes_can_construct_notarization() {
         same_term_optimistic_future_votes_can_construct_notarization(
             bls12381_threshold_vrf::fixture::<MinPk, _>,
         );
-        same_term_optimistic_future_votes_can_construct_notarization(
-            bls12381_threshold_vrf::fixture::<MinSig, _>,
-        );
-        same_term_optimistic_future_votes_can_construct_notarization(
-            bls12381_threshold_std::fixture::<MinPk, _>,
-        );
-        same_term_optimistic_future_votes_can_construct_notarization(
-            bls12381_threshold_std::fixture::<MinSig, _>,
-        );
-        same_term_optimistic_future_votes_can_construct_notarization(
-            bls12381_multisig::fixture::<MinPk, _>,
-        );
-        same_term_optimistic_future_votes_can_construct_notarization(
-            bls12381_multisig::fixture::<MinSig, _>,
-        );
         same_term_optimistic_future_votes_can_construct_notarization(ed25519::fixture);
-        same_term_optimistic_future_votes_can_construct_notarization(secp256r1::fixture);
     }
 
     /// Test that votes above finalized trigger verification/construction,

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -5,8 +5,8 @@ mod verifier;
 
 use crate::{
     Relay, Reporter,
-    simplex::config::ForwardingPolicy,
-    types::{Epoch, TermLength, View, ViewDelta},
+    simplex::{Lookahead, config::ForwardingPolicy},
+    types::{Epoch, View, ViewDelta},
 };
 pub use actor::Actor;
 use commonware_cryptography::certificate::Scheme;
@@ -31,7 +31,9 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
     pub skip_timeout: Duration,
     pub epoch: Epoch,
     pub mailbox_size: NonZeroUsize,
-    pub term_length: TermLength,
+
+    /// Term geometry bounding which future views are admitted and verified.
+    pub lookahead: Lookahead,
     pub forwarding: ForwardingPolicy,
 
     /// Highest finalized view at startup; anchors the viewport before
@@ -63,7 +65,7 @@ mod tests {
                 Nullification, Nullify, Proposal, Vote,
             },
         },
-        types::{Epoch, Participant, Round, View},
+        types::{Epoch, Participant, Round, TermLength, View},
     };
     use commonware_actor::{Feedback, mailbox};
     use commonware_codec::Encode;
@@ -77,7 +79,7 @@ mod tests {
     use commonware_macros::{select, test_async, test_collect_traces, test_traced};
     use commonware_p2p::{
         Manager as _, Recipients, Sender as _, TrackedPeers,
-        simulated::{Config as NConfig, Link, Network, Oracle},
+        simulated::{Config as NConfig, Link, Network, Oracle, Sender},
     };
     use commonware_parallel::Sequential;
     use commonware_runtime::{
@@ -146,6 +148,35 @@ mod tests {
         oracle
     }
 
+    /// Registers `peer` on `channel` and links it to `me` with a reliable
+    /// connection of the given latency, returning the peer's sender.
+    async fn register_and_link_peer(
+        oracle: &Oracle<PublicKey, deterministic::Context>,
+        peer: PublicKey,
+        me: PublicKey,
+        channel: u64,
+        latency: Duration,
+    ) -> Sender<PublicKey, deterministic::Context> {
+        let (sender, _receiver) = oracle
+            .control(peer.clone())
+            .register(channel, TEST_QUOTA)
+            .await
+            .unwrap();
+        oracle
+            .add_link(
+                peer,
+                me,
+                Link {
+                    latency,
+                    jitter: Duration::from_millis(0),
+                    success_rate: 1.0,
+                },
+            )
+            .await
+            .unwrap();
+        sender
+    }
+
     async fn track_test_peers(
         context: &mut deterministic::Context,
         oracle: &commonware_p2p::simulated::Oracle<PublicKey, deterministic::Context>,
@@ -181,7 +212,7 @@ mod tests {
     struct BatcherOptions {
         view_retention: ViewDelta,
         skip_timeout: Duration,
-        term_length: TermLength,
+        lookahead: Lookahead,
         forwarding: ForwardingPolicy,
         floor: View,
     }
@@ -191,7 +222,10 @@ mod tests {
             Self {
                 view_retention: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
-                term_length: TermLength::ONE,
+                lookahead: Lookahead {
+                    term_length: TermLength::ONE,
+                    optimistic_views: ViewDelta::new(0),
+                },
                 forwarding: ForwardingPolicy::Disabled,
                 floor: View::zero(),
             }
@@ -218,7 +252,7 @@ mod tests {
             skip_timeout: options.skip_timeout,
             epoch,
             mailbox_size: NZUsize!(128),
-            term_length: options.term_length,
+            lookahead: options.lookahead,
             forwarding: options.forwarding,
             floor: options.floor,
         }
@@ -487,6 +521,540 @@ mod tests {
         assert!(round.try_verify(&mut rng, &Sequential).await.is_none());
     }
 
+    /// A round accumulates a numerical quorum of finalizes (`quorum - 1` for
+    /// the leader's proposal A plus one for the certified override B) split
+    /// across two proposals; the batcher must not mix them into a
+    /// finalization certificate.
+    #[test_traced]
+    fn test_finalization_construction_filters_overridden_proposal() {
+        let n = 5;
+        let quorum = quorum(n) as usize;
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|_context| async move {
+            let mut rng = test_rng();
+            let Fixture { schemes, .. } = ed25519::fixture(&mut rng, b"batcher_test", n);
+            let round_id = Round::new(Epoch::new(333), View::new(7));
+            let mut round = super::Round::new(
+                round_id,
+                Arc::new(schemes[0].clone()),
+                NoopBlocker,
+                NoopReporter(PhantomData),
+            );
+
+            let proposal_a = Proposal::new(round_id, View::new(6), Sha256::hash(&[b"proposal_a"]));
+            let proposal_b = Proposal::new(round_id, View::new(6), Sha256::hash(&[b"proposal_b"]));
+            round.set_leader(Participant::new(0));
+            round.add_constructed(Vote::Notarize(
+                Notarize::sign(&schemes[0], proposal_a.clone()).unwrap(),
+            ));
+            for scheme in schemes.iter().take(quorum - 1) {
+                round.add_constructed(Vote::Finalize(
+                    Finalize::sign(scheme, proposal_a.clone()).unwrap(),
+                ));
+            }
+
+            let notarization_b = build_notarization(&schemes, &proposal_b, quorum);
+            round.set_certificate(&Certificate::Notarization(notarization_b));
+            round.add_constructed(Vote::Finalize(
+                Finalize::sign(&schemes[quorum - 1], proposal_b.clone()).unwrap(),
+            ));
+            assert!(
+                round.try_construct_certificate(&Sequential).await.is_none(),
+                "mixed finalizes for old and certified proposals must not form a certificate"
+            );
+
+            // Control: all finalizes match the certified proposal.
+            let mut round = super::Round::new(
+                round_id,
+                Arc::new(schemes[0].clone()),
+                NoopBlocker,
+                NoopReporter(PhantomData),
+            );
+            round.set_certificate(&Certificate::Notarization(build_notarization(
+                &schemes,
+                &proposal_b,
+                quorum,
+            )));
+            for scheme in schemes.iter().take(quorum) {
+                round.add_constructed(Vote::Finalize(
+                    Finalize::sign(scheme, proposal_b.clone()).unwrap(),
+                ));
+            }
+            let certificate = round
+                .try_construct_certificate(&Sequential)
+                .await
+                .expect("matching finalizes should form a certificate");
+            let Certificate::Finalization(finalization) = certificate else {
+                panic!("expected a finalization certificate");
+            };
+            assert_eq!(finalization.proposal, proposal_b);
+        });
+    }
+
+    /// Finalize votes buffer unverifiable while the leader's proposal is
+    /// unknown. The leader's notarize vote arrives last, after a full
+    /// finalize quorum is already buffered, so setting the proposal must
+    /// drain the ready finalize batch in the same pass, yielding both
+    /// certificates. (The notarize loop starts at signer 2 to keep the
+    /// leader's vote, which reveals the proposal, for the end.)
+    #[test_traced]
+    fn test_local_notarization_drains_ready_finalization() {
+        let n = 5;
+        let quorum = quorum(n) as usize;
+        let namespace = b"batcher_test".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter,
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+            let (voter_sender, mut voter_receiver) = mailbox::new::<
+                voter::Message<ed25519::Scheme, Sha256Digest>,
+            >(
+                context.child("mailbox"), NZUsize!(1024)
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let mut participant_senders = Vec::new();
+            for (i, pk) in participants.iter().enumerate() {
+                if i == 0 {
+                    participant_senders.push(None);
+                    continue;
+                }
+                let sender = register_and_link_peer(
+                    &oracle,
+                    pk.clone(),
+                    me.clone(),
+                    0,
+                    Duration::from_millis(1),
+                )
+                .await;
+                participant_senders.push(Some(sender));
+            }
+            track_test_peers(&mut context, &oracle, 1, &participants, &[]).await;
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            let view = View::new(1);
+            let leader = Participant::new(1);
+            batcher_mailbox.update(Span::none(), view, leader, View::zero(), None);
+            context.sleep(Duration::from_millis(5)).await;
+
+            let round = Round::new(epoch, view);
+            let proposal = Proposal::new(round, View::zero(), Sha256::hash(&[b"test_payload"]));
+
+            for i in 1..=quorum {
+                let vote = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+                participant_senders[i]
+                    .as_mut()
+                    .expect("participant sender")
+                    .send(
+                        Recipients::One(me.clone()),
+                        Vote::Finalize(vote).encode(),
+                        true,
+                    );
+            }
+            context.sleep(Duration::from_millis(10)).await;
+
+            for i in 2..=quorum {
+                let vote = Notarize::sign(&schemes[i], proposal.clone()).unwrap();
+                participant_senders[i]
+                    .as_mut()
+                    .expect("participant sender")
+                    .send(
+                        Recipients::One(me.clone()),
+                        Vote::Notarize(vote).encode(),
+                        true,
+                    );
+            }
+            context.sleep(Duration::from_millis(10)).await;
+
+            let leader_vote = Notarize::sign(&schemes[1], proposal.clone()).unwrap();
+            participant_senders[1]
+                .as_mut()
+                .expect("leader sender")
+                .send(
+                    Recipients::One(me.clone()),
+                    Vote::Notarize(leader_vote).encode(),
+                    true,
+                );
+
+            let mut saw_notarization = false;
+            let mut saw_finalization = false;
+            loop {
+                select! {
+                    output = voter_receiver.recv() => match output {
+                        Some(voter::Message::Proposal { proposal: p, .. }) => {
+                            assert_eq!(p, proposal);
+                        }
+                        Some(voter::Message::Verified {
+                            certificate: Certificate::Notarization(n),
+                            ..
+                        }) => {
+                            assert_eq!(n.proposal, proposal);
+                            saw_notarization = true;
+                        }
+                        Some(voter::Message::Verified {
+                            certificate: Certificate::Finalization(f),
+                            ..
+                        }) => {
+                            assert_eq!(f.proposal, proposal);
+                            saw_finalization = true;
+                        }
+                        Some(_) => panic!("unexpected batcher output"),
+                        None => panic!("voter receiver closed"),
+                    },
+                    _ = context.sleep(Duration::from_secs(2)) => {
+                        panic!("timed out waiting for recovered notarization and finalization");
+                    },
+                }
+                if saw_notarization && saw_finalization {
+                    break;
+                }
+            }
+        });
+    }
+
+    /// Finalize votes buffer unverifiable while the leader's proposal is
+    /// unknown. A notarization certificate received from the network reveals
+    /// the proposal, so the actor must revisit the round and construct a
+    /// finalization from the votes the certificate unlocked.
+    #[test_traced]
+    fn test_network_notarization_unlocks_buffered_finalization() {
+        let n = 5;
+        let quorum = quorum(n) as usize;
+        let namespace = b"batcher_test".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter,
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+            let (voter_sender, mut voter_receiver) = mailbox::new::<
+                voter::Message<ed25519::Scheme, Sha256Digest>,
+            >(
+                context.child("mailbox"), NZUsize!(1024)
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let mut participant_senders = Vec::new();
+            for (i, pk) in participants.iter().enumerate() {
+                if i == 0 {
+                    participant_senders.push(None);
+                    continue;
+                }
+                let sender = register_and_link_peer(
+                    &oracle,
+                    pk.clone(),
+                    me.clone(),
+                    0,
+                    Duration::from_millis(1),
+                )
+                .await;
+                participant_senders.push(Some(sender));
+            }
+            // Certificate channel for participant 1 (the vote link already exists).
+            let (mut certificate_injector, _receiver) = oracle
+                .control(participants[1].clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+            track_test_peers(&mut context, &oracle, 1, &participants, &[]).await;
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            let view = View::new(1);
+            let leader = Participant::new(1);
+            batcher_mailbox.update(Span::none(), view, leader, View::zero(), None);
+            context.sleep(Duration::from_millis(5)).await;
+
+            let round = Round::new(epoch, view);
+            let proposal = Proposal::new(round, View::zero(), Sha256::hash(&[b"test_payload"]));
+
+            // Buffer a finalize quorum. The proposal stays unknown (the
+            // leader's notarize never arrives), so none of them can verify.
+            for i in 1..=quorum {
+                let vote = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+                participant_senders[i]
+                    .as_mut()
+                    .expect("participant sender")
+                    .send(
+                        Recipients::One(me.clone()),
+                        Vote::Finalize(vote).encode(),
+                        true,
+                    );
+            }
+            context.sleep(Duration::from_millis(10)).await;
+
+            // A network notarization certificate reveals the proposal.
+            let notarization = build_notarization(&schemes, &proposal, quorum);
+            certificate_injector.send(
+                Recipients::One(me.clone()),
+                Certificate::<ed25519::Scheme, Sha256Digest>::Notarization(notarization).encode(),
+                true,
+            );
+
+            // The certificate is forwarded and the finalizes it unlocked must
+            // yield a finalization certificate.
+            let mut saw_notarization = false;
+            let mut saw_finalization = false;
+            loop {
+                select! {
+                    output = voter_receiver.recv() => match output {
+                        Some(voter::Message::Proposal { proposal: p, .. }) => {
+                            assert_eq!(p, proposal);
+                        }
+                        Some(voter::Message::Verified {
+                            certificate: Certificate::Notarization(n),
+                            ..
+                        }) => {
+                            assert_eq!(n.proposal, proposal);
+                            saw_notarization = true;
+                        }
+                        Some(voter::Message::Verified {
+                            certificate: Certificate::Finalization(f),
+                            ..
+                        }) => {
+                            assert_eq!(f.proposal, proposal);
+                            saw_finalization = true;
+                        }
+                        Some(_) => panic!("unexpected batcher output"),
+                        None => panic!("voter receiver closed"),
+                    },
+                    _ = context.sleep(Duration::from_secs(2)) => {
+                        panic!("timed out waiting for forwarded notarization and unlocked finalization");
+                    },
+                }
+                if saw_notarization && saw_finalization {
+                    break;
+                }
+            }
+        });
+    }
+
+    /// A notarization certificate for a view beyond the admission window
+    /// creates a leaderless round holding the certified proposal. When the
+    /// current view advances so the view enters the window, the revisit on
+    /// update must stamp the leader and forward the now-complete proposal.
+    #[test_traced]
+    fn test_update_stamps_leader_on_certificate_created_round() {
+        let n = 5;
+        let quorum = quorum(n) as usize;
+        let namespace = b"batcher_test".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter,
+                MockRelay::new(),
+                epoch,
+                BatcherOptions {
+                    lookahead: Lookahead {
+                        term_length: TermLength::new(commonware_utils::NZU32!(5)),
+                        optimistic_views: ViewDelta::new(2),
+                    },
+                    ..Default::default()
+                },
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+            let (voter_sender, mut voter_receiver) = mailbox::new::<
+                voter::Message<ed25519::Scheme, Sha256Digest>,
+            >(
+                context.child("mailbox"), NZUsize!(1024)
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let mut certificate_injector = register_and_link_peer(
+                &oracle,
+                participants[1].clone(),
+                me.clone(),
+                1,
+                Duration::from_millis(1),
+            )
+            .await;
+            track_test_peers(&mut context, &oracle, 1, &participants, &[]).await;
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            // With optimistic_views=2, view 4 is beyond the admission window
+            // anchored at view 1 but still inside the current term.
+            let leader = Participant::new(1);
+            batcher_mailbox.update(Span::none(), View::new(1), leader, View::zero(), None);
+            context.sleep(Duration::from_millis(5)).await;
+
+            let future_view = View::new(4);
+            let future_round = Round::new(epoch, future_view);
+            let proposal =
+                Proposal::new(future_round, View::new(3), Sha256::hash(&[b"future_payload"]));
+            let notarization = build_notarization(&schemes, &proposal, quorum);
+            certificate_injector.send(
+                Recipients::One(me.clone()),
+                Certificate::<ed25519::Scheme, Sha256Digest>::Notarization(notarization).encode(),
+                true,
+            );
+
+            // The certificate is forwarded, but the round has no leader yet so
+            // the proposal must not be.
+            let output = voter_receiver.recv().await.unwrap();
+            assert!(
+                matches!(&output, voter::Message::Verified { certificate: Certificate::Notarization(n), .. } if n.proposal == proposal)
+            );
+            select! {
+                output = voter_receiver.recv() => {
+                    panic!("unexpected batcher output before leader is known: {:?}", output.map(|m| m.view()));
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {},
+            }
+
+            // Advancing to view 2 pulls view 4 into the admission window: the
+            // revisit stamps the leader and the proposal is forwarded.
+            batcher_mailbox.update(Span::none(), View::new(2), leader, View::zero(), None);
+            loop {
+                select! {
+                    output = voter_receiver.recv() => match output {
+                        Some(voter::Message::Proposal { proposal: p, .. }) => {
+                            assert_eq!(p, proposal);
+                            break;
+                        }
+                        Some(_) => continue,
+                        None => panic!("voter receiver closed"),
+                    },
+                    _ = context.sleep(Duration::from_secs(2)) => {
+                        panic!("timed out waiting for forwarded proposal after leader stamping");
+                    },
+                }
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_rejected_finalize_still_detects_conflicting_finalize() {
+        let n = 5;
+        let quorum = quorum(n) as usize;
+        let namespace = b"batcher_test".to_vec();
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let reporter = test_reporter(&mut context, &schemes[0]);
+            let round_id = Round::new(Epoch::new(333), View::new(7));
+            let mut round = super::Round::new(
+                round_id,
+                Arc::new(schemes[0].clone()),
+                NoopBlocker,
+                reporter.clone(),
+            );
+
+            let proposal_a = Proposal::new(round_id, View::new(6), Sha256::hash(&[b"proposal_a"]));
+            let proposal_b = Proposal::new(round_id, View::new(6), Sha256::hash(&[b"proposal_b"]));
+            round.set_certificate(&Certificate::Notarization(build_notarization(
+                &schemes,
+                &proposal_b,
+                quorum,
+            )));
+
+            let sender = participants[1].clone();
+            let finalize_a = Finalize::sign(&schemes[1], proposal_a).unwrap();
+            assert!(!round.add_network(sender.clone(), Vote::Finalize(finalize_a)));
+            assert!(
+                reporter.faults.lock().is_empty(),
+                "a single rejected finalize is not conflicting evidence"
+            );
+
+            let finalize_b = Finalize::sign(&schemes[1], proposal_b).unwrap();
+            assert!(!round.add_network(sender.clone(), Vote::Finalize(finalize_b)));
+            let faults = reporter.faults.lock();
+            let has_expected_fault = faults
+                .get(&sender)
+                .and_then(|sf| sf.get(&round_id.view()))
+                .is_some_and(|vf| vf.iter().any(is_conflicting_finalize));
+            assert!(
+                has_expected_fault,
+                "conflicting finalize should be reported even if the first vote was not accepted for verification"
+            );
+        });
+    }
+
     fn certificate_forwarding_from_network<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
@@ -707,22 +1275,14 @@ mod tests {
 
             // Create a peer to inject certificates.
             let injector_pk = PrivateKey::from_seed(1_000_001).public_key();
-            let (mut injector_sender, _injector_receiver) = oracle
-                .control(injector_pk.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            // Set up link from injector to batcher.
-            let link = Link {
-                latency: Duration::from_millis(1),
-                jitter: Duration::from_millis(0),
-                success_rate: 1.0,
-            };
-            oracle
-                .add_link(injector_pk.clone(), me.clone(), link)
-                .await
-                .unwrap();
+            let mut injector_sender = register_and_link_peer(
+                &oracle,
+                injector_pk.clone(),
+                me.clone(),
+                1,
+                Duration::from_millis(1),
+            )
+            .await;
             track_test_peers(
                 &mut context,
                 &oracle,
@@ -799,6 +1359,284 @@ mod tests {
         old_notarization_after_nullification_is_forwarded(bls12381_multisig::fixture::<MinSig, _>);
         old_notarization_after_nullification_is_forwarded(ed25519::fixture);
         old_notarization_after_nullification_is_forwarded(secp256r1::fixture);
+    }
+
+    /// A certificate that fails verification must block the sender, while a
+    /// valid certificate from the same sender must not.
+    fn invalid_certificate_blocks_sender<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum_size = quorum(n) as usize;
+        let namespace = b"batcher_invalid_certificate".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            // Create simulated network
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter.clone(),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            let (voter_sender, _voter_receiver) = mailbox::new::<voter::Message<S, Sha256Digest>>(
+                context.child("mailbox"),
+                NZUsize!(1024),
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            // Create a peer to inject certificates.
+            let injector_pk = PrivateKey::from_seed(1_000_001).public_key();
+            let mut injector_sender = register_and_link_peer(
+                &oracle,
+                injector_pk.clone(),
+                me.clone(),
+                1,
+                Duration::from_millis(1),
+            )
+            .await;
+            track_test_peers(
+                &mut context,
+                &oracle,
+                1,
+                &participants,
+                std::slice::from_ref(&injector_pk),
+            )
+            .await;
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            let target_view = View::new(1);
+            batcher_mailbox.update(
+                Span::none(),
+                target_view,
+                Participant::new(0),
+                View::zero(),
+                None,
+            );
+
+            let round = Round::new(epoch, target_view);
+            let proposal = Proposal::new(round, View::zero(), Sha256::hash(&[b"test_payload"]));
+
+            // A valid certificate must not block the sender.
+            let nullification = build_nullification(&schemes, round, quorum_size);
+            injector_sender.send(
+                Recipients::One(me.clone()),
+                Certificate::<S, Sha256Digest>::Nullification(nullification).encode(),
+                true,
+            );
+            context.sleep(Duration::from_millis(50)).await;
+            let blocked = oracle.blocked().await.unwrap();
+            assert!(
+                blocked.is_empty(),
+                "Valid certificate should not block the sender"
+            );
+
+            // Tamper with a valid notarization: the certificate no longer
+            // covers the substituted proposal, so verification must fail and
+            // the sender must be blocked.
+            let mut notarization = build_notarization(&schemes, &proposal, quorum_size);
+            notarization.proposal =
+                Proposal::new(round, View::zero(), Sha256::hash(&[b"other_payload"]));
+            injector_sender.send(
+                Recipients::One(me.clone()),
+                Certificate::Notarization(notarization).encode(),
+                true,
+            );
+            context.sleep(Duration::from_millis(50)).await;
+            let blocked = oracle.blocked().await.unwrap();
+            assert!(
+                blocked.iter().any(|(_, blocked)| blocked == &injector_pk),
+                "Sender should be blocked for invalid certificate"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_invalid_certificate_blocks_sender() {
+        invalid_certificate_blocks_sender(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        invalid_certificate_blocks_sender(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        invalid_certificate_blocks_sender(bls12381_threshold_std::fixture::<MinPk, _>);
+        invalid_certificate_blocks_sender(bls12381_threshold_std::fixture::<MinSig, _>);
+        invalid_certificate_blocks_sender(bls12381_multisig::fixture::<MinPk, _>);
+        invalid_certificate_blocks_sender(bls12381_multisig::fixture::<MinSig, _>);
+        invalid_certificate_blocks_sender(ed25519::fixture);
+        invalid_certificate_blocks_sender(secp256r1::fixture);
+    }
+
+    /// Regression: a valid notarization for a view beyond the admission
+    /// window creates a round with a certificate proposal but no leader. The
+    /// batcher must survive processing it (it previously panicked unwrapping
+    /// the missing leader when forwarding the proposal).
+    fn future_notarization_without_leader_does_not_panic<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let quorum_size = quorum(n) as usize;
+        let namespace = b"batcher_future_notarization_without_leader".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            // Get participants.
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            // Create simulated network
+            let oracle = start_test_network_with_peers(context.child("network"),
+                participants.clone(),
+            )
+            .await;
+
+            // Setup reporter mock.
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            // Initialize batcher actor.
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter.clone(),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            // Create voter mailbox for batcher to send to.
+            let (voter_sender, mut voter_receiver) =
+                mailbox::new::<voter::Message<S, Sha256Digest>>(context.child("mailbox"), NZUsize!(1024));
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            // Create a peer to inject certificates.
+            let injector_pk = PrivateKey::from_seed(1_000_001).public_key();
+            let mut injector_sender = register_and_link_peer(
+                &oracle,
+                injector_pk.clone(),
+                me.clone(),
+                1,
+                Duration::from_millis(1),
+            )
+            .await;
+            track_test_peers(
+                &mut context,
+                &oracle,
+                1,
+                &participants,
+                std::slice::from_ref(&injector_pk),
+            )
+            .await;
+
+            // Start the batcher.
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            // Initialize batcher at view 1.
+            let current_view = View::new(1);
+            batcher_mailbox
+                .update(Span::none(), current_view, Participant::new(0), View::zero(), None);
+
+            // Send a valid notarization for a view beyond the admission
+            // window (the leader is a signer other than us, so the proposal is
+            // a candidate for forwarding).
+            let future_view = View::new(3);
+            let future_round = Round::new(epoch, future_view);
+            let future_proposal =
+                Proposal::new(future_round, View::zero(), Sha256::hash(&[b"future_payload"]));
+            let notarization = build_notarization(&schemes, &future_proposal, quorum_size);
+            injector_sender
+                .send(
+                    Recipients::One(me.clone()),
+                    Certificate::<S, Sha256Digest>::Notarization(notarization).encode(),
+                    true,
+                );
+            context.sleep(Duration::from_millis(50)).await;
+
+            // The certificate must be forwarded to the voter.
+            let output = voter_receiver.recv().await.unwrap();
+            assert!(
+                matches!(output, voter::Message::Verified { certificate: Certificate::Notarization(n), .. } if n.view() == future_view)
+            );
+
+            // The batcher must still be alive to process further certificates.
+            let current_round = Round::new(epoch, current_view);
+            let nullification = build_nullification(&schemes, current_round, quorum_size);
+            injector_sender
+                .send(
+                    Recipients::One(me.clone()),
+                    Certificate::<S, Sha256Digest>::Nullification(nullification).encode(),
+                    true,
+                );
+            context.sleep(Duration::from_millis(50)).await;
+
+            let output = voter_receiver.recv().await.unwrap();
+            assert!(
+                matches!(output, voter::Message::Verified { certificate: Certificate::Nullification(n), .. } if n.view() == current_view)
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_future_notarization_without_leader_does_not_panic() {
+        future_notarization_without_leader_does_not_panic(
+            bls12381_threshold_vrf::fixture::<MinPk, _>,
+        );
+        future_notarization_without_leader_does_not_panic(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+        );
+        future_notarization_without_leader_does_not_panic(
+            bls12381_threshold_std::fixture::<MinPk, _>,
+        );
+        future_notarization_without_leader_does_not_panic(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+        );
+        future_notarization_without_leader_does_not_panic(bls12381_multisig::fixture::<MinPk, _>);
+        future_notarization_without_leader_does_not_panic(bls12381_multisig::fixture::<MinSig, _>);
+        future_notarization_without_leader_does_not_panic(ed25519::fixture);
+        future_notarization_without_leader_does_not_panic(secp256r1::fixture);
     }
 
     fn quorum_votes_construct_certificate<S, F>(mut fixture: F, traces: TraceStorage)
@@ -1007,7 +1845,7 @@ mod tests {
 
     /// Test that constructing a notarization does not forward immediately, but
     /// entering the next view with an explicit forwardable proposal does.
-    fn forward_emitted_on_view_advance_with_certified_proposal<S, F>(mut fixture: F)
+    fn forward_emitted_on_view_advance_with_forwardable_proposal<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
@@ -1155,27 +1993,27 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_forward_emitted_on_view_advance_with_certified_proposal() {
-        forward_emitted_on_view_advance_with_certified_proposal(
+    fn test_forward_emitted_on_view_advance_with_forwardable_proposal() {
+        forward_emitted_on_view_advance_with_forwardable_proposal(
             bls12381_threshold_vrf::fixture::<MinPk, _>,
         );
-        forward_emitted_on_view_advance_with_certified_proposal(
+        forward_emitted_on_view_advance_with_forwardable_proposal(
             bls12381_threshold_vrf::fixture::<MinSig, _>,
         );
-        forward_emitted_on_view_advance_with_certified_proposal(
+        forward_emitted_on_view_advance_with_forwardable_proposal(
             bls12381_threshold_std::fixture::<MinPk, _>,
         );
-        forward_emitted_on_view_advance_with_certified_proposal(
+        forward_emitted_on_view_advance_with_forwardable_proposal(
             bls12381_threshold_std::fixture::<MinSig, _>,
         );
-        forward_emitted_on_view_advance_with_certified_proposal(
+        forward_emitted_on_view_advance_with_forwardable_proposal(
             bls12381_multisig::fixture::<MinPk, _>,
         );
-        forward_emitted_on_view_advance_with_certified_proposal(
+        forward_emitted_on_view_advance_with_forwardable_proposal(
             bls12381_multisig::fixture::<MinSig, _>,
         );
-        forward_emitted_on_view_advance_with_certified_proposal(ed25519::fixture);
-        forward_emitted_on_view_advance_with_certified_proposal(secp256r1::fixture);
+        forward_emitted_on_view_advance_with_forwardable_proposal(ed25519::fixture);
+        forward_emitted_on_view_advance_with_forwardable_proposal(secp256r1::fixture);
     }
 
     /// Test that `SilentLeader` forwards only to the newly entered leader, and
@@ -1406,7 +2244,7 @@ mod tests {
     }
 
     /// Test that a network notarization waits until the next-view update marks
-    /// the previous proposal as certified before forwarding the block.
+    /// the previous proposal as forwardable before forwarding the block.
     fn forward_emitted_for_network_notarization_on_view_advance<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
@@ -2809,6 +3647,121 @@ mod tests {
         proposal_forwarded_before_leader_set(secp256r1::fixture);
     }
 
+    /// Regression: a leader vote for an in-window optimistic future view must forward
+    /// its proposal to the voter even when current view is behind.
+    fn optimistic_future_proposal_forwarded<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let namespace = b"batcher_optimistic_future_proposal_forwarded".to_vec();
+        let epoch = Epoch::new(335);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter,
+                MockRelay::new(),
+                epoch,
+                BatcherOptions {
+                    lookahead: Lookahead {
+                        term_length: TermLength::new(commonware_utils::NZU32!(5)),
+                        optimistic_views: ViewDelta::new(2),
+                    },
+                    ..Default::default()
+                },
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            let (voter_sender, mut voter_receiver) =
+                mailbox::new::<voter::Message<S, Sha256Digest>>(
+                    context.child("voter_mailbox"),
+                    NZUsize!(1024),
+                );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let leader = Participant::new(1);
+            let leader_pk = participants[usize::from(leader)].clone();
+            let mut leader_sender = register_and_link_peer(
+                &oracle,
+                leader_pk,
+                me.clone(),
+                0,
+                Duration::from_millis(1),
+            )
+            .await;
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            let current_view = View::new(1);
+            batcher_mailbox.update(Span::none(), current_view, leader, View::zero(), None);
+
+            let future_view = View::new(3);
+            let proposal = Proposal::new(
+                Round::new(epoch, future_view),
+                View::new(2),
+                Sha256::hash(&[b"optimistic_future_proposal"]),
+            );
+            let vote = Notarize::sign(&schemes[usize::from(leader)], proposal.clone()).unwrap();
+            let _ = leader_sender.send(
+                Recipients::One(me),
+                Vote::<S, Sha256Digest>::Notarize(vote).encode(),
+                true,
+            );
+
+            select! {
+                message = voter_receiver.recv() => match message {
+                    Some(voter::Message::Proposal { proposal: p, .. }) => {
+                        assert_eq!(p.view(), future_view);
+                        assert_eq!(p.payload, proposal.payload);
+                    },
+                    Some(_) => panic!("expected forwarded optimistic future proposal"),
+                    None => panic!("voter channel closed"),
+                },
+                _ = context.sleep(Duration::from_millis(250)) => {
+                    panic!("expected forwarded optimistic future proposal for view {}", future_view)
+                }
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_optimistic_future_proposal_forwarded() {
+        optimistic_future_proposal_forwarded(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        optimistic_future_proposal_forwarded(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        optimistic_future_proposal_forwarded(bls12381_threshold_std::fixture::<MinPk, _>);
+        optimistic_future_proposal_forwarded(bls12381_threshold_std::fixture::<MinSig, _>);
+        optimistic_future_proposal_forwarded(bls12381_multisig::fixture::<MinPk, _>);
+        optimistic_future_proposal_forwarded(bls12381_multisig::fixture::<MinSig, _>);
+        optimistic_future_proposal_forwarded(ed25519::fixture);
+        optimistic_future_proposal_forwarded(secp256r1::fixture);
+    }
+
     /// Test that leader activity detection works correctly:
     /// 1. Leaders remain active before `skip_timeout` elapses.
     /// 2. Quiet networks fail open until a quorum has recent activity.
@@ -3064,6 +4017,133 @@ mod tests {
         leader_inactivity_reported_after_quorum_activity(bls12381_multisig::fixture::<MinSig, _>);
         leader_inactivity_reported_after_quorum_activity(ed25519::fixture);
         leader_inactivity_reported_after_quorum_activity(secp256r1::fixture);
+    }
+
+    /// Test that an inactivity hint does not suppress the later leader-nullify
+    /// fast path for the same view.
+    ///
+    /// The voter treats inactivity as advisory and ignores it when the leader's
+    /// proposal is already buffered, so the batcher must still deliver the
+    /// leader's own nullify.
+    ///
+    /// The interaction is in the batcher's timeout bookkeeping and does not
+    /// touch signature handling, so one scheme is enough.
+    #[test_traced]
+    fn test_leader_nullify_after_inactivity_still_fast_paths() {
+        let n = 5;
+        let namespace = b"batcher_leader_nullify_after_inactivity".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter.clone(),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            let (voter_sender, mut voter_receiver) = mailbox::new::<
+                voter::Message<ed25519::Scheme, Sha256Digest>,
+            >(
+                context.child("mailbox"), NZUsize!(1024)
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let leader = Participant::new(1);
+            let mut leader_sender = register_and_link_peer(
+                &oracle,
+                participants[usize::from(leader)].clone(),
+                me.clone(),
+                0,
+                Duration::from_millis(1),
+            )
+            .await;
+            let mut peer_senders = Vec::new();
+            for (i, pk) in participants.iter().enumerate().skip(2) {
+                let sender = register_and_link_peer(
+                    &oracle,
+                    pk.clone(),
+                    me.clone(),
+                    0,
+                    Duration::from_millis(1),
+                )
+                .await;
+                peer_senders.push((i, sender));
+            }
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            // Make everyone but the leader recently active so the inactivity
+            // heuristic arms for the next view.
+            let view = View::new(1);
+            batcher_mailbox.update(Span::none(), view, leader, View::zero(), None);
+            for (i, sender) in peer_senders.iter_mut() {
+                let vote = Nullify::sign::<Sha256Digest>(&schemes[*i], Round::new(epoch, view))
+                    .expect("peer nullify");
+                sender.send(
+                    Recipients::One(me.clone()),
+                    Vote::<ed25519::Scheme, Sha256Digest>::Nullify(vote).encode(),
+                    true,
+                );
+            }
+            context.sleep(Duration::from_millis(50)).await;
+
+            let next_view = view.next();
+            batcher_mailbox.update(Span::none(), next_view, leader, View::zero(), None);
+            expect_timeout(
+                &mut context,
+                &mut voter_receiver,
+                next_view,
+                TimeoutReason::Inactivity,
+            )
+            .await;
+
+            // The leader is silent but alive: its nullify must still reach the
+            // voter, which may have discarded the advisory hint above.
+            let leader_nullify = Nullify::sign::<Sha256Digest>(
+                &schemes[usize::from(leader)],
+                Round::new(epoch, next_view),
+            )
+            .expect("leader nullify");
+            leader_sender.send(
+                Recipients::One(me.clone()),
+                Vote::<ed25519::Scheme, Sha256Digest>::Nullify(leader_nullify).encode(),
+                true,
+            );
+            expect_timeout(
+                &mut context,
+                &mut voter_receiver,
+                next_view,
+                TimeoutReason::LeaderNullify,
+            )
+            .await;
+        });
     }
 
     /// Test that nullify-only participation marks a leader as active for skip-timeout
@@ -3585,6 +4665,303 @@ mod tests {
         leader_nullify_wrong_view_no_expire(bls12381_multisig::fixture::<MinSig, _>);
         leader_nullify_wrong_view_no_expire(ed25519::fixture);
         leader_nullify_wrong_view_no_expire(secp256r1::fixture);
+    }
+
+    /// Admission is observed through the reporter: an admitted vote is
+    /// reported immediately, a vote beyond the window is not (see the
+    /// companion `..._can_construct_notarization` for buffered votes becoming
+    /// usable).
+    fn same_term_optimistic_future_votes_are_admitted<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let namespace = b"batcher_same_term_optimistic_future_votes_are_admitted".to_vec();
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter.clone(),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions {
+                    lookahead: Lookahead {
+                        term_length: TermLength::new(commonware_utils::NZU32!(5)),
+                        optimistic_views: ViewDelta::new(2),
+                    },
+                    ..Default::default()
+                },
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            let (voter_sender, _voter_receiver) = mailbox::new::<voter::Message<S, Sha256Digest>>(
+                context.child("voter_mailbox"),
+                NZUsize!(1024),
+            );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let peer = Participant::new(1);
+            let peer_pk = participants[usize::from(peer)].clone();
+            let mut peer_sender = register_and_link_peer(
+                &oracle,
+                peer_pk.clone(),
+                me.clone(),
+                0,
+                Duration::from_millis(0),
+            )
+            .await;
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            let current_view = View::new(1);
+            batcher_mailbox.update(Span::none(), current_view, peer, View::zero(), None);
+
+            // With optimistic_views=2 and term_length=5, view 3 is accepted while
+            // view 4 is still too far in the future.
+            let accepted_view = View::new(3);
+            let accepted_payload = Sha256::hash(&[b"accepted_optimistic_view"]);
+            let accepted_vote = Notarize::sign(
+                &schemes[usize::from(peer)],
+                Proposal::new(
+                    Round::new(epoch, accepted_view),
+                    View::new(2),
+                    accepted_payload,
+                ),
+            )
+            .expect("notarize");
+            let _ = peer_sender.send(
+                Recipients::One(me.clone()),
+                Vote::<S, Sha256Digest>::Notarize(accepted_vote).encode(),
+                true,
+            );
+            context.sleep(Duration::from_millis(50)).await;
+
+            {
+                let notarizes = reporter.notarizes.lock();
+                let payloads = notarizes
+                    .get(&accepted_view)
+                    .expect("accepted optimistic future view should be tracked");
+                let signers = payloads
+                    .get(&accepted_payload)
+                    .expect("accepted optimistic future vote should be recorded");
+                assert!(
+                    signers.contains(&peer_pk),
+                    "accepted optimistic future vote should include sender"
+                );
+            }
+
+            let rejected_view = View::new(4);
+            let rejected_vote = Notarize::sign(
+                &schemes[usize::from(peer)],
+                Proposal::new(
+                    Round::new(epoch, rejected_view),
+                    View::new(3),
+                    Sha256::hash(&[b"rejected_optimistic_view"]),
+                ),
+            )
+            .expect("notarize");
+            let _ = peer_sender.send(
+                Recipients::One(me),
+                Vote::<S, Sha256Digest>::Notarize(rejected_vote).encode(),
+                true,
+            );
+            context.sleep(Duration::from_millis(50)).await;
+
+            assert!(
+                !reporter.notarizes.lock().contains_key(&rejected_view),
+                "view beyond optimistic depth should still be dropped"
+            );
+        });
+    }
+
+    fn same_term_optimistic_future_votes_can_construct_notarization<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+    {
+        let n = 5;
+        let namespace =
+            b"batcher_same_term_optimistic_future_votes_can_construct_notarization".to_vec();
+        let epoch = Epoch::new(334);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone()).await;
+
+            let reporter = test_reporter(&mut context, &schemes[0]);
+
+            let me = participants[0].clone();
+            let batcher_cfg = test_config(
+                schemes[0].clone(),
+                oracle.control(me.clone()),
+                reporter,
+                MockRelay::new(),
+                epoch,
+                BatcherOptions {
+                    lookahead: Lookahead {
+                        term_length: TermLength::new(commonware_utils::NZU32!(5)),
+                        optimistic_views: ViewDelta::new(2),
+                    },
+                    ..Default::default()
+                },
+            );
+            let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
+
+            let (voter_sender, mut voter_receiver) =
+                mailbox::new::<voter::Message<S, Sha256Digest>>(
+                    context.child("voter_mailbox"),
+                    NZUsize!(1024),
+                );
+            let voter_mailbox = voter::Mailbox::new(voter_sender);
+
+            let (_vote_sender, vote_receiver) = oracle
+                .control(me.clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            let (_certificate_sender, certificate_receiver) = oracle
+                .control(me.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+
+            let mut peer_senders = Vec::new();
+            for peer_pk in participants.iter().skip(1).cloned() {
+                let peer_sender = register_and_link_peer(
+                    &oracle,
+                    peer_pk,
+                    me.clone(),
+                    0,
+                    Duration::from_millis(0),
+                )
+                .await;
+                peer_senders.push(peer_sender);
+            }
+
+            batcher.start(voter_mailbox, vote_receiver, certificate_receiver);
+
+            let current_view = View::new(1);
+            let leader = Participant::new(1);
+            batcher_mailbox.update(Span::none(), current_view, leader, View::zero(), None);
+
+            let future_view = View::new(3);
+            let proposal = Proposal::new(
+                Round::new(epoch, future_view),
+                View::new(2),
+                Sha256::hash(&[b"same_term_future_notarization"]),
+            );
+
+            // Send quorum votes for an optimistic future view while current remains at view 1.
+            let quorum_votes = usize::try_from(quorum(n)).expect("quorum fits");
+            for (scheme, sender) in schemes
+                .iter()
+                .skip(1)
+                .zip(peer_senders.iter_mut())
+                .take(quorum_votes)
+            {
+                let vote = Notarize::sign(scheme, proposal.clone()).expect("notarize");
+                let _ = sender.send(
+                    Recipients::One(me.clone()),
+                    Vote::<S, Sha256Digest>::Notarize(vote).encode(),
+                    true,
+                );
+            }
+
+            loop {
+                select! {
+                    message = voter_receiver.recv() => {
+                        if matches!(
+                            message,
+                            Some(voter::Message::Verified {
+                                certificate: Certificate::Notarization(ref notarization),
+                                from_resolver: false,
+                                ..
+                            }) if notarization.view() == future_view
+                        ) {
+                            break;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(2)) => {
+                        panic!(
+                            "expected notarization for optimistic future view {} without waiting for view update",
+                            future_view
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_same_term_optimistic_future_votes_are_admitted() {
+        same_term_optimistic_future_votes_are_admitted(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        same_term_optimistic_future_votes_are_admitted(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+        );
+        same_term_optimistic_future_votes_are_admitted(bls12381_threshold_std::fixture::<MinPk, _>);
+        same_term_optimistic_future_votes_are_admitted(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+        );
+        same_term_optimistic_future_votes_are_admitted(bls12381_multisig::fixture::<MinPk, _>);
+        same_term_optimistic_future_votes_are_admitted(bls12381_multisig::fixture::<MinSig, _>);
+        same_term_optimistic_future_votes_are_admitted(ed25519::fixture);
+        same_term_optimistic_future_votes_are_admitted(secp256r1::fixture);
+    }
+
+    #[test_traced]
+    fn test_same_term_optimistic_future_votes_can_construct_notarization() {
+        same_term_optimistic_future_votes_can_construct_notarization(
+            bls12381_threshold_vrf::fixture::<MinPk, _>,
+        );
+        same_term_optimistic_future_votes_can_construct_notarization(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+        );
+        same_term_optimistic_future_votes_can_construct_notarization(
+            bls12381_threshold_std::fixture::<MinPk, _>,
+        );
+        same_term_optimistic_future_votes_can_construct_notarization(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+        );
+        same_term_optimistic_future_votes_can_construct_notarization(
+            bls12381_multisig::fixture::<MinPk, _>,
+        );
+        same_term_optimistic_future_votes_can_construct_notarization(
+            bls12381_multisig::fixture::<MinSig, _>,
+        );
+        same_term_optimistic_future_votes_can_construct_notarization(ed25519::fixture);
+        same_term_optimistic_future_votes_can_construct_notarization(secp256r1::fixture);
     }
 
     /// Test that votes above finalized trigger verification/construction,

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -1,4 +1,4 @@
-use super::Verifier;
+use super::{Verifier, VerifiedVotes, VerifyJob};
 use crate::{
     Reporter,
     simplex::{
@@ -16,7 +16,7 @@ use commonware_p2p::Blocker;
 use commonware_parallel::Strategy;
 use commonware_utils::{N3f1, ordered::Quorum};
 use rand_core::CryptoRng;
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 use tracing::Span;
 
 /// Per-view state for vote accumulation and certificate tracking.
@@ -293,9 +293,8 @@ impl<
 
     /// Batch verifies the first kind of vote worth verifying (notarizes, then
     /// nullifies, then finalizes), or `None` if no kind is worthwhile.
-    ///
-    /// Returns the number of votes processed and the signers that failed
-    /// verification.
+    /// Test-only shim over the `begin_verify_*` methods.
+    #[cfg(test)]
     pub async fn try_verify<E: CryptoRng>(
         &mut self,
         rng: &mut E,
@@ -308,6 +307,45 @@ impl<
             return Some(result);
         }
         self.verifier.try_verify_finalizes(rng, strategy).await
+    }
+
+    /// Constructs the next recoverable certificate inline. Test-only shim over
+    /// [Self::begin_construct_certificate].
+    #[cfg(test)]
+    pub async fn try_construct_certificate(
+        &mut self,
+        strategy: &impl Strategy,
+    ) -> Option<Certificate<S, D>> {
+        self.verifier.try_construct_certificate(strategy).await
+    }
+
+    /// Begins a batch verification of the first kind of vote worth verifying
+    /// (notarizes, then nullifies, then finalizes), or `None` if no kind is
+    /// worthwhile. Each kind independently tracks an in-flight batch, so call
+    /// repeatedly to start every worthwhile kind.
+    ///
+    /// Returns the batch size and an owned future that resolves to the
+    /// verified votes and the signers that failed verification. The caller
+    /// must feed the future's votes back through [Self::finish_verify]; until
+    /// then, no further batch of that kind begins.
+    pub fn begin_verify<E: CryptoRng>(
+        &mut self,
+        rng: &mut E,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
+        if let Some(begun) = self.verifier.begin_verify_notarizes(rng, strategy) {
+            return Some(begun);
+        }
+        if let Some(begun) = self.verifier.begin_verify_nullifies(rng, strategy) {
+            return Some(begun);
+        }
+        self.verifier.begin_verify_finalizes(rng, strategy)
+    }
+
+    /// Reintegrates the result of a completed verification batch. See
+    /// [Verifier::finish_verify].
+    pub fn finish_verify(&mut self, votes: VerifiedVotes<S, D>) {
+        self.verifier.finish_verify(votes);
     }
 
     /// Returns true if `signer` has a nullify vote in this round.
@@ -358,16 +396,16 @@ impl<
             .collect()
     }
 
-    /// Attempts to construct a certificate from verified votes: the first kind
+    /// Begins recovery of a certificate from verified votes: the first kind
     /// (notarization, then nullification, then finalization) with an unconsumed
     /// verified quorum. Call repeatedly to drain every constructible kind.
     ///
-    /// Once recovery starts, it consumes the verified votes. Do not cancel unless the round will
-    /// also be discarded.
-    pub async fn try_construct_certificate(
+    /// Recovery consumes the verified votes when it begins. Do not drop the
+    /// returned future unless the round will also be discarded.
+    pub fn begin_construct_certificate(
         &mut self,
         strategy: &impl Strategy,
-    ) -> Option<Certificate<S, D>> {
-        self.verifier.try_construct_certificate(strategy).await
+    ) -> Option<impl Future<Output = Certificate<S, D>> + Send + 'static> {
+        self.verifier.begin_construct_certificate(strategy)
     }
 }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -96,6 +96,21 @@ impl<
         self.verifier.record_certificate(kind);
     }
 
+    /// Records a verified certificate, returning true when it may have made
+    /// buffered votes verifiable.
+    ///
+    /// A notarization also informs the verifier of the certified proposal so
+    /// buffered votes for other proposals are dropped and buffered votes for
+    /// the certified proposal become verifiable.
+    pub fn set_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
+        let kind = certificate.kind();
+        if let Certificate::Notarization(notarization) = certificate {
+            self.verifier.set_proposal(notarization.proposal.clone());
+        }
+        self.record_certificate(kind);
+        matches!(kind, Kind::Notarization)
+    }
+
     /// Adds a vote from the network to this round's verifier.
     pub fn add_network(&mut self, sender: S::PublicKey, message: Vote<S, D>) -> bool {
         // Check if sender is a participant
@@ -129,8 +144,7 @@ impl<
                     None => {
                         self.reporter.report(Activity::Notarize(notarize.clone()));
                         self.votes.insert_notarize(notarize.clone());
-                        self.verifier.add(Vote::Notarize(notarize), false);
-                        true
+                        self.verifier.add(Vote::Notarize(notarize), false)
                     }
                 }
             }
@@ -196,8 +210,7 @@ impl<
                     None => {
                         self.reporter.report(Activity::Finalize(finalize.clone()));
                         self.votes.insert_finalize(finalize.clone());
-                        self.verifier.add(Vote::Finalize(finalize), false);
-                        true
+                        self.verifier.add(Vote::Finalize(finalize), false)
                     }
                 }
             }

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -58,6 +58,30 @@ enum State<V> {
     Complete,
 }
 
+impl<V: Attributable> Certification<V> {
+    /// Buffers a vote for verification (or, if already verified, for
+    /// certificate recovery), unless its signer is already counted: a
+    /// verified vote displaces the signer's pending duplicate, while a
+    /// pending vote is dropped if the signer is already buffered. This keeps
+    /// each signer's vote counted at most once toward the quorum. Dropped
+    /// once complete.
+    fn add(&mut self, vote: V, is_verified: bool) {
+        let State::Incomplete { pending, verified } = &mut self.state else {
+            return;
+        };
+        let signer = vote.signer();
+        if verified.iter().any(|v| v.signer() == signer) {
+            return;
+        }
+        if is_verified {
+            pending.retain(|v| v.signer() != signer);
+            verified.push(vote);
+        } else if !pending.iter().any(|v| v.signer() == signer) {
+            pending.push(vote);
+        }
+    }
+}
+
 impl<V> Certification<V> {
     /// Creates an empty [State::Incomplete] with buffers sized for `quorum` votes.
     fn new(quorum: usize, batchable: bool) -> Self {
@@ -68,14 +92,6 @@ impl<V> Certification<V> {
                 pending: Vec::with_capacity(quorum),
                 verified: Vec::with_capacity(quorum),
             },
-        }
-    }
-
-    /// Buffers a vote for verification (or, if already verified, for
-    /// certificate recovery). Dropped once complete.
-    fn add(&mut self, vote: V, is_verified: bool) {
-        if let State::Incomplete { pending, verified } = &mut self.state {
-            if is_verified { verified } else { pending }.push(vote);
         }
     }
 
@@ -154,19 +170,6 @@ impl<V> Certification<V> {
     }
 }
 
-/// The leader lifecycle for one view.
-enum Leader<D: Digest> {
-    /// Not yet announced by the voter.
-    Unknown,
-    /// Announced, but their proposal is not yet known.
-    Known(Participant),
-    /// Their proposal is known. Notarize and finalize votes filter to it.
-    Proposed {
-        leader: Participant,
-        proposal: Proposal<D>,
-    },
-}
-
 /// `Verifier` is a utility for tracking and verifying consensus messages.
 ///
 /// For schemes where [`Verifier::is_batchable()`](commonware_cryptography::certificate::Verifier::is_batchable)
@@ -192,8 +195,14 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
     /// The round being certified.
     round: Rnd,
 
-    /// The leader lifecycle.
-    leader: Leader<D>,
+    /// The leader, once announced by the voter.
+    leader: Option<Participant>,
+
+    /// The proposal notarize and finalize votes filter to, learned from the
+    /// leader's own notarize or a verified notarization certificate (which
+    /// overrides a vote-learned proposal). A certificate can set it before
+    /// any leader is known (e.g. for a view beyond the admission window).
+    proposal: Option<Proposal<D>>,
 
     /// Notarize certification progress.
     notarize: Certification<Notarize<S, D>>,
@@ -220,7 +229,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
 
             round,
 
-            leader: Leader::Unknown,
+            leader: None,
+            proposal: None,
 
             notarize: Certification::new(quorum, batchable),
             nullify: Certification::new(quorum, batchable),
@@ -309,27 +319,30 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         }
     }
 
-    /// Learns the leader's proposal from `notarize`, dropping buffered votes
-    /// for any other proposal (they cannot contribute to a certificate).
-    /// Does nothing unless the leader is [Leader::Known] and the vote is theirs.
+    /// Learns the proposal from the known leader's own `notarize`, unless one
+    /// is already set.
     fn try_learn_proposal(&mut self, notarize: &Notarize<S, D>) {
-        let Leader::Known(leader) = &self.leader else {
-            return;
-        };
-        let leader = *leader;
-        if leader != notarize.signer() {
+        if self.proposal.is_some() || self.leader != Some(notarize.signer()) {
             return;
         }
-        let proposal = notarize.proposal.clone();
-        self.notarize.retain(|n| n.proposal == proposal);
-        self.finalize.retain(|f| f.proposal == proposal);
-        self.leader = Leader::Proposed { leader, proposal };
+        self.set_proposal(notarize.proposal.clone());
     }
 
-    /// Returns the leader and their proposal, once known.
+    /// Sets the proposal notarize and finalize votes filter to, dropping
+    /// buffered votes for any other proposal.
+    pub fn set_proposal(&mut self, proposal: Proposal<D>) {
+        self.notarize.retain(|n| n.proposal == proposal);
+        self.finalize.retain(|f| f.proposal == proposal);
+        self.proposal = Some(proposal);
+    }
+
+    /// Returns the leader and their proposal, once both are known.
+    ///
+    /// A certificate can set the proposal before any leader is assigned; no
+    /// proposal is returned until the leader is also known.
     pub const fn get_leader_proposal(&self) -> Option<(Participant, &Proposal<D>)> {
-        match &self.leader {
-            Leader::Proposed { leader, proposal } => Some((*leader, proposal)),
+        match (self.leader, &self.proposal) {
+            (Some(leader), Some(proposal)) => Some((leader, proposal)),
             _ => None,
         }
     }
@@ -348,46 +361,62 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// * `msg` - The [Vote] message to add.
     /// * `verified` - A boolean indicating if the message has already been verified.
-    pub fn add(&mut self, msg: Vote<S, D>, verified: bool) {
+    ///
+    /// # Returns
+    ///
+    /// `false` only if the vote was dropped because it references a different
+    /// proposal than the known one; `true` otherwise, including votes ignored
+    /// as duplicates of an already-buffered signer.
+    pub fn add(&mut self, msg: Vote<S, D>, verified: bool) -> bool {
         match msg {
             Vote::Notarize(notarize) => {
                 self.try_learn_proposal(&notarize);
 
-                // If the leader's proposal is known and the message is not for it, drop it
-                if let Leader::Proposed { proposal, .. } = &self.leader
+                // If the proposal is known and the message is not for it, drop it
+                if let Some(proposal) = &self.proposal
                     && proposal != &notarize.proposal
                 {
-                    return;
+                    return false;
                 }
                 self.notarize.add(notarize, verified);
+                true
             }
             Vote::Nullify(nullify) => {
                 self.nullify.add(nullify, verified);
+                true
             }
             Vote::Finalize(finalize) => {
-                // If the leader's proposal is known and the message is not for it, drop it
-                if let Leader::Proposed { proposal, .. } = &self.leader
+                // If the proposal is known and the message is not for it, drop it
+                if let Some(proposal) = &self.proposal
                     && proposal != &finalize.proposal
                 {
-                    return;
+                    return false;
                 }
                 self.finalize.add(finalize, verified);
+                true
             }
         }
     }
 
-    /// Sets the leader for the current consensus view.
+    /// Sets the leader for the current consensus view. Setting the same
+    /// leader again is a no-op (stable leaders are re-stamped as the voter's
+    /// current view advances through a term).
     ///
     /// `notarize` carries the leader's already-received vote, if any. Their
     /// proposal is learned from it and votes for other proposals are dropped.
     ///
     /// # Panics
     ///
-    /// Panics if a leader was already set or if `notarize` is not from
-    /// `leader`.
+    /// Panics if a different leader was already set or if `notarize` is not
+    /// from `leader`. Both values are locally derived (round stamping and
+    /// voter updates), never taken from peers, so neither assertion can fire
+    /// on adversarial input.
     pub fn set_leader(&mut self, leader: Participant, notarize: Option<&Notarize<S, D>>) {
-        assert!(matches!(self.leader, Leader::Unknown));
-        self.leader = Leader::Known(leader);
+        if let Some(existing) = self.leader {
+            // Enforces the stable-leader contract (see `Elector::elect`).
+            assert_eq!(existing, leader, "leader changed within round");
+        }
+        self.leader = Some(leader);
         if let Some(notarize) = notarize {
             assert_eq!(notarize.signer(), leader, "notarize must be from leader");
             self.try_learn_proposal(notarize);
@@ -415,11 +444,10 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        // Until the leader's proposal is known, notarizes may reference many
-        // different proposals.
-        if !matches!(self.leader, Leader::Proposed { .. }) {
-            return None;
-        }
+        // Until the canonical proposal is known (from the leader's vote or a
+        // verified certificate), notarizes may reference many different
+        // proposals.
+        self.proposal.as_ref()?;
         self.notarize
             .try_verify(|notarizes, mut verified_notarizes| {
                 let span = info_span!(
@@ -527,11 +555,12 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        // Until the leader's proposal is known, finalizes may reference many
-        // different proposals.
-        if !matches!(self.leader, Leader::Proposed { .. }) {
-            return None;
-        }
+        // Until the canonical proposal is known (from the leader's vote or a
+        // verified certificate), finalizes may reference many different
+        // proposals. A proposal set from a verified notarization certificate
+        // suffices even when the leader is unknown (e.g. a round only learned
+        // about through certificates).
+        self.proposal.as_ref()?;
         self.finalize
             .try_verify(|finalizes, mut verified_finalizes| {
                 let span = info_span!(
@@ -666,8 +695,9 @@ mod tests {
         assert_eq!(verifier.notarize.pending().len(), 1);
         assert_eq!(verifier.notarize.verified().len(), 0);
 
+        // The verified copy displaces the pending duplicate from the same signer.
         verifier.add(Vote::Notarize(notarize1.clone()), true);
-        assert_eq!(verifier.notarize.pending().len(), 1);
+        assert!(verifier.notarize.pending().is_empty());
         assert_eq!(verifier.notarize.verified().len(), 1);
 
         verifier.set_leader(notarize1.signer(), Some(&notarize1));
@@ -675,13 +705,14 @@ mod tests {
             verifier.get_leader_proposal(),
             Some((notarize1.signer(), &notarize1.proposal))
         );
+        assert!(verifier.notarize.pending().is_empty());
+
+        assert!(verifier.add(Vote::Notarize(notarize2), false));
         assert_eq!(verifier.notarize.pending().len(), 1);
 
-        verifier.add(Vote::Notarize(notarize2), false);
-        assert_eq!(verifier.notarize.pending().len(), 2);
-
-        verifier.add(Vote::Notarize(notarize_diff), false);
-        assert_eq!(verifier.notarize.pending().len(), 2);
+        // A notarize for a different proposal is rejected.
+        assert!(!verifier.add(Vote::Notarize(notarize_diff), false));
+        assert_eq!(verifier.notarize.pending().len(), 1);
 
         let mut verifier2 = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
@@ -740,7 +771,7 @@ mod tests {
 
         let leader = leader_notarize.signer();
         verifier.set_leader(leader, None);
-        assert!(matches!(verifier.leader, Leader::Known(l) if l == leader));
+        assert_eq!(verifier.leader, Some(leader));
         assert!(verifier.get_leader_proposal().is_none());
         assert_eq!(verifier.notarize.pending().len(), 1);
 
@@ -889,8 +920,9 @@ mod tests {
         assert_eq!(verifier.nullify.pending().len(), 1);
         assert_eq!(verifier.nullify.verified().len(), 0);
 
+        // The verified copy displaces the pending duplicate from the same signer.
         verifier.add(Vote::Nullify(nullify), true);
-        assert_eq!(verifier.nullify.pending().len(), 1);
+        assert!(verifier.nullify.pending().is_empty());
         assert_eq!(verifier.nullify.verified().len(), 1);
     }
 
@@ -992,12 +1024,13 @@ mod tests {
         assert_eq!(verifier.finalize.pending()[0], finalize_a);
         assert_eq!(verifier.finalize.verified().len(), 0);
 
+        // The verified copy displaces the pending duplicate from the same signer.
         verifier.add(Vote::Finalize(finalize_a), true);
-        assert_eq!(verifier.finalize.pending().len(), 1);
+        assert!(verifier.finalize.pending().is_empty());
         assert_eq!(verifier.finalize.verified().len(), 1);
 
         verifier.add(Vote::Finalize(finalize_b), false);
-        assert_eq!(verifier.finalize.pending().len(), 1);
+        assert!(verifier.finalize.pending().is_empty());
         assert_eq!(verifier.finalize.verified().len(), 1);
     }
 
@@ -1103,19 +1136,18 @@ mod tests {
         verifier.add(Vote::Finalize(finalize_a), true);
         verifier.add(Vote::Finalize(finalize_b), true);
 
-        assert_eq!(verifier.notarize.pending().len(), 2);
+        // The verified copies displace the pending duplicates from the same signers.
+        assert!(verifier.notarize.pending().is_empty());
         assert_eq!(verifier.notarize.verified().len(), 2);
-        assert_eq!(verifier.finalize.pending().len(), 2);
+        assert!(verifier.finalize.pending().is_empty());
         assert_eq!(verifier.finalize.verified().len(), 2);
 
         verifier.set_leader(notarize_a.signer(), Some(&notarize_a));
 
-        assert_eq!(verifier.notarize.pending().len(), 1);
-        assert_eq!(verifier.notarize.pending()[0].proposal, proposal_a);
+        assert!(verifier.notarize.pending().is_empty());
         assert_eq!(verifier.notarize.verified().len(), 1);
         assert_eq!(verifier.notarize.verified()[0].proposal, proposal_a);
-        assert_eq!(verifier.finalize.pending().len(), 1);
-        assert_eq!(verifier.finalize.pending()[0].proposal, proposal_a);
+        assert!(verifier.finalize.pending().is_empty());
         assert_eq!(verifier.finalize.verified().len(), 1);
         assert_eq!(verifier.finalize.verified()[0].proposal, proposal_a);
     }
@@ -1132,7 +1164,36 @@ mod tests {
         leader_proposal_filters_messages(secp256r1::fixture);
     }
 
-    fn set_leader_twice_panics<S, F>(mut fixture: F)
+    fn set_leader_twice_same_value_is_noop<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256, PublicKey = PublicKey>,
+        F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
+    {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
+        let mut verifier = Verifier::<S, Sha256>::new(
+            Round::new(Epoch::new(0), View::new(1)),
+            schemes[0].clone(),
+            3,
+        );
+        let leader = Participant::new(0);
+        verifier.set_leader(leader, None);
+        verifier.set_leader(leader, None);
+    }
+
+    #[test]
+    fn test_set_leader_twice_same_value_is_noop() {
+        set_leader_twice_same_value_is_noop(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        set_leader_twice_same_value_is_noop(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        set_leader_twice_same_value_is_noop(bls12381_threshold_std::fixture::<MinSig, _>);
+        set_leader_twice_same_value_is_noop(bls12381_threshold_std::fixture::<MinPk, _>);
+        set_leader_twice_same_value_is_noop(bls12381_multisig::fixture::<MinSig, _>);
+        set_leader_twice_same_value_is_noop(bls12381_multisig::fixture::<MinPk, _>);
+        set_leader_twice_same_value_is_noop(ed25519::fixture);
+        set_leader_twice_same_value_is_noop(secp256r1::fixture);
+    }
+
+    fn set_leader_change_panics<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256, PublicKey = PublicKey>,
         F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
@@ -1149,51 +1210,51 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_bls_threshold_minsig() {
-        set_leader_twice_panics(bls12381_threshold_vrf::fixture::<MinSig, _>);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_bls_threshold_minsig() {
+        set_leader_change_panics(bls12381_threshold_vrf::fixture::<MinSig, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_bls_threshold_minpk() {
-        set_leader_twice_panics(bls12381_threshold_vrf::fixture::<MinPk, _>);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_bls_threshold_minpk() {
+        set_leader_change_panics(bls12381_threshold_vrf::fixture::<MinPk, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_bls_threshold_std_minsig() {
-        set_leader_twice_panics(bls12381_threshold_std::fixture::<MinSig, _>);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_bls_threshold_std_minsig() {
+        set_leader_change_panics(bls12381_threshold_std::fixture::<MinSig, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_bls_threshold_std_minpk() {
-        set_leader_twice_panics(bls12381_threshold_std::fixture::<MinPk, _>);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_bls_threshold_std_minpk() {
+        set_leader_change_panics(bls12381_threshold_std::fixture::<MinPk, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_bls_multisig_minsig() {
-        set_leader_twice_panics(bls12381_multisig::fixture::<MinSig, _>);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_bls_multisig_minsig() {
+        set_leader_change_panics(bls12381_multisig::fixture::<MinSig, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_bls_multisig_minpk() {
-        set_leader_twice_panics(bls12381_multisig::fixture::<MinPk, _>);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_bls_multisig_minpk() {
+        set_leader_change_panics(bls12381_multisig::fixture::<MinPk, _>);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_ed() {
-        set_leader_twice_panics(ed25519::fixture);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_ed() {
+        set_leader_change_panics(ed25519::fixture);
     }
 
     #[test]
-    #[should_panic(expected = "Leader::Unknown")]
-    fn test_set_leader_twice_panics_secp() {
-        set_leader_twice_panics(secp256r1::fixture);
+    #[should_panic(expected = "leader changed within round")]
+    fn test_set_leader_change_panics_secp() {
+        set_leader_change_panics(secp256r1::fixture);
     }
 
     async fn notarizes_wait_for_quorum<S, F>(mut fixture: F)
@@ -1351,6 +1412,25 @@ mod tests {
             "Should not verify without leader_proposal set"
         );
         assert_eq!(verifier.finalize.pending().len(), quorum as usize);
+
+        // A proposal set without a leader (as from a verified notarization
+        // certificate on a round the leader was never assigned for) suffices.
+        let mut verifier = Verifier::<S, Sha256>::new(
+            Round::new(Epoch::new(0), View::new(1)),
+            schemes[0].clone(),
+            quorum,
+        );
+        for finalize in finalizes.iter() {
+            verifier.add(Vote::Finalize(finalize.clone()), false);
+        }
+        verifier.set_proposal(finalizes[0].proposal.clone());
+        assert!(
+            verifier
+                .try_verify_finalizes(&mut rng, &Sequential)
+                .await
+                .is_some(),
+            "Should verify with a certificate proposal and no leader"
+        );
     }
 
     #[test_async]
@@ -1363,6 +1443,220 @@ mod tests {
         ready_finalizes_without_leader(bls12381_multisig::fixture::<MinPk, _>).await;
         ready_finalizes_without_leader(ed25519::fixture).await;
         ready_finalizes_without_leader(secp256r1::fixture).await;
+    }
+
+    async fn verified_leader_notarize_is_not_reverified<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256, PublicKey = PublicKey>,
+        F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
+    {
+        if !S::is_batchable() {
+            return;
+        }
+
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
+        let quorum = N3f1::quorum(schemes.len());
+        let mut verifier = Verifier::<S, Sha256>::new(
+            Round::new(Epoch::new(0), View::new(2)),
+            schemes[0].clone(),
+            quorum,
+        );
+        let round = Round::new(Epoch::new(0), View::new(2));
+        let leader_vote = create_notarize(&schemes[0], round, View::new(1), 10);
+
+        assert!(verifier.add(Vote::Notarize(leader_vote.clone()), true));
+        assert!(verifier.notarize.pending().is_empty());
+        assert_eq!(verifier.notarize.verified().len(), 1);
+
+        verifier.set_leader(leader_vote.signer(), Some(&leader_vote));
+
+        // A network duplicate of the already-verified leader vote is dropped.
+        assert!(verifier.add(Vote::Notarize(leader_vote.clone()), false));
+        assert!(verifier.notarize.pending().is_empty());
+
+        for scheme in schemes.iter().skip(1).take(quorum as usize - 2) {
+            verifier.add(
+                Vote::Notarize(create_notarize(scheme, round, View::new(1), 10)),
+                false,
+            );
+        }
+        assert!(
+            verifier
+                .try_verify_notarizes(&mut rng, &Sequential)
+                .await
+                .is_none(),
+            "verified leader vote must not also count as pending"
+        );
+
+        verifier.add(
+            Vote::Notarize(create_notarize(
+                &schemes[quorum as usize - 1],
+                round,
+                View::new(1),
+                10,
+            )),
+            false,
+        );
+        let (batch, failed) = verifier
+            .try_verify_notarizes(&mut rng, &Sequential)
+            .await
+            .expect("batch should be worthwhile at quorum");
+        assert_eq!(batch, quorum as usize - 1);
+        assert!(failed.is_empty());
+        assert_eq!(verifier.notarize.verified().len(), quorum as usize);
+    }
+
+    #[test_async]
+    async fn test_verified_leader_notarize_is_not_reverified() {
+        verified_leader_notarize_is_not_reverified(bls12381_threshold_vrf::fixture::<MinSig, _>)
+            .await;
+        verified_leader_notarize_is_not_reverified(bls12381_threshold_vrf::fixture::<MinPk, _>)
+            .await;
+        verified_leader_notarize_is_not_reverified(bls12381_threshold_std::fixture::<MinSig, _>)
+            .await;
+        verified_leader_notarize_is_not_reverified(bls12381_threshold_std::fixture::<MinPk, _>)
+            .await;
+        verified_leader_notarize_is_not_reverified(bls12381_multisig::fixture::<MinSig, _>).await;
+        verified_leader_notarize_is_not_reverified(bls12381_multisig::fixture::<MinPk, _>).await;
+        verified_leader_notarize_is_not_reverified(ed25519::fixture).await;
+        verified_leader_notarize_is_not_reverified(secp256r1::fixture).await;
+    }
+
+    async fn certificate_proposal_allows_finalize_verification<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256, PublicKey = PublicKey>,
+        F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
+    {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
+        let quorum = N3f1::quorum(schemes.len());
+        let mut verifier = Verifier::<S, Sha256>::new(
+            Round::new(Epoch::new(0), View::new(3)),
+            schemes[0].clone(),
+            quorum,
+        );
+        let round = Round::new(Epoch::new(0), View::new(3));
+        let conflicting = Proposal::new(round, View::new(2), sample_digest(8));
+        let proposal = Proposal::new(round, View::new(2), sample_digest(9));
+
+        verifier.set_leader(Participant::new(0), None);
+        assert!(verifier.add(
+            Vote::Notarize(Notarize::sign(&schemes[0], conflicting.clone()).unwrap()),
+            false,
+        ));
+        assert_eq!(
+            verifier.get_leader_proposal(),
+            Some((Participant::new(0), &conflicting))
+        );
+
+        // A certificate-set proposal overrides the vote-learned one.
+        verifier.set_proposal(proposal.clone());
+        assert_eq!(
+            verifier.get_leader_proposal(),
+            Some((Participant::new(0), &proposal))
+        );
+
+        for scheme in schemes.iter().take(quorum as usize) {
+            verifier.add(
+                Vote::Finalize(Finalize::sign(scheme, proposal.clone()).unwrap()),
+                false,
+            );
+        }
+        let (batch, failed) = verifier
+            .try_verify_finalizes(&mut rng, &Sequential)
+            .await
+            .expect("finalizes should verify against the certificate proposal");
+        assert_eq!(batch, quorum as usize);
+        assert!(failed.is_empty());
+    }
+
+    #[test_async]
+    async fn test_certificate_proposal_allows_finalize_verification() {
+        certificate_proposal_allows_finalize_verification(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+        )
+        .await;
+        certificate_proposal_allows_finalize_verification(
+            bls12381_threshold_vrf::fixture::<MinPk, _>,
+        )
+        .await;
+        certificate_proposal_allows_finalize_verification(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+        )
+        .await;
+        certificate_proposal_allows_finalize_verification(
+            bls12381_threshold_std::fixture::<MinPk, _>,
+        )
+        .await;
+        certificate_proposal_allows_finalize_verification(bls12381_multisig::fixture::<MinSig, _>)
+            .await;
+        certificate_proposal_allows_finalize_verification(bls12381_multisig::fixture::<MinPk, _>)
+            .await;
+        certificate_proposal_allows_finalize_verification(ed25519::fixture).await;
+        certificate_proposal_allows_finalize_verification(secp256r1::fixture).await;
+    }
+
+    #[test_async]
+    async fn test_nonbatchable_finalize_accounting_tracks_proposal_override() {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = secp256r1::fixture(&mut rng, NAMESPACE, 5);
+        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let mut verifier = Verifier::<_, Sha256>::new(
+            Round::new(Epoch::new(333), View::new(7)),
+            schemes[0].clone(),
+            quorum.try_into().unwrap(),
+        );
+        let round = Round::new(Epoch::new(333), View::new(7));
+        let proposal_a = Proposal::new(round, View::new(6), sample_digest(1));
+        let proposal_b = Proposal::new(round, View::new(6), sample_digest(2));
+
+        verifier.set_leader(Participant::new(0), None);
+        assert!(verifier.add(
+            Vote::Notarize(Notarize::sign(&schemes[0], proposal_a.clone()).unwrap()),
+            false,
+        ));
+        assert!(verifier.add(
+            Vote::Finalize(Finalize::sign(&schemes[0], proposal_a).unwrap()),
+            false,
+        ));
+        let (batch, failed) = verifier
+            .try_verify_finalizes(&mut rng, &Sequential)
+            .await
+            .expect("nonbatchable schemes verify eagerly");
+        assert_eq!(batch, 1);
+        assert!(failed.is_empty());
+        assert_eq!(verifier.finalize.verified().len(), 1);
+
+        // The override drops the verified finalize for the old proposal.
+        verifier.set_proposal(proposal_b.clone());
+        assert!(verifier.finalize.verified().is_empty());
+
+        for scheme in schemes.iter().take(quorum).skip(1) {
+            assert!(verifier.add(
+                Vote::Finalize(Finalize::sign(scheme, proposal_b.clone()).unwrap()),
+                false,
+            ));
+            let (batch, failed) = verifier
+                .try_verify_finalizes(&mut rng, &Sequential)
+                .await
+                .expect("nonbatchable schemes verify eagerly");
+            assert_eq!(batch, 1);
+            assert!(failed.is_empty());
+        }
+        assert_eq!(verifier.finalize.verified().len(), quorum - 1);
+
+        assert!(verifier.add(
+            Vote::Finalize(Finalize::sign(&schemes[quorum], proposal_b).unwrap()),
+            false,
+        ));
+        let (batch, failed) = verifier
+            .try_verify_finalizes(&mut rng, &Sequential)
+            .await
+            .expect("nonbatchable schemes verify eagerly");
+        assert_eq!(batch, 1);
+        assert!(failed.is_empty());
+        assert_eq!(verifier.finalize.verified().len(), quorum);
     }
 
     fn verify_notarizes_empty<S, F>(mut fixture: F)
@@ -1806,45 +2100,68 @@ mod tests {
         ready_finalizes_quorum_already_met_by_verified(secp256r1::fixture);
     }
 
+    /// A minimal vote for exercising [Certification] mechanics.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct TestVote(u32);
+
+    impl Attributable for TestVote {
+        fn signer(&self) -> Participant {
+            Participant::new(self.0)
+        }
+    }
+
     #[test_async]
     async fn test_certification_lifecycle() {
         // Non-batchable schemes verify eagerly whenever votes are pending
-        let mut eager = Certification::<u64>::new(3, false);
-        eager.add(1, false);
+        let mut eager = Certification::<TestVote>::new(3, false);
+        eager.add(TestVote(1), false);
         assert!(eager.should_verify());
 
-        let mut votes = Certification::<u64>::new(3, true);
-        votes.add(1, false);
-        votes.add(2, true);
-        assert_eq!(votes.pending(), &[1]);
-        assert_eq!(votes.verified(), &[2]);
+        let mut votes = Certification::<TestVote>::new(3, true);
+        votes.add(TestVote(1), false);
+        votes.add(TestVote(2), true);
+        assert_eq!(votes.pending(), &[TestVote(1)]);
+        assert_eq!(votes.verified(), &[TestVote(2)]);
+
+        // Duplicate signers never double-count. A pending duplicate is
+        // dropped and a verified copy displaces the pending original.
+        votes.add(TestVote(1), false);
+        assert_eq!(votes.pending(), &[TestVote(1)]);
+        votes.add(TestVote(1), true);
+        assert!(votes.pending().is_empty());
+        assert_eq!(votes.verified(), &[TestVote(2), TestVote(1)]);
+        votes.add(TestVote(1), false);
+        assert!(votes.pending().is_empty());
 
         // Batchable schemes wait until the buffers could reach quorum
         assert!(!votes.should_verify());
-        votes.add(3, false);
+        votes.add(TestVote(3), false);
         assert!(votes.should_verify());
 
         // Verification consumes both buffers and stores the new verified set.
         // Below quorum, recovery is refused.
         let (batch, invalid) = votes
             .try_verify(|pending, verified| async move {
-                assert_eq!(pending, vec![1, 3]);
-                assert_eq!(verified, vec![2]);
-                (vec![1, 2], vec![])
+                assert_eq!(pending, vec![TestVote(3)]);
+                assert_eq!(verified, vec![TestVote(2), TestVote(1)]);
+                (vec![TestVote(1), TestVote(2)], vec![])
             })
             .await
             .unwrap();
-        assert_eq!(batch, 2);
+        assert_eq!(batch, 1);
         assert!(invalid.is_empty());
         assert!(votes.pending().is_empty());
         assert!(votes.try_complete().is_none());
 
         // At quorum, recovery surrenders the votes and completes. All later
         // votes are dropped.
-        votes.add(3, true);
-        assert_eq!(votes.try_complete(), Some(vec![1, 2, 3]));
+        votes.add(TestVote(3), true);
+        assert_eq!(
+            votes.try_complete(),
+            Some(vec![TestVote(1), TestVote(2), TestVote(3)])
+        );
         assert!(votes.is_complete());
-        votes.add(5, false);
+        votes.add(TestVote(5), false);
         assert!(votes.pending().is_empty());
         assert!(votes.verified().is_empty());
         assert!(
@@ -1856,8 +2173,8 @@ mod tests {
         assert!(votes.try_complete().is_none());
 
         // Network certificates complete without any votes
-        let mut votes = Certification::<u64>::new(3, true);
-        votes.add(1, false);
+        let mut votes = Certification::<TestVote>::new(3, true);
+        votes.add(TestVote(1), false);
         votes.complete();
         assert!(votes.is_complete());
         assert!(votes.pending().is_empty());

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -14,12 +14,19 @@ use commonware_runtime::telemetry::traces::TracedExt as _;
 use commonware_utils::ordered::Set;
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
-use std::{future::Future, mem, sync::Arc};
+use std::{future::Future, mem, pin::Pin, sync::Arc};
 use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
-/// instrumenting the awaited future so the offloaded work stays attributed to the caller's trace.
-async fn offload<P, F, T>(span: Span, strategy: &P, job: F) -> T
+/// instrumenting the returned future so the offloaded work stays attributed to the caller's trace.
+///
+/// Returns an owned future so callers can either await it inline or hold it in
+/// a pool while continuing to process messages.
+fn offload<P, F, T>(
+    span: Span,
+    strategy: &P,
+    job: F,
+) -> impl Future<Output = T> + Send + 'static
 where
     P: Strategy,
     F: FnOnce(P) -> T + Send + 'static,
@@ -29,7 +36,6 @@ where
     strategy
         .spawn(move |strategy| worker_span.in_scope(|| job(strategy)))
         .instrument(span)
-        .await
 }
 
 /// Certification progress for one kind of vote.
@@ -41,6 +47,9 @@ struct Certification<V> {
     quorum: usize,
     /// Whether the scheme benefits from batching signature verification.
     batchable: bool,
+    /// Whether a verification batch is currently in flight. At most one batch
+    /// per kind runs at a time; votes arriving meanwhile buffer as pending.
+    in_flight: bool,
     /// Progress toward a certificate.
     state: State<V>,
 }
@@ -80,6 +89,42 @@ impl<V: Attributable> Certification<V> {
             pending.push(vote);
         }
     }
+
+    /// Runs `f` over the buffered votes and reintegrates the verified set it
+    /// returns, or `None` if a batch is not worth verifying (see
+    /// [Self::should_verify]). Test-only shim over [Self::begin_verify] and
+    /// [Self::finish_verify].
+    #[cfg(test)]
+    async fn try_verify<F, Fut>(&mut self, f: F) -> Option<(usize, Vec<Participant>)>
+    where
+        F: FnOnce(Vec<V>, Vec<V>) -> Fut,
+        Fut: Future<Output = (Vec<V>, Vec<Participant>)>,
+    {
+        let (batch, pending, prior) = self.begin_verify()?;
+        let (votes, invalid) = f(pending, prior).await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Reintegrates the verified votes of a completed batch, merging them with
+    /// any votes verified while the batch was in flight (keeping each signer
+    /// counted once) and dropping pending duplicates of now-verified signers.
+    ///
+    /// Dropped without effect if a certificate completed while the batch was
+    /// in flight.
+    fn finish_verify(&mut self, votes: Vec<V>) {
+        self.in_flight = false;
+        let State::Incomplete { pending, verified } = &mut self.state else {
+            return;
+        };
+        for vote in votes {
+            let signer = vote.signer();
+            if !verified.iter().any(|v| v.signer() == signer) {
+                verified.push(vote);
+            }
+        }
+        pending.retain(|p| !verified.iter().any(|v| v.signer() == p.signer()));
+    }
 }
 
 impl<V> Certification<V> {
@@ -88,6 +133,7 @@ impl<V> Certification<V> {
         Self {
             quorum,
             batchable,
+            in_flight: false,
             state: State::Incomplete {
                 pending: Vec::with_capacity(quorum),
                 verified: Vec::with_capacity(quorum),
@@ -95,10 +141,13 @@ impl<V> Certification<V> {
         }
     }
 
-    /// Returns true if a batch verification should run: pending votes exist,
-    /// the quorum is unmet, and (for batchable schemes) the buffers together
-    /// could reach it.
+    /// Returns true if a batch verification should run: no batch is already in
+    /// flight, pending votes exist, the quorum is unmet, and (for batchable
+    /// schemes) the buffers together could reach it.
     const fn should_verify(&self) -> bool {
+        if self.in_flight {
+            return false;
+        }
         match &self.state {
             State::Incomplete { pending, verified } => {
                 !pending.is_empty()
@@ -109,18 +158,14 @@ impl<V> Certification<V> {
         }
     }
 
-    /// Runs `f` over the buffered votes and stores the verified set it
-    /// returns, or `None` if a batch is not worth verifying (see
-    /// [Self::should_verify]).
+    /// Surrenders the buffered votes for a verification batch, or `None` if a
+    /// batch is not worth verifying (see [Self::should_verify]).
     ///
-    /// `f` receives the pending and previously verified votes and returns the
-    /// new verified set plus the signers that failed verification. Returns
-    /// the number of votes processed alongside those signers.
-    async fn try_verify<F, Fut>(&mut self, f: F) -> Option<(usize, Vec<Participant>)>
-    where
-        F: FnOnce(Vec<V>, Vec<V>) -> Fut,
-        Fut: Future<Output = (Vec<V>, Vec<Participant>)>,
-    {
+    /// Returns the number of pending votes alongside the pending and
+    /// previously verified votes. Marks the certification in flight until
+    /// [Self::finish_verify] reintegrates the batch's result; votes arriving
+    /// meanwhile buffer as pending for a later batch.
+    fn begin_verify(&mut self) -> Option<(usize, Vec<V>, Vec<V>)> {
         if !self.should_verify() {
             return None;
         }
@@ -129,12 +174,8 @@ impl<V> Certification<V> {
         };
         let batch = pending.len();
         let (pending, prior) = (mem::take(pending), mem::take(verified));
-        let (votes, invalid) = f(pending, prior).await;
-        let State::Incomplete { verified, .. } = &mut self.state else {
-            unreachable!("certification completed mid-verification");
-        };
-        *verified = votes;
-        Some((batch, invalid))
+        self.in_flight = true;
+        Some((batch, pending, prior))
     }
 
     /// Completes with a verified quorum, surrendering it for certificate
@@ -169,6 +210,20 @@ impl<V> Certification<V> {
         }
     }
 }
+
+/// The verified votes of one completed batch, tagged by kind so a pooled
+/// verification's result can be routed back to the right [Certification].
+pub enum VerifiedVotes<S: Scheme<D>, D: Digest> {
+    Notarizes(Vec<Notarize<S, D>>),
+    Nullifies(Vec<Nullify<S>>),
+    Finalizes(Vec<Finalize<S, D>>),
+}
+
+/// An owned, in-flight verification batch: resolves to the verified votes and
+/// the signers that failed verification. Feed the votes back through
+/// [Verifier::finish_verify].
+pub type VerifyJob<S, D> =
+    Pin<Box<dyn Future<Output = (VerifiedVotes<S, D>, Vec<Participant>)> + Send>>;
 
 /// `Verifier` is a utility for tracking and verifying consensus messages.
 ///
@@ -249,56 +304,57 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// Once recovery starts, it consumes the verified votes. Do not cancel unless
     /// the verifier will also be discarded.
+    #[cfg(test)]
     pub async fn try_construct_certificate(
         &mut self,
         strategy: &impl Strategy,
     ) -> Option<Certificate<S, D>> {
-        if let Some(notarizes) = self.notarize.try_complete() {
-            let span = info_span!(
-                "simplex.batcher.try_construct_notarization",
-                epoch = self.round.epoch().traced(),
-                view = self.round.view().traced()
-            );
-            let scheme = Arc::clone(&self.scheme);
-            let notarization = offload(span, strategy, move |strategy| {
+        Some(self.begin_construct_certificate(strategy)?.await)
+    }
+
+    /// Begins recovery of a certificate from verified votes: the first kind
+    /// (notarization, then nullification, then finalization) with an
+    /// unconsumed verified quorum. Call repeatedly to drain every
+    /// constructible kind.
+    ///
+    /// Returns an owned future that resolves to the certificate. Recovery
+    /// consumes the verified votes when it begins; do not drop the future
+    /// unless the verifier will also be discarded.
+    pub fn begin_construct_certificate(
+        &mut self,
+        strategy: &impl Strategy,
+    ) -> Option<impl Future<Output = Certificate<S, D>> + Send + 'static> {
+        let (quorum, name) = if let Some(notarizes) = self.notarize.try_complete() {
+            (VerifiedVotes::Notarizes(notarizes), "notarization")
+        } else if let Some(nullifies) = self.nullify.try_complete() {
+            (VerifiedVotes::Nullifies(nullifies), "nullification")
+        } else {
+            (
+                VerifiedVotes::Finalizes(self.finalize.try_complete()?),
+                "finalization",
+            )
+        };
+        let span = info_span!(
+            "simplex.batcher.construct_certificate",
+            kind = name,
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let scheme = Arc::clone(&self.scheme);
+        Some(offload(span, strategy, move |strategy| match quorum {
+            VerifiedVotes::Notarizes(notarizes) => Certificate::Notarization(
                 Notarization::from_owned_notarizes(scheme.as_ref(), notarizes, &strategy)
-                    .expect("verified notarize quorum must assemble")
-            })
-            .await;
-            return Some(Certificate::Notarization(notarization));
-        }
-
-        if let Some(nullifies) = self.nullify.try_complete() {
-            let span = info_span!(
-                "simplex.batcher.try_construct_nullification",
-                epoch = self.round.epoch().traced(),
-                view = self.round.view().traced()
-            );
-            let scheme = Arc::clone(&self.scheme);
-            let nullification = offload(span, strategy, move |strategy| {
+                    .expect("verified notarize quorum must assemble"),
+            ),
+            VerifiedVotes::Nullifies(nullifies) => Certificate::Nullification(
                 Nullification::from_owned_nullifies(scheme.as_ref(), nullifies, &strategy)
-                    .expect("verified nullify quorum must assemble")
-            })
-            .await;
-            return Some(Certificate::Nullification(nullification));
-        }
-
-        if let Some(finalizes) = self.finalize.try_complete() {
-            let span = info_span!(
-                "simplex.batcher.try_construct_finalization",
-                epoch = self.round.epoch().traced(),
-                view = self.round.view().traced()
-            );
-            let scheme = Arc::clone(&self.scheme);
-            let finalization = offload(span, strategy, move |strategy| {
+                    .expect("verified nullify quorum must assemble"),
+            ),
+            VerifiedVotes::Finalizes(finalizes) => Certificate::Finalization(
                 Finalization::from_owned_finalizes(scheme.as_ref(), finalizes, &strategy)
-                    .expect("verified finalize quorum must assemble")
-            })
-            .await;
-            return Some(Certificate::Finalization(finalization));
-        }
-
-        None
+                    .expect("verified finalize quorum must assemble"),
+            ),
+        }))
     }
 
     /// Returns true if a certificate of `kind` exists.
@@ -439,50 +495,67 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// The number of votes processed and the signer indices for whom verification
     /// failed, or `None` if verification was not worthwhile.
+    #[cfg(test)]
     pub async fn try_verify_notarizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
+        let (batch, job) = self.begin_verify_notarizes(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Begins a batch verification of pending [Vote::Notarize] messages, if
+    /// worthwhile (see [Certification::should_verify]), returning the batch
+    /// size and an owned future that resolves to the verified votes and the
+    /// signers that failed verification.
+    ///
+    /// The caller must feed the future's votes back through
+    /// [Self::finish_verify]; until then, no further notarize batch begins.
+    pub fn begin_verify_notarizes<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
         // Until the canonical proposal is known (from the leader's vote or a
         // verified certificate), notarizes may reference many different
         // proposals.
         self.proposal.as_ref()?;
-        self.notarize
-            .try_verify(|notarizes, mut verified_notarizes| {
-                let span = info_span!(
-                    "simplex.batcher.verify_notarizes",
-                    epoch = self.round.epoch().traced(),
-                    view = self.round.view().traced()
-                );
-                let scheme = Arc::clone(&self.scheme);
-                let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
-                    let (proposals, attestations): (Vec<_>, Vec<_>) = notarizes
-                        .into_iter()
-                        .map(|n| (n.proposal, n.attestation))
-                        .unzip();
-                    // All proposals here are equal: pending votes are filtered to the
-                    // leader's proposal before verification becomes ready.
-                    let proposal = &proposals[0];
+        let (batch, notarizes, mut verified_notarizes) = self.notarize.begin_verify()?;
+        let span = info_span!(
+            "simplex.batcher.verify_notarizes",
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let scheme = Arc::clone(&self.scheme);
+        let mut rng = StdRng::from_rng(rng);
+        let job = offload(span, strategy, move |strategy| {
+            let (proposals, attestations): (Vec<_>, Vec<_>) = notarizes
+                .into_iter()
+                .map(|n| (n.proposal, n.attestation))
+                .unzip();
+            // All proposals here are equal: pending votes are filtered to the
+            // leader's proposal before verification becomes ready.
+            let proposal = &proposals[0];
 
-                    let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
-                        &mut rng,
-                        Subject::Notarize { proposal },
-                        attestations,
-                        &strategy,
-                    );
+            let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
+                &mut rng,
+                Subject::Notarize { proposal },
+                attestations,
+                &strategy,
+            );
 
-                    verified_notarizes.extend(verified.into_iter().zip(proposals).map(
-                        |(attestation, proposal)| Notarize {
-                            proposal,
-                            attestation,
-                        },
-                    ));
-                    (verified_notarizes, invalid)
-                })
-            })
-            .await
+            verified_notarizes.extend(verified.into_iter().zip(proposals).map(
+                |(attestation, proposal)| Notarize {
+                    proposal,
+                    attestation,
+                },
+            ));
+            (VerifiedVotes::Notarizes(verified_notarizes), invalid)
+        });
+        Some((batch, Box::pin(job) as VerifyJob<S, D>))
     }
 
     /// Batch verifies pending [Vote::Nullify] messages, if worthwhile (see
@@ -500,38 +573,55 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// The number of votes processed and the signer indices for whom verification
     /// failed, or `None` if verification was not worthwhile.
+    #[cfg(test)]
     pub async fn try_verify_nullifies<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        self.nullify
-            .try_verify(|nullifies, mut verified_nullifies| {
-                let span = info_span!(
-                    "simplex.batcher.verify_nullifies",
-                    epoch = self.round.epoch().traced(),
-                    view = self.round.view().traced()
-                );
-                let round = nullifies[0].round;
-                let scheme = Arc::clone(&self.scheme);
-                let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
-                    let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
-                        &mut rng,
-                        Subject::Nullify { round },
-                        nullifies.into_iter().map(|nullify| nullify.attestation),
-                        &strategy,
-                    );
+        let (batch, job) = self.begin_verify_nullifies(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
 
-                    verified_nullifies.extend(
-                        verified
-                            .into_iter()
-                            .map(|attestation| Nullify { round, attestation }),
-                    );
-                    (verified_nullifies, invalid)
-                })
-            })
-            .await
+    /// Begins a batch verification of pending [Vote::Nullify] messages, if
+    /// worthwhile (see [Certification::should_verify]), returning the batch
+    /// size and an owned future that resolves to the verified votes and the
+    /// signers that failed verification.
+    ///
+    /// The caller must feed the future's votes back through
+    /// [Self::finish_verify]; until then, no further nullify batch begins.
+    pub fn begin_verify_nullifies<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
+        let (batch, nullifies, mut verified_nullifies) = self.nullify.begin_verify()?;
+        let span = info_span!(
+            "simplex.batcher.verify_nullifies",
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let round = nullifies[0].round;
+        let scheme = Arc::clone(&self.scheme);
+        let mut rng = StdRng::from_rng(rng);
+        let job = offload(span, strategy, move |strategy| {
+            let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
+                &mut rng,
+                Subject::Nullify { round },
+                nullifies.into_iter().map(|nullify| nullify.attestation),
+                &strategy,
+            );
+
+            verified_nullifies.extend(
+                verified
+                    .into_iter()
+                    .map(|attestation| Nullify { round, attestation }),
+            );
+            (VerifiedVotes::Nullifies(verified_nullifies), invalid)
+        });
+        Some((batch, Box::pin(job) as VerifyJob<S, D>))
     }
 
     /// Batch verifies pending [Vote::Finalize] messages, if worthwhile: the
@@ -550,50 +640,91 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// The number of votes processed and the signer indices for whom verification
     /// failed, or `None` if verification was not worthwhile.
+    #[cfg(test)]
     pub async fn try_verify_finalizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
+        let (batch, job) = self.begin_verify_finalizes(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Begins a batch verification of pending [Vote::Finalize] messages, if
+    /// worthwhile (see [Certification::should_verify]), returning the batch
+    /// size and an owned future that resolves to the verified votes and the
+    /// signers that failed verification.
+    ///
+    /// The caller must feed the future's votes back through
+    /// [Self::finish_verify]; until then, no further finalize batch begins.
+    pub fn begin_verify_finalizes<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
         // Until the canonical proposal is known (from the leader's vote or a
         // verified certificate), finalizes may reference many different
         // proposals. A proposal set from a verified notarization certificate
         // suffices even when the leader is unknown (e.g. a round only learned
         // about through certificates).
         self.proposal.as_ref()?;
-        self.finalize
-            .try_verify(|finalizes, mut verified_finalizes| {
-                let span = info_span!(
-                    "simplex.batcher.verify_finalizes",
-                    epoch = self.round.epoch().traced(),
-                    view = self.round.view().traced()
-                );
-                let scheme = Arc::clone(&self.scheme);
-                let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
-                    let (proposals, attestations): (Vec<_>, Vec<_>) = finalizes
-                        .into_iter()
-                        .map(|n| (n.proposal, n.attestation))
-                        .unzip();
-                    let proposal = &proposals[0];
+        let (batch, finalizes, mut verified_finalizes) = self.finalize.begin_verify()?;
+        let span = info_span!(
+            "simplex.batcher.verify_finalizes",
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let scheme = Arc::clone(&self.scheme);
+        let mut rng = StdRng::from_rng(rng);
+        let job = offload(span, strategy, move |strategy| {
+            let (proposals, attestations): (Vec<_>, Vec<_>) = finalizes
+                .into_iter()
+                .map(|n| (n.proposal, n.attestation))
+                .unzip();
+            let proposal = &proposals[0];
 
-                    let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
-                        &mut rng,
-                        Subject::Finalize { proposal },
-                        attestations,
-                        &strategy,
-                    );
+            let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
+                &mut rng,
+                Subject::Finalize { proposal },
+                attestations,
+                &strategy,
+            );
 
-                    verified_finalizes.extend(verified.into_iter().zip(proposals).map(
-                        |(attestation, proposal)| Finalize {
-                            proposal,
-                            attestation,
-                        },
-                    ));
-                    (verified_finalizes, invalid)
-                })
-            })
-            .await
+            verified_finalizes.extend(verified.into_iter().zip(proposals).map(
+                |(attestation, proposal)| Finalize {
+                    proposal,
+                    attestation,
+                },
+            ));
+            (VerifiedVotes::Finalizes(verified_finalizes), invalid)
+        });
+        Some((batch, Box::pin(job) as VerifyJob<S, D>))
+    }
+
+    /// Reintegrates the result of a completed verification batch, unblocking
+    /// the next batch of that kind.
+    ///
+    /// Notarize and finalize votes are re-filtered against the current leader
+    /// proposal: a certificate may have displaced the proposal while the batch
+    /// was in flight, and stale-proposal votes must not count toward a quorum.
+    pub fn finish_verify(&mut self, votes: VerifiedVotes<S, D>) {
+        match votes {
+            VerifiedVotes::Notarizes(mut votes) => {
+                if let Some(proposal) = &self.proposal {
+                    votes.retain(|n| &n.proposal == proposal);
+                }
+                self.notarize.finish_verify(votes);
+            }
+            VerifiedVotes::Nullifies(votes) => self.nullify.finish_verify(votes),
+            VerifiedVotes::Finalizes(mut votes) => {
+                if let Some(proposal) = &self.proposal {
+                    votes.retain(|f| &f.proposal == proposal);
+                }
+                self.finalize.finish_verify(votes);
+            }
+        }
     }
 }
 

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -1164,14 +1164,13 @@ mod tests {
         leader_proposal_filters_messages(secp256r1::fixture);
     }
 
-    fn set_leader_twice_same_value_is_noop<S, F>(mut fixture: F)
-    where
-        S: Scheme<Sha256, PublicKey = PublicKey>,
-        F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
-    {
+    /// Re-stamping the same leader is scheme-independent bookkeeping, so one
+    /// scheme is enough.
+    #[test]
+    fn test_set_leader_twice_same_value_is_noop() {
         let mut rng = test_rng();
-        let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let mut verifier = Verifier::<S, Sha256>::new(
+        let Fixture { schemes, .. } = ed25519::fixture(&mut rng, NAMESPACE, 3);
+        let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
             3,
@@ -1179,18 +1178,6 @@ mod tests {
         let leader = Participant::new(0);
         verifier.set_leader(leader, None);
         verifier.set_leader(leader, None);
-    }
-
-    #[test]
-    fn test_set_leader_twice_same_value_is_noop() {
-        set_leader_twice_same_value_is_noop(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        set_leader_twice_same_value_is_noop(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        set_leader_twice_same_value_is_noop(bls12381_threshold_std::fixture::<MinSig, _>);
-        set_leader_twice_same_value_is_noop(bls12381_threshold_std::fixture::<MinPk, _>);
-        set_leader_twice_same_value_is_noop(bls12381_multisig::fixture::<MinSig, _>);
-        set_leader_twice_same_value_is_noop(bls12381_multisig::fixture::<MinPk, _>);
-        set_leader_twice_same_value_is_noop(ed25519::fixture);
-        set_leader_twice_same_value_is_noop(secp256r1::fixture);
     }
 
     fn set_leader_change_panics<S, F>(mut fixture: F)

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -1,6 +1,6 @@
 use crate::{
     Viewable,
-    simplex::types::{Certificate, Notarization},
+    simplex::types::Certificate,
     types::{TermLength, View},
 };
 use commonware_cryptography::{Digest, certificate::Scheme};
@@ -50,10 +50,16 @@ pub(crate) enum Effect {
 pub struct State<S: Scheme, D: Digest> {
     /// Highest seen view.
     current_view: View,
-    /// Most recent certified notarization or finalization.
-    floor: Option<Certificate<S, D>>,
-    /// Notarizations pending certification (possible floors).
-    notarizations: BTreeMap<View, Notarization<S, D>>,
+    /// Highest finalization observed (always a [Certificate::Finalization]).
+    /// Kept until a higher finalization arrives, because it is the one
+    /// certificate any peer at or below its view can always use.
+    finalized: Option<Certificate<S, D>>,
+    /// View of the highest certified notarization above the finalization,
+    /// if any. The certificate itself lives in `notarizations`.
+    certified: Option<View>,
+    /// Notarizations pending certification (possible floors), plus those
+    /// retained below the floor (see [`Self::notarization_cutoff`]).
+    notarizations: BTreeMap<View, Certificate<S, D>>,
     /// Nullifications that cover any view greater than the floor.
     nullifications: BTreeMap<View, Certificate<S, D>>,
     /// Window of requests to send to the resolver.
@@ -76,7 +82,8 @@ impl<S: Scheme, D: Digest> State<S, D> {
     pub fn new(fetch_concurrent: NonZeroUsize, term_length: TermLength) -> Self {
         Self {
             current_view: View::zero(),
-            floor: None,
+            finalized: None,
+            certified: None,
             notarizations: BTreeMap::new(),
             nullifications: BTreeMap::new(),
             fetch_concurrent: fetch_concurrent.get(),
@@ -115,14 +122,23 @@ impl<S: Scheme, D: Digest> State<S, D> {
             }
             Certificate::Notarization(notarization) => {
                 let view = notarization.view();
-                if view > self.floor_view() {
-                    self.notarizations.insert(view, notarization);
+                // Admit anything `prune` would retain, including views the
+                // floor has already passed.
+                if view >= self.notarization_cutoff() {
+                    self.notarizations
+                        .insert(view, Certificate::Notarization(notarization));
                 }
             }
             Certificate::Finalization(finalization) => {
                 let view = finalization.view();
-                if view > self.floor_view() || self.can_upgrade_floor(view) {
-                    self.floor = Some(Certificate::Finalization(finalization));
+                if view > self.finalized_view() {
+                    self.finalized = Some(Certificate::Finalization(finalization));
+                    // A finalization settles everything at or below it, making
+                    // a certified notarization there useless (`certified` is
+                    // always above the finalization when set).
+                    if self.certified.is_some_and(|certified| certified <= view) {
+                        self.certified = None;
+                    }
                     effects.push(self.prune());
                 }
             }
@@ -136,15 +152,10 @@ impl<S: Scheme, D: Digest> State<S, D> {
     pub fn handle_certified(&mut self, view: View, success: bool) -> Vec<Effect> {
         let mut effects = Vec::new();
         if success {
-            // Certification passed: raise the floor to the notarization if we
-            // still hold it. This may occur before or after a nullification
-            // for the same view (and should always be favored). Finalization
-            // remains the stronger proof and can later supersede this floor
-            // at the same or higher view.
-            if let Some(notarization) = self.notarizations.remove(&view)
-                && view > self.floor_view()
-            {
-                self.floor = Some(Certificate::Notarization(notarization));
+            if view > self.floor_view() && self.notarizations.contains_key(&view) {
+                // The notarization stays in the map: same-term peers stuck
+                // below the new floor still need it (see `prune`).
+                self.certified = Some(view);
                 effects.push(self.prune());
             }
 
@@ -172,17 +183,27 @@ impl<S: Scheme, D: Digest> State<S, D> {
         effects
     }
 
-    /// Get the best certificate for a given view (or the floor
-    /// if the view is below the floor).
+    /// Get the best certificate for a given view.
+    ///
+    /// A finalization at or above the view settles the request outright.
+    /// Below the certified-notarization floor, serves the exact-view
+    /// notarization when one is retained (see [`Self::notarization_cutoff`]
+    /// for why the exact view matters), otherwise the floor. Above the floor,
+    /// serves the nullification covering the view, if any.
     pub fn get(&self, view: View) -> Option<&Certificate<S, D>> {
-        // If view is <= floor, return the floor
-        if let Some(floor) = &self.floor
-            && view <= floor.view()
+        if let Some(finalized) = &self.finalized
+            && finalized.view() >= view
         {
-            return Some(floor);
+            return Some(finalized);
         }
-
-        // Otherwise, return the nullification covering the view if it exists.
+        if let Some(certified) = self.certified
+            && view <= certified
+        {
+            return self
+                .notarizations
+                .get(&view)
+                .or_else(|| self.notarizations.get(&certified));
+        }
         self.covering_nullification(view)
     }
 
@@ -197,26 +218,43 @@ impl<S: Scheme, D: Digest> State<S, D> {
             .map(|(_, n)| n)
     }
 
-    /// Get the view of the floor.
+    /// Get the view of the floor: the highest view settled by a finalization
+    /// or a certified notarization.
     fn floor_view(&self) -> View {
-        self.floor
+        self.finalized_view()
+            .max(self.certified.unwrap_or(View::zero()))
+    }
+
+    /// Get the view of the highest finalization observed.
+    fn finalized_view(&self) -> View {
+        self.finalized
             .as_ref()
-            .map(|floor| floor.view())
+            .map(|finalized| finalized.view())
             .unwrap_or(View::zero())
+    }
+
+    /// Get the lowest view whose notarization is still useful.
+    ///
+    /// Below a certified-notarization floor, notarizations remain useful back
+    /// to the floor's term start: peers stuck below the floor must certify
+    /// each view of the term in order, which requires the exact-view
+    /// certificates. A finalization floor settles everything below it instead
+    /// (`certified` is cleared when a finalization overtakes it).
+    ///
+    /// This makes retention scale with the term. A term that notarizes
+    /// without finalizing holds up to `term_length` notarizations, where a
+    /// finalization floor holds none. Long terms should account for that.
+    fn notarization_cutoff(&self) -> View {
+        self.certified.map_or_else(
+            || self.floor_view().next(),
+            |certified| certified.term_start(self.term_length),
+        )
     }
 
     /// Returns whether `view` still needs a covering nullification to make
     /// progress: it is above the floor and no stored nullification covers it.
     fn needs_nullification(&self, view: View) -> bool {
         view > self.floor_view() && self.covering_nullification(view).is_none()
-    }
-
-    /// Returns true if the floor can be upgraded at the given view.
-    fn can_upgrade_floor(&self, view: View) -> bool {
-        matches!(
-            self.floor.as_ref(),
-            Some(Certificate::Notarization(n)) if n.view() == view
-        )
     }
 
     /// Return requests for any missing nullifications.
@@ -248,8 +286,8 @@ impl<S: Scheme, D: Digest> State<S, D> {
     /// Prune stored certificates and requests that are not higher than the floor.
     fn prune(&mut self) -> Effect {
         let floor = self.floor_view();
-        self.notarizations.retain(|view, _| *view > floor);
         let term_length = self.term_length;
+        self.notarizations = self.notarizations.split_off(&self.notarization_cutoff());
         self.nullifications
             .retain(|view, _| covers_above_floor(*view, term_length, floor));
         self.failed_views.retain(|view| *view > floor);
@@ -503,7 +541,8 @@ mod tests {
         let notarization = build_notarization(&schemes, &verifier, EPOCH, View::new(6));
         let effects = state.handle(Certificate::Notarization(notarization));
         apply_effects(&mut outstanding, &effects);
-        assert!(state.floor.is_none());
+        assert!(state.finalized.is_none());
+        assert!(state.certified.is_none());
         assert_eq!(state.nullifications.len(), 3);
         assert_eq!(outstanding_views(&outstanding), vec![1, 2, 3]);
 
@@ -512,7 +551,7 @@ mod tests {
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(6))]);
         apply_effects(&mut outstanding, &effects);
         assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Finalization(f)) if f == &finalization)
+            matches!(state.finalized.as_ref(), Some(Certificate::Finalization(f)) if f == &finalization)
         );
         assert!(state.notarizations.is_empty());
         assert!(state.nullifications.is_empty());
@@ -610,9 +649,9 @@ mod tests {
         // Certification succeeds for view 5
         let effects = state.handle_certified(View::new(5), true);
 
-        // The certified notarization becomes the floor and view 5 is not marked failed
+        assert_eq!(state.certified, Some(View::new(5)));
         assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v5)
+            matches!(state.get(View::new(5)), Some(Certificate::Notarization(n)) if n == &notarization_v5)
         );
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(5))]);
         assert!(!state.is_failed(View::new(5)));
@@ -633,7 +672,7 @@ mod tests {
         // The notarization answers the request for anchor 1, so the fetch
         // cursor advances to the next missing anchor instead of re-requesting.
         let notarization_v5 = build_notarization(&schemes, &verifier, EPOCH, View::new(5));
-        let effects = state.handle(Certificate::Notarization(notarization_v5.clone()));
+        let effects = state.handle(Certificate::Notarization(notarization_v5));
         assert_eq!(
             effects,
             vec![fetch(6, 5, FetchReason::MissingNullification)]
@@ -645,9 +684,7 @@ mod tests {
         let effects = state.handle_certified(View::new(5), true);
         apply_effects(&mut outstanding, &effects);
 
-        assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v5)
-        );
+        assert_eq!(state.certified, Some(View::new(5)));
         assert_eq!(state.current_view, View::new(14));
         assert_eq!(outstanding_views(&outstanding), vec![6, 11]);
     }
@@ -667,7 +704,7 @@ mod tests {
         // A mid-term notarization answers the request for anchor 1, but once
         // certified it only covers views 1..=3 of term [1, 5].
         let notarization_v3 = build_notarization(&schemes, &verifier, EPOCH, View::new(3));
-        let effects = state.handle(Certificate::Notarization(notarization_v3.clone()));
+        let effects = state.handle(Certificate::Notarization(notarization_v3));
         apply_effects(&mut outstanding, &effects);
         assert_eq!(outstanding_views(&outstanding), vec![1, 6, 11]);
 
@@ -678,10 +715,147 @@ mod tests {
         // from just above the mid-term floor rather than from the cursor.
         let effects = state.handle_certified(View::new(3), true);
         apply_effects(&mut outstanding, &effects);
-        assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v3)
-        );
+        assert_eq!(state.certified, Some(View::new(3)));
         assert_eq!(outstanding_views(&outstanding), vec![4, 6, 11]);
+    }
+
+    #[test]
+    fn notarization_floor_serves_exact_same_term_views_below() {
+        let (schemes, verifier) = ed25519_fixture();
+        let mut state: State<TestScheme, Sha256Digest> =
+            State::new(NZUsize!(10), TermLength::new(NZU32!(5)));
+
+        // Certified notarizations at views 7 and 8 of term [6, 10] promote
+        // the floor step by step, as when running optimistically ahead.
+        let notarization_v7 = build_notarization(&schemes, &verifier, EPOCH, View::new(7));
+        state.handle(Certificate::Notarization(notarization_v7.clone()));
+        state.handle_certified(View::new(7), true);
+        let notarization_v8 = build_notarization(&schemes, &verifier, EPOCH, View::new(8));
+        state.handle(Certificate::Notarization(notarization_v8.clone()));
+        state.handle_certified(View::new(8), true);
+        assert_eq!(state.certified, Some(View::new(8)));
+
+        // A peer stuck below the floor must certify view 7 before it can use
+        // the floor at view 8, so the exact-view notarization is served
+        // instead of the floor.
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Notarization(n)) if n == &notarization_v7)
+        );
+        assert!(
+            matches!(state.get(View::new(8)), Some(Certificate::Notarization(n)) if n == &notarization_v8)
+        );
+
+        // A finalization floor settles everything below it, so the retained
+        // same-term notarizations are dropped and the floor is served.
+        let finalization_v9 = build_finalization(&schemes, &verifier, EPOCH, View::new(9));
+        state.handle(Certificate::Finalization(finalization_v9.clone()));
+        assert!(state.notarizations.is_empty());
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Finalization(f)) if f == &finalization_v9)
+        );
+    }
+
+    #[test]
+    fn notarization_floor_served_when_exact_view_absent() {
+        let (schemes, verifier) = ed25519_fixture();
+        let mut state: State<TestScheme, Sha256Digest> =
+            State::new(NZUsize!(10), TermLength::new(NZU32!(5)));
+
+        // A certified notarization at view 8 of term [6, 10] becomes the
+        // floor; view 7's notarization was never received.
+        let notarization_v8 = build_notarization(&schemes, &verifier, EPOCH, View::new(8));
+        state.handle(Certificate::Notarization(notarization_v8.clone()));
+        state.handle_certified(View::new(8), true);
+        assert_eq!(state.certified, Some(View::new(8)));
+
+        // Requests below the floor without a retained exact-view notarization
+        // fall back to the floor itself, whether in the floor's term (view 7)
+        // or an earlier term (view 3).
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Notarization(n)) if n == &notarization_v8)
+        );
+        assert!(
+            matches!(state.get(View::new(3)), Some(Certificate::Notarization(n)) if n == &notarization_v8)
+        );
+    }
+
+    #[test]
+    fn notarization_below_floor_retained_when_still_useful() {
+        let (schemes, verifier) = ed25519_fixture();
+        let mut state: State<TestScheme, Sha256Digest> =
+            State::new(NZUsize!(10), TermLength::new(NZU32!(5)));
+
+        // A certified notarization at view 8 of term [6, 10] becomes the floor.
+        let notarization_v8 = build_notarization(&schemes, &verifier, EPOCH, View::new(8));
+        state.handle(Certificate::Notarization(notarization_v8));
+        state.handle_certified(View::new(8), true);
+        assert_eq!(state.certified, Some(View::new(8)));
+
+        // View 7's notarization arrives only after the floor passed it. It is
+        // still what a same-term peer stuck below the floor needs, so
+        // admission must match what `prune` would retain.
+        let notarization_v7 = build_notarization(&schemes, &verifier, EPOCH, View::new(7));
+        state.handle(Certificate::Notarization(notarization_v7.clone()));
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Notarization(n)) if n == &notarization_v7)
+        );
+
+        // Views below the floor's term start are settled by the floor itself
+        // and are not retained.
+        let notarization_v3 = build_notarization(&schemes, &verifier, EPOCH, View::new(3));
+        state.handle(Certificate::Notarization(notarization_v3));
+        assert!(!state.notarizations.contains_key(&View::new(3)));
+    }
+
+    #[test]
+    fn promoted_floor_keeps_serving_lower_finalization() {
+        let (schemes, verifier) = ed25519_fixture();
+        let mut state: State<TestScheme, Sha256Digest> =
+            State::new(NZUsize!(10), TermLength::new(NZU32!(5)));
+
+        // A finalization at view 7 of term [6, 10] becomes the floor, then a
+        // certified notarization at view 8 promotes past it.
+        let finalization_v7 = build_finalization(&schemes, &verifier, EPOCH, View::new(7));
+        state.handle(Certificate::Finalization(finalization_v7.clone()));
+        let notarization_v8 = build_notarization(&schemes, &verifier, EPOCH, View::new(8));
+        state.handle(Certificate::Notarization(notarization_v8.clone()));
+        state.handle_certified(View::new(8), true);
+        assert_eq!(state.certified, Some(View::new(8)));
+
+        // The finalization must remain servable. A peer stuck at or below
+        // view 7 cannot use the mid-term notarization floor (it lacks the
+        // exact parents to certify it) but a finalization at or above its
+        // request settles it outright.
+        assert!(
+            matches!(state.get(View::new(6)), Some(Certificate::Finalization(f)) if f == &finalization_v7)
+        );
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Finalization(f)) if f == &finalization_v7)
+        );
+        assert!(
+            matches!(state.get(View::new(8)), Some(Certificate::Notarization(n)) if n == &notarization_v8)
+        );
+
+        // Further same-term promotions keep the finalization and the
+        // exact-view notarizations between it and the floor.
+        let notarization_v9 = build_notarization(&schemes, &verifier, EPOCH, View::new(9));
+        state.handle(Certificate::Notarization(notarization_v9));
+        state.handle_certified(View::new(9), true);
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Finalization(f)) if f == &finalization_v7)
+        );
+        assert!(
+            matches!(state.get(View::new(8)), Some(Certificate::Notarization(n)) if n == &notarization_v8)
+        );
+
+        // A finalization catching up to the floor upgrades it and drops the
+        // retained certificates below, because the floor settles everything.
+        let finalization_v9 = build_finalization(&schemes, &verifier, EPOCH, View::new(9));
+        state.handle(Certificate::Finalization(finalization_v9.clone()));
+        assert!(state.notarizations.is_empty());
+        assert!(
+            matches!(state.get(View::new(7)), Some(Certificate::Finalization(f)) if f == &finalization_v9)
+        );
     }
 
     #[test]
@@ -695,7 +869,7 @@ mod tests {
         // fetch scan requests anchor 1, and the cursor jumps past the
         // current view to the next term anchor.
         let notarization_v4 = build_notarization(&schemes, &verifier, EPOCH, View::new(4));
-        let effects = state.handle(Certificate::Notarization(notarization_v4.clone()));
+        let effects = state.handle(Certificate::Notarization(notarization_v4));
         apply_effects(&mut outstanding, &effects);
         assert_eq!(outstanding_views(&outstanding), vec![1]);
 
@@ -705,9 +879,7 @@ mod tests {
         // fetched here.
         let effects = state.handle_certified(View::new(4), true);
         apply_effects(&mut outstanding, &effects);
-        assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v4)
-        );
+        assert_eq!(state.certified, Some(View::new(4)));
         assert!(outstanding_views(&outstanding).is_empty());
 
         // Once the current view grows, the scan must resume from just above
@@ -800,16 +972,21 @@ mod tests {
         let effects = state.handle_certified(View::new(5), true);
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(5))]);
 
+        assert_eq!(state.certified, Some(View::new(5)));
         assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v5)
+            matches!(state.get(View::new(5)), Some(Certificate::Notarization(n)) if n == &notarization_v5)
         );
         assert_eq!(state.floor_view(), View::new(5));
 
         let finalization_v5 = build_finalization(&schemes, &verifier, EPOCH, View::new(5));
         let effects = state.handle(Certificate::Finalization(finalization_v5.clone()));
 
+        // The finalization supersedes the certified notarization at the same
+        // view: the notarization is dropped and the finalization is served.
+        assert!(state.certified.is_none());
+        assert!(state.notarizations.is_empty());
         assert!(
-            matches!(state.floor.as_ref(), Some(Certificate::Finalization(f)) if f == &finalization_v5)
+            matches!(state.get(View::new(5)), Some(Certificate::Finalization(f)) if f == &finalization_v5)
         );
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(5))]);
     }

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -207,9 +207,10 @@ impl<
         )
     }
 
-    /// Returns the elapsed wall-clock seconds for `view` when we are its leader.
+    /// Returns the wall-clock seconds since entering `view` when we are its
+    /// leader. None if we never entered the view (no meaningful sample).
     fn leader_elapsed(&self, view: View) -> Option<f64> {
-        let elapsed = self.state.elapsed_since_start(view)?;
+        let elapsed = self.state.elapsed_since_entry(view)?;
         let leader = self.state.leader_index(view)?;
         if !self.state.is_me(leader) {
             return None;
@@ -651,11 +652,11 @@ impl<
             }
         };
 
-        // If we have already moved to another view, drop the response as we will
-        // not broadcast it
-        let our_round = Rnd::new(self.state.epoch(), self.state.current_view());
-        if our_round != context.round {
-            debug!(round = ?context.round, ?our_round, "dropping requested proposal");
+        // If we have already moved past this view, drop the response as we
+        // will not broadcast it. Proposals for the current or optimistic
+        // future views are kept.
+        if context.view() < self.state.current_view() {
+            debug!(round = ?context.round, current = ?self.state.current_view(), "dropping requested proposal");
             return None;
         }
 
@@ -665,7 +666,7 @@ impl<
             warn!(round = ?context.round, "dropped our proposal");
             return None;
         }
-        let view = self.state.current_view();
+        let view = context.view();
 
         // Notify the application of the proposal. To lower view latency as
         // much as possible while preserving safety, this precedes the notarize
@@ -699,12 +700,12 @@ impl<
             Ok(false) => {
                 warn!(round = ?context.round, "proposal failed verification");
                 self.state
-                    .trigger_timeout(context.view(), TimeoutReason::InvalidProposal);
+                    .verification_failed(view, TimeoutReason::InvalidProposal);
             }
             Err(err) => {
                 debug!(?err, round = ?context.round, "failed to verify proposal");
                 self.state
-                    .trigger_timeout(context.view(), TimeoutReason::IgnoredProposal);
+                    .verification_failed(view, TimeoutReason::IgnoredProposal);
             }
         };
         view
@@ -962,9 +963,9 @@ impl<
         .await
         .expect("unable to open journal");
 
-        // Add initial view from the configured floor. Genesis starts from view
-        // zero; non-genesis floors skip replayed artifacts at or below the floor
-        // certificate view.
+        // Add initial view from the configured floor. Replay skips all
+        // artifacts at or below the floor's view (see the nullify-skip
+        // rationale in the replay loop below).
         let floor = self.floor.take().expect("floor not initialized");
         let replay_floor = floor.view();
 
@@ -985,6 +986,7 @@ impl<
         });
 
         // Rebuild from journal, nested under the startup span.
+        let mut replayed_successful_certifications = Vec::new();
         let replayed;
         (self, replayed) = async {
             let mut replay = journal
@@ -1024,6 +1026,7 @@ impl<
                         resolver.certified(round, success);
                         if success {
                             self.reporter.report(Activity::Certification(notarization));
+                            replayed_successful_certifications.push(round.view());
                         }
                     }
                     Artifact::Nullify(nullify) => {
@@ -1078,6 +1081,24 @@ impl<
         let (span, finalized) = self.state.batcher_context(observed_view);
         batcher.update(span, observed_view, leader, finalized, None);
 
+        // Re-attempt finalize votes for certifications that completed before
+        // shutdown: no later event re-triggers construction for an
+        // already-certified view (see [Self::construct]), so recovery would
+        // otherwise require abandoning the term through timeouts. This builds
+        // a fresh vote through `construct_finalize`'s usual gates rather than
+        // replaying an artifact, and is a no-op if the prior vote was
+        // journaled (replay restores its broadcast flag).
+        for view in replayed_successful_certifications {
+            let finalize;
+            (self, finalize) = self.prepare_finalize(&mut batcher, view).await;
+            let Some(finalize) = finalize else {
+                continue;
+            };
+            self = self.sync_journal(view).await;
+            debug!(proposal=?finalize.proposal, "broadcasting replayed finalize");
+            self.broadcast_vote(&mut vote_sender, Vote::Finalize(finalize));
+        }
+
         // Process messages
         let mut pending_propose: Option<Request<Context<D, S::PublicKey>, D>> = None;
         let mut pending_verify: Option<Request<Context<D, S::PublicKey>, bool>> = None;
@@ -1086,18 +1107,19 @@ impl<
         select_loop! {
             self.context,
             on_start => {
-                // Drop any pending items if we have moved to a new view. A view
-                // is exited only on successful certification, nullification, or
-                // finalization. Nullification does not cancel certification work
-                // for the exited view, so the automaton must tolerate a dropped
-                // verify receiver while certify still wants the result.
+                // Drop any pending items if we have moved past their view (work
+                // for optimistic future views is kept). A view is exited only on
+                // successful certification, nullification, or finalization.
+                // Nullification does not cancel certification work for the
+                // exited view, so the automaton must tolerate a dropped verify
+                // receiver while certify still wants the result.
                 if let Some(ref pp) = pending_propose
-                    && pp.view() != self.state.current_view()
+                    && pp.view() < self.state.current_view()
                 {
                     pending_propose = None;
                 }
                 if let Some(ref pv) = pending_verify
-                    && pv.view() != self.state.current_view()
+                    && pv.view() < self.state.current_view()
                 {
                     pending_verify = None;
                 }
@@ -1275,16 +1297,16 @@ impl<
                         .leader_index(current_view)
                         .expect("leader not set");
 
-                    // If we skip a view, we don't worry about forwarding our latest certified proposal
+                    // If we skip a view, we don't worry about forwarding our latest forwardable proposal
                     // because the network has already moved on
-                    let certified_proposal = current_view
+                    let forwardable_proposal = current_view
                         .previous()
-                        .and_then(|view| self.state.certified_proposal(view));
+                        .and_then(|view| self.state.forwardable_proposal(view));
 
                     // If the leader nullified or is inactive, the batcher
                     // responds with a timeout that expires the view immediately
                     let (span, finalized) = self.state.batcher_context(current_view);
-                    batcher.update(span, current_view, leader, finalized, certified_proposal);
+                    batcher.update(span, current_view, leader, finalized, forwardable_proposal);
                 }
             },
         }

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -77,7 +77,7 @@ mod tests {
     use commonware_cryptography::{
         Hasher as _, Sha256,
         bls12381::primitives::variant::{MinPk, MinSig},
-        certificate::mocks::Fixture,
+        certificate::{Scheme as _, mocks::Fixture},
         ed25519::PublicKey,
         sha256::Digest as Sha256Digest,
     };
@@ -186,6 +186,11 @@ mod tests {
         leader_timeout: Duration,
         certification_timeout: Duration,
         timeout_retry: Duration,
+        /// Index of the participant hosting the voter under test.
+        local_index: usize,
+        /// Mock application propose latency, in milliseconds.
+        propose_latency_ms: f64,
+        /// Mock application certify latency, in milliseconds.
         certify_latency_ms: f64,
         certifier: mocks::application::Certifier<Sha256Digest>,
     }
@@ -198,6 +203,8 @@ mod tests {
                 leader_timeout: Duration::from_millis(500),
                 certification_timeout: Duration::from_secs(1000),
                 timeout_retry: Duration::from_secs(1000),
+                local_index: 0,
+                propose_latency_ms: 1.0,
                 certify_latency_ms: 1.0,
                 certifier: mocks::application::Certifier::Always,
             }
@@ -223,8 +230,8 @@ mod tests {
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         L: elector::Config<S>,
     {
-        let signing = schemes[0].clone();
-        let me = participants[0].clone();
+        let signing = schemes[options.local_index].clone();
+        let me = participants[options.local_index].clone();
         let reporter_cfg = mocks::reporter::Config {
             participants: participants.to_vec().try_into().unwrap(),
             scheme: signing.clone(),
@@ -237,7 +244,7 @@ mod tests {
         let application_cfg = mocks::application::Config::<Sha256, _> {
             relay: relay.clone(),
             me: me.clone(),
-            propose_latency: (1.0, 0.0),
+            propose_latency: (options.propose_latency_ms, 0.0),
             verify_latency: (1.0, 0.0),
             certify_latency: (options.certify_latency_ms, 0.0),
             should_certify: options.certifier,
@@ -376,6 +383,7 @@ mod tests {
         Mailbox<S, Sha256Digest>,
         mailbox::Receiver<batcher::Message<S, Sha256Digest>>,
         mailbox::Receiver<resolver::MailboxMessage<S, Sha256Digest>>,
+        Arc<mocks::relay::Relay<Sha256Digest, S::PublicKey>>,
         mocks::reporter::Reporter<deterministic::Context, S, L, Sha256Digest>,
         commonware_runtime::Handle<()>,
     )
@@ -451,6 +459,7 @@ mod tests {
             mailbox,
             batcher_receiver,
             resolver_receiver,
+            relay,
             reporter,
             handle,
         )
@@ -549,7 +558,7 @@ mod tests {
                 Sha256::hash(&[b"newer-floor-finalization"]),
             );
             let (_, floor_finalization) = build_finalization(&schemes, &floor_proposal, quorum);
-            let (_mailbox, mut batcher_receiver, mut resolver_receiver, reporter, _handle) =
+            let (_mailbox, mut batcher_receiver, mut resolver_receiver, _relay, reporter, _handle) =
                 start_voter_with_floor(
                     &mut context,
                     &oracle,
@@ -629,7 +638,7 @@ mod tests {
                 Sha256::hash(&[b"older-floor-finalization"]),
             );
             let (_, floor_finalization) = build_finalization(&schemes, &floor_proposal, quorum);
-            let (_mailbox, mut batcher_receiver, mut resolver_receiver, reporter, _handle) =
+            let (_mailbox, mut batcher_receiver, mut resolver_receiver, _relay, reporter, _handle) =
                 start_voter_with_floor(
                     &mut context,
                     &oracle,
@@ -717,7 +726,7 @@ mod tests {
             )
             .await;
 
-            let (_mailbox, mut batcher_receiver, mut resolver_receiver, reporter, _handle) =
+            let (_mailbox, mut batcher_receiver, mut resolver_receiver, _relay, reporter, _handle) =
                 start_voter_with_floor(
                     &mut context,
                     &oracle,
@@ -2490,8 +2499,11 @@ mod tests {
                 schemes,
                 ..
             } = fixture(&mut context, &namespace, n);
-            let elector = RoundRobin::<Sha256>::default()
-                .with_term(TermLength::new(NZU32!(2)), Duration::from_secs(5));
+            let elector = RoundRobin::<Sha256>::default().with_term(
+                TermLength::new(NZU32!(2)),
+                Duration::from_secs(5),
+                ViewDelta::new(0),
+            );
             let first_round = Round::new(Epoch::new(333), View::new(1));
             let built_elector: RoundRobinElector<S> =
                 elector.clone().build(schemes[0].participants());
@@ -2600,7 +2612,7 @@ mod tests {
                 ..
             } = fixture(&mut context, &namespace, n);
             let elector =
-                RoundRobin::<Sha256>::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(20));
+                RoundRobin::<Sha256>::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(20), ViewDelta::new(0));
             let (mut mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
                 &mut context,
                 &oracle,
@@ -2708,6 +2720,211 @@ mod tests {
         finalize_resumes_after_same_term_heal::<_, _>(bls12381_multisig::fixture::<MinSig, _>);
         finalize_resumes_after_same_term_heal::<_, _>(ed25519::fixture);
         finalize_resumes_after_same_term_heal::<_, _>(secp256r1::fixture);
+    }
+
+    /// Regression: optimistic future proposal requests must not be dropped when
+    /// unrelated events (like current-view timeout handling) occur first.
+    #[test_traced]
+    fn test_optimistic_future_proposal_survives_interleaved_timeout() {
+        let n = 5;
+        let namespace = b"optimistic_future_proposal_survives_interleaved_timeout".to_vec();
+        let epoch = Epoch::new(333);
+        let term_length = TermLength::new(NZU32!(5));
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+
+            let oracle = start_test_network_with_peers(
+                context.child("network"),
+                participants.clone(),
+                true,
+            )
+            .await;
+
+            let elector = RoundRobin::<Sha256>::default().with_term(
+                term_length,
+                Duration::from_secs(30),
+                ViewDelta::new(2),
+            );
+            let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let local_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
+
+            let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    leader_timeout: Duration::from_secs(2),
+                    // Certify latency exceeds the certification timeout, so
+                    // view 1's timeout is guaranteed to fire while the view-2
+                    // optimistic proposal request is still in flight; the
+                    // propose latency delays that request long enough for the
+                    // timeout to win the race.
+                    certification_timeout: Duration::from_secs(4),
+                    timeout_retry: Duration::from_millis(200),
+                    local_index,
+                    propose_latency_ms: 200.0,
+                    certify_latency_ms: 5_000.0,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            let mut saw_view_1_notarize = false;
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        match msg.unwrap() {
+                            batcher::Message::Update { .. } => {}
+                            batcher::Message::Constructed(Vote::Notarize(notarize)) => {
+                                if notarize.view() == View::new(1) {
+                                    saw_view_1_notarize = true;
+                                }
+                                if notarize.view() == View::new(2) {
+                                    assert!(
+                                        saw_view_1_notarize,
+                                        "expected view 1 notarize before optimistic view 2 notarize"
+                                    );
+                                    break;
+                                }
+                            }
+                            _ => {}
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(8)) => {
+                        panic!(
+                            "expected optimistic notarize for view 2 despite interleaved timeout handling"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    /// Regression: same-term optimistic future verification may run after a
+    /// local parent notarize, without waiting for parent certification.
+    #[test_traced]
+    fn test_optimistic_future_verify_uses_local_parent_notarize() {
+        let n = 5;
+        let namespace = b"optimistic_future_verify_uses_local_parent_notarize".to_vec();
+        let epoch = Epoch::new(333);
+        let term_length = TermLength::new(NZU32!(5));
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+
+            let elector = RoundRobin::<Sha256>::default().with_term(
+                term_length,
+                Duration::from_secs(30),
+                ViewDelta::new(2),
+            );
+            let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let leader_idx = built_elector.elect(Round::new(epoch, View::new(1)), None);
+            let local_index = (usize::from(leader_idx) + 1) % participants.len();
+            let leader = participants[usize::from(leader_idx)].clone();
+
+            let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    // Timeouts long enough that none fires within the test:
+                    // any progress past view 1 can only come from optimistic
+                    // verification against the local parent notarize.
+                    leader_timeout: Duration::from_secs(10),
+                    certification_timeout: Duration::from_secs(10),
+                    timeout_retry: Duration::from_secs(30),
+                    local_index,
+                    propose_latency_ms: 10.0,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            match batcher_receiver.recv().await.unwrap() {
+                batcher::Message::Update { .. } => {}
+                _ => panic!("expected initial update"),
+            }
+
+            let genesis = mocks::application::genesis::<Sha256>(epoch);
+
+            let proposal_1 = Proposal::new(
+                Round::new(epoch, View::new(1)),
+                View::zero(),
+                Sha256::hash(&[b"optimistic_future_verify_view_1"]),
+            );
+            let contents_1 = (proposal_1.round, genesis, 0u64).encode();
+            relay.broadcast(&leader, Recipients::All, (proposal_1.payload, contents_1));
+            mailbox.proposal(proposal_1.clone());
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        match msg.unwrap() {
+                            batcher::Message::Update { .. } => {}
+                            batcher::Message::Constructed(Vote::Notarize(notarize))
+                                if notarize.view() == View::new(1) =>
+                            {
+                                break;
+                            }
+                            _ => {}
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected local notarize for view 1 before testing optimistic future verify");
+                    }
+                }
+            }
+
+            let proposal_2 = Proposal::new(
+                Round::new(epoch, View::new(2)),
+                View::new(1),
+                Sha256::hash(&[b"optimistic_future_verify_view_2"]),
+            );
+            let contents_2 = (proposal_2.round, proposal_1.payload, 1u64).encode();
+            relay.broadcast(&leader, Recipients::All, (proposal_2.payload, contents_2));
+            mailbox.proposal(proposal_2.clone());
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        match msg.unwrap() {
+                            batcher::Message::Update { .. } => {}
+                            batcher::Message::Constructed(Vote::Notarize(notarize))
+                                if notarize.view() == View::new(2) =>
+                            {
+                                break;
+                            }
+                            _ => {}
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(8)) => {
+                        panic!(
+                            "expected optimistic notarize for view 2 after local parent notarize"
+                        );
+                    }
+                }
+            }
+        });
     }
 
     fn finalization_from_resolver<S, F, L>(mut fixture: F)
@@ -8893,6 +9110,117 @@ mod tests {
         successful_certification_replayed_after_restart(bls12381_multisig::fixture::<MinSig, _>);
         successful_certification_replayed_after_restart(ed25519::fixture);
         successful_certification_replayed_after_restart(secp256r1::fixture);
+    }
+
+    /// A journal-replayed `Certification(view, true)` must reconstruct the
+    /// finalize vote without re-invoking the application: the certifier
+    /// panics on any call, so it doubles as the no-recertify assertion.
+    #[test_traced]
+    fn test_replayed_certification_reconstructs_finalize() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let n = 5;
+            let quorum = quorum(n);
+            let namespace = b"cert_replay_finalize".to_vec();
+            let partition = "cert_replay_finalize".to_string();
+            let epoch = Epoch::new(333);
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+            let me = participants[0].clone();
+            let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+
+            let proposal = Proposal::new(
+                Round::new(epoch, View::new(1)),
+                View::zero(),
+                Sha256::hash(&[b"cert_replay_finalize_payload"]),
+            );
+            let (_, notarization) = build_notarization(&schemes, &proposal, quorum);
+            seed_voter_journal_artifacts(
+                context.child("seed_journal"),
+                partition.clone(),
+                page_cache.clone(),
+                &schemes[0],
+                proposal.view(),
+                vec![
+                    Artifact::Notarization(notarization),
+                    Artifact::Certification(proposal.round, true),
+                ],
+            )
+            .await;
+
+            let relay = Arc::new(mocks::relay::Relay::new());
+            let app_cfg = mocks::application::Config::<Sha256, _> {
+                relay: relay.clone(),
+                me: me.clone(),
+                propose_latency: (1.0, 0.0),
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Custom(Box::new(|round, _| {
+                    panic!("unexpected certification request during replay for {round:?}")
+                })),
+            };
+            let (app_actor, application) =
+                mocks::application::Application::new(context.child("app"), app_cfg);
+            app_actor.start();
+            let reporter_cfg = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[0].clone(),
+                elector: RoundRobin::<Sha256>::default(),
+            };
+            let reporter = mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
+            let voter_cfg = Config {
+                scheme: schemes[0].clone(),
+                elector: RoundRobin::<Sha256>::default()
+                    .build(&participants.clone().try_into().unwrap()),
+                blocker: oracle.control(me.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter,
+                partition,
+                epoch,
+                floor: Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
+                mailbox_size: NZUsize!(128),
+                leader_timeout: Duration::from_secs(5),
+                certification_timeout: Duration::from_secs(5),
+                timeout_retry: Duration::from_mins(60),
+                view_retention: ViewDelta::new(10),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache,
+            };
+            let (voter, _mailbox) = Actor::new(context.child("voter"), voter_cfg);
+            let (resolver_sender, _resolver_receiver) =
+                mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
+            let (batcher_sender, mut batcher_receiver) =
+                mailbox::new(context.child("batcher_mailbox"), NZUsize!(8));
+            let (vote_sender, _) = oracle.control(me.clone()).register(0, TEST_QUOTA).await.unwrap();
+            let (cert_sender, _) = oracle.control(me).register(1, TEST_QUOTA).await.unwrap();
+            voter.start(
+                batcher::Mailbox::new(batcher_sender),
+                resolver::Mailbox::new(resolver_sender),
+                vote_sender,
+                cert_sender,
+            );
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => match msg.unwrap() {
+                        batcher::Message::Constructed(Vote::Finalize(finalize))
+                            if finalize.view() == proposal.view() => break,
+                        _ => {}
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("timed out waiting for replayed certification to reconstruct finalize");
+                    },
+                }
+            }
+        });
     }
 
     /// Tests that a failed certification (certify returns false) is correctly replayed

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -5,7 +5,7 @@ use crate::{
         metrics::TimeoutReason,
         types::{Artifact, Attributable, Finalization, Notarization, Nullification, Proposal},
     },
-    types::{Participant, Round as Rnd},
+    types::{Participant, Round as Rnd, View},
 };
 use commonware_cryptography::{Digest, PublicKey, certificate::Scheme};
 use commonware_runtime::telemetry::traces::TracedExt as _;
@@ -37,7 +37,10 @@ enum CertifyState {
 
 /// Per-[Rnd] state machine.
 pub struct Round<S: Scheme, D: Digest> {
-    start: SystemTime,
+    // When the local node entered this view (see `State::enter_view`). Unset
+    // for rounds created early by optimistic lookahead or future-view
+    // messages, so latency samples are only taken for views actually entered.
+    entered: Option<SystemTime>,
     scheme: S,
 
     round: Rnd,
@@ -69,12 +72,17 @@ pub struct Round<S: Scheme, D: Digest> {
     broadcast_finalize: bool,
     broadcast_finalization: bool,
     certify: CertifyState,
+
+    // Parent selected when peer proposal verification was started. Used to
+    // detect the parent being displaced by a conflicting certificate before
+    // we sign (see `State::verified_parent_matches`).
+    verifying_parent: Option<(View, D)>,
 }
 
 impl<S: Scheme, D: Digest> Round<S, D> {
-    pub const fn new(scheme: S, round: Rnd, start: SystemTime) -> Self {
+    pub const fn new(scheme: S, round: Rnd) -> Self {
         Self {
-            start,
+            entered: None,
             scheme,
             round,
             span: ViewSpan::new(),
@@ -95,6 +103,7 @@ impl<S: Scheme, D: Digest> Round<S, D> {
             broadcast_finalize: false,
             broadcast_finalization: false,
             certify: CertifyState::Ready,
+            verifying_parent: None,
         }
     }
 
@@ -122,26 +131,43 @@ impl<S: Scheme, D: Digest> Round<S, D> {
     /// Returns the leader info if we should verify a proposal.
     fn verify_ready(&self) -> Option<&Leader<S::PublicKey>> {
         let leader = self.leader.as_ref()?;
-        if self.is_signer(leader.idx) || self.broadcast_nullify {
+        if self.is_signer(leader.idx) || self.broadcast_nullify || !self.proposal.should_verify() {
             return None;
         }
         Some(leader)
     }
 
-    /// Returns the leader key and proposal when the view is ready for verification.
+    /// Returns the leader key and proposal ready for verification, without
+    /// recording the request. Resolve ancestry before calling
+    /// [`Self::request_verify`], which retires the round from later offers.
     #[allow(clippy::type_complexity)]
-    pub fn should_verify(&self) -> Option<(Leader<S::PublicKey>, Proposal<D>)> {
+    pub fn pending_verification(&self) -> Option<(Leader<S::PublicKey>, Proposal<D>)> {
         let leader = self.verify_ready()?;
         let proposal = self.proposal.proposal().cloned()?;
         Some((leader.clone(), proposal))
     }
 
     /// Marks that verification is in-flight; returns `false` to avoid duplicate requests.
-    pub fn try_verify(&mut self) -> bool {
+    pub fn request_verify(&mut self) -> bool {
         if self.verify_ready().is_none() {
             return false;
         }
         self.proposal.request_verify()
+    }
+
+    /// Records the parent selected when peer proposal verification started.
+    pub const fn set_verifying_parent(&mut self, parent: View, payload: D) {
+        self.verifying_parent = Some((parent, payload));
+    }
+
+    /// Returns the parent recorded when verification started, if any.
+    pub const fn verifying_parent(&self) -> Option<&(View, D)> {
+        self.verifying_parent.as_ref()
+    }
+
+    /// Clears the recorded verification parent.
+    pub const fn clear_verifying_parent(&mut self) {
+        self.verifying_parent = None;
     }
 
     /// Attempt to certify this round's proposal.
@@ -254,6 +280,33 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         matches!(self.certify, CertifyState::Certified(true))
     }
 
+    /// Returns true if we observed a notarization or finalization certificate
+    /// for this round, as opposed to one only implied by a descendant's.
+    pub const fn is_directly_notarized(&self) -> bool {
+        self.notarization.is_some() || self.finalization.is_some()
+    }
+
+    // `certified_proposal` below requires an explicit certification (or a
+    // finalization). `certified_ancestry_payload` and `forwardable_proposal`
+    // share a weaker rule: finalized, or notarized without a failed
+    // certification. They differ only in source, the certificate versus the
+    // slot's proposal.
+
+    /// Returns the payload of ancestry this round's certificate supports: the
+    /// finalized proposal's, or the notarized proposal's unless our own
+    /// certification rejected it (a finalization overrides the rejection).
+    pub fn certified_ancestry_payload(&self) -> Option<&D> {
+        if let Some(finalization) = &self.finalization {
+            return Some(&finalization.proposal.payload);
+        }
+        if self.is_failed_certification() {
+            return None;
+        }
+        self.notarization
+            .as_ref()
+            .map(|notarization| &notarization.proposal.payload)
+    }
+
     /// Returns the certified proposal for this round, if any (a finalized
     /// round is implicitly certified).
     pub const fn certified_proposal(&self) -> Option<&Proposal<D>> {
@@ -272,15 +325,52 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         }
     }
 
+    /// Returns the proposal if it is eligible for forwarding: certified (or
+    /// finalized), or notarized without a failed certification.
+    pub const fn forwardable_proposal(&self) -> Option<&Proposal<D>> {
+        if self.finalization.is_some()
+            || (self.notarization.is_some() && !self.is_failed_certification())
+        {
+            return self.proposal();
+        }
+        None
+    }
+
+    /// Returns true if certification completed and rejected the proposal.
+    pub const fn is_failed_certification(&self) -> bool {
+        matches!(self.certify, CertifyState::Certified(false))
+    }
+
+    /// Returns true if this node has verified the proposal.
+    ///
+    /// This includes both locally built proposals and peer proposals that
+    /// completed local verification.
+    pub const fn is_verified(&self) -> bool {
+        matches!(self.proposal.status(), ProposalStatus::Verified)
+    }
+
+    /// Returns true if we already broadcast a notarize vote for this round.
+    pub const fn broadcast_notarize(&self) -> bool {
+        self.broadcast_notarize
+    }
+
     /// Returns true if certification was aborted due to finalization.
     #[cfg(test)]
     pub const fn is_certify_aborted(&self) -> bool {
         matches!(self.certify, CertifyState::Aborted)
     }
 
-    /// Returns how much time elapsed since the round started, if the clock monotonicity holds.
-    pub fn elapsed_since_start(&self, now: SystemTime) -> Duration {
-        now.duration_since(self.start).unwrap_or_default()
+    /// Records when the local node entered this view. First entry wins.
+    pub fn mark_entered(&mut self, now: SystemTime) {
+        self.entered.get_or_insert(now);
+    }
+
+    /// Returns how much time elapsed since the local node entered this view,
+    /// or None if the view was never entered (e.g. a round created by
+    /// optimistic lookahead).
+    pub fn elapsed_since_entry(&self, now: SystemTime) -> Option<Duration> {
+        self.entered
+            .map(|entered| now.duration_since(entered).unwrap_or_default())
     }
 
     /// Completes the local proposal flow after the automaton returns a payload.
@@ -340,6 +430,11 @@ impl<S: Scheme, D: Digest> Round<S, D> {
 
     pub const fn proposal(&self) -> Option<&Proposal<D>> {
         self.proposal.proposal()
+    }
+
+    /// Returns true if the round contains a proposal and no equivocation.
+    pub fn has_unequivocated_proposal(&self) -> bool {
+        self.proposal.has_unequivocated_proposal()
     }
 
     /// Arms the round's deadlines when its view is entered.
@@ -554,26 +649,28 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         None
     }
 
+    /// Returns true if [Self::construct_notarize] would yield a proposal,
+    /// without marking it broadcast.
+    pub const fn can_construct_notarize(&self) -> bool {
+        // Ensure we haven't already broadcast a notarize vote or nullify vote.
+        // Even if we've already seen a notarization, we are still willing to
+        // broadcast our notarize vote in case someone is recording our activity.
+        //
+        // Requiring a verified proposal prevents us from voting for a proposal if
+        // we have observed equivocation (where the proposal would be set to
+        // ProposalStatus::Equivocated) or if verification hasn't completed yet.
+        !self.broadcast_notarize
+            && !self.broadcast_nullify
+            && matches!(self.proposal.status(), ProposalStatus::Verified)
+    }
+
     /// Returns a proposal candidate for notarization if we're ready to vote.
     ///
     /// Marks that we've broadcast our notarize vote to prevent duplicates.
     pub const fn construct_notarize(&mut self) -> Option<&Proposal<D>> {
-        // Ensure we haven't already broadcast a notarize vote or nullify vote.
-        if self.broadcast_notarize || self.broadcast_nullify {
+        if !self.can_construct_notarize() {
             return None;
         }
-        // Even if we've already seen a notarization, we are still willing to broadcast
-        // our notarize vote in case someone is recording our activity.
-
-        // If we don't have a verified proposal, return None.
-        //
-        // This check prevents us from voting for a proposal if we have observed equivocation (where
-        // the proposal would be set to ProposalStatus::Equivocated) or if verification hasn't
-        // completed yet.
-        if !matches!(self.proposal.status(), ProposalStatus::Verified) {
-            return None;
-        }
-
         self.broadcast_notarize = true;
         self.proposal.proposal()
     }
@@ -626,10 +723,12 @@ impl<S: Scheme, D: Digest> Round<S, D> {
                 // proposal was built locally; follower rounds also journal local
                 // notarize votes over other leaders' proposals.
                 //
-                // This relies on journal replay remaining append-ordered. By the
-                // time we replay a local vote for round `v`, the earlier
-                // certificate for `v - 1` has already replayed and seeded this
-                // round's leader.
+                // A vote for the current view replays after the certificate for
+                // `v - 1` (journal replay is append-ordered), which seeds this
+                // round's leader. An optimistic vote replays with no leader set
+                // (the parent certificate did not exist when it was journaled),
+                // so a leader-owned optimistic round takes the `notarized`
+                // branch; the two branches restore the same slot state.
                 if self
                     .leader
                     .as_ref()
@@ -708,7 +807,7 @@ mod tests {
             Sha256Digest::from([2u8; 32]),
         );
         let leader_scheme = schemes[0].clone();
-        let mut round = Round::new(leader_scheme, proposal_a.round, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(leader_scheme, proposal_a.round);
 
         // Set proposal from batcher
         round.set_leader(Participant::new(0));
@@ -762,7 +861,7 @@ mod tests {
             Sha256Digest::from([2u8; 32]),
         );
         let leader_scheme = schemes[0].clone();
-        let mut round = Round::new(leader_scheme, proposal_a.round, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(leader_scheme, proposal_a.round);
 
         // Set proposal from batcher
         round.set_leader(Participant::new(0));
@@ -830,7 +929,7 @@ mod tests {
         let proposal_y = Proposal::new(round_info, View::new(0), Sha256Digest::from([2u8; 32]));
 
         // We are participant 1; participant 0 is the equivocating leader.
-        let mut round = Round::new(schemes[1].clone(), round_info, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(schemes[1].clone(), round_info);
         round.set_leader(Participant::new(0));
 
         // Restart: replay our journaled notarize for the leader's first proposal.
@@ -874,7 +973,7 @@ mod tests {
         let proposal_y = Proposal::new(round_info, View::new(0), Sha256Digest::from([2u8; 32]));
 
         // We are participant 1; participant 0 is the equivocating leader.
-        let mut round = Round::new(schemes[1].clone(), round_info, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(schemes[1].clone(), round_info);
         round.set_leader(Participant::new(0));
 
         // Restart: replay our journaled notarize for the leader's first proposal.
@@ -919,7 +1018,7 @@ mod tests {
             Sha256Digest::from([1u8; 32]),
         );
         let leader_scheme = schemes[0].clone();
-        let mut round = Round::new(leader_scheme, proposal.round, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(leader_scheme, proposal.round);
 
         // Set proposal from batcher
         round.set_leader(Participant::new(0));
@@ -948,7 +1047,7 @@ mod tests {
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([9u8; 32]));
 
-        let mut round = Round::new(schemes[0].clone(), round_info, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(schemes[0].clone(), round_info);
         round.set_leader(Participant::new(0));
 
         // Recover a certificate built entirely from remote votes.
@@ -984,7 +1083,7 @@ mod tests {
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([10u8; 32]));
 
-        let mut round = Round::new(schemes[0].clone(), round_info, SystemTime::UNIX_EPOCH);
+        let mut round = Round::new(schemes[0].clone(), round_info);
         round.set_leader(Participant::new(0));
 
         // Recover a certificate built entirely from remote votes.
@@ -1020,7 +1119,6 @@ mod tests {
         let local_scheme = schemes[0].clone();
 
         // Setup round and proposal
-        let now = SystemTime::UNIX_EPOCH;
         let view = 2;
         let round = Rnd::new(Epoch::new(5), View::new(view));
         let proposal = Proposal::new(round, View::new(0), Sha256Digest::from([40u8; 32]));
@@ -1055,7 +1153,7 @@ mod tests {
                 .expect("finalization");
 
         // Replay messages and verify broadcast flags
-        let mut round = Round::new(local_scheme, round, now);
+        let mut round = Round::new(local_scheme, round);
         round.set_leader(Participant::new(0));
         round.replay(&Artifact::Notarize(notarize_local));
         assert!(round.broadcast_notarize);
@@ -1091,13 +1189,12 @@ mod tests {
         let local_scheme = schemes[0].clone();
 
         // Create a proposal where we (participant 0) are the leader.
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(5), View::new(2));
         let proposal = Proposal::new(round_info, View::new(1), Sha256Digest::from([41u8; 32]));
         let notarize_local = Notarize::sign(&local_scheme, proposal.clone()).expect("notarize");
 
         // Replay the local notarize into a fresh round.
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         round.replay(&Artifact::Notarize(notarize_local));
 
@@ -1108,7 +1205,7 @@ mod tests {
 
         // No verification request should be emitted.
         assert!(
-            !round.try_verify(),
+            !round.request_verify(),
             "leader-owned replay should not request verification again"
         );
 
@@ -1135,7 +1232,6 @@ mod tests {
         let local_scheme = schemes[0].clone();
 
         // Setup round and proposal
-        let now = SystemTime::UNIX_EPOCH;
         let view = 2;
         let round_info = Rnd::new(Epoch::new(5), View::new(view));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([40u8; 32]));
@@ -1144,7 +1240,7 @@ mod tests {
         let finalize_local = Finalize::sign(&local_scheme, proposal).expect("finalize");
 
         // Replay finalize and verify nullify is blocked
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         round.replay(&Artifact::Finalize(finalize_local));
 
@@ -1159,11 +1255,10 @@ mod tests {
         let Fixture { schemes, .. } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.set_proposal(proposal));
         assert!(round.verified());
@@ -1181,11 +1276,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.set_proposal(proposal.clone()));
         assert!(round.verified());
@@ -1224,11 +1318,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([7u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.proposed(proposal.clone()));
 
@@ -1256,11 +1349,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.set_proposal(proposal.clone()));
         assert!(round.verified());
@@ -1298,11 +1390,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.set_proposal(proposal.clone()));
         assert!(round.verified());
@@ -1342,11 +1433,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(1));
         // Don't set proposal yet
 
@@ -1375,11 +1465,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.set_proposal(proposal.clone()));
 
@@ -1416,11 +1505,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([1u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
         assert!(round.set_proposal(proposal.clone()));
         assert!(round.verified());
@@ -1460,11 +1548,10 @@ mod tests {
         } = ed25519::fixture(&mut rng, namespace, 4);
         let local_scheme = schemes[0].clone();
 
-        let now = SystemTime::UNIX_EPOCH;
         let round_info = Rnd::new(Epoch::new(1), View::new(1));
         let proposal = Proposal::new(round_info, View::new(0), Sha256Digest::from([3u8; 32]));
 
-        let mut round = Round::new(local_scheme, round_info, now);
+        let mut round = Round::new(local_scheme, round_info);
         round.set_leader(Participant::new(0));
 
         // Recover the proposal and notarization without running local verify.

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -286,21 +286,23 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         self.notarization.is_some() || self.finalization.is_some()
     }
 
-    // `certified_proposal` below requires an explicit certification (or a
-    // finalization). `certified_ancestry_payload` and `forwardable_proposal`
-    // share a weaker rule: finalized, or notarized without a failed
-    // certification. They differ only in source, the certificate versus the
-    // slot's proposal.
+    /// Returns true if this round's certificate supports building on its
+    /// proposal: finalized, or notarized unless our own certification
+    /// rejected it (a finalization overrides the rejection).
+    const fn has_usable_certificate(&self) -> bool {
+        self.finalization.is_some()
+            || (self.notarization.is_some() && !self.is_failed_certification())
+    }
 
-    /// Returns the payload of ancestry this round's certificate supports: the
-    /// finalized proposal's, or the notarized proposal's unless our own
-    /// certification rejected it (a finalization overrides the rejection).
+    /// Returns the payload of ancestry this round's certificate supports
+    /// (see [`Self::has_usable_certificate`]), read from the certificate
+    /// rather than the slot's proposal.
     pub fn certified_ancestry_payload(&self) -> Option<&D> {
+        if !self.has_usable_certificate() {
+            return None;
+        }
         if let Some(finalization) = &self.finalization {
             return Some(&finalization.proposal.payload);
-        }
-        if self.is_failed_certification() {
-            return None;
         }
         self.notarization
             .as_ref()
@@ -325,12 +327,10 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         }
     }
 
-    /// Returns the proposal if it is eligible for forwarding: certified (or
-    /// finalized), or notarized without a failed certification.
+    /// Returns the proposal if it is eligible for forwarding (see
+    /// [`Self::has_usable_certificate`]).
     pub const fn forwardable_proposal(&self) -> Option<&Proposal<D>> {
-        if self.finalization.is_some()
-            || (self.notarization.is_some() && !self.is_failed_certification())
-        {
+        if self.has_usable_certificate() {
             return self.proposal();
         }
         None

--- a/consensus/src/simplex/actors/voter/slot.rs
+++ b/consensus/src/simplex/actors/voter/slot.rs
@@ -82,6 +82,15 @@ where
         self.requested_build = true;
     }
 
+    /// Returns whether verification has yet to be requested for this slot.
+    ///
+    /// Unlike [`Self::should_build`], this does not test for an absent
+    /// proposal: verification is driven by a proposal the caller already
+    /// holds, where building is what produces one.
+    pub const fn should_verify(&self) -> bool {
+        !self.requested_verify
+    }
+
     /// Records a proposal that has already been verified.
     ///
     /// Additional observations of the same proposal are ignored here.

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -173,11 +173,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let timeouts = context.family("timeouts", "timed out views");
         let nullifications = context.family("nullifications", "nullifications");
 
-        let terms = cfg.elector.terms();
-        let lookahead = Lookahead {
-            term_length: terms.length(),
-            optimistic_views: terms.optimistic_views(),
-        };
+        let lookahead = cfg.elector.terms().lookahead();
 
         Self {
             context,
@@ -312,30 +308,31 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         true
     }
 
-    /// Sets the leader for the given view if it is not already set.
-    fn set_leader(&mut self, view: View, certificate: Option<&S::Certificate>) {
-        if self
-            .views
+    /// Returns true if the round for `view` exists and has a leader.
+    fn leader_is_set(&self, view: View) -> bool {
+        self.views
             .get(&view)
             .is_some_and(|round| round.leader().is_some())
-        {
+    }
+
+    /// Sets the leader for the given view if it is not already set.
+    fn set_leader(&mut self, view: View, certificate: Option<&S::Certificate>) {
+        if self.leader_is_set(view) {
             return;
         }
         let leader = self.elector.elect(Rnd::new(self.epoch, view), certificate);
-        let round = self.create_round(view);
-        round.set_leader(leader);
+        self.create_round(view).set_leader(leader);
     }
 
     /// Copies the same-term stable leader into an optimistic successor.
     fn inherit_leader(&mut self, from: View, to: View) {
+        if self.leader_is_set(to) {
+            return;
+        }
         let Some(leader) = self.views.get(&from).and_then(|round| round.leader()) else {
             return;
         };
-        let round = self.create_round(to);
-        if round.leader().is_some() {
-            return;
-        }
-        round.set_leader(leader.idx);
+        self.create_round(to).set_leader(leader.idx);
     }
 
     /// Ensures a round exists for the given view.
@@ -594,14 +591,11 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// current) the parent's explicit certification. Only meaningful inside
     /// [`Self::in_issuance_window`].
     ///
-    /// This is the weaker sibling of [`Self::explicit_parent_ready`]. It
-    /// throttles notarize issuance rather than gating safety. Signing still
-    /// runs full `parent_payload` resolution plus `verified_parent_matches`.
-    ///
-    /// It must never be *stricter* than
-    /// [`Self::optimistic_ancestry_payload`], because votes are constructed
-    /// once per event, so a gate that rejects at the child's verified event
-    /// loses the vote permanently.
+    /// This throttles notarize issuance (signing still resolves and checks
+    /// full ancestry) and must never be *stricter* than
+    /// [`Self::optimistic_ancestry_payload`]: votes are constructed once per
+    /// event, so a gate that rejects at the child's verified event loses the
+    /// vote permanently.
     fn optimistic_parent_ready(&self, view: View) -> bool {
         let Some(parent) = self.previous_in_term(view) else {
             return true;
@@ -714,8 +708,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.views.get(&view).and_then(|round| round.finalization())
     }
 
-    /// Returns the proposal for `view` if it is eligible for forwarding:
-    /// certified (or finalized), or notarized without a failed certification.
+    /// Returns the proposal for `view` if it is eligible for forwarding
+    /// (see [`Round::forwardable_proposal`]).
     pub fn forwardable_proposal(&self, view: View) -> Option<Proposal<D>> {
         self.views.get(&view)?.forwardable_proposal().cloned()
     }
@@ -777,14 +771,15 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// [`Round::latch_timeout`]); the latched reason is delivered back through
     /// [`Self::next_timeout`] when the timeout fires.
     ///
-    /// Views already advanced past are ignored. Failures for tracked
+    /// Views already advanced past are ignored, except for a failed
+    /// certification, which always nullifies. Failures for tracked
     /// optimistic future views latch on their round. The buffered proposal
     /// suppresses the leader timeout and its verification request is consumed,
     /// so a dropped latch would stall the view until certification timeout
     /// once it becomes current. Latching early does not nullify early because
     /// [`Self::next_timeout`] only polls the current round.
     pub fn trigger_timeout(&mut self, view: View, reason: TimeoutReason) {
-        if view < self.view {
+        if view < self.view && !matches!(reason, TimeoutReason::FailedCertification) {
             return;
         }
 
@@ -803,22 +798,27 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
     /// Attempt to propose a new block.
     pub fn try_propose(&mut self) -> Option<Context<D, S::PublicKey>> {
+        // Nothing above the next term start is admissible (see
+        // [`Self::peers_admit`]), so bound the scan rather than walking every
+        // tracked future round (certificates can land arbitrarily far ahead).
+        let limit = self.view.next_term_start(self.term_length());
         let mut cursor = self.view;
         while let Some(view) = self.next_tracked_view(cursor) {
+            if view > limit {
+                break;
+            }
             cursor = view.next();
             if view == GENESIS_VIEW {
                 continue;
             }
-            // Check the cheap round-local readiness before the window
-            // arithmetic, matching `try_verify`.
+            if !self.peers_admit(view) {
+                continue;
+            }
             if !self
                 .views
                 .get(&view)
                 .is_some_and(|round| round.should_propose())
             {
-                continue;
-            }
-            if !self.peers_admit(view) {
                 continue;
             }
 
@@ -868,11 +868,17 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// ask us to fetch junk).
     #[allow(clippy::type_complexity)]
     pub fn try_verify(&mut self) -> Option<(Context<D, S::PublicKey>, Proposal<D>)> {
+        // Bound the scan as in [`Self::try_propose`].
+        let limit = self.view.next_term_start(self.term_length());
         let mut cursor = self.view;
         while let Some(view) = self.next_tracked_view(cursor) {
+            if view > limit {
+                break;
+            }
             cursor = view.next();
-            // Check the cheap round-local readiness before the ancestry walk
-            // in `parent_payload`.
+            if !self.peers_admit(view) {
+                continue;
+            }
             let Some((leader, proposal)) = self
                 .views
                 .get(&view)
@@ -880,9 +886,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             else {
                 continue;
             };
-            if !self.peers_admit(view) {
-                continue;
-            }
             let parent_payload = match self.parent_payload(&proposal) {
                 Ok(parent_payload) => parent_payload,
                 Err(err) => {
@@ -1001,22 +1004,19 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     pub fn certified(&mut self, view: View, is_success: bool) -> Option<Notarization<S, D>> {
         let round = self.views.get_mut(&view)?;
         round.certified(is_success);
-        if !is_success {
-            // Latch directly rather than through `trigger_timeout`. Its
-            // past-views filter must never suppress a failed certification,
-            // which always nullifies even after we advance past `view`.
-            let now = self.context.current();
-            round.latch_timeout(now, TimeoutReason::FailedCertification);
-        }
-
-        // Remove from outstanding since certification is complete
-        self.outstanding_certifications.remove(&view);
 
         // Get notarization before advancing state
         let notarization = round
             .notarization()
             .cloned()
             .expect("notarization must exist for certified view");
+
+        if !is_success {
+            self.trigger_timeout(view, TimeoutReason::FailedCertification);
+        }
+
+        // Remove from outstanding since certification is complete
+        self.outstanding_certifications.remove(&view);
 
         if is_success {
             // Keep the stall deadline armed after certification so the

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -2,7 +2,7 @@ use super::round::Round;
 use crate::{
     Viewable,
     simplex::{
-        Floor, Viewport,
+        Floor, Lookahead, Viewport,
         elector::Elector,
         metrics::{Leader, Timeout, TimeoutReason},
         scheme::Scheme,
@@ -102,6 +102,9 @@ pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D:
     scheme: S,
     elector: L,
     epoch: Epoch,
+
+    /// Term geometry of the elector, fixed for its lifetime.
+    lookahead: Lookahead,
     view_retention: ViewDelta,
     leader_timeout: Duration,
     certification_timeout: Duration,
@@ -136,17 +139,52 @@ pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D:
 }
 
 impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> State<E, S, L, D> {
+    /// Returns true when `view` is within the optimistic *issuance* window:
+    /// a directly-notarized view anchors it no more than `optimistic_views`
+    /// hops above that anchor's child (see [`Lookahead::issuance_floor`]).
+    ///
+    /// The scanned range spans at most `optimistic_views + 1` views, so
+    /// reading the rounds directly is cheap and avoids maintaining a parallel
+    /// index that could drift from them.
+    fn in_issuance_window(&self, view: View) -> bool {
+        let Some(floor) = self.lookahead.issuance_floor(view) else {
+            return false;
+        };
+        // Genesis anchors the window until the first notarization lands.
+        floor == GENESIS_VIEW
+            || self
+                .views
+                .range(floor..view)
+                .any(|(_, round)| round.is_directly_notarized())
+    }
+
+    /// Returns the lowest tracked view at or above `from`.
+    ///
+    /// Walking the tracked views by cursor rather than collecting them keeps
+    /// the forward scans in [`Self::try_propose`] and [`Self::try_verify`]
+    /// allocation-free while leaving their bodies free to take `&mut self`.
+    fn next_tracked_view(&self, from: View) -> Option<View> {
+        self.views.range(from..).next().map(|(&view, _)| view)
+    }
+
     pub fn new(context: E, cfg: Config<S, L>) -> Self {
         let current_view = context.gauge("current_view", "current view");
         let tracked_views = context.gauge("tracked_views", "tracked views");
         let timeouts = context.family("timeouts", "timed out views");
         let nullifications = context.family("nullifications", "nullifications");
 
+        let terms = cfg.elector.terms();
+        let lookahead = Lookahead {
+            term_length: terms.length(),
+            optimistic_views: terms.optimistic_views(),
+        };
+
         Self {
             context,
             scheme: cfg.scheme,
             elector: cfg.elector,
             epoch: cfg.epoch,
+            lookahead,
             view_retention: cfg.view_retention,
             leader_timeout: cfg.leader_timeout,
             certification_timeout: cfg.certification_timeout,
@@ -205,22 +243,22 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     }
 
     /// Returns the lowest view that must remain in memory to satisfy the activity timeout.
-    pub fn min_active(&self) -> View {
+    pub const fn min_active(&self) -> View {
         self.viewport().floor()
     }
 
     /// Returns the term length of the elector.
-    fn term_length(&self) -> TermLength {
-        self.elector.terms().length()
+    const fn term_length(&self) -> TermLength {
+        self.lookahead.term_length
     }
 
     /// Returns the window of views this state machine tracks.
-    fn viewport(&self) -> Viewport {
+    const fn viewport(&self) -> Viewport {
         Viewport {
             finalized: self.last_finalized,
             current: self.view,
             view_retention: self.view_retention,
-            term_length: self.term_length(),
+            lookahead: self.lookahead,
         }
     }
 
@@ -231,8 +269,16 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
     /// Returns whether a certificate for `pending` is tracked (see
     /// [Viewport::admits_certificate]).
-    pub fn admits_certificate(&self, pending: View) -> bool {
+    pub const fn admits_certificate(&self, pending: View) -> bool {
         self.viewport().admits_certificate(pending)
+    }
+
+    /// Returns true if peers would admit locally emitted work for `view`
+    /// (see [Lookahead::admits]; views at or below the current view always
+    /// are). Unlike [Self::admits_vote] and [Self::admits_certificate], which
+    /// filter incoming messages, this gates our outgoing work.
+    fn peers_admit(&self, view: View) -> bool {
+        self.lookahead.admits(self.view, view)
     }
 
     /// Returns true when the local signer is the participant with index `idx`.
@@ -256,6 +302,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             .map(|timeout| now + timeout);
 
         let round = self.create_round(view);
+        round.mark_entered(now);
         round.open_span();
         round.set_deadlines(leader_deadline, certification_deadline, stall_deadline);
         self.view = view;
@@ -267,23 +314,35 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
     /// Sets the leader for the given view if it is not already set.
     fn set_leader(&mut self, view: View, certificate: Option<&S::Certificate>) {
+        if self
+            .views
+            .get(&view)
+            .is_some_and(|round| round.leader().is_some())
+        {
+            return;
+        }
         let leader = self.elector.elect(Rnd::new(self.epoch, view), certificate);
         let round = self.create_round(view);
+        round.set_leader(leader);
+    }
+
+    /// Copies the same-term stable leader into an optimistic successor.
+    fn inherit_leader(&mut self, from: View, to: View) {
+        let Some(leader) = self.views.get(&from).and_then(|round| round.leader()) else {
+            return;
+        };
+        let round = self.create_round(to);
         if round.leader().is_some() {
             return;
         }
-        round.set_leader(leader);
+        round.set_leader(leader.idx);
     }
 
     /// Ensures a round exists for the given view.
     fn create_round(&mut self, view: View) -> &mut Round<S, D> {
-        self.views.entry(view).or_insert_with(|| {
-            Round::new(
-                self.scheme.clone(),
-                Rnd::new(self.epoch, view),
-                self.context.current(),
-            )
-        })
+        self.views
+            .entry(view)
+            .or_insert_with(|| Round::new(self.scheme.clone(), Rnd::new(self.epoch, view)))
     }
 
     /// Returns the root span for `view`, or a disabled span if the view is not
@@ -455,11 +514,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         notarization: Notarization<S, D>,
     ) -> (bool, Option<S::PublicKey>) {
         let view = notarization.view();
-        // Do not advance to the next view until the certification passes
         self.set_leader(view.next(), Some(&notarization.certificate));
         let result = self.create_round(view).add_notarization(notarization);
-        if result.0 && view > self.last_finalized {
-            self.certification_candidates.insert(view);
+        if result.0 {
+            if view > self.last_finalized {
+                self.certification_candidates.insert(view);
+            }
+            self.slide_optimistic_frontier(view);
         }
         result
     }
@@ -520,15 +581,64 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
         self.enter_view(view.next());
         self.set_leader(view.next(), Some(&finalization.certificate));
-        self.create_round(view).add_finalization(finalization)
+        let result = self.create_round(view).add_finalization(finalization);
+        if result.0 {
+            self.slide_optimistic_frontier(view);
+        }
+        result
+    }
+
+    /// Returns true when an optimistic in-term `view` has local evidence for
+    /// its immediate parent: our own broadcast notarize vote, an observed
+    /// notarization or finalization certificate, or (when `view` is already
+    /// current) the parent's explicit certification. Only meaningful inside
+    /// [`Self::in_issuance_window`].
+    ///
+    /// This is the weaker sibling of [`Self::explicit_parent_ready`]. It
+    /// throttles notarize issuance rather than gating safety. Signing still
+    /// runs full `parent_payload` resolution plus `verified_parent_matches`.
+    ///
+    /// It must never be *stricter* than
+    /// [`Self::optimistic_ancestry_payload`], because votes are constructed
+    /// once per event, so a gate that rejects at the child's verified event
+    /// loses the vote permanently.
+    fn optimistic_parent_ready(&self, view: View) -> bool {
+        let Some(parent) = self.previous_in_term(view) else {
+            return true;
+        };
+
+        let parent_completed =
+            view == self.view && self.explicit_ancestry_payload(parent).is_some();
+        parent_completed
+            || self.views.get(&parent).is_some_and(|round| {
+                // A parent certificate is stronger evidence than our own vote.
+                round.broadcast_notarize() || round.certified_ancestry_payload().is_some()
+            })
     }
 
     /// Construct a notarize vote for this view when we're ready to sign.
     pub fn construct_notarize(&mut self, view: View) -> Option<Notarize<S, D>> {
+        if !self.peers_admit(view) {
+            return None;
+        }
+        // Check the cheap round-local eligibility before the ancestry gates
+        // below, which re-resolve parent payloads on every event otherwise.
+        if !self.views.get(&view)?.can_construct_notarize() {
+            return None;
+        }
+        // Optimistic views wait for local evidence of their parent; anything
+        // outside the issuance window carries certified ancestry already.
+        if self.in_issuance_window(view) && !self.optimistic_parent_ready(view) {
+            return None;
+        }
+        if !self.verified_parent_matches(view) {
+            return None;
+        }
         let candidate = self
             .views
             .get_mut(&view)
             .and_then(|round| round.construct_notarize().cloned())?;
+        self.prepare_optimistic_successor(view);
 
         // Signing can only fail if we are a verifier, so we don't need to worry about
         // unwinding our broadcast toggle.
@@ -540,9 +650,16 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// The term safety rule applies: a prior same-term nullify vote blocks the
     /// finalize vote unless an observed finalization covers it (see
     /// [Same-Term Vote Safety](crate::simplex#same-term-vote-safety)).
+    ///
+    /// Indirect notarization can make a view usable as ancestry, but does not
+    /// replace the local certification requirement for finalization.
     pub fn construct_finalize(&mut self, view: View) -> Option<Finalize<S, D>> {
         // We don't need to finalize views that are already finalized.
         if view <= self.last_finalized {
+            return None;
+        }
+
+        if !self.peers_admit(view) {
             return None;
         }
 
@@ -559,10 +676,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             return None;
         }
 
-        let candidate = self
-            .views
-            .get_mut(&view)
-            .and_then(|round| round.construct_finalize().cloned())?;
+        // Optimistic notarize votes can notarize a child ahead of its parent's
+        // certification, and finalization must not run ahead of that anchor.
+        // Certification already applies this, so it only bites when replay
+        // restores a certified round without re-running that precheck.
+        if !self.explicit_parent_ready(view) {
+            return None;
+        }
+        let candidate = self.views.get_mut(&view)?.construct_finalize()?.clone();
 
         // Signing can only fail if we are a verifier, so we don't need to worry about
         // unwinding our broadcast toggle.
@@ -593,13 +714,10 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.views.get(&view).and_then(|round| round.finalization())
     }
 
-    /// Returns the certified (or finalized) proposal for `view`, if any,
-    /// for forwarding to peers.
-    pub fn certified_proposal(&self, view: View) -> Option<Proposal<D>> {
-        self.views
-            .get(&view)
-            .and_then(|round| round.certified_proposal())
-            .cloned()
+    /// Returns the proposal for `view` if it is eligible for forwarding:
+    /// certified (or finalized), or notarized without a failed certification.
+    pub fn forwardable_proposal(&self, view: View) -> Option<Proposal<D>> {
+        self.views.get(&view)?.forwardable_proposal().cloned()
     }
 
     /// Construct a nullification certificate once the round has quorum.
@@ -641,12 +759,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             .and_then(|round| round.leader().map(|leader| leader.idx))
     }
 
-    /// Returns how long `view` has been live based on the clock samples stored by its round.
-    pub fn elapsed_since_start(&self, view: View) -> Option<Duration> {
+    /// Returns how long ago the local node entered `view`, or None if the
+    /// view is untracked or was never entered.
+    pub fn elapsed_since_entry(&self, view: View) -> Option<Duration> {
         let now = self.context.current();
         self.views
             .get(&view)
-            .map(|round| round.elapsed_since_start(now))
+            .and_then(|round| round.elapsed_since_entry(now))
     }
 
     /// Immediately expires `view` on first timeout, forcing a timeout to fire on the next tick.
@@ -657,53 +776,73 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// This only latches the first timeout for the view (see
     /// [`Round::latch_timeout`]); the latched reason is delivered back through
     /// [`Self::next_timeout`] when the timeout fires.
+    ///
+    /// Views already advanced past are ignored. Failures for tracked
+    /// optimistic future views latch on their round. The buffered proposal
+    /// suppresses the leader timeout and its verification request is consumed,
+    /// so a dropped latch would stall the view until certification timeout
+    /// once it becomes current. Latching early does not nullify early because
+    /// [`Self::next_timeout`] only polls the current round.
     pub fn trigger_timeout(&mut self, view: View, reason: TimeoutReason) {
-        if view != self.view {
+        if view < self.view {
             return;
         }
 
         let now = self.context.current();
-        self.views
-            .get_mut(&view)
-            .expect("current round must exist")
-            .latch_timeout(now, reason);
+        let Some(round) = self.views.get_mut(&view) else {
+            return;
+        };
+        // An inactivity timeout is only a hint that the leader is silent; a
+        // buffered unequivocated proposal proves the leader is active, so
+        // ignore it (other timeout reasons still latch).
+        if matches!(reason, TimeoutReason::Inactivity) && round.has_unequivocated_proposal() {
+            return;
+        }
+        round.latch_timeout(now, reason);
     }
 
     /// Attempt to propose a new block.
     pub fn try_propose(&mut self) -> Option<Context<D, S::PublicKey>> {
-        // Perform fast checks before lookback
-        let view = self.view;
-        if view == GENESIS_VIEW {
-            return None;
-        }
-        if !self
-            .views
-            .get_mut(&view)
-            .expect("view must exist")
-            .should_propose()
-        {
-            return None;
-        }
-
-        // Look for parent
-        let parent = self.find_parent(view);
-        let (parent_view, parent_payload) = match parent {
-            Ok(parent) => parent,
-            Err(missing) => {
-                debug!(%view, %missing, "missing parent during proposal");
-                return None;
+        let mut cursor = self.view;
+        while let Some(view) = self.next_tracked_view(cursor) {
+            cursor = view.next();
+            if view == GENESIS_VIEW {
+                continue;
             }
-        };
-        let leader = self
-            .views
-            .get_mut(&view)
-            .expect("view must exist")
-            .try_propose()?;
-        Some(Context {
-            round: Rnd::new(self.epoch, view),
-            leader: leader.key,
-            parent: (parent_view, parent_payload),
-        })
+            // Check the cheap round-local readiness before the window
+            // arithmetic, matching `try_verify`.
+            if !self
+                .views
+                .get(&view)
+                .is_some_and(|round| round.should_propose())
+            {
+                continue;
+            }
+            if !self.peers_admit(view) {
+                continue;
+            }
+
+            let (parent_view, parent_payload) = match self.find_parent(view) {
+                Ok(parent) => parent,
+                Err(missing) => {
+                    debug!(%view, %missing, "missing parent during proposal");
+                    continue;
+                }
+            };
+            let Some(leader) = self
+                .views
+                .get_mut(&view)
+                .and_then(|round| round.try_propose())
+            else {
+                continue;
+            };
+            return Some(Context {
+                round: Rnd::new(self.epoch, view),
+                leader: leader.key,
+                parent: (parent_view, parent_payload),
+            });
+        }
+        None
     }
 
     /// Records a locally constructed proposal once the automaton finishes building it.
@@ -718,6 +857,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     ///
     /// Returns true if the proposal should trigger verification, false otherwise.
     pub fn set_proposal(&mut self, view: View, proposal: Proposal<D>) -> bool {
+        self.prepare_optimistic_successor(view);
         self.create_round(view).set_proposal(proposal)
     }
 
@@ -728,42 +868,95 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// ask us to fetch junk).
     #[allow(clippy::type_complexity)]
     pub fn try_verify(&mut self) -> Option<(Context<D, S::PublicKey>, Proposal<D>)> {
-        let view = self.view;
-        let (leader, proposal) = self.views.get(&view)?.should_verify()?;
-        let parent_payload = match self.parent_payload(&proposal) {
-            Ok(parent_payload) => parent_payload,
-            Err(err) => {
-                if err.invalid_proposal() {
-                    warn!(round = ?proposal.round, ?err, "proposal failed verification");
-                    self.trigger_timeout(view, TimeoutReason::InvalidProposal);
-                } else {
-                    debug!(
-                        %view,
-                        ?proposal,
-                        ?err,
-                        "proposal exists but ancestry is not yet certified"
-                    );
-                }
-                return None;
+        let mut cursor = self.view;
+        while let Some(view) = self.next_tracked_view(cursor) {
+            cursor = view.next();
+            // Check the cheap round-local readiness before the ancestry walk
+            // in `parent_payload`.
+            let Some((leader, proposal)) = self
+                .views
+                .get(&view)
+                .and_then(|round| round.pending_verification())
+            else {
+                continue;
+            };
+            if !self.peers_admit(view) {
+                continue;
             }
-        };
-        if !self.views.get_mut(&view)?.try_verify() {
-            return None;
+            let parent_payload = match self.parent_payload(&proposal) {
+                Ok(parent_payload) => parent_payload,
+                Err(err) => {
+                    if err.invalid_proposal() {
+                        warn!(round = ?proposal.round, ?err, "proposal failed verification");
+                        self.trigger_timeout(view, TimeoutReason::InvalidProposal);
+                    } else {
+                        debug!(
+                            %view,
+                            ?proposal,
+                            ?err,
+                            "proposal exists but ancestry is not yet notarized"
+                        );
+                    }
+                    continue;
+                }
+            };
+            let Some(round) = self.views.get_mut(&view) else {
+                continue;
+            };
+            if !round.request_verify() {
+                continue;
+            }
+            round.set_verifying_parent(proposal.parent, parent_payload);
+            return Some((
+                Context {
+                    round: proposal.round,
+                    leader: leader.key,
+                    parent: (proposal.parent, parent_payload),
+                },
+                proposal,
+            ));
         }
-        let context = Context {
-            round: proposal.round,
-            leader: leader.key,
-            parent: (proposal.parent, parent_payload),
-        };
-        Some((context, proposal))
+        None
+    }
+
+    /// Returns true when a verification completion describes a parent we have
+    /// since replaced, discarding the stale binding.
+    ///
+    /// An optimistic child is verified before its parent is certified, so a
+    /// conflicting parent certificate can land while the request is in flight.
+    /// The completion then reports on ancestry we no longer hold and says
+    /// nothing about the proposal under the parent we now accept.
+    fn verification_is_stale(&mut self, view: View) -> bool {
+        if self.verified_parent_matches(view) {
+            return false;
+        }
+        if let Some(round) = self.views.get_mut(&view) {
+            round.clear_verifying_parent();
+        }
+        true
     }
 
     /// Marks proposal verification as complete when the peer payload validates.
     pub fn verified(&mut self, view: View) -> bool {
+        if self.verification_is_stale(view) {
+            return false;
+        }
         self.views
             .get_mut(&view)
             .map(|round| round.verified())
             .unwrap_or(false)
+    }
+
+    /// Latches `reason` after the automaton rejected or dropped a proposal.
+    ///
+    /// A stale completion is discarded rather than latched: nullifying on a
+    /// verdict about a parent we have already replaced would forfeit the view
+    /// over ancestry that no longer applies.
+    pub fn verification_failed(&mut self, view: View, reason: TimeoutReason) {
+        if self.verification_is_stale(view) {
+            return;
+        }
+        self.trigger_timeout(view, reason);
     }
 
     /// Store the abort handle for an in-flight certification request.
@@ -784,6 +977,17 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                 if view <= self.last_finalized {
                     return None;
                 }
+
+                let proposal = self.views.get(&view)?.proposal()?.clone();
+                if let Err(err) = self.certification_parent_ready(&proposal) {
+                    if err.invalid_proposal() {
+                        warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
+                    } else {
+                        self.certification_candidates.insert(view);
+                    }
+                    return None;
+                }
+
                 let candidate = self.views.get_mut(&view)?.try_certify()?;
                 Some(candidate)
             })
@@ -797,6 +1001,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     pub fn certified(&mut self, view: View, is_success: bool) -> Option<Notarization<S, D>> {
         let round = self.views.get_mut(&view)?;
         round.certified(is_success);
+        if !is_success {
+            // Latch directly rather than through `trigger_timeout`. Its
+            // past-views filter must never suppress a failed certification,
+            // which always nullifies even after we advance past `view`.
+            let now = self.context.current();
+            round.latch_timeout(now, TimeoutReason::FailedCertification);
+        }
 
         // Remove from outstanding since certification is complete
         self.outstanding_certifications.remove(&view);
@@ -812,8 +1023,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             // term-level timeout can still abandon a term that certifies but
             // never finalizes.
             self.enter_view(view.next());
-        } else {
-            self.trigger_timeout(view, TimeoutReason::FailedCertification);
         }
 
         Some(notarization)
@@ -839,9 +1048,21 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         removed
     }
 
-    /// Returns the payload of the proposal if it is certified (including finalized).
-    fn is_certified(&self, view: View) -> Option<&D> {
-        // Special case for genesis view
+    // ---- Ancestry rules ----
+    //
+    // The `*_ancestry_payload` resolvers answer what payload a view may
+    // contribute as ancestry. Verification and proposal go through
+    // `ancestry_payload_for_child`, which picks the optimistic rule inside the
+    // issuance window and the explicit rule outside it.
+    //
+    // The `*_parent_ready` predicates answer whether a view's immediate parent
+    // is settled enough to act on. Certification and finalization require
+    // `explicit_parent_ready`. Notarize issuance uses the weaker
+    // `optimistic_parent_ready`.
+
+    /// Returns the payload of `view`'s explicitly certified (or finalized)
+    /// proposal, the strongest form of ancestry.
+    fn explicit_ancestry_payload(&self, view: View) -> Option<&D> {
         if view == GENESIS_VIEW {
             return Some(self.genesis.as_ref().expect("genesis must be present"));
         }
@@ -866,6 +1087,113 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             .range(term_start..view)
             .next_back()
             .copied()
+    }
+
+    /// Resolves `parent`'s payload under the ancestry rule `child` is
+    /// entitled to: optimistic ancestry inside the issuance window, explicit
+    /// certification outside it.
+    fn ancestry_payload_for_child(&self, child: View, parent: View) -> Option<&D> {
+        if self.in_issuance_window(child) {
+            return self.optimistic_ancestry_payload(parent);
+        }
+        self.explicit_ancestry_payload(parent)
+    }
+
+    /// Returns the payload of a parent usable as *optimistic* ancestry: a
+    /// certificate-backed payload when one exists, otherwise our own verified,
+    /// unequivocated, notarize-broadcast proposal; recursively, so the whole
+    /// uncertified chain rests on views we voted for ourselves.
+    fn optimistic_ancestry_payload(&self, view: View) -> Option<&D> {
+        if view == GENESIS_VIEW {
+            return Some(self.genesis.as_ref().expect("genesis must be present"));
+        }
+
+        let round = self.views.get(&view)?;
+
+        // Serve directly-certified ancestry from the stored certificate so it
+        // is always payload the certificate actually supports, independent of
+        // the slot's proposal bookkeeping. The acceptance rule is shared with
+        // `optimistic_parent_ready`.
+        if round.is_directly_notarized() {
+            return round.certified_ancestry_payload();
+        }
+
+        // `view` may only be used as optimistic same-term ancestry when its
+        // child is within the optimistic lookahead window.
+        if !self.in_issuance_window(view.next()) {
+            return None;
+        }
+
+        if !round.has_unequivocated_proposal()
+            || !round.broadcast_notarize()
+            || !round.is_verified()
+        {
+            return None;
+        }
+
+        let proposal = round.proposal()?;
+        if proposal.parent < self.last_finalized {
+            return None;
+        }
+        if let Some(missing_view) = self.first_unnullified_view(proposal.parent, proposal.view()) {
+            debug!(%view, %missing_view, "optimistic ancestor missing nullification");
+            return None;
+        }
+        self.optimistic_ancestry_payload(proposal.parent)?;
+        Some(&proposal.payload)
+    }
+
+    /// Pushes the optimistic frontier one view, so stable leaders can chain
+    /// proposals. Called when we sign a notarize vote or receive the leader's
+    /// proposal for a view.
+    fn prepare_optimistic_successor(&mut self, view: View) {
+        let next = view.next();
+        if !self.in_issuance_window(next) {
+            return;
+        }
+        self.inherit_leader(view, next);
+    }
+
+    /// Re-extends the optimistic frontier (the highest same-term view stamped
+    /// with the term's stable leader, and so able to accept a proposal before
+    /// its ancestry certifies) through the issuance window that `view`'s
+    /// notarization just opened. The window predicate bounds the walk.
+    fn slide_optimistic_frontier(&mut self, view: View) {
+        let mut frontier = view;
+        while self.in_issuance_window(frontier.next()) {
+            self.inherit_leader(frontier, frontier.next());
+            frontier = frontier.next();
+        }
+    }
+
+    fn verified_parent_matches(&self, view: View) -> bool {
+        // Parents are recorded only for peer proposals (in try_verify). A locally
+        // built proposal's parent can only be displaced by conflicting certificates
+        // for the parent view, which requires more than f faults.
+        let Some(round) = self.views.get(&view) else {
+            return true;
+        };
+        let Some((parent_view, parent_payload)) = round.verifying_parent() else {
+            return true;
+        };
+        let Some(proposal) = round.proposal() else {
+            return false;
+        };
+        if proposal.parent != *parent_view {
+            return false;
+        }
+        self.parent_payload(proposal)
+            .is_ok_and(|payload| payload == *parent_payload)
+    }
+
+    fn previous_in_term(&self, view: View) -> Option<View> {
+        if view == GENESIS_VIEW || view.is_term_start(self.term_length()) {
+            return None;
+        }
+        Some(
+            view.previous()
+                .expect("non-genesis non-term-start views must have a predecessor"),
+        )
     }
 
     /// Returns the first non-nullified view in the open interval (after, before).
@@ -899,8 +1227,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             let parent = view
                 .previous()
                 .expect("non-genesis views must have a previous view");
-            return self
-                .is_certified(parent)
+            let payload = self.ancestry_payload_for_child(view, parent);
+            return payload
                 .copied()
                 .map(|payload| (parent, payload))
                 .ok_or(parent);
@@ -938,14 +1266,77 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// - It is certified (or finalized, which implies certification).
     /// - All views between it and the proposal view have been nullified.
     fn parent_payload(&self, proposal: &Proposal<D>) -> Result<D, ParentPayloadError> {
-        // Sanity check that the parent view is less than the proposal view.
+        self.validate_parent_span(proposal)?;
         let (view, parent) = (proposal.view(), proposal.parent);
+
+        // May return `None` if the parent view is not yet either:
+        // - notarized and certified
+        // - finalized
+        let payload = self.ancestry_payload_for_child(view, parent);
+        payload
+            .copied()
+            .ok_or(ParentPayloadError::ParentNotCertified {
+                proposal_view: view,
+                parent_view: parent,
+            })
+    }
+
+    /// Returns whether certification may run for a proposal.
+    ///
+    /// Optimistic notarize votes can make a same-term child notarized before
+    /// its immediate parent has certified, but certification waits for explicit
+    /// certified or finalized parent ancestry.
+    ///
+    /// Exempting term-start views is sound because this precheck exists only
+    /// to close the intra-term optimistic gap, which term starts cannot be in:
+    /// they are never issued optimistically (see
+    /// [`Lookahead::issuance_floor`](crate::simplex::Lookahead)), so a
+    /// term-start proposal can only have verified through explicit ancestry.
+    fn certification_parent_ready(&self, proposal: &Proposal<D>) -> Result<(), ParentPayloadError> {
+        let (view, parent) = (proposal.view(), proposal.parent);
+        Self::ensure_parent_precedes(view, parent)?;
+
+        if view.is_term_start(self.term_length()) {
+            return Ok(());
+        }
+
+        // Intra-term views share the structural rules (the nullification check
+        // is trivially satisfied once contiguity holds).
+        self.validate_parent_span(proposal)?;
+
+        if self.explicit_parent_ready(view) {
+            return Ok(());
+        }
+
+        Err(ParentPayloadError::ParentNotCertified {
+            proposal_view: view,
+            parent_view: parent,
+        })
+    }
+
+    /// Returns true when `view`'s immediate in-term parent is explicitly
+    /// certified (or finalized), the ancestry certification and finalization
+    /// both require. Term starts have no in-term parent and always pass.
+    fn explicit_parent_ready(&self, view: View) -> bool {
+        self.previous_in_term(view)
+            .is_none_or(|parent| self.explicit_ancestry_payload(parent).is_some())
+    }
+
+    /// Ensures the parent view strictly precedes the proposal view.
+    fn ensure_parent_precedes(view: View, parent: View) -> Result<(), ParentPayloadError> {
         if view <= parent {
             return Err(ParentPayloadError::ParentNotBeforeProposal {
                 proposal_view: view,
                 parent_view: parent,
             });
         }
+        Ok(())
+    }
+
+    /// Validates the structural link between a proposal and its parent view.
+    fn validate_parent_span(&self, proposal: &Proposal<D>) -> Result<(), ParentPayloadError> {
+        let (view, parent) = (proposal.view(), proposal.parent);
+        Self::ensure_parent_precedes(view, parent)?;
 
         // Ignore any requests for outdated parent views.
         if parent < self.last_finalized {
@@ -973,20 +1364,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             });
         }
 
-        // May return `None` if the parent view is not yet either:
-        // - notarized and certified
-        // - finalized
-        //
-        // We do not request the parent's notarization from the resolver
-        // (a nullification covering the parent satisfies its term anchor).
-        // Until it arrives via gossip or buffered votes, we cannot vote for
-        // this proposal, but we still advance on later certificates.
-        self.is_certified(parent)
-            .copied()
-            .ok_or(ParentPayloadError::ParentNotCertified {
-                proposal_view: view,
-                parent_view: parent,
-            })
+        Ok(())
     }
 
     /// Returns the certificate for the parent of the proposal at the given view.
@@ -1010,7 +1388,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 mod tests {
     use super::*;
     use crate::simplex::{
-        elector::{Config as _, RoundRobin, RoundRobinElector},
+        elector::{Config as _, RoundRobin, RoundRobinElector, Terms},
         scheme::ed25519,
         types::{Finalization, Finalize, Notarization, Notarize, Nullification, Nullify, Proposal},
     };
@@ -1029,9 +1407,10 @@ mod tests {
         scheme: &S,
         term_length: TermLength,
         stall_timeout: Duration,
+        optimistic_views: ViewDelta,
     ) -> RoundRobinElector<S> {
         <RoundRobin>::default()
-            .with_term(term_length, stall_timeout)
+            .with_term(term_length, stall_timeout, optimistic_views)
             .build(scheme.participants())
     }
 
@@ -1150,6 +1529,7 @@ mod tests {
                 &fixture.verifier,
                 TermLength::new(NZU32!(term_length)),
                 Duration::from_secs(30),
+                ViewDelta::new(0),
             ),
         };
         let state = State::new(
@@ -1167,6 +1547,82 @@ mod tests {
         let mut state = state;
         state.set_genesis(test_genesis());
         (fixture, state)
+    }
+
+    /// Like [setup_state], but signs as `schemes[signer]` (rather than the
+    /// verifier) and parameterizes `optimistic_views`.
+    fn setup_state_with(
+        context: &mut deterministic::Context,
+        validators: usize,
+        signer: usize,
+        epoch: u64,
+        view_retention: u64,
+        term_length: TermLength,
+        optimistic_views: ViewDelta,
+    ) -> (Fixture<ed25519::Scheme>, TestState) {
+        let namespace = b"ns".to_vec();
+        let fixture = ed25519::fixture(
+            context,
+            &namespace,
+            validators.try_into().expect("validator count fits in u32"),
+        );
+        let scheme = fixture.schemes[signer].clone();
+        let mut state = State::new(
+            context.child("state"),
+            Config {
+                scheme: scheme.clone(),
+                elector: round_robin_with_term(
+                    &scheme,
+                    term_length,
+                    Duration::from_secs(4),
+                    optimistic_views,
+                ),
+                epoch: Epoch::new(epoch),
+                view_retention: ViewDelta::new(view_retention),
+                leader_timeout: Duration::from_secs(1),
+                certification_timeout: Duration::from_secs(2),
+                timeout_retry: Duration::from_secs(3),
+            },
+        );
+        state.set_genesis(test_genesis());
+        (fixture, state)
+    }
+
+    /// Proposes `payload` at view 1 (on top of genesis) and broadcasts our
+    /// notarize vote for it, returning the proposal.
+    fn propose_and_notarize_view1(state: &mut TestState, payload: u8) -> Proposal<Sha256Digest> {
+        let proposal = Proposal::new(
+            Rnd::new(state.epoch(), View::new(1)),
+            GENESIS_VIEW,
+            Sha256Digest::from([payload; 32]),
+        );
+        state.create_round(View::new(1));
+        assert!(state.proposed(proposal.clone()));
+        assert!(state.construct_notarize(View::new(1)).is_some());
+        proposal
+    }
+
+    /// An elector that panics if asked to elect a leader without a certificate
+    /// (past view 1). Optimistic successors must inherit the stable leader
+    /// instead of running a fresh election.
+    #[derive(Clone)]
+    struct RequireCertificateElector<S> {
+        term_length: TermLength,
+        _phantom: std::marker::PhantomData<S>,
+    }
+
+    impl<S: certificate::Scheme> Elector<S> for RequireCertificateElector<S> {
+        fn terms(&self) -> Terms {
+            Terms::stable(self.term_length, Duration::from_secs(30), ViewDelta::new(1))
+        }
+
+        fn elect(&self, round: Rnd, certificate: Option<&S::Certificate>) -> Participant {
+            assert!(
+                certificate.is_some() || round.view() == View::new(1),
+                "certificate required after view 1"
+            );
+            Participant::new(0)
+        }
     }
 
     #[test]
@@ -1338,7 +1794,7 @@ mod tests {
             assert_eq!(
                 state.timeouts.get_or_create(&label).get(),
                 1,
-                "first timeout nullify should record a leader-timeout metric"
+                "first nullify should record a leader-timeout metric"
             );
 
             context.sleep(Duration::from_secs(2)).await;
@@ -1484,6 +1940,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(33),
                 view_retention: ViewDelta::new(10),
@@ -1580,6 +2037,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     Duration::from_secs(12),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(34),
                 view_retention: ViewDelta::new(10),
@@ -1625,6 +2083,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     same_term_timeout,
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(35),
                 view_retention: ViewDelta::new(10),
@@ -1686,6 +2145,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     same_term_timeout,
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(36),
                 view_retention: ViewDelta::new(10),
@@ -1742,6 +2202,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(5)),
                     stall_timeout,
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(7),
                 view_retention: ViewDelta::new(10),
@@ -1822,6 +2283,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(9),
                 view_retention: ViewDelta::new(10),
@@ -1884,6 +2346,58 @@ mod tests {
             state.trigger_timeout(view_1, TimeoutReason::Inactivity);
             assert_eq!(state.current_view(), View::new(2));
             assert_eq!(state.next_timeout(), deadline_v2);
+        });
+    }
+
+    #[test]
+    fn inactivity_timeout_ignores_buffered_current_proposal() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let namespace = b"ns".to_vec();
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, &namespace, 4);
+            let certification_timeout = Duration::from_secs(10);
+            let mut state = State::new(
+                context.child("state"),
+                Config {
+                    scheme: schemes[1].clone(),
+                    elector: round_robin_with_term(
+                        &schemes[1],
+                        TermLength::new(NZU32!(5)),
+                        Duration::from_secs(20),
+                        ViewDelta::new(1),
+                    ),
+                    epoch: Epoch::new(15),
+                    view_retention: ViewDelta::new(10),
+                    leader_timeout: Duration::from_secs(10),
+                    certification_timeout,
+                    timeout_retry: Duration::from_secs(30),
+                },
+            );
+            state.set_genesis(test_genesis());
+
+            let parent = propose_and_notarize_view1(&mut state, 118);
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(15), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([119u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child));
+
+            let finalization = build_finalization(&verifier, &schemes, &parent);
+            assert!(state.add_finalization(finalization).0);
+            assert_eq!(state.current_view(), View::new(2));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(2)));
+
+            let now = context.current();
+            state.trigger_timeout(View::new(2), TimeoutReason::Inactivity);
+
+            let (deadline, reason) = state.next_timeout();
+            assert_eq!(reason, TimeoutReason::CertificationTimeout);
+            assert_eq!(deadline, now + certification_timeout);
         });
     }
 
@@ -2167,7 +2681,7 @@ mod tests {
             let notarization = build_notarization(&verifier, &schemes, &parent_proposal);
             state.add_notarization(notarization);
 
-            // The parent is still not certified
+            // The parent is still not certified.
             assert_eq!(
                 state.parent_payload(&proposal),
                 Err(ParentPayloadError::ParentNotCertified {
@@ -2440,6 +2954,1182 @@ mod tests {
     }
 
     #[test]
+    fn optimistic_views_zero_disables_intra_term_lookahead() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(0),
+            );
+
+            let parent = propose_and_notarize_view1(&mut state, 93);
+
+            let parent_notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(parent_notarization).0);
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([94u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            assert!(state.try_verify().is_none());
+
+            let child_notarization = build_notarization(&verifier, &schemes, &child);
+            assert!(state.add_notarization(child_notarization).0);
+            let candidates = state.certify_candidates();
+            assert_eq!(candidates.len(), 1);
+            assert_eq!(candidates[0].round.view(), View::new(1));
+
+            assert!(state.certified(View::new(1), true).is_some());
+            assert!(state.try_verify().is_some());
+        });
+    }
+
+    #[test]
+    fn optimistic_child_certification_waits_for_parent() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let parent = propose_and_notarize_view1(&mut state, 101);
+
+            let parent_notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(parent_notarization).0);
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([102u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(2)));
+
+            let child_notarization = build_notarization(&verifier, &schemes, &child);
+            assert!(state.add_notarization(child_notarization).0);
+
+            let candidates = state.certify_candidates();
+            assert_eq!(candidates.len(), 1);
+            assert!(
+                candidates
+                    .iter()
+                    .any(|proposal| proposal.round.view() == View::new(1))
+            );
+
+            assert!(state.certified(View::new(1), false).is_some());
+
+            let nullification =
+                build_nullification(&verifier, &schemes, Rnd::new(Epoch::new(9), View::new(1)));
+            assert!(state.add_nullification(nullification));
+
+            assert_eq!(
+                state.find_parent(View::new(6)),
+                Ok((GENESIS_VIEW, test_genesis()))
+            );
+            let next_term_proposal = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(6)),
+                View::new(2),
+                Sha256Digest::from([103u8; 32]),
+            );
+            assert_eq!(
+                state.parent_payload(&next_term_proposal),
+                Err(ParentPayloadError::ParentNotCertified {
+                    proposal_view: View::new(6),
+                    parent_view: View::new(2),
+                })
+            );
+            assert!(state.certify_candidates().is_empty());
+        });
+    }
+
+    #[test]
+    fn optimistic_views_bounds_chain_length() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (_, mut state) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            let first_payload = Sha256Digest::from([95u8; 32]);
+            let first = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                first_payload,
+            );
+            state.create_round(View::new(1));
+            assert!(state.proposed(first));
+
+            let second = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([96u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), second.clone()));
+            assert!(
+                state.try_verify().is_none(),
+                "future same-term verification should wait for local parent notarize"
+            );
+            assert!(state.construct_notarize(View::new(1)).is_some());
+
+            let (ctx, proposal) = state
+                .try_verify()
+                .expect("future view should verify after local parent notarize");
+            assert_eq!(ctx.round.view(), View::new(2));
+            assert_eq!(ctx.parent, (View::new(1), first_payload));
+            assert_eq!(proposal, second);
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+
+            let third = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(3)),
+                View::new(2),
+                Sha256Digest::from([97u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(3), third));
+            assert!(
+                state.try_verify().is_none(),
+                "depth=1 should block a second optimistic hop"
+            );
+        });
+    }
+
+    #[test]
+    fn optimistic_successor_inherits_leader_without_none_election() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let namespace = b"ns".to_vec();
+            let Fixture { verifier, .. } = ed25519::fixture(&mut context, &namespace, 4);
+            let mut state = State::new(
+                context,
+                Config {
+                    scheme: verifier,
+                    elector: RequireCertificateElector {
+                        term_length: TermLength::new(NZU32!(5)),
+                        _phantom: std::marker::PhantomData,
+                    },
+                    epoch: Epoch::new(99),
+                    view_retention: ViewDelta::new(10),
+                    leader_timeout: Duration::from_secs(1),
+                    certification_timeout: Duration::from_secs(2),
+                    timeout_retry: Duration::from_secs(3),
+                },
+            );
+            state.set_genesis(test_genesis());
+
+            let proposal = Proposal::new(
+                Rnd::new(Epoch::new(99), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([9u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(1), proposal));
+            assert!(
+                state
+                    .views
+                    .get(&View::new(2))
+                    .and_then(|round| round.leader())
+                    .is_some()
+            );
+        });
+    }
+
+    #[test]
+    fn catch_up_from_parent_finalization_allows_child_notarize() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let parent = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([111u8; 32]),
+            );
+            let finalization = build_finalization(&verifier, &schemes, &parent);
+            assert!(state.add_finalization(finalization).0);
+            assert_eq!(state.current_view(), View::new(2));
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([112u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            let (ctx, proposal) = state.try_verify().expect("child should verify");
+            assert_eq!(proposal, child);
+            assert_eq!(ctx.parent, (View::new(1), parent.payload));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+        });
+    }
+
+    #[test]
+    fn catch_up_from_parent_certification_allows_child_notarize() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let parent = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([113u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(1), true).is_some());
+            assert_eq!(state.current_view(), View::new(2));
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([114u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            let (ctx, proposal) = state.try_verify().expect("child should verify");
+            assert_eq!(proposal, child);
+            assert_eq!(ctx.parent, (View::new(1), parent.payload));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+        });
+    }
+
+    #[test]
+    fn failed_certification_round_is_not_forwardable_after_nullification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state(&mut context, 4, 13, 10, 1);
+
+            let view = View::new(1);
+            let proposal = Proposal::new(
+                Rnd::new(Epoch::new(13), view),
+                GENESIS_VIEW,
+                Sha256Digest::from([116u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &proposal);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(view, false).is_some());
+
+            let nullification =
+                build_nullification(&verifier, &schemes, Rnd::new(Epoch::new(13), view));
+            assert!(state.add_nullification(nullification));
+            assert_eq!(state.current_view(), View::new(2));
+            assert!(state.forwardable_proposal(view).is_none());
+        });
+    }
+
+    #[test]
+    fn pending_optimistic_child_verification_rejects_replaced_parent_notarization() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let parent_a = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([117u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(1), parent_a.clone()));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(1)));
+            assert!(state.construct_notarize(View::new(1)).is_some());
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([118u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            let (ctx, proposal) = state.try_verify().expect("child should verify");
+            assert_eq!(proposal, child);
+            assert_eq!(ctx.parent, (View::new(1), parent_a.payload));
+
+            let parent_b = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([119u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &parent_b);
+            let (added, equivocator) = state.add_notarization(notarization);
+            assert!(added);
+            assert!(equivocator.is_some());
+            assert_eq!(state.parent_payload(&child), Ok(parent_b.payload));
+            assert!(!state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_none());
+        });
+    }
+
+    /// A verification failure that arrives after the child's parent was
+    /// replaced describes ancestry we no longer hold, so it must not latch.
+    ///
+    /// Latching would nullify the view over a verdict on the displaced parent,
+    /// and the latch outlives the round's consumed verification request.
+    #[test]
+    fn failed_optimistic_child_verification_ignores_replaced_parent_verdict() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let parent_a = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([120u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(1), parent_a.clone()));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(1)));
+            assert!(state.construct_notarize(View::new(1)).is_some());
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([121u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            let (ctx, _) = state.try_verify().expect("child should verify");
+            assert_eq!(ctx.parent, (View::new(1), parent_a.payload));
+
+            // The parent view certifies a conflicting payload while the child's
+            // verification is still in flight.
+            let parent_b = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([122u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &parent_b);
+            assert!(state.add_notarization(notarization).0);
+            assert_eq!(state.parent_payload(&child), Ok(parent_b.payload));
+
+            // The automaton then rejects the child it verified against
+            // parent_a. That verdict says nothing about parent_b.
+            state.verification_failed(View::new(2), TimeoutReason::InvalidProposal);
+
+            assert!(state.certified(View::new(1), true).is_some());
+            assert_eq!(state.current_view(), View::new(2));
+            assert!(!matches!(
+                state.next_timeout(),
+                (_, TimeoutReason::InvalidProposal)
+            ));
+        });
+    }
+
+    #[test]
+    fn verified_optimistic_child_notarize_rejects_replaced_parent_finalization() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let parent_a = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([120u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(1), parent_a.clone()));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(1)));
+            assert!(state.construct_notarize(View::new(1)).is_some());
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([121u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child.clone()));
+            let (ctx, proposal) = state.try_verify().expect("child should verify");
+            assert_eq!(proposal, child);
+            assert_eq!(ctx.parent, (View::new(1), parent_a.payload));
+            assert!(state.verified(View::new(2)));
+
+            let parent_b = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([122u8; 32]),
+            );
+            let finalization = build_finalization(&verifier, &schemes, &parent_b);
+            let (added, equivocator) = state.add_finalization(finalization);
+            assert!(added);
+            assert!(equivocator.is_some());
+            assert_eq!(state.parent_payload(&child), Ok(parent_b.payload));
+            assert!(state.construct_notarize(View::new(2)).is_none());
+        });
+    }
+
+    #[test]
+    fn failed_certification_blocks_optimistic_child_notarize() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            let parent = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([116u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(1), parent.clone()));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(1)));
+            assert!(state.construct_notarize(View::new(1)).is_some());
+
+            let notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(notarization).0);
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([117u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), child));
+            assert!(state.try_verify().is_some());
+            assert!(state.verified(View::new(2)));
+
+            // Local certification rejects the parent and we nullify it. The
+            // optimistic child must no longer be signable.
+            assert!(state.certified(View::new(1), false).is_some());
+            assert!(
+                state
+                    .construct_nullify(View::new(1), TimeoutReason::FailedCertification)
+                    .is_some()
+            );
+            assert!(
+                state.construct_notarize(View::new(2)).is_none(),
+                "failed-certified parent must not unlock optimistic child notarize"
+            );
+
+            // A finalization certificate for the parent overrides the local
+            // rejection and restores it as usable ancestry.
+            let finalization = build_finalization(&verifier, &schemes, &parent);
+            assert!(state.add_finalization(finalization).0);
+            assert!(state.construct_notarize(View::new(2)).is_some());
+        });
+    }
+
+    #[test]
+    fn same_term_notarize_respects_admission_window() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (_, mut state) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            for view in [View::new(1), View::new(2), View::new(3)] {
+                let proposal = Proposal::new(
+                    Rnd::new(Epoch::new(9), view),
+                    view.previous().unwrap_or(GENESIS_VIEW),
+                    Sha256Digest::from([view.get() as u8; 32]),
+                );
+                assert!(state.set_proposal(view, proposal));
+                assert!(state.verified(view));
+                assert!(
+                    state.construct_notarize(view).is_some(),
+                    "view {view} is in the admission window from current view 1"
+                );
+            }
+
+            let view = View::new(4);
+            let proposal = Proposal::new(
+                Rnd::new(Epoch::new(9), view),
+                View::new(3),
+                Sha256Digest::from([4u8; 32]),
+            );
+            assert!(state.set_proposal(view, proposal));
+            assert!(state.verified(view));
+            assert!(
+                state.construct_notarize(view).is_none(),
+                "view 4 is outside the admission window from current view 1"
+            );
+        });
+    }
+
+    #[test]
+    fn certify_candidates_wait_for_parent_certification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            let parent = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([98u8; 32]),
+            );
+            let parent_notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(parent_notarization).0);
+
+            let child = Proposal::new(
+                Rnd::new(Epoch::new(9), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([99u8; 32]),
+            );
+            let child_notarization = build_notarization(&verifier, &schemes, &child);
+            assert!(state.add_notarization(child_notarization).0);
+
+            let candidates = state.certify_candidates();
+            assert_eq!(candidates.len(), 1);
+            assert_eq!(candidates[0].round.view(), View::new(1));
+
+            assert!(state.certified(View::new(1), true).is_some());
+            let candidates = state.certify_candidates();
+            assert_eq!(candidates.len(), 1);
+            assert_eq!(candidates[0].round.view(), View::new(2));
+        });
+    }
+
+    #[test]
+    fn optimistic_frontier_slides_with_direct_notarization() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                10,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            propose_and_notarize_view1(&mut state, 98);
+
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(10), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([99u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2.clone()));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+
+            assert!(state.views.contains_key(&View::new(3)));
+            assert!(
+                !state.views.contains_key(&View::new(4)),
+                "issuance window should initially stop at view 3"
+            );
+
+            let notarization = build_notarization(&verifier, &schemes, &proposal_v2);
+            assert!(state.add_notarization(notarization).0);
+
+            assert!(
+                state.views.contains_key(&View::new(4)),
+                "direct notarization should slide optimistic frontier"
+            );
+        });
+    }
+
+    /// Regression: the frontier walk must start adjacent to the notarized view.
+    /// A far-future same-term round (created by an unbounded-future certificate)
+    /// previously hijacked the walk, leaving the window the notarization just
+    /// opened without leaders.
+    #[test]
+    fn optimistic_frontier_slides_despite_far_future_round() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                10,
+                10,
+                TermLength::new(NZU32!(20)),
+                ViewDelta::new(2),
+            );
+
+            // A notarization for a far-future same-term view arrives first.
+            let proposal_v10 = Proposal::new(
+                Rnd::new(Epoch::new(10), View::new(10)),
+                View::new(9),
+                Sha256Digest::from([96u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &proposal_v10);
+            assert!(state.add_notarization(notarization).0);
+
+            // A notarization for view 1 must still open its own window.
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(10), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([97u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &proposal_v1);
+            assert!(state.add_notarization(notarization).0);
+
+            for view in 2..=4u64 {
+                assert!(
+                    state.leader_index(View::new(view)).is_some(),
+                    "view {view} must inherit the stable leader"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn indirect_notarization_still_requires_certification_for_finalize() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                10,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            propose_and_notarize_view1(&mut state, 101);
+
+            let descendant = Proposal::new(
+                Rnd::new(Epoch::new(10), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([102u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), descendant.clone()));
+            assert!(state.verified(View::new(2)));
+
+            let notarization = build_notarization(&verifier, &schemes, &descendant);
+            let (added, equivocator) = state.add_notarization(notarization);
+            assert!(added);
+            assert!(equivocator.is_none());
+            assert_eq!(
+                state.optimistic_ancestry_payload(View::new(1)).copied(),
+                Some(Sha256Digest::from([101u8; 32]))
+            );
+            let round = state.views.get(&View::new(1)).expect("ancestor round");
+            assert!(round.proposal().is_some());
+            assert!(round.is_verified());
+
+            assert!(state.construct_finalize(View::new(1)).is_none());
+        });
+    }
+
+    #[test]
+    fn indirect_notarization_requires_verified_unequivocated_ancestors() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                11,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            propose_and_notarize_view1(&mut state, 111);
+
+            let view2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([112u8; 32]),
+            );
+            state.create_round(View::new(2));
+            assert!(state.proposed(view2));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+            let conflicting_view2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([113u8; 32]),
+            );
+            assert!(!state.set_proposal(View::new(2), conflicting_view2));
+
+            let view3 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(3)),
+                View::new(2),
+                Sha256Digest::from([114u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(3), view3.clone()));
+            assert!(state.verified(View::new(3)));
+            let notarization = build_notarization(&verifier, &schemes, &view3);
+            assert!(state.add_notarization(notarization).0);
+
+            assert!(state.optimistic_ancestry_payload(View::new(2)).is_none());
+        });
+    }
+
+    #[test]
+    fn optimistic_notarize_requires_parent_participation_within_term() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (_, mut state) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                11,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+            assert!(state.enter_view(View::new(2)));
+
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([118u8; 32]),
+            );
+            state.create_round(View::new(2));
+            assert!(state.proposed(proposal_v2));
+            assert!(state.construct_notarize(View::new(2)).is_none());
+
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([119u8; 32]),
+            );
+            state.create_round(View::new(1));
+            assert!(state.proposed(proposal_v1));
+            assert!(state.construct_notarize(View::new(1)).is_some());
+            assert!(state.construct_notarize(View::new(2)).is_some());
+        });
+    }
+
+    /// Regression: a parent notarization certificate observed from the network
+    /// (without our own notarize vote) must satisfy the optimistic parent gate.
+    /// The actor constructs votes once per event, so the gate must pass at the
+    /// child's verified event or the vote is permanently lost.
+    #[test]
+    fn optimistic_notarize_accepts_directly_notarized_parent() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                11,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            // Peers notarize view 1 without our participation.
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([120u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes[1..], &proposal_v1);
+            assert!(state.add_notarization(notarization).0);
+
+            // The optimistic child of the notarized view is immediately votable.
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([121u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+        });
+    }
+
+    /// A directly-notarized parent whose certification we rejected must not
+    /// anchor an optimistic notarize vote (mirrors payload resolution).
+    #[test]
+    fn optimistic_notarize_blocks_on_parent_failed_certification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                11,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([122u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes[1..], &proposal_v1);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(1), false).is_some());
+
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([123u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_none());
+        });
+    }
+
+    /// A view whose only certificate is a finalization must anchor the
+    /// issuance window, exactly as a notarized view does.
+    #[test]
+    fn finalization_anchors_optimistic_issuance_window() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                11,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            // View 1 is finalized without us ever seeing its notarization, so
+            // it is the only possible anchor below the chain that follows.
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([130u8; 32]),
+            );
+            let finalization = build_finalization(&verifier, &schemes, &proposal_v1);
+            assert!(state.add_finalization(finalization).0);
+            assert!(state.notarization(View::new(1)).is_none());
+
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([131u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+
+            // View 3 is inside the window only because view 1 anchors it
+            // (`3 <= 1 + 1 + optimistic_views`); an anchor at genesis would
+            // put it out of reach.
+            let proposal_v3 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(3)),
+                View::new(2),
+                Sha256Digest::from([132u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(3), proposal_v3));
+            assert!(state.verified(View::new(3)));
+            assert!(
+                state.construct_notarize(View::new(3)).is_some(),
+                "finalized view 1 should anchor the issuance window"
+            );
+        });
+    }
+
+    /// Pruned rounds must not leave anchors behind. A stale entry below the
+    /// activity floor would widen the issuance window past its bound.
+    #[test]
+    fn prune_drops_stale_optimistic_anchors() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                11,
+                1,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            for (view, payload) in [(1u64, 140u8), (2, 141)] {
+                let proposal = Proposal::new(
+                    Rnd::new(Epoch::new(11), View::new(view)),
+                    View::new(view - 1),
+                    Sha256Digest::from([payload; 32]),
+                );
+                let notarization = build_notarization(&verifier, &schemes, &proposal);
+                assert!(state.add_notarization(notarization).0);
+            }
+
+            // View 4's window spans views 1..4, so the notarization at view 2
+            // anchors it.
+            assert!(state.in_issuance_window(View::new(4)));
+
+            let proposal_v4 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(4)),
+                View::new(3),
+                Sha256Digest::from([142u8; 32]),
+            );
+            let finalization = build_finalization(&verifier, &schemes, &proposal_v4);
+            assert!(state.add_finalization(finalization).0);
+
+            // Retention of 1 puts the activity floor at view 3.
+            let removed = state.prune();
+            assert_eq!(removed, vec![View::new(1), View::new(2)]);
+            assert!(
+                !state.in_issuance_window(View::new(4)),
+                "pruned views must not anchor the issuance window"
+            );
+        });
+    }
+
+    /// An optimistic child may be notarized ahead of its parent's
+    /// certification, but must not be finalized until the parent is explicitly
+    /// certified.
+    ///
+    /// Marking the child certified while the parent is not cannot happen on the
+    /// live path (`certification_parent_ready` gates it), so this drives
+    /// [`State::certified`] directly to reproduce what journal replay restores.
+    #[test]
+    fn optimistic_finalize_blocks_on_uncertified_parent() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                11,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            // Peers notarize view 1; we never certify it.
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([124u8; 32]),
+            );
+            let notarization_v1 = build_notarization(&verifier, &schemes[1..], &proposal_v1);
+            assert!(state.add_notarization(notarization_v1).0);
+
+            // The optimistic child is votable and reaches a notarization.
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(11), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([125u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2.clone()));
+            assert!(state.verified(View::new(2)));
+            assert!(state.construct_notarize(View::new(2)).is_some());
+            let notarization_v2 = build_notarization(&verifier, &schemes, &proposal_v2);
+            assert!(state.add_notarization(notarization_v2).0);
+
+            // A certified child alone does not authorize a finalize vote.
+            assert!(state.certified(View::new(2), true).is_some());
+            assert!(
+                state.construct_finalize(View::new(2)).is_none(),
+                "finalize must wait for the parent's explicit certification"
+            );
+
+            // Certifying the parent releases the gate.
+            assert!(state.certified(View::new(1), true).is_some());
+            assert!(state.construct_finalize(View::new(2)).is_some());
+        });
+    }
+
+    #[test]
+    fn failed_certification_still_nullifies_current_view() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                13,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            let proposal = Proposal::new(
+                Rnd::new(Epoch::new(13), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([115u8; 32]),
+            );
+            let notarization = build_notarization(&verifier, &schemes, &proposal);
+
+            assert!(state.add_notarization(notarization).0);
+            assert_eq!(state.current_view(), View::new(1));
+
+            assert!(state.certified(View::new(1), false).is_some());
+
+            let (is_retry, nullify) = state
+                .construct_nullify(View::new(1), TimeoutReason::FailedCertification)
+                .expect("failed certification should still nullify the current view");
+            assert!(!is_retry);
+            assert_eq!(nullify.view(), View::new(1));
+            let (is_retry, nullify) = state
+                .construct_nullify(View::new(1), TimeoutReason::Retry)
+                .expect("failed certification nullify should allow retry");
+            assert!(is_retry);
+            assert_eq!(nullify.view(), View::new(1));
+        });
+    }
+
+    #[test]
     fn nullification_sets_entry_certificate() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
@@ -2630,6 +4320,7 @@ mod tests {
                         &verifier,
                         TermLength::new(NZU32!(5)),
                         Duration::from_secs(4),
+                        ViewDelta::new(2),
                     ),
                     epoch,
                     view_retention: ViewDelta::new(20),
@@ -2648,7 +4339,7 @@ mod tests {
             );
             let notarization = build_notarization(&verifier, &schemes, &notarization_proposal);
             state.add_notarization(notarization);
-            assert!(state.enter_view(View::new(3)));
+            assert!(state.leader_index(View::new(3)).is_some());
 
             // Inject a proposal at view 3 whose parent is view 1. Both are
             // in the same term (views 1-5), so this is an intra-term skip.
@@ -2662,9 +4353,15 @@ mod tests {
             let initial_deadline = state.next_timeout();
             assert!(initial_deadline.0 > context.current());
 
-            // Permanent ancestry error should immediately expire the timeout.
+            // Permanent ancestry error in a non-current view should not emit
+            // a nullify vote for that non-current view.
             assert!(state.try_verify().is_none());
-            assert!(state.next_timeout().0 <= context.current());
+            assert!(
+                state
+                    .construct_nullify(View::new(3), TimeoutReason::LeaderTimeout)
+                    .is_none()
+            );
+            assert_eq!(state.next_timeout(), initial_deadline);
         });
     }
 
@@ -3010,6 +4707,212 @@ mod tests {
     }
 
     #[test]
+    fn replay_restores_indirect_notarization_state() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let namespace = b"ns".to_vec();
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, &namespace, 4);
+            let local_scheme = schemes[1].clone();
+            let ancestor = Proposal::new(
+                Rnd::new(Epoch::new(12), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([121u8; 32]),
+            );
+            let descendant = Proposal::new(
+                Rnd::new(Epoch::new(12), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([122u8; 32]),
+            );
+
+            let mut state = State::new(
+                context.child("initial"),
+                Config {
+                    scheme: local_scheme.clone(),
+                    elector: round_robin_with_term(
+                        &local_scheme,
+                        TermLength::new(NZU32!(5)),
+                        Duration::from_secs(4),
+                        ViewDelta::new(2),
+                    ),
+                    epoch: Epoch::new(12),
+                    view_retention: ViewDelta::new(10),
+                    leader_timeout: Duration::from_secs(1),
+                    certification_timeout: Duration::from_secs(2),
+                    timeout_retry: Duration::from_secs(3),
+                },
+            );
+            state.set_genesis(test_genesis());
+            state.create_round(View::new(1));
+            assert!(state.proposed(ancestor));
+            let local_vote = state
+                .construct_notarize(View::new(1))
+                .expect("local notarize vote");
+            assert!(state.set_proposal(View::new(2), descendant.clone()));
+            assert!(state.verified(View::new(2)));
+            let notarization = build_notarization(&verifier, &schemes, &descendant);
+            assert!(state.add_notarization(notarization.clone()).0);
+            assert_eq!(
+                state.optimistic_ancestry_payload(View::new(1)).copied(),
+                Some(Sha256Digest::from([121u8; 32]))
+            );
+
+            let mut restarted = State::new(
+                context.child("restarted"),
+                Config {
+                    scheme: local_scheme.clone(),
+                    elector: round_robin_with_term(
+                        &local_scheme,
+                        TermLength::new(NZU32!(5)),
+                        Duration::from_secs(4),
+                        ViewDelta::new(2),
+                    ),
+                    epoch: Epoch::new(12),
+                    view_retention: ViewDelta::new(10),
+                    leader_timeout: Duration::from_secs(1),
+                    certification_timeout: Duration::from_secs(2),
+                    timeout_retry: Duration::from_secs(3),
+                },
+            );
+            restarted.set_genesis(test_genesis());
+            restarted.replay(&Artifact::Notarize(local_vote));
+            assert!(restarted.set_proposal(View::new(2), descendant));
+            assert!(restarted.verified(View::new(2)));
+            restarted.add_notarization(notarization.clone());
+            restarted.replay(&Artifact::Notarization(notarization));
+
+            assert_eq!(
+                restarted.optimistic_ancestry_payload(View::new(1)).copied(),
+                Some(Sha256Digest::from([121u8; 32]))
+            );
+        });
+    }
+
+    #[test]
+    fn trigger_timeout_latches_optimistic_future_view() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (fixture, mut state) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                14,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+            let Fixture {
+                schemes, verifier, ..
+            } = fixture;
+
+            let parent = propose_and_notarize_view1(&mut state, 116);
+
+            let future = Proposal::new(
+                Rnd::new(Epoch::new(14), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([117u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), future));
+            assert_eq!(state.current_view(), View::new(1));
+
+            // A verification failure for the optimistic future view latches on
+            // its round without disturbing the current view's schedule or
+            // nullifying the future view early.
+            let initial_deadline = state.next_timeout();
+            let latched_at = context.current();
+            state.trigger_timeout(View::new(2), TimeoutReason::InvalidProposal);
+            assert!(
+                state
+                    .construct_nullify(View::new(2), TimeoutReason::InvalidProposal)
+                    .is_none()
+            );
+            assert_eq!(state.next_timeout(), initial_deadline);
+
+            // Once the view becomes current, the latch fires immediately: the
+            // buffered invalid proposal suppresses the leader timeout and its
+            // verification request was consumed, so without the latch the view
+            // would stall until certification timeout.
+            let notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(1), true).is_some());
+            assert_eq!(state.current_view(), View::new(2));
+            assert_eq!(
+                state.next_timeout(),
+                (latched_at, TimeoutReason::InvalidProposal)
+            );
+            assert!(
+                state
+                    .construct_nullify(View::new(2), TimeoutReason::InvalidProposal)
+                    .is_some()
+            );
+        });
+    }
+
+    /// A structurally invalid proposal for an optimistic future view must
+    /// latch when we first look at it, not when the view becomes current.
+    ///
+    /// The buffered proposal suppresses the leader timeout and the round's
+    /// verification request is consumed either way, so deferring the latch
+    /// would stall the view until certification timeout.
+    #[test]
+    fn try_verify_latches_invalid_optimistic_future_proposal() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                15,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            // The leader's view 1 proposal stamps the stable leader on view 2,
+            // making it an optimistic future view we will look at.
+            let parent = Proposal::new(
+                Rnd::new(Epoch::new(15), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([150u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(1), parent.clone()));
+            assert!(state.try_verify().is_some());
+
+            // View 2 skips view 1, which no future certificate can repair.
+            let invalid = Proposal::new(
+                Rnd::new(Epoch::new(15), View::new(2)),
+                GENESIS_VIEW,
+                Sha256Digest::from([151u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), invalid));
+            assert_eq!(state.current_view(), View::new(1));
+
+            let initial_deadline = state.next_timeout();
+            let latched_at = context.current();
+            assert!(state.try_verify().is_none());
+
+            // Latching a future view leaves the current view's schedule alone.
+            assert_eq!(state.next_timeout(), initial_deadline);
+
+            // Entering view 2 finds the latch already armed.
+            let notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(1), true).is_some());
+            assert_eq!(state.current_view(), View::new(2));
+            assert_eq!(
+                state.next_timeout(),
+                (latched_at, TimeoutReason::InvalidProposal)
+            );
+        });
+    }
+
+    #[test]
     fn certification_lifecycle() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
@@ -3257,7 +5160,7 @@ mod tests {
 
             // Late certification completion is still accepted until the view is finalized.
             assert!(state.certified(view, true).is_some());
-            assert!(state.is_certified(view).is_some());
+            assert!(state.explicit_ancestry_payload(view).is_some());
         });
     }
 
@@ -3503,6 +5406,7 @@ mod tests {
                         &schemes[2],
                         TermLength::new(NZU32!(5)),
                         Duration::from_secs(4),
+                        ViewDelta::new(0),
                     ),
                     epoch: Epoch::new(1),
                     view_retention: ViewDelta::new(10),
@@ -3552,6 +5456,7 @@ mod tests {
                         &schemes[3],
                         TermLength::new(NZU32!(5)),
                         Duration::from_secs(4),
+                        ViewDelta::new(0),
                     ),
                     epoch: Epoch::new(1),
                     view_retention: ViewDelta::new(20),
@@ -3717,6 +5622,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(5)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),
@@ -3756,6 +5662,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),
@@ -3845,6 +5752,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(5)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),
@@ -3924,6 +5832,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(5)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),
@@ -3970,7 +5879,113 @@ mod tests {
     }
 
     #[test]
-    fn replay_restores_nullify_views_for_term_safety() {
+    fn recovered_parent_finalization_allows_same_term_child_finalize() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                1,
+                20,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(0),
+            );
+            assert!(state.enter_view(View::new(2)));
+
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(1), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([44u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2.clone()));
+
+            let notarization = build_notarization(&verifier, &schemes, &proposal_v2);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(2), true).is_some());
+
+            assert!(state.construct_finalize(View::new(2)).is_none());
+
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(1), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([45u8; 32]),
+            );
+            let finalization_v1 = build_finalization(&verifier, &schemes, &proposal_v1);
+            state.add_finalization(finalization_v1);
+
+            assert!(state.construct_finalize(View::new(2)).is_some());
+        });
+    }
+
+    #[test]
+    fn replayed_certification_withholds_finalize_until_parent_anchor() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                0,
+                1,
+                20,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(0),
+            );
+
+            // View 1 notarizes, but its certification artifact did not
+            // survive the crash (per-view journal sections sync
+            // independently).
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(1), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([50u8; 32]),
+            );
+            let notarization_v1 = build_notarization(&verifier, &schemes, &proposal_v1);
+            assert!(state.add_notarization(notarization_v1).0);
+
+            // View 2 notarizes and its certification replays, restoring the
+            // certified round without re-running the certification parent
+            // precheck.
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(1), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([51u8; 32]),
+            );
+            assert!(state.set_proposal(View::new(2), proposal_v2.clone()));
+            let notarization_v2 = build_notarization(&verifier, &schemes, &proposal_v2);
+            assert!(state.add_notarization(notarization_v2).0);
+            state.replay(&Artifact::Certification(
+                Rnd::new(Epoch::new(1), View::new(2)),
+                true,
+            ));
+
+            assert!(
+                state.construct_finalize(View::new(2)).is_none(),
+                "finalize must wait for the parent's explicit certification anchor"
+            );
+
+            // Re-certifying the parent (as the actor does after replay while
+            // its notarization is still present) restores the anchor.
+            assert!(state.certified(View::new(1), true).is_some());
+            assert!(
+                state.construct_finalize(View::new(2)).is_some(),
+                "finalize should proceed once the parent is explicitly certified"
+            );
+        });
+    }
+
+    #[test]
+    fn replay_restores_term_nullify_tracking_for_term_safety() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let namespace = b"ns".to_vec();
@@ -3983,6 +5998,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(5)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),
@@ -3991,8 +6007,22 @@ mod tests {
                 timeout_retry: Duration::from_secs(3),
             };
 
-            // Helper that prepares a certified notarization at view 2.
-            let build_certified_view_2 = |state: &mut State<_, _, _, _>| {
+            // Helper that prepares a locally finalized parent at view 1 and a
+            // certified child at view 2 within the same term.
+            let build_finalizable_view_2 = |state: &mut State<_, _, _, _>| {
+                let proposal_v1 = Proposal::new(
+                    Rnd::new(Epoch::new(1), View::new(1)),
+                    GENESIS_VIEW,
+                    Sha256Digest::from([98u8; 32]),
+                );
+                assert!(state.set_proposal(View::new(1), proposal_v1.clone()));
+                assert!(state.try_verify().is_some());
+                assert!(state.verified(View::new(1)));
+                let notarization_v1 = build_notarization(&verifier, &schemes, &proposal_v1);
+                assert!(state.add_notarization(notarization_v1).0);
+                assert!(state.certified(View::new(1), true).is_some());
+                assert!(state.construct_finalize(View::new(1)).is_some());
+
                 let proposal = Proposal::new(
                     Rnd::new(Epoch::new(1), View::new(2)),
                     View::new(1),
@@ -4008,13 +6038,14 @@ mod tests {
             // Baseline: without replayed nullify, finalization is allowed at view 2.
             let mut baseline = State::new(context.child("baseline"), cfg);
             baseline.set_genesis(test_genesis());
-            build_certified_view_2(&mut baseline);
+            build_finalizable_view_2(&mut baseline);
             assert!(
                 baseline.construct_finalize(View::new(2)).is_some(),
                 "finalize should be allowed without prior nullify"
             );
 
-            // Restarted state: replay local nullify at view 1, then same certified view 2.
+            // Restarted state: replay local nullify at view 1, then restore the
+            // same certified suffix via replay/local certification artifacts.
             let mut restarted = State::new(
                 context.child("restarted"),
                 Config {
@@ -4023,6 +6054,7 @@ mod tests {
                         &schemes[0],
                         TermLength::new(NZU32!(5)),
                         Duration::from_secs(4),
+                        ViewDelta::new(0),
                     ),
                     epoch: Epoch::new(1),
                     view_retention: ViewDelta::new(20),
@@ -4036,7 +6068,28 @@ mod tests {
                 Nullify::sign::<Sha256Digest>(&schemes[0], Rnd::new(Epoch::new(1), View::new(1)))
                     .expect("nullify");
             restarted.replay(&Artifact::Nullify(nullify));
-            build_certified_view_2(&mut restarted);
+
+            let proposal_v1 = Proposal::new(
+                Rnd::new(Epoch::new(1), View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([98u8; 32]),
+            );
+            let local_notarize_v1 =
+                Notarize::sign(&schemes[0], proposal_v1.clone()).expect("local notarize");
+            restarted.replay(&Artifact::Notarize(local_notarize_v1));
+            let notarization_v1 = build_notarization(&verifier, &schemes, &proposal_v1);
+            assert!(restarted.add_notarization(notarization_v1).0);
+            assert!(restarted.certified(View::new(1), true).is_some());
+
+            let proposal_v2 = Proposal::new(
+                Rnd::new(Epoch::new(1), View::new(2)),
+                View::new(1),
+                Sha256Digest::from([99u8; 32]),
+            );
+            assert!(restarted.set_proposal(View::new(2), proposal_v2.clone()));
+            let notarization_v2 = build_notarization(&verifier, &schemes, &proposal_v2);
+            assert!(restarted.add_notarization(notarization_v2).0);
+            assert!(restarted.certified(View::new(2), true).is_some());
 
             assert!(
                 restarted.construct_finalize(View::new(2)).is_none(),
@@ -4059,6 +6112,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(20)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(2),
@@ -4127,6 +6181,7 @@ mod tests {
                         &schemes[0],
                         TermLength::new(NZU32!(20)),
                         Duration::from_secs(4),
+                        ViewDelta::new(0),
                     ),
                     epoch: Epoch::new(1),
                     view_retention: ViewDelta::new(2),
@@ -4163,6 +6218,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),
@@ -4223,6 +6279,7 @@ mod tests {
                     &schemes[0],
                     TermLength::new(NZU32!(3)),
                     Duration::from_secs(4),
+                    ViewDelta::new(0),
                 ),
                 epoch: Epoch::new(1),
                 view_retention: ViewDelta::new(20),

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -13,24 +13,27 @@ use commonware_runtime::buffer::paged::CacheRef;
 use rand_core::CryptoRng;
 use std::{num::NonZeroUsize, time::Duration};
 
-/// Controls whether and how the engine proactively forwards certified blocks
-/// when entering the next view.
+/// Controls whether and how the engine proactively forwards blocks when
+/// entering the next view.
 ///
-/// Forwarding is a best-effort liveness aid: when enabled, the batcher
-/// broadcasts only after we locally certify a proposal and enter the next
-/// view, avoiding sends for proposals that never pass certification.
+/// Forwarding is a best-effort liveness aid. When enabled, the batcher
+/// broadcasts on entering the next view for a proposal that is finalized, or
+/// notarized without a failed certification, avoiding sends for proposals
+/// certification has already rejected. Targets come from votes observed
+/// locally, so a certificate signer whose vote never reached us is still one.
 #[derive(Debug, Clone, Copy)]
 pub enum ForwardingPolicy {
-    /// Do nothing when a certified proposal becomes eligible for forwarding.
+    /// Do nothing when a proposal becomes eligible for forwarding.
     Disabled,
-    /// Forward the block to all participants that did not vote for the proposal.
+    /// Forward the block to all participants whose matching vote was not
+    /// observed locally.
     ///
     /// To only send to the leader of the newly entered view, see [ForwardingPolicy::SilentLeader].
     SilentVoters,
-    /// Forward the block to the leader of the newly entered view if they did not
-    /// vote for the proposal.
+    /// Forward the block to the leader of the newly entered view if the
+    /// leader's matching vote was not observed locally.
     ///
-    /// To forward to all participants that did not vote for the proposal, see [ForwardingPolicy::SilentVoters].
+    /// To forward to all such participants, see [ForwardingPolicy::SilentVoters].
     SilentLeader,
 }
 
@@ -195,8 +198,7 @@ where
     /// Number of concurrent requests to make at once.
     pub fetch_concurrent: NonZeroUsize,
 
-    /// Policy for proactively forwarding certified blocks when entering the
-    /// next view.
+    /// Policy for proactively forwarding blocks when entering the next view.
     pub forwarding: ForwardingPolicy,
 }
 

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -26,7 +26,7 @@
 
 use crate::{
     simplex::scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
-    types::{Participant, Round, TermLength, View},
+    types::{Participant, Round, TermLength, View, ViewDelta},
 };
 use commonware_codec::Encode;
 use commonware_cryptography::{
@@ -68,6 +68,8 @@ pub struct Terms {
     length: TermLength,
     /// Term-abandonment timeout (set if and only if `length` exceeds one).
     stall_timeout: Option<Duration>,
+    /// Optimistic intra-term lookahead (zero unless `length` exceeds one).
+    optimistic_views: ViewDelta,
 }
 
 impl Terms {
@@ -77,6 +79,7 @@ impl Terms {
         Self {
             length: TermLength::ONE,
             stall_timeout: None,
+            optimistic_views: ViewDelta::zero(),
         }
     }
 
@@ -98,12 +101,26 @@ impl Terms {
     /// rotation bounds such a stall to one view. With longer terms, this
     /// timeout bounds it instead.
     ///
+    /// `optimistic_views` is how far a participant may optimistically run
+    /// ahead of certified ancestry within a term; zero disables optimistic
+    /// validation entirely, and values wider than `length` are accepted but
+    /// capped by the windows themselves. See [Optimistic Validation] for what
+    /// it governs. Like the stall timeout, this is local policy: mismatched
+    /// values across participants only degrade the optimization, never
+    /// safety.
+    ///
+    /// [Optimistic Validation]: crate::simplex#optimistic-validation
+    ///
     /// # Panics
     ///
     /// Panics if `length` is 1 or if `stall_timeout` is zero. Single-view
     /// terms are [`Terms::rotating`] (the default), where per-view timeouts
-    /// already bound a stall.
-    pub const fn stable(length: TermLength, stall_timeout: Duration) -> Self {
+    /// already bound a stall and no optimistic window exists.
+    pub const fn stable(
+        length: TermLength,
+        stall_timeout: Duration,
+        optimistic_views: ViewDelta,
+    ) -> Self {
         assert!(
             length.get() > 1,
             "stable leaders require a term length greater than 1"
@@ -115,6 +132,7 @@ impl Terms {
         Self {
             length,
             stall_timeout: Some(stall_timeout),
+            optimistic_views,
         }
     }
 
@@ -136,6 +154,13 @@ impl Terms {
     /// Returns `Some` if and only if [`Self::length`] is greater than one.
     pub const fn stall_timeout(&self) -> Option<Duration> {
         self.stall_timeout
+    }
+
+    /// Returns the optimistic intra-term lookahead (see [`Terms::stable`]).
+    ///
+    /// Always zero when [`Self::length`] is one.
+    pub const fn optimistic_views(&self) -> ViewDelta {
+        self.optimistic_views
     }
 }
 
@@ -181,7 +206,11 @@ pub trait Elector<S: Scheme>: Clone + Send + 'static {
     /// Implementations **must** return the same leader for every view within a
     /// stable-leader term (as defined by [`Self::terms`]): nullification
     /// coverage, finalize gating, and leader-inactivity tracking all assume the
-    /// leader is constant for the remainder of a term.
+    /// leader is constant for the remainder of a term. This contract is
+    /// panic-backed: with optimistic views enabled, future in-term rounds are
+    /// stamped with the current term leader, and an elector that later returns
+    /// a different leader for such a round panics in the batcher verifier's
+    /// `set_leader` when the two assignments meet.
     ///
     /// The `certificate` is expected to be `None` only for view 1.
     ///
@@ -227,18 +256,25 @@ impl<H: Hasher> RoundRobin<H> {
     }
 
     /// Enables stable leaders: `term_length` consecutive views share a leader,
-    /// and a term abandoned after `stall_timeout` evicts them (see
+    /// a term abandoned after `stall_timeout` evicts them, and participants
+    /// may run up to `optimistic_views` ahead within a term (see
     /// [`Terms::stable`]).
     ///
     /// The term length is consensus-critical: every participant must configure
-    /// the same value (see [`TermLength`]). The timeout is local policy.
+    /// the same value (see [`TermLength`]). The timeout and lookahead are
+    /// local policy.
     ///
     /// # Panics
     ///
     /// Panics if `term_length` is 1 or `stall_timeout` is zero (see
     /// [`Terms::stable`]).
-    pub const fn with_term(mut self, term_length: TermLength, stall_timeout: Duration) -> Self {
-        self.terms = Terms::stable(term_length, stall_timeout);
+    pub const fn with_term(
+        mut self,
+        term_length: TermLength,
+        stall_timeout: Duration,
+        optimistic_views: ViewDelta,
+    ) -> Self {
+        self.terms = Terms::stable(term_length, stall_timeout, optimistic_views);
         self
     }
 }
@@ -403,6 +439,20 @@ mod tests {
         bls12381_threshold_vrf::Scheme<commonware_cryptography::ed25519::PublicKey, MinPk>;
 
     #[test]
+    fn stable_terms_preserve_optimistic_views() {
+        let stall = Duration::from_secs(1);
+        let length = TermLength::new(NZU32!(5));
+
+        // The configured lookahead is stored verbatim, including values wider
+        // than the term (bounded by the issuance window, not by config) and
+        // zero (optimistic validation disabled).
+        for requested in [0, 3, 4, 5, 6, u64::MAX] {
+            let terms = Terms::stable(length, stall, ViewDelta::new(requested));
+            assert_eq!(terms.optimistic_views(), ViewDelta::new(requested));
+        }
+    }
+
+    #[test]
     fn round_robin_rotates_through_participants() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
@@ -457,7 +507,11 @@ mod tests {
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
         let participants = Set::try_from_iter(participants).unwrap();
         let elector: RoundRobinElector<ed25519::Scheme> = RoundRobin::<Sha256>::default()
-            .with_term(TermLength::new(NZU32!(5)), Duration::from_secs(10))
+            .with_term(
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(10),
+                ViewDelta::new(0),
+            )
             .build(&participants);
 
         let round = Round::new(Epoch::new(u64::MAX - 1), View::new(6));
@@ -476,7 +530,11 @@ mod tests {
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
         let participants = Set::try_from_iter(participants).unwrap();
         let elector: RoundRobinElector<ed25519::Scheme> = RoundRobin::<Sha256>::default()
-            .with_term(TermLength::new(NZU32!(3)), Duration::from_secs(10))
+            .with_term(
+                TermLength::new(NZU32!(3)),
+                Duration::from_secs(10),
+                ViewDelta::new(0),
+            )
             .build(&participants);
         let epoch = Epoch::new(0);
 
@@ -500,7 +558,11 @@ mod tests {
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
         let participants = Set::try_from_iter(participants).unwrap();
         let elector: RoundRobinElector<ed25519::Scheme> = RoundRobin::<Sha256>::default()
-            .with_term(TermLength::new(NZU32!(3)), Duration::from_secs(10))
+            .with_term(
+                TermLength::new(NZU32!(3)),
+                Duration::from_secs(10),
+                ViewDelta::new(0),
+            )
             .build(&participants);
 
         let leader_epoch_0 = elector.elect(Round::new(Epoch::new(0), View::new(1)), None);

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -25,7 +25,7 @@
 //! the initialized [`Elector`] with the scheme participants before starting.
 
 use crate::{
-    simplex::scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
+    simplex::{Lookahead, scheme::bls12381_threshold::vrf as bls12381_threshold_vrf},
     types::{Participant, Round, TermLength, View, ViewDelta},
 };
 use commonware_codec::Encode;
@@ -161,6 +161,14 @@ impl Terms {
     /// Always zero when [`Self::length`] is one.
     pub const fn optimistic_views(&self) -> ViewDelta {
         self.optimistic_views
+    }
+
+    /// Returns the term geometry as a [`Lookahead`].
+    pub(crate) const fn lookahead(&self) -> Lookahead {
+        Lookahead {
+            term_length: self.length,
+            optimistic_views: self.optimistic_views,
+        }
     }
 }
 

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -1,4 +1,5 @@
 use super::{
+    Lookahead,
     actors::{batcher, resolver, voter},
     config::Config,
     elector::{self, Elector as _},
@@ -81,7 +82,10 @@ impl<
                 mailbox_size: cfg.mailbox_size,
                 view_retention: cfg.view_retention,
                 skip_timeout: cfg.skip_timeout,
-                term_length,
+                lookahead: Lookahead {
+                    term_length,
+                    optimistic_views: terms.optimistic_views(),
+                },
                 forwarding: cfg.forwarding,
                 floor: cfg.floor.view(),
             },

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -1,5 +1,4 @@
 use super::{
-    Lookahead,
     actors::{batcher, resolver, voter},
     config::Config,
     elector::{self, Elector as _},
@@ -82,10 +81,7 @@ impl<
                 mailbox_size: cfg.mailbox_size,
                 view_retention: cfg.view_retention,
                 skip_timeout: cfg.skip_timeout,
-                lookahead: Lookahead {
-                    term_length,
-                    optimistic_views: terms.optimistic_views(),
-                },
+                lookahead: terms.lookahead(),
                 forwarding: cfg.forwarding,
                 floor: cfg.floor.view(),
             },

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -1262,7 +1262,7 @@ mod tests {
             elector::{self, Elector as _, RoundRobin},
             scheme::ed25519,
         },
-        types::Epoch,
+        types::{Epoch, ViewDelta},
     };
     use commonware_cryptography::{Sha256, Signer, ed25519::PrivateKey};
     use commonware_utils::{NZU32, TestRng, ordered::Set, test_rng};
@@ -2275,14 +2275,22 @@ mod tests {
         let term_length = TermLength::new(NZU32!(3));
         let twins = <Elector<RoundRobin<Sha256>> as elector::Config<ed25519::Scheme>>::build(
             Elector::new(
-                RoundRobin::<Sha256>::default().with_term(term_length, Duration::from_secs(10)),
+                RoundRobin::<Sha256>::default().with_term(
+                    term_length,
+                    Duration::from_secs(10),
+                    ViewDelta::new(0),
+                ),
                 &scenario,
                 3,
             ),
             &participants,
         );
         let fallback = <RoundRobin<Sha256> as elector::Config<ed25519::Scheme>>::build(
-            RoundRobin::<Sha256>::default().with_term(term_length, Duration::from_secs(10)),
+            RoundRobin::<Sha256>::default().with_term(
+                term_length,
+                Duration::from_secs(10),
+                ViewDelta::new(0),
+            ),
             &participants,
         );
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -130,6 +130,10 @@
 //! * With stable leaders (`term_length > 1`), a prior same-term `nullify` vote blocks later `finalize` votes until
 //!   a covering finalization is observed; notarize votes are never withheld (see
 //!   [Same-Term Vote Safety](#same-term-vote-safety)).
+//! * With stable leaders, optionally verify proposals and broadcast `notarize` votes up to
+//!   `optimistic_views` views ahead of certified ancestry within a term (configured alongside the
+//!   term length, see [`elector::Terms::stable`]); certification and `finalize` votes always wait
+//!   for explicit parent certification (see [Optimistic Validation](#optimistic-validation)).
 //! * If an entered view remains unfinalized for the stall timeout (configured alongside the term
 //!   length, see [`elector::Terms`]) and we are still in the same term, we locally time out the
 //!   current view and vote `nullify`. In practice, this tracks the oldest unfinalized view we have
@@ -205,6 +209,35 @@
 //! participants withhold `finalize`). Such a view is either finalized transitively by the
 //! finalization of a descendant in a later term or skipped entirely by a covering nullification:
 //! the timeouts that blocked the gate also mean forced inclusion does not apply to it.
+//!
+//! ### Optimistic Validation
+//!
+//! With stable leaders, a leader can propose for view `v+1` as soon as its proposal for view `v`
+//! is notarized, but participants that wait for `v`'s certification before verifying the new
+//! proposal add a round of certification latency to every view. When a nonzero `optimistic_views`
+//! lookahead is configured (see [`elector::Terms::stable`]), a participant instead verifies a
+//! proposal and broadcasts its `notarize` vote before the parent is certified, if all of the
+//! following hold:
+//!
+//! * The proposal's view is in the same term as its parent (optimism never crosses a term
+//!   boundary; a term start always requires explicitly certified ancestry).
+//! * At most `optimistic_views` views lie between the proposal's view and the last *directly
+//!   notarized* view (a view with an observed notarization or finalization certificate; a view is
+//!   *indirectly notarized* when only a descendant's certificate implies it), bounding
+//!   how far local votes run ahead of certified ancestry. This is the *issuance* window.
+//! * There is local evidence for the immediate parent: our own broadcast `notarize` vote, an
+//!   observed notarization certificate (unless our own certification rejected it), or (once the
+//!   proposal's view is current) the parent's explicit certification.
+//!
+//! Certification requests and `finalize` votes never run ahead: both require the parent's
+//! explicit certification first. If an optimistic ancestor fails to notarize or certify, the
+//! usual timeout and nullification path skips it, and any optimistic votes above it are inert.
+//!
+//! Peers admit and buffer votes up to `optimistic_views` views beyond their own current
+//! view (the *admission* window), so optimistic votes are not dropped by participants that have
+//! not yet observed the sender's ancestry. The setting is local: mismatched values across
+//! participants only degrade the optimization (votes beyond a peer's window are dropped until it
+//! catches up), never safety.
 //!
 //! ### Optimistic Finality
 //!
@@ -440,6 +473,79 @@ cfg_if::cfg_if! {
         pub use engine::Engine;
         mod metrics;
 
+        /// The view geometry of a term: its length and `optimistic_views`, the
+        /// depth of the *admission* window (anchored at the current view, see
+        /// [`Self::in_admission_window`]) and the *issuance* window (anchored
+        /// at the last directly-notarized view, see [`Self::issuance_floor`]).
+        /// See the [module docs] for what each governs.
+        ///
+        /// The `current` argument must be a locally derived view, since it
+        /// feeds panicking arithmetic ([`View::term_end`]). Candidate arguments
+        /// (`pending`, `view`) feed only comparisons and non-panicking
+        /// arithmetic, so they may be adversarial.
+        ///
+        /// [module docs]: crate::simplex#optimistic-validation
+        #[derive(Clone, Copy)]
+        pub(crate) struct Lookahead {
+            /// Number of views in each leader term.
+            pub term_length: TermLength,
+            /// Depth of the admission and issuance windows; zero disables
+            /// optimistic validation.
+            pub optimistic_views: ViewDelta,
+        }
+
+        impl Lookahead {
+            /// Returns true when `pending` is inside the optimistic admission
+            /// window of `current`: a same-term future view at most
+            /// `optimistic_views` ahead.
+            pub fn in_admission_window(&self, current: View, pending: View) -> bool {
+                current < pending && pending <= self.admission_limit(current)
+            }
+
+            /// Returns whether `pending` is admissible relative to `current`
+            /// (extending [`View::admits`] with the optimistic admission
+            /// window).
+            ///
+            /// Views at or below `current` are always admitted. Admitted futures are:
+            /// - `current + 1`
+            /// - `next_term_start(current)`
+            /// - views in the optimistic admission window
+            pub fn admits(&self, current: View, pending: View) -> bool {
+                current.admits(pending, self.term_length)
+                    || self.in_admission_window(current, pending)
+            }
+
+            /// Returns the highest view in the admission window of `current`
+            /// (`current` itself when the window is empty).
+            pub fn admission_limit(&self, current: View) -> View {
+                current
+                    .term_end(self.term_length)
+                    .min(current.saturating_add(self.optimistic_views))
+            }
+
+            /// Returns the lowest view whose direct notarization can anchor
+            /// `view` inside the optimistic *issuance* window, or `None` when
+            /// `view` can never be issued optimistically, either because
+            /// optimism is disabled or because `view` starts a term and so
+            /// requires explicitly certified ancestry.
+            ///
+            /// An anchor below the floor fails the hop bound exactly like no
+            /// anchor at all, so a caller decides membership by asking whether
+            /// any directly-notarized view sits in `floor..view`. A floor of
+            /// genesis means the window is open until the first notarization
+            /// lands. Compare [`Self::in_admission_window`], which anchors at
+            /// the current view instead.
+            pub const fn issuance_floor(&self, view: View) -> Option<View> {
+                if self.optimistic_views.is_zero() || view.is_term_start(self.term_length) {
+                    return None;
+                }
+                Some(
+                    view.saturating_sub(self.optimistic_views)
+                        .saturating_sub(ViewDelta::new(1)),
+                )
+            }
+        }
+
         /// The window of views an actor tracks, bounded below by retention
         /// and above by admission policy.
         #[derive(Clone, Copy)]
@@ -450,8 +556,8 @@ cfg_if::cfg_if! {
             pub current: View,
             /// Views retained below `finalized` (for reporting and backfill).
             pub view_retention: ViewDelta,
-            /// Number of views in each leader term.
-            pub term_length: TermLength,
+            /// Term geometry bounding admitted future views.
+            pub lookahead: Lookahead,
         }
 
         impl Viewport {
@@ -468,20 +574,21 @@ cfg_if::cfg_if! {
                 !view.is_zero() && view.get() >= self.floor().get()
             }
 
-            /// Returns whether a vote at `view` is tracked: retained and no
-            /// further ahead than the next view or the first view of the next
-            /// term, bounding memory committed to unverified votes (see
+            /// Returns whether a vote at `pending` is tracked: retained and no
+            /// further ahead than the next view, the first view of the next
+            /// term, or a bounded same-term optimistic lookahead view,
+            /// bounding memory committed to unverified votes (see
             /// [`View::admits`]).
-            pub const fn admits_vote(&self, view: View) -> bool {
-                self.retains(view) && self.current.admits(view, self.term_length)
+            pub fn admits_vote(&self, pending: View) -> bool {
+                self.retains(pending) && self.lookahead.admits(self.current, pending)
             }
 
-            /// Returns whether a certificate at `view` is tracked: certificates
-            /// are self-certifying and may arrive from arbitrarily far ahead
-            /// (letting a lagging participant fast-forward), so only retention
-            /// bounds them.
-            pub const fn admits_certificate(&self, view: View) -> bool {
-                self.retains(view)
+            /// Returns whether a certificate at `pending` is tracked:
+            /// certificates are self-certifying and may arrive from arbitrarily
+            /// far ahead (letting a lagging participant fast-forward), so only
+            /// retention bounds them.
+            pub const fn admits_certificate(&self, pending: View) -> bool {
+                self.retains(pending)
             }
         }
 
@@ -654,6 +761,92 @@ mod tests {
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
+
+    /// Builds a [Lookahead] with a term length of 5.
+    fn test_lookahead(optimistic_views: u64) -> Lookahead {
+        Lookahead {
+            term_length: TermLength::new(NZU32!(5)),
+            optimistic_views: ViewDelta::new(optimistic_views),
+        }
+    }
+
+    #[test]
+    fn test_lookahead_admits() {
+        let current = View::new(6);
+
+        // Always allow immediate successor.
+        assert!(test_lookahead(0).admits(current, current.next()));
+
+        // Always allow next-term start.
+        let next_term_start = current.next_term_start(test_lookahead(0).term_length);
+        assert!(test_lookahead(0).admits(current, next_term_start));
+
+        // Bounded same-term optimistic lookahead.
+        assert!(test_lookahead(2).admits(current, View::new(8)));
+        assert!(!test_lookahead(2).admits(current, View::new(9)));
+
+        // Never allow arbitrarily far future when outside all accepted lanes.
+        assert!(!test_lookahead(10).admits(current, View::new(100)));
+    }
+
+    #[test]
+    fn test_optimistic_future_does_not_bleed_into_next_term() {
+        let lookahead = test_lookahead(100);
+        let current = View::new(9);
+        let next_term_start = current.next_term_start(lookahead.term_length);
+
+        // Large configuration still caps same-term optimism at term end (view 10).
+        assert!(lookahead.admits(current, View::new(10)));
+
+        // Next-term start is always accepted as a special transition.
+        assert!(lookahead.admits(current, next_term_start));
+
+        // But optimistic lookahead must not bleed into later views of the next term.
+        assert!(!lookahead.admits(current, next_term_start.next()));
+    }
+
+    #[test]
+    fn test_admission_limit() {
+        // Term of view 6 spans views 6..=10.
+        let current = View::new(6);
+
+        // No optimism: the window is empty and the limit is `current` itself.
+        assert_eq!(test_lookahead(0).admission_limit(current), current);
+
+        // Bounded by the optimistic lookahead when it fits within the term.
+        assert_eq!(test_lookahead(3).admission_limit(current), View::new(9));
+
+        // Clamped at term end when the lookahead would cross it.
+        assert_eq!(test_lookahead(100).admission_limit(current), View::new(10));
+
+        // At the last view of a term, the window is always empty.
+        assert_eq!(
+            test_lookahead(3).admission_limit(View::new(10)),
+            View::new(10)
+        );
+    }
+
+    #[test]
+    fn test_issuance_floor() {
+        // No optimism: nothing is issuable.
+        assert!(test_lookahead(0).issuance_floor(View::new(7)).is_none());
+
+        // Term starts are never issued optimistically (terms start at 1, 6, 11).
+        assert!(test_lookahead(100).issuance_floor(View::new(11)).is_none());
+
+        // The floor sits `optimistic_views + 1` views below: view 9 is anchored
+        // by a notarization at view 6, but not by one at view 5.
+        assert_eq!(
+            test_lookahead(2).issuance_floor(View::new(9)),
+            Some(View::new(6))
+        );
+
+        // Genesis floors the window until the first notarization lands.
+        assert_eq!(
+            test_lookahead(2).issuance_floor(View::new(2)),
+            Some(View::zero())
+        );
+    }
 
     /// Register a validator with the oracle.
     async fn register_validator(
@@ -859,9 +1052,13 @@ mod tests {
                     .await;
             let mut registrations = register_validators(&mut oracle, &participants).await;
 
-            // Link all validators
+            // Link all validators. The 200ms latency is deliberate: high
+            // enough (relative to the 2s/3s timeouts below) that stable-leader
+            // variants only stay nullification-free by pipelining views
+            // optimistically, while still leaving the non-optimistic variants
+            // comfortable margin.
             let link = Link {
-                latency: Duration::from_millis(10),
+                latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(1),
                 success_rate: 1.0,
             };
@@ -915,8 +1112,8 @@ mod tests {
                     floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(
                         Epoch::new(333),
                     )),
-                    leader_timeout: Duration::from_secs(1),
-                    certification_timeout: Duration::from_secs(2),
+                    leader_timeout: Duration::from_secs(2),
+                    certification_timeout: Duration::from_secs(3),
                     timeout_retry: Duration::from_secs(10),
                     fetch_timeout: Duration::from_secs(1),
                     view_retention,
@@ -1335,7 +1532,11 @@ mod tests {
     #[test_traced]
     fn test_non_genesis_floor_joiner_catches_tip_stable_leader() {
         non_genesis_floor_joiner_catches_tip_with_term::<_, _, RoundRobin>(
-            RoundRobin::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(12)),
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(3)),
+                Duration::from_secs(12),
+                ViewDelta::new(0),
+            ),
             scheme_mocks::fixture,
         );
     }
@@ -1494,6 +1695,296 @@ mod tests {
         dishonest_leader_certification_rejected::<_, _>(secp256r1::fixture);
     }
 
+    /// Reporter used by the stable-leader end-to-end tests.
+    type StableLeaderReporter = mocks::reporter::Reporter<
+        deterministic::Context,
+        ed25519::Scheme,
+        RoundRobin<Sha256>,
+        Sha256Digest,
+    >;
+
+    /// Spins up the fully-linked five-validator ed25519 cluster shared by the
+    /// stable-leader end-to-end tests, parameterized by the knobs that differ
+    /// between them. Returns the per-validator reporters, the index of the
+    /// leader elected for view 1 (stable for the whole term), and the network
+    /// oracle.
+    ///
+    /// The 1.5s leader / 3.5s certification timeouts are load-bearing
+    /// relative to the callers' link latencies: with latency near or above
+    /// half the leader timeout, a view that waits for its parent's
+    /// certification (two or more network trips) times out, so runs stay
+    /// nullification-free only when views pipeline optimistically.
+    async fn setup_stable_leader_cluster(
+        context: &mut deterministic::Context,
+        namespace: &[u8],
+        link: Link,
+        term_length: TermLength,
+        optimistic_views: ViewDelta,
+        propose_latency: (f64, f64),
+        stall_timeout: Duration,
+    ) -> (
+        Vec<StableLeaderReporter>,
+        usize,
+        Oracle<PublicKey, deterministic::Context>,
+    ) {
+        let epoch = Epoch::new(333);
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(context, namespace, 5);
+        let mut oracle =
+            start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                .await;
+        let mut registrations = register_validators(&mut oracle, &participants).await;
+        link_validators(&mut oracle, &participants, Action::Link(link), None).await;
+
+        let elector =
+            RoundRobin::<Sha256>::default().with_term(term_length, stall_timeout, optimistic_views);
+        let relay = Arc::new(mocks::relay::Relay::new());
+        let mut reporters = Vec::new();
+
+        for (idx, validator) in participants.iter().enumerate() {
+            let context = context
+                .child("validator")
+                .with_attribute("public_key", validator);
+            let reporter_config = mocks::reporter::Config {
+                participants: participants.clone().try_into().unwrap(),
+                scheme: schemes[idx].clone(),
+                elector: elector.clone(),
+            };
+            let reporter =
+                mocks::reporter::Reporter::new(context.child("reporter"), reporter_config);
+            reporters.push(reporter.clone());
+
+            let application_cfg = mocks::application::Config::<Sha256, _> {
+                relay: relay.clone(),
+                me: validator.clone(),
+                propose_latency,
+                verify_latency: (1.0, 0.0),
+                certify_latency: (1.0, 0.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (actor, application) =
+                mocks::application::Application::new(context.child("application"), application_cfg);
+            actor.start();
+
+            let blocker = oracle.control(validator.clone());
+            let cfg = config::Config {
+                scheme: schemes[idx].clone(),
+                elector: elector.clone(),
+                blocker,
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter: reporter.clone(),
+                strategy: Sequential,
+                partition: validator.to_string(),
+                mailbox_size: NZUsize!(1024),
+                epoch,
+                floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
+                leader_timeout: Duration::from_millis(1_500),
+                certification_timeout: Duration::from_millis(3_500),
+                timeout_retry: Duration::from_secs(10),
+                fetch_timeout: Duration::from_secs(1),
+                view_retention: ViewDelta::new(10),
+                skip_timeout: Duration::from_secs(12),
+                fetch_concurrent: NZUsize!(4),
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                forwarding: ForwardingPolicy::Disabled,
+            };
+            let engine = Engine::new(context.child("engine"), cfg);
+            let (pending, recovered, resolver) = registrations
+                .remove(validator)
+                .expect("validator should be registered");
+            engine.start(pending, recovered, resolver);
+        }
+
+        let participants_set = participants.clone().try_into().unwrap();
+        let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+            elector.build(&participants_set);
+        let leader_idx = usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
+
+        (reporters, leader_idx, oracle)
+    }
+
+    #[test_traced]
+    fn test_stable_leader_optimistic_blocks_faster_than_network_latency() {
+        let required_containers = View::new(100);
+        let link_latency = Duration::from_millis(100);
+        let executor = deterministic::Runner::timed(Duration::from_secs(30));
+        executor.start(|mut context| async move {
+            let (reporters, leader_idx, _oracle) = setup_stable_leader_cluster(
+                &mut context,
+                b"consensus_stable_leader_high_latency",
+                Link {
+                    latency: link_latency,
+                    jitter: Duration::from_millis(0),
+                    success_rate: 1.0,
+                },
+                TermLength::new(NZU32!(128)),
+                ViewDelta::new(128),
+                /* propose_latency */ (10.0, 0.0),
+                /* stall_timeout */ Duration::from_secs(20),
+            )
+            .await;
+
+            let leader_reporter = reporters[leader_idx].clone();
+            let start = context.current();
+            while !leader_reporter
+                .notarizes
+                .lock()
+                .contains_key(&required_containers)
+            {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            let elapsed = context.current().duration_since(start).unwrap_or_default();
+            let average_block_time_s = elapsed.as_secs_f64() / required_containers.get() as f64;
+            let network_latency_s = link_latency.as_secs_f64();
+            assert!(
+                average_block_time_s < network_latency_s,
+                "expected average optimistic block time ({:.3}ms) to be below network latency ({:.3}ms); elapsed {:?} for {} views",
+                average_block_time_s * 1000.0,
+                network_latency_s * 1000.0,
+                elapsed,
+                required_containers
+            );
+
+            for reporter in reporters.iter() {
+                reporter.assert_no_invalid();
+            }
+        });
+    }
+
+    #[test_group("slow")]
+    #[test]
+    fn test_stable_leader_finalizes_full_term_without_nullification() {
+        let required_view = View::new(1000);
+        let executor = deterministic::Runner::timed(Duration::from_secs(40));
+        executor.start(|mut context| async move {
+            let (reporters, leader_idx, oracle) = setup_stable_leader_cluster(
+                &mut context,
+                b"consensus_stable_leader_full_term_no_nullify",
+                // 1s latency shrinks the 1.5s leader timeout below a
+                // certification round-trip: staying nullification-free (the
+                // assertion below) is only possible via optimistic pipelining.
+                Link {
+                    latency: Duration::from_millis(1_000),
+                    jitter: Duration::from_millis(1),
+                    success_rate: 1.0,
+                },
+                TermLength::new(NZU32!(1000)),
+                ViewDelta::new(100),
+                /* propose_latency */ (1.0, 0.0),
+                /* stall_timeout */ Duration::from_secs(6),
+            )
+            .await;
+
+            let start = context.current();
+            let deadline = start + Duration::from_secs(25);
+            while !reporters
+                .iter()
+                .all(|reporter| reporter.finalizations.lock().contains_key(&required_view))
+            {
+                if context.current() >= deadline {
+                    let progress = reporters
+                        .iter()
+                        .enumerate()
+                        .map(|(idx, reporter)| {
+                            let max_finalized = reporter
+                                .finalizations
+                                .lock()
+                                .keys()
+                                .copied()
+                                .max()
+                                .unwrap_or(View::zero());
+                            let max_notarized = reporter
+                                .notarizations
+                                .lock()
+                                .keys()
+                                .copied()
+                                .max()
+                                .unwrap_or(View::zero());
+                            let max_notarize_vote = reporter
+                                .notarizes
+                                .lock()
+                                .keys()
+                                .copied()
+                                .max()
+                                .unwrap_or(View::zero());
+                            let nullify_votes = reporter.nullifies.lock().len();
+                            let nullification_certs = reporter.nullifications.lock().len();
+                            format!(
+                                "r{idx}: finalized={max_finalized} notarize_vote={max_notarize_vote} notarized={max_notarized} nullify_votes={nullify_votes} nullifications={nullification_certs}"
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .join("; ");
+                    panic!(
+                        "expected all validators to finalize view {} before {:?}; progress: {}",
+                        required_view, deadline, progress
+                    );
+                }
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            let leader_reporter = &reporters[leader_idx];
+            assert!(
+                leader_reporter.notarizes.lock().contains_key(&required_view),
+                "stable leader must notarize through full term ending at view {}",
+                required_view
+            );
+            let leader_tip_notarization = leader_reporter
+                .notarizations
+                .lock()
+                .get(&required_view)
+                .cloned()
+                .expect("leader reporter missing tip notarization");
+            assert_eq!(
+                leader_tip_notarization.proposal.parent,
+                required_view.previous().unwrap_or(View::zero()),
+                "unexpected parent for leader tip notarization"
+            );
+
+            for (idx, reporter) in reporters.iter().enumerate() {
+                reporter.assert_no_invalid();
+                reporter.assert_no_faults();
+
+                assert!(
+                    reporter.nullifies.lock().is_empty(),
+                    "reporter {} observed unexpected nullify votes",
+                    idx
+                );
+                assert!(
+                    reporter.nullifications.lock().is_empty(),
+                    "reporter {} observed unexpected nullification certificates",
+                    idx
+                );
+
+                let finalization = reporter
+                    .finalizations
+                    .lock()
+                    .get(&required_view)
+                    .cloned()
+                    .unwrap_or_else(|| panic!("reporter {idx} missing tip finalization"));
+                assert_eq!(
+                    finalization.proposal.round.view(),
+                    required_view,
+                    "reporter {idx} has mismatched tip finalization round"
+                );
+                assert_eq!(
+                    finalization.proposal.parent,
+                    required_view.previous().unwrap_or(View::zero()),
+                    "reporter {idx} has non-chain tip finalization parent"
+                );
+            }
+
+            let blocked = oracle.blocked().await.unwrap();
+            assert!(blocked.is_empty());
+        });
+    }
+
     fn observer<S, F, L>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
@@ -1646,7 +2137,16 @@ mod tests {
 
     test_for_all_fixtures!(observer);
 
-    fn unclean_shutdown<S, F, L>(mut fixture: F)
+    fn unclean_shutdown<S, F, L>(fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
+        L: elector::Config<S>,
+    {
+        unclean_shutdown_with_term::<S, F, L>(L::default(), fixture);
+    }
+
+    fn unclean_shutdown_with_term<S, F, L>(elector: L, mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
@@ -1682,6 +2182,7 @@ mod tests {
             let shutdowns = shutdowns.clone();
             let supervised = supervised.clone();
             let relay = relay.clone();
+            let elector = elector.clone();
             relay.deregister_all(); // Clear all recipients from previous restart.
 
             let f = |mut context: deterministic::Context| async move {
@@ -1703,7 +2204,7 @@ mod tests {
                 link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
                 // Create engines
-                let elector = L::default();
+                let elector = elector.clone();
                 let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
                 let mut reporters = HashMap::new();
                 let mut engine_handlers = Vec::new();
@@ -1835,7 +2336,36 @@ mod tests {
 
     test_for_all_fixtures!(unclean_shutdown);
 
-    fn backfill<S, F, L>(mut fixture: F)
+    /// Regression test: with stable leaders and optimistic validation, a
+    /// whole-cluster crash can leave a mid-term view without any certificate
+    /// while a higher same-term notarization survives in some journals. Nodes
+    /// stuck below that view must be able to fetch the exact-view notarization
+    /// (a higher-view floor cannot substitute for certification's per-view
+    /// parent requirement) or the cluster wedges permanently (see
+    /// [`resolver::State::get`]).
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_unclean_shutdown_stable_leader_optimistic() {
+        unclean_shutdown_with_term::<_, _, RoundRobin>(
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(13),
+                ViewDelta::new(2),
+            ),
+            ed25519::fixture,
+        );
+    }
+
+    fn backfill<S, F, L>(fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+        L: elector::Config<S>,
+    {
+        backfill_with_term::<S, F, L>(L::default(), fixture);
+    }
+
+    fn backfill_with_term<S, F, L>(elector: L, mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
@@ -1875,7 +2405,7 @@ mod tests {
             .await;
 
             // Create engines
-            let elector = L::default();
+            let elector = elector.clone();
             let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
             let mut reporters = Vec::new();
             let mut engine_handlers = Vec::new();
@@ -2081,6 +2611,21 @@ mod tests {
     }
 
     test_for_all_fixtures!(backfill);
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_backfill_stable_leader_optimistic() {
+        backfill_with_term::<_, _, RoundRobin>(
+            // Keep the stall timeout long so the healthy prefix of the run
+            // (finalizing with one validator offline) never stall-nullifies.
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(51),
+                ViewDelta::new(2),
+            ),
+            ed25519::fixture,
+        );
+    }
 
     fn one_offline<S, F, L>(fixture: F)
     where
@@ -2321,7 +2866,11 @@ mod tests {
     #[test_traced]
     fn test_one_offline_stable_leader() {
         one_offline_with_term::<_, _, RoundRobin>(
-            RoundRobin::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(12)),
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(3)),
+                Duration::from_secs(12),
+                ViewDelta::new(0),
+            ),
             scheme_mocks::fixture,
         );
     }
@@ -2927,7 +3476,16 @@ mod tests {
 
     test_for_all_fixtures!(all_crash_after_nullify);
 
-    fn partition<S, F, L>(mut fixture: F)
+    fn partition<S, F, L>(fixture: F)
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+        L: elector::Config<S>,
+    {
+        partition_with_term::<S, F, L>(L::default(), fixture);
+    }
+
+    fn partition_with_term<S, F, L>(elector: L, mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
@@ -2961,7 +3519,7 @@ mod tests {
             link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
 
             // Create engines
-            let elector = L::default();
+            let elector = elector.clone();
             let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
             let mut reporters = Vec::new();
             let mut engine_handlers = Vec::new();
@@ -3104,6 +3662,19 @@ mod tests {
     }
 
     test_for_all_fixtures!(partition);
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_partition_stable_leader_optimistic() {
+        partition_with_term::<_, _, RoundRobin>(
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(13),
+                ViewDelta::new(2),
+            ),
+            ed25519::fixture,
+        );
+    }
 
     fn slow_and_lossy_links_seeded<S, F, L>(seed: u64, mut fixture: F) -> String
     where
@@ -4080,7 +4651,16 @@ mod tests {
 
     test_for_all_fixtures!(impersonator, seeds = 5);
 
-    fn equivocator_seeded<S, F, L>(seed: u64, mut fixture: F) -> bool
+    fn equivocator_seeded<S, F, L>(seed: u64, fixture: F) -> bool
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+        L: elector::Config<S>,
+    {
+        equivocator_seeded_with_term::<S, F, L>(seed, L::default(), fixture)
+    }
+
+    fn equivocator_seeded_with_term<S, F, L>(seed: u64, elector: L, mut fixture: F) -> bool
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
@@ -4117,7 +4697,7 @@ mod tests {
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
             // Create engines
-            let elector = L::default();
+            let elector = elector.clone();
             let mut engines = Vec::new();
             let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
             let mut reporters = Vec::new();
@@ -4328,6 +4908,26 @@ mod tests {
     }
 
     test_for_all_fixtures!(equivocator);
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_equivocator_stable_leader_optimistic() {
+        let detected = (0..5).any(|seed| {
+            equivocator_seeded_with_term::<_, _, RoundRobin>(
+                seed,
+                RoundRobin::default().with_term(
+                    TermLength::new(NZU32!(5)),
+                    Duration::from_secs(13),
+                    ViewDelta::new(2),
+                ),
+                ed25519::fixture,
+            )
+        });
+        assert!(
+            detected,
+            "expected at least one seed to detect equivocation"
+        );
+    }
 
     fn reconfigurer<S, F, L>(seed: u64, mut fixture: F)
     where
@@ -6093,16 +6693,22 @@ mod tests {
                 0,
                 10,
                 ViewDelta::new(15),
-                RoundRobin::default()
-                    .with_term(TermLength::new(NZU32!(3)), Duration::from_secs(12)),
+                RoundRobin::default().with_term(
+                    TermLength::new(NZU32!(3)),
+                    Duration::from_secs(12),
+                    ViewDelta::new(0)
+                ),
                 ed25519::fixture
             ),
             run_hailstorm::<_, _, RoundRobin>(
                 0,
                 10,
                 ViewDelta::new(15),
-                RoundRobin::default()
-                    .with_term(TermLength::new(NZU32!(3)), Duration::from_secs(12)),
+                RoundRobin::default().with_term(
+                    TermLength::new(NZU32!(3)),
+                    Duration::from_secs(12),
+                    ViewDelta::new(0)
+                ),
                 ed25519::fixture
             )
         );
@@ -6144,6 +6750,11 @@ mod tests {
     ///   considered successful. This is the liveness assertion -- it ensures
     ///   the protocol actually commits blocks under synchrony, not just
     ///   reaches a high view via nullifications.
+    ///
+    /// The term structure (length and optimistic lookahead) comes from the
+    /// elector passed to [twins_campaign]: multi-view terms exercise the
+    /// stable-leader finalize gate under equivocation, and a nonzero
+    /// lookahead exercises optimistic validation.
     #[derive(Clone, Copy, Debug)]
     struct TwinsCampaign {
         n: u32,
@@ -6641,7 +7252,24 @@ mod tests {
     fn test_twins_stable_leader() {
         twins_campaign_all_links(
             TWINS_CAMPAIGN,
-            RoundRobin::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(12)),
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(3)),
+                Duration::from_secs(12),
+                ViewDelta::new(0),
+            ),
+        );
+    }
+
+    #[test_group("slow")]
+    #[test_traced("INFO")]
+    fn test_twins_stable_leader_optimistic() {
+        twins_campaign_all_links(
+            TWINS_CAMPAIGN,
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(3)),
+                Duration::from_secs(12),
+                ViewDelta::new(2),
+            ),
         );
     }
 
@@ -6703,7 +7331,10 @@ mod tests {
             finalized: View::new(20),
             current: View::new(25),
             view_retention: ViewDelta::new(10),
-            term_length: TermLength::new(commonware_utils::NZU32!(10)),
+            lookahead: Lookahead {
+                term_length: TermLength::new(commonware_utils::NZU32!(10)),
+                optimistic_views: ViewDelta::new(0),
+            },
         };
 
         // Genesis is never tracked
@@ -6727,5 +7358,32 @@ mod tests {
         // respect the retention floor
         assert!(!viewport.admits_certificate(View::new(9)));
         assert!(viewport.admits_certificate(View::new(10_000)));
+
+        // With an optimistic window, votes are additionally admitted up to
+        // `optimistic_views` ahead within the current term
+        let optimistic = Viewport {
+            lookahead: Lookahead {
+                optimistic_views: ViewDelta::new(2),
+                ..viewport.lookahead
+            },
+            ..viewport
+        };
+        assert!(optimistic.admits_vote(View::new(26)));
+        assert!(optimistic.admits_vote(View::new(27)));
+        assert!(!optimistic.admits_vote(View::new(28)));
+        assert!(optimistic.admits_vote(View::new(31)));
+
+        // The window never crosses the term boundary (term [21, 30])
+        let term_edge = Viewport {
+            current: View::new(29),
+            lookahead: Lookahead {
+                optimistic_views: ViewDelta::new(5),
+                ..viewport.lookahead
+            },
+            ..viewport
+        };
+        assert!(term_edge.admits_vote(View::new(30)));
+        assert!(term_edge.admits_vote(View::new(31)));
+        assert!(!term_edge.admits_vote(View::new(32)));
     }
 }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -479,10 +479,9 @@ cfg_if::cfg_if! {
         /// at the last directly-notarized view, see [`Self::issuance_floor`]).
         /// See the [module docs] for what each governs.
         ///
-        /// The `current` argument must be a locally derived view, since it
-        /// feeds panicking arithmetic ([`View::term_end`]). Candidate arguments
-        /// (`pending`, `view`) feed only comparisons and non-panicking
-        /// arithmetic, so they may be adversarial.
+        /// `current` arguments must be locally derived views (they feed
+        /// panicking arithmetic in [`View::term_end`]); candidate arguments
+        /// (`pending`, `view`) may be adversarial.
         ///
         /// [module docs]: crate::simplex#optimistic-validation
         #[derive(Clone, Copy)]
@@ -1888,42 +1887,21 @@ mod tests {
                 .all(|reporter| reporter.finalizations.lock().contains_key(&required_view))
             {
                 if context.current() >= deadline {
-                    let progress = reporters
+                    let progress: Vec<_> = reporters
                         .iter()
-                        .enumerate()
-                        .map(|(idx, reporter)| {
-                            let max_finalized = reporter
+                        .map(|reporter| {
+                            let finalized = reporter
                                 .finalizations
                                 .lock()
                                 .keys()
                                 .copied()
                                 .max()
                                 .unwrap_or(View::zero());
-                            let max_notarized = reporter
-                                .notarizations
-                                .lock()
-                                .keys()
-                                .copied()
-                                .max()
-                                .unwrap_or(View::zero());
-                            let max_notarize_vote = reporter
-                                .notarizes
-                                .lock()
-                                .keys()
-                                .copied()
-                                .max()
-                                .unwrap_or(View::zero());
-                            let nullify_votes = reporter.nullifies.lock().len();
-                            let nullification_certs = reporter.nullifications.lock().len();
-                            format!(
-                                "r{idx}: finalized={max_finalized} notarize_vote={max_notarize_vote} notarized={max_notarized} nullify_votes={nullify_votes} nullifications={nullification_certs}"
-                            )
+                            (finalized, reporter.nullifications.lock().len())
                         })
-                        .collect::<Vec<_>>()
-                        .join("; ");
+                        .collect();
                     panic!(
-                        "expected all validators to finalize view {} before {:?}; progress: {}",
-                        required_view, deadline, progress
+                        "expected all validators to finalize view {required_view} before {deadline:?}; (max finalized, nullifications) per reporter: {progress:?}",
                     );
                 }
                 context.sleep(Duration::from_millis(10)).await;

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -530,6 +530,22 @@ impl<S: Scheme, D: Digest> Viewable for Certificate<S, D> {
     }
 }
 
+impl<S: Scheme, D: Digest> Certificate<S, D> {
+    /// Verifies this certificate against the provided signing scheme.
+    pub fn verify<R: CryptoRng>(&self, rng: &mut R, scheme: &S, strategy: &impl Strategy) -> bool
+    where
+        S: scheme::Scheme<D>,
+    {
+        match self {
+            Self::Notarization(notarization) => notarization.verify(rng, scheme, strategy),
+            Self::Nullification(nullification) => {
+                nullification.verify::<_, D>(rng, scheme, strategy)
+            }
+            Self::Finalization(finalization) => finalization.verify(rng, scheme, strategy),
+        }
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<S: Scheme, D: Digest> arbitrary::Arbitrary<'_> for Certificate<S, D>
 where


### PR DESCRIPTION
Closes #4353.

## Problem

The batcher actor awaits signature verification and certificate recovery inline in its event loop. On a loaded network this serializes ~2.2ms batch-verifies and ~0.55ms recoveries back-to-back per view (~92% actor occupancy at 335 batches/s), during which the actor cannot ingest votes, verify another vote kind, or construct a ready certificate. On `bc/optimistic-validation` this caps certification throughput, which pegs the optimistic issuance window and slaves block production in the back half of every term to notarization cadence.

## Change

Split `Certification::try_verify` into a sync `begin_verify` (takes the pending batch, marks the kind in-flight) and `finish_verify` (reintegrates results); same split for certificate recovery. The actor pushes the owned offload futures into a `commonware_utils::futures::Pool` drained by a new select branch, so crypto overlaps with message ingestion and with crypto for other views/kinds.

Notes:

- `finish_verify` re-filters notarizes/finalizes against the current leader proposal, since a certificate can displace the proposal while a batch is in flight — stale-proposal votes must not count toward a quorum.
- A completion for a view pruned mid-flight is dropped.
- The previous `try_verify`/`try_construct_certificate` entry points are kept as `#[cfg(test)]` shims implemented over begin/finish, so existing tests run unchanged.

## Results

A/B on an 11-validator global testnet (10 regions) (`TARGET_BLOCK_INTERVAL_MS = 5`, term length 1000, optimistic window 100), ~40k blocks per sample:

| | before | after |
|---|---|---|
| blocks/s | 175.5 | **192.4** |
| exactly-5ms intervals | 88.8% | **99.46%** |
| 6ms bucket | 8.1% | **0.23%** |
| term-boundary stall | ~500ms | **186ms** |
| mean excess per view | 0.49ms | **0.18ms** |

Exactly-5ms adherence is flat at 99.4–99.8% across all term-position deciles (previously degraded to 66–72% in the back half as the issuance window pegged).

The same inline-await structure exists in main's batcher (`actor.rs` `try_verify(...).await` / `try_construct_certificate(...).await`); there it costs view latency rather than throughput. Porting this to main is worthwhile follow-up, but main's batcher has diverged, so it would be a separate change.

