### PR TITLE
[consensus/simplex] Restore Finalizations

### DIFF
--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -507,7 +507,7 @@ where
                 }
 
                 // Store and forward to voter
-                let proposal_changed = work
+                let reprocess_votes = work
                     .entry(view)
                     .or_insert_with(|| self.new_round(view))
                     .record_certificate(&message);
@@ -515,7 +515,7 @@ where
 
                 // Reprocess buffered votes only if the notarization changed the
                 // round's proposal.
-                if !proposal_changed {
+                if !reprocess_votes {
                     // Otherwise, certificates are already forwarded to voter,
                     // no need for construction.
                     continue;
@@ -590,7 +590,8 @@ where
                     "updated view must be greater than zero"
                 );
 
-                // Forward leader's proposal to voter (if we're not the leader and haven't already)
+                // Forward the selected proposal to voter if we are not the
+                // leader and have not already forwarded it.
                 if let Some(round) = work.get_mut(&current.view)
                     && let Some(me) = self.scheme.me()
                     && let Some(proposal) = round.try_forward_proposal(me)

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -449,8 +449,8 @@ mod tests {
         );
     }
 
-    /// A finalization establishes a proposal that a later leader selection
-    /// cannot replace.
+    /// A finalization replaces a conflicting leader-selected proposal and
+    /// makes its proposal authoritative.
     #[test]
     fn test_finalization_establishes_proposal() {
         let mut rng = test_rng();
@@ -468,19 +468,20 @@ mod tests {
         );
 
         // The leader's notarize arrives before the leader is known.
-        let leader_proposal =
-            Proposal::new(round_id, View::zero(), Sha256::hash(&[b"leader"]));
+        let leader_proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"leader"]));
         let notarize = Notarize::sign(&schemes[0], leader_proposal).unwrap();
         assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
 
-        // The finalization establishes a conflicting authoritative proposal.
+        // Setting the leader selects its buffered proposal.
+        round.set_leader(Participant::from_usize(0));
+
+        // The finalization replaces the leader-selected proposal.
         let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"finalized"]));
         let finalization = build_finalization(&schemes, &proposal, quorum(5) as usize);
-        round.record_certificate(&Certificate::Finalization(finalization));
+        assert!(!round.record_certificate(&Certificate::Finalization(finalization)));
+        assert!(round.has_certificate(Kind::Finalization));
 
-        // Setting the leader cannot replace the finalization's proposal with
-        // its buffered vote.
-        round.set_leader(Participant::from_usize(0));
+        // The finalization's proposal remains selected.
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(1)),
             Some(proposal)
@@ -513,6 +514,65 @@ mod tests {
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(0)),
             Some(proposal)
+        );
+    }
+
+    /// A notarization restores matching finalize votes that were filtered when
+    /// a conflicting leader proposal was selected.
+    #[test_async]
+    async fn test_notarization_restores_filtered_finalizes() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            verifier,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let quorum_size = quorum(5) as usize;
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(verifier),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"notarized"]));
+
+        // Buffer some matching finalizes before selecting a proposal.
+        for i in 0..quorum_size / 2 {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+
+        // Selecting a conflicting leader proposal filters the buffered votes.
+        let leader = Participant::from_usize(quorum_size);
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+        let notarize = Notarize::sign(&schemes[quorum_size], conflicting).unwrap();
+        assert!(round.add_network(participants[quorum_size].clone(), Vote::Notarize(notarize)));
+        round.set_leader(leader);
+
+        // Matching finalizes received afterward are retained only by the vote
+        // tracker because they do not match the selected proposal.
+        for i in quorum_size / 2..quorum_size {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+
+        // The authoritative notarization restores both sets of votes.
+        let notarization = build_notarization(&schemes, &proposal, quorum_size);
+        assert!(round.record_certificate(&Certificate::Notarization(notarization)));
+        let (batch, invalid) = round
+            .try_verify(&mut rng, &Sequential)
+            .await
+            .expect("restored finalize quorum must be ready");
+        assert_eq!(batch, quorum_size);
+        assert!(invalid.is_empty());
+        let certificate = round
+            .try_construct_certificate(&Sequential)
+            .await
+            .expect("restored finalize quorum must construct a certificate");
+        assert!(
+            matches!(certificate, Certificate::Finalization(finalization) if finalization.proposal == proposal)
         );
     }
 
@@ -715,26 +775,10 @@ mod tests {
         certificate_forwarding_from_network(secp256r1::fixture);
     }
 
-    #[derive(Clone, Copy)]
-    enum ConflictingLeaderTiming {
-        /// No conflicting leader proposal is selected.
-        None,
-        /// Select the conflicting leader proposal before matching finalize
-        /// votes arrive.
-        BeforeFinalizes,
-        /// Select the conflicting leader proposal after matching finalize
-        /// votes arrive.
-        AfterFinalizes,
-    }
-
-    /// A notarization must unlock matching finalize votes when it first selects
-    /// a proposal and when it replaces a conflicting leader proposal.
-    /// Replacement must work whether the votes arrived before or after leader
-    /// selection.
-    fn notarization_unlocks_future_finalizes<S, F>(
-        mut fixture: F,
-        conflict: ConflictingLeaderTiming,
-    ) where
+    /// Regression: a notarization for a future view must unlock already-buffered
+    /// finalize votes even though that view's leader is not yet known.
+    fn notarization_unlocks_future_finalizes<S, F>(mut fixture: F)
+    where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
     {
@@ -814,23 +858,6 @@ mod tests {
                 finalize_senders.push((i, sender));
             }
 
-            // Reserve a participant outside the finalize quorum as the
-            // equivocating leader.
-            let future_leader = quorum_size;
-            let (mut conflicting_leader_sender, _receiver) = oracle
-                .control(participants[future_leader].clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            oracle
-                .add_link(
-                    participants[future_leader].clone(),
-                    me.clone(),
-                    link.clone(),
-                )
-                .await
-                .unwrap();
-
             // Register a sender for the notarization certificate.
             let (mut notarization_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -859,39 +886,8 @@ mod tests {
                 Sha256::hash(&[b"future_payload"]),
             );
 
-            // Send an equivocating leader vote before the future view's leader
-            // is announced. Learning the leader later selects this proposal
-            // until the authoritative notarization arrives.
-            if !matches!(conflict, ConflictingLeaderTiming::None) {
-                let conflicting = Proposal::new(
-                    Round::new(epoch, future),
-                    current,
-                    Sha256::hash(&[b"conflicting_payload"]),
-                );
-                let notarize =
-                    Notarize::sign(&schemes[future_leader], conflicting).unwrap();
-                conflicting_leader_sender.send(
-                    Recipients::One(me.clone()),
-                    Vote::Notarize(notarize).encode(),
-                    true,
-                );
-            }
-
-            if matches!(conflict, ConflictingLeaderTiming::BeforeFinalizes) {
-                // Select the conflicting proposal before matching finalizes
-                // arrive. The tracker retains votes the verifier rejects.
-                batcher_mailbox.update(
-                    Span::none(),
-                    future,
-                    Participant::from_usize(future_leader),
-                    View::zero(),
-                    None,
-                );
-                context.sleep(Duration::from_millis(50)).await;
-            }
-
-            // Submit all network finalize votes before the authoritative
-            // notarization.
+            // Buffer the network finalize votes before the notarization. The
+            // future round has no leader yet, so they cannot be verified.
             for (i, mut sender) in finalize_senders {
                 let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
                 sender
@@ -902,21 +898,8 @@ mod tests {
                     );
             }
 
-            // Allow all finalize votes to arrive before the next state change.
+            // Allow all finalize votes to arrive before the notarization.
             context.sleep(Duration::from_millis(50)).await;
-
-            if matches!(conflict, ConflictingLeaderTiming::AfterFinalizes) {
-                // Select the conflicting proposal after matching finalizes were
-                // buffered. Proposal selection filters them from the verifier.
-                batcher_mailbox.update(
-                    Span::none(),
-                    future,
-                    Participant::from_usize(future_leader),
-                    View::zero(),
-                    None,
-                );
-                context.sleep(Duration::from_millis(50)).await;
-            }
 
             // The notarization authenticates the proposal without announcing
             // the future round's leader.
@@ -964,42 +947,16 @@ mod tests {
         });
     }
 
-    fn notarization_unlocks_future_finalizes_all_schemes(conflict: ConflictingLeaderTiming) {
-        notarization_unlocks_future_finalizes(
-            bls12381_threshold_vrf::fixture::<MinPk, _>,
-            conflict,
-        );
-        notarization_unlocks_future_finalizes(
-            bls12381_threshold_vrf::fixture::<MinSig, _>,
-            conflict,
-        );
-        notarization_unlocks_future_finalizes(
-            bls12381_threshold_std::fixture::<MinPk, _>,
-            conflict,
-        );
-        notarization_unlocks_future_finalizes(
-            bls12381_threshold_std::fixture::<MinSig, _>,
-            conflict,
-        );
-        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinPk, _>, conflict);
-        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinSig, _>, conflict);
-        notarization_unlocks_future_finalizes(ed25519::fixture, conflict);
-        notarization_unlocks_future_finalizes(secp256r1::fixture, conflict);
-    }
-
     #[test_traced]
     fn test_notarization_unlocks_future_finalizes() {
-        notarization_unlocks_future_finalizes_all_schemes(ConflictingLeaderTiming::None);
-    }
-
-    #[test_traced]
-    fn test_notarization_replays_finalizes_filtered_by_leader_selection() {
-        notarization_unlocks_future_finalizes_all_schemes(ConflictingLeaderTiming::AfterFinalizes);
-    }
-
-    #[test_traced]
-    fn test_notarization_replays_finalizes_received_after_leader_selection() {
-        notarization_unlocks_future_finalizes_all_schemes(ConflictingLeaderTiming::BeforeFinalizes);
+        notarization_unlocks_future_finalizes(bls12381_threshold_vrf::fixture::<MinPk, _>);
+        notarization_unlocks_future_finalizes(bls12381_threshold_vrf::fixture::<MinSig, _>);
+        notarization_unlocks_future_finalizes(bls12381_threshold_std::fixture::<MinPk, _>);
+        notarization_unlocks_future_finalizes(bls12381_threshold_std::fixture::<MinSig, _>);
+        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinPk, _>);
+        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinSig, _>);
+        notarization_unlocks_future_finalizes(ed25519::fixture);
+        notarization_unlocks_future_finalizes(secp256r1::fixture);
     }
 
     /// Regression: an old notarization for view `V` is still forwarded to voter even

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -517,6 +517,61 @@ mod tests {
         );
     }
 
+    /// A constructed finalize is added as verified while restoring only
+    /// matching network votes after replacing a conflicting leader proposal.
+    #[test_async]
+    async fn test_constructed_finalize_restores_only_network_votes() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            verifier,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let quorum_size = quorum(5) as usize;
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(verifier),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"notarized"]));
+
+        // Select a conflicting proposal from the leader's buffered vote.
+        let leader = Participant::from_usize(quorum_size);
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+        let notarize = Notarize::sign(&schemes[quorum_size], conflicting).unwrap();
+        assert!(round.add_network(participants[quorum_size].clone(), Vote::Notarize(notarize)));
+        round.set_leader(leader);
+
+        // These votes are retained by the tracker but filtered from the verifier.
+        for i in 1..quorum_size {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+
+        // The constructed finalize replaces the proposal and restores the
+        // matching network votes before it enters the tracker itself.
+        let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+        round.add_constructed(Vote::Finalize(finalize));
+
+        // Only the network votes require verification.
+        let (batch, invalid) = round
+            .try_verify(&mut rng, &Sequential)
+            .await
+            .expect("restored finalize quorum must be ready");
+        assert_eq!(batch, quorum_size - 1);
+        assert!(invalid.is_empty());
+        let certificate = round
+            .try_construct_certificate(&Sequential)
+            .await
+            .expect("restored finalize quorum must construct a certificate");
+        assert!(
+            matches!(certificate, Certificate::Finalization(finalization) if finalization.proposal == proposal)
+        );
+    }
+
     /// A notarization restores matching finalize votes that were filtered when
     /// a conflicting leader proposal was selected.
     #[test_async]

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -449,11 +449,10 @@ mod tests {
         );
     }
 
-    /// A finalization observed before the leader is known does not establish
-    /// the proposal. Setting the leader still discovers it from the leader's
-    /// buffered notarize vote.
+    /// A finalization establishes a proposal that a later leader selection
+    /// cannot replace.
     #[test]
-    fn test_set_leader_after_finalization() {
+    fn test_finalization_establishes_proposal() {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -468,20 +467,51 @@ mod tests {
             NoopReporter(PhantomData),
         );
 
-        // The leader's notarize arrives before the leader is known
-        let proposal = Proposal::new(round_id, View::new(0), Sha256::hash(&[b"payload"]));
-        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
+        // The leader's notarize arrives before the leader is known.
+        let leader_proposal =
+            Proposal::new(round_id, View::zero(), Sha256::hash(&[b"leader"]));
+        let notarize = Notarize::sign(&schemes[0], leader_proposal).unwrap();
         assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
 
-        // A finalization does not establish the proposal
+        // The finalization establishes a conflicting authoritative proposal.
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"finalized"]));
         let finalization = build_finalization(&schemes, &proposal, quorum(5) as usize);
-        assert!(!round.record_certificate(&Certificate::Finalization(finalization)));
-        assert!(round.has_certificate(Kind::Finalization));
+        round.record_certificate(&Certificate::Finalization(finalization));
 
-        // Setting the leader discovers the proposal from its buffered vote
+        // Setting the leader cannot replace the finalization's proposal with
+        // its buffered vote.
         round.set_leader(Participant::from_usize(0));
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(1)),
+            Some(proposal)
+        );
+    }
+
+    /// A locally constructed finalize establishes the proposal without a known
+    /// leader.
+    #[test]
+    fn test_constructed_finalize_establishes_proposal() {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(
+            round_id,
+            View::zero(),
+            Sha256::hash(&[b"notarized_payload"]),
+        );
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+        );
+
+        // The constructed finalize establishes the proposal without relying
+        // on a leader vote.
+        let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+        round.add_constructed(Vote::Finalize(finalize));
+        assert_eq!(
+            round.try_forward_proposal(Participant::from_usize(0)),
             Some(proposal)
         );
     }
@@ -860,9 +890,8 @@ mod tests {
                 context.sleep(Duration::from_millis(50)).await;
             }
 
-            // Submit a finalize quorum before the authoritative notarization.
-            let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-            batcher_mailbox.constructed(Vote::Finalize(finalize));
+            // Submit all network finalize votes before the authoritative
+            // notarization.
             for (i, mut sender) in finalize_senders {
                 let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
                 sender
@@ -914,6 +943,11 @@ mod tests {
                         ..
                     } => {
                         assert_eq!(notarization.proposal, proposal);
+
+                        // Complete the quorum only after the notarization has
+                        // restored the network votes.
+                        let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
+                        batcher_mailbox.constructed(Vote::Finalize(finalize));
                         saw_notarization = true;
                     }
                     voter::Message::Verified {

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -685,10 +685,26 @@ mod tests {
         certificate_forwarding_from_network(secp256r1::fixture);
     }
 
-    /// Regression: a notarization for a future view must unlock already-buffered
-    /// finalize votes even though that view's leader is not yet known.
-    fn notarization_unlocks_future_finalizes<S, F>(mut fixture: F)
-    where
+    #[derive(Clone, Copy)]
+    enum ConflictingLeaderTiming {
+        /// No conflicting leader proposal is selected.
+        None,
+        /// Select the conflicting leader proposal before matching finalize
+        /// votes arrive.
+        BeforeFinalizes,
+        /// Select the conflicting leader proposal after matching finalize
+        /// votes arrive.
+        AfterFinalizes,
+    }
+
+    /// A notarization must unlock matching finalize votes when it first selects
+    /// a proposal and when it replaces a conflicting leader proposal.
+    /// Replacement must work whether the votes arrived before or after leader
+    /// selection.
+    fn notarization_unlocks_future_finalizes<S, F>(
+        mut fixture: F,
+        conflict: ConflictingLeaderTiming,
+    ) where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
     {
@@ -768,6 +784,23 @@ mod tests {
                 finalize_senders.push((i, sender));
             }
 
+            // Reserve a participant outside the finalize quorum as the
+            // equivocating leader.
+            let future_leader = quorum_size;
+            let (mut conflicting_leader_sender, _receiver) = oracle
+                .control(participants[future_leader].clone())
+                .register(0, TEST_QUOTA)
+                .await
+                .unwrap();
+            oracle
+                .add_link(
+                    participants[future_leader].clone(),
+                    me.clone(),
+                    link.clone(),
+                )
+                .await
+                .unwrap();
+
             // Register a sender for the notarization certificate.
             let (mut notarization_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -796,8 +829,38 @@ mod tests {
                 Sha256::hash(&[b"future_payload"]),
             );
 
-            // Buffer a finalize quorum before the notarization. The future
-            // round has no leader yet, so these votes cannot be verified.
+            // Send an equivocating leader vote before the future view's leader
+            // is announced. Learning the leader later selects this proposal
+            // until the authoritative notarization arrives.
+            if !matches!(conflict, ConflictingLeaderTiming::None) {
+                let conflicting = Proposal::new(
+                    Round::new(epoch, future),
+                    current,
+                    Sha256::hash(&[b"conflicting_payload"]),
+                );
+                let notarize =
+                    Notarize::sign(&schemes[future_leader], conflicting).unwrap();
+                conflicting_leader_sender.send(
+                    Recipients::One(me.clone()),
+                    Vote::Notarize(notarize).encode(),
+                    true,
+                );
+            }
+
+            if matches!(conflict, ConflictingLeaderTiming::BeforeFinalizes) {
+                // Select the conflicting proposal before matching finalizes
+                // arrive. The tracker retains votes the verifier rejects.
+                batcher_mailbox.update(
+                    Span::none(),
+                    future,
+                    Participant::from_usize(future_leader),
+                    View::zero(),
+                    None,
+                );
+                context.sleep(Duration::from_millis(50)).await;
+            }
+
+            // Submit a finalize quorum before the authoritative notarization.
             let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
             batcher_mailbox.constructed(Vote::Finalize(finalize));
             for (i, mut sender) in finalize_senders {
@@ -810,8 +873,21 @@ mod tests {
                     );
             }
 
-            // Allow all finalize votes to arrive before the notarization.
+            // Allow all finalize votes to arrive before the next state change.
             context.sleep(Duration::from_millis(50)).await;
+
+            if matches!(conflict, ConflictingLeaderTiming::AfterFinalizes) {
+                // Select the conflicting proposal after matching finalizes were
+                // buffered. Proposal selection filters them from the verifier.
+                batcher_mailbox.update(
+                    Span::none(),
+                    future,
+                    Participant::from_usize(future_leader),
+                    View::zero(),
+                    None,
+                );
+                context.sleep(Duration::from_millis(50)).await;
+            }
 
             // The notarization authenticates the proposal without announcing
             // the future round's leader.
@@ -854,16 +930,42 @@ mod tests {
         });
     }
 
+    fn notarization_unlocks_future_finalizes_all_schemes(conflict: ConflictingLeaderTiming) {
+        notarization_unlocks_future_finalizes(
+            bls12381_threshold_vrf::fixture::<MinPk, _>,
+            conflict,
+        );
+        notarization_unlocks_future_finalizes(
+            bls12381_threshold_vrf::fixture::<MinSig, _>,
+            conflict,
+        );
+        notarization_unlocks_future_finalizes(
+            bls12381_threshold_std::fixture::<MinPk, _>,
+            conflict,
+        );
+        notarization_unlocks_future_finalizes(
+            bls12381_threshold_std::fixture::<MinSig, _>,
+            conflict,
+        );
+        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinPk, _>, conflict);
+        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinSig, _>, conflict);
+        notarization_unlocks_future_finalizes(ed25519::fixture, conflict);
+        notarization_unlocks_future_finalizes(secp256r1::fixture, conflict);
+    }
+
     #[test_traced]
     fn test_notarization_unlocks_future_finalizes() {
-        notarization_unlocks_future_finalizes(bls12381_threshold_vrf::fixture::<MinPk, _>);
-        notarization_unlocks_future_finalizes(bls12381_threshold_vrf::fixture::<MinSig, _>);
-        notarization_unlocks_future_finalizes(bls12381_threshold_std::fixture::<MinPk, _>);
-        notarization_unlocks_future_finalizes(bls12381_threshold_std::fixture::<MinSig, _>);
-        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinPk, _>);
-        notarization_unlocks_future_finalizes(bls12381_multisig::fixture::<MinSig, _>);
-        notarization_unlocks_future_finalizes(ed25519::fixture);
-        notarization_unlocks_future_finalizes(secp256r1::fixture);
+        notarization_unlocks_future_finalizes_all_schemes(ConflictingLeaderTiming::None);
+    }
+
+    #[test_traced]
+    fn test_notarization_replays_finalizes_filtered_by_leader_selection() {
+        notarization_unlocks_future_finalizes_all_schemes(ConflictingLeaderTiming::AfterFinalizes);
+    }
+
+    #[test_traced]
+    fn test_notarization_replays_finalizes_received_after_leader_selection() {
+        notarization_unlocks_future_finalizes_all_schemes(ConflictingLeaderTiming::BeforeFinalizes);
     }
 
     /// Regression: an old notarization for view `V` is still forwarded to voter even

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -30,8 +30,8 @@ pub struct Round<
     reporter: R,
     /// The verifier attempts to recover notarizations and finalizations only
     /// from votes for one proposal. It initially filters to the first proposal
-    /// observed from the known leader. A verified notarization is authoritative
-    /// and switches the filter to its proposal.
+    /// observed from the known leader. Independently authenticated proposal
+    /// evidence is authoritative and switches the filter.
     verifier: Verifier<S, D>,
     /// At most one vote of each kind per signer.
     ///
@@ -95,44 +95,54 @@ impl<
         self.verifier.has_certificate(kind)
     }
 
-    /// Records a verified certificate and returns whether the round's proposal
-    /// changed.
+    /// Records a verified certificate.
     ///
-    /// Only the first notarization can establish or replace the proposal. It may
-    /// replace a conflicting proposal learned from the leader's vote. A proposal
-    /// learned from a notarization is never replaced.
+    /// The first notarization or finalization establishes an authoritative
+    /// proposal and may replace one learned from the leader's vote. Returns
+    /// `true` when a notarization selects a new proposal, making its buffered
+    /// finalize votes eligible for processing.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
-        let proposal_changed = match certificate {
+        let process_votes = match certificate {
             Certificate::Notarization(notarization) => {
-                let proposal_replaced = self
-                    .verifier
-                    .proposal()
-                    .is_some_and(|proposal| proposal != &notarization.proposal);
-                let proposal_changed = self
-                    .verifier
-                    .set_proposal(ProposalState::Notarization(notarization.proposal.clone()));
-                if proposal_changed && proposal_replaced {
-                    self.restore_tracked_finalizes(&notarization.proposal);
-                }
-                proposal_changed
+                self.set_authoritative_proposal(&notarization.proposal)
             }
-            Certificate::Nullification(_) | Certificate::Finalization(_) => false,
+            Certificate::Finalization(finalization) => {
+                self.verifier.set_proposal(ProposalState::Authoritative(
+                    finalization.proposal.clone(),
+                ));
+                false
+            }
+            Certificate::Nullification(_) => false,
         };
         self.verifier.record_certificate(certificate.kind());
+        process_votes
+    }
+
+    /// Makes an independently authenticated proposal authoritative, restoring
+    /// finalize votes filtered by a conflicting leader proposal.
+    ///
+    /// Returns whether the selected proposal changed.
+    fn set_authoritative_proposal(&mut self, proposal: &Proposal<D>) -> bool {
+        let proposal_replaced = self
+            .verifier
+            .proposal()
+            .is_some_and(|selected| selected != proposal);
+        let proposal_changed = self
+            .verifier
+            .set_proposal(ProposalState::Authoritative(proposal.clone()));
+        if proposal_changed && proposal_replaced {
+            self.restore_tracked_finalizes(proposal);
+        }
         proposal_changed
     }
 
-    /// Restores finalize votes after an authoritative proposal replaces the
-    /// leader-selected proposal.
+    /// Restores network finalize votes after an authoritative proposal
+    /// replaces the leader-selected proposal.
+    ///
+    /// Constructed finalizes establish the proposal before entering the tracker.
     fn restore_tracked_finalizes(&mut self, proposal: &Proposal<D>) {
-        // A differing notarization can only replace a leader-selected proposal.
-        // The verifier then has no votes for the replacement proposal, while
-        // the tracker holds at most one finalize vote per signer.
-        // Network votes for the replacement proposal were never eligible for
-        // verification: they were buffered while the proposal was unknown or
-        // discarded while the conflicting leader proposal was selected. The
-        // tracker does not retain constructed-vote provenance, so matching
-        // votes are conservatively re-added as pending.
+        // No matching finalize can already be verified: unknown proposals do
+        // not verify, and selecting a conflicting leader proposal filters them.
         for finalize in self
             .votes
             .iter_finalizes()
@@ -282,7 +292,9 @@ impl<
                 self.reporter.report(Activity::Nullify(nullify.clone()));
             }
             Vote::Finalize(finalize) => {
-                // Our own votes are already verified
+                // The voter only constructs a finalize after independently
+                // authenticating the proposal.
+                self.set_authoritative_proposal(&finalize.proposal);
                 assert!(
                     self.votes.insert_finalize(finalize.clone()),
                     "duplicate finalize"

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -107,6 +107,8 @@ impl<
                 self.set_authoritative_proposal(&notarization.proposal)
             }
             Certificate::Finalization(finalization) => {
+                // A finalization may replace the leader-selected proposal, but its
+                // certificate makes reprocessing buffered finalize votes unnecessary.
                 self.verifier
                     .set_proposal(ProposalState::Authoritative(finalization.proposal.clone()));
                 false

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -40,7 +40,7 @@ pub struct Round<
     /// proposal-switch recovery.
     votes: VoteTracker<S, D>,
 
-    /// Whether we've already sent the leader's proposal to the voter.
+    /// Whether we've already sent the selected proposal to the voter.
     proposal_sent: bool,
 
     /// Root span of the view, shared with the voter's round.
@@ -107,9 +107,8 @@ impl<
                 self.set_authoritative_proposal(&notarization.proposal)
             }
             Certificate::Finalization(finalization) => {
-                self.verifier.set_proposal(ProposalState::Authoritative(
-                    finalization.proposal.clone(),
-                ));
+                self.verifier
+                    .set_proposal(ProposalState::Authoritative(finalization.proposal.clone()));
                 false
             }
             Certificate::Nullification(_) => false,
@@ -305,7 +304,7 @@ impl<
             }
         }
 
-        // The verifier drops votes for a different proposal than the leader's.
+        // The verifier drops votes for a different proposal than the selected one.
         self.verifier.add(message, true);
     }
 

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -132,25 +132,18 @@ impl<
             .verifier
             .set_proposal(ProposalState::Certificate(proposal.clone()));
         if proposal_changed && proposal_replaced {
-            self.restore_tracked_finalizes(proposal);
+            // Matching tracked finalizes are unverified network votes: the conflicting
+            // leader proposal filtered them, while constructed finalizes establish the
+            // proposal before entering the tracker.
+            for finalize in self
+                .votes
+                .iter_finalizes()
+                .filter(|finalize| &finalize.proposal == proposal)
+            {
+                self.verifier.add(Vote::Finalize(finalize.clone()), false);
+            }
         }
         proposal_changed
-    }
-
-    /// Restores network finalize votes after an authoritative proposal
-    /// replaces the leader-selected proposal.
-    ///
-    /// Constructed finalizes establish the proposal before entering the tracker.
-    fn restore_tracked_finalizes(&mut self, proposal: &Proposal<D>) {
-        // No matching finalize can already be verified: unknown proposals do
-        // not verify, and selecting a conflicting leader proposal filters them.
-        for finalize in self
-            .votes
-            .iter_finalizes()
-            .filter(|finalize| &finalize.proposal == proposal)
-        {
-            self.verifier.add(Vote::Finalize(finalize.clone()), false);
-        }
     }
 
     /// Adds a vote from the network to this round's verifier.

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -30,14 +30,14 @@ pub struct Round<
     reporter: R,
     /// The verifier attempts to recover notarizations and finalizations only
     /// from votes for one proposal. It initially filters to the first proposal
-    /// observed from the known leader. If the leader equivocates, a node that
-    /// observed the losing proposal cannot recover a proposal certificate
-    /// locally, but can still forward certificates recovered elsewhere. A
-    /// verified notarization is authoritative and switches the filter to its
-    /// proposal.
+    /// observed from the known leader. A verified notarization is authoritative
+    /// and switches the filter to its proposal.
     verifier: Verifier<S, D>,
-    /// Votes received from network (may not be verified yet).
-    /// Used for duplicate detection and conflict reporting.
+    /// At most one vote of each kind per signer.
+    ///
+    /// Includes locally constructed votes and network votes that may not be
+    /// verified. Used for duplicate detection, conflict reporting, and
+    /// proposal-switch recovery.
     votes: VoteTracker<S, D>,
 
     /// Whether we've already sent the leader's proposal to the voter.
@@ -98,18 +98,48 @@ impl<
     /// Records a verified certificate and returns whether the round's proposal
     /// changed.
     ///
-    /// Only a notarization can change the proposal. Its proposal is
-    /// authoritative and replaces any conflicting proposal learned from the
-    /// leader's vote.
+    /// Only the first notarization can establish or replace the proposal. It may
+    /// replace a conflicting proposal learned from the leader's vote. A proposal
+    /// learned from a notarization is never replaced.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
         let proposal_changed = match certificate {
-            Certificate::Notarization(notarization) => self
-                .verifier
-                .set_proposal(ProposalState::Notarization(notarization.proposal.clone())),
+            Certificate::Notarization(notarization) => {
+                let proposal_replaced = self
+                    .verifier
+                    .proposal()
+                    .is_some_and(|proposal| proposal != &notarization.proposal);
+                let proposal_changed = self
+                    .verifier
+                    .set_proposal(ProposalState::Notarization(notarization.proposal.clone()));
+                if proposal_changed && proposal_replaced {
+                    self.restore_tracked_finalizes(&notarization.proposal);
+                }
+                proposal_changed
+            }
             Certificate::Nullification(_) | Certificate::Finalization(_) => false,
         };
         self.verifier.record_certificate(certificate.kind());
         proposal_changed
+    }
+
+    /// Restores finalize votes after an authoritative proposal replaces the
+    /// leader-selected proposal.
+    fn restore_tracked_finalizes(&mut self, proposal: &Proposal<D>) {
+        // A differing notarization can only replace a leader-selected proposal.
+        // The verifier then has no votes for the replacement proposal, while
+        // the tracker holds at most one finalize vote per signer.
+        // Network votes for the replacement proposal were never eligible for
+        // verification: they were buffered while the proposal was unknown or
+        // discarded while the conflicting leader proposal was selected. The
+        // tracker does not retain constructed-vote provenance, so matching
+        // votes are conservatively re-added as pending.
+        for finalize in self
+            .votes
+            .iter_finalizes()
+            .filter(|finalize| &finalize.proposal == proposal)
+        {
+            self.verifier.add(Vote::Finalize(finalize.clone()), false);
+        }
     }
 
     /// Adds a vote from the network to this round's verifier.

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -110,7 +110,7 @@ impl<
                 // A finalization may replace the leader-selected proposal, but its
                 // certificate makes reprocessing buffered finalize votes unnecessary.
                 self.verifier
-                    .set_proposal(ProposalState::Authoritative(finalization.proposal.clone()));
+                    .set_proposal(ProposalState::Certificate(finalization.proposal.clone()));
                 false
             }
             Certificate::Nullification(_) => false,
@@ -130,7 +130,7 @@ impl<
             .is_some_and(|selected| selected != proposal);
         let proposal_changed = self
             .verifier
-            .set_proposal(ProposalState::Authoritative(proposal.clone()));
+            .set_proposal(ProposalState::Certificate(proposal.clone()));
         if proposal_changed && proposal_replaced {
             self.restore_tracked_finalizes(proposal);
         }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -124,14 +124,10 @@ impl<
     ///
     /// Returns whether the selected proposal changed.
     fn set_authoritative_proposal(&mut self, proposal: &Proposal<D>) -> bool {
-        let proposal_replaced = self
-            .verifier
-            .proposal()
-            .is_some_and(|selected| selected != proposal);
-        let proposal_changed = self
+        let update = self
             .verifier
             .set_proposal(ProposalState::Certificate(proposal.clone()));
-        if proposal_changed && proposal_replaced {
+        if update.replaced {
             // Matching tracked finalizes are unverified network votes: the conflicting
             // leader proposal filtered them, while constructed finalizes establish the
             // proposal before entering the tracker.
@@ -143,7 +139,7 @@ impl<
                 self.verifier.add(Vote::Finalize(finalize.clone()), false);
             }
         }
-        proposal_changed
+        update.changed
     }
 
     /// Adds a vote from the network to this round's verifier.

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -154,6 +154,14 @@ impl<V> Certification<V> {
     }
 }
 
+/// How the selected proposal changed after an update.
+pub(super) struct ProposalUpdate {
+    /// Whether the selected proposal changed.
+    pub(super) changed: bool,
+    /// Whether an existing proposal was replaced with a different one.
+    pub(super) replaced: bool,
+}
+
 /// What the round knows about its proposal, and how it was learned.
 pub(super) enum ProposalState<D: Digest> {
     /// No proposal is known.
@@ -371,16 +379,23 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Updates the proposal state and, if the selected proposal changes, drops
     /// buffered notarize and finalize votes for any other proposal.
     ///
-    /// Returns `true` only if the selected proposal changed. Rejected
-    /// transitions and a provenance-only change from a leader vote to
-    /// authoritative state for the same proposal return `false`.
-    pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> bool {
+    /// Returns whether the selected proposal changed and whether the accepted
+    /// change replaced an existing proposal. Rejected transitions and a
+    /// provenance-only change return `false` for both.
+    pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> ProposalUpdate {
+        let replaced = self.proposal.proposal().is_some();
         let Some(proposal) = self.proposal.update(proposal) else {
-            return false;
+            return ProposalUpdate {
+                changed: false,
+                replaced: false,
+            };
         };
         self.notarize.retain(|n| &n.proposal == proposal);
         self.finalize.retain(|f| &f.proposal == proposal);
-        true
+        ProposalUpdate {
+            changed: true,
+            replaced,
+        }
     }
 
     /// Adds a [Vote] message to the batch for later verification.
@@ -808,16 +823,26 @@ mod tests {
         // from the leader's vote.
         let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
         assert_ne!(notarized_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(ProposalState::Certificate(notarized_proposal.clone())));
+        assert!(
+            verifier2
+                .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
+                .changed
+        );
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // Re-adopting the same proposal reports no change.
-        assert!(!verifier2.set_proposal(ProposalState::Certificate(notarized_proposal.clone())));
+        assert!(
+            !verifier2
+                .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
+                .changed
+        );
 
         // The first notarization remains authoritative.
         let conflicting_notarized_proposal = Proposal::new(round, View::new(0), sample_digest(3));
         assert!(
-            !verifier2.set_proposal(ProposalState::Certificate(conflicting_notarized_proposal))
+            !verifier2
+                .set_proposal(ProposalState::Certificate(conflicting_notarized_proposal))
+                .changed
         );
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
@@ -828,7 +853,11 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(ProposalState::Certificate(notarized_proposal.clone())));
+        assert!(
+            verifier3
+                .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
+                .changed
+        );
         assert!(verifier3.leader().is_none());
         assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -158,10 +158,11 @@ impl<V> Certification<V> {
 pub(super) enum ProposalState<D: Digest> {
     /// No proposal is known.
     Unknown,
-    /// Learned from the leader's notarize vote. May be replaced by a notarization.
+    /// Learned from the leader's notarize vote. An authoritative proposal may
+    /// replace it.
     Leader(Proposal<D>),
-    /// Learned from a verified notarization. Never replaced.
-    Notarization(Proposal<D>),
+    /// Authenticated independently of the leader's vote. Never replaced.
+    Authoritative(Proposal<D>),
 }
 
 impl<D: Digest> ProposalState<D> {
@@ -169,23 +170,21 @@ impl<D: Digest> ProposalState<D> {
     const fn proposal(&self) -> Option<&Proposal<D>> {
         match self {
             Self::Unknown => None,
-            Self::Leader(proposal) | Self::Notarization(proposal) => Some(proposal),
+            Self::Leader(proposal) | Self::Authoritative(proposal) => Some(proposal),
         }
     }
 
-    /// Updates the proposal from a leader vote or notarization.
+    /// Updates the proposal from a leader vote or authoritative evidence.
     ///
-    /// An unknown proposal accepts either source, while a proposal from a
-    /// leader vote may be superseded by the first notarization. All other
-    /// transitions are ignored.
+    /// An unknown proposal accepts either source. An authoritative proposal
+    /// may supersede a leader vote. All other transitions are ignored.
     ///
-    /// Returns the selected proposal if its value changed. A provenance-only
-    /// change from a leader vote to a notarization of the same proposal returns
-    /// `None`.
+    /// Returns the selected proposal if its value changed. Certifying the
+    /// leader-selected proposal returns `None`.
     fn update(&mut self, next: Self) -> Option<&Proposal<D>> {
         match (&*self, &next) {
-            (Self::Unknown, Self::Leader(_) | Self::Notarization(_)) => {}
-            (Self::Leader(_), Self::Notarization(_)) => {}
+            (Self::Unknown, Self::Leader(_) | Self::Authoritative(_)) => {}
+            (Self::Leader(_), Self::Authoritative(_)) => {}
             _ => return None,
         }
 
@@ -225,9 +224,9 @@ pub struct Verifier<S: Scheme<D>, D: Digest> {
 
     /// The round's proposal, once known.
     ///
-    /// A known leader's notarize vote may supply the initial proposal. A
-    /// verified notarization is authoritative and may replace it, or establish
-    /// the proposal before the leader is identified.
+    /// A known leader's notarize vote may supply the initial proposal. An
+    /// independently authenticated proposal is authoritative and may replace
+    /// it, or be established before the leader is identified.
     proposal: ProposalState<D>,
 
     /// Notarize certification progress.
@@ -372,8 +371,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// buffered notarize and finalize votes for any other proposal.
     ///
     /// Returns `true` only if the selected proposal changed. Rejected
-    /// transitions and a provenance-only change from a leader vote to a
-    /// notarization of the same proposal return `false`.
+    /// transitions and a provenance-only change from a leader vote to
+    /// authoritative state for the same proposal return `false`.
     pub(super) fn set_proposal(&mut self, proposal: ProposalState<D>) -> bool {
         let Some(proposal) = self.proposal.update(proposal) else {
             return false;
@@ -428,8 +427,8 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Sets the leader for the current consensus view.
     ///
     /// `notarize` carries the leader's already-received vote, if any. Its
-    /// proposal is learned when none is known. A proposal already established
-    /// by a verified notarization remains authoritative.
+    /// proposal is learned when none is known. An authoritative proposal is
+    /// never replaced.
     ///
     /// # Panics
     ///
@@ -485,7 +484,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                         .map(|n| (n.proposal, n.attestation))
                         .unzip();
                     // All proposals here are equal: pending votes are filtered to the
-                    // leader's proposal before verification becomes ready.
+                    // selected proposal before verification becomes ready.
                     let proposal = &proposals[0];
 
                     let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
@@ -808,17 +807,21 @@ mod tests {
         // from the leader's vote.
         let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
         assert_ne!(notarized_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert!(verifier2.set_proposal(ProposalState::Authoritative(
+            notarized_proposal.clone()
+        )));
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // Re-adopting the same proposal reports no change.
-        assert!(!verifier2.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert!(!verifier2.set_proposal(ProposalState::Authoritative(
+            notarized_proposal.clone()
+        )));
 
         // The first notarization remains authoritative.
         let conflicting_notarized_proposal = Proposal::new(round, View::new(0), sample_digest(3));
-        assert!(
-            !verifier2.set_proposal(ProposalState::Notarization(conflicting_notarized_proposal))
-        );
+        assert!(!verifier2.set_proposal(ProposalState::Authoritative(
+            conflicting_notarized_proposal
+        )));
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // If the notarization arrives first, setting the leader cannot replace
@@ -828,7 +831,9 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(ProposalState::Notarization(notarized_proposal.clone())));
+        assert!(verifier3.set_proposal(ProposalState::Authoritative(
+            notarized_proposal.clone()
+        )));
         assert!(verifier3.leader().is_none());
         assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));
@@ -1432,7 +1437,7 @@ mod tests {
 
         let (mut verifier, finalize) = test_verifier_finalize();
 
-        verifier.set_proposal(ProposalState::Notarization(finalize.proposal.clone()));
+        verifier.set_proposal(ProposalState::Authoritative(finalize.proposal.clone()));
         assert!(verifier.leader.is_none());
         assert!(
             verifier

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -161,8 +161,9 @@ pub(super) enum ProposalState<D: Digest> {
     /// Learned from the leader's notarize vote. An authoritative proposal may
     /// replace it.
     Leader(Proposal<D>),
-    /// Authenticated independently of the leader's vote. Never replaced.
-    Authoritative(Proposal<D>),
+    /// Learned from a verified certificate or locally constructed finalize.
+    /// Never replaced.
+    Certificate(Proposal<D>),
 }
 
 impl<D: Digest> ProposalState<D> {
@@ -170,7 +171,7 @@ impl<D: Digest> ProposalState<D> {
     const fn proposal(&self) -> Option<&Proposal<D>> {
         match self {
             Self::Unknown => None,
-            Self::Leader(proposal) | Self::Authoritative(proposal) => Some(proposal),
+            Self::Leader(proposal) | Self::Certificate(proposal) => Some(proposal),
         }
     }
 
@@ -183,8 +184,8 @@ impl<D: Digest> ProposalState<D> {
     /// leader-selected proposal returns `None`.
     fn update(&mut self, next: Self) -> Option<&Proposal<D>> {
         match (&*self, &next) {
-            (Self::Unknown, Self::Leader(_) | Self::Authoritative(_)) => {}
-            (Self::Leader(_), Self::Authoritative(_)) => {}
+            (Self::Unknown, Self::Leader(_) | Self::Certificate(_)) => {}
+            (Self::Leader(_), Self::Certificate(_)) => {}
             _ => return None,
         }
 
@@ -807,16 +808,16 @@ mod tests {
         // from the leader's vote.
         let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
         assert_ne!(notarized_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(ProposalState::Authoritative(notarized_proposal.clone())));
+        assert!(verifier2.set_proposal(ProposalState::Certificate(notarized_proposal.clone())));
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // Re-adopting the same proposal reports no change.
-        assert!(!verifier2.set_proposal(ProposalState::Authoritative(notarized_proposal.clone())));
+        assert!(!verifier2.set_proposal(ProposalState::Certificate(notarized_proposal.clone())));
 
         // The first notarization remains authoritative.
         let conflicting_notarized_proposal = Proposal::new(round, View::new(0), sample_digest(3));
         assert!(
-            !verifier2.set_proposal(ProposalState::Authoritative(conflicting_notarized_proposal))
+            !verifier2.set_proposal(ProposalState::Certificate(conflicting_notarized_proposal))
         );
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
@@ -827,7 +828,7 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(ProposalState::Authoritative(notarized_proposal.clone())));
+        assert!(verifier3.set_proposal(ProposalState::Certificate(notarized_proposal.clone())));
         assert!(verifier3.leader().is_none());
         assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));
@@ -1431,7 +1432,7 @@ mod tests {
 
         let (mut verifier, finalize) = test_verifier_finalize();
 
-        verifier.set_proposal(ProposalState::Authoritative(finalize.proposal.clone()));
+        verifier.set_proposal(ProposalState::Certificate(finalize.proposal.clone()));
         assert!(verifier.leader.is_none());
         assert!(
             verifier

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -807,21 +807,17 @@ mod tests {
         // from the leader's vote.
         let notarized_proposal = Proposal::new(round, View::new(0), sample_digest(2));
         assert_ne!(notarized_proposal, leader_notarize.proposal);
-        assert!(verifier2.set_proposal(ProposalState::Authoritative(
-            notarized_proposal.clone()
-        )));
+        assert!(verifier2.set_proposal(ProposalState::Authoritative(notarized_proposal.clone())));
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // Re-adopting the same proposal reports no change.
-        assert!(!verifier2.set_proposal(ProposalState::Authoritative(
-            notarized_proposal.clone()
-        )));
+        assert!(!verifier2.set_proposal(ProposalState::Authoritative(notarized_proposal.clone())));
 
         // The first notarization remains authoritative.
         let conflicting_notarized_proposal = Proposal::new(round, View::new(0), sample_digest(3));
-        assert!(!verifier2.set_proposal(ProposalState::Authoritative(
-            conflicting_notarized_proposal
-        )));
+        assert!(
+            !verifier2.set_proposal(ProposalState::Authoritative(conflicting_notarized_proposal))
+        );
         assert_eq!(verifier2.proposal(), Some(&notarized_proposal));
 
         // If the notarization arrives first, setting the leader cannot replace
@@ -831,9 +827,7 @@ mod tests {
             schemes[0].clone(),
             quorum,
         );
-        assert!(verifier3.set_proposal(ProposalState::Authoritative(
-            notarized_proposal.clone()
-        )));
+        assert!(verifier3.set_proposal(ProposalState::Authoritative(notarized_proposal.clone())));
         assert!(verifier3.leader().is_none());
         assert_eq!(verifier3.proposal(), Some(&notarized_proposal));
         verifier3.set_leader(leader, Some(&leader_notarize));


### PR DESCRIPTION
## Summary

Builds on #4347 by treating the first independently authenticated proposal as authoritative whether it comes from a verified notarization, a verified finalization, or a locally constructed finalize. This state may replace a proposal learned from the leader's vote and cannot be replaced by later conflicting evidence.

When a notarization replaces a conflicting leader-selected proposal, matching network finalize votes retained by the round are restored so they can be verified. Votes buffered before any proposal was selected remain in the verifier and need no replay.

## Testing

Adds deterministic coverage for finalizations and constructed finalizes establishing authoritative proposal state, and for restoring finalize votes received both before and after conflicting leader selection.
