### PR TITLE
[storage/qmdb/sync] remove cancel_tx

### DIFF
--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -150,7 +150,6 @@ where
         start_loc: Location,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
-        _cancel_rx: oneshot::Receiver<()>,
     ) -> Result<sync::resolver::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>
     {
         fetch_operation_range(

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -406,11 +406,9 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary() {
         .expect("test epoch should be supported");
     let crash_window_start = state_sync_floor.get() + EPOCH_LENGTH.get() / 2;
     // The node processes nothing until state sync finishes, and sync converges
-    // only once two fetch round trips fit inside one block interval. On the
-    // default 10ms link a round trip is ~24ms against a ~40ms interval, so two
-    // never fit and the node lands on whatever height the coincidence happens
-    // to occur at. The fast link below converges it promptly, which is what lets
-    // the processed hold park the node at `crash_window_start` and crash there.
+    // only when two fetch round trips fit inside one block interval. The fast
+    // link below guarantees that, so the processed hold, not sync timing, parks
+    // the node at `crash_window_start`.
     let crash_window_end = FixedEpocher::new(EPOCH_LENGTH)
         .first(next_player_epoch.next())
         .expect("test epoch should be supported");

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -405,12 +405,12 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary() {
         .first(next_player_epoch)
         .expect("test epoch should be supported");
     let crash_window_start = state_sync_floor.get() + EPOCH_LENGTH.get() / 2;
-    // The application state sync follows the finalized tip, so the node's
-    // first processed height after sync is bounded only by the next epoch
-    // boundary (block production pauses there, letting sync converge). The
-    // crash window therefore extends to the next epoch's first block, and the
-    // processed hold parks the node at whatever height it lands on so the
-    // crash triggers deterministically instead of sampling a moving value.
+    // The node processes nothing until state sync finishes, and sync converges
+    // only once two fetch round trips fit inside one block interval. On the
+    // default 10ms link a round trip is ~24ms against a ~40ms interval, so two
+    // never fit and the node lands on whatever height the coincidence happens
+    // to occur at. The fast link below converges it promptly, which is what lets
+    // the processed hold park the node at `crash_window_start` and crash there.
     let crash_window_end = FixedEpocher::new(EPOCH_LENGTH)
         .first(next_player_epoch.next())
         .expect("test epoch should be supported");
@@ -427,6 +427,11 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary() {
         next_player_epoch.next(),
         BoundaryEpochInfos::new(4),
     )
+    .link(Link {
+        latency: Duration::from_millis(4),
+        jitter: Duration::from_millis(1),
+        success_rate: 1.0,
+    })
     .crash(Crash::ProcessedHeight {
         participant: delayed.clone(),
         heights: crash_window_start..=crash_window_end.get(),

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -204,16 +204,9 @@ where
         start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
     ) -> Result<resolver::FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         self.0
-            .get_operations(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                cancel_rx,
-            )
+            .get_operations(op_count, start_loc, max_ops, include_pinned_nodes)
             .await
     }
 }

--- a/glue/src/stateful/db/p2p/cancel.rs
+++ b/glue/src/stateful/db/p2p/cancel.rs
@@ -2,13 +2,13 @@
 
 use commonware_actor::mailbox::{Policy, Sender};
 
-/// Sends its message on drop, unless [`CancelGuard::disarm`] ran first.
-pub(super) struct CancelGuard<T: Policy> {
+/// Sends its message on drop, unless [`Guard::disarm`] ran first.
+pub(super) struct Guard<T: Policy> {
     sender: Sender<T>,
     cancel: Option<T>,
 }
 
-impl<T: Policy> CancelGuard<T> {
+impl<T: Policy> Guard<T> {
     pub(super) const fn new(sender: Sender<T>, cancel: T) -> Self {
         Self {
             sender,
@@ -22,7 +22,7 @@ impl<T: Policy> CancelGuard<T> {
     }
 }
 
-impl<T: Policy> Drop for CancelGuard<T> {
+impl<T: Policy> Drop for Guard<T> {
     fn drop(&mut self) {
         let Some(cancel) = self.cancel.take() else {
             return;

--- a/glue/src/stateful/db/p2p/cancel.rs
+++ b/glue/src/stateful/db/p2p/cancel.rs
@@ -1,0 +1,32 @@
+//! Cancellation of an in-flight resolver request.
+
+use commonware_actor::mailbox::{Policy, Sender};
+
+/// Sends its message on drop, unless [`CancelGuard::disarm`] ran first.
+pub(super) struct CancelGuard<T: Policy> {
+    sender: Sender<T>,
+    cancel: Option<T>,
+}
+
+impl<T: Policy> CancelGuard<T> {
+    pub(super) const fn new(sender: Sender<T>, cancel: T) -> Self {
+        Self {
+            sender,
+            cancel: Some(cancel),
+        }
+    }
+
+    /// Leaves the request with the actor, for a fetch that reached an answer.
+    pub(super) fn disarm(&mut self) {
+        self.cancel = None;
+    }
+}
+
+impl<T: Policy> Drop for CancelGuard<T> {
+    fn drop(&mut self) {
+        let Some(cancel) = self.cancel.take() else {
+            return;
+        };
+        let _ = self.sender.enqueue(cancel);
+    }
+}

--- a/glue/src/stateful/db/p2p/cancel.rs
+++ b/glue/src/stateful/db/p2p/cancel.rs
@@ -16,7 +16,7 @@ impl<T: Policy> CancelGuard<T> {
         }
     }
 
-    /// Leaves the request with the actor, for a fetch that reached an answer.
+    /// Suppresses the drop-time cancel; call once the fetch has completed.
     pub(super) fn disarm(&mut self) {
         self.cancel = None;
     }

--- a/glue/src/stateful/db/p2p/compact/actor.rs
+++ b/glue/src/stateful/db/p2p/compact/actor.rs
@@ -234,7 +234,7 @@ where
 
     fn should_cancel_request(&mut self, request: &handler::Request<F, H::Digest>) -> bool {
         let Some(subscribers) = self.pending.get_mut(request) else {
-            return false;
+            return true;
         };
         subscribers.retain(|subscriber| !subscriber.is_closed());
         if !subscribers.is_empty() {
@@ -692,6 +692,24 @@ mod tests {
                 .expect("request should remain pending");
             assert_eq!(subscribers.len(), 1);
             assert!(!subscribers[0].is_closed());
+        });
+    }
+
+    #[test]
+    fn cancel_state_cancels_pruned_request() {
+        deterministic::Runner::default().start(|context| async move {
+            let (mut actor, _mailbox) = TestActor::new(context.child("actor"), test_config(None));
+            let target = compact::Target {
+                root: sha256::Digest::from([7; 32]),
+                leaf_count: mmr::Location::new(1),
+            };
+            let request = handler::Request::from_target(target);
+
+            let action = actor.handle_mailbox_message(mailbox::Message::CancelState {
+                request: request.clone(),
+            });
+
+            assert!(matches!(action, MailboxAction::Cancel(ref key) if key == &request));
         });
     }
 }

--- a/glue/src/stateful/db/p2p/compact/mailbox.rs
+++ b/glue/src/stateful/db/p2p/compact/mailbox.rs
@@ -1,7 +1,7 @@
 //! Mailbox for the compact QMDB P2P resolver.
 
 use super::handler;
-use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel::CancelGuard};
+use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_storage::{merkle::Family, qmdb::sync::compact};
@@ -140,9 +140,10 @@ where
             request: request.clone(),
             response,
         });
-        let mut cancel = CancelGuard::new(self.sender.clone(), Message::CancelState { request });
+
+        let mut guard = cancel::Guard::new(self.sender.clone(), Message::CancelState { request });
         let result = receiver.await;
-        cancel.disarm();
+        guard.disarm();
         result.map_err(|_| ResponseDropped)?
     }
 }

--- a/glue/src/stateful/db/p2p/compact/mailbox.rs
+++ b/glue/src/stateful/db/p2p/compact/mailbox.rs
@@ -1,39 +1,12 @@
 //! Mailbox for the compact QMDB P2P resolver.
 
 use super::handler;
-use crate::stateful::db::{AttachableResolver, Shared};
+use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel::CancelGuard};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_storage::{merkle::Family, qmdb::sync::compact};
 use commonware_utils::channel::oneshot;
 use std::{collections::VecDeque, future::Future};
-
-struct CancelGuard<DB, F: Family, Op, D: Digest> {
-    sender: Sender<Message<DB, F, Op, D>>,
-    request: Option<handler::Request<F, D>>,
-}
-
-impl<DB, F: Family, Op, D: Digest> CancelGuard<DB, F, Op, D> {
-    const fn new(sender: Sender<Message<DB, F, Op, D>>, request: handler::Request<F, D>) -> Self {
-        Self {
-            sender,
-            request: Some(request),
-        }
-    }
-
-    const fn disarm(&mut self) {
-        self.request = None;
-    }
-}
-
-impl<DB, F: Family, Op, D: Digest> Drop for CancelGuard<DB, F, Op, D> {
-    fn drop(&mut self) {
-        let Some(request) = self.request.take() else {
-            return;
-        };
-        let _ = self.sender.enqueue(Message::CancelState { request });
-    }
-}
 
 /// The resolver actor dropped the response before completion.
 #[derive(Debug, thiserror::Error)]
@@ -167,7 +140,7 @@ where
             request: request.clone(),
             response,
         });
-        let mut cancel = CancelGuard::new(self.sender.clone(), request);
+        let mut cancel = CancelGuard::new(self.sender.clone(), Message::CancelState { request });
         let result = receiver.await;
         cancel.disarm();
         result.map_err(|_| ResponseDropped)?

--- a/glue/src/stateful/db/p2p/mod.rs
+++ b/glue/src/stateful/db/p2p/mod.rs
@@ -4,5 +4,6 @@
 //! - [`compact`]: resolver for compact-storage QMDBs that fetch one
 //!   authenticated frontier state instead of replaying operations.
 
+mod cancel;
 pub mod compact;
 pub mod standard;

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -354,14 +354,12 @@ where
             self.metrics.serve_requests.inc(status::Status::Dropped);
             return;
         }
-        let (_cancel_tx, cancel_rx) = oneshot::channel();
         let result = database
             .get_operations(
                 key.op_count,
                 key.start_loc,
                 key.max_ops,
                 key.include_pinned_nodes,
-                cancel_rx,
             )
             .await;
 

--- a/glue/src/stateful/db/p2p/standard/actor.rs
+++ b/glue/src/stateful/db/p2p/standard/actor.rs
@@ -261,7 +261,7 @@ where
     /// Returns `true` if a request should be cancelled.
     fn should_cancel_request(&mut self, request: &handler::Request<F>) -> bool {
         let Some(subscribers) = self.pending.get_mut(request) else {
-            return false;
+            return true;
         };
         subscribers.retain(|subscriber| !subscriber.is_closed());
         if !subscribers.is_empty() {
@@ -708,6 +708,20 @@ mod tests {
             let pending = actor.pending.get(&request).unwrap();
             assert_eq!(pending.len(), 1);
             assert!(!pending[0].is_closed());
+        });
+    }
+
+    #[test]
+    fn cancel_operations_cancels_pruned_request() {
+        deterministic::Runner::default().start(|context| async move {
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let request = test_request_at(Location::new(1));
+
+            let action = actor.handle_mailbox_message(mailbox::Message::CancelOperations {
+                request: request.clone(),
+            });
+
+            assert!(matches!(action, MailboxAction::Cancel(ref key) if key == &request));
         });
     }
 }

--- a/glue/src/stateful/db/p2p/standard/mailbox.rs
+++ b/glue/src/stateful/db/p2p/standard/mailbox.rs
@@ -5,14 +5,39 @@ use crate::stateful::db::{AttachableResolver, Shared};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_codec::Read;
 use commonware_cryptography::Digest;
-use commonware_macros::select;
 use commonware_storage::{
     merkle::{Family, Location},
     qmdb::sync::resolver::{FetchResult, Resolver as SyncResolver},
 };
 use commonware_utils::channel::oneshot;
-use futures::FutureExt as _;
 use std::{collections::VecDeque, future::Future, num::NonZeroU64};
+
+struct CancelGuard<DB, F: Family, Op, D: Digest> {
+    sender: Sender<Message<DB, F, Op, D>>,
+    request: Option<handler::Request<F>>,
+}
+
+impl<DB, F: Family, Op, D: Digest> CancelGuard<DB, F, Op, D> {
+    const fn new(sender: Sender<Message<DB, F, Op, D>>, request: handler::Request<F>) -> Self {
+        Self {
+            sender,
+            request: Some(request),
+        }
+    }
+
+    const fn disarm(&mut self) {
+        self.request = None;
+    }
+}
+
+impl<DB, F: Family, Op, D: Digest> Drop for CancelGuard<DB, F, Op, D> {
+    fn drop(&mut self) {
+        let Some(request) = self.request.take() else {
+            return;
+        };
+        let _ = self.sender.enqueue(Message::CancelOperations { request });
+    }
+}
 
 /// The resolver actor dropped the response before completion.
 #[derive(Debug, thiserror::Error)]
@@ -144,7 +169,6 @@ where
         start_loc: Location<F>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
     ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         let request = handler::Request {
             op_count,
@@ -153,24 +177,15 @@ where
             include_pinned_nodes,
         };
 
-        futures::pin_mut!(cancel_rx);
         let (response_tx, response_rx) = oneshot::channel();
         let _ = self.sender.enqueue(Message::GetOperations {
             request: request.clone(),
             response: response_tx,
         });
-        futures::pin_mut!(response_rx);
-
-        select! {
-            response = response_rx.as_mut() => response.map_err(|_| ResponseDropped)?,
-            _ = cancel_rx.as_mut() => {
-                if let Some(response) = response_rx.as_mut().now_or_never() {
-                    return response.map_err(|_| ResponseDropped)?;
-                }
-                let _ = self.sender.enqueue(Message::CancelOperations { request });
-                Err(ResponseDropped)
-            },
-        }
+        let mut cancel = CancelGuard::new(self.sender.clone(), request);
+        let result = response_rx.await;
+        cancel.disarm();
+        result.map_err(|_| ResponseDropped)?
     }
 }
 
@@ -195,8 +210,10 @@ mod tests {
     use commonware_storage::mmr;
     use commonware_utils::{NZU64, NZUsize};
 
+    /// A caller that abandons its fetch drops the future, which retracts the request from the
+    /// actor. Nothing fires a channel: the drop guard is the whole mechanism.
     #[test]
-    fn get_operations_cancellation_sends_cancel_message() {
+    fn dropping_get_operations_sends_cancel_message() {
         deterministic::Runner::default().start(|context| async move {
             let (sender, mut receiver) = commonware_actor::mailbox::new(context, NZUsize!(4));
             let mailbox = Mailbox::<(), mmr::Family, u64, sha256::Digest>::new(sender);
@@ -204,39 +221,65 @@ mod tests {
             let start_loc = mmr::Location::new(3);
             let max_ops = NZU64!(2);
 
-            let (cancel_tx, cancel_rx) = oneshot::channel();
-            let get = mailbox.get_operations(op_count, start_loc, max_ops, false, cancel_rx);
-            let observe = async move {
-                let response = match receiver.recv().await.expect("request should be queued") {
-                    Message::GetOperations { request, response } => {
-                        assert_eq!(request.op_count, op_count);
-                        assert_eq!(request.start_loc, start_loc);
-                        assert_eq!(request.max_ops, max_ops);
-                        assert!(!request.include_pinned_nodes);
-                        response
-                    }
-                    Message::AttachDatabase(_) => panic!("unexpected attach message"),
-                    Message::CancelOperations { .. } => panic!("cancel should come after request"),
-                };
+            // Poll once so the request is enqueued, then abandon the fetch.
+            {
+                let get = mailbox.get_operations(op_count, start_loc, max_ops, false);
+                futures::pin_mut!(get);
+                assert!(futures::poll!(get.as_mut()).is_pending());
+            }
 
-                drop(cancel_tx);
-
-                match receiver.recv().await.expect("cancel should be queued") {
-                    Message::CancelOperations { request } => {
-                        assert_eq!(request.op_count, op_count);
-                        assert_eq!(request.start_loc, start_loc);
-                        assert_eq!(request.max_ops, max_ops);
-                        assert!(!request.include_pinned_nodes);
-                    }
-                    Message::AttachDatabase(_) => panic!("unexpected attach message"),
-                    Message::GetOperations { .. } => panic!("unexpected duplicate request"),
+            match receiver.recv().await.expect("request should be queued") {
+                Message::GetOperations { request, .. } => {
+                    assert_eq!(request.op_count, op_count);
+                    assert_eq!(request.start_loc, start_loc);
+                    assert_eq!(request.max_ops, max_ops);
+                    assert!(!request.include_pinned_nodes);
                 }
+                Message::AttachDatabase(_) => panic!("unexpected attach message"),
+                Message::CancelOperations { .. } => panic!("cancel should come after request"),
+            }
 
-                drop(response);
+            match receiver.recv().await.expect("cancel should be queued") {
+                Message::CancelOperations { request } => {
+                    assert_eq!(request.op_count, op_count);
+                    assert_eq!(request.start_loc, start_loc);
+                    assert_eq!(request.max_ops, max_ops);
+                    assert!(!request.include_pinned_nodes);
+                }
+                Message::AttachDatabase(_) => panic!("unexpected attach message"),
+                Message::GetOperations { .. } => panic!("unexpected duplicate request"),
+            }
+        });
+    }
+
+    /// A fetch that completes normally disarms the guard, so no cancel follows.
+    #[test]
+    fn completed_get_operations_sends_no_cancel() {
+        deterministic::Runner::default().start(|context| async move {
+            let (sender, mut receiver) = commonware_actor::mailbox::new(context, NZUsize!(4));
+            let mailbox = Mailbox::<(), mmr::Family, u64, sha256::Digest>::new(sender);
+            let get = mailbox.get_operations(
+                mmr::Location::new(10),
+                mmr::Location::new(3),
+                NZU64!(2),
+                false,
+            );
+            let observe = async move {
+                let Message::GetOperations { response, .. } =
+                    receiver.recv().await.expect("request should be queued")
+                else {
+                    panic!("expected a fetch request");
+                };
+                let _ = response.send(Err(ResponseDropped));
+                receiver
             };
 
-            let (result, _) = futures::join!(get, observe);
+            let (result, mut receiver) = futures::join!(get, observe);
             assert!(matches!(result, Err(ResponseDropped)));
+            assert!(
+                receiver.try_recv().is_err(),
+                "a completed fetch must not enqueue a cancel"
+            );
         });
     }
 }

--- a/glue/src/stateful/db/p2p/standard/mailbox.rs
+++ b/glue/src/stateful/db/p2p/standard/mailbox.rs
@@ -185,7 +185,7 @@ mod tests {
     use commonware_utils::{NZU64, NZUsize};
 
     /// A caller that abandons its fetch drops the future, which retracts the request from the
-    /// actor. Nothing fires a channel: the drop guard is the whole mechanism.
+    /// actor.
     #[test]
     fn dropping_get_operations_sends_cancel_message() {
         deterministic::Runner::default().start(|context| async move {

--- a/glue/src/stateful/db/p2p/standard/mailbox.rs
+++ b/glue/src/stateful/db/p2p/standard/mailbox.rs
@@ -1,7 +1,7 @@
 //! Mailbox and wire types for the QMDB sync resolver service.
 
 use super::handler;
-use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel::CancelGuard};
+use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_codec::Read;
 use commonware_cryptography::Digest;
@@ -155,10 +155,11 @@ where
             request: request.clone(),
             response: response_tx,
         });
-        let mut cancel =
-            CancelGuard::new(self.sender.clone(), Message::CancelOperations { request });
+
+        let mut guard =
+            cancel::Guard::new(self.sender.clone(), Message::CancelOperations { request });
         let result = response_rx.await;
-        cancel.disarm();
+        guard.disarm();
         result.map_err(|_| ResponseDropped)?
     }
 }

--- a/glue/src/stateful/db/p2p/standard/mailbox.rs
+++ b/glue/src/stateful/db/p2p/standard/mailbox.rs
@@ -1,7 +1,7 @@
 //! Mailbox and wire types for the QMDB sync resolver service.
 
 use super::handler;
-use crate::stateful::db::{AttachableResolver, Shared};
+use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel::CancelGuard};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_codec::Read;
 use commonware_cryptography::Digest;
@@ -11,33 +11,6 @@ use commonware_storage::{
 };
 use commonware_utils::channel::oneshot;
 use std::{collections::VecDeque, future::Future, num::NonZeroU64};
-
-struct CancelGuard<DB, F: Family, Op, D: Digest> {
-    sender: Sender<Message<DB, F, Op, D>>,
-    request: Option<handler::Request<F>>,
-}
-
-impl<DB, F: Family, Op, D: Digest> CancelGuard<DB, F, Op, D> {
-    const fn new(sender: Sender<Message<DB, F, Op, D>>, request: handler::Request<F>) -> Self {
-        Self {
-            sender,
-            request: Some(request),
-        }
-    }
-
-    const fn disarm(&mut self) {
-        self.request = None;
-    }
-}
-
-impl<DB, F: Family, Op, D: Digest> Drop for CancelGuard<DB, F, Op, D> {
-    fn drop(&mut self) {
-        let Some(request) = self.request.take() else {
-            return;
-        };
-        let _ = self.sender.enqueue(Message::CancelOperations { request });
-    }
-}
 
 /// The resolver actor dropped the response before completion.
 #[derive(Debug, thiserror::Error)]
@@ -182,7 +155,8 @@ where
             request: request.clone(),
             response: response_tx,
         });
-        let mut cancel = CancelGuard::new(self.sender.clone(), request);
+        let mut cancel =
+            CancelGuard::new(self.sender.clone(), Message::CancelOperations { request });
         let result = response_rx.await;
         cancel.disarm();
         result.map_err(|_| ResponseDropped)?

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -1795,17 +1795,10 @@ where
         start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
     ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         let mut result = self
             .inner
-            .get_operations(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                cancel_rx,
-            )
+            .get_operations(op_count, start_loc, max_ops, include_pinned_nodes)
             .await?;
         // Corrupt pinned nodes only on the first request that includes them.
         if result.pinned_nodes.is_some()
@@ -1898,21 +1891,12 @@ impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
         start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
     ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         if op_count == self.historical_target_size {
             if include_pinned_nodes {
-                let _ = cancel_rx.await;
-                return self
-                    .inner
-                    .get_operations(
-                        op_count,
-                        start_loc,
-                        max_ops,
-                        include_pinned_nodes,
-                        oneshot::channel().1,
-                    )
-                    .await;
+                // Never answers. The engine abandons this request when the target moves,
+                // which drops this future.
+                return std::future::pending().await;
             }
 
             let release = self.release_historical_gap.lock().take();
@@ -1926,13 +1910,7 @@ impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
             if attempt == 0 {
                 let mut result = self
                     .inner
-                    .get_operations(
-                        self.historical_target_size,
-                        start_loc,
-                        max_ops,
-                        false,
-                        oneshot::channel().1,
-                    )
+                    .get_operations(self.historical_target_size, start_loc, max_ops, false)
                     .await?;
                 result.pinned_nodes = None;
                 return Ok(result);
@@ -1945,13 +1923,7 @@ impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
         }
 
         self.inner
-            .get_operations(
-                op_count,
-                start_loc,
-                max_ops,
-                include_pinned_nodes,
-                cancel_rx,
-            )
+            .get_operations(op_count, start_loc, max_ops, include_pinned_nodes)
             .await
     }
 }

--- a/storage/src/qmdb/any/sync/tests.rs
+++ b/storage/src/qmdb/any/sync/tests.rs
@@ -1894,8 +1894,9 @@ impl<R: Resolver<Digest = Digest>> Resolver for ReplayFreshBoundaryResolver<R> {
     ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
         if op_count == self.historical_target_size {
             if include_pinned_nodes {
-                // Never answers. The engine abandons this request when the target moves,
-                // which drops this future.
+                // Simulate a resolver that has not answered the old target's pinned-nodes
+                // request when the target changes. The update cancels the request and drops
+                // this pending future.
                 return std::future::pending().await;
             }
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -73,7 +73,7 @@ use commonware_codec::{Codec, CodecShared, Read as CodecRead};
 use commonware_cryptography::{DigestOf, Hasher};
 use commonware_parallel::Strategy;
 use commonware_runtime::Spawner;
-use commonware_utils::{Array, bitmap::Prunable as BitMap, channel::oneshot, range::NonEmptyRange};
+use commonware_utils::{Array, bitmap::Prunable as BitMap, range::NonEmptyRange};
 use core::num::NonZeroUsize;
 use std::sync::Arc;
 
@@ -403,7 +403,6 @@ macro_rules! impl_current_resolver {
                 start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, Self::Error> {
                 fetch_operations(
                     op_count,
@@ -451,7 +450,6 @@ macro_rules! impl_current_resolver {
                 start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, qmdb::Error<F>> {
                 let db = self.read().await;
                 fetch_operations(
@@ -496,7 +494,6 @@ macro_rules! impl_current_resolver {
                 start_loc: Location<F>,
                 max_ops: std::num::NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<crate::qmdb::sync::FetchResult<F, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -21,13 +21,10 @@ use commonware_utils::{
     NZU64,
     channel::{
         fallible::{AsyncFallibleExt, OneshotExt as _},
-        mpsc, oneshot,
+        mpsc,
     },
 };
-use futures::{
-    StreamExt,
-    future::{Either, pending},
-};
+use futures::future::{Aborted, Either, pending};
 use mpsc::error::TryRecvError;
 use std::{collections::BTreeMap, fmt::Debug, num::NonZeroU64};
 
@@ -49,8 +46,8 @@ pub(crate) enum NextStep<C, D> {
 enum Event<F: Family, Op, D: Digest, E> {
     /// A target update was received
     TargetUpdate(Target<F, D>),
-    /// A batch of operations was received
-    BatchReceived(IndexedFetchResult<F, Op, D, E>),
+    /// A batch of operations was received, or its request was aborted by a target update
+    BatchReceived(Result<IndexedFetchResult<F, Op, D, E>, Aborted>),
     /// The target update channel was closed
     UpdateChannelClosed,
     /// A finish signal was received
@@ -70,7 +67,7 @@ pub(super) struct IndexedFetchResult<F: Family, Op, D: Digest, E> {
 
 /// Wait for the next synchronization event.
 /// Returns `None` when there are no outstanding requests and no channels to wait on.
-async fn wait_for_event<F: Family, Op, D: Digest, E>(
+async fn wait_for_event<F: Family, Op: Send, D: Digest, E: Send>(
     update_rx: &mut Option<mpsc::Receiver<Target<F, D>>>,
     finish_rx: &mut Option<mpsc::Receiver<()>>,
     outstanding_requests: &mut Requests<F, Op, D, E>,
@@ -87,11 +84,8 @@ async fn wait_for_event<F: Family, Op, D: Digest, E>(
         || Either::Right(pending()),
         |finish_rx| Either::Left(finish_rx.recv()),
     );
-    let batch_result_fut = if outstanding_requests.len() == 0 {
-        Either::Right(pending())
-    } else {
-        Either::Left(outstanding_requests.futures_mut().next())
-    };
+    // The pool never resolves while nothing is outstanding, so it needs no empty-case arm.
+    let batch_result_fut = outstanding_requests.next_completed();
 
     select! {
         finish = finish_fut => finish.map_or_else(
@@ -102,7 +96,7 @@ async fn wait_for_event<F: Family, Op, D: Digest, E>(
             || Some(Event::UpdateChannelClosed),
             |target| Some(Event::TargetUpdate(target))
         ),
-        result = batch_result_fut => result.map(|fetch_result| Event::BatchReceived(fetch_result)),
+        result = batch_result_fut => Some(Event::BatchReceived(result)),
     }
 }
 
@@ -317,20 +311,14 @@ where
         {
             let start_loc = self.target.range.start();
             let resolver = self.resolver.clone();
-            let (cancel_tx, cancel_rx) = oneshot::channel();
             let id = self.outstanding_requests.next_id();
-            self.outstanding_requests.insert(
-                id,
-                start_loc,
-                target_size,
-                cancel_tx,
-                Box::pin(async move {
+            self.outstanding_requests
+                .insert(id, start_loc, target_size, async move {
                     let result = resolver
-                        .get_operations(target_size, start_loc, NZU64!(1), true, cancel_rx)
+                        .get_operations(target_size, start_loc, NZU64!(1), true)
                         .await;
                     IndexedFetchResult { id, result }
-                }),
-            );
+                });
         }
 
         // Calculate the maximum number of requests to make
@@ -365,20 +353,14 @@ where
 
             // Schedule the request
             let resolver = self.resolver.clone();
-            let (cancel_tx, cancel_rx) = oneshot::channel();
             let id = self.outstanding_requests.next_id();
-            self.outstanding_requests.insert(
-                id,
-                gap_range.start,
-                target_size,
-                cancel_tx,
-                Box::pin(async move {
+            self.outstanding_requests
+                .insert(id, gap_range.start, target_size, async move {
                     let result = resolver
-                        .get_operations(target_size, gap_range.start, batch_size, false, cancel_rx)
+                        .get_operations(target_size, gap_range.start, batch_size, false)
                         .await;
                     IndexedFetchResult { id, result }
-                }),
-            );
+                });
         }
 
         Ok(())
@@ -685,7 +667,10 @@ where
             }
             Event::FinishChannelClosed => Err(SyncError::Engine(EngineError::FinishChannelClosed)),
             Event::BatchReceived(fetch_result) => {
-                self.handle_fetch_result(fetch_result)?;
+                // An aborted request carries no result, but still wakes the loop to reschedule.
+                if let Ok(fetch_result) = fetch_result {
+                    self.handle_fetch_result(fetch_result)?;
+                }
                 self.schedule_requests()?;
                 let mut engine = self.apply_operations().await?;
                 engine.record_progress();
@@ -778,13 +763,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        merkle::mmr::{Family as MmrFamily, Proof},
-        qmdb::sync::requests::FetchFuture,
-    };
+    use crate::merkle::mmr::{Family as MmrFamily, Proof};
     use commonware_cryptography::{Sha256, sha256};
     use commonware_runtime::{Runner as _, deterministic};
-    use commonware_utils::{NZU64, channel::oneshot, non_empty_range};
+    use commonware_utils::{NZU64, non_empty_range};
     use std::{
         convert::Infallible,
         sync::{
@@ -896,7 +878,6 @@ mod tests {
             _start_loc: Location<Self::Family>,
             _max_ops: NonZeroU64,
             _include_pinned_nodes: bool,
-            _cancel_rx: oneshot::Receiver<()>,
         ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
             Ok(FetchResult::new(
                 Proof {
@@ -960,22 +941,20 @@ mod tests {
         });
     }
 
-    /// Create a no-op fetch result future for testing request tracking.
-    fn dummy_future(id: RequestId) -> FetchFuture<MmrFamily, i32, sha256::Digest, ()> {
-        Box::pin(async move {
-            IndexedFetchResult {
-                id,
-                result: Ok(FetchResult::new(
-                    Proof {
-                        leaves: Location::new(0),
-                        inactive_peaks: 0,
-                        digests: vec![],
-                    },
-                    vec![],
-                    None,
-                )),
-            }
-        })
+    /// A no-op fetch result for testing request tracking.
+    fn dummy_result(id: RequestId) -> IndexedFetchResult<MmrFamily, i32, sha256::Digest, ()> {
+        IndexedFetchResult {
+            id,
+            result: Ok(FetchResult::new(
+                Proof {
+                    leaves: Location::new(0),
+                    inactive_peaks: 0,
+                    digests: vec![],
+                },
+                vec![],
+                None,
+            )),
+        }
     }
 
     /// Helper to add a request at a given location.
@@ -985,8 +964,7 @@ mod tests {
             id,
             Location::new(loc),
             Location::new(loc),
-            oneshot::channel().0,
-            dummy_future(id),
+            std::future::ready(dummy_result(id)),
         );
         id
     }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -543,17 +543,14 @@ where
 
     /// Handle the result of a fetch operation.
     ///
-    /// Discards results for requests no longer tracked (removed by
-    /// `remove_before` during a target update). For tracked requests,
-    /// verifies the proof against the current root first, then falls back
+    /// Verifies the proof against the current root first, then falls back
     /// to a matching historical root from `retained_roots` if available.
     fn handle_fetch_result(
         &mut self,
         fetch_result: IndexedFetchResult<DB::Family, DB::Op, DB::Digest, R::Error>,
     ) -> Result<(), Error<DB, R>> {
-        // Discard results for stale requests (removed by a target update).
-        // Using the request ID prevents a stale future from consuming the
-        // tracking entry of a fresh request at the same location.
+        // Defensive: removal aborts a request's future, so a result for an
+        // untracked ID should be unreachable.
         let Some(request) = self.outstanding_requests.remove(fetch_result.id) else {
             return Ok(());
         };
@@ -1069,5 +1066,21 @@ mod tests {
         let new_id = add(&mut requests, 5);
         assert_ne!(old_id, new_id);
         assert!(requests.remove(new_id).is_some());
+    }
+
+    #[test]
+    fn test_remove_before_aborts_future() {
+        deterministic::Runner::default().start(|_context| async move {
+            let mut requests: Requests<MmrFamily, i32, sha256::Digest, ()> = Requests::new();
+            let id = requests.next_id();
+            requests.insert(
+                id,
+                Location::new(5),
+                Location::new(5),
+                std::future::pending(),
+            );
+            requests.remove_before(Location::new(10));
+            assert!(matches!(requests.next_completed().await, Err(Aborted)));
+        });
     }
 }

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -549,8 +549,8 @@ where
         &mut self,
         fetch_result: IndexedFetchResult<DB::Family, DB::Op, DB::Digest, R::Error>,
     ) -> Result<(), Error<DB, R>> {
-        // Defensive: removal aborts a request's future, so a result for an
-        // untracked ID should be unreachable.
+        // Request metadata binds a result to the target it was fetched against. Ignore
+        // results whose request has already been canceled or superseded.
         let Some(request) = self.outstanding_requests.remove(fetch_result.id) else {
             return Ok(());
         };
@@ -667,6 +667,7 @@ where
                 if let Ok(fetch_result) = fetch_result {
                     self.handle_fetch_result(fetch_result)?;
                 }
+
                 self.schedule_requests()?;
                 let mut engine = self.apply_operations().await?;
                 engine.record_progress();

--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -84,7 +84,6 @@ async fn wait_for_event<F: Family, Op: Send, D: Digest, E: Send>(
         || Either::Right(pending()),
         |finish_rx| Either::Left(finish_rx.recv()),
     );
-    // The pool never resolves while nothing is outstanding, so it needs no empty-case arm.
     let batch_result_fut = outstanding_requests.next_completed();
 
     select! {

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -1,9 +1,8 @@
 //! Manages outstanding fetch requests with monotonically increasing request IDs.
 //!
 //! Each request is assigned a unique ID and remembers the tree size it was issued
-//! against. This prevents stale futures from colliding with fresh requests at the
-//! same location after a target update, and lets the engine reject replies that
-//! do not match the requested historical view.
+//! against, letting the engine reject replies that do not match the requested
+//! historical view. Removing a request aborts its future.
 
 use crate::{
     merkle::{Family, Location},
@@ -128,7 +127,8 @@ impl<F: Family, Op: Send, D: Digest, E: Send> Requests<F, Op, D, E> {
         self.by_location.contains_key(loc)
     }
 
-    /// Resolve to the next fetch result, or [`Aborted`] if that request was cancelled.
+    /// Resolves to the next fetch result, or [`Aborted`] if the request was cancelled.
+    /// Never resolves once all completed and aborted results have been drained.
     pub async fn next_completed(&mut self) -> Result<IndexedFetchResult<F, Op, D, E>, Aborted> {
         self.futures.next_completed().await
     }

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -10,17 +10,12 @@ use crate::{
     qmdb::sync::engine::IndexedFetchResult,
 };
 use commonware_cryptography::Digest;
-use commonware_utils::channel::oneshot;
-use futures::stream::FuturesUnordered;
+use commonware_utils::futures::{AbortablePool, Aborter};
+use futures::future::Aborted;
 use std::{
     collections::{BTreeMap, HashMap},
     future::Future,
-    pin::Pin,
 };
-
-/// Boxed future that resolves to an [`IndexedFetchResult`].
-pub(super) type FetchFuture<F, Op, D, E> =
-    Pin<Box<dyn Future<Output = IndexedFetchResult<F, Op, D, E>> + Send>>;
 
 /// Unique identifier for a fetch request.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -38,29 +33,29 @@ pub(super) struct RequestInfo<F: Family> {
 /// Mutable request state kept while the request is still tracked.
 struct TrackedRequest<F: Family> {
     info: RequestInfo<F>,
-    _cancel_tx: oneshot::Sender<()>,
+    _aborter: Aborter,
 }
 
 /// Manages outstanding fetch requests.
 pub(super) struct Requests<F: Family, Op, D: Digest, E> {
     /// Futures that will resolve to fetch results.
-    futures: FuturesUnordered<FetchFuture<F, Op, D, E>>,
+    pool: AbortablePool<IndexedFetchResult<F, Op, D, E>>,
 
     /// Counter for assigning unique request IDs.
     next_id: u64,
 
-    /// Active requests keyed by ID. Removing an entry drops the cancel sender,
-    /// causing the resolver's `cancel_rx.await` to return `Err`.
+    /// Active requests keyed by ID. Removing an entry drops its [`Aborter`],
+    /// which aborts and drops the request's future.
     tracked: HashMap<Id, TrackedRequest<F>>,
 
     /// Reverse index from location to request ID, for gap detection.
     by_location: BTreeMap<Location<F>, Id>,
 }
 
-impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
+impl<F: Family, Op: Send, D: Digest, E: Send> Requests<F, Op, D, E> {
     pub fn new() -> Self {
         Self {
-            futures: FuturesUnordered::new(),
+            pool: AbortablePool::default(),
             next_id: 0,
             tracked: HashMap::new(),
             by_location: BTreeMap::new(),
@@ -76,19 +71,18 @@ impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
     }
 
     /// Register a request with a previously allocated ID. If a request already
-    /// exists at `start_loc`, the old one is superseded (its cancel sender is
-    /// dropped and its future will be discarded when it completes).
+    /// exists at `start_loc`, the old one is superseded and aborted.
     pub fn insert(
         &mut self,
         id: Id,
         start_loc: Location<F>,
         target_size: Location<F>,
-        cancel_tx: oneshot::Sender<()>,
-        future: FetchFuture<F, Op, D, E>,
+        future: impl Future<Output = IndexedFetchResult<F, Op, D, E>> + Send + 'static,
     ) {
         if let Some(old_id) = self.by_location.insert(start_loc, id) {
             self.tracked.remove(&old_id);
         }
+        let aborter = self.pool.push(future);
         self.tracked.insert(
             id,
             TrackedRequest {
@@ -96,19 +90,14 @@ impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
                     start_loc,
                     target_size,
                 },
-                _cancel_tx: cancel_tx,
+                _aborter: aborter,
             },
         );
-        self.futures.push(future);
     }
 
     /// Complete a request by ID. Returns its metadata if it was tracked.
     pub fn remove(&mut self, id: Id) -> Option<RequestInfo<F>> {
-        if let Some(TrackedRequest {
-            info,
-            _cancel_tx: _,
-        }) = self.tracked.remove(&id)
-        {
+        if let Some(TrackedRequest { info, _aborter: _ }) = self.tracked.remove(&id) {
             // Only remove from by_location if it still points to this ID.
             // A newer request may have superseded this location.
             if self.by_location.get(&info.start_loc) == Some(&id) {
@@ -120,8 +109,7 @@ impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
         }
     }
 
-    /// Remove all requests at locations before `loc`. Dropped cancel senders
-    /// signal resolvers to abort.
+    /// Remove all requests at locations before `loc`, aborting their futures.
     pub fn remove_before(&mut self, loc: Location<F>) {
         let keep = self.by_location.split_off(&loc);
         for id in self.by_location.values() {
@@ -140,18 +128,18 @@ impl<F: Family, Op, D: Digest, E> Requests<F, Op, D, E> {
         self.by_location.contains_key(loc)
     }
 
-    /// Get a mutable reference to the futures stream.
-    pub fn futures_mut(&mut self) -> &mut FuturesUnordered<FetchFuture<F, Op, D, E>> {
-        &mut self.futures
+    /// Resolve to the next fetch result, or [`Aborted`] if that request was cancelled.
+    pub async fn next_completed(&mut self) -> Result<IndexedFetchResult<F, Op, D, E>, Aborted> {
+        self.pool.next_completed().await
     }
 
-    /// Get the number of outstanding requests
+    /// Get the number of outstanding requests, not including aborted ones.
     pub fn len(&self) -> usize {
         self.tracked.len()
     }
 }
 
-impl<F: Family, Op, D: Digest, E> Default for Requests<F, Op, D, E> {
+impl<F: Family, Op: Send, D: Digest, E: Send> Default for Requests<F, Op, D, E> {
     fn default() -> Self {
         Self::new()
     }

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -39,7 +39,7 @@ struct TrackedRequest<F: Family> {
 /// Manages outstanding fetch requests.
 pub(super) struct Requests<F: Family, Op, D: Digest, E> {
     /// Futures that will resolve to fetch results.
-    pool: AbortablePool<IndexedFetchResult<F, Op, D, E>>,
+    futures: AbortablePool<IndexedFetchResult<F, Op, D, E>>,
 
     /// Counter for assigning unique request IDs.
     next_id: u64,
@@ -55,7 +55,7 @@ pub(super) struct Requests<F: Family, Op, D: Digest, E> {
 impl<F: Family, Op: Send, D: Digest, E: Send> Requests<F, Op, D, E> {
     pub fn new() -> Self {
         Self {
-            pool: AbortablePool::default(),
+            futures: AbortablePool::default(),
             next_id: 0,
             tracked: HashMap::new(),
             by_location: BTreeMap::new(),
@@ -82,7 +82,7 @@ impl<F: Family, Op: Send, D: Digest, E: Send> Requests<F, Op, D, E> {
         if let Some(old_id) = self.by_location.insert(start_loc, id) {
             self.tracked.remove(&old_id);
         }
-        let aborter = self.pool.push(future);
+        let aborter = self.futures.push(future);
         self.tracked.insert(
             id,
             TrackedRequest {
@@ -130,7 +130,7 @@ impl<F: Family, Op: Send, D: Digest, E: Send> Requests<F, Op, D, E> {
 
     /// Resolve to the next fetch result, or [`Aborted`] if that request was cancelled.
     pub async fn next_completed(&mut self) -> Result<IndexedFetchResult<F, Op, D, E>, Aborted> {
-        self.pool.next_completed().await
+        self.futures.next_completed().await
     }
 
     /// Get the number of outstanding requests, not including aborted ones.

--- a/storage/src/qmdb/sync/resolver.rs
+++ b/storage/src/qmdb/sync/resolver.rs
@@ -207,10 +207,6 @@ pub trait Resolver: Send + Sync + Clone + 'static {
     /// Returns the operations and a proof that they were present in the database when it had
     /// `op_count` operations. If `include_pinned_nodes` is true, the result will include the
     /// pinned merkle nodes at `start_loc`.
-    ///
-    /// The corresponding `cancel_tx` is dropped when the engine no longer needs this
-    /// request (e.g. due to a target update), causing `cancel_rx.await` to return
-    /// `Err`. Implementations may `select!` on it to abort in-flight work early.
     #[allow(clippy::type_complexity)]
     fn get_operations<'a>(
         &'a self,
@@ -218,7 +214,6 @@ pub trait Resolver: Send + Sync + Clone + 'static {
         start_loc: Location<Self::Family>,
         max_ops: NonZeroU64,
         include_pinned_nodes: bool,
-        cancel_rx: oneshot::Receiver<()>,
     ) -> impl Future<Output = Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error>>
     + Send
     + 'a;
@@ -248,7 +243,6 @@ macro_rules! impl_resolver {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_operations(
                     op_count,
@@ -290,7 +284,6 @@ macro_rules! impl_resolver {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 fetch_operations(
@@ -329,7 +322,6 @@ macro_rules! impl_resolver {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
@@ -388,7 +380,6 @@ macro_rules! impl_resolver_immutable {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_operations(
                     op_count,
@@ -430,7 +421,6 @@ macro_rules! impl_resolver_immutable {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 fetch_operations(
@@ -469,7 +459,6 @@ macro_rules! impl_resolver_immutable {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
@@ -517,7 +506,6 @@ macro_rules! impl_resolver_keyless {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 fetch_operations(
                     op_count,
@@ -556,7 +544,6 @@ macro_rules! impl_resolver_keyless {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let db = self.read().await;
                 fetch_operations(
@@ -592,7 +579,6 @@ macro_rules! impl_resolver_keyless {
                 start_loc: Location<Self::Family>,
                 max_ops: NonZeroU64,
                 include_pinned_nodes: bool,
-                _cancel_rx: oneshot::Receiver<()>,
             ) -> Result<FetchResult<Self::Family, Self::Op, Self::Digest>, Self::Error> {
                 let guard = self.read().await;
                 let db = guard.as_ref().ok_or(ServeError::MissingSource)?;
@@ -691,7 +677,6 @@ pub(crate) mod tests {
             _start_loc: Location<F>,
             _max_ops: NonZeroU64,
             _include_pinned_nodes: bool,
-            _cancel: oneshot::Receiver<()>,
         ) -> Result<FetchResult<F, Op, D>, qmdb::Error<F>> {
             Err(qmdb::Error::KeyNotFound) // Arbitrary dummy error
         }


### PR DESCRIPTION
`Resolver::get_operations` took a `cancel_rx`. Dropping a future already cancels it in Rust so I don't think this is useful.

## What replaces it

**Caller side.** `Requests` now uses `commonware_utils::futures::{AbortablePool, Aborter}`. `TrackedRequest`'s cancel sender becomes an `Aborter`, so every existing cancellation point still cancels by dropping the tracked entry and the surrounding logic is unchanged. `next_completed()` yields `Ok(..)` or `Err(Aborted)`, and `handle_event` skips the aborted case while still waking the loop to reschedule. `handle_fetch_result`'s behavior is unchanged; its untracked-id guard is now purely defensive, since an aborted future can no longer surface a result.

The pool holds a never-resolving future internally, so `wait_for_event` also drops its empty-pool arm. Its all-empty early return, which is what produces `SyncStalled`, is unchanged, and `len()` still counts tracked requests rather than pooled futures.

**Implementor side.** Glue's standard mailbox gains a `CancelGuard` that retracts the request on drop. This is not a new pattern: glue's *compact* mailbox already works exactly this way with no channel, and the two now read identically. It is also a small correctness gain, since the mailbox previously retracted only when the channel fired, so a caller that simply dropped its future never told the actor.

## Test Fix 1

`any/sync/tests.rs` had two `oneshot::channel().1` call sites feeding the removed parameter. The storage-side resolvers bind it as `_cancel_rx` and never read it, so these were dead plumbing; they go with the parameter. One of the two test resolvers also awaited its receiver before serving pinned nodes; it now returns a pending future, exercising the same never-answers path without the channel.

## Test Fix 2

`reshare_e2e_state_sync_restart_before_epoch_boundary` failed on this branch as previously written, and now runs on a fast link (4ms latency, 1ms jitter) instead of the default 10ms/5ms.

The scenario crashes a state-syncing node inside a height window of `48..=64`. The node processes nothing until sync finishes, so it lands on whatever height the chain reached by then, and that landing height is what the window has to contain.

At the default link sync cannot converge on a moving target. Every target update kills the in-flight request covering the frontier and re-issues it at the new start, so exactly one fetch lands per block interval and each interval ends an operation or two short of the target. Converging takes two round trips inside one interval, roughly 48ms of a 40ms interval, which happens only when a slightly long interval arrives while the engine is idle. Whichever cycle that coincidence falls on decides the landing height.

**This PR moves which cycle that is.** Nothing in the sync loop got slower; measured before and after, the fetch round trip is 23.0ms and 24.9ms, the block interval 40.3ms and 41.0ms, the fetches killed by the next target update 25 of 48 and 34 of 65, and the slack left in an interval after its one fetch 17.8ms and 14.3ms. What moved is when the engine wakes for a killed request: its doomed reply used to come back from the peer about 20ms later and wake the loop then, and now the abort resolves at once. Same wakeups, different times, so the coincidence lands on cycle 34 instead of cycle 25, which is height 67 instead of 58, three blocks past the bound. The retraction messages are not the cause: the old mailbox patched to always retract, instead of harvesting a reply that had already arrived, still lands at 58.

On the fast link two round trips fit in one interval, so sync converges promptly, the node reaches the window under its own steam through heights 44 to 47, and the processed hold parks it at exactly `crash_window_start`. The landing height is now pinned by the hold rather than by sync timing, which is what the hold was for. The upper bound was not widened: it is the scenario, since a restart after the boundary is a different test.

