### PR TITLE
[runtime] Generalize transports for portable peers

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -374,6 +374,12 @@ jobs:
       run: cargo rustc --target wasm32-unknown-unknown --release --manifest-path utils/Cargo.toml --crate-type cdylib && du -h "${CARGO_TARGET_DIR:-target}/wasm32-unknown-unknown/release/commonware_utils.wasm"
     - name: Build runtime
       run: cargo rustc --target wasm32-unknown-unknown --release --manifest-path runtime/Cargo.toml --crate-type cdylib && du -h "${CARGO_TARGET_DIR:-target}/wasm32-unknown-unknown/release/commonware_runtime.wasm"
+    - name: Check portable P2P stack
+      run: |
+        cargo check --target wasm32-unknown-unknown -p commonware-runtime
+        cargo check --target wasm32-unknown-unknown -p commonware-actor
+        cargo check --target wasm32-unknown-unknown -p commonware-stream
+        cargo check --target wasm32-unknown-unknown -p commonware-p2p
     - name: Build consensus
       run: cargo rustc --target wasm32-unknown-unknown --release --manifest-path consensus/Cargo.toml --crate-type cdylib && du -h "${CARGO_TARGET_DIR:-target}/wasm32-unknown-unknown/release/commonware_consensus.wasm"
     - name: Build storage

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,20 @@
 
 ## v2026.7.0
 
+### Portable Scheduling and Transports
+
+The runtime now separates portable task scheduling from native thread-placement
+hints. `Scheduler` owns `spawn`, `stop`, and `stopped`; `Spawner` extends it with
+`shared` and `dedicated`. Existing runtime implementations should move the
+portable methods to `Scheduler` while retaining `Spawner` for native placement.
+
+Runtime networking now exposes separate `Dialer` and `Acceptor` capabilities,
+with established streams represented by `Connection`. TCP implementations use
+`TcpEndpoint`, `TcpOrigin`, and the optional `TcpListener` extension. The BETA
+authenticated discovery and lookup constructions remain TCP-oriented, while
+new ALPHA lookup constructions accept generic endpoints, support dial-only
+participation, and attach already-established authenticated connections.
+
 ### Staged Batch Updates in QMDB
 
 QMDB batches gained an explicit staged path for read-then-write workloads

--- a/actor/Cargo.toml
+++ b/actor/Cargo.toml
@@ -17,13 +17,13 @@ workspace = true
 cfg-if.workspace = true
 commonware-macros.workspace = true
 commonware-runtime.workspace = true
+commonware-utils = { workspace = true, features = ["std"] }
 crossbeam-queue.workspace = true
 futures-util.workspace = true
 loom = { workspace = true, features = ["futures"], optional = true }
 parking_lot.workspace = true
 
 [dev-dependencies]
-commonware-utils = { workspace = true, features = ["std"] }
 criterion.workspace = true
 futures.workspace = true
 

--- a/actor/src/mailbox.rs
+++ b/actor/src/mailbox.rs
@@ -45,6 +45,7 @@ use commonware_runtime::{
     Metrics,
     telemetry::metrics::{Counter, MetricsExt as _},
 };
+use commonware_utils::PlatformSend;
 use std::{
     collections::VecDeque,
     fmt,
@@ -56,7 +57,7 @@ use std::{
 };
 
 /// Retained overflow messages for a mailbox policy.
-pub trait Overflow<T>: Default {
+pub trait Overflow<T>: Default + PlatformSend {
     /// Return whether the retained message set is empty.
     fn is_empty(&self) -> bool;
 
@@ -70,7 +71,7 @@ pub trait Overflow<T>: Default {
         F: FnMut(T) -> Option<T>;
 }
 
-impl<T> Overflow<T> for VecDeque<T> {
+impl<T: PlatformSend> Overflow<T> for VecDeque<T> {
     fn is_empty(&self) -> bool {
         self.is_empty()
     }
@@ -89,7 +90,7 @@ impl<T> Overflow<T> for VecDeque<T> {
 }
 
 /// Overflow behavior for actor messages when an inbox is full.
-pub trait Policy: Sized {
+pub trait Policy: Sized + PlatformSend {
     /// Overflow storage used by this policy.
     type Overflow: Overflow<Self>;
 
@@ -112,7 +113,7 @@ pub trait Policy: Sized {
 }
 
 /// Overflow behavior for actor messages that can be rejected when an inbox is full.
-pub trait UnreliablePolicy: Sized {
+pub trait UnreliablePolicy: Sized + PlatformSend {
     /// Overflow storage used by this policy.
     type Overflow: Overflow<Self>;
 
@@ -906,6 +907,22 @@ mod tests {
                 Self::Vote(_) => false,
             }
         }
+    }
+
+    const fn assert_send<T: Send>(_: &T) {}
+
+    const fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn native_mailboxes_remain_thread_safe() {
+        assert_send_sync::<Sender<Ack>>();
+        assert_send_sync::<UnreliableSender<Message>>();
+
+        let (_sender, mut receiver) = new::<Ack>(NZUsize!(1));
+        assert_send(&receiver.recv());
+
+        let (_sender, mut receiver) = new_unreliable::<Message>(NZUsize!(1));
+        assert_send(&receiver.recv());
     }
 
     struct Ack {

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -34,7 +34,7 @@ use commonware_p2p::{
 };
 use commonware_parallel::Sequential;
 use commonware_runtime::{
-    Clock, IoBuf, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef, deterministic,
+    Clock, IoBuf, Runner, Scheduler as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
 };
 use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, channel::mpsc::Receiver};
 use futures::future::join_all;

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -115,7 +115,7 @@ mod tests {
     use commonware_p2p::simulated::{Link, Network, Oracle, Receiver, Sender};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        Clock, Quota, Runner, Spawner, Supervisor as _,
+        Clock, Quota, Runner, Scheduler, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic::{self, Context},
     };

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -245,7 +245,7 @@ mod tests {
     use super::*;
     use crate::types::{Epoch, View};
     use commonware_cryptography::{Hasher, Sha256, sha256::Digest as Sha256Digest};
-    use commonware_runtime::{Runner, Spawner, deterministic};
+    use commonware_runtime::{Runner, Scheduler, deterministic};
     use std::future::ready;
 
     type D = Sha256Digest;

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -95,7 +95,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_resolver::{Consumer, Delivery, Fetch, Resolver, TargetedResolver};
     use commonware_runtime::{
-        Clock, Metrics, Quota, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef,
+        Clock, Metrics, Quota, Runner, Scheduler, Supervisor as _, buffer::paged::CacheRef,
         deterministic,
     };
     use commonware_storage::{

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -93,7 +93,7 @@ mod tests {
     use commonware_p2p::simulated::{Link, Network, Oracle, Receiver, Sender};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        Clock, Quota, Runner, Spawner, Supervisor as _,
+        Clock, Quota, Runner, Scheduler, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic::{self, Context},
     };

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -569,7 +569,7 @@ mod tests {
     };
     use commonware_parallel::{Sequential, Strategy};
     use commonware_runtime::{
-        Clock, IoBuf, Metrics as _, Quota, Runner, Spawner, Strategizer as _, Supervisor as _,
+        Clock, IoBuf, Metrics as _, Quota, Runner, Scheduler, Strategizer as _, Supervisor as _,
         buffer::paged::CacheRef, deterministic, telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{

--- a/cryptography/src/handshake/cipher.rs
+++ b/cryptography/src/handshake/cipher.rs
@@ -1,7 +1,7 @@
 use super::error::Error;
 use crate::Secret;
+use alloc::{vec, vec::Vec};
 use rand_core::CryptoRng;
-use std::vec::Vec;
 use zeroize::Zeroizing;
 
 /// Size of the ChaCha20-Poly1305 authentication tag.

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -10,7 +10,15 @@
 )]
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
-#[cfg(not(feature = "std"))]
+#[cfg_attr(
+    any(
+        commonware_stability_GAMMA,
+        commonware_stability_DELTA,
+        commonware_stability_EPSILON,
+        commonware_stability_RESERVED
+    ),
+    allow(unused_extern_crates)
+)]
 extern crate alloc;
 
 // Modules containing #[macro_export] macros must use verbose cfg.
@@ -80,7 +88,6 @@ commonware_macros::stability_scope!(BETA {
     #[cfg(feature = "std")]
     pub use crate::crc32::Crc32;
 
-    #[cfg(feature = "std")]
     pub mod handshake;
 
     /// Produces [Signature]s over messages that can be verified with a corresponding [PublicKey].

--- a/examples/bridge/src/bin/indexer.rs
+++ b/examples/bridge/src/bin/indexer.rs
@@ -24,7 +24,9 @@ use commonware_cryptography::{
 };
 use commonware_formatting::from_hex;
 use commonware_parallel::Sequential;
-use commonware_runtime::{Listener, Network, Runner, Spawner, Supervisor as _, tokio};
+use commonware_runtime::{
+    Acceptor as _, Connection as _, Listener as _, Runner, Scheduler as _, Supervisor as _, tokio,
+};
 use commonware_stream::encrypted::{Config as StreamConfig, listen};
 use commonware_utils::{
     TryCollect,
@@ -236,7 +238,10 @@ fn main() {
         });
 
         // Start listener
-        let mut listener = context.bind(socket).await.expect("failed to bind listener");
+        let mut listener = context
+            .bind(&socket)
+            .await
+            .expect("failed to bind listener");
         let config = StreamConfig {
             signing_key: signer,
             namespace: INDEXER_NAMESPACE.to_vec(),
@@ -247,10 +252,11 @@ fn main() {
         };
         loop {
             // Listen for connection
-            let Ok((_, sink, stream)) = listener.accept().await else {
+            let Ok(connection) = listener.accept().await else {
                 debug!("failed to accept connection");
                 continue;
             };
+            let (sink, stream, _) = connection.split();
 
             let (peer, mut sender, mut receiver) = match listen(
                 context.child("listener"),

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -21,7 +21,8 @@ use commonware_cryptography::{
 use commonware_formatting::from_hex;
 use commonware_p2p::{Manager as _, authenticated};
 use commonware_runtime::{
-    Network, Quota, Runner, Strategizer, Supervisor as _, buffer::paged::CacheRef, tokio,
+    Connection as _, Dialer as _, Quota, Runner, Strategizer, Supervisor as _, TcpEndpoint,
+    buffer::paged::CacheRef, tokio,
 };
 use commonware_stream::encrypted::{Config as StreamConfig, dial};
 use commonware_utils::{NZU16, NZU32, NZUsize, TryCollect, ordered::Set, union};
@@ -180,10 +181,11 @@ fn main() {
     // Start context
     executor.start(|context| async move {
         // Dial indexer
-        let (sink, stream) = context
-            .dial(indexer_address)
+        let connection = context
+            .dial(&TcpEndpoint::from(indexer_address))
             .await
             .expect("Failed to dial indexer");
+        let (sink, stream, _) = connection.split();
         let indexer = dial(context.child("dialer"), indexer_cfg, indexer, stream, sink)
             .await
             .expect("Failed to upgrade connection with indexer");

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -9,8 +9,8 @@ use commonware_p2p::{
     utils::codec::{WrappedReceiver, WrappedSender, wrap},
 };
 use commonware_runtime::{
-    BufferPool, BufferPooler, Clock, Handle, Metrics, Network as RNetwork, Quota, Runner, Spawner,
-    deterministic,
+    Acceptor, BufferPool, BufferPooler, Clock, Connection, Dialer, Handle, Metrics, Quota, Runner,
+    Spawner, TcpEndpoint, TcpOrigin, deterministic,
 };
 use commonware_utils::{
     NZUsize,
@@ -24,6 +24,7 @@ use futures::future::try_join_all;
 use rand_core::Rng;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    net::SocketAddr,
     num::NonZeroU32,
     time::{Duration, SystemTime},
 };
@@ -290,14 +291,23 @@ fn run_single_simulation(
 }
 
 /// Core simulation logic that runs the network simulation
-async fn run_simulation_logic<C: Spawner + BufferPooler + Clock + Metrics + RNetwork + Rng>(
+async fn run_simulation_logic<C>(
     context: C,
     proposer_idx: usize,
     peers: usize,
     distribution: &Distribution,
     commands: &[(usize, Command)],
     latencies: &Latencies,
-) -> Steps {
+) -> Steps
+where
+    C: Acceptor<Bind = SocketAddr, Connection: Connection<Origin = TcpOrigin>>
+        + Dialer<Endpoint = TcpEndpoint, Connection: Connection<Origin = TcpOrigin>>
+        + Spawner
+        + BufferPooler
+        + Clock
+        + Metrics
+        + Rng,
+{
     let mut peer_addresses: Vec<(ed25519::PublicKey, String)> = Vec::with_capacity(peers);
     for (region, config) in distribution {
         for _ in 0..config.count {

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -9,7 +9,7 @@ use commonware_flood::Config;
 use commonware_formatting::from_hex;
 use commonware_p2p::{Manager as _, Receiver, Recipients, Sender, authenticated::discovery};
 use commonware_runtime::{
-    Buf, Quota, Runner, Spawner, Supervisor as _,
+    Buf, Quota, Runner, Scheduler as _, Supervisor as _,
     telemetry::metrics::{HistogramExt as _, MetricsExt as _},
     tokio,
 };

--- a/examples/sync/src/bin/client.rs
+++ b/examples/sync/src/bin/client.rs
@@ -7,7 +7,7 @@ use clap::{Arg, Command};
 use commonware_codec::{EncodeShared, Read};
 use commonware_macros::boxed;
 use commonware_runtime::{
-    BufferPooler, Clock, Metrics, Network, Runner, Spawner, Storage, Supervisor as _,
+    BufferPooler, Clock, Dialer, Metrics, Runner, Spawner, Storage, Supervisor as _, TcpEndpoint,
     tokio as tokio_runtime,
 };
 use commonware_storage::{
@@ -126,7 +126,7 @@ async fn run_full_sync<DB, Op, E, SyncOnce, SyncFut>(
     label: &'static str,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
     Op: Clone + Read + EncodeShared + 'static,
     Op::Cfg: commonware_codec::IsUnit,
     SyncOnce: Fn(
@@ -182,7 +182,7 @@ where
 #[boxed]
 async fn run_any<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
 {
     run_full_sync::<any::Database<_>, any::Operation, _, _, _>(
         context,
@@ -224,7 +224,7 @@ where
 #[boxed]
 async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
 {
     run_full_sync::<current::Database<_>, current::Operation, _, _, _>(
         context,
@@ -263,7 +263,7 @@ where
 /// Repeatedly sync an Immutable database to the server's state.
 async fn run_immutable<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
 {
     run_full_sync::<immutable::Database<_>, immutable::Operation, _, _, _>(
         context,
@@ -303,7 +303,7 @@ where
 /// Repeatedly sync a Keyless database to the server's state.
 async fn run_keyless<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
 {
     run_full_sync::<keyless::Database<_>, keyless::Operation, _, _, _>(
         context,
@@ -346,7 +346,7 @@ async fn run_compact_sync<DB, Op, E, MakeConfig>(
     label: &'static str,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
     DB: compact::Database<Family = mmr::Family, Context = E, Digest = Key, Op = Op>,
     Op: Clone + Read + EncodeShared + 'static,
     Op::Cfg: commonware_codec::IsUnit,
@@ -397,7 +397,7 @@ async fn run_immutable_compact<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
 {
     run_compact_sync::<immutable_compact::Database<_>, immutable_compact::Operation, _, _>(
         context,
@@ -413,7 +413,7 @@ async fn run_keyless_compact<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner,
+    E: BufferPooler + Storage + Clock + Metrics + Dialer<Endpoint = TcpEndpoint> + Spawner,
 {
     run_compact_sync::<keyless_compact::Database<_>, keyless_compact::Operation, _, _>(
         context,

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -8,7 +8,7 @@ use clap::{Arg, Command};
 use commonware_codec::{DecodeExt, Encode, Read};
 use commonware_macros::{boxed, select_loop};
 use commonware_runtime::{
-    BufferPooler, Clock, Listener, Metrics, Network, Runner, SinkOf, Spawner, Storage, StreamOf,
+    Acceptor, BufferPooler, Clock, Connection, Listener, Metrics, Runner, Spawner, Storage,
     Supervisor as _,
     telemetry::metrics::{Counter, MetricsExt as _},
     tokio as tokio_runtime,
@@ -46,6 +46,9 @@ const MAX_BATCH_SIZE: u64 = 100;
 
 /// Size of the channel for responses.
 const RESPONSE_BUFFER_SIZE: usize = 64;
+
+type SinkOf<E> = <<E as Acceptor>::Connection as Connection>::Sink;
+type StreamOf<E> = <<E as Acceptor>::Connection as Connection>::Stream;
 
 /// Server configuration.
 #[derive(Debug)]
@@ -458,12 +461,12 @@ async fn recv_loop<DB, E, Mode>(
     state: Arc<State<DB>>,
     mut stream: StreamOf<E>,
     response_sender: mpsc::Sender<wire::Message<DB::Operation, Key>>,
-    client_addr: SocketAddr,
+    client_addr: String,
 ) where
     DB: ExampleDatabase<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Metrics + Network + Spawner,
+    E: Metrics + Acceptor<Bind = SocketAddr> + Spawner,
     Mode: ServeMode<DB> + 'static,
 {
     loop {
@@ -487,6 +490,7 @@ async fn recv_loop<DB, E, Mode>(
         context.child("request_handler").spawn({
             let state = state.clone();
             let response_sender = response_sender.clone();
+            let client_addr = client_addr.clone();
             move |_| async move {
                 let response = Mode::handle_message(state.as_ref(), message).await;
                 if let Err(err) = response_sender.send(response).await {
@@ -507,13 +511,13 @@ async fn handle_client<DB, E, Mode>(
     state: Arc<State<DB>>,
     mut sink: SinkOf<E>,
     stream: StreamOf<E>,
-    client_addr: SocketAddr,
+    client_addr: String,
 ) -> Result<(), BoxError>
 where
     DB: ExampleDatabase<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner,
+    E: Storage + Clock + Metrics + Acceptor<Bind = SocketAddr> + Spawner,
     Mode: ServeMode<DB> + 'static,
 {
     info!(client_addr = %client_addr, "client connected");
@@ -524,6 +528,7 @@ where
     let recv_handle = context.child("recv").spawn({
         let state = state.clone();
         let response_sender = response_sender.clone();
+        let client_addr = client_addr.clone();
         move |context| {
             recv_loop::<DB, E, Mode>(context, state, stream, response_sender, client_addr)
         }
@@ -618,12 +623,12 @@ where
     DB: ExampleDatabase<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: Storage + Clock + Metrics + Acceptor<Bind = SocketAddr> + Spawner + Rng + Send,
     Mode: ServeMode<DB> + 'static,
 {
     // Create listener to accept connections
     let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, config.port));
-    let mut listener = context.child("listener").bind(addr).await?;
+    let mut listener = context.child("listener").bind(&addr).await?;
     info!(
         addr = %addr,
         op_interval = ?config.op_interval,
@@ -648,13 +653,12 @@ where
             next_op_time = context.current() + config.op_interval;
         },
         client_result = listener.accept() => match client_result {
-            Ok((client_addr, sink, stream)) => {
+            Ok(connection) => {
+                let (sink, stream, info) = connection.split();
+                let client_addr = format!("{:?}", info.origin);
                 let state = state.clone();
                 context.child("client").spawn(move |context| async move {
-                    if let Err(err) =
-                        handle_client::<DB, _, Mode>(context, state, sink, stream, client_addr)
-                            .await
-                    {
+                    if let Err(err) = handle_client::<DB, _, Mode>(context, state, sink, stream, client_addr.clone()).await {
                         error!(client_addr = %client_addr, ?err, "error handling client");
                     }
                 });
@@ -674,7 +678,7 @@ where
     DB: Syncable<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: Storage + Clock + Metrics + Acceptor<Bind = SocketAddr> + Spawner + Rng + Send,
 {
     let database = initialize_database(database, &config, &mut context).await?;
     run_server::<DB, E, FullMode>(context, config, database).await
@@ -690,7 +694,7 @@ where
     DB: CompactSyncable<Family = mmr::Family> + Send + Sync + 'static,
     DB::Operation: Read + Encode + Send,
     <DB::Operation as Read>::Cfg: commonware_codec::IsUnit,
-    E: Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: Storage + Clock + Metrics + Acceptor<Bind = SocketAddr> + Spawner + Rng + Send,
     Arc<AsyncRwLock<Option<DB>>>: compact::Resolver<
             Family = mmr::Family,
             Op = DB::Operation,
@@ -706,7 +710,14 @@ where
 #[boxed]
 async fn run_any<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = any::create_config(&context);
     let database = any::Database::init(context.child("database"), db_config).await?;
@@ -718,7 +729,14 @@ where
 #[boxed]
 async fn run_current<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = current::create_config(&context);
     let database = current::Database::init(context.child("database"), db_config).await?;
@@ -730,7 +748,14 @@ where
 #[boxed]
 async fn run_immutable<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = immutable::create_config(&context);
     let database = immutable::Database::init(context.child("database"), db_config).await?;
@@ -745,7 +770,14 @@ async fn run_immutable_full_source<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = immutable::create_config(&context);
     let database = immutable::Database::init(context.child("database"), db_config).await?;
@@ -757,7 +789,14 @@ where
 #[boxed]
 async fn run_keyless<E>(context: E, config: Config) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = keyless::create_config(&context);
     let database = keyless::Database::init(context.child("database"), db_config).await?;
@@ -772,7 +811,14 @@ async fn run_keyless_full_source<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = keyless::create_config(&context);
     let database = keyless::Database::init(context.child("database"), db_config).await?;
@@ -786,7 +832,14 @@ async fn run_immutable_compact<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = immutable_compact::create_config(&context);
     let database = immutable_compact::Database::init(context.child("database"), db_config).await?;
@@ -800,7 +853,14 @@ async fn run_keyless_compact<E>(
     config: Config,
 ) -> Result<(), Box<dyn std::error::Error>>
 where
-    E: BufferPooler + Storage + Clock + Metrics + Network + Spawner + Rng + Send,
+    E: BufferPooler
+        + Storage
+        + Clock
+        + Metrics
+        + Acceptor<Bind = SocketAddr>
+        + Spawner
+        + Rng
+        + Send,
 {
     let db_config = keyless_compact::create_config(&context);
     let database = keyless_compact::Database::init(context.child("database"), db_config).await?;

--- a/examples/sync/src/net/resolver.rs
+++ b/examples/sync/src/net/resolver.rs
@@ -2,7 +2,7 @@ use super::{io, wire};
 use crate::net::request_id;
 use commonware_codec::{EncodeShared, IsUnit, Read};
 use commonware_cryptography::Digest;
-use commonware_runtime::{Network, Spawner};
+use commonware_runtime::{Connection as _, Dialer, Spawner, TcpEndpoint};
 use commonware_storage::{
     mmr::{self, Location},
     qmdb::sync::{self, compact, resolver::fetch_operation_range},
@@ -34,9 +34,10 @@ where
         server_addr: std::net::SocketAddr,
     ) -> Result<Self, commonware_runtime::Error>
     where
-        E: Network + Spawner,
+        E: Dialer<Endpoint = TcpEndpoint> + Spawner,
     {
-        let (sink, stream) = context.dial(server_addr).await?;
+        let connection = context.dial(&server_addr.into()).await?;
+        let (sink, stream, _) = connection.split();
         let (request_tx, _handle) = io::run(context, sink, stream)?;
         Ok(Self {
             request_id_generator: request_id::Generator::new(),

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -28,7 +28,7 @@ use commonware_p2p::{
 };
 use commonware_parallel::Strategy;
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Spawner, Storage,
+    BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage,
     buffer::paged::CacheRef,
     spawn_cell,
     telemetry::metrics::{Gauge, GaugeExt, MetricsExt as _},
@@ -183,7 +183,7 @@ where
 /// Consensus engine orchestrator.
 pub struct Actor<E, B, M, P, MV, DV, C, A, L, T, ACK = Exact>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage + Network,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage,
     B: Blocker<PublicKey = <P::Scheme as Verifier>::PublicKey>,
     M: Manager<PublicKey = <P::Scheme as Verifier>::PublicKey>,
     P: Provider<Scope = Epoch>,
@@ -225,7 +225,7 @@ where
 
 impl<E, B, M, P, MV, DV, C, A, L, T, ACK> Actor<E, B, M, P, MV, DV, C, A, L, T, ACK>
 where
-    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage + Network,
+    E: BufferPooler + Spawner + Metrics + CryptoRng + Clock + Storage,
     B: Blocker<PublicKey = <P::Scheme as Verifier>::PublicKey>,
     M: Manager<PublicKey = <P::Scheme as Verifier>::PublicKey>,
     P: Provider<Scope = Epoch>,

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -95,8 +95,8 @@ mod tests {
     use commonware_p2p::simulated::{Config as NetworkConfig, Link, Network, Oracle};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        Clock as _, Handle, Quota, Runner, Spawner as _, Supervisor as _, buffer::paged::CacheRef,
-        deterministic,
+        Clock as _, Handle, Quota, Runner, Scheduler as _, Supervisor as _,
+        buffer::paged::CacheRef, deterministic,
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{

--- a/glue/src/dkg/reshare/actor/inclusion.rs
+++ b/glue/src/dkg/reshare/actor/inclusion.rs
@@ -710,7 +710,7 @@ mod tests {
         bls12381::primitives::sharing::Mode as SharingMode,
         ed25519::{PrivateKey, PublicKey},
     };
-    use commonware_runtime::{Runner, Spawner, Supervisor, deterministic};
+    use commonware_runtime::{Runner, Scheduler, Supervisor, deterministic};
     use commonware_utils::{N3f1, NZU32, NZU64, channel::oneshot, ordered::Set};
     use futures::{FutureExt, stream};
     use std::sync::Arc;

--- a/glue/src/dkg/reshare/application.rs
+++ b/glue/src/dkg/reshare/application.rs
@@ -272,7 +272,9 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
         sha256::Sha256,
     };
-    use commonware_runtime::{Clock, Metrics, Runner, Spawner, Supervisor, deterministic};
+    use commonware_runtime::{
+        Clock, Metrics, Runner, Scheduler as _, Spawner, Supervisor, deterministic,
+    };
     use commonware_utils::{
         Acknowledgement, N3f1, NZU32, NZU64, NZUsize, TestRng, channel::oneshot, ordered::Set,
         sync::Mutex,

--- a/glue/src/dkg/tests/dkg/harness.rs
+++ b/glue/src/dkg/tests/dkg/harness.rs
@@ -35,7 +35,7 @@ use commonware_p2p::{
 };
 use commonware_parallel::Sequential;
 use commonware_runtime::{
-    Clock as _, Handle, Quota, Runner as _, Spawner as _, Supervisor as _, deterministic,
+    Clock as _, Handle, Quota, Runner as _, Scheduler as _, Supervisor as _, deterministic,
     telemetry::metrics::count_running_tasks,
 };
 use commonware_utils::{

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -58,8 +58,8 @@ use commonware_formatting::hex;
 use commonware_math::algebra::Random;
 use commonware_parallel::Sequential;
 use commonware_runtime::{
-    Buf, BufMut, BufferPooler, Clock, Handle, Metrics, Quota, Spawner, Storage, Supervisor as _,
-    buffer::paged::CacheRef, deterministic::Context as DeterministicContext,
+    Buf, BufMut, BufferPooler, Clock, Handle, Metrics, Quota, Scheduler as _, Spawner, Storage,
+    Supervisor as _, buffer::paged::CacheRef, deterministic::Context as DeterministicContext,
 };
 use commonware_storage::{
     archive::prunable,

--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -15,7 +15,7 @@ use commonware_p2p::{
     Manager as _,
     simulated::{self, Link, Network},
 };
-use commonware_runtime::{Clock, Runner as _, Spawner, Supervisor as _, deterministic};
+use commonware_runtime::{Clock, Runner as _, Scheduler, Supervisor as _, deterministic};
 use commonware_utils::{NZUsize, TryCollect, channel::mpsc, ordered::Set};
 use rand::seq::IndexedRandom;
 use std::{
@@ -848,7 +848,7 @@ mod tests {
     use super::*;
     use commonware_consensus::types::{Epoch, Round, View};
     use commonware_cryptography::{Signer as _, ed25519};
-    use commonware_runtime::{Clock, Handle, Quota, Spawner};
+    use commonware_runtime::{Clock, Handle, Quota};
     use std::{
         future::Future,
         pin::Pin,

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -336,7 +336,7 @@ mod tests {
     use commonware_cryptography::{certificate::ConstantProvider, sha256::Digest as Sha256Digest};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        ContextCell, Runner as _, Spawner as _, Supervisor as _,
+        ContextCell, Runner as _, Scheduler as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, next_pending_sync},

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -416,7 +416,7 @@ mod tests {
     use commonware_macros::select;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Clock as _, Metrics as _, Runner as _, Spawner as _, Supervisor as _,
+        BufferPooler, Clock as _, Metrics as _, Runner as _, Scheduler as _, Supervisor as _,
         buffer::paged::CacheRef, deterministic,
     };
     use commonware_storage::{

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -396,7 +396,7 @@ mod tests {
     use commonware_macros::select;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Clock as _, Metrics as _, Runner as _, Spawner as _, Supervisor as _,
+        BufferPooler, Clock as _, Metrics as _, Runner as _, Scheduler as _, Supervisor as _,
         buffer::paged::CacheRef, deterministic,
     };
     use commonware_storage::{

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1630,7 +1630,7 @@ mod tests {
     use commonware_cryptography::sha256;
     use commonware_macros::select;
     use commonware_runtime::{
-        Clock, Runner as _, Spawner as _, Supervisor as _, deterministic, reschedule,
+        Clock, Runner as _, Scheduler as _, Supervisor as _, deterministic, reschedule,
     };
     use commonware_utils::channel::{mpsc, oneshot, ring};
     use futures::{FutureExt, SinkExt, pin_mut};

--- a/glue/src/stateful/db/p2p/compact/mailbox.rs
+++ b/glue/src/stateful/db/p2p/compact/mailbox.rs
@@ -5,7 +5,7 @@ use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel};
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_storage::{merkle::Family, qmdb::sync::compact};
-use commonware_utils::channel::oneshot;
+use commonware_utils::{PlatformSend, channel::oneshot};
 use std::{collections::VecDeque, future::Future};
 
 /// The resolver actor dropped the response before completion.
@@ -47,7 +47,11 @@ impl<DB, F: Family, Op, D: Digest> Default for Pending<DB, F, Op, D> {
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<DB, F, Op, D> {
+impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<DB, F, Op, D>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     fn is_empty(&self) -> bool {
         self.database.is_none() && self.messages.is_empty()
     }
@@ -76,7 +80,11 @@ impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<D
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D> {
+impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     type Overflow = Pending<DB, F, Op, D>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
@@ -94,11 +102,19 @@ impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D> {
 }
 
 /// Client-facing resolver mailbox used by compact QMDB sync.
-pub struct Mailbox<DB, F: Family, Op, H: Hasher> {
+pub struct Mailbox<DB, F: Family, Op, H: Hasher>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     sender: Sender<Message<DB, F, Op, H::Digest>>,
 }
 
-impl<DB, F: Family, Op, H: Hasher> Clone for Mailbox<DB, F, Op, H> {
+impl<DB, F: Family, Op, H: Hasher> Clone for Mailbox<DB, F, Op, H>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     fn clone(&self) -> Self {
         Self {
             sender: self.sender.clone(),
@@ -106,7 +122,11 @@ impl<DB, F: Family, Op, H: Hasher> Clone for Mailbox<DB, F, Op, H> {
     }
 }
 
-impl<DB, F: Family, Op, H: Hasher> Mailbox<DB, F, Op, H> {
+impl<DB, F: Family, Op, H: Hasher> Mailbox<DB, F, Op, H>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     pub(super) const fn new(sender: Sender<Message<DB, F, Op, H::Digest>>) -> Self {
         Self { sender }
     }

--- a/glue/src/stateful/db/p2p/standard/mailbox.rs
+++ b/glue/src/stateful/db/p2p/standard/mailbox.rs
@@ -9,7 +9,7 @@ use commonware_storage::{
     merkle::{Family, Location},
     qmdb::sync::resolver::{FetchResult, Resolver as SyncResolver},
 };
-use commonware_utils::channel::oneshot;
+use commonware_utils::{PlatformSend, channel::oneshot};
 use std::{collections::VecDeque, future::Future, num::NonZeroU64};
 
 /// The resolver actor dropped the response before completion.
@@ -53,7 +53,11 @@ impl<DB, F: Family, Op, D: Digest> Default for Pending<DB, F, Op, D> {
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<DB, F, Op, D> {
+impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<DB, F, Op, D>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     fn is_empty(&self) -> bool {
         self.database.is_none() && self.messages.is_empty()
     }
@@ -82,7 +86,11 @@ impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<D
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D> {
+impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     type Overflow = Pending<DB, F, Op, D>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
@@ -100,11 +108,19 @@ impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D> {
 }
 
 /// Client-facing resolver mailbox used by the QMDB sync engine.
-pub struct Mailbox<DB, F: Family, Op, D: Digest> {
+pub struct Mailbox<DB, F: Family, Op, D: Digest>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     sender: Sender<Message<DB, F, Op, D>>,
 }
 
-impl<DB, F: Family, Op, D: Digest> Clone for Mailbox<DB, F, Op, D> {
+impl<DB, F: Family, Op, D: Digest> Clone for Mailbox<DB, F, Op, D>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     fn clone(&self) -> Self {
         Self {
             sender: self.sender.clone(),
@@ -112,7 +128,11 @@ impl<DB, F: Family, Op, D: Digest> Clone for Mailbox<DB, F, Op, D> {
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Mailbox<DB, F, Op, D> {
+impl<DB, F: Family, Op, D: Digest> Mailbox<DB, F, Op, D>
+where
+    Shared<DB>: PlatformSend,
+    Op: PlatformSend,
+{
     pub(super) const fn new(sender: Sender<Message<DB, F, Op, D>>) -> Self {
         Self { sender }
     }

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -195,7 +195,7 @@ pub use commonware_macros_impl::select;
 /// ```rust,ignore
 /// use commonware_macros::select_loop;
 ///
-/// async fn run(context: impl commonware_runtime::Spawner, mut receiver: Receiver<Message>) {
+/// async fn run(context: impl commonware_runtime::Scheduler, mut receiver: Receiver<Message>) {
 ///     let mut counter = 0;
 ///     commonware_macros::select_loop! {
 ///         context,

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -19,7 +19,6 @@ commonware-actor.workspace = true
 commonware-codec.workspace = true
 commonware-cryptography.workspace = true
 commonware-macros = { workspace = true, features = ["std"] }
-commonware-parallel = { workspace = true, features = ["std"] }
 commonware-runtime.workspace = true
 commonware-stream.workspace = true
 commonware-utils.workspace = true
@@ -29,11 +28,14 @@ num-bigint.workspace = true
 num-integer.workspace = true
 num-rational.workspace = true
 num-traits.workspace = true
-rand.workspace = true
+rand = { workspace = true, features = ["std_rng"] }
 rand_core.workspace = true
 rand_distr.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+commonware-parallel = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 commonware-conformance.workspace = true

--- a/p2p/conformance.toml
+++ b/p2p/conformance.toml
@@ -22,6 +22,14 @@ hash = "d3e85c4a686b2b20a7af190a6446d22c356584166b1e245757c4a45428c4c416"
 n_cases = 65536
 hash = "7839d952c09aea96d40dcfd33b3219babe805bd0b8aa7d80b30f65041cf43a8c"
 
+["commonware_p2p::types::tests::conformance::CodecConformance<Advertisement<Ingress>>"]
+n_cases = 65536
+hash = "f61f28283896523a65bf12f501f48aafe7ef42ec3002756e722b5347077a0dd3"
+
 ["commonware_p2p::types::tests::conformance::CodecConformance<Ingress>"]
 n_cases = 65536
 hash = "e773b0aaebf079d380a4652b17c063f7a936f0da853d28e4a88ccb55a82574f2"
+
+["commonware_p2p::types::tests::conformance::CodecConformance<Reachability<Ingress>>"]
+n_cases = 65536
+hash = "326d241a2341632b43590d82abe535b2204547db2ee0747ef649486e690e9c76"

--- a/p2p/src/authenticated/admission.rs
+++ b/p2p/src/authenticated/admission.rs
@@ -1,0 +1,569 @@
+//! Admission policies for inbound authenticated connections.
+
+use commonware_cryptography::PublicKey;
+use commonware_macros::stability;
+use commonware_runtime::{
+    Clock, ConnectionInfo, KeyedRateLimiter, Metrics, Quota, TcpOrigin,
+    telemetry::metrics::{Counter, MetricsExt as _},
+};
+use commonware_utils::{
+    IpAddrExt, PlatformSend, PlatformSync,
+    net::{Subnet, SubnetMask},
+    sync::RwLock,
+};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    net::{IpAddr, SocketAddr},
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+use thiserror::Error;
+
+/// Subnet mask used to rate limit inbound TCP handshakes.
+const SUBNET_MASK: SubnetMask = SubnetMask::new(24, 48);
+
+/// Number of admitted origins between rate-limiter cleanup attempts.
+const CLEANUP_INTERVAL: u32 = 16_384;
+
+/// Authorizes an inbound connection before and after peer authentication.
+///
+/// The pre-authentication permit carries policy state across the encrypted handshake. It is
+/// dropped without calling [`InboundAdmission::post_auth`] if the handshake fails.
+pub trait InboundAdmission<P: PublicKey, O>: PlatformSend + PlatformSync + 'static {
+    /// State retained while the encrypted handshake is in progress.
+    type Permit: PlatformSend + 'static;
+
+    /// Decides whether authentication should begin.
+    fn pre_auth(&self, info: &ConnectionInfo<O>) -> Result<Self::Permit, Rejection>;
+
+    /// Checks the claimed peer before performing the cryptographic handshake.
+    ///
+    /// Policies that bind transport origins to peer identities should reject mismatches here and
+    /// repeat the check in [`InboundAdmission::post_auth`] to guard against concurrent policy
+    /// updates.
+    fn accept_peer(
+        &self,
+        _peer: &P,
+        _info: &ConnectionInfo<O>,
+    ) -> bool {
+        true
+    }
+
+    /// Decides whether the authenticated peer may use the connection.
+    fn post_auth(
+        &self,
+        permit: Self::Permit,
+        peer: &P,
+        info: &ConnectionInfo<O>,
+    ) -> impl Future<Output = Result<(), Rejection>> + PlatformSend;
+}
+
+/// Admits only one expected authenticated peer, independent of transport origin.
+#[stability(ALPHA)]
+#[derive(Clone, Debug)]
+pub struct ExactPeerAdmission<P> {
+    expected: P,
+}
+
+#[stability(ALPHA)]
+impl<P> ExactPeerAdmission<P> {
+    /// Creates an admission policy for `expected`.
+    pub const fn new(expected: P) -> Self {
+        Self { expected }
+    }
+}
+
+#[stability(ALPHA)]
+impl<P, O> InboundAdmission<P, O> for ExactPeerAdmission<P>
+where
+    P: PublicKey,
+    O: PlatformSend + PlatformSync + 'static,
+{
+    type Permit = ();
+
+    fn pre_auth(&self, _info: &ConnectionInfo<O>) -> Result<Self::Permit, Rejection> {
+        Ok(())
+    }
+
+    fn accept_peer(
+        &self,
+        peer: &P,
+        _info: &ConnectionInfo<O>,
+    ) -> bool {
+        peer == &self.expected
+    }
+
+    async fn post_auth(
+        &self,
+        _permit: Self::Permit,
+        peer: &P,
+        _info: &ConnectionInfo<O>,
+    ) -> Result<(), Rejection> {
+        if peer == &self.expected {
+            return Ok(());
+        }
+        Err(Rejection::Application)
+    }
+}
+
+/// Configuration for TCP inbound admission.
+#[derive(Clone)]
+pub struct TcpAdmissionConfig {
+    /// Whether non-global source IP addresses are allowed.
+    pub allow_private_ips: bool,
+
+    /// Whether a source IP must be present in the registered IP set.
+    pub require_registered_ip: bool,
+
+    /// Quota for handshake attempts from one IP address.
+    pub allowed_handshake_rate_per_ip: Quota,
+
+    /// Quota for handshake attempts from one `/24` IPv4 or `/48` IPv6 subnet.
+    pub allowed_handshake_rate_per_subnet: Quota,
+}
+
+/// Reason an inbound TCP connection was rejected before authentication.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum Rejection {
+    /// The transport did not provide the remote TCP socket.
+    #[error("TCP connection is missing its remote origin")]
+    MissingOrigin,
+
+    /// The remote IP is not globally routable.
+    #[error("private IP is not allowed")]
+    PrivateIp,
+
+    /// The remote IP is not registered by an authorized peer.
+    #[error("IP is not registered")]
+    UnregisteredIp,
+
+    /// The remote IP exceeded its handshake quota.
+    #[error("IP exceeded its handshake quota")]
+    IpRateLimited,
+
+    /// The remote subnet exceeded its handshake quota.
+    #[error("subnet exceeded its handshake quota")]
+    SubnetRateLimited,
+
+    /// An application-specific admission rule rejected the connection.
+    #[cfg(not(any(
+        commonware_stability_BETA,
+        commonware_stability_GAMMA,
+        commonware_stability_DELTA,
+        commonware_stability_EPSILON,
+        commonware_stability_RESERVED
+    )))] // ALPHA
+    #[error("application admission policy rejected the connection")]
+    Application,
+}
+
+/// Permit retained across a TCP handshake.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TcpPermit {
+    source: SocketAddr,
+}
+
+/// Applies private-IP, registered-IP, exact-IP, and subnet admission rules to TCP connections.
+pub struct TcpAdmission<E: Clock + Metrics, P: PublicKey> {
+    allow_private_ips: bool,
+    require_registered_ip: bool,
+    address_book: Arc<RwLock<TcpAddressBook<P>>>,
+    eligibility: Option<PeerEligibility<P>>,
+    ip_rate_limiter: KeyedRateLimiter<IpAddr, E>,
+    subnet_rate_limiter: KeyedRateLimiter<Subnet, E>,
+    admitted: AtomicU32,
+    handshakes_blocked: Counter,
+    handshakes_ip_rate_limited: Counter,
+    handshakes_subnet_rate_limited: Counter,
+}
+
+/// Handle used to atomically replace TCP peer-origin associations.
+#[derive(Clone)]
+pub struct TcpAdmissionUpdates<P: PublicKey> {
+    address_book: Arc<RwLock<TcpAddressBook<P>>>,
+}
+
+struct TcpAddressBook<P> {
+    registered_ips: HashSet<IpAddr>,
+    peers_by_ip: HashMap<IpAddr, HashSet<P>>,
+    peer_ips: HashMap<P, HashSet<IpAddr>>,
+}
+
+impl<P> Default for TcpAddressBook<P> {
+    fn default() -> Self {
+        Self {
+            registered_ips: HashSet::new(),
+            peers_by_ip: HashMap::new(),
+            peer_ips: HashMap::new(),
+        }
+    }
+}
+
+/// Shared snapshot of peers currently eligible for inbound authentication.
+#[derive(Clone)]
+pub(crate) struct PeerEligibility<P> {
+    peers: Arc<RwLock<HashSet<P>>>,
+}
+
+impl<P> Default for PeerEligibility<P> {
+    fn default() -> Self {
+        Self {
+            peers: Arc::new(RwLock::new(HashSet::new())),
+        }
+    }
+}
+
+impl<P: Eq + std::hash::Hash> PeerEligibility<P> {
+    pub(crate) fn set(&self, peers: HashSet<P>) {
+        *self.peers.write() = peers;
+    }
+
+    fn allows_any(&self, peers: &HashSet<P>) -> bool {
+        let eligible = self.peers.read();
+        peers.iter().any(|peer| eligible.contains(peer))
+    }
+}
+
+impl<P: PublicKey> TcpAdmissionUpdates<P> {
+    /// Replaces the registered union and exact peer-to-origin associations together.
+    pub fn set(&self, peer_ips: HashMap<P, HashSet<IpAddr>>) {
+        let registered_ips = peer_ips.values().flatten().copied().collect();
+        let mut peers_by_ip: HashMap<IpAddr, HashSet<P>> = HashMap::new();
+        for (peer, ips) in &peer_ips {
+            for ip in ips {
+                peers_by_ip.entry(*ip).or_default().insert(peer.clone());
+            }
+        }
+        *self.address_book.write() = TcpAddressBook {
+            registered_ips,
+            peers_by_ip,
+            peer_ips,
+        };
+    }
+}
+
+impl<E: Clock + Metrics, P: PublicKey> TcpAdmission<E, P> {
+    /// Creates a policy and a handle for updating its registered peer origins.
+    #[cfg(test)]
+    pub fn with_updates(context: E, cfg: TcpAdmissionConfig) -> (Self, TcpAdmissionUpdates<P>) {
+        Self::new(context, cfg, None)
+    }
+
+    pub(crate) fn with_eligibility(
+        context: E,
+        cfg: TcpAdmissionConfig,
+        eligibility: PeerEligibility<P>,
+    ) -> (Self, TcpAdmissionUpdates<P>) {
+        Self::new(context, cfg, Some(eligibility))
+    }
+
+    fn new(
+        context: E,
+        cfg: TcpAdmissionConfig,
+        eligibility: Option<PeerEligibility<P>>,
+    ) -> (Self, TcpAdmissionUpdates<P>) {
+        let ip_rate_limiter = KeyedRateLimiter::hashmap_with_clock(
+            cfg.allowed_handshake_rate_per_ip,
+            context.child("ip_rate_limiter"),
+        );
+        let subnet_rate_limiter = KeyedRateLimiter::hashmap_with_clock(
+            cfg.allowed_handshake_rate_per_subnet,
+            context.child("subnet_rate_limiter"),
+        );
+        let handshakes_blocked = context.counter(
+            "handshakes_blocked",
+            "number of handshake attempts blocked by TCP origin policy",
+        );
+        let handshakes_ip_rate_limited = context.counter(
+            "handshake_ip_rate_limited",
+            "number of handshake attempts dropped because an IP exceeded its rate limit",
+        );
+        let handshakes_subnet_rate_limited = context.counter(
+            "handshake_subnet_rate_limited",
+            "number of handshake attempts dropped because a subnet exceeded its rate limit",
+        );
+
+        let address_book = Arc::new(RwLock::new(TcpAddressBook::default()));
+        let updates = TcpAdmissionUpdates {
+            address_book: address_book.clone(),
+        };
+        let admission = Self {
+            allow_private_ips: cfg.allow_private_ips,
+            require_registered_ip: cfg.require_registered_ip,
+            address_book,
+            eligibility,
+            ip_rate_limiter,
+            subnet_rate_limiter,
+            admitted: AtomicU32::new(0),
+            handshakes_blocked,
+            handshakes_ip_rate_limited,
+            handshakes_subnet_rate_limited,
+        };
+        (admission, updates)
+    }
+
+    fn registered(&self, ip: &IpAddr) -> bool {
+        let address_book = self.address_book.read();
+        let Some(eligibility) = &self.eligibility else {
+            return address_book.registered_ips.contains(ip);
+        };
+        address_book
+            .peers_by_ip
+            .get(ip)
+            .is_some_and(|peers| eligibility.allows_any(peers))
+    }
+
+    fn peer_registered(&self, source: IpAddr, peer: &P) -> bool {
+        !self.require_registered_ip
+            || self
+                .address_book
+                .read()
+                .peer_ips
+                .get(peer)
+                .is_some_and(|ips| ips.contains(&source))
+    }
+
+    fn pre_auth(&self, info: &ConnectionInfo<TcpOrigin>) -> Result<TcpPermit, Rejection> {
+        let Some(origin) = &info.origin else {
+            self.handshakes_blocked.inc();
+            return Err(Rejection::MissingOrigin);
+        };
+        let source = origin.remote;
+        let ip = source.ip();
+
+        if !self.allow_private_ips && !IpAddrExt::is_global(&ip) {
+            self.handshakes_blocked.inc();
+            return Err(Rejection::PrivateIp);
+        }
+        if self.require_registered_ip && !self.registered(&ip) {
+            self.handshakes_blocked.inc();
+            return Err(Rejection::UnregisteredIp);
+        }
+
+        if self.admitted.fetch_add(1, Ordering::Relaxed) >= CLEANUP_INTERVAL {
+            self.ip_rate_limiter.retain_recent();
+            self.subnet_rate_limiter.retain_recent();
+            self.admitted.store(0, Ordering::Relaxed);
+        }
+
+        // Charge both buckets even when the first is exhausted. This prevents an attacker from
+        // avoiding the subnet quota by first exhausting its exact-IP quota.
+        let ip_limited = self.ip_rate_limiter.check_key(&ip).is_err();
+        let subnet = ip.subnet(&SUBNET_MASK);
+        let subnet_limited = self.subnet_rate_limiter.check_key(&subnet).is_err();
+
+        if ip_limited {
+            self.handshakes_ip_rate_limited.inc();
+        }
+        if subnet_limited {
+            self.handshakes_subnet_rate_limited.inc();
+        }
+        if ip_limited {
+            return Err(Rejection::IpRateLimited);
+        }
+        if subnet_limited {
+            return Err(Rejection::SubnetRateLimited);
+        }
+
+        Ok(TcpPermit { source })
+    }
+}
+
+impl<E, P> InboundAdmission<P, TcpOrigin> for TcpAdmission<E, P>
+where
+    E: Clock + Metrics,
+    P: PublicKey,
+{
+    type Permit = TcpPermit;
+    fn pre_auth(&self, info: &ConnectionInfo<TcpOrigin>) -> Result<Self::Permit, Rejection> {
+        Self::pre_auth(self, info)
+    }
+
+    fn accept_peer(
+        &self,
+        peer: &P,
+        info: &ConnectionInfo<TcpOrigin>,
+    ) -> bool {
+        let Some(origin) = &info.origin else {
+            return false;
+        };
+        if self.peer_registered(origin.remote.ip(), peer) {
+            return true;
+        }
+        self.handshakes_blocked.inc();
+        false
+    }
+
+    async fn post_auth(
+        &self,
+        permit: Self::Permit,
+        peer: &P,
+        _info: &ConnectionInfo<TcpOrigin>,
+    ) -> Result<(), Rejection> {
+        if !self.peer_registered(permit.source.ip(), peer) {
+            self.handshakes_blocked.inc();
+            return Err(Rejection::UnregisteredIp);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_cryptography::{
+        Signer as _,
+        ed25519::{PrivateKey, PublicKey},
+    };
+    use commonware_runtime::{Quota, Runner as _, Supervisor as _, deterministic};
+    use commonware_utils::NZU32;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn info(ip: IpAddr) -> ConnectionInfo<TcpOrigin> {
+        ConnectionInfo {
+            origin: Some(TcpOrigin {
+                remote: SocketAddr::new(ip, 1234),
+            }),
+            transport: "tcp",
+        }
+    }
+
+    fn config(ip: Quota, subnet: Quota) -> TcpAdmissionConfig {
+        TcpAdmissionConfig {
+            allow_private_ips: true,
+            require_registered_ip: true,
+            allowed_handshake_rate_per_ip: ip,
+            allowed_handshake_rate_per_subnet: subnet,
+        }
+    }
+
+    #[test]
+    fn enforces_origin_and_registered_ip() {
+        deterministic::Runner::default().start(|context| async move {
+            let (admission, updates) = TcpAdmission::with_updates(
+                context.child("admission"),
+                config(Quota::per_second(NZU32!(10)), Quota::per_second(NZU32!(10))),
+            );
+            let peer = PrivateKey::from_seed(1).public_key();
+            let missing = ConnectionInfo {
+                origin: None,
+                transport: "tcp",
+            };
+            assert_eq!(
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &admission, &missing
+                ),
+                Err(Rejection::MissingOrigin)
+            );
+
+            let source = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+            assert_eq!(
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &admission,
+                    &info(source),
+                ),
+                Err(Rejection::UnregisteredIp)
+            );
+            updates.set(HashMap::from([(peer, HashSet::from([source]))]));
+            assert!(
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &admission,
+                    &info(source),
+                )
+                .is_ok()
+            );
+
+            let private_admission = TcpAdmission::with_updates(
+                context.child("private"),
+                TcpAdmissionConfig {
+                    allow_private_ips: false,
+                    require_registered_ip: false,
+                    allowed_handshake_rate_per_ip: Quota::per_second(NZU32!(10)),
+                    allowed_handshake_rate_per_subnet: Quota::per_second(NZU32!(10)),
+                },
+            )
+            .0;
+            assert_eq!(
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &private_admission,
+                    &info(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+                ),
+                Err(Rejection::PrivateIp)
+            );
+        });
+    }
+
+    #[test]
+    fn charges_exact_ip_and_subnet_limits() {
+        deterministic::Runner::default().start(|context| async move {
+            let (admission, updates) = TcpAdmission::with_updates(
+                context.child("admission"),
+                config(Quota::per_second(NZU32!(1)), Quota::per_second(NZU32!(2))),
+            );
+            let first = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 1));
+            let second = IpAddr::V6(Ipv6Addr::new(0x2001, 0xdb8, 1, 0, 0, 0, 0, 2));
+            let peer = PrivateKey::from_seed(1).public_key();
+            updates.set(HashMap::from([(peer, HashSet::from([first, second]))]));
+
+            let admit = |source| {
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &admission,
+                    &info(source),
+                )
+            };
+            assert!(admit(first).is_ok());
+            assert_eq!(admit(first), Err(Rejection::IpRateLimited));
+            assert_eq!(admit(second), Err(Rejection::SubnetRateLimited));
+
+            let metrics = context.encode();
+            assert!(metrics.contains("handshake_ip_rate_limited_total 1"));
+            assert!(metrics.contains("handshake_subnet_rate_limited_total 1"));
+        });
+    }
+
+    #[test]
+    fn revalidates_peer_origin_after_authentication() {
+        deterministic::Runner::default().start(|context| async move {
+            let (admission, updates) = TcpAdmission::with_updates(
+                context.child("admission"),
+                config(Quota::per_second(NZU32!(10)), Quota::per_second(NZU32!(10))),
+            );
+            let peer = PrivateKey::from_seed(1).public_key();
+            let other = PrivateKey::from_seed(2).public_key();
+            let source = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1));
+            let replacement = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 2));
+            updates.set(HashMap::from([(peer.clone(), HashSet::from([source]))]));
+
+            let permit =
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &admission,
+                    &info(source),
+                )
+                .expect("registered source should begin authentication");
+            assert_eq!(
+                admission.post_auth(permit, &other, &info(source)).await,
+                Err(Rejection::UnregisteredIp),
+                "an origin registered to another peer must be rejected"
+            );
+
+            let permit =
+                <TcpAdmission<_, PublicKey> as InboundAdmission<PublicKey, TcpOrigin>>::pre_auth(
+                    &admission,
+                    &info(source),
+                )
+                .expect("registered source should begin authentication");
+            updates.set(HashMap::from([(
+                peer.clone(),
+                HashSet::from([replacement]),
+            )]));
+            assert_eq!(
+                admission.post_auth(permit, &peer, &info(source)).await,
+                Err(Rejection::UnregisteredIp),
+                "address-book changes during authentication must be revalidated"
+            );
+        });
+    }
+}

--- a/p2p/src/authenticated/attachment.rs
+++ b/p2p/src/authenticated/attachment.rs
@@ -1,0 +1,820 @@
+//! Authentication and attachment of established transport connections.
+
+use super::{
+    Mailbox,
+    admission::{InboundAdmission, Rejection},
+};
+use commonware_actor::{
+    Feedback, Unreliable,
+    mailbox::{self, UnreliablePolicy},
+};
+use commonware_cryptography::{PublicKey, Signer};
+use commonware_macros::{select_loop, stability};
+use commonware_runtime::{
+    BufferPooler, Clock, Connection, ConnectionInfo, ContextCell, Handle, Metrics, Scheduler,
+    spawn_cell,
+    telemetry::metrics::{Counter, MetricsExt as _},
+};
+use commonware_stream::encrypted::{self, Config as StreamConfig};
+use commonware_utils::{PlatformSend, PlatformSync, channel::oneshot, concurrency::Limiter};
+use rand_core::CryptoRng;
+use std::{
+    collections::VecDeque,
+    future::Future,
+    num::{NonZeroU32, NonZeroUsize},
+    sync::Arc,
+};
+use thiserror::Error;
+use tracing::debug;
+
+/// Failure to authenticate or attach a transport connection.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum Error {
+    /// The attachment actor is no longer available.
+    #[error("attachment actor unavailable")]
+    Unavailable,
+    /// The network cannot accept another connection without exceeding configured capacity.
+    #[error("too many pending connection handshakes")]
+    Busy,
+    /// The inbound admission policy rejected the connection.
+    #[error("connection rejected: {0}")]
+    Rejected(Rejection),
+    /// The encrypted handshake failed.
+    #[error("encrypted handshake failed")]
+    Handshake,
+    /// The authenticated peer could not be reserved.
+    #[error("peer unavailable")]
+    PeerUnavailable,
+    /// The peer spawner rejected the connection due to backpressure or shutdown.
+    #[error("peer spawner unavailable")]
+    SpawnerUnavailable,
+}
+
+pub(crate) enum Direction {
+    Outbound,
+    Inbound,
+}
+
+/// Connects an authenticated stream to a protocol-specific peer actor.
+pub(crate) trait Protocol<P: PublicKey, N: Connection>:
+    Clone + PlatformSend + PlatformSync + 'static
+{
+    type Reservation: PlatformSend + 'static;
+
+    fn acceptable(
+        &self,
+        peer: P,
+        direction: &Direction,
+        info: &ConnectionInfo<N::Origin>,
+    ) -> impl Future<Output = bool> + PlatformSend;
+
+    fn reserve(
+        &self,
+        peer: P,
+        direction: &Direction,
+        info: &ConnectionInfo<N::Origin>,
+    ) -> impl Future<Output = Option<Self::Reservation>> + PlatformSend;
+
+    fn spawn(
+        &self,
+        connection: (encrypted::Sender<N::Sink>, encrypted::Receiver<N::Stream>),
+        reservation: Self::Reservation,
+    ) -> bool;
+}
+
+/// Authenticates an established outbound connection as an exact peer.
+pub(crate) async fn authenticate_outbound<E, C, N>(
+    context: E,
+    stream_cfg: StreamConfig<C>,
+    expected_peer: C::PublicKey,
+    connection: N,
+) -> Result<
+    (
+        (encrypted::Sender<N::Sink>, encrypted::Receiver<N::Stream>),
+        ConnectionInfo<N::Origin>,
+    ),
+    Error,
+>
+where
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+{
+    let (sink, stream, info) = connection.split();
+    let encrypted = encrypted::dial(context, stream_cfg, expected_peer, stream, sink)
+        .await
+        .map_err(|_| Error::Handshake)?;
+    Ok((encrypted, info))
+}
+
+enum Message<N, P, T>
+where
+    N: Connection,
+    P: PublicKey,
+{
+    #[allow(dead_code, reason = "constructed by ALPHA attachment APIs")]
+    Outbound {
+        expected_peer: P,
+        connection: N,
+        responder: oneshot::Sender<Result<(), Error>>,
+    },
+    Inbound {
+        connection: Inbound<N, T>,
+        responder: oneshot::Sender<Result<(), Error>>,
+    },
+}
+
+struct Inbound<N: Connection, T> {
+    sink: N::Sink,
+    stream: N::Stream,
+    info: ConnectionInfo<N::Origin>,
+    permit: T,
+}
+
+impl<N: Connection, P: PublicKey, T: PlatformSend> UnreliablePolicy for Message<N, P, T> {
+    type Overflow = VecDeque<Self>;
+
+    fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
+        false
+    }
+}
+
+/// Handle for attaching established transport connections to an authenticated network.
+pub struct Attachments<N, P, A>
+where
+    N: Connection,
+    P: PublicKey,
+    A: InboundAdmission<P, N::Origin>,
+{
+    mailbox: Mailbox<Message<N, P, A::Permit>>,
+    admission: Arc<A>,
+}
+
+impl<N, P, A> Clone for Attachments<N, P, A>
+where
+    N: Connection,
+    P: PublicKey,
+    A: InboundAdmission<P, N::Origin>,
+{
+    fn clone(&self) -> Self {
+        Self {
+            mailbox: self.mailbox.clone(),
+            admission: self.admission.clone(),
+        }
+    }
+}
+
+impl<N, P, A> Attachments<N, P, A>
+where
+    N: Connection,
+    P: PublicKey,
+    A: InboundAdmission<P, N::Origin>,
+{
+    fn enqueue(&self, message: Message<N, P, A::Permit>) -> Result<(), Error> {
+        match self.mailbox.0.enqueue(message) {
+            Unreliable::Outcome(Feedback::Ok | Feedback::Backoff) => Ok(()),
+            Unreliable::Outcome(Feedback::Closed) => Err(Error::Unavailable),
+            Unreliable::Rejected => Err(Error::Busy),
+        }
+    }
+
+    /// Attaches an outbound connection expected to authenticate as `expected_peer`.
+    #[stability(ALPHA)]
+    pub async fn attach_outbound(&self, expected_peer: P, connection: N) -> Result<(), Error> {
+        let receiver = self.submit_outbound(expected_peer, connection)?;
+        receiver.await.unwrap_or(Err(Error::Unavailable))
+    }
+
+    /// Attaches an inbound connection whose peer identity is learned during authentication.
+    #[stability(ALPHA)]
+    pub async fn attach_inbound(&self, connection: N) -> Result<(), Error> {
+        let receiver = self.submit_inbound(connection)?;
+        receiver.await.unwrap_or(Err(Error::Unavailable))
+    }
+
+    #[stability(ALPHA)]
+    fn submit_outbound(
+        &self,
+        expected_peer: P,
+        connection: N,
+    ) -> Result<oneshot::Receiver<Result<(), Error>>, Error> {
+        let (responder, receiver) = oneshot::channel();
+        self.enqueue(Message::Outbound {
+            expected_peer,
+            connection,
+            responder,
+        })?;
+        Ok(receiver)
+    }
+
+    /// Submits an inbound connection without waiting for its handshake to finish.
+    ///
+    /// Listener actors use this method to keep accepting connections while earlier handshakes are
+    /// in progress.
+    pub(crate) fn submit_inbound(
+        &self,
+        connection: N,
+    ) -> Result<oneshot::Receiver<Result<(), Error>>, Error> {
+        let (sink, stream, info) = connection.split();
+        let permit = self.admission.pre_auth(&info).map_err(Error::Rejected)?;
+        let (responder, receiver) = oneshot::channel();
+        self.enqueue(Message::Inbound {
+            connection: Inbound {
+                sink,
+                stream,
+                info,
+                permit,
+            },
+            responder,
+        })?;
+        Ok(receiver)
+    }
+}
+
+/// Shared engine for authenticating established transport connections.
+pub(crate) struct Actor<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+    A: InboundAdmission<C::PublicKey, N::Origin>,
+> {
+    context: ContextCell<E>,
+    stream_cfg: StreamConfig<C>,
+    admission: Arc<A>,
+    handshake_limiter: Limiter,
+    receiver: mailbox::UnreliableReceiver<Message<N, C::PublicKey, A::Permit>>,
+    handshakes_concurrent_rate_limited: Counter,
+}
+
+impl<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+    A: InboundAdmission<C::PublicKey, N::Origin>,
+> Actor<E, C, N, A>
+{
+    pub(crate) fn new(
+        context: E,
+        stream_cfg: StreamConfig<C>,
+        admission: A,
+        mailbox_size: NonZeroUsize,
+        max_concurrent_handshakes: NonZeroU32,
+    ) -> (Self, Attachments<N, C::PublicKey, A>) {
+        let (mailbox, receiver) = Mailbox::new(context.child("mailbox"), mailbox_size);
+        let handshakes_concurrent_rate_limited = context.counter(
+            "handshake_concurrent_rate_limited",
+            "number of handshake attempts dropped because maximum concurrent handshakes was reached",
+        );
+        let admission = Arc::new(admission);
+        (
+            Self {
+                context: ContextCell::new(context),
+                stream_cfg,
+                admission: admission.clone(),
+                handshake_limiter: Limiter::new(max_concurrent_handshakes),
+                receiver,
+                handshakes_concurrent_rate_limited,
+            },
+            Attachments { mailbox, admission },
+        )
+    }
+
+    pub(crate) fn start<H>(mut self, protocol: H) -> Handle<()>
+    where
+        H: Protocol<C::PublicKey, N>,
+    {
+        spawn_cell!(self.context, self.run(protocol))
+    }
+
+    async fn run<H>(mut self, protocol: H)
+    where
+        H: Protocol<C::PublicKey, N>,
+    {
+        select_loop! {
+            self.context,
+            on_stopped => {
+                debug!("context shutdown, stopping attachment actor");
+            },
+            Some(message) = self.receiver.recv() else {
+                debug!("attachment mailbox closed");
+                break;
+            } => {
+                let Some(handshake_reservation) = self.handshake_limiter.try_acquire() else {
+                    self.handshakes_concurrent_rate_limited.inc();
+                    let responder = match message {
+                        Message::Outbound { responder, .. }
+                        | Message::Inbound { responder, .. } => responder,
+                    };
+                    let _ = responder.send(Err(Error::Busy));
+                    continue;
+                };
+
+                let stream_cfg = self.stream_cfg.clone();
+                let admission = self.admission.clone();
+                let protocol = protocol.clone();
+                self.context.child("handshake").spawn(move |context| async move {
+                    let _handshake_reservation = handshake_reservation;
+                    let (result, responder) = match message {
+                        Message::Outbound { expected_peer, connection, responder } => (
+                            Self::attach_outbound(
+                                context,
+                                stream_cfg,
+                                expected_peer,
+                                connection,
+                                protocol,
+                            ).await,
+                            responder,
+                        ),
+                        Message::Inbound { connection, responder } => (
+                            Self::attach_inbound(
+                                context,
+                                stream_cfg,
+                                admission,
+                                connection,
+                                protocol,
+                            ).await,
+                            responder,
+                        ),
+                    };
+                    let _ = responder.send(result);
+                });
+            },
+        }
+    }
+
+    async fn attach_outbound<H>(
+        context: E,
+        stream_cfg: StreamConfig<C>,
+        expected_peer: C::PublicKey,
+        connection: N,
+        protocol: H,
+    ) -> Result<(), Error>
+    where
+        H: Protocol<C::PublicKey, N>,
+    {
+        let (encrypted, info) =
+            authenticate_outbound(context, stream_cfg, expected_peer.clone(), connection).await?;
+        let direction = Direction::Outbound;
+        let reservation = protocol
+            .reserve(expected_peer, &direction, &info)
+            .await
+            .ok_or(Error::PeerUnavailable)?;
+        if protocol.spawn(encrypted, reservation) {
+            Ok(())
+        } else {
+            Err(Error::SpawnerUnavailable)
+        }
+    }
+
+    async fn attach_inbound<H>(
+        context: E,
+        stream_cfg: StreamConfig<C>,
+        admission: Arc<A>,
+        connection: Inbound<N, A::Permit>,
+        protocol: H,
+    ) -> Result<(), Error>
+    where
+        H: Protocol<C::PublicKey, N>,
+    {
+        let Inbound {
+            sink,
+            stream,
+            info,
+            permit,
+        } = connection;
+        let direction = Direction::Inbound;
+        let acceptable_protocol = protocol.clone();
+        let acceptable_admission = admission.clone();
+        let (peer, sender, receiver) = encrypted::listen(
+            context,
+            |peer| async {
+                if !acceptable_admission.accept_peer(&peer, &info) {
+                    return false;
+                }
+                acceptable_protocol
+                    .acceptable(peer, &direction, &info)
+                    .await
+            },
+            stream_cfg,
+            stream,
+            sink,
+        )
+        .await
+        .map_err(|_| Error::Handshake)?;
+        let reservation = protocol
+            .reserve(peer.clone(), &direction, &info)
+            .await
+            .ok_or(Error::PeerUnavailable)?;
+        admission
+            .post_auth(permit, &peer, &info)
+            .await
+            .map_err(Error::Rejected)?;
+        if protocol.spawn((sender, receiver), reservation) {
+            Ok(())
+        } else {
+            Err(Error::SpawnerUnavailable)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authenticated::admission::{TcpAdmission, TcpAdmissionConfig};
+    use commonware_cryptography::ed25519::{PrivateKey, PublicKey as Ed25519PublicKey};
+    use commonware_runtime::{
+        Quota, Runner as _, Supervisor as _, TcpOrigin, deterministic, mocks,
+    };
+    use commonware_utils::{NZU32, NZUsize};
+    use std::{
+        collections::{HashMap, HashSet},
+        net::{Ipv4Addr, SocketAddr},
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
+
+    struct TestConnection {
+        sink: mocks::Sink,
+        stream: mocks::Stream,
+        origin: Option<u8>,
+    }
+
+    impl Connection for TestConnection {
+        type Sink = mocks::Sink;
+        type Stream = mocks::Stream;
+        type Origin = u8;
+
+        fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>) {
+            (
+                self.sink,
+                self.stream,
+                ConnectionInfo {
+                    origin: self.origin,
+                    transport: "test",
+                },
+            )
+        }
+    }
+
+    fn connection(origin: Option<u8>) -> (TestConnection, (mocks::Sink, mocks::Stream)) {
+        let (local_sink, remote_stream) = mocks::Channel::init();
+        let (remote_sink, local_stream) = mocks::Channel::init();
+        (
+            TestConnection {
+                sink: local_sink,
+                stream: local_stream,
+                origin,
+            },
+            (remote_sink, remote_stream),
+        )
+    }
+
+    struct TcpTestConnection {
+        sink: mocks::Sink,
+        stream: mocks::Stream,
+        origin: TcpOrigin,
+    }
+
+    impl Connection for TcpTestConnection {
+        type Sink = mocks::Sink;
+        type Stream = mocks::Stream;
+        type Origin = TcpOrigin;
+
+        fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>) {
+            (
+                self.sink,
+                self.stream,
+                ConnectionInfo {
+                    origin: Some(self.origin),
+                    transport: "tcp",
+                },
+            )
+        }
+    }
+
+    fn tcp_connection(
+        remote: SocketAddr,
+    ) -> (TcpTestConnection, (mocks::Sink, mocks::Stream)) {
+        let (local_sink, remote_stream) = mocks::Channel::init();
+        let (remote_sink, local_stream) = mocks::Channel::init();
+        (
+            TcpTestConnection {
+                sink: local_sink,
+                stream: local_stream,
+                origin: TcpOrigin { remote },
+            },
+            (remote_sink, remote_stream),
+        )
+    }
+
+    struct TestAdmission {
+        accepted: Arc<AtomicBool>,
+    }
+
+    impl InboundAdmission<Ed25519PublicKey, u8> for TestAdmission {
+        type Permit = ();
+
+        fn pre_auth(&self, info: &ConnectionInfo<u8>) -> Result<Self::Permit, Rejection> {
+            if info.origin.is_none() {
+                return Err(Rejection::MissingOrigin);
+            }
+            self.accepted.store(true, Ordering::Relaxed);
+            Ok(())
+        }
+
+        async fn post_auth(
+            &self,
+            _permit: Self::Permit,
+            _peer: &Ed25519PublicKey,
+            _info: &ConnectionInfo<u8>,
+        ) -> Result<(), Rejection> {
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestProtocol;
+
+    impl Protocol<Ed25519PublicKey, TestConnection> for TestProtocol {
+        type Reservation = ();
+
+        async fn acceptable(
+            &self,
+            _peer: Ed25519PublicKey,
+            _direction: &Direction,
+            _info: &ConnectionInfo<u8>,
+        ) -> bool {
+            true
+        }
+
+        async fn reserve(
+            &self,
+            _peer: Ed25519PublicKey,
+            _direction: &Direction,
+            _info: &ConnectionInfo<u8>,
+        ) -> Option<Self::Reservation> {
+            Some(())
+        }
+
+        fn spawn(
+            &self,
+            _connection: (
+                encrypted::Sender<mocks::Sink>,
+                encrypted::Receiver<mocks::Stream>,
+            ),
+            _reservation: Self::Reservation,
+        ) -> bool {
+            true
+        }
+    }
+
+    #[derive(Clone)]
+    struct TrackingTcpProtocol {
+        reserved: Arc<AtomicBool>,
+    }
+
+    impl Protocol<Ed25519PublicKey, TcpTestConnection> for TrackingTcpProtocol {
+        type Reservation = ();
+
+        async fn acceptable(
+            &self,
+            _peer: Ed25519PublicKey,
+            _direction: &Direction,
+            _info: &ConnectionInfo<TcpOrigin>,
+        ) -> bool {
+            true
+        }
+
+        async fn reserve(
+            &self,
+            _peer: Ed25519PublicKey,
+            _direction: &Direction,
+            _info: &ConnectionInfo<TcpOrigin>,
+        ) -> Option<Self::Reservation> {
+            self.reserved.store(true, Ordering::Relaxed);
+            Some(())
+        }
+
+        fn spawn(
+            &self,
+            _connection: (
+                encrypted::Sender<mocks::Sink>,
+                encrypted::Receiver<mocks::Stream>,
+            ),
+            _reservation: Self::Reservation,
+        ) -> bool {
+            true
+        }
+    }
+
+    struct RevalidationAdmission {
+        invalidated: Arc<AtomicBool>,
+    }
+
+    impl InboundAdmission<Ed25519PublicKey, u8> for RevalidationAdmission {
+        type Permit = ();
+
+        fn pre_auth(&self, _info: &ConnectionInfo<u8>) -> Result<Self::Permit, Rejection> {
+            Ok(())
+        }
+
+        async fn post_auth(
+            &self,
+            _permit: Self::Permit,
+            _peer: &Ed25519PublicKey,
+            _info: &ConnectionInfo<u8>,
+        ) -> Result<(), Rejection> {
+            if self.invalidated.load(Ordering::Relaxed) {
+                return Err(Rejection::UnregisteredIp);
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Clone)]
+    struct RevalidatingProtocol {
+        invalidated: Arc<AtomicBool>,
+    }
+
+    impl Protocol<Ed25519PublicKey, TestConnection> for RevalidatingProtocol {
+        type Reservation = ();
+
+        async fn acceptable(
+            &self,
+            _peer: Ed25519PublicKey,
+            _direction: &Direction,
+            _info: &ConnectionInfo<u8>,
+        ) -> bool {
+            true
+        }
+
+        async fn reserve(
+            &self,
+            _peer: Ed25519PublicKey,
+            _direction: &Direction,
+            _info: &ConnectionInfo<u8>,
+        ) -> Option<Self::Reservation> {
+            self.invalidated.store(true, Ordering::Relaxed);
+            Some(())
+        }
+
+        fn spawn(
+            &self,
+            _connection: (
+                encrypted::Sender<mocks::Sink>,
+                encrypted::Receiver<mocks::Stream>,
+            ),
+            _reservation: Self::Reservation,
+        ) -> bool {
+            true
+        }
+    }
+
+    fn stream_config(signing_key: PrivateKey) -> StreamConfig<PrivateKey> {
+        StreamConfig {
+            signing_key,
+            namespace: b"test-attachment-admission".to_vec(),
+            max_message_size: 1_024,
+            synchrony_bound: Duration::from_secs(10),
+            max_handshake_age: Duration::from_secs(10),
+            handshake_timeout: Duration::from_secs(10),
+        }
+    }
+
+    #[test]
+    fn test_pre_auth_rejection_does_not_consume_attachment_capacity() {
+        deterministic::Runner::default().start(|context| async move {
+            let (_actor, attachments) = Actor::new(
+                context.child("attachment"),
+                stream_config(PrivateKey::from_seed(0)),
+                TestAdmission {
+                    accepted: Arc::new(AtomicBool::new(false)),
+                },
+                NZUsize!(1),
+                NZU32!(1),
+            );
+            let (rejected, _remote) = connection(None);
+            assert!(matches!(
+                attachments.submit_inbound(rejected),
+                Err(Error::Rejected(Rejection::MissingOrigin))
+            ));
+
+            let (accepted, _remote) = connection(Some(1));
+            assert!(attachments.submit_inbound(accepted).is_ok());
+        });
+    }
+
+    #[test]
+    fn test_tcp_peer_origin_mismatch_rejected_before_reservation() {
+        deterministic::Runner::default().start(|context| async move {
+            let listener_key = PrivateKey::from_seed(0);
+            let peer_a = PrivateKey::from_seed(1).public_key();
+            let peer_b_key = PrivateKey::from_seed(2);
+            let peer_b = peer_b_key.public_key();
+            let origin_a = SocketAddr::from((Ipv4Addr::new(8, 8, 8, 8), 1000));
+            let origin_b = SocketAddr::from((Ipv4Addr::new(1, 1, 1, 1), 1000));
+            let (admission, updates) = TcpAdmission::with_updates(
+                context.child("admission"),
+                TcpAdmissionConfig {
+                    allow_private_ips: false,
+                    require_registered_ip: true,
+                    allowed_handshake_rate_per_ip: Quota::per_second(NZU32!(100)),
+                    allowed_handshake_rate_per_subnet: Quota::per_second(NZU32!(100)),
+                },
+            );
+            updates.set(HashMap::from([
+                (peer_a, HashSet::from([origin_a.ip()])),
+                (peer_b, HashSet::from([origin_b.ip()])),
+            ]));
+            let reserved = Arc::new(AtomicBool::new(false));
+            let (actor, attachments) = Actor::new(
+                context.child("attachment"),
+                stream_config(listener_key.clone()),
+                admission,
+                NZUsize!(1),
+                NZU32!(1),
+            );
+            let _actor = actor.start(TrackingTcpProtocol {
+                reserved: reserved.clone(),
+            });
+
+            let (connection, (remote_sink, remote_stream)) = tcp_connection(origin_a);
+            let attach = attachments.attach_inbound(connection);
+            let dial = encrypted::dial(
+                context.child("dialer"),
+                stream_config(peer_b_key),
+                listener_key.public_key(),
+                remote_stream,
+                remote_sink,
+            );
+            let (result, _remote) = futures::join!(attach, dial);
+
+            assert!(result.is_err());
+            assert!(!reserved.load(Ordering::Relaxed));
+        });
+    }
+
+    #[test]
+    fn test_inbound_reservation_precedes_final_admission_check() {
+        deterministic::Runner::default().start(|context| async move {
+            let listener_key = PrivateKey::from_seed(0);
+            let peer_key = PrivateKey::from_seed(1);
+            let invalidated = Arc::new(AtomicBool::new(false));
+            let (actor, attachments) = Actor::new(
+                context.child("attachment"),
+                stream_config(listener_key.clone()),
+                RevalidationAdmission {
+                    invalidated: invalidated.clone(),
+                },
+                NZUsize!(1),
+                NZU32!(1),
+            );
+            let _actor = actor.start(RevalidatingProtocol { invalidated });
+
+            let (connection, (remote_sink, remote_stream)) = connection(Some(1));
+            let attach = attachments.attach_inbound(connection);
+            let dial = encrypted::dial(
+                context.child("dialer"),
+                stream_config(peer_key),
+                listener_key.public_key(),
+                remote_stream,
+                remote_sink,
+            );
+            let (result, _remote) = futures::join!(attach, dial);
+
+            assert_eq!(
+                result,
+                Err(Error::Rejected(Rejection::UnregisteredIp))
+            );
+        });
+    }
+
+    #[test]
+    fn test_pre_auth_rejection_does_not_require_handshake_permit() {
+        deterministic::Runner::default().start(|context| async move {
+            let accepted = Arc::new(AtomicBool::new(false));
+            let (actor, attachments) = Actor::new(
+                context.child("attachment"),
+                stream_config(PrivateKey::from_seed(0)),
+                TestAdmission {
+                    accepted: accepted.clone(),
+                },
+                NZUsize!(2),
+                NZU32!(1),
+            );
+            let _actor = actor.start(TestProtocol);
+
+            let (pending, _pending_remote) = connection(Some(1));
+            let _pending_result = attachments.submit_inbound(pending).unwrap();
+            while !accepted.load(Ordering::Relaxed) {
+                commonware_runtime::utils::reschedule().await;
+            }
+
+            let (rejected, _rejected_remote) = connection(None);
+            assert!(matches!(
+                attachments.submit_inbound(rejected),
+                Err(Error::Rejected(Rejection::MissingOrigin))
+            ));
+        });
+    }
+}

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -9,6 +9,7 @@ use commonware_actor::{
 };
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, IoBufs, Metrics, Quota};
+use commonware_utils::PlatformSend;
 use std::{
     collections::{BTreeMap, VecDeque},
     fmt::Debug,
@@ -50,7 +51,7 @@ impl<P: PublicKey> crate::UnlimitedSender for UnlimitedSender<P> {
     fn send(
         &mut self,
         recipients: Recipients<Self::PublicKey>,
-        message: impl Into<IoBufs> + Send,
+        message: impl Into<IoBufs> + PlatformSend,
         priority: bool,
     ) -> Unreliable<Feedback> {
         let message = message.into();
@@ -100,7 +101,7 @@ impl<P: PublicKey, C: Clock> Sender<P, C> {
 impl<P, C> crate::LimitedSender for Sender<P, C>
 where
     P: PublicKey,
-    C: Clock + Send + 'static,
+    C: Clock + PlatformSend + 'static,
 {
     type PublicKey = P;
     type Checked<'a>

--- a/p2p/src/authenticated/discovery/actors/dialer.rs
+++ b/p2p/src/authenticated/discovery/actors/dialer.rs
@@ -13,8 +13,8 @@ use crate::authenticated::{
 use commonware_cryptography::Signer;
 use commonware_macros::{select, select_loop};
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Resolver, SinkOf, Spawner,
-    StreamOf, spawn_cell,
+    BufferPooler, Clock, Connection, ContextCell, Dialer, Handle, Metrics, Resolver, SinkOf,
+    Spawner, StreamOf, TcpEndpoint, spawn_cell,
     telemetry::metrics::{CounterFamily, MetricsExt as _},
 };
 use commonware_stream::encrypted::{Config as StreamConfig, dial};
@@ -49,7 +49,10 @@ pub struct Config<C: Signer> {
 }
 
 /// Actor responsible for dialing peers and establishing outgoing connections.
-pub struct Actor<E: Spawner + Clock + Network + Resolver + Metrics, C: Signer> {
+pub struct Actor<
+    E: Spawner + Clock + Dialer<Endpoint = TcpEndpoint> + Resolver + Metrics,
+    C: Signer,
+> {
     context: ContextCell<E>,
 
     // ---------- State ----------
@@ -68,8 +71,16 @@ pub struct Actor<E: Spawner + Clock + Network + Resolver + Metrics, C: Signer> {
     attempts: CounterFamily<metrics::Peer<C::PublicKey>>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metrics, C: Signer>
-    Actor<E, C>
+impl<
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + Dialer<Endpoint = TcpEndpoint>
+        + Resolver
+        + CryptoRng
+        + Metrics,
+    C: Signer,
+> Actor<E, C>
 {
     pub fn new(context: E, cfg: Config<C>) -> Self {
         let attempts = context.family("attempts", "The number of dial attempts made to each peer");
@@ -108,7 +119,7 @@ impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metric
             move |mut context| async move {
                 let timeout = context.sleep(dial_timeout);
                 let dial = async {
-                    // Resolve ingress to socket addresses (filtered by private IP policy)
+                    // Preserve the legacy policy of selecting one resolved address per attempt.
                     let addresses: Vec<_> = ingress
                         .resolve_filtered(&context, allow_private_ips)
                         .await
@@ -120,14 +131,15 @@ impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metric
                     };
 
                     // Attempt to dial peer
-                    let (sink, stream) = match context.dial(address).await {
-                        Ok(stream) => stream,
+                    let connection = match context.dial(&TcpEndpoint::Socket(address)).await {
+                        Ok(connection) => connection,
                         Err(err) => {
                             debug!(?err, "failed to dial peer");
                             return;
                         }
                     };
-                    debug!(?peer, ?ingress, "dialed peer");
+                    let (sink, stream, _) = connection.split();
+                    debug!(?peer, ?address, "dialed peer");
 
                     // Upgrade connection
                     let instance = match dial(context, config, peer.clone(), stream, sink).await {
@@ -218,7 +230,9 @@ mod tests {
     use commonware_actor::mailbox;
     use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
     use commonware_macros::select;
-    use commonware_runtime::{Clock, Runner, Supervisor as _, deterministic};
+    use commonware_runtime::{
+        Acceptor as _, Clock, Runner, Scheduler as _, Supervisor as _, deterministic,
+    };
     use commonware_stream::encrypted::Config as StreamConfig;
     use commonware_utils::NZUsize;
     use std::{
@@ -249,7 +263,7 @@ mod tests {
             // The deterministic network completes the transport dial immediately, but retaining
             // the listener without accepting leaves the encrypted handshake pending.
             let _listener = context
-                .bind(address)
+                .bind(&address)
                 .await
                 .expect("Failed to bind listener");
             let mut dialer = Actor::new(

--- a/p2p/src/authenticated/discovery/actors/listener.rs
+++ b/p2p/src/authenticated/discovery/actors/listener.rs
@@ -7,8 +7,9 @@ use crate::authenticated::{
 use commonware_cryptography::Signer;
 use commonware_macros::select_loop;
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, KeyedRateLimiter, Listener, Metrics, Network, Quota,
-    SinkOf, Spawner, StreamOf, spawn_cell,
+    Acceptor, BufferPooler, Clock, Connection, ConnectionOf, ContextCell, Dialer, Handle,
+    KeyedRateLimiter, Listener, Metrics, Quota, SinkOf, Spawner, StreamOf, TcpEndpoint, TcpOrigin,
+    spawn_cell,
     telemetry::metrics::{Counter, MetricsExt as _},
 };
 use commonware_stream::encrypted::{Config as StreamConfig, listen};
@@ -33,7 +34,18 @@ pub struct Config<C: Signer> {
     pub allowed_handshake_rate_per_subnet: Quota,
 }
 
-pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> {
+pub struct Actor<
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + Dialer<Endpoint = TcpEndpoint>
+        + Acceptor<Bind = SocketAddr, Connection = ConnectionOf<E>>
+        + CryptoRng
+        + Metrics,
+    C: Signer,
+> where
+    ConnectionOf<E>: Connection<Origin = TcpOrigin>,
+{
     context: ContextCell<E>,
 
     address: SocketAddr,
@@ -48,7 +60,19 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metri
     handshakes_subnet_rate_limited: Counter,
 }
 
-impl<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> Actor<E, C> {
+impl<
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + Dialer<Endpoint = TcpEndpoint>
+        + Acceptor<Bind = SocketAddr, Connection = ConnectionOf<E>>
+        + CryptoRng
+        + Metrics,
+    C: Signer,
+> Actor<E, C>
+where
+    ConnectionOf<E>: Connection<Origin = TcpOrigin>,
+{
     pub fn new(context: E, cfg: Config<C>) -> Self {
         // Create metrics
         let handshakes_blocked = context.counter(
@@ -150,7 +174,7 @@ impl<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signe
         // Start listening for incoming connections
         let mut listener = self
             .context
-            .bind(self.address)
+            .bind(&self.address)
             .await
             .expect("failed to bind listener");
 
@@ -163,13 +187,19 @@ impl<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signe
             },
             conn = listener.accept() => {
                 // Accept a new connection
-                let (address, sink, stream) = match conn {
-                    Ok((address, sink, stream)) => (address, sink, stream),
+                let connection = match conn {
+                    Ok(connection) => connection,
                     Err(e) => {
                         debug!(error = ?e, "failed to accept connection");
                         continue;
                     }
                 };
+                let (sink, stream, info) = connection.split();
+                let Some(origin) = info.origin else {
+                    debug!(transport = info.transport, "connection missing TCP origin");
+                    continue;
+                };
+                let address = origin.remote;
                 debug!(?address, "accepted incoming connection");
 
                 // Check whether the IP is private
@@ -243,7 +273,8 @@ mod tests {
     use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        Error as RuntimeError, Runner as _, Stream, Supervisor as _, deterministic,
+        Error as RuntimeError, Runner as _, Scheduler as _, Stream, Supervisor as _, TcpEndpoint,
+        deterministic,
     };
     use commonware_utils::{NZU32, NZUsize};
     use std::{
@@ -310,9 +341,9 @@ mod tests {
                 actor.start(tracker::Mailbox::new(tracker_mailbox), supervisor_mailbox);
 
             // Allow a single handshake attempt from this IP.
-            let (sink, mut stream) = loop {
-                match context.dial(address).await {
-                    Ok(pair) => break pair,
+            let (sink, mut stream, _) = loop {
+                match context.dial(&TcpEndpoint::from(address)).await {
+                    Ok(connection) => break connection.split(),
                     Err(RuntimeError::ConnectionFailed) => {
                         context.sleep(Duration::from_millis(1)).await;
                     }
@@ -326,7 +357,11 @@ mod tests {
 
             // Additional attempts should be rate limited immediately.
             for _ in 0..3 {
-                let (sink, mut stream) = context.dial(address).await.expect("dial");
+                let (sink, mut stream, _) = context
+                    .dial(&TcpEndpoint::from(address))
+                    .await
+                    .expect("dial")
+                    .split();
 
                 // Wait for some message or drop.
                 let _ = stream.recv(1).await;
@@ -456,9 +491,9 @@ mod tests {
                 actor.start(tracker::Mailbox::new(tracker_mailbox), supervisor_mailbox);
 
             // Connect to the listener from a private IP
-            let (sink, mut stream) = loop {
-                match context.dial(address).await {
-                    Ok(pair) => break pair,
+            let (sink, mut stream, _) = loop {
+                match context.dial(&TcpEndpoint::from(address)).await {
+                    Ok(connection) => break connection.split(),
                     Err(RuntimeError::ConnectionFailed) => {
                         context.sleep(Duration::from_millis(1)).await;
                     }

--- a/p2p/src/authenticated/discovery/actors/peer/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/peer/actor.rs
@@ -408,7 +408,7 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
     };
     use commonware_runtime::{
-        BufferPooler, IoBuf, Runner, Spawner, Supervisor as _, deterministic, mocks,
+        BufferPooler, IoBuf, Runner, Scheduler, Supervisor as _, deterministic, mocks,
         telemetry::metrics::MetricsExt as _,
     };
     use commonware_stream::encrypted::Config as StreamConfig;

--- a/p2p/src/authenticated/discovery/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/actor.rs
@@ -168,7 +168,7 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
     };
     use commonware_macros::select;
-    use commonware_runtime::{Runner as _, Supervisor as _, deterministic, mocks};
+    use commonware_runtime::{Runner as _, Scheduler as _, Supervisor as _, deterministic, mocks};
     use commonware_stream::encrypted::{
         Config as StreamConfig, Receiver as EncryptedReceiver, Sender as EncryptedSender, dial,
         listen,

--- a/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/spawner/ingress.rs
@@ -56,7 +56,7 @@ mod tests {
         Signer as _,
         ed25519::{PrivateKey, PublicKey},
     };
-    use commonware_runtime::{Runner as _, Spawner as _, Supervisor as _, deterministic, mocks};
+    use commonware_runtime::{Runner as _, Scheduler as _, Supervisor as _, deterministic, mocks};
     use commonware_stream::encrypted::{
         Config as StreamConfig, Receiver as EncryptedReceiver, Sender as EncryptedSender, dial,
         listen,

--- a/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/discovery/actors/tracker/ingress.rs
@@ -14,7 +14,10 @@ use commonware_actor::{
     mailbox::{self, Policy},
 };
 use commonware_cryptography::PublicKey;
-use commonware_utils::channel::{mpsc, oneshot};
+use commonware_utils::{
+    PlatformSend,
+    channel::{mpsc, oneshot},
+};
 use std::collections::VecDeque;
 
 /// Messages that can be sent to the tracker actor.
@@ -301,7 +304,7 @@ impl<C: PublicKey> crate::Provider for Oracle<C> {
 impl<C: PublicKey> crate::Manager for Oracle<C> {
     fn track<R>(&mut self, index: u64, peers: R) -> Feedback
     where
-        R: Into<TrackedPeers<Self::PublicKey>> + Send,
+        R: Into<TrackedPeers<Self::PublicKey>> + PlatformSend,
     {
         self.sender.enqueue(Message::Register {
             index,

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -157,7 +157,7 @@
 //! ```rust
 //! use commonware_p2p::{authenticated::discovery::{self, Network}, Ingress, Manager, Sender, Recipients};
 //! use commonware_cryptography::{ed25519, Signer, PrivateKey as _, PublicKey as _, };
-//! use commonware_runtime::{deterministic, IoBuf, Metrics, Quota, Runner, Spawner, Supervisor};
+//! use commonware_runtime::{deterministic, IoBuf, Metrics, Quota, Runner, Scheduler, Supervisor};
 //! use commonware_utils::{ordered::Set, NZU32};
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 //!
@@ -262,8 +262,9 @@ mod tests {
     use commonware_cryptography::{Signer as _, ed25519};
     use commonware_macros::{select, select_loop, test_group, test_traced};
     use commonware_runtime::{
-        BufferPooler, Clock, Handle, IoBuf, Metrics, Network as RNetwork, Quota, Resolver, Runner,
-        Spawner, Supervisor as _, deterministic, telemetry::metrics::count_running_tasks, tokio,
+        Acceptor, BufferPooler, Clock, Connection, ConnectionOf, Dialer, Handle, IoBuf, Metrics,
+        Quota, Resolver, Runner, Scheduler, Spawner, Supervisor as _, TcpEndpoint, TcpOrigin,
+        deterministic, telemetry::metrics::count_running_tasks, tokio,
     };
     use commonware_utils::{NZU32, NZUsize, TryCollect, channel::mpsc, hostname, ordered::Set};
     use rand_core::{CryptoRng, Rng};
@@ -302,13 +303,18 @@ mod tests {
     ///
     /// We set a unique `base_port` for each test to avoid "address already in use"
     /// errors when tests are run immediately after each other.
-    async fn run_network(
-        context: impl Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics,
-        max_message_size: u32,
-        base_port: u16,
-        n: usize,
-        mode: Mode,
-    ) {
+    async fn run_network<E>(context: E, max_message_size: u32, base_port: u16, n: usize, mode: Mode)
+    where
+        E: Spawner
+            + BufferPooler
+            + Clock
+            + CryptoRng
+            + Dialer<Endpoint = TcpEndpoint>
+            + Resolver
+            + Acceptor<Bind = SocketAddr, Connection = ConnectionOf<E>>
+            + Metrics,
+        ConnectionOf<E>: Connection<Origin = TcpOrigin>,
+    {
         // Create peers
         let mut peers = Vec::new();
         for i in 0..n {

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -16,8 +16,8 @@ use crate::{
 use commonware_cryptography::Signer;
 use commonware_macros::select;
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, Metrics, Network as RNetwork, Quota, Resolver,
-    Spawner, spawn_cell,
+    Acceptor, BufferPooler, Clock, Connection, ConnectionOf, ContextCell, Dialer, Handle, Metrics,
+    Quota, Resolver, Spawner, TcpEndpoint, TcpOrigin, spawn_cell,
 };
 use commonware_stream::encrypted::Config as StreamConfig;
 use commonware_utils::union;
@@ -32,9 +32,18 @@ const STREAM_SUFFIX: &[u8] = b"_STREAM";
 
 /// Implementation of an `authenticated` network.
 pub struct Network<
-    E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics,
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + CryptoRng
+        + Dialer<Endpoint = TcpEndpoint>
+        + Resolver
+        + Acceptor<Bind = std::net::SocketAddr, Connection = ConnectionOf<E>>
+        + Metrics,
     C: Signer,
-> {
+> where
+    ConnectionOf<E>: Connection<Origin = TcpOrigin>,
+{
     context: ContextCell<E>,
     cfg: Config<C>,
 
@@ -46,8 +55,19 @@ pub struct Network<
     info_verifier: InfoVerifier<C::PublicKey>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics, C: Signer>
-    Network<E, C>
+impl<
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + CryptoRng
+        + Dialer<Endpoint = TcpEndpoint>
+        + Resolver
+        + Acceptor<Bind = std::net::SocketAddr, Connection = ConnectionOf<E>>
+        + Metrics,
+    C: Signer,
+> Network<E, C>
+where
+    ConnectionOf<E>: Connection<Origin = TcpOrigin>,
 {
     /// Create a new instance of an `authenticated` network.
     ///

--- a/p2p/src/authenticated/lookup/actors/attachment.rs
+++ b/p2p/src/authenticated/lookup/actors/attachment.rs
@@ -1,0 +1,149 @@
+//! Lookup adapter for explicitly attached connections.
+
+#[stability(ALPHA)]
+pub use crate::authenticated::{
+    admission::{ExactPeerAdmission, InboundAdmission as PeerAdmission, Rejection as Rejected},
+    attachment::{Attachments, Error},
+};
+use crate::{
+    PeerEndpoint,
+    authenticated::{
+        Mailbox,
+        admission::InboundAdmission,
+        attachment::{self, Direction, Protocol},
+        lookup::actors::{spawner, tracker},
+    },
+};
+use commonware_cryptography::{PublicKey, Signer};
+use commonware_macros::stability;
+use commonware_runtime::{
+    BufferPooler, Clock, Connection, ConnectionInfo, Handle, Metrics, Scheduler,
+};
+use commonware_stream::encrypted::Config as StreamConfig;
+use rand_core::CryptoRng;
+use std::num::{NonZeroU32, NonZeroUsize};
+
+type SpawnerMailbox<N, P, E> =
+    Mailbox<spawner::Message<<N as Connection>::Sink, <N as Connection>::Stream, P, E>>;
+
+struct LookupProtocol<N: Connection, P: PublicKey, E: PeerEndpoint> {
+    tracker: tracker::Mailbox<P, E>,
+    spawner: SpawnerMailbox<N, P, E>,
+    attached: bool,
+}
+
+impl<N: Connection, P: PublicKey, E: PeerEndpoint> Clone for LookupProtocol<N, P, E> {
+    fn clone(&self) -> Self {
+        Self {
+            tracker: self.tracker.clone(),
+            spawner: self.spawner.clone(),
+            attached: self.attached,
+        }
+    }
+}
+
+impl<N: Connection, P: PublicKey, E: PeerEndpoint> Protocol<P, N> for LookupProtocol<N, P, E> {
+    type Reservation = tracker::Reservation<P, E>;
+
+    async fn acceptable(
+        &self,
+        peer: P,
+        _direction: &Direction,
+        _info: &ConnectionInfo<N::Origin>,
+    ) -> bool {
+        self.attached || self.tracker.acceptable(peer).await
+    }
+
+    async fn reserve(
+        &self,
+        peer: P,
+        direction: &Direction,
+        _info: &ConnectionInfo<N::Origin>,
+    ) -> Option<Self::Reservation> {
+        if self.attached {
+            return self
+                .tracker
+                .attach(peer, matches!(direction, Direction::Inbound))
+                .await;
+        }
+        match direction {
+            Direction::Inbound => self.tracker.listen(peer).await,
+            Direction::Outbound => None,
+        }
+    }
+
+    fn spawn(
+        &self,
+        connection: (
+            commonware_stream::encrypted::Sender<N::Sink>,
+            commonware_stream::encrypted::Receiver<N::Stream>,
+        ),
+        reservation: Self::Reservation,
+    ) -> bool {
+        let mut spawner = self.spawner.clone();
+        spawner.spawn(connection, reservation).accepted()
+    }
+}
+
+pub struct Actor<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+    A: InboundAdmission<C::PublicKey, N::Origin>,
+> {
+    inner: attachment::Actor<E, C, N, A>,
+}
+
+impl<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+    A: InboundAdmission<C::PublicKey, N::Origin>,
+> Actor<E, C, N, A>
+{
+    pub fn new(
+        context: E,
+        stream_cfg: StreamConfig<C>,
+        admission: A,
+        mailbox_size: NonZeroUsize,
+        max_concurrent_handshakes: NonZeroU32,
+    ) -> (
+        Self,
+        crate::authenticated::attachment::Attachments<N, C::PublicKey, A>,
+    ) {
+        let (inner, attachments) = attachment::Actor::new(
+            context,
+            stream_cfg,
+            admission,
+            mailbox_size,
+            max_concurrent_handshakes,
+        );
+        (Self { inner }, attachments)
+    }
+
+    #[stability(ALPHA)]
+    pub fn start<Ep: PeerEndpoint>(
+        self,
+        tracker: tracker::Mailbox<C::PublicKey, Ep>,
+        spawner: SpawnerMailbox<N, C::PublicKey, Ep>,
+    ) -> Handle<()> {
+        self.inner.start(LookupProtocol {
+            tracker,
+            spawner,
+            attached: true,
+        })
+    }
+
+    /// Starts an inbound listener attachment engine that only reserves tracked peers.
+    pub(crate) fn start_listener<Ep: PeerEndpoint>(
+        self,
+        tracker: tracker::Mailbox<C::PublicKey, Ep>,
+        spawner: SpawnerMailbox<N, C::PublicKey, Ep>,
+    ) -> Handle<()> {
+        self.inner.start(LookupProtocol {
+            tracker,
+            spawner,
+            attached: false,
+        })
+    }
+}

--- a/p2p/src/authenticated/lookup/actors/dialer.rs
+++ b/p2p/src/authenticated/lookup/actors/dialer.rs
@@ -1,9 +1,9 @@
-//! Actor responsible for dialing peers and establishing connections.
+//! Dials advertised endpoints and establishes authenticated peer connections.
 
 use crate::{
-    Ingress,
+    Advertisement, PeerEndpoint,
     authenticated::{
-        Mailbox,
+        Mailbox, attachment,
         lookup::{
             actors::{
                 spawner,
@@ -16,160 +16,143 @@ use crate::{
 use commonware_cryptography::Signer;
 use commonware_macros::{select, select_loop};
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, Metrics, Network, Resolver, SinkOf, Spawner,
-    StreamOf, spawn_cell,
+    BufferPooler, Clock, ContextCell, Dialer, Handle, Metrics, Scheduler, SinkOf, StreamOf,
+    spawn_cell,
     telemetry::metrics::{CounterFamily, MetricsExt as _},
 };
-use commonware_stream::encrypted::{Config as StreamConfig, dial};
-use rand::seq::{IndexedRandom, SliceRandom};
+use commonware_stream::encrypted::Config as StreamConfig;
+use rand::seq::SliceRandom;
 use rand_core::CryptoRng;
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tracing::debug;
 
-// Mailbox for the spawner actor.
-type SupervisorMailbox<E, C> =
-    Mailbox<spawner::Message<SinkOf<E>, StreamOf<E>, <C as Signer>::PublicKey>>;
+type SupervisorMailbox<D, C> = Mailbox<
+    spawner::Message<SinkOf<D>, StreamOf<D>, <C as Signer>::PublicKey, <D as Dialer>::Endpoint>,
+>;
 
 /// Configuration for the dialer actor.
 pub struct Config<C: Signer> {
-    /// Configuration for the stream.
     pub stream_cfg: StreamConfig<C>,
-
-    /// Maximum duration of an outbound dial attempt.
     pub dial_timeout: Duration,
-
-    /// The frequency at which to dial a single peer from the queue. This also limits the rate at
-    /// which we attempt to dial peers in general.
     pub dial_frequency: Duration,
-
-    /// The maximum interval between tracker queries when the queue is empty. This tracks the
-    /// configured peer connection cooldown, since that is the soonest any peer could become
-    /// reservable again.
     pub peer_connection_cooldown: Duration,
-
-    /// Whether to allow dialing private IP addresses after DNS resolution.
-    pub allow_private_ips: bool,
 }
 
-/// Actor responsible for dialing peers and establishing outgoing connections.
-pub struct Actor<E: Spawner + BufferPooler + Clock + Network + Resolver + Metrics, C: Signer> {
-    context: ContextCell<E>,
-
-    // ---------- State ----------
-    /// The list of peers to dial.
+/// Actor responsible for dialing peers with an explicitly supplied transport.
+pub struct Actor<R, C, D>
+where
+    R: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    D: Dialer,
+    D::Endpoint: PeerEndpoint,
+{
+    context: ContextCell<R>,
+    dialer: Arc<D>,
     queue: Vec<C::PublicKey>,
-
-    // ---------- Configuration ----------
     stream_cfg: StreamConfig<C>,
     dial_timeout: Duration,
     dial_frequency: Duration,
     peer_connection_cooldown: Duration,
-    allow_private_ips: bool,
-
-    // ---------- Metrics ----------
-    /// The number of dial attempts made to each peer.
     attempts: CounterFamily<metrics::Peer<C::PublicKey>>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metrics, C: Signer>
-    Actor<E, C>
+impl<R, C, D> Actor<R, C, D>
+where
+    R: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    D: Dialer,
+    D::Endpoint: PeerEndpoint,
 {
-    pub fn new(context: E, cfg: Config<C>) -> Self {
+    pub fn new(context: R, dialer: D, cfg: Config<C>) -> Self {
         let attempts = context.family("attempts", "The number of dial attempts made to each peer");
         Self {
             context: ContextCell::new(context),
+            dialer: Arc::new(dialer),
             queue: Vec::new(),
             stream_cfg: cfg.stream_cfg,
             dial_timeout: cfg.dial_timeout,
             dial_frequency: cfg.dial_frequency,
             peer_connection_cooldown: cfg.peer_connection_cooldown,
-            allow_private_ips: cfg.allow_private_ips,
             attempts,
         }
     }
 
-    /// Dial a peer for which we have a reservation.
     fn dial_peer(
         &mut self,
-        reservation: Reservation<C::PublicKey>,
-        ingress: Ingress,
-        supervisor: &mut SupervisorMailbox<E, C>,
+        reservation: Reservation<C::PublicKey, D::Endpoint>,
+        advertisement: Advertisement<D::Endpoint>,
+        supervisor: &SupervisorMailbox<D, C>,
     ) {
-        // Extract metadata from the reservation
         let Metadata::Dialer(peer) = reservation.metadata().clone() else {
             unreachable!("unexpected reservation metadata");
         };
-
-        // Increment metrics.
         self.attempts.get_or_create_by(&peer).inc();
 
-        // Spawn dialer to connect to peer
-        self.context.child("dialer").spawn({
-            let config = self.stream_cfg.clone();
-            let mut supervisor = supervisor.clone();
-            let allow_private_ips = self.allow_private_ips;
-            let dial_timeout = self.dial_timeout;
-            move |mut context| async move {
+        let dialer = self.dialer.clone();
+        let config = self.stream_cfg.clone();
+        let mut supervisor = supervisor.clone();
+        let dial_timeout = self.dial_timeout;
+        self.context
+            .child("dialer")
+            .spawn(move |context| async move {
                 let timeout = context.sleep(dial_timeout);
-                let dial = async {
-                    // Resolve ingress to socket addresses (filtered by private IP policy)
-                    let addresses: Vec<_> = ingress
-                        .resolve_filtered(&context, allow_private_ips)
+                let attempt = async {
+                    for endpoint in advertisement.endpoints() {
+                        if !dialer.supports(endpoint) {
+                            continue;
+                        }
+                        let connection = match dialer.dial(endpoint).await {
+                            Ok(connection) => connection,
+                            Err(error) => {
+                                debug!(?peer, ?endpoint, ?error, "failed to dial endpoint");
+                                continue;
+                            }
+                        };
+                        let (connection, info) = match attachment::authenticate_outbound(
+                            context.child("handshake"),
+                            config.clone(),
+                            peer.clone(),
+                            connection,
+                        )
                         .await
-                        .map(Iterator::collect)
-                        .unwrap_or_default();
-                    let Some(&address) = addresses.choose(&mut context) else {
-                        debug!(?ingress, "failed to resolve or no valid addresses");
+                        {
+                            Ok(connection) => connection,
+                            Err(error) => {
+                                debug!(?peer, ?endpoint, ?error, "failed to authenticate endpoint");
+                                continue;
+                            }
+                        };
+                        debug!(
+                            ?peer,
+                            ?endpoint,
+                            transport = info.transport,
+                            "authenticated endpoint"
+                        );
+                        let _ = supervisor.spawn(connection, reservation);
                         return;
-                    };
-
-                    // Attempt to dial peer
-                    let (sink, stream) = match context.dial(address).await {
-                        Ok(stream) => stream,
-                        Err(err) => {
-                            debug!(?err, "failed to dial peer");
-                            return;
-                        }
-                    };
-                    debug!(?peer, ?address, "dialed peer");
-
-                    // Upgrade connection
-                    let connection = match dial(context, config, peer.clone(), stream, sink).await {
-                        Ok(instance) => instance,
-                        Err(err) => {
-                            debug!(?err, "failed to upgrade connection");
-                            return;
-                        }
-                    };
-                    debug!(?peer, ?address, "upgraded connection");
-
-                    // Start peer to handle messages
-                    let _ = supervisor.spawn(connection, reservation);
+                    }
+                    debug!(?peer, "all advertised endpoints failed");
                 };
 
                 select! {
-                    _ = dial => {},
-                    _ = timeout => {
-                        debug!(?peer, ?ingress, "dial attempt timed out");
-                    },
+                    _ = attempt => {},
+                    _ = timeout => debug!(?peer, "dial attempt timed out"),
                 }
-            }
-        });
+            });
     }
 
-    /// Start the dialer actor.
     pub fn start(
         mut self,
-        tracker: tracker::Mailbox<C::PublicKey>,
-        supervisor: SupervisorMailbox<E, C>,
+        tracker: tracker::Mailbox<C::PublicKey, D::Endpoint>,
+        supervisor: SupervisorMailbox<D, C>,
     ) -> Handle<()> {
         spawn_cell!(self.context, self.run(tracker, supervisor))
     }
 
     async fn run(
         mut self,
-        tracker: tracker::Mailbox<C::PublicKey>,
-        mut supervisor: SupervisorMailbox<E, C>,
+        tracker: tracker::Mailbox<C::PublicKey, D::Endpoint>,
+        supervisor: SupervisorMailbox<D, C>,
     ) {
         let mut dial_deadline = self.context.current();
         select_loop! {
@@ -178,7 +161,6 @@ impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metric
                 debug!("context shutdown, stopping dialer");
             },
             _ = self.context.sleep_until(dial_deadline) => {
-                // Refill the queue if empty.
                 let now = self.context.current();
                 let mut next_query_at = None;
                 if self.queue.is_empty() {
@@ -188,7 +170,6 @@ impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metric
                     next_query_at = dialable.next_query_at;
                 }
 
-                // Set next deadline.
                 dial_deadline = if self.queue.is_empty() {
                     let min = now + self.dial_frequency;
                     let max = (now + self.peer_connection_cooldown).max(min);
@@ -197,12 +178,19 @@ impl<E: Spawner + BufferPooler + Clock + Network + Resolver + CryptoRng + Metric
                     now + self.dial_frequency
                 };
 
-                // Pop through peers until we can reserve and dial one.
                 while let Some(peer) = self.queue.pop() {
-                    if let Some((reservation, ingress)) = tracker.dial(peer).await {
-                        self.dial_peer(reservation, ingress, &mut supervisor);
-                        break;
+                    let Some((reservation, advertisement)) = tracker.dial(peer).await else {
+                        continue;
+                    };
+                    if !advertisement
+                        .endpoints()
+                        .iter()
+                        .any(|endpoint| self.dialer.supports(endpoint))
+                    {
+                        continue;
                     }
+                    self.dial_peer(reservation, advertisement, &supervisor);
+                    break;
                 }
             },
         }
@@ -219,13 +207,55 @@ mod tests {
     use commonware_actor::mailbox;
     use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
     use commonware_macros::select;
-    use commonware_runtime::{Clock, Runner, Supervisor as _, deterministic};
+    use commonware_runtime::{
+        Acceptor as _, Clock, Runner, Supervisor as _, TcpEndpoint, deterministic,
+    };
     use commonware_stream::encrypted::Config as StreamConfig;
-    use commonware_utils::NZUsize;
+    use commonware_utils::{NZUsize, sync::Mutex};
     use std::{
         net::{Ipv4Addr, SocketAddr},
+        sync::Arc,
         time::Duration,
     };
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    enum TestEndpoint {
+        Unsupported,
+        Socket(SocketAddr),
+        Failing(u8),
+    }
+
+    impl PeerEndpoint for TestEndpoint {}
+
+    struct TestDialer {
+        context: deterministic::Context,
+        attempts: Arc<Mutex<Vec<TestEndpoint>>>,
+    }
+
+    impl commonware_runtime::Dialer for TestDialer {
+        type Endpoint = TestEndpoint;
+        type Connection = <deterministic::Context as commonware_runtime::Dialer>::Connection;
+
+        fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+            *endpoint != TestEndpoint::Unsupported
+        }
+
+        async fn dial(
+            &self,
+            endpoint: &Self::Endpoint,
+        ) -> Result<Self::Connection, commonware_runtime::Error> {
+            self.attempts.lock().push(*endpoint);
+            match endpoint {
+                TestEndpoint::Unsupported => Err(commonware_runtime::Error::UnsupportedEndpoint),
+                TestEndpoint::Socket(address) => {
+                    self.context.dial(&TcpEndpoint::Socket(*address)).await
+                }
+                TestEndpoint::Failing(_) => Err(commonware_runtime::Error::ConnectionFailed),
+            }
+        }
+    }
+
+    type TestActor = Actor<deterministic::Context, PrivateKey, TestDialer>;
 
     fn test_stream_config(signing_key: PrivateKey) -> StreamConfig<PrivateKey> {
         StreamConfig {
@@ -236,6 +266,37 @@ mod tests {
             synchrony_bound: Duration::from_secs(5),
             max_handshake_age: Duration::from_secs(10),
         }
+    }
+
+    fn test_dialer(
+        context: &deterministic::Context,
+        config: Config<PrivateKey>,
+    ) -> (TestActor, Arc<Mutex<Vec<TestEndpoint>>>) {
+        let attempts = Arc::new(Mutex::new(Vec::new()));
+        let transport = TestDialer {
+            context: context.child("transport"),
+            attempts: attempts.clone(),
+        };
+        let actor = Actor::new(context.child("dialer"), transport, config);
+        (actor, attempts)
+    }
+
+    fn advertisement(endpoint: TestEndpoint) -> Advertisement<TestEndpoint> {
+        Advertisement::new(vec![endpoint]).expect("test advertisement should be valid")
+    }
+
+    fn supervisor(
+        context: &deterministic::Context,
+    ) -> SupervisorMailbox<TestDialer, PrivateKey> {
+        let (supervisor, mut receiver) =
+            Mailbox::<spawner::Message<_, _, PublicKey, TestEndpoint>>::new(
+                context.child("supervisor_mailbox"),
+                NZUsize!(100),
+            );
+        context
+            .child("supervisor")
+            .spawn(|_| async move { while receiver.recv().await.is_some() {} });
+        supervisor
     }
 
     #[test]
@@ -250,33 +311,38 @@ mod tests {
             // The deterministic network completes the transport dial immediately, but retaining
             // the listener without accepting leaves the encrypted handshake pending.
             let _listener = context
-                .bind(address)
+                .bind(&address)
                 .await
                 .expect("Failed to bind listener");
-            let mut dialer = Actor::new(
-                context.child("dialer"),
+            let (mut dialer, _) = test_dialer(
+                &context,
                 Config {
                     stream_cfg: test_stream_config(signer),
                     dial_timeout,
                     dial_frequency: Duration::from_secs(1),
                     peer_connection_cooldown: Duration::from_secs(60),
-                    allow_private_ips: true,
                 },
             );
 
             let (releaser, mut releases) =
-                mailbox::new::<tracker::Message<PublicKey>>(context.child("releaser"), NZUsize!(1));
-            let ingress = Ingress::from(address);
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("releaser"),
+                    NZUsize!(1),
+                );
             let reservation =
                 Reservation::new(Metadata::Dialer(peer.clone()), Releaser::new(releaser));
-            let (mut supervisor, _supervisor_rx) =
-                Mailbox::<spawner::Message<_, _, PublicKey>>::new(
+            let (supervisor, _supervisor_rx) =
+                Mailbox::<spawner::Message<_, _, PublicKey, TestEndpoint>>::new(
                     context.child("supervisor_mailbox"),
                     NZUsize!(1),
                 );
 
             let start = context.current();
-            dialer.dial_peer(reservation, ingress, &mut supervisor);
+            dialer.dial_peer(
+                reservation,
+                advertisement(TestEndpoint::Socket(address)),
+                &supervisor,
+            );
 
             // The outer dial timeout must cancel the pending handshake and drop its reservation
             // before the much longer handshake timeout can fire.
@@ -303,27 +369,26 @@ mod tests {
         executor.start(|context| async move {
             let signer = PrivateKey::from_seed(0);
             let dial_frequency = Duration::from_millis(100);
-
             let dialer_cfg = Config {
                 stream_cfg: test_stream_config(signer),
                 dial_timeout: Duration::from_secs(15),
                 dial_frequency,
                 peer_connection_cooldown: Duration::from_secs(60),
-                allow_private_ips: true,
             };
 
-            let dialer = Actor::new(context.child("dialer"), dialer_cfg);
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
+            let (dialer, _) = test_dialer(&context, dialer_cfg);
+            let (tracker_mailbox, mut tracker_rx) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("tracker_mailbox"),
+                    NZUsize!(1024),
+                );
 
             // Create a releaser for reservations
-            let (sender, _receiver) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("releaser"),
-                NZUsize!(1024),
-            );
+            let (sender, _receiver) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("releaser"),
+                    NZUsize!(1024),
+                );
             let releaser = Releaser::new(sender);
 
             // Generate 10 peers
@@ -332,13 +397,7 @@ mod tests {
                 .collect();
 
             // Create a supervisor that just drops spawn messages
-            let (supervisor, mut supervisor_rx) = Mailbox::<spawner::Message<_, _, PublicKey>>::new(
-                context.child("supervisor_mailbox"),
-                NZUsize!(100),
-            );
-            context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
+            let supervisor = supervisor(&context);
 
             // Start the dialer
             let _handle = dialer.start(tracker::Mailbox::new(tracker_mailbox), supervisor);
@@ -362,9 +421,10 @@ mod tests {
                             dial_count += 1;
                             let metadata = Metadata::Dialer(public_key);
                             let res = tracker::Reservation::new(metadata, releaser.clone());
-                            let ingress: Ingress =
-                                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8000).into();
-                            let _ = reservation.send(Some((res, ingress)));
+                            let advertisement = advertisement(TestEndpoint::Socket(
+                                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8000),
+                            ));
+                            let _ = reservation.send(Some((res, advertisement)));
                         }
                         _ => {}
                     },
@@ -382,36 +442,97 @@ mod tests {
     }
 
     #[test]
+    fn test_unsupported_peer_does_not_consume_dial_tick() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|context| async move {
+            let (dialer, _) = test_dialer(
+                &context,
+                Config {
+                    stream_cfg: test_stream_config(PrivateKey::from_seed(0)),
+                    dial_timeout: Duration::from_secs(1),
+                    dial_frequency: Duration::from_secs(1),
+                    peer_connection_cooldown: Duration::from_secs(60),
+                },
+            );
+            let (tracker_mailbox, mut tracker_rx) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("tracker_mailbox"),
+                    NZUsize!(16),
+                );
+            let (releaser, _releases) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("releaser"),
+                    NZUsize!(16),
+                );
+            let releaser = Releaser::new(releaser);
+            let peers = vec![
+                PrivateKey::from_seed(1).public_key(),
+                PrivateKey::from_seed(2).public_key(),
+            ];
+            let _dialer = dialer.start(
+                tracker::Mailbox::new(tracker_mailbox),
+                supervisor(&context),
+            );
+
+            let deadline = context.current() + Duration::from_millis(100);
+            let mut reservations = 0;
+            loop {
+                select! {
+                    message = tracker_rx.recv() => match message {
+                        Some(tracker::Message::Dialable { responder }) => {
+                            let _ = responder.send(Dialable {
+                                peers: peers.clone(),
+                                next_query_at: None,
+                            });
+                        }
+                        Some(tracker::Message::Dial { public_key, reservation }) => {
+                            let endpoint = if reservations == 0 {
+                                TestEndpoint::Unsupported
+                            } else {
+                                TestEndpoint::Failing(1)
+                            };
+                            reservations += 1;
+                            let value = Reservation::new(
+                                Metadata::Dialer(public_key),
+                                releaser.clone(),
+                            );
+                            let _ = reservation.send(Some((value, advertisement(endpoint))));
+                            if reservations == 2 {
+                                break;
+                            }
+                        }
+                        _ => {}
+                    },
+                    _ = context.sleep_until(deadline) => break,
+                }
+            }
+
+            assert_eq!(reservations, 2);
+        });
+    }
+
+    #[test]
     fn test_dialer_uses_tracker_next_query_deadline() {
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|context| async move {
             let signer = PrivateKey::from_seed(0);
 
             let dial_frequency = Duration::from_millis(500);
-
-            let dialer = Actor::new(
-                context.child("dialer"),
+            let (dialer, _) = test_dialer(
+                &context,
                 Config {
                     stream_cfg: test_stream_config(signer),
                     dial_timeout: Duration::from_secs(15),
                     dial_frequency,
                     peer_connection_cooldown: dial_frequency,
-                    allow_private_ips: true,
                 },
             );
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-            let (supervisor, mut supervisor_rx) = Mailbox::<spawner::Message<_, _, PublicKey>>::new(
-                context.child("supervisor_mailbox"),
-                NZUsize!(100),
-            );
-            context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-
+            let (tracker_mailbox, mut tracker_rx) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("tracker_mailbox"),
+                    NZUsize!(1024),
+                );
+            let supervisor = supervisor(&context);
             let _handle = dialer.start(tracker::Mailbox::new(tracker_mailbox), supervisor);
 
             // Tracker reports next_query_at=100ms, which is shorter than
@@ -448,43 +569,33 @@ mod tests {
         executor.start(|context| async move {
             let signer = PrivateKey::from_seed(0);
             let dial_frequency = Duration::from_millis(100);
-
-            let dialer = Actor::new(
-                context.child("dialer"),
+            let (dialer, _) = test_dialer(
+                &context,
                 Config {
                     stream_cfg: test_stream_config(signer),
                     dial_timeout: Duration::from_secs(15),
                     dial_frequency,
                     peer_connection_cooldown: Duration::from_secs(60),
-                    allow_private_ips: true,
                 },
             );
+            let (tracker_mailbox, mut tracker_rx) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("tracker_mailbox"),
+                    NZUsize!(1024),
+                );
 
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-
-            let (sender, _receiver) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("releaser"),
-                NZUsize!(1024),
-            );
+            let (sender, _receiver) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("releaser"),
+                    NZUsize!(1024),
+                );
             let releaser = Releaser::new(sender);
-
             let peers: Vec<PublicKey> = (0..3)
                 .map(|i| PrivateKey::from_seed(i).public_key())
                 .collect();
 
-            let (supervisor, mut supervisor_rx) = Mailbox::<spawner::Message<_, _, PublicKey>>::new(
-                context.child("supervisor_mailbox"),
-                NZUsize!(100),
-            );
-            context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-
+            let supervisor = supervisor(&context);
             let _handle = dialer.start(tracker::Mailbox::new(tracker_mailbox), supervisor);
-
             let mut dial_count = 0;
             let deadline = context.current() + Duration::from_millis(250);
             loop {
@@ -503,9 +614,10 @@ mod tests {
                             dial_count += 1;
                             let metadata = Metadata::Dialer(public_key);
                             let res = tracker::Reservation::new(metadata, releaser.clone());
-                            let ingress: Ingress =
-                                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8000).into();
-                            let _ = reservation.send(Some((res, ingress)));
+                            let advertisement = advertisement(TestEndpoint::Socket(
+                                SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8000),
+                            ));
+                            let _ = reservation.send(Some((res, advertisement)));
                         }
                         _ => {}
                     },
@@ -527,32 +639,22 @@ mod tests {
         executor.start(|context| async move {
             let signer = PrivateKey::from_seed(0);
             let dial_frequency = Duration::from_millis(200);
-
-            let dialer = Actor::new(
-                context.child("dialer"),
+            let (dialer, _) = test_dialer(
+                &context,
                 Config {
                     stream_cfg: test_stream_config(signer),
                     dial_timeout: Duration::from_secs(15),
                     dial_frequency,
                     peer_connection_cooldown: Duration::from_millis(50),
-                    allow_private_ips: true,
                 },
             );
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-            let (supervisor, mut supervisor_rx) = Mailbox::<spawner::Message<_, _, PublicKey>>::new(
-                context.child("supervisor_mailbox"),
-                NZUsize!(100),
-            );
-            context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-
+            let (tracker_mailbox, mut tracker_rx) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("tracker_mailbox"),
+                    NZUsize!(1024),
+                );
+            let supervisor = supervisor(&context);
             let _handle = dialer.start(tracker::Mailbox::new(tracker_mailbox), supervisor);
-
             let mut refresh_count = 0;
             let deadline = context.current() + Duration::from_millis(350);
             loop {
@@ -574,6 +676,54 @@ mod tests {
                 refresh_count, 2,
                 "expected 2 refreshes at dial_frequency without panicking, got {}",
                 refresh_count
+            );
+        });
+    }
+
+    #[test]
+    fn test_dialer_skips_unsupported_endpoints_and_preserves_supported_order() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|context| async move {
+            let signer = PrivateKey::from_seed(0);
+            let peer = PrivateKey::from_seed(1).public_key();
+            let (mut dialer, attempts) = test_dialer(
+                &context,
+                Config {
+                    stream_cfg: test_stream_config(signer),
+                    dial_timeout: Duration::from_secs(1),
+                    dial_frequency: Duration::from_secs(1),
+                    peer_connection_cooldown: Duration::from_secs(60),
+                },
+            );
+            let (releaser, mut releases) =
+                mailbox::new::<tracker::Message<PublicKey, TestEndpoint>>(
+                    context.child("releaser"),
+                    NZUsize!(1),
+                );
+            let reservation =
+                Reservation::new(Metadata::Dialer(peer.clone()), Releaser::new(releaser));
+            let (supervisor, _supervisor_rx) =
+                Mailbox::<spawner::Message<_, _, PublicKey, TestEndpoint>>::new(
+                    context.child("supervisor_mailbox"),
+                    NZUsize!(1),
+                );
+            let advertisement = Advertisement::new(vec![
+                TestEndpoint::Unsupported,
+                TestEndpoint::Failing(1),
+                TestEndpoint::Failing(2),
+            ])
+            .expect("test advertisement should be valid");
+
+            dialer.dial_peer(reservation, advertisement, &supervisor);
+
+            let message = releases.recv().await.expect("reservation should be released");
+            let tracker::Message::Release { metadata } = message else {
+                panic!("Unexpected releaser message");
+            };
+            assert_eq!(metadata.public_key(), &peer);
+            assert_eq!(
+                *attempts.lock(),
+                vec![TestEndpoint::Failing(1), TestEndpoint::Failing(2)]
             );
         });
     }

--- a/p2p/src/authenticated/lookup/actors/listener.rs
+++ b/p2p/src/authenticated/lookup/actors/listener.rs
@@ -1,761 +1,84 @@
-//! Listener
+//! Accepts transport connections and submits them to the shared attachment engine.
 
 use crate::authenticated::{
-    Mailbox as SpawnerMailbox,
-    lookup::actors::{spawner, tracker},
+    admission::InboundAdmission,
+    attachment::{Attachments, Error},
 };
-use commonware_actor::Feedback;
-use commonware_cryptography::Signer;
 use commonware_macros::select_loop;
-use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, KeyedRateLimiter, Listener, Metrics, Network, Quota,
-    SinkOf, Spawner, StreamOf, spawn_cell,
-    telemetry::metrics::{Counter, MetricsExt as _},
-};
-use commonware_stream::encrypted::{Config as StreamConfig, listen};
-use commonware_utils::{IpAddrExt, NZUsize, channel::ring, concurrency::Limiter, net::SubnetMask};
-use futures::{Sink, StreamExt};
-use rand_core::CryptoRng;
-use std::{
-    collections::HashSet,
-    fmt,
-    net::{IpAddr, SocketAddr},
-    num::NonZeroU32,
-    pin::Pin,
-};
+use commonware_runtime::{Acceptor, ContextCell, Handle, Listener, Scheduler, spawn_cell};
 use tracing::debug;
 
-/// Subnet mask of `/24` for IPv4 and `/48` for IPv6 networks.
-const SUBNET_MASK: SubnetMask = SubnetMask::new(24, 48);
-
-/// Interval at which to prune tracked IPs and Subnets.
-const CLEANUP_INTERVAL: u32 = 16_384;
-
-pub(crate) type Updates = ring::Receiver<HashSet<IpAddr>>;
-
-#[derive(Clone)]
-pub(crate) struct Mailbox(ring::Sender<HashSet<IpAddr>>);
-
-impl fmt::Debug for Mailbox {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("Mailbox").finish()
-    }
+/// Configuration for a transport listener.
+pub struct Config<B> {
+    /// Transport-specific binding instructions.
+    pub bind: B,
 }
 
-impl Mailbox {
-    pub(crate) fn new() -> (Self, Updates) {
-        let (sender, receiver) = ring::channel(NZUsize!(1));
-        (Self(sender), receiver)
-    }
-
-    pub(crate) fn set(&mut self, registered_ips: HashSet<IpAddr>) -> Feedback {
-        if Pin::new(&mut self.0).start_send(registered_ips).is_ok() {
-            Feedback::Ok
-        } else {
-            Feedback::Closed
-        }
-    }
+/// Actor that accepts connections without waiting for their handshakes to finish.
+pub struct Actor<R: Scheduler, A: Acceptor> {
+    context: ContextCell<R>,
+    acceptor: A,
+    bind: A::Bind,
 }
 
-/// Configuration for the listener actor.
-pub struct Config<C: Signer> {
-    pub address: SocketAddr,
-    pub stream_cfg: StreamConfig<C>,
-    pub allow_private_ips: bool,
-    pub bypass_ip_check: bool,
-    pub max_concurrent_handshakes: NonZeroU32,
-    pub allowed_handshake_rate_per_ip: Quota,
-    pub allowed_handshake_rate_per_subnet: Quota,
-}
-
-pub struct Actor<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> {
-    context: ContextCell<E>,
-
-    address: SocketAddr,
-    stream_cfg: StreamConfig<C>,
-    allow_private_ips: bool,
-    bypass_ip_check: bool,
-    handshake_limiter: Limiter,
-    allowed_handshake_rate_per_ip: Quota,
-    allowed_handshake_rate_per_subnet: Quota,
-    registered_ips: HashSet<IpAddr>,
-    updates: Updates,
-    handshakes_blocked: Counter,
-    handshakes_concurrent_rate_limited: Counter,
-    handshakes_ip_rate_limited: Counter,
-    handshakes_subnet_rate_limited: Counter,
-}
-
-impl<E: Spawner + BufferPooler + Clock + Network + CryptoRng + Metrics, C: Signer> Actor<E, C> {
-    pub fn new(context: E, cfg: Config<C>, updates: Updates) -> Self {
-        // Create metrics
-        let handshakes_blocked = context.counter(
-            "handshakes_blocked",
-            "number of handshake attempts blocked because the IP was not registered",
-        );
-        let handshakes_concurrent_rate_limited = context.counter(
-            "handshake_concurrent_rate_limited",
-            "number of handshake attempts dropped because maximum concurrent handshakes was reached",
-        );
-        let handshakes_ip_rate_limited = context.counter(
-            "handshake_ip_rate_limited",
-            "number of handshake attempts dropped because an IP exceeded its rate limit",
-        );
-        let handshakes_subnet_rate_limited = context.counter(
-            "handshake_subnet_rate_limited",
-            "number of handshake attempts dropped because a subnet exceeded its rate limit",
-        );
-
+impl<R: Scheduler, A: Acceptor> Actor<R, A> {
+    /// Creates a listener using an explicitly supplied acceptor.
+    pub fn new(context: R, acceptor: A, cfg: Config<A::Bind>) -> Self {
         Self {
             context: ContextCell::new(context),
-
-            address: cfg.address,
-            stream_cfg: cfg.stream_cfg,
-            allow_private_ips: cfg.allow_private_ips,
-            bypass_ip_check: cfg.bypass_ip_check,
-            handshake_limiter: Limiter::new(cfg.max_concurrent_handshakes),
-            allowed_handshake_rate_per_ip: cfg.allowed_handshake_rate_per_ip,
-            allowed_handshake_rate_per_subnet: cfg.allowed_handshake_rate_per_subnet,
-            registered_ips: HashSet::new(),
-            updates,
-            handshakes_blocked,
-            handshakes_concurrent_rate_limited,
-            handshakes_ip_rate_limited,
-            handshakes_subnet_rate_limited,
+            acceptor,
+            bind: cfg.bind,
         }
     }
 
-    #[allow(clippy::type_complexity)]
-    async fn handshake(
-        context: E,
-        address: SocketAddr,
-        stream_cfg: StreamConfig<C>,
-        sink: SinkOf<E>,
-        stream: StreamOf<E>,
-        tracker: tracker::Mailbox<C::PublicKey>,
-        mut supervisor: SpawnerMailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
-    ) {
-        // Perform handshake
-        let source_ip = address.ip();
-        let (peer, send, recv) = match listen(
-            context,
-            |peer| tracker.acceptable(peer, source_ip),
-            stream_cfg,
-            stream,
-            sink,
-        )
-        .await
-        {
-            Ok(connection) => connection,
-            Err(err) => {
-                debug!(?err, ?address, "failed to upgrade connection");
-                return;
-            }
-        };
-        debug!(?peer, ?address, "completed handshake");
-
-        // Attempt to claim the connection
-        let Some(reservation) = tracker.listen(peer.clone(), source_ip).await else {
-            debug!(?peer, ?address, "unable to reserve connection to peer");
-            return;
-        };
-        debug!(?peer, ?address, "reserved connection");
-
-        // Start peer to handle messages
-        let _ = supervisor.spawn((send, recv), reservation);
+    /// Starts accepting connections for the attachment engine.
+    pub fn start<P, I>(mut self, attachments: Attachments<A::Connection, P, I>) -> Handle<()>
+    where
+        P: commonware_cryptography::PublicKey,
+        I: InboundAdmission<P, <A::Connection as commonware_runtime::Connection>::Origin>,
+    {
+        spawn_cell!(self.context, self.run(attachments))
     }
 
-    #[allow(clippy::type_complexity)]
-    pub fn start(
-        mut self,
-        tracker: tracker::Mailbox<C::PublicKey>,
-        supervisor: SpawnerMailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
-    ) -> Handle<()> {
-        spawn_cell!(self.context, self.run(tracker, supervisor))
-    }
-
-    #[allow(clippy::type_complexity)]
-    async fn run(
-        mut self,
-        tracker: tracker::Mailbox<C::PublicKey>,
-        supervisor: SpawnerMailbox<spawner::Message<SinkOf<E>, StreamOf<E>, C::PublicKey>>,
-    ) {
-        // Setup the rate limiters
-        let ip_rate_limiter = KeyedRateLimiter::hashmap_with_clock(
-            self.allowed_handshake_rate_per_ip,
-            self.context.child("ip_rate_limiter"),
-        );
-        let subnet_rate_limiter = KeyedRateLimiter::hashmap_with_clock(
-            self.allowed_handshake_rate_per_subnet,
-            self.context.child("subnet_rate_limiter"),
-        );
-
-        // Start listening for incoming connections
+    async fn run<P, I>(self, attachments: Attachments<A::Connection, P, I>)
+    where
+        P: commonware_cryptography::PublicKey,
+        I: InboundAdmission<P, <A::Connection as commonware_runtime::Connection>::Origin>,
+    {
         let mut listener = self
-            .context
-            .bind(self.address)
+            .acceptor
+            .bind(&self.bind)
             .await
             .expect("failed to bind listener");
 
-        // Loop over incoming connections
-        let mut accepted = 0;
         select_loop! {
             self.context,
             on_stopped => {
                 debug!("context shutdown, stopping listener");
             },
-            Some(registered_ips) = self.updates.next() else {
-                debug!("listener updates closed");
-                break;
-            } => {
-                self.registered_ips = registered_ips;
-            },
-            listener = listener.accept() => {
-                // Accept a new connection
-                let (address, sink, stream) = match listener {
-                    Ok((address, sink, stream)) => (address, sink, stream),
-                    Err(e) => {
-                        debug!(error = ?e, "failed to accept connection");
+            connection = listener.accept() => {
+                let connection = match connection {
+                    Ok(connection) => connection,
+                    Err(error) => {
+                        debug!(?error, "failed to accept connection");
                         continue;
                     }
                 };
-                debug!(?address, "accepted incoming connection");
 
-                // Check whether the IP is private
-                let ip = address.ip();
-                if !self.allow_private_ips && !IpAddrExt::is_global(&ip) {
-                    self.handshakes_blocked.inc();
-                    debug!(?address, "rejecting private address");
-                    continue;
-                }
-
-                // Check whether the IP is registered
-                if !self.bypass_ip_check && !self.registered_ips.contains(&ip) {
-                    self.handshakes_blocked.inc();
-                    debug!(?address, "rejecting unregistered address");
-                    continue;
-                }
-
-                // Cleanup the rate limiters periodically
-                if accepted > CLEANUP_INTERVAL {
-                    ip_rate_limiter.retain_recent();
-                    subnet_rate_limiter.retain_recent();
-                    accepted = 0;
-                }
-                accepted += 1;
-
-                // Check whether the IP (and subnet) exceeds its rate limit
-                let ip_limited = if ip_rate_limiter.check_key(&ip).is_err() {
-                    self.handshakes_ip_rate_limited.inc();
-                    debug!(?address, "ip exceeded handshake rate limit");
-                    true
-                } else {
-                    false
-                };
-                let subnet = ip.subnet(&SUBNET_MASK);
-                let subnet_limited = if subnet_rate_limiter.check_key(&subnet).is_err() {
-                    self.handshakes_subnet_rate_limited.inc();
-                    debug!(?address, "subnet exceeded handshake rate limit");
-                    true
-                } else {
-                    false
-                };
-
-                // We wait to check whether the handshake is permitted until after updating both the ip
-                // and subnet rate limiters
-                if ip_limited || subnet_limited {
-                    continue;
-                }
-
-                // Check whether there are too many ongoing handshakes
-                let Some(reservation) = self.handshake_limiter.try_acquire() else {
-                    self.handshakes_concurrent_rate_limited.inc();
-                    debug!(?address, "maximum concurrent handshakes reached");
-                    continue;
-                };
-
-                // Spawn a new handshaker to upgrade connection
-                self.context.child("handshaker").spawn({
-                    let stream_cfg = self.stream_cfg.clone();
-                    let tracker = tracker.clone();
-                    let supervisor = supervisor.clone();
-                    move |context| async move {
-                        Self::handshake(
-                            context, address, stream_cfg, sink, stream, tracker, supervisor,
-                        )
-                        .await;
-
-                        // Once the handshake attempt is complete, release the reservation
-                        drop(reservation);
+                match attachments.submit_inbound(connection) {
+                    Ok(_) => {}
+                    Err(Error::Busy) => {
+                        debug!("attachment engine busy, dropping connection");
                     }
-                });
+                    Err(Error::Rejected(error)) => {
+                        debug!(?error, "connection rejected before authentication");
+                    }
+                    Err(error) => {
+                        debug!(?error, "attachment engine unavailable");
+                        break;
+                    }
+                }
             },
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use commonware_actor::mailbox;
-    use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
-    use commonware_macros::test_traced;
-    use commonware_runtime::{
-        Error as RuntimeError, Runner as _, Stream, Supervisor as _, deterministic,
-    };
-    use commonware_utils::{NZU32, NZUsize};
-    use std::{
-        net::{IpAddr, Ipv4Addr},
-        time::Duration,
-    };
-
-    #[test]
-    fn mailbox_keeps_latest_registered_ips() {
-        let runner = deterministic::Runner::default();
-        runner.start(|_| async move {
-            let (mut mailbox, mut receiver) = Mailbox::new();
-            let first = HashSet::from([IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))]);
-            let second = HashSet::from([IpAddr::V4(Ipv4Addr::new(127, 0, 0, 2))]);
-            let third = HashSet::from([IpAddr::V4(Ipv4Addr::new(127, 0, 0, 3))]);
-
-            assert_eq!(mailbox.set(first), Feedback::Ok);
-            assert_eq!(mailbox.set(second), Feedback::Ok);
-            assert_eq!(mailbox.set(third.clone()), Feedback::Ok);
-
-            assert_eq!(receiver.next().await, Some(third));
-        });
-    }
-
-    fn check_rate_limits<CheckMetrics>(
-        allowed_handshake_rate_per_ip: Quota,
-        allowed_handshake_rate_per_subnet: Quota,
-        check_metrics: CheckMetrics,
-    ) where
-        CheckMetrics: FnOnce(&str),
-    {
-        let runner = deterministic::Runner::default();
-        runner.start(|context| async move {
-            let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 30_101);
-            let stream_cfg = StreamConfig {
-                signing_key: PrivateKey::from_seed(1),
-                namespace: b"test-rate-limit".to_vec(),
-                max_message_size: 1024,
-                synchrony_bound: Duration::from_secs(1),
-                max_handshake_age: Duration::from_secs(1),
-                handshake_timeout: Duration::from_millis(5),
-            };
-
-            let (mut updates_tx, updates_rx) = Mailbox::new();
-            let actor = Actor::new(
-                context.child("listener"),
-                Config {
-                    address,
-                    stream_cfg,
-                    allow_private_ips: true,
-                    max_concurrent_handshakes: NZU32!(8),
-                    bypass_ip_check: false,
-                    allowed_handshake_rate_per_ip,
-                    allowed_handshake_rate_per_subnet,
-                },
-                updates_rx,
-            );
-
-            let mut allowed = HashSet::new();
-            allowed.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
-            assert_eq!(updates_tx.set(allowed), Feedback::Ok);
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-            let tracker_task = context.child("tracker").spawn(|_| async move {
-                while let Some(message) = tracker_rx.recv().await {
-                    match message {
-                        tracker::Message::Acceptable { responder, .. } => {
-                            let _ = responder.send(true);
-                        }
-                        tracker::Message::Listen { reservation, .. } => {
-                            let _ = reservation.send(None);
-                        }
-                        tracker::Message::Release { .. } => {}
-                        _ => panic!("unexpected tracker message"),
-                    }
-                }
-            });
-
-            let (supervisor_mailbox, mut supervisor_rx) =
-                SpawnerMailbox::new(context.child("supervisor_mailbox"), NZUsize!(1));
-            let supervisor_task = context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-            let listener_handle =
-                actor.start(tracker::Mailbox::new(tracker_mailbox), supervisor_mailbox);
-
-            // Connect to the listener
-            let (sink, mut stream) = loop {
-                match context.dial(address).await {
-                    Ok(pair) => break pair,
-                    Err(RuntimeError::ConnectionFailed) => {
-                        context.sleep(Duration::from_millis(1)).await;
-                    }
-                    Err(err) => panic!("unexpected dial error: {err:?}"),
-                }
-            };
-
-            // Wait for some message or drop
-            let _ = stream.recv(1).await;
-            drop((sink, stream));
-
-            // Additional attempts should be rate limited immediately
-            for _ in 0..3 {
-                let (sink, mut stream) = context.dial(address).await.expect("dial");
-
-                // Wait for some message or drop
-                let _ = stream.recv(1).await;
-                drop((sink, stream));
-            }
-
-            let metrics = context.encode();
-            check_metrics(&metrics);
-
-            listener_handle.abort();
-            tracker_task.abort();
-            supervisor_task.abort();
-        });
-    }
-
-    #[test_traced("DEBUG")]
-    fn rate_limits_ip() {
-        check_rate_limits(
-            Quota::per_hour(NZU32!(1)),
-            Quota::per_hour(NZU32!(100)),
-            |metrics| {
-                assert!(
-                    metrics.contains("handshake_ip_rate_limited_total 3"),
-                    "{}",
-                    metrics
-                );
-                assert!(
-                    metrics.contains("handshake_subnet_rate_limited_total 0"),
-                    "{}",
-                    metrics
-                );
-                assert!(
-                    metrics.contains("handshakes_blocked_total 0"),
-                    "{}",
-                    metrics
-                );
-            },
-        );
-    }
-
-    #[test_traced("DEBUG")]
-    fn rate_limits_subnet() {
-        check_rate_limits(
-            Quota::per_hour(NZU32!(100)),
-            Quota::per_hour(NZU32!(1)),
-            |metrics| {
-                assert!(
-                    metrics.contains("handshake_subnet_rate_limited_total 3"),
-                    "{}",
-                    metrics
-                );
-                assert!(
-                    metrics.contains("handshake_ip_rate_limited_total 0"),
-                    "{}",
-                    metrics
-                );
-                assert!(
-                    metrics.contains("handshakes_blocked_total 0"),
-                    "{}",
-                    metrics
-                );
-            },
-        );
-    }
-
-    #[test_traced("DEBUG")]
-    fn rate_limits_both() {
-        check_rate_limits(
-            Quota::per_hour(NZU32!(1)),
-            Quota::per_hour(NZU32!(1)),
-            |metrics| {
-                assert!(
-                    metrics.contains("handshake_ip_rate_limited_total 3"),
-                    "{}",
-                    metrics
-                );
-                assert!(
-                    metrics.contains("handshake_subnet_rate_limited_total 3"),
-                    "{}",
-                    metrics
-                );
-                assert!(
-                    metrics.contains("handshakes_blocked_total 0"),
-                    "{}",
-                    metrics
-                );
-            },
-        );
-    }
-
-    #[test_traced("DEBUG")]
-    fn blocks_unregistered_ips() {
-        let runner = deterministic::Runner::default();
-        runner.start(|context| async move {
-            let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 30_101);
-            let stream_cfg = StreamConfig {
-                signing_key: PrivateKey::from_seed(1),
-                namespace: b"test-rate-limit".to_vec(),
-                max_message_size: 1024,
-                synchrony_bound: Duration::from_secs(1),
-                max_handshake_age: Duration::from_secs(1),
-                handshake_timeout: Duration::from_millis(5),
-            };
-
-            let (_updates_tx, updates_rx) = Mailbox::new();
-            let actor = Actor::new(
-                context.child("listener"),
-                Config {
-                    address,
-                    stream_cfg,
-                    allow_private_ips: true,
-                    bypass_ip_check: false,
-                    max_concurrent_handshakes: NZU32!(8),
-                    allowed_handshake_rate_per_ip: Quota::per_hour(NZU32!(100)),
-                    allowed_handshake_rate_per_subnet: Quota::per_hour(NZU32!(100)),
-                },
-                updates_rx,
-            );
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-            let tracker_task = context.child("tracker").spawn(|_| async move {
-                while let Some(message) = tracker_rx.recv().await {
-                    match message {
-                        tracker::Message::Acceptable { responder, .. } => {
-                            let _ = responder.send(true);
-                        }
-                        tracker::Message::Listen { reservation, .. } => {
-                            let _ = reservation.send(None);
-                        }
-                        tracker::Message::Release { .. } => {}
-                        _ => panic!("unexpected tracker message"),
-                    }
-                }
-            });
-
-            let (supervisor_mailbox, mut supervisor_rx) =
-                SpawnerMailbox::new(context.child("supervisor_mailbox"), NZUsize!(1));
-            let supervisor_task = context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-            let listener_handle =
-                actor.start(tracker::Mailbox::new(tracker_mailbox), supervisor_mailbox);
-
-            // Connect to the listener
-            let (sink, mut stream) = loop {
-                match context.dial(address).await {
-                    Ok(pair) => break pair,
-                    Err(RuntimeError::ConnectionFailed) => {
-                        context.sleep(Duration::from_millis(1)).await;
-                    }
-                    Err(err) => panic!("unexpected dial error: {err:?}"),
-                }
-            };
-
-            // Wait for some message or drop
-            let _ = stream.recv(1).await;
-            drop((sink, stream));
-
-            // Check metrics
-            let metrics = context.encode();
-            assert!(
-                metrics.contains("handshakes_blocked_total 1"),
-                "{}",
-                metrics
-            );
-
-            listener_handle.abort();
-            tracker_task.abort();
-            supervisor_task.abort();
-        });
-    }
-
-    #[test_traced("DEBUG")]
-    fn allows_unregistered_ips() {
-        let runner = deterministic::Runner::default();
-        runner.start(|context| async move {
-            let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 30_101);
-            let stream_cfg = StreamConfig {
-                signing_key: PrivateKey::from_seed(1),
-                namespace: b"test-rate-limit".to_vec(),
-                max_message_size: 1024,
-                synchrony_bound: Duration::from_secs(1),
-                max_handshake_age: Duration::from_secs(1),
-                handshake_timeout: Duration::from_millis(5),
-            };
-
-            let (_updates_tx, updates_rx) = Mailbox::new();
-            let actor = Actor::new(
-                context.child("listener"),
-                Config {
-                    address,
-                    stream_cfg,
-                    allow_private_ips: true,
-                    bypass_ip_check: true,
-                    max_concurrent_handshakes: NZU32!(8),
-                    allowed_handshake_rate_per_ip: Quota::per_hour(NZU32!(100)),
-                    allowed_handshake_rate_per_subnet: Quota::per_hour(NZU32!(100)),
-                },
-                updates_rx,
-            );
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-            let tracker_task = context.child("tracker").spawn(|_| async move {
-                while let Some(message) = tracker_rx.recv().await {
-                    match message {
-                        tracker::Message::Acceptable { responder, .. } => {
-                            let _ = responder.send(true);
-                        }
-                        tracker::Message::Listen { reservation, .. } => {
-                            let _ = reservation.send(None);
-                        }
-                        tracker::Message::Release { .. } => {}
-                        _ => panic!("unexpected tracker message"),
-                    }
-                }
-            });
-
-            let (supervisor_mailbox, mut supervisor_rx) =
-                SpawnerMailbox::new(context.child("supervisor_mailbox"), NZUsize!(1));
-            let supervisor_task = context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-            let listener_handle =
-                actor.start(tracker::Mailbox::new(tracker_mailbox), supervisor_mailbox);
-
-            // Connect to the listener
-            let (sink, mut stream) = loop {
-                match context.dial(address).await {
-                    Ok(pair) => break pair,
-                    Err(RuntimeError::ConnectionFailed) => {
-                        context.sleep(Duration::from_millis(1)).await;
-                    }
-                    Err(err) => panic!("unexpected dial error: {err:?}"),
-                }
-            };
-
-            // Wait for some message or drop
-            let _ = stream.recv(1).await;
-            drop((sink, stream));
-
-            // Check metrics
-            let metrics = context.encode();
-            assert!(
-                metrics.contains("handshakes_blocked_total 0"),
-                "{}",
-                metrics
-            );
-
-            listener_handle.abort();
-            tracker_task.abort();
-            supervisor_task.abort();
-        });
-    }
-
-    #[test_traced("DEBUG")]
-    fn blocks_private_ips() {
-        let runner = deterministic::Runner::default();
-        runner.start(|context| async move {
-            let address = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 30_101);
-            let stream_cfg = StreamConfig {
-                signing_key: PrivateKey::from_seed(1),
-                namespace: b"test-private-ips".to_vec(),
-                max_message_size: 1024,
-                synchrony_bound: Duration::from_secs(1),
-                max_handshake_age: Duration::from_secs(1),
-                handshake_timeout: Duration::from_millis(5),
-            };
-
-            let (mut updates_tx, updates_rx) = Mailbox::new();
-            let actor = Actor::new(
-                context.child("listener"),
-                Config {
-                    address,
-                    stream_cfg,
-                    allow_private_ips: false,
-                    bypass_ip_check: true,
-                    max_concurrent_handshakes: NZU32!(8),
-                    allowed_handshake_rate_per_ip: Quota::per_hour(NZU32!(100)),
-                    allowed_handshake_rate_per_subnet: Quota::per_hour(NZU32!(100)),
-                },
-                updates_rx,
-            );
-
-            // Register the IP so it would be allowed if not for the private IP check
-            let mut allowed = HashSet::new();
-            allowed.insert(IpAddr::V4(Ipv4Addr::LOCALHOST));
-            assert_eq!(updates_tx.set(allowed), Feedback::Ok);
-
-            let (tracker_mailbox, mut tracker_rx) = mailbox::new::<tracker::Message<PublicKey>>(
-                context.child("tracker_mailbox"),
-                NZUsize!(1024),
-            );
-            let tracker_task = context.child("tracker").spawn(|_| async move {
-                while let Some(message) = tracker_rx.recv().await {
-                    match message {
-                        tracker::Message::Acceptable { responder, .. } => {
-                            let _ = responder.send(true);
-                        }
-                        tracker::Message::Listen { reservation, .. } => {
-                            let _ = reservation.send(None);
-                        }
-                        tracker::Message::Release { .. } => {}
-                        _ => panic!("unexpected tracker message"),
-                    }
-                }
-            });
-
-            let (supervisor_mailbox, mut supervisor_rx) =
-                SpawnerMailbox::new(context.child("supervisor_mailbox"), NZUsize!(1));
-            let supervisor_task = context
-                .child("supervisor")
-                .spawn(|_| async move { while supervisor_rx.recv().await.is_some() {} });
-            let listener_handle =
-                actor.start(tracker::Mailbox::new(tracker_mailbox), supervisor_mailbox);
-
-            // Connect to the listener from a private IP
-            let (sink, mut stream) = loop {
-                match context.dial(address).await {
-                    Ok(pair) => break pair,
-                    Err(RuntimeError::ConnectionFailed) => {
-                        context.sleep(Duration::from_millis(1)).await;
-                    }
-                    Err(err) => panic!("unexpected dial error: {err:?}"),
-                }
-            };
-
-            // Wait for some message or drop
-            let _ = stream.recv(1).await;
-            drop((sink, stream));
-
-            // Check metrics - should be blocked because it's a private IP
-            let metrics = context.encode();
-            assert!(
-                metrics.contains("handshakes_blocked_total 1"),
-                "{}",
-                metrics
-            );
-
-            listener_handle.abort();
-            tracker_task.abort();
-            supervisor_task.abort();
-        });
     }
 }

--- a/p2p/src/authenticated/lookup/actors/mod.rs
+++ b/p2p/src/authenticated/lookup/actors/mod.rs
@@ -1,3 +1,4 @@
+pub mod attachment;
 pub mod dialer;
 pub mod listener;
 pub mod peer;

--- a/p2p/src/authenticated/lookup/actors/peer/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/peer/actor.rs
@@ -10,7 +10,7 @@ use commonware_codec::Decode;
 use commonware_cryptography::PublicKey;
 use commonware_macros::{select, select_loop};
 use commonware_runtime::{
-    BufferPooler, Clock, Handle, IoBufs, Metrics, Quota, RateLimiter, Sink, Spawner, Stream,
+    BufferPooler, Clock, Handle, IoBufs, Metrics, Quota, RateLimiter, Scheduler, Sink, Stream,
     iobuf::EncodeExt, telemetry::metrics::CounterFamily,
 };
 use commonware_stream::encrypted::{Receiver, Sender};
@@ -20,7 +20,7 @@ use rand_core::CryptoRng;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 use tracing::debug;
 
-pub struct Actor<E: Spawner + BufferPooler + Clock + Metrics, C: PublicKey> {
+pub struct Actor<E: Scheduler + BufferPooler + Clock + Metrics, C: PublicKey> {
     context: E,
 
     ping_frequency: Duration,
@@ -36,7 +36,7 @@ pub struct Actor<E: Spawner + BufferPooler + Clock + Metrics, C: PublicKey> {
     _phantom: std::marker::PhantomData<C>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + CryptoRng + Metrics, C: PublicKey> Actor<E, C> {
+impl<E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics, C: PublicKey> Actor<E, C> {
     pub fn new(context: E, cfg: Config<C>) -> (Self, Mailbox, Relay<EncodedData>) {
         let (control_sender, control_receiver) = Mailbox::new(cfg.mailbox_size);
         let (relay, receivers) = Relay::new(context.child("relay"), cfg.mailbox_size);
@@ -345,7 +345,7 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
     };
     use commonware_runtime::{
-        BufferPooler, Error as RuntimeError, IoBuf, IoBufs, Runner, Spawner, Supervisor as _,
+        BufferPooler, Error as RuntimeError, IoBuf, IoBufs, Runner, Scheduler, Supervisor as _,
         deterministic, mocks, telemetry::metrics::MetricsExt as _,
     };
     use commonware_stream::encrypted::Config as StreamConfig;

--- a/p2p/src/authenticated/lookup/actors/spawner/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/actor.rs
@@ -1,17 +1,20 @@
 use super::{Config, ingress::Message};
-use crate::authenticated::{
-    Mailbox,
-    lookup::{
-        actors::{peer, tracker},
-        metrics,
+use crate::{
+    PeerEndpoint,
+    authenticated::{
+        Mailbox,
+        lookup::{
+            actors::{peer, tracker},
+            metrics,
+        },
+        router,
     },
-    router,
 };
 use commonware_actor::mailbox;
 use commonware_cryptography::PublicKey;
 use commonware_macros::select_loop;
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, Metrics, Sink, Spawner, Stream, spawn_cell,
+    BufferPooler, Clock, ContextCell, Handle, Metrics, Scheduler, Sink, Stream, spawn_cell,
     telemetry::metrics::{CounterFamily, MetricsExt as _},
 };
 use rand_core::CryptoRng;
@@ -19,10 +22,11 @@ use std::num::NonZeroUsize;
 use tracing::debug;
 
 pub struct Actor<
-    E: Spawner + BufferPooler + Clock + CryptoRng + Metrics,
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
     Si: Sink,
     St: Stream,
     C: PublicKey,
+    P: PeerEndpoint,
 > {
     context: ContextCell<E>,
 
@@ -30,17 +34,22 @@ pub struct Actor<
     send_batch_size: NonZeroUsize,
     ping_frequency: std::time::Duration,
 
-    receiver: mailbox::UnreliableReceiver<Message<Si, St, C>>,
+    receiver: mailbox::UnreliableReceiver<Message<Si, St, C, P>>,
 
     sent_messages: CounterFamily<metrics::Message<C>>,
     received_messages: CounterFamily<metrics::Message<C>>,
     rate_limited: CounterFamily<metrics::Message<C>>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + CryptoRng + Metrics, Si: Sink, St: Stream, C: PublicKey>
-    Actor<E, Si, St, C>
+impl<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    Si: Sink,
+    St: Stream,
+    C: PublicKey,
+    P: PeerEndpoint,
+> Actor<E, Si, St, C, P>
 {
-    pub fn new(context: E, cfg: Config) -> (Self, Mailbox<Message<Si, St, C>>) {
+    pub fn new(context: E, cfg: Config) -> (Self, Mailbox<Message<Si, St, C, P>>) {
         let sent_messages = context.family("messages_sent", "messages sent");
         let received_messages = context.family("messages_received", "messages received");
         let rate_limited = context.family("messages_rate_limited", "messages rate limited");
@@ -61,11 +70,15 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + Metrics, Si: Sink, St: Stre
         )
     }
 
-    pub fn start(mut self, tracker: tracker::Mailbox<C>, router: router::Mailbox<C>) -> Handle<()> {
+    pub fn start(
+        mut self,
+        tracker: tracker::Mailbox<C, P>,
+        router: router::Mailbox<C>,
+    ) -> Handle<()> {
         spawn_cell!(self.context, self.run(tracker, router))
     }
 
-    async fn run(mut self, tracker: tracker::Mailbox<C>, router: router::Mailbox<C>) {
+    async fn run(mut self, tracker: tracker::Mailbox<C, P>, router: router::Mailbox<C>) {
         select_loop! {
             self.context,
             on_stopped => {

--- a/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/spawner/ingress.rs
@@ -1,4 +1,7 @@
-use crate::authenticated::{Mailbox, lookup::actors::tracker::Reservation};
+use crate::{
+    PeerEndpoint,
+    authenticated::{Mailbox, lookup::actors::tracker::Reservation},
+};
 use commonware_actor::{Feedback, Unreliable, mailbox::UnreliablePolicy};
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Sink, Stream};
@@ -6,7 +9,7 @@ use commonware_stream::encrypted::{Receiver, Sender};
 use std::collections::VecDeque;
 
 /// Messages that can be processed by the spawner actor.
-pub enum Message<Si: Sink, St: Stream, P: PublicKey> {
+pub enum Message<Si: Sink, St: Stream, P: PublicKey, E: PeerEndpoint = crate::Ingress> {
     /// Notify the spawner to create a new task for the given peer.
     Spawn {
         /// The peer's public key.
@@ -14,11 +17,13 @@ pub enum Message<Si: Sink, St: Stream, P: PublicKey> {
         /// The connection to the peer.
         connection: (Sender<Si>, Receiver<St>),
         /// The reservation for the peer.
-        reservation: Reservation<P>,
+        reservation: Reservation<P, E>,
     },
 }
 
-impl<Si: Sink, St: Stream, P: PublicKey> UnreliablePolicy for Message<Si, St, P> {
+impl<Si: Sink, St: Stream, P: PublicKey, E: PeerEndpoint> UnreliablePolicy
+    for Message<Si, St, P, E>
+{
     type Overflow = VecDeque<Self>;
 
     fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
@@ -29,7 +34,7 @@ impl<Si: Sink, St: Stream, P: PublicKey> UnreliablePolicy for Message<Si, St, P>
     }
 }
 
-impl<Si: Sink, St: Stream, P: PublicKey> Mailbox<Message<Si, St, P>> {
+impl<Si: Sink, St: Stream, P: PublicKey, E: PeerEndpoint> Mailbox<Message<Si, St, P, E>> {
     /// Send a message to the actor to spawn a new task for the given peer.
     ///
     /// This may be rejected when the spawner is backlogged, or return closed after shutdown, which
@@ -37,7 +42,7 @@ impl<Si: Sink, St: Stream, P: PublicKey> Mailbox<Message<Si, St, P>> {
     pub fn spawn(
         &mut self,
         connection: (Sender<Si>, Receiver<St>),
-        reservation: Reservation<P>,
+        reservation: Reservation<P, E>,
     ) -> Unreliable<Feedback> {
         self.0.enqueue(Message::Spawn {
             peer: reservation.metadata().public_key().clone(),
@@ -56,7 +61,7 @@ mod tests {
         Signer as _,
         ed25519::{PrivateKey, PublicKey},
     };
-    use commonware_runtime::{Runner as _, Spawner as _, Supervisor as _, deterministic, mocks};
+    use commonware_runtime::{Runner as _, Scheduler as _, Supervisor as _, deterministic, mocks};
     use commonware_stream::encrypted::{
         Config as StreamConfig, Receiver as EncryptedReceiver, Sender as EncryptedSender, dial,
         listen,

--- a/p2p/src/authenticated/lookup/actors/tracker/actor.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/actor.rs
@@ -1,17 +1,20 @@
 use super::{
-    Config,
+    Config, Metadata,
     directory::{self, Directory},
     ingress::{Mailbox, Message, Oracle},
 };
 use crate::{
-    PeerSetUpdate,
-    authenticated::lookup::actors::{listener, peer, tracker::ingress::Releaser},
+    PeerEndpoint, PeerSetUpdate,
+    authenticated::{
+        admission::PeerEligibility,
+        lookup::actors::{peer, tracker::ingress::Releaser},
+    },
 };
 use commonware_actor::mailbox;
 use commonware_cryptography::Signer;
-use commonware_macros::select_loop;
+use commonware_macros::{select_loop, stability};
 use commonware_runtime::{
-    Clock, ContextCell, Handle, Metrics as RuntimeMetrics, Spawner, spawn_cell,
+    Clock, ContextCell, Handle, Metrics as RuntimeMetrics, Scheduler, spawn_cell,
 };
 use commonware_utils::channel::{fallible::FallibleExt, mpsc};
 use rand_core::Rng;
@@ -19,22 +22,23 @@ use std::collections::HashMap;
 use tracing::debug;
 
 /// The tracker actor that manages peer discovery and connection reservations.
-pub struct Actor<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> {
-    context: ContextCell<E>,
+pub struct Actor<
+    R: Scheduler + Rng + Clock + RuntimeMetrics,
+    C: Signer,
+    E: PeerEndpoint = crate::Ingress,
+> {
+    context: ContextCell<R>,
 
     // ---------- Message-Passing ----------
     /// The mailbox for the actor.
     ///
     /// We use this to support sending a [`Message::Release`] message to the actor
     /// during [`Drop`].
-    receiver: mailbox::Receiver<Message<C::PublicKey>>,
-
-    /// The mailbox for the listener.
-    listener: listener::Mailbox,
+    receiver: mailbox::Receiver<Message<C::PublicKey, E>>,
 
     // ---------- State ----------
     /// Tracks peer sets and peer connectivity information.
-    directory: Directory<E, C::PublicKey>,
+    directory: Directory<R, C::PublicKey, E>,
 
     /// Maps a peer's public key to its mailbox.
     /// Set when a peer connects and cleared when it is blocked or released.
@@ -42,19 +46,40 @@ pub struct Actor<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> {
 
     /// Subscribers to peer set updates.
     subscribers: Vec<mpsc::UnboundedSender<PeerSetUpdate<C::PublicKey>>>,
+
+    /// Identity-only snapshot consumed by transport-specific inbound admission.
+    eligibility: PeerEligibility<C::PublicKey>,
 }
 
-impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
+impl<R: Scheduler + Rng + Clock + RuntimeMetrics, C: Signer, E: PeerEndpoint> Actor<R, C, E> {
     /// Create a new tracker [Actor] from the given `context` and `cfg`.
     #[allow(clippy::type_complexity)]
-    pub fn new(context: E, cfg: Config<C>) -> (Self, Mailbox<C::PublicKey>, Oracle<C::PublicKey>) {
+    #[stability(ALPHA)]
+    pub fn new(
+        context: R,
+        cfg: Config<C>,
+    ) -> (Self, Mailbox<C::PublicKey, E>, Oracle<C::PublicKey, E>) {
+        let (actor, mailbox, oracle, _) = Self::with_eligibility(context, cfg);
+        (actor, mailbox, oracle)
+    }
+
+    #[allow(
+        clippy::type_complexity,
+        reason = "the returned handles are the actor's construction interface"
+    )]
+    pub(crate) fn with_eligibility(
+        context: R,
+        cfg: Config<C>,
+    ) -> (
+        Self,
+        Mailbox<C::PublicKey, E>,
+        Oracle<C::PublicKey, E>,
+        PeerEligibility<C::PublicKey>,
+    ) {
         // General initialization
         let directory_cfg = directory::Config {
             max_sets: cfg.tracked_peer_sets,
             peer_connection_cooldown: cfg.peer_connection_cooldown,
-            allow_private_ips: cfg.allow_private_ips,
-            allow_dns: cfg.allow_dns,
-            bypass_ip_check: cfg.bypass_ip_check,
             block_duration: cfg.block_duration,
         };
 
@@ -62,6 +87,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
         let (sender, receiver) = mailbox::new(context.child("mailbox"), cfg.mailbox_size);
         let oracle = Oracle::new(sender.clone());
         let releaser = Releaser::new(sender.clone());
+        let eligibility = PeerEligibility::default();
 
         // Create the directory
         let directory = Directory::init(
@@ -76,12 +102,13 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
                 context: ContextCell::new(context),
                 receiver,
                 directory,
-                listener: cfg.listener,
                 mailboxes: HashMap::new(),
                 subscribers: Vec::new(),
+                eligibility: eligibility.clone(),
             },
             Mailbox::new(sender),
             oracle,
+            eligibility,
         )
     }
 
@@ -98,7 +125,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
             },
             _ = self.directory.wait_for_unblock() => {
                 if self.directory.unblock_expired() {
-                    let _ = self.listener.set(self.directory.listenable());
+                    self.refresh_eligibility();
                 }
             },
             Some(msg) = self.receiver.recv() else {
@@ -111,7 +138,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
     }
 
     /// Handle a [`Message`].
-    fn handle_msg(&mut self, msg: Message<C::PublicKey>) {
+    fn handle_msg(&mut self, msg: Message<C::PublicKey, E>) {
         match msg {
             Message::Register { index, peers } => {
                 // Identify peers whose connection state should be torn down.
@@ -123,9 +150,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
                 for peer in kill_peers {
                     self.kill_peer(&peer);
                 }
-
-                // Send the updated listenable IPs to the listener.
-                let _ = self.listener.set(self.directory.listenable());
+                self.refresh_eligibility();
 
                 // Notify all subscribers about the new peer set
                 let update = self
@@ -136,21 +161,13 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
                     .retain(|subscriber| subscriber.send_lossy(update.clone()));
             }
             Message::Overwrite { peers } => {
-                let mut any_changed = false;
                 for (public_key, address) in peers {
                     // Update the peer address.
                     if !self.directory.overwrite(&public_key, address) {
                         continue;
                     }
-                    any_changed = true;
-
                     // Kill the existing connection since it was established to the old address.
                     self.kill_peer(&public_key);
-                }
-
-                // Send the updated listenable IPs to the listener (if any changes occurred).
-                if any_changed {
-                    let _ = self.listener.set(self.directory.listenable());
                 }
             }
             Message::PeerSet { index, responder } => {
@@ -192,38 +209,47 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
             } => {
                 let _ = reservation.send(self.directory.dial(&public_key));
             }
+            Message::Attach {
+                public_key,
+                inbound,
+                reservation,
+            } => {
+                let metadata = if inbound {
+                    Metadata::Listener(public_key.clone())
+                } else {
+                    Metadata::Dialer(public_key.clone())
+                };
+                let _ = reservation.send(self.directory.attach(public_key, metadata));
+            }
             Message::Acceptable {
                 public_key,
-                source_ip,
                 responder,
             } => {
-                let _ = responder.send(self.directory.acceptable(&public_key, source_ip));
+                let _ = responder.send(self.directory.acceptable(&public_key));
             }
             Message::Listen {
                 public_key,
-                source_ip,
                 reservation,
             } => {
-                let _ = reservation.send(self.directory.listen(&public_key, source_ip));
+                let _ = reservation.send(self.directory.listen(&public_key));
             }
             Message::Block { public_key } => {
                 // Block the peer
                 self.directory.block(&public_key);
+                self.refresh_eligibility();
 
                 // Kill the peer if we're connected to it
                 self.kill_peer(&public_key);
-
-                // Send the updated listenable IPs to the listener.
-                let _ = self.listener.set(self.directory.listenable());
             }
             Message::Release { metadata } => {
-                // Clear the peer handle if it exists
-                self.mailboxes.remove(metadata.public_key());
-
-                // Release the peer
-                self.directory.release(metadata);
+                self.release(metadata);
             }
         }
+    }
+
+    fn release(&mut self, metadata: Metadata<C::PublicKey>) {
+        self.mailboxes.remove(metadata.public_key());
+        self.directory.release(metadata);
     }
 
     fn kill_peer(&mut self, public_key: &C::PublicKey) {
@@ -231,14 +257,18 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: Signer> Actor<E, C> {
             peer.kill();
         }
     }
+
+    fn refresh_eligibility(&self) {
+        self.eligibility.set(self.directory.admissible());
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        AddressableManager, AddressableTrackedPeers, Ingress, Provider,
-        authenticated::lookup::actors::peer,
+        Advertisement, PeerEndpoint, Provider, Reachability, ReachabilityManager,
+        ReachableTrackedPeers, authenticated::lookup::actors::peer,
     };
     use commonware_cryptography::{
         Signer,
@@ -253,28 +283,32 @@ mod tests {
         ordered::{Map, Set},
     };
     use futures::{FutureExt, StreamExt};
-    use std::{
-        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
-        time::Duration,
-    };
+    use std::time::Duration;
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct Endpoint(u16);
+
+    impl PeerEndpoint for Endpoint {}
+
+    fn dialable(endpoint: Endpoint) -> Reachability<Endpoint> {
+        Reachability::Dialable(Advertisement::new(vec![endpoint]).unwrap())
+    }
+
+    fn primary(
+        peers: impl IntoIterator<Item = (PublicKey, Reachability<Endpoint>)>,
+    ) -> Map<PublicKey, Reachability<Endpoint>> {
+        Map::from_iter_dedup(peers)
+    }
 
     // Test Configuration Setup
-    fn test_config<C: Signer>(crypto: C, bypass_ip_check: bool) -> (Config<C>, listener::Updates) {
-        let (registered_ips_sender, registered_ips_receiver) = listener::Mailbox::new();
-        (
-            Config {
-                crypto,
-                mailbox_size: NZUsize!(1024),
-                tracked_peer_sets: NZUsize!(2),
-                peer_connection_cooldown: Duration::from_millis(200),
-                allow_private_ips: true,
-                allow_dns: true,
-                bypass_ip_check,
-                listener: registered_ips_sender,
-                block_duration: Duration::from_secs(100),
-            },
-            registered_ips_receiver,
-        )
+    fn test_config<C: Signer>(crypto: C) -> Config<C> {
+        Config {
+            crypto,
+            mailbox_size: NZUsize!(1024),
+            tracked_peer_sets: NZUsize!(2),
+            peer_connection_cooldown: Duration::from_millis(200),
+            block_duration: Duration::from_secs(100),
+        }
     }
 
     // Helper to create Ed25519 signer and public key
@@ -286,8 +320,8 @@ mod tests {
 
     // Test Harness
     struct TestHarness {
-        mailbox: Mailbox<PublicKey>,
-        oracle: Oracle<PublicKey>,
+        mailbox: Mailbox<PublicKey, Endpoint>,
+        oracle: Oracle<PublicKey, Endpoint>,
     }
 
     fn setup_actor(
@@ -295,7 +329,7 @@ mod tests {
         cfg_to_clone: Config<PrivateKey>, // Pass by value to allow cloning
     ) -> TestHarness {
         // Actor::new takes ownership, so clone again if cfg_to_clone is needed later
-        let (actor, mailbox, oracle) = Actor::new(runner_context, cfg_to_clone);
+        let (actor, mailbox, oracle) = Actor::<_, _, Endpoint>::new(runner_context, cfg_to_clone);
         actor.start();
 
         TestHarness { mailbox, oracle }
@@ -305,7 +339,7 @@ mod tests {
     fn test_connect_unauthorized_peer_is_killed() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness { mailbox, .. } = setup_actor(context.child("actor"), cfg);
 
             let (_unauth_signer, unauth_pk) = new_signer_and_pk(1);
@@ -324,7 +358,7 @@ mod tests {
     fn test_block_peer_standard_behavior() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg_initial, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg_initial = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -332,11 +366,7 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg_initial);
 
             let (_, pk) = new_signer_and_pk(1);
-            let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(pk.clone(), dialable(Endpoint(1001)))]));
             context.sleep(Duration::from_millis(10)).await;
 
             let dialable = mailbox.dialable().await;
@@ -354,7 +384,7 @@ mod tests {
     fn test_block_peer_already_blocked_is_noop() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg_initial, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg_initial = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -362,11 +392,7 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg_initial);
 
             let (_, pk1) = new_signer_and_pk(1);
-            let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk1.clone(), addr.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(pk1.clone(), dialable(Endpoint(1001)))]));
             context.sleep(Duration::from_millis(10)).await;
 
             crate::block_peer(&mut oracle, pk1.clone());
@@ -387,7 +413,7 @@ mod tests {
     fn test_block_peer_non_existent_is_noop() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg_initial, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg_initial = test_config(PrivateKey::from_seed(0));
             let TestHarness { mut oracle, .. } = setup_actor(context.child("actor"), cfg_initial);
 
             let (_s1_signer, pk_non_existent) = new_signer_and_pk(100);
@@ -398,16 +424,13 @@ mod tests {
     }
 
     #[test]
-    fn test_listenable() {
+    fn test_acceptable() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (peer_signer, peer_pk) = new_signer_and_pk(1);
-            let peer_addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1001);
             let (_peer_signer2, peer_pk2) = new_signer_and_pk(2);
-            let peer_addr2 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), 1002);
             let (_peer_signer3, peer_pk3) = new_signer_and_pk(3);
-            let peer_addr3 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 3).into(), 1003);
-            let (cfg_initial, _) = test_config(peer_signer, false);
+            let cfg_initial = test_config(peer_signer);
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -415,75 +438,67 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg_initial);
 
             // None acceptable because not registered
-            assert!(!mailbox.acceptable(peer_pk.clone(), peer_addr.ip()).await);
-            assert!(!mailbox.acceptable(peer_pk2.clone(), peer_addr2.ip()).await);
-            assert!(!mailbox.acceptable(peer_pk3.clone(), peer_addr3.ip()).await);
+            assert!(!mailbox.acceptable(peer_pk.clone()).await);
+            assert!(!mailbox.acceptable(peer_pk2.clone()).await);
+            assert!(!mailbox.acceptable(peer_pk3.clone()).await);
 
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([
-                    (peer_pk.clone(), peer_addr.into()),
-                    (peer_pk2.clone(), peer_addr2.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (peer_pk.clone(), dialable(Endpoint(1001))),
+                    (peer_pk2.clone(), dialable(Endpoint(1002))),
+                ]),
             );
             context.sleep(Duration::from_millis(10)).await;
 
             // Not acceptable because self
-            assert!(!mailbox.acceptable(peer_pk, peer_addr.ip()).await);
-            // Acceptable because registered with correct IP
-            assert!(mailbox.acceptable(peer_pk2.clone(), peer_addr2.ip()).await);
-            // Not acceptable with wrong IP
-            assert!(!mailbox.acceptable(peer_pk2, peer_addr.ip()).await);
+            assert!(!mailbox.acceptable(peer_pk).await);
+            // Acceptable because registered
+            assert!(mailbox.acceptable(peer_pk2.clone()).await);
             // Not acceptable because not registered
-            assert!(!mailbox.acceptable(peer_pk3, peer_addr3.ip()).await);
+            assert!(!mailbox.acceptable(peer_pk3).await);
         });
     }
 
     #[test]
-    fn test_acceptable_bypass_ip_check() {
+    fn test_outbound_only_peer_is_acceptable() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (peer_signer, peer_pk) = new_signer_and_pk(1);
-            let peer_addr = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 1).into(), 1001);
             let (_peer_signer2, peer_pk2) = new_signer_and_pk(2);
-            let peer_addr2 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), 1002);
             let (_peer_signer3, peer_pk3) = new_signer_and_pk(3);
-            let peer_addr3 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 3).into(), 1003);
 
-            // Create a tracker with bypass_ip_check=true (skips IP verification)
-            let (cfg, _) = test_config(peer_signer, true);
+            let cfg = test_config(peer_signer);
             let TestHarness {
                 mailbox,
                 mut oracle,
                 ..
             } = setup_actor(context.child("actor"), cfg);
 
-            // Unknown peer is NOT acceptable (bypass_ip_check only skips IP check)
+            // Unknown peers are not acceptable.
             assert!(
-                !mailbox.acceptable(peer_pk3.clone(), peer_addr3.ip()).await,
+                !mailbox.acceptable(peer_pk3.clone()).await,
                 "Unknown peer should not be acceptable"
             );
 
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([
-                    (peer_pk.clone(), peer_addr.into()),
-                    (peer_pk2.clone(), peer_addr2.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (peer_pk.clone(), dialable(Endpoint(1001))),
+                    (peer_pk2.clone(), Reachability::OutboundOnly),
+                ]),
             );
             context.sleep(Duration::from_millis(10)).await;
 
-            // With bypass_ip_check=true, tracked peer with wrong IP is acceptable
+            // Outbound-only peers may still establish inbound connections.
             assert!(
-                mailbox.acceptable(peer_pk2.clone(), peer_addr.ip()).await,
-                "Registered peer with wrong IP should be acceptable with bypass_ip_check=true"
+                mailbox.acceptable(peer_pk2.clone()).await,
+                "outbound-only peer should be acceptable"
             );
 
             // Self is still not acceptable
             assert!(
-                !mailbox.acceptable(peer_pk.clone(), peer_addr.ip()).await,
+                !mailbox.acceptable(peer_pk.clone()).await,
                 "Self should not be acceptable"
             );
 
@@ -492,7 +507,7 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(
-                !mailbox.acceptable(peer_pk2.clone(), peer_addr2.ip()).await,
+                !mailbox.acceptable(peer_pk2.clone()).await,
                 "Blocked peer should not be acceptable"
             );
         });
@@ -502,7 +517,7 @@ mod tests {
     fn test_listen() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg_initial, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg_initial = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -510,31 +525,26 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg_initial);
 
             let (_peer_signer, peer_pk) = new_signer_and_pk(1);
-            let peer_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080);
-
-            let reservation = mailbox.listen(peer_pk.clone(), peer_addr.ip()).await;
+            let reservation = mailbox.listen(peer_pk.clone()).await;
             assert!(reservation.is_none());
 
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(peer_pk.clone(), peer_addr.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(peer_pk.clone(), dialable(Endpoint(8080)))]));
             context.sleep(Duration::from_millis(10)).await; // Allow register to process
 
-            assert!(mailbox.acceptable(peer_pk.clone(), peer_addr.ip()).await);
+            assert!(mailbox.acceptable(peer_pk.clone()).await);
 
-            let reservation = mailbox.listen(peer_pk.clone(), peer_addr.ip()).await;
+            let reservation = mailbox.listen(peer_pk.clone()).await;
             assert!(reservation.is_some());
 
-            assert!(!mailbox.acceptable(peer_pk.clone(), peer_addr.ip()).await);
+            assert!(!mailbox.acceptable(peer_pk.clone()).await);
 
-            let failed_reservation = mailbox.listen(peer_pk.clone(), peer_addr.ip()).await;
+            let failed_reservation = mailbox.listen(peer_pk.clone()).await;
             assert!(failed_reservation.is_none());
 
             drop(reservation.unwrap());
             context.sleep(Duration::from_millis(1_010)).await; // Allow release and rate limit to pass
 
-            let reservation_after_release = mailbox.listen(peer_pk.clone(), peer_addr.ip()).await;
+            let reservation_after_release = mailbox.listen(peer_pk.clone()).await;
             assert!(reservation_after_release.is_some());
         });
     }
@@ -544,17 +554,13 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (_boot_signer, boot_pk) = new_signer_and_pk(99);
-            let boot_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
-            let (cfg_initial, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg_initial = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
                 ..
             } = setup_actor(context.child("actor"), cfg_initial);
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(boot_pk.clone(), boot_addr.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(boot_pk.clone(), dialable(Endpoint(9000)))]));
 
             let dialable = mailbox.dialable().await;
             assert_eq!(dialable.peers.len(), 1);
@@ -567,8 +573,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (_boot_signer, boot_pk) = new_signer_and_pk(99);
-            let boot_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
-            let (cfg_initial, _) = test_config(PrivateKey::from_seed(0), false);
+            let boot_endpoint = Endpoint(9000);
+            let cfg_initial = test_config(PrivateKey::from_seed(0));
 
             let TestHarness {
                 mailbox,
@@ -578,19 +584,19 @@ mod tests {
 
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([(boot_pk.clone(), boot_addr.into())]).unwrap(),
+                primary([(boot_pk.clone(), dialable(boot_endpoint.clone()))]),
             );
 
             let result = mailbox.dial(boot_pk.clone()).await;
             assert!(result.is_some());
-            if let Some((res, ingress)) = result {
+            if let Some((res, advertisement)) = result {
                 match res.metadata() {
                     crate::authenticated::lookup::actors::tracker::Metadata::Dialer(pk) => {
                         assert_eq!(pk, &boot_pk);
                     }
                     _ => panic!("Expected Dialer metadata"),
                 }
-                assert_eq!(ingress, Ingress::Socket(boot_addr));
+                assert_eq!(advertisement.endpoints(), &[boot_endpoint]);
             }
 
             let (_unknown_signer, unknown_pk) = new_signer_and_pk(100);
@@ -603,7 +609,7 @@ mod tests {
     fn test_secondary_peers_are_acceptable_but_not_primary_or_dialable() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -613,20 +619,13 @@ mod tests {
             let mut subscription = oracle.subscribe().await;
 
             let (_primary_signer, primary_pk) = new_signer_and_pk(1);
-            let primary_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9001);
             let (_secondary_signer, secondary_pk) = new_signer_and_pk(2);
-            let secondary_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9002);
 
             oracle.track(
                 0,
-                AddressableTrackedPeers::new(
-                    Map::<_, crate::Address>::try_from([(primary_pk.clone(), primary_addr.into())])
-                        .unwrap(),
-                    Map::<_, crate::Address>::try_from([(
-                        secondary_pk.clone(),
-                        secondary_addr.into(),
-                    )])
-                    .unwrap(),
+                ReachableTrackedPeers::new(
+                    primary([(primary_pk.clone(), dialable(Endpoint(9001)))]),
+                    primary([(secondary_pk.clone(), Reachability::OutboundOnly)]),
                 ),
             );
 
@@ -649,7 +648,7 @@ mod tests {
             assert!(dialable.peers.iter().any(|peer| peer == &primary_pk));
             assert!(!dialable.peers.iter().any(|peer| peer == &secondary_pk));
             assert!(mailbox.dial(secondary_pk.clone()).await.is_none());
-            assert!(mailbox.acceptable(secondary_pk, secondary_addr.ip()).await);
+            assert!(mailbox.acceptable(secondary_pk).await);
         });
     }
 
@@ -658,7 +657,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Duplicate key across primary/secondary maps; deduplicated as primary only.
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -668,12 +667,11 @@ mod tests {
             let mut subscription = oracle.subscribe().await;
 
             let (_signer, pk) = new_signer_and_pk(1);
-            let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9001);
             oracle.track(
                 0,
-                AddressableTrackedPeers::new(
-                    Map::<_, crate::Address>::try_from([(pk.clone(), addr.into())]).unwrap(),
-                    Map::<_, crate::Address>::try_from([(pk.clone(), addr.into())]).unwrap(),
+                ReachableTrackedPeers::new(
+                    primary([(pk.clone(), dialable(Endpoint(9001)))]),
+                    primary([(pk.clone(), Reachability::OutboundOnly)]),
                 ),
             );
 
@@ -693,7 +691,7 @@ mod tests {
 
             let dialable = mailbox.dialable().await;
             assert!(dialable.peers.iter().any(|peer| peer == &pk));
-            assert!(mailbox.acceptable(pk, addr.ip()).await);
+            assert!(mailbox.acceptable(pk).await);
         });
     }
 
@@ -702,7 +700,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // 1) Setup actor
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -711,15 +709,11 @@ mod tests {
 
             // 2) Register & connect an authorized peer
             let (_peer_signer, peer_pk) = new_signer_and_pk(1);
-            let peer_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 12345);
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(peer_pk.clone(), peer_addr.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(peer_pk.clone(), dialable(Endpoint(12345)))]));
             // let the register take effect
             context.sleep(Duration::from_millis(10)).await;
 
-            let reservation = mailbox.listen(peer_pk.clone(), peer_addr.ip()).await;
+            let reservation = mailbox.listen(peer_pk.clone()).await;
             assert!(reservation.is_some());
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
@@ -751,14 +745,11 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (my_sk, my_pk) = new_signer_and_pk(0);
-            let my_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
 
             let pk_1 = new_signer_and_pk(1).1;
-            let addr_1 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), 9001);
             let pk_2 = new_signer_and_pk(2).1;
-            let addr_2 = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 9002);
 
-            let (mut cfg, mut listener_receiver) = test_config(my_sk, false);
+            let mut cfg = test_config(my_sk);
             cfg.tracked_peer_sets = NZUsize!(1);
 
             let TestHarness {
@@ -770,39 +761,30 @@ mod tests {
             // Register set with myself and one other peer
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([
-                    (my_pk.clone(), my_addr.into()),
-                    (pk_1.clone(), addr_1.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (my_pk.clone(), dialable(Endpoint(9000))),
+                    (pk_1.clone(), dialable(Endpoint(9001))),
+                ]),
             );
             // let the register take effect
             context.sleep(Duration::from_millis(10)).await;
 
-            // Wait for a listener update
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&my_addr.ip()));
-            assert!(registered_ips.contains(&addr_1.ip()));
-            assert!(!registered_ips.contains(&addr_2.ip()));
+            assert!(!mailbox.acceptable(my_pk).await);
+            assert!(mailbox.acceptable(pk_1.clone()).await);
+            assert!(!mailbox.acceptable(pk_2.clone()).await);
 
             // Mark peer as connected
-            let reservation = mailbox.listen(pk_1.clone(), addr_1.ip()).await;
+            let reservation = mailbox.listen(pk_1.clone()).await;
             assert!(reservation.is_some());
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk_1.clone(), peer_mailbox);
 
             // Register another set which doesn't include first peer
-            oracle.track(
-                1,
-                Map::<_, crate::Address>::try_from([(pk_2.clone(), addr_2.into())]).unwrap(),
-            );
+            oracle.track(1, primary([(pk_2.clone(), dialable(Endpoint(9002)))]));
 
-            // Wait for a listener update
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&my_addr.ip()));
-            assert!(!registered_ips.contains(&addr_1.ip()));
-            assert!(registered_ips.contains(&addr_2.ip()));
+            assert!(!mailbox.acceptable(pk_1.clone()).await);
+            assert!(mailbox.acceptable(pk_2).await);
 
             // The first peer should have received a kill message because its
             // peer set was removed when `tracked_peer_sets` is 1.
@@ -816,11 +798,9 @@ mod tests {
         executor.start(|context| async move {
             let (my_sk, _) = new_signer_and_pk(0);
             let pk_1 = new_signer_and_pk(1).1;
-            let addr_1 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), 9001);
             let pk_2 = new_signer_and_pk(2).1;
-            let addr_2 = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 9002);
 
-            let (mut cfg, mut listener_receiver) = test_config(my_sk, false);
+            let mut cfg = test_config(my_sk);
             cfg.tracked_peer_sets = NZUsize!(1);
             let TestHarness {
                 mailbox,
@@ -830,14 +810,13 @@ mod tests {
 
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([(pk_1.clone(), addr_1.into())]).unwrap(),
+                primary([(pk_1.clone(), dialable(Endpoint(9001)))]),
             );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_1.ip()));
-            assert!(!registered_ips.contains(&addr_2.ip()));
+            assert!(mailbox.acceptable(pk_1.clone()).await);
+            assert!(!mailbox.acceptable(pk_2.clone()).await);
 
             let reservation = mailbox
-                .listen(pk_1.clone(), addr_1.ip())
+                .listen(pk_1.clone())
                 .await
                 .expect("peer should reserve");
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
@@ -845,15 +824,12 @@ mod tests {
 
             oracle.track(
                 1,
-                Map::<_, crate::Address>::try_from([
-                    (pk_1.clone(), addr_1.into()),
-                    (pk_2.clone(), addr_2.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (pk_1.clone(), dialable(Endpoint(9001))),
+                    (pk_2.clone(), dialable(Endpoint(9002))),
+                ]),
             );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_1.ip()));
-            assert!(registered_ips.contains(&addr_2.ip()));
+            assert!(mailbox.acceptable(pk_2).await);
 
             assert!(
                 !matches!(peer_rx.next().now_or_never(), Some(Some(peer::Message::Kill))),
@@ -869,11 +845,9 @@ mod tests {
         executor.start(|context| async move {
             let (my_sk, _) = new_signer_and_pk(0);
             let pk_1 = new_signer_and_pk(1).1;
-            let addr_1 = SocketAddr::new(Ipv4Addr::new(127, 0, 0, 2).into(), 9001);
             let pk_2 = new_signer_and_pk(2).1;
-            let addr_2 = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 9002);
 
-            let (mut cfg, mut listener_receiver) = test_config(my_sk, false);
+            let mut cfg = test_config(my_sk);
             cfg.tracked_peer_sets = NZUsize!(1);
             let TestHarness {
                 mailbox,
@@ -881,27 +855,19 @@ mod tests {
                 ..
             } = setup_actor(context.child("actor"), cfg);
 
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk_1.clone(), addr_1.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_1.ip()));
-            assert!(!registered_ips.contains(&addr_2.ip()));
+            oracle.track(0, primary([(pk_1.clone(), dialable(Endpoint(9001)))]));
+            assert!(mailbox.acceptable(pk_1.clone()).await);
+            assert!(!mailbox.acceptable(pk_2.clone()).await);
 
             let reservation = mailbox
-                .listen(pk_1.clone(), addr_1.ip())
+                .listen(pk_1.clone())
                 .await
                 .expect("peer should reserve");
             assert_eq!(reservation.metadata().public_key(), &pk_1);
 
-            oracle.track(
-                1,
-                Map::<_, crate::Address>::try_from([(pk_2.clone(), addr_2.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_1.ip()));
-            assert!(registered_ips.contains(&addr_2.ip()));
+            oracle.track(1, primary([(pk_2.clone(), dialable(Endpoint(9002)))]));
+            assert!(!mailbox.acceptable(pk_1.clone()).await);
+            assert!(mailbox.acceptable(pk_2).await);
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk_1.clone(), peer_mailbox);
@@ -918,10 +884,10 @@ mod tests {
         executor.start(|context| async move {
             let (my_sk, _) = new_signer_and_pk(0);
             let pk = new_signer_and_pk(1).1;
-            let addr_a = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1001);
-            let addr_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1002);
+            let endpoint_a = Endpoint(1001);
+            let endpoint_b = Endpoint(1002);
 
-            let (mut cfg, mut listener_receiver) = test_config(my_sk, false);
+            let mut cfg = test_config(my_sk);
             cfg.tracked_peer_sets = NZUsize!(2);
             let TestHarness {
                 mailbox,
@@ -929,25 +895,14 @@ mod tests {
                 ..
             } = setup_actor(context.child("actor"), cfg);
 
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_a.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_a.ip()));
+            oracle.track(0, primary([(pk.clone(), dialable(endpoint_a.clone()))]));
 
-            let (reservation, ingress) =
+            let (reservation, advertisement) =
                 mailbox.dial(pk.clone()).await.expect("peer should reserve");
             assert_eq!(reservation.metadata().public_key(), &pk);
-            assert_eq!(ingress, Ingress::Socket(addr_a));
+            assert_eq!(advertisement.endpoints(), &[endpoint_a]);
 
-            oracle.track(
-                1,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_b.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_a.ip()));
-            assert!(registered_ips.contains(&addr_b.ip()));
+            oracle.track(1, primary([(pk.clone(), dialable(endpoint_b))]));
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk.clone(), peer_mailbox);
@@ -964,32 +919,23 @@ mod tests {
         executor.start(|context| async move {
             let (my_sk, _) = new_signer_and_pk(0);
             let pk = new_signer_and_pk(1).1;
-            let addr_a = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1001);
-            let addr_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1002);
+            let endpoint_a = Endpoint(1001);
 
-            let (cfg, mut listener_receiver) = test_config(my_sk, false);
+            let cfg = test_config(my_sk);
             let TestHarness {
                 mailbox,
                 mut oracle,
                 ..
             } = setup_actor(context.child("actor"), cfg);
 
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_a.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_a.ip()));
+            oracle.track(0, primary([(pk.clone(), dialable(endpoint_a.clone()))]));
 
-            let (reservation, ingress) =
+            let (reservation, advertisement) =
                 mailbox.dial(pk.clone()).await.expect("peer should reserve");
             assert_eq!(reservation.metadata().public_key(), &pk);
-            assert_eq!(ingress, Ingress::Socket(addr_a));
+            assert_eq!(advertisement.endpoints(), &[endpoint_a]);
 
-            oracle.overwrite([(pk.clone(), addr_b.into())].try_into().unwrap());
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_a.ip()));
-            assert!(registered_ips.contains(&addr_b.ip()));
+            oracle.overwrite(primary([(pk.clone(), dialable(Endpoint(1002)))]));
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk.clone(), peer_mailbox);
@@ -1001,77 +947,56 @@ mod tests {
     }
 
     #[test]
-    fn test_stale_inbound_source_rejected_after_overwrite() {
+    fn test_outbound_only_peer_remains_acceptable_after_overwrite() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (my_sk, _) = new_signer_and_pk(0);
             let pk = new_signer_and_pk(1).1;
-            let addr_a = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1001);
-            let addr_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1002);
 
-            let (cfg, mut listener_receiver) = test_config(my_sk, false);
+            let cfg = test_config(my_sk);
             let TestHarness {
                 mailbox,
                 mut oracle,
                 ..
             } = setup_actor(context.child("actor"), cfg);
 
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_a.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_a.ip()));
-            assert!(mailbox.acceptable(pk.clone(), addr_a.ip()).await);
+            oracle.track(0, primary([(pk.clone(), dialable(Endpoint(1001)))]));
+            assert!(mailbox.acceptable(pk.clone()).await);
 
-            oracle.overwrite([(pk.clone(), addr_b.into())].try_into().unwrap());
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_a.ip()));
-            assert!(registered_ips.contains(&addr_b.ip()));
+            oracle.overwrite(primary([(pk.clone(), Reachability::OutboundOnly)]));
 
-            let reservation = mailbox.listen(pk.clone(), addr_a.ip()).await;
-            assert!(
-                reservation.is_none(),
-                "inbound handshake from the old source IP must be rejected"
-            );
-
-            let reservation = mailbox.listen(pk.clone(), addr_b.ip()).await;
+            assert!(mailbox.acceptable(pk.clone()).await);
+            assert!(mailbox.dial(pk.clone()).await.is_none());
+            let reservation = mailbox.listen(pk).await;
             assert!(reservation.is_some());
         });
     }
 
     #[test]
-    fn test_overwrite_triggers_listener() {
+    fn test_overwrite_updates_advertisement() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (my_sk, my_pk) = new_signer_and_pk(0);
-            let my_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
 
             let pk_1 = new_signer_and_pk(1).1;
-            let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 9001);
-            let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 9002);
 
-            let (cfg, mut listener_receiver) = test_config(my_sk, false);
-            let TestHarness { mut oracle, .. } = setup_actor(context.child("actor"), cfg);
+            let cfg = test_config(my_sk);
+            let TestHarness {
+                mailbox,
+                mut oracle,
+            } = setup_actor(context.child("actor"), cfg);
 
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([
-                    (my_pk.clone(), my_addr.into()),
-                    (pk_1.clone(), addr_1.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (my_pk, dialable(Endpoint(9000))),
+                    (pk_1.clone(), dialable(Endpoint(9001))),
+                ]),
             );
 
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_1.ip()));
-            assert!(!registered_ips.contains(&addr_2.ip()));
-
-            oracle.overwrite([(pk_1.clone(), addr_2.into())].try_into().unwrap());
-
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_1.ip()));
-            assert!(registered_ips.contains(&addr_2.ip()));
+            oracle.overwrite(primary([(pk_1.clone(), dialable(Endpoint(9002)))]));
+            let (_, advertisement) = mailbox.dial(pk_1).await.unwrap();
+            assert_eq!(advertisement.endpoints(), &[Endpoint(9002)]);
         });
     }
 
@@ -1079,7 +1004,7 @@ mod tests {
     fn test_overwrite_via_oracle() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -1087,66 +1012,53 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg);
 
             let (_, pk) = new_signer_and_pk(1);
-            let addr_1 = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
-            let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1002);
-
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_1.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(pk.clone(), dialable(Endpoint(1001)))]));
             context.sleep(Duration::from_millis(10)).await;
 
             let result = mailbox.dial(pk.clone()).await;
             assert!(result.is_some());
-            let (_, ingress) = result.unwrap();
-            assert_eq!(ingress, Ingress::Socket(addr_1));
+            let (_, advertisement) = result.unwrap();
+            assert_eq!(advertisement.endpoints(), &[Endpoint(1001)]);
 
-            oracle.overwrite([(pk.clone(), addr_2.into())].try_into().unwrap());
+            oracle.overwrite(primary([(pk.clone(), dialable(Endpoint(1002)))]));
 
             context.sleep(Duration::from_millis(1010)).await;
 
             let result = mailbox.dial(pk.clone()).await;
             assert!(result.is_some());
-            let (_, ingress) = result.unwrap();
-            assert_eq!(ingress, Ingress::Socket(addr_2));
+            let (_, advertisement) = result.unwrap();
+            assert_eq!(advertisement.endpoints(), &[Endpoint(1002)]);
         });
     }
 
     #[test]
-    fn test_overwrite_blocked_peer_not_in_listenable() {
+    fn test_overwrite_blocked_peer_remains_unacceptable() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (my_sk, my_pk) = new_signer_and_pk(0);
-            let my_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 9000);
 
             let pk_1 = new_signer_and_pk(1).1;
-            let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 9001);
-            let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 9002);
 
-            let (cfg, mut listener_receiver) = test_config(my_sk, false);
-            let TestHarness { mut oracle, .. } = setup_actor(context.child("actor"), cfg);
+            let cfg = test_config(my_sk);
+            let TestHarness {
+                mailbox,
+                mut oracle,
+            } = setup_actor(context.child("actor"), cfg);
 
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([
-                    (my_pk.clone(), my_addr.into()),
-                    (pk_1.clone(), addr_1.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (my_pk, dialable(Endpoint(9000))),
+                    (pk_1.clone(), dialable(Endpoint(9001))),
+                ]),
             );
 
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_1.ip()));
-
             crate::block_peer(&mut oracle, pk_1.clone());
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_1.ip()));
+            assert!(!mailbox.acceptable(pk_1.clone()).await);
 
-            oracle.overwrite([(pk_1.clone(), addr_2.into())].try_into().unwrap());
+            oracle.overwrite(primary([(pk_1.clone(), dialable(Endpoint(9002)))]));
 
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_1.ip()));
-            assert!(!registered_ips.contains(&addr_2.ip()));
+            assert!(!mailbox.acceptable(pk_1).await);
         });
     }
 
@@ -1154,45 +1066,36 @@ mod tests {
     fn test_overwrite_untracked_peer_silently_ignored() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness { mut oracle, .. } = setup_actor(context.child("actor"), cfg);
 
             let (_, pk) = new_signer_and_pk(1);
-            let addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1001);
-
             // Peer not in the directory is silently skipped (no error, no effect)
-            oracle.overwrite([(pk, addr.into())].try_into().unwrap());
+            oracle.overwrite(primary([(pk, dialable(Endpoint(1001)))]));
         });
     }
 
     #[test]
-    fn test_overwrite_changes_acceptable_ip() {
+    fn test_overwrite_preserves_acceptability() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let pk_1 = new_signer_and_pk(1).1;
-            let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 9001);
-            let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 9002);
 
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
                 ..
             } = setup_actor(context.child("actor"), cfg);
 
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk_1.clone(), addr_1.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(pk_1.clone(), dialable(Endpoint(9001)))]));
             context.sleep(Duration::from_millis(10)).await;
 
-            assert!(mailbox.acceptable(pk_1.clone(), addr_1.ip()).await);
-            assert!(!mailbox.acceptable(pk_1.clone(), addr_2.ip()).await);
+            assert!(mailbox.acceptable(pk_1.clone()).await);
 
-            oracle.overwrite([(pk_1.clone(), addr_2.into())].try_into().unwrap());
+            oracle.overwrite(primary([(pk_1.clone(), dialable(Endpoint(9002)))]));
 
-            assert!(!mailbox.acceptable(pk_1.clone(), addr_1.ip()).await);
-            assert!(mailbox.acceptable(pk_1.clone(), addr_2.ip()).await);
+            assert!(mailbox.acceptable(pk_1).await);
         });
     }
 
@@ -1200,7 +1103,7 @@ mod tests {
     fn test_overwrite_severs_existing_connection() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, _) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -1208,24 +1111,18 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg);
 
             let (_, pk) = new_signer_and_pk(1);
-            let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1001);
-            let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1002);
-
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_1.into())]).unwrap(),
-            );
+            oracle.track(0, primary([(pk.clone(), dialable(Endpoint(1001)))]));
             context.sleep(Duration::from_millis(10)).await;
 
             // Establish connection
-            let reservation = mailbox.listen(pk.clone(), addr_1.ip()).await;
+            let reservation = mailbox.listen(pk.clone()).await;
             assert!(reservation.is_some());
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk.clone(), peer_mailbox);
 
             // Update address - should kill the connection
-            oracle.overwrite([(pk.clone(), addr_2.into())].try_into().unwrap());
+            oracle.overwrite(primary([(pk.clone(), dialable(Endpoint(1002)))]));
 
             // Peer should receive kill message
             assert!(matches!(peer_rx.next().await, Some(peer::Message::Kill)));
@@ -1236,7 +1133,7 @@ mod tests {
     fn test_add_set_severs_connection_on_address_change() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, mut listener_receiver) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -1244,37 +1141,26 @@ mod tests {
             } = setup_actor(context.child("actor"), cfg);
 
             let (_, pk) = new_signer_and_pk(1);
-            let addr_a = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1001);
-            let addr_b = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1002);
-
             // Register peer set with peer at address A
-            oracle.track(
-                0,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_a.into())]).unwrap(),
-            );
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(registered_ips.contains(&addr_a.ip()));
+            oracle.track(0, primary([(pk.clone(), dialable(Endpoint(1001)))]));
 
             // Establish connection to peer
-            let reservation = mailbox.listen(pk.clone(), addr_a.ip()).await;
+            let reservation = mailbox.listen(pk.clone()).await;
             assert!(reservation.is_some());
 
             let (peer_mailbox, mut peer_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk.clone(), peer_mailbox);
 
             // Register new peer set with same peer at address B
-            oracle.track(
-                1,
-                Map::<_, crate::Address>::try_from([(pk.clone(), addr_b.into())]).unwrap(),
-            );
+            oracle.track(1, primary([(pk.clone(), dialable(Endpoint(1002)))]));
 
             // Peer should receive Kill message (connection severed due to address change)
             assert!(matches!(peer_rx.next().await, Some(peer::Message::Kill)));
 
-            // Verify listenable IPs updated to new address
-            let registered_ips = listener_receiver.next().await.unwrap();
-            assert!(!registered_ips.contains(&addr_a.ip()));
-            assert!(registered_ips.contains(&addr_b.ip()));
+            drop(reservation);
+            context.sleep(Duration::from_millis(210)).await;
+            let (_, advertisement) = mailbox.dial(pk).await.unwrap();
+            assert_eq!(advertisement.endpoints(), &[Endpoint(1002)]);
         });
     }
 
@@ -1282,7 +1168,7 @@ mod tests {
     fn test_overwrite_batch_mixed_peers() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let (cfg, mut listener_receiver) = test_config(PrivateKey::from_seed(0), false);
+            let cfg = test_config(PrivateKey::from_seed(0));
             let TestHarness {
                 mailbox,
                 mut oracle,
@@ -1293,45 +1179,33 @@ mod tests {
             let (_, pk_unchanged) = new_signer_and_pk(2);
             let (_, pk_untracked) = new_signer_and_pk(3);
 
-            let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1001);
-            let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1002);
-            let addr_unchanged = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 10, 10, 10)), 1003);
-
             // Register some peers
             oracle.track(
                 0,
-                Map::<_, crate::Address>::try_from([
-                    (pk_tracked.clone(), addr_1.into()),
-                    (pk_unchanged.clone(), addr_unchanged.into()),
-                ])
-                .unwrap(),
+                primary([
+                    (pk_tracked.clone(), dialable(Endpoint(1001))),
+                    (pk_unchanged.clone(), dialable(Endpoint(1003))),
+                ]),
             );
-            let _ = listener_receiver.next().await.unwrap();
 
             // Establish connection to pk_tracked
-            let reservation = mailbox.listen(pk_tracked.clone(), addr_1.ip()).await;
+            let reservation = mailbox.listen(pk_tracked.clone()).await;
             assert!(reservation.is_some());
             let (tracked_mailbox, mut tracked_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk_tracked.clone(), tracked_mailbox);
 
             // Establish connection to pk_unchanged
-            let reservation = mailbox
-                .listen(pk_unchanged.clone(), addr_unchanged.ip())
-                .await;
+            let reservation = mailbox.listen(pk_unchanged.clone()).await;
             assert!(reservation.is_some());
             let (unchanged_mailbox, mut unchanged_rx) = peer::Mailbox::new(NZUsize!(1));
             let _ = mailbox.connect(pk_unchanged.clone(), unchanged_mailbox);
 
             // Call overwrite with mix of tracked+changed, tracked+unchanged, and unknown peers
-            oracle.overwrite(
-                [
-                    (pk_tracked.clone(), addr_2.into()),
-                    (pk_unchanged.clone(), addr_unchanged.into()),
-                    (pk_untracked.clone(), addr_1.into()),
-                ]
-                .try_into()
-                .unwrap(),
-            );
+            oracle.overwrite(primary([
+                (pk_tracked.clone(), dialable(Endpoint(1002))),
+                (pk_unchanged.clone(), dialable(Endpoint(1003))),
+                (pk_untracked.clone(), dialable(Endpoint(1001))),
+            ]));
 
             // Only tracked+changed peer (pk_tracked) gets killed
             assert!(matches!(tracked_rx.next().await, Some(peer::Message::Kill)));

--- a/p2p/src/authenticated/lookup/actors/tracker/directory.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/directory.rs
@@ -1,20 +1,20 @@
 use super::{Metadata, Reservation, metrics::Metrics, record::Record};
 use crate::{
-    AddressableTrackedPeers, Ingress, PeerSetUpdate, TrackedPeers,
+    Advertisement, PeerEndpoint, PeerSetUpdate, Reachability, ReachableTrackedPeers, TrackedPeers,
     authenticated::{
         dialing::{DialStatus, Dialable, ReserveResult, earliest},
         lookup::actors::tracker::ingress::Releaser,
     },
-    types::Address,
     utils::PeerSetsAtIndex as PeerSetsAtIndexBase,
 };
 use commonware_cryptography::PublicKey;
-use commonware_runtime::{Clock, Metrics as RuntimeMetrics, Spawner, telemetry::metrics::GaugeExt};
-use commonware_utils::{IpAddrExt, PrioritySet, SystemTimeExt, ordered::Set};
+use commonware_runtime::{
+    Clock, Metrics as RuntimeMetrics, Scheduler, telemetry::metrics::GaugeExt,
+};
+use commonware_utils::{PrioritySet, SystemTimeExt, ordered::Set};
 use rand_core::Rng;
 use std::{
     collections::{BTreeMap, HashMap, HashSet, hash_map::Entry},
-    net::IpAddr,
     num::NonZeroUsize,
     time::{Duration, SystemTime},
 };
@@ -25,15 +25,6 @@ type PeerSetsAtIndex<C> = PeerSetsAtIndexBase<Set<C>, Set<C>>;
 
 /// Configuration for the [Directory].
 pub struct Config {
-    /// Whether private IPs are connectable.
-    pub allow_private_ips: bool,
-
-    /// Whether DNS-based ingress addresses are allowed.
-    pub allow_dns: bool,
-
-    /// Whether to skip IP verification for incoming connections (allows unknown IPs).
-    pub bypass_ip_check: bool,
-
     /// The maximum number of peer sets to track.
     pub max_sets: NonZeroUsize,
 
@@ -45,21 +36,12 @@ pub struct Config {
 }
 
 /// Represents a collection of records for all peers.
-pub struct Directory<E: Rng + Clock + RuntimeMetrics, C: PublicKey> {
-    context: E,
+pub struct Directory<R: Rng + Clock + RuntimeMetrics, C: PublicKey, E: PeerEndpoint> {
+    context: R,
 
     // ---------- Configuration ----------
     /// The maximum number of peer sets to track.
     max_sets: NonZeroUsize,
-
-    /// Whether private IPs are connectable.
-    pub allow_private_ips: bool,
-
-    /// Whether DNS-based ingress addresses are allowed.
-    allow_dns: bool,
-
-    /// Whether to skip IP verification for incoming connections (allows unknown IPs).
-    bypass_ip_check: bool,
 
     /// Duration after which a blocked peer is allowed to reconnect.
     block_duration: Duration,
@@ -69,7 +51,7 @@ pub struct Directory<E: Rng + Clock + RuntimeMetrics, C: PublicKey> {
 
     // ---------- State ----------
     /// The records of all peers.
-    peers: HashMap<C, Record>,
+    peers: HashMap<C, Record<E>>,
 
     /// Primary and secondary peer sets indexed by peer set ID.
     peer_sets: BTreeMap<u64, PeerSetsAtIndex<C>>,
@@ -80,16 +62,18 @@ pub struct Directory<E: Rng + Clock + RuntimeMetrics, C: PublicKey> {
 
     // ---------- Message-Passing ----------
     /// The releaser for the tracker actor.
-    releaser: Releaser<C>,
+    releaser: Releaser<C, E>,
 
     // ---------- Metrics ----------
     /// The metrics for the records.
     metrics: Metrics<C>,
 }
 
-impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
+impl<R: Scheduler + Rng + Clock + RuntimeMetrics, C: PublicKey, E: PeerEndpoint>
+    Directory<R, C, E>
+{
     /// Create a new set of records using the given local node information.
-    pub fn init(context: E, myself: C, cfg: Config, releaser: Releaser<C>) -> Self {
+    pub fn init(context: R, myself: C, cfg: Config, releaser: Releaser<C, E>) -> Self {
         // Create the list of peers and add myself.
         let mut peers = HashMap::new();
         peers.insert(myself, Record::myself());
@@ -100,9 +84,6 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
         Self {
             context,
             max_sets: cfg.max_sets,
-            allow_private_ips: cfg.allow_private_ips,
-            allow_dns: cfg.allow_dns,
-            bypass_ip_check: cfg.bypass_ip_check,
             block_duration: cfg.block_duration,
             peer_connection_cooldown: cfg.peer_connection_cooldown,
             peers,
@@ -154,7 +135,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
     /// tracked peer sets or had their address changed.
     ///
     /// Returns `None` if the index is invalid.
-    pub fn track(&mut self, index: u64, peers: AddressableTrackedPeers<C>) -> Option<Set<C>> {
+    pub fn track(&mut self, index: u64, peers: ReachableTrackedPeers<C, E>) -> Option<Set<C>> {
         // Check if peer set already exists
         if self.peer_sets.contains_key(&index) {
             warn!(index, "peer set already exists");
@@ -260,11 +241,11 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
     ///
     /// Returns `false` if the peer has no record, is ourselves, or the
     /// new address is identical to the existing one.
-    pub fn overwrite(&mut self, peer: &C, address: Address) -> bool {
+    pub fn overwrite(&mut self, peer: &C, reachability: Reachability<E>) -> bool {
         let Some(record) = self.peers.get_mut(peer) else {
             return false;
         };
-        record.update(address)
+        record.update(reachability)
     }
 
     /// Gets the peer set (primary and secondary) at the given index.
@@ -294,23 +275,39 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
     /// Attempt to reserve a peer for the dialer.
     ///
     /// Returns `Some` on success, `None` otherwise.
-    pub fn dial(&mut self, peer: &C) -> Option<(Reservation<C>, Ingress)> {
+    pub fn dial(&mut self, peer: &C) -> Option<(Reservation<C, E>, Advertisement<E>)> {
         let record = self.peers.get(peer)?;
         if !record.is_outbound_target() {
             return None;
         }
-        let ingress = record.ingress()?;
+        let advertisement = record.advertisement()?;
         let reservation = self.reserve(Metadata::Dialer(peer.clone()))?;
-        Some((reservation, ingress))
+        Some((reservation, advertisement))
+    }
+
+    /// Reserve a peer whose transport connection was established outside the dialer or listener.
+    pub fn attach(&mut self, peer: C, metadata: Metadata<C>) -> Option<Reservation<C, E>> {
+        if metadata.public_key() != &peer || self.is_blocked(&peer) {
+            return None;
+        }
+
+        let inserted = !self.peers.contains_key(&peer);
+        if inserted {
+            self.metrics.tracked.inc();
+            self.peers.insert(peer.clone(), Record::undialable());
+        }
+        let reservation = self.reserve_record(metadata);
+        if reservation.is_none() && inserted {
+            self.delete_if_needed(&peer);
+        }
+        reservation
     }
 
     /// Attempt to reserve a peer for the listener.
     ///
     /// Returns `Some` on success, `None` otherwise.
-    pub fn listen(&mut self, peer: &C, source_ip: IpAddr) -> Option<Reservation<C>> {
-        // Re-check the source IP when reserving: the handshake's earlier
-        // acceptability check may be stale if the peer address changed.
-        if !self.acceptable(peer, source_ip) {
+    pub fn listen(&mut self, peer: &C) -> Option<Reservation<C, E>> {
+        if !self.acceptable(peer) {
             return None;
         }
         self.reserve(Metadata::Listener(peer.clone()))
@@ -381,6 +378,15 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
         !self.is_blocked(peer) && self.peers.get(peer).is_some_and(|r| r.eligible())
     }
 
+    /// Returns peers eligible to begin inbound authentication.
+    pub fn admissible(&self) -> HashSet<C> {
+        self.peers
+            .iter()
+            .filter(|(peer, record)| !self.is_blocked(peer) && record.eligible())
+            .map(|(peer, _)| peer.clone())
+            .collect()
+    }
+
     /// Returns dialable peers and the next time another peer may become dialable.
     pub fn dialable(&self) -> Dialable<C> {
         let now = self.context.current();
@@ -391,7 +397,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
                 next_query_at = earliest(next_query_at, blocked_until);
                 continue;
             }
-            match record.dialable(now, self.allow_private_ips, self.allow_dns) {
+            match record.dialable(now) {
                 DialStatus::Now => peers.push(peer.clone()),
                 DialStatus::After(t) => {
                     next_query_at = earliest(next_query_at, t);
@@ -409,28 +415,9 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
 
     /// Returns true if this peer is acceptable (can accept an incoming connection from them).
     ///
-    /// Checks eligibility (peer set membership), blocked status, egress IP match (if not bypass_ip_check),
-    /// and connection status.
-    pub fn acceptable(&self, peer: &C, source_ip: IpAddr) -> bool {
-        !self.is_blocked(peer)
-            && self
-                .peers
-                .get(peer)
-                .is_some_and(|record| record.acceptable(source_ip, self.bypass_ip_check))
-    }
-
-    /// Return egress IPs we should listen for (accept incoming connections from).
-    ///
-    /// Only includes IPs from peers that are:
-    /// - Currently eligible (not blocked, in a peer set)
-    /// - Have a valid egress IP (global, or private IPs are allowed)
-    pub fn listenable(&self) -> HashSet<IpAddr> {
-        self.peers
-            .iter()
-            .filter(|(peer, r)| !self.is_blocked(peer) && r.eligible())
-            .filter_map(|(_, r)| r.egress_ip())
-            .filter(|ip| self.allow_private_ips || IpAddrExt::is_global(ip))
-            .collect()
+    /// Origin and endpoint admission policies are enforced before this tracker is queried.
+    pub fn acceptable(&self, peer: &C) -> bool {
+        !self.is_blocked(peer) && self.peers.get(peer).is_some_and(Record::acceptable)
     }
 
     /// Unblock all peers whose block has expired.
@@ -473,7 +460,7 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
     /// Attempt to reserve a peer.
     ///
     /// Returns `Some(Reservation)` if the peer was successfully reserved, `None` otherwise.
-    fn reserve(&mut self, metadata: Metadata<C>) -> Option<Reservation<C>> {
+    fn reserve(&mut self, metadata: Metadata<C>) -> Option<Reservation<C, E>> {
         let peer = metadata.public_key();
 
         // Not reservable (must be in a peer set)
@@ -481,6 +468,11 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
             return None;
         }
 
+        self.reserve_record(metadata)
+    }
+
+    fn reserve_record(&mut self, metadata: Metadata<C>) -> Option<Reservation<C, E>> {
+        let peer = metadata.public_key();
         // Reserve
         let record = self.peers.get_mut(peer).unwrap();
         match record.reserve(&mut self.context, self.peer_connection_cooldown) {
@@ -532,14 +524,14 @@ impl<E: Spawner + Rng + Clock + RuntimeMetrics, C: PublicKey> Directory<E, C> {
 #[cfg(test)]
 mod tests {
     use crate::{
-        AddressableTrackedPeers, Ingress,
-        authenticated::lookup::actors::tracker::directory::Directory, types::Address,
+        Advertisement, PeerEndpoint, Reachability, ReachableTrackedPeers,
+        authenticated::lookup::actors::tracker::directory::Directory,
     };
     use commonware_actor::mailbox;
     use commonware_cryptography::{Signer, ed25519};
     use commonware_runtime::{Clock, Metrics as _, Runner, Supervisor as _, deterministic};
     use commonware_utils::{
-        NZUsize, SystemTimeExt, hostname,
+        NZUsize, SystemTimeExt,
         ordered::{Map, Set},
     };
     use std::{
@@ -547,14 +539,23 @@ mod tests {
         time::Duration,
     };
 
-    fn addr(socket: SocketAddr) -> Address {
-        Address::Symmetric(socket)
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct Endpoint(SocketAddr);
+
+    impl PeerEndpoint for Endpoint {}
+
+    fn advertisement(socket: SocketAddr) -> Advertisement<Endpoint> {
+        Advertisement::new(vec![Endpoint(socket)]).unwrap()
+    }
+
+    fn dialable(socket: SocketAddr) -> Reachability<Endpoint> {
+        Reachability::Dialable(advertisement(socket))
     }
 
     fn primary(
-        map: Map<ed25519::PublicKey, Address>,
-    ) -> AddressableTrackedPeers<ed25519::PublicKey> {
-        AddressableTrackedPeers::from(map)
+        map: Map<ed25519::PublicKey, Reachability<Endpoint>>,
+    ) -> ReachableTrackedPeers<ed25519::PublicKey, Endpoint> {
+        ReachableTrackedPeers::from(map)
     }
 
     fn metric_value(metrics: &str, name: &str, peer: &str) -> Option<i64> {
@@ -567,9 +568,59 @@ mod tests {
 
     fn new_releaser<C: commonware_cryptography::PublicKey>(
         metrics: impl commonware_runtime::Metrics,
-    ) -> super::Releaser<C> {
+    ) -> super::Releaser<C, Endpoint> {
         let (tx, _rx) = mailbox::new(metrics, NZUsize!(1024));
         super::Releaser::new(tx)
+    }
+
+    #[test]
+    fn test_rejected_attachment_does_not_retain_unknown_peer() {
+        deterministic::Runner::default().start(|context| async move {
+            let myself = ed25519::PrivateKey::from_seed(0).public_key();
+            let peer = ed25519::PrivateKey::from_seed(1).public_key();
+            let config = super::Config {
+                max_sets: NZUsize!(1),
+                peer_connection_cooldown: Duration::ZERO,
+                block_duration: Duration::from_secs(100),
+            };
+            let releaser = new_releaser(context.child("releaser"));
+            let mut directory = Directory::init(context, myself, config, releaser);
+
+            let reservation = directory
+                .attach(peer.clone(), super::Metadata::Listener(peer.clone()))
+                .expect("unknown peer should be provisionally reservable");
+            let metadata = reservation.metadata().clone();
+            std::mem::forget(reservation);
+            directory.release(metadata);
+
+            assert!(!directory.peers.contains_key(&peer));
+        });
+    }
+
+    #[test]
+    fn test_connected_attachment_retains_unknown_peer() {
+        deterministic::Runner::default().start(|context| async move {
+            let myself = ed25519::PrivateKey::from_seed(0).public_key();
+            let peer = ed25519::PrivateKey::from_seed(1).public_key();
+            let config = super::Config {
+                max_sets: NZUsize!(1),
+                peer_connection_cooldown: Duration::ZERO,
+                block_duration: Duration::from_secs(100),
+            };
+            let releaser = new_releaser(context.child("releaser"));
+            let mut directory = Directory::init(context, myself, config, releaser);
+
+            let reservation = directory
+                .attach(peer.clone(), super::Metadata::Listener(peer.clone()))
+                .expect("unknown peer should be provisionally reservable");
+            let metadata = reservation.metadata().clone();
+            std::mem::forget(reservation);
+            assert!(directory.connect(&peer));
+            directory.release(metadata);
+
+            assert!(directory.peers.contains_key(&peer));
+            assert!(directory.eligible(&peer));
+        });
     }
 
     #[test]
@@ -577,9 +628,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(1),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -600,9 +648,12 @@ mod tests {
                 .track(
                     0,
                     primary(
-                        [(pk_1.clone(), addr(addr_1)), (pk_2.clone(), addr(addr_2))]
-                            .try_into()
-                            .unwrap(),
+                        [
+                            (pk_1.clone(), dialable(addr_1)),
+                            (pk_2.clone(), dialable(addr_2)),
+                        ]
+                        .try_into()
+                        .unwrap(),
                     ),
                 )
                 .unwrap();
@@ -615,9 +666,12 @@ mod tests {
                 .track(
                     1,
                     primary(
-                        [(pk_2.clone(), addr(addr_2)), (pk_3.clone(), addr(addr_3))]
-                            .try_into()
-                            .unwrap(),
+                        [
+                            (pk_2.clone(), dialable(addr_2)),
+                            (pk_3.clone(), dialable(addr_3)),
+                        ]
+                        .try_into()
+                        .unwrap(),
                     ),
                 )
                 .unwrap();
@@ -629,7 +683,7 @@ mod tests {
             let kill_peers = directory
                 .track(
                     2,
-                    primary([(pk_3.clone(), addr(addr_3))].try_into().unwrap()),
+                    primary([(pk_3.clone(), dialable(addr_3))].try_into().unwrap()),
                 )
                 .unwrap();
             assert!(
@@ -640,7 +694,7 @@ mod tests {
             let kill_peers = directory
                 .track(
                     3,
-                    primary([(pk_3.clone(), addr(addr_3))].try_into().unwrap()),
+                    primary([(pk_3.clone(), dialable(addr_3))].try_into().unwrap()),
                 )
                 .unwrap();
             assert!(kill_peers.is_empty(), "No peers should be killed");
@@ -652,9 +706,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(1),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -672,18 +723,16 @@ mod tests {
             directory
                 .track(
                     0,
-                    primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                    primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
                 )
                 .unwrap();
-            let reservation = directory
-                .listen(&pk_1, addr_1.ip())
-                .expect("peer should reserve");
+            let reservation = directory.listen(&pk_1).expect("peer should reserve");
             directory.connect(&pk_1);
 
             let kill_peers = directory
                 .track(
                     1,
-                    primary([(pk_2.clone(), addr(addr_2))].try_into().unwrap()),
+                    primary([(pk_2.clone(), dialable(addr_2))].try_into().unwrap()),
                 )
                 .unwrap();
 
@@ -701,9 +750,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(2),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -728,9 +774,9 @@ mod tests {
                 directory
                     .track(
                         0,
-                        AddressableTrackedPeers::new(
-                            [(primary_0, addr(primary_0_addr))].try_into().unwrap(),
-                            [(secondary_0.clone(), addr(secondary_0_addr))]
+                        ReachableTrackedPeers::new(
+                            [(primary_0, dialable(primary_0_addr))].try_into().unwrap(),
+                            [(secondary_0.clone(), dialable(secondary_0_addr))]
                                 .try_into()
                                 .unwrap(),
                         ),
@@ -743,9 +789,9 @@ mod tests {
                 directory
                     .track(
                         1,
-                        AddressableTrackedPeers::new(
-                            [(primary_1, addr(primary_1_addr))].try_into().unwrap(),
-                            [(secondary_1.clone(), addr(secondary_1_addr))]
+                        ReachableTrackedPeers::new(
+                            [(primary_1, dialable(primary_1_addr))].try_into().unwrap(),
+                            [(secondary_1.clone(), dialable(secondary_1_addr))]
                                 .try_into()
                                 .unwrap(),
                         ),
@@ -759,7 +805,7 @@ mod tests {
                 directory
                     .track(
                         2,
-                        primary([(primary_2, addr(primary_2_addr))].try_into().unwrap(),),
+                        primary([(primary_2, dialable(primary_2_addr))].try_into().unwrap(),),
                     )
                     .is_some()
             );
@@ -774,9 +820,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let my_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 1234);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -801,19 +844,29 @@ mod tests {
             directory.track(
                 0,
                 primary(
-                    [(pk_1.clone(), addr(addr_1)), (pk_2.clone(), addr(addr_2))]
-                        .try_into()
-                        .unwrap(),
+                    [
+                        (pk_1.clone(), dialable(addr_1)),
+                        (pk_2.clone(), dialable(addr_2)),
+                    ]
+                    .try_into()
+                    .unwrap(),
                 ),
             );
-            assert!(directory.peers.get(&my_pk).unwrap().ingress().is_none());
-            assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_1))
+            assert!(
+                directory
+                    .peers
+                    .get(&my_pk)
+                    .unwrap()
+                    .advertisement()
+                    .is_none()
             );
             assert_eq!(
-                directory.peers.get(&pk_2).unwrap().ingress(),
-                Some(Ingress::Socket(addr_2))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_1))
+            );
+            assert_eq!(
+                directory.peers.get(&pk_2).unwrap().advertisement(),
+                Some(advertisement(addr_2))
             );
             assert!(!directory.peers.contains_key(&pk_3));
             assert_eq!(
@@ -827,16 +880,23 @@ mod tests {
 
             directory.track(
                 1,
-                primary([(pk_1.clone(), addr(addr_4))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_4))].try_into().unwrap()),
             );
-            assert!(directory.peers.get(&my_pk).unwrap().ingress().is_none());
-            assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_4))
+            assert!(
+                directory
+                    .peers
+                    .get(&my_pk)
+                    .unwrap()
+                    .advertisement()
+                    .is_none()
             );
             assert_eq!(
-                directory.peers.get(&pk_2).unwrap().ingress(),
-                Some(Ingress::Socket(addr_2))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_4))
+            );
+            assert_eq!(
+                directory.peers.get(&pk_2).unwrap().advertisement(),
+                Some(advertisement(addr_2))
             );
             assert!(!directory.peers.contains_key(&pk_3));
             assert_eq!(
@@ -850,23 +910,30 @@ mod tests {
 
             directory.track(
                 2,
-                primary([(my_pk.clone(), addr(addr_3))].try_into().unwrap()),
+                primary([(my_pk.clone(), dialable(addr_3))].try_into().unwrap()),
             );
-            assert!(directory.peers.get(&my_pk).unwrap().ingress().is_none());
-            assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_4))
+            assert!(
+                directory
+                    .peers
+                    .get(&my_pk)
+                    .unwrap()
+                    .advertisement()
+                    .is_none()
             );
             assert_eq!(
-                directory.peers.get(&pk_2).unwrap().ingress(),
-                Some(Ingress::Socket(addr_2))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_4))
+            );
+            assert_eq!(
+                directory.peers.get(&pk_2).unwrap().advertisement(),
+                Some(advertisement(addr_2))
             );
             assert!(!directory.peers.contains_key(&pk_3));
 
             let kill_peers = directory
                 .track(
                     3,
-                    primary([(my_pk.clone(), addr(my_addr))].try_into().unwrap()),
+                    primary([(my_pk.clone(), dialable(my_addr))].try_into().unwrap()),
                 )
                 .unwrap();
             assert!(kill_peers.is_empty());
@@ -874,7 +941,7 @@ mod tests {
             let kill_peers = directory
                 .track(
                     4,
-                    primary([(my_pk.clone(), addr(addr_3))].try_into().unwrap()),
+                    primary([(my_pk.clone(), dialable(addr_3))].try_into().unwrap()),
                 )
                 .unwrap();
             assert!(kill_peers.is_empty());
@@ -882,9 +949,12 @@ mod tests {
             let result = directory.track(
                 0,
                 primary(
-                    [(pk_1.clone(), addr(addr_1)), (pk_2.clone(), addr(addr_2))]
-                        .try_into()
-                        .unwrap(),
+                    [
+                        (pk_1.clone(), dialable(addr_1)),
+                        (pk_2.clone(), dialable(addr_2)),
+                    ]
+                    .try_into()
+                    .unwrap(),
                 ),
             );
             assert!(result.is_none());
@@ -892,13 +962,10 @@ mod tests {
     }
 
     #[test]
-    fn test_track_updates_metric_for_secondary_address_change() {
+    fn test_track_updates_metric_for_secondary_reachability_change() {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -919,9 +986,9 @@ mod tests {
             directory
                 .track(
                     0,
-                    AddressableTrackedPeers::new(
+                    ReachableTrackedPeers::new(
                         Map::default(),
-                        [(pk_1.clone(), addr(addr_1))].try_into().unwrap(),
+                        [(pk_1.clone(), dialable(addr_1))].try_into().unwrap(),
                     ),
                 )
                 .unwrap();
@@ -937,9 +1004,9 @@ mod tests {
             directory
                 .track(
                     1,
-                    AddressableTrackedPeers::new(
+                    ReachableTrackedPeers::new(
                         Map::default(),
-                        [(pk_1.clone(), addr(addr_2))].try_into().unwrap(),
+                        [(pk_1.clone(), dialable(addr_2))].try_into().unwrap(),
                     ),
                 )
                 .unwrap();
@@ -959,9 +1026,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -979,9 +1043,11 @@ mod tests {
             let kill_peers = directory
                 .track(
                     0,
-                    AddressableTrackedPeers::new(
-                        [(pk_1.clone(), addr(primary_addr))].try_into().unwrap(),
-                        [(pk_1.clone(), addr(secondary_addr))].try_into().unwrap(),
+                    ReachableTrackedPeers::new(
+                        [(pk_1.clone(), dialable(primary_addr))].try_into().unwrap(),
+                        [(pk_1.clone(), dialable(secondary_addr))]
+                            .try_into()
+                            .unwrap(),
                     ),
                 )
                 .unwrap();
@@ -996,8 +1062,8 @@ mod tests {
             );
             assert!(directory.eligible(&pk_1));
             assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(primary_addr))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(primary_addr))
             );
             assert_eq!(directory.all().primary, [pk_1.clone()].try_into().unwrap());
             assert!(directory.all().secondary.is_empty());
@@ -1013,9 +1079,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(2),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -1034,9 +1097,9 @@ mod tests {
             directory
                 .track(
                     0,
-                    AddressableTrackedPeers::new(
-                        [(pk_x.clone(), addr(addr_x))].try_into().unwrap(),
-                        [(pk_y.clone(), addr(addr_y))].try_into().unwrap(),
+                    ReachableTrackedPeers::new(
+                        [(pk_x.clone(), dialable(addr_x))].try_into().unwrap(),
+                        [(pk_y.clone(), dialable(addr_y))].try_into().unwrap(),
                     ),
                 )
                 .unwrap();
@@ -1049,9 +1112,9 @@ mod tests {
             directory
                 .track(
                     1,
-                    AddressableTrackedPeers::new(
-                        [(pk_y.clone(), addr(addr_y))].try_into().unwrap(),
-                        [(pk_x.clone(), addr(addr_x))].try_into().unwrap(),
+                    ReachableTrackedPeers::new(
+                        [(pk_y.clone(), dialable(addr_y))].try_into().unwrap(),
+                        [(pk_x.clone(), dialable(addr_x))].try_into().unwrap(),
                     ),
                 )
                 .unwrap();
@@ -1074,9 +1137,9 @@ mod tests {
             directory
                 .track(
                     2,
-                    AddressableTrackedPeers::new(
-                        [(pk_y.clone(), addr(addr_y))].try_into().unwrap(),
-                        [(pk_x.clone(), addr(addr_x))].try_into().unwrap(),
+                    ReachableTrackedPeers::new(
+                        [(pk_y.clone(), dialable(addr_y))].try_into().unwrap(),
+                        [(pk_x.clone(), dialable(addr_x))].try_into().unwrap(),
                     ),
                 )
                 .unwrap();
@@ -1099,13 +1162,10 @@ mod tests {
     }
 
     #[test]
-    fn test_track_primary_wins_conflicting_overlap_when_updating_existing_address() {
+    fn test_track_primary_wins_conflicting_overlap_when_updating_reachability() {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::ZERO,
             block_duration: Duration::from_secs(100),
@@ -1122,21 +1182,19 @@ mod tests {
             let initial_kill = directory
                 .track(
                     0,
-                    primary([(pk_1.clone(), addr(old_addr))].try_into().unwrap()),
+                    primary([(pk_1.clone(), dialable(old_addr))].try_into().unwrap()),
                 )
                 .unwrap();
             assert!(initial_kill.is_empty());
-            let reservation = directory
-                .listen(&pk_1, old_addr.ip())
-                .expect("peer should reserve");
+            let reservation = directory.listen(&pk_1).expect("peer should reserve");
             directory.connect(&pk_1);
 
             let kill_peers = directory
                 .track(
                     1,
-                    AddressableTrackedPeers::new(
-                        [(pk_1.clone(), addr(new_addr))].try_into().unwrap(),
-                        [(pk_1.clone(), addr(old_addr))].try_into().unwrap(),
+                    ReachableTrackedPeers::new(
+                        [(pk_1.clone(), dialable(new_addr))].try_into().unwrap(),
+                        [(pk_1.clone(), dialable(old_addr))].try_into().unwrap(),
                     ),
                 )
                 .unwrap();
@@ -1148,15 +1206,13 @@ mod tests {
                 [pk_1.clone()].try_into().unwrap()
             );
             assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(new_addr))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(new_addr))
             );
             assert_eq!(directory.all().primary, [pk_1.clone()].try_into().unwrap());
             directory.release(reservation.metadata().clone());
             assert_eq!(directory.dialable().peers, vec![pk_1.clone()]);
-            assert_eq!(directory.dial(&pk_1).unwrap().1, Ingress::Socket(new_addr));
-            assert!(directory.listenable().contains(&new_addr.ip()));
-            assert!(!directory.listenable().contains(&old_addr.ip()));
+            assert_eq!(directory.dial(&pk_1).unwrap().1, advertisement(new_addr));
         });
     }
 
@@ -1165,9 +1221,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -1185,7 +1238,7 @@ mod tests {
         let addr_sec = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 4)), 4004);
 
         runtime.start(|context| async move {
-            // pk_overlap: primary in set 0 (address addr_overlap_p), secondary in set 1 (addr_overlap_s).
+            // pk_overlap: primary in set 0, secondary in set 1.
             let releaser = new_releaser(context.child("releaser"));
             let mut directory = Directory::init(context, my_pk, config, releaser);
 
@@ -1195,8 +1248,8 @@ mod tests {
                         10,
                         primary(
                             [
-                                (pk_a.clone(), addr(addr_a)),
-                                (pk_overlap.clone(), addr(addr_overlap_p)),
+                                (pk_a.clone(), dialable(addr_a)),
+                                (pk_overlap.clone(), dialable(addr_overlap_p)),
                             ]
                             .try_into()
                             .unwrap(),
@@ -1208,11 +1261,11 @@ mod tests {
                 directory
                     .track(
                         11,
-                        AddressableTrackedPeers::new(
-                            [(pk_b.clone(), addr(addr_b))].try_into().unwrap(),
+                        ReachableTrackedPeers::new(
+                            [(pk_b.clone(), dialable(addr_b))].try_into().unwrap(),
                             [
-                                (pk_overlap.clone(), addr(addr_overlap_s)),
-                                (pk_sec.clone(), addr(addr_sec)),
+                                (pk_overlap.clone(), dialable(addr_overlap_s)),
+                                (pk_sec.clone(), dialable(addr_sec)),
                             ]
                             .try_into()
                             .unwrap(),
@@ -1242,9 +1295,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(1),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -1263,13 +1313,11 @@ mod tests {
             directory
                 .track(
                     0,
-                    primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                    primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
                 )
                 .unwrap();
 
-            let _reservation = directory
-                .listen(&pk_1, addr_1.ip())
-                .expect("peer should reserve");
+            let _reservation = directory.listen(&pk_1).expect("peer should reserve");
             let connected_at: i64 = context.current().epoch_millis().try_into().unwrap();
             directory.connect(&pk_1);
 
@@ -1297,9 +1345,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -1319,355 +1364,128 @@ mod tests {
 
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
             directory.block(&pk_1);
             assert!(
                 directory.blocked.contains(&pk_1),
                 "Peer should be blocked after call to block"
             );
-            // Address is preserved (blocking is tracked in PrioritySet)
+            // Reachability is preserved (blocking is tracked in PrioritySet)
             let record = directory.peers.get(&pk_1).unwrap();
             assert_eq!(
-                record.ingress(),
-                Some(Ingress::Socket(addr_1)),
-                "Record still has address (blocking is at Directory level)"
+                record.advertisement(),
+                Some(advertisement(addr_1)),
+                "Record still has reachability (blocking is at Directory level)"
             );
 
-            // Update the address while blocked
+            // Update the reachability while blocked
             directory.track(
                 1,
-                primary([(pk_1.clone(), addr(addr_2))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_2))].try_into().unwrap()),
             );
             assert!(
                 directory.blocked.contains(&pk_1),
                 "Blocked peer should remain blocked after update"
             );
-            // Address is updated
+            // Reachability is updated
             let record = directory.peers.get(&pk_1).unwrap();
             assert_eq!(
-                record.ingress(),
-                Some(Ingress::Socket(addr_2)),
-                "Record has updated address"
+                record.advertisement(),
+                Some(advertisement(addr_2)),
+                "Record has updated reachability"
             );
 
             // Advance time past block duration and unblock
             context.sleep(block_duration + Duration::from_secs(1)).await;
             directory.unblock_expired();
 
-            // Verify the peer is unblocked with the UPDATED address
+            // Verify the peer is unblocked with the updated reachability.
             assert!(
                 !directory.blocked.contains(&pk_1),
                 "Peer should be unblocked after expiry"
             );
             let record = directory.peers.get(&pk_1).unwrap();
             assert_eq!(
-                record.ingress(),
-                Some(Ingress::Socket(addr_2)),
-                "Unblocked peer should have the updated address"
+                record.advertisement(),
+                Some(advertisement(addr_2)),
+                "Unblocked peer should have the updated reachability"
             );
         });
     }
 
     #[test]
-    fn test_asymmetric_addresses() {
+    fn test_multiple_endpoint_advertisement() {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
-        let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
-            max_sets: NZUsize!(3),
-            peer_connection_cooldown: Duration::from_millis(100),
-            block_duration: Duration::from_secs(100),
-        };
-
-        // Create asymmetric address where ingress differs from egress
         let pk_1 = ed25519::PrivateKey::from_seed(1).public_key();
-        let ingress_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 8080);
-        let egress_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 9090);
-        let asymmetric_addr = Address::Asymmetric {
-            ingress: Ingress::Socket(ingress_socket),
-            egress: egress_socket,
-        };
-
-        // Create another peer with DNS-based ingress
-        let pk_2 = ed25519::PrivateKey::from_seed(2).public_key();
-        let egress_socket_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), 9090);
-        let dns_addr = Address::Asymmetric {
-            ingress: Ingress::Dns {
-                host: hostname!("node.example.com"),
-                port: 8080,
-            },
-            egress: egress_socket_2,
-        };
-
-        runtime.start(|context| async move {
-            let releaser = new_releaser(context.child("releaser"));
-            let mut directory = Directory::init(context, my_pk.clone(), config, releaser);
-
-            // Add set with asymmetric addresses
-            let kill_peers = directory
-                .track(
-                    0,
-                    primary(
-                        [
-                            (pk_1.clone(), asymmetric_addr.clone()),
-                            (pk_2.clone(), dns_addr.clone()),
-                        ]
-                        .try_into()
-                        .unwrap(),
-                    ),
-                )
-                .unwrap();
-            assert!(kill_peers.is_empty());
-
-            // Verify peer 1 has correct ingress and egress
-            let record_1 = directory.peers.get(&pk_1).unwrap();
-            assert_eq!(
-                record_1.ingress(),
-                Some(Ingress::Socket(ingress_socket)),
-                "Ingress should match the asymmetric address's ingress"
-            );
-            assert_eq!(
-                record_1.egress_ip(),
-                Some(egress_socket.ip()),
-                "Egress IP should be from the egress socket"
-            );
-
-            // Verify peer 2 has DNS ingress and correct egress
-            let record_2 = directory.peers.get(&pk_2).unwrap();
-            assert_eq!(
-                record_2.ingress(),
-                Some(Ingress::Dns {
-                    host: hostname!("node.example.com"),
-                    port: 8080
-                }),
-                "Ingress should be DNS address"
-            );
-            assert_eq!(
-                record_2.egress_ip(),
-                Some(egress_socket_2.ip()),
-                "Egress IP should be from the egress socket"
-            );
-
-            // Verify listenable() returns egress IPs for IP filtering
-            let listenable = directory.listenable();
-            assert!(
-                listenable.contains(&egress_socket.ip()),
-                "Listenable should contain peer 1's egress IP"
-            );
-            assert!(
-                listenable.contains(&egress_socket_2.ip()),
-                "Listenable should contain peer 2's egress IP"
-            );
-            assert!(
-                !listenable.contains(&ingress_socket.ip()),
-                "Listenable should NOT contain peer 1's ingress IP"
-            );
-        });
-    }
-
-    #[test]
-    fn test_dns_addresses_registered_but_not_dialable_when_disabled() {
-        let runtime = deterministic::Runner::default();
-        let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
-
-        // DNS is disabled
+        let preferred = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 8080);
+        let fallback = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 9090);
+        let advertisement =
+            Advertisement::new(vec![Endpoint(preferred), Endpoint(fallback)]).unwrap();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: false,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
-        };
-
-        // Create peers with different address types
-        let pk_socket = ed25519::PrivateKey::from_seed(1).public_key();
-        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)), 8080);
-        let socket_peer_addr = Address::Symmetric(socket_addr);
-
-        let pk_dns = ed25519::PrivateKey::from_seed(2).public_key();
-        let egress_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), 9090);
-        let dns_peer_addr = Address::Asymmetric {
-            ingress: Ingress::Dns {
-                host: hostname!("node.example.com"),
-                port: 8080,
-            },
-            egress: egress_socket,
         };
 
         runtime.start(|context| async move {
             let releaser = new_releaser(context.child("releaser"));
             let mut directory = Directory::init(context, my_pk, config, releaser);
 
-            // Add set with both socket and DNS addresses
             let kill_peers = directory
                 .track(
                     0,
                     primary(
-                        [
-                            (pk_socket.clone(), socket_peer_addr.clone()),
-                            (pk_dns.clone(), dns_peer_addr.clone()),
-                        ]
-                        .try_into()
-                        .unwrap(),
+                        [(pk_1.clone(), Reachability::Dialable(advertisement.clone()))]
+                            .try_into()
+                            .unwrap(),
                     ),
                 )
                 .unwrap();
             assert!(kill_peers.is_empty());
-
-            // Both peers should be in the peer set (for consistency)
-            assert!(
-                directory.peers.contains_key(&pk_socket),
-                "Socket peer should be in the peer set"
+            assert_eq!(
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement.clone())
             );
-            assert!(
-                directory.peers.contains_key(&pk_dns),
-                "DNS peer should be in the peer set for consistency"
-            );
-
-            // Only socket peer should be dialable (DNS ingress invalid when disabled)
-            let dialable = directory.dialable();
-            assert_eq!(dialable.peers.len(), 1);
-            assert_eq!(dialable.peers[0], pk_socket);
+            assert_eq!(directory.dial(&pk_1).unwrap().1, advertisement);
         });
     }
 
     #[test]
-    fn test_private_egress_ip_in_peer_set_but_not_dialable_or_tracked() {
+    fn test_outbound_only_peer_is_tracked_but_not_dialable() {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
-
-        // Private IPs are NOT allowed
+        let dialable_pk = ed25519::PrivateKey::from_seed(1).public_key();
+        let outbound_only_pk = ed25519::PrivateKey::from_seed(2).public_key();
+        let dialable_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 8080);
         let config = super::Config {
-            allow_private_ips: false,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
         };
-
-        // Create peer with public egress IP
-        let pk_public = ed25519::PrivateKey::from_seed(1).public_key();
-        let public_addr =
-            Address::Symmetric(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 8080));
-
-        // Create peer with private egress IP
-        let pk_private = ed25519::PrivateKey::from_seed(2).public_key();
-        let private_addr = Address::Symmetric(SocketAddr::new(
-            IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1)),
-            8080,
-        ));
 
         runtime.start(|context| async move {
             let releaser = new_releaser(context.child("releaser"));
             let mut directory = Directory::init(context, my_pk, config, releaser);
-
-            // Add set with both public and private egress IPs
-            let kill_peers = directory
+            directory
                 .track(
                     0,
                     primary(
                         [
-                            (pk_public.clone(), public_addr.clone()),
-                            (pk_private.clone(), private_addr.clone()),
+                            (dialable_pk.clone(), dialable(dialable_addr)),
+                            (outbound_only_pk.clone(), Reachability::OutboundOnly),
                         ]
                         .try_into()
                         .unwrap(),
                     ),
                 )
                 .unwrap();
-            assert!(kill_peers.is_empty());
 
-            // Both peers should be in the peer set (for consistency)
-            assert!(
-                directory.peers.contains_key(&pk_public),
-                "Public peer should be in the peer set"
-            );
-            assert!(
-                directory.peers.contains_key(&pk_private),
-                "Private peer should be in the peer set for consistency"
-            );
-
-            // Only public peer should be dialable (private ingress IP not allowed)
-            let dialable = directory.dialable();
-            assert_eq!(dialable.peers.len(), 1);
-            assert_eq!(dialable.peers[0], pk_public);
-
-            // Verify listenable() only returns public IP (private IP excluded from filter)
-            let listenable = directory.listenable();
-            assert!(listenable.contains(&Ipv4Addr::new(8, 8, 8, 8).into()));
-            assert!(!listenable.contains(&Ipv4Addr::new(10, 0, 0, 1).into()));
-        });
-    }
-
-    #[test]
-    fn test_listenable_ip_collision_eligible_wins() {
-        let runtime = deterministic::Runner::default();
-        let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
-        let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
-            max_sets: NZUsize!(3),
-            peer_connection_cooldown: Duration::from_millis(100),
-            block_duration: Duration::from_secs(100),
-        };
-
-        // Two peers with the same egress IP (simulating NAT scenario)
-        let pk_1 = ed25519::PrivateKey::from_seed(1).public_key();
-        let pk_2 = ed25519::PrivateKey::from_seed(2).public_key();
-        let shared_ip = IpAddr::V4(Ipv4Addr::new(203, 0, 113, 1));
-        let addr_1 = Address::Symmetric(SocketAddr::new(shared_ip, 8080));
-        let addr_2 = Address::Symmetric(SocketAddr::new(shared_ip, 8081));
-
-        runtime.start(|context| async move {
-            let mut directory = Directory::init(
-                context.child("directory"),
-                my_pk,
-                config,
-                new_releaser(context.child("releaser")),
-            );
-
-            // Add both peers with the same IP
-            directory.track(
-                0,
-                primary(
-                    [(pk_1.clone(), addr_1), (pk_2.clone(), addr_2)]
-                        .try_into()
-                        .unwrap(),
-                ),
-            );
-
-            // Both peers eligible: IP should be in listenable set
-            let listenable = directory.listenable();
-            assert!(
-                listenable.contains(&shared_ip),
-                "IP should be listenable when both peers are eligible"
-            );
-
-            // Block one peer
-            directory.block(&pk_1);
-
-            // One eligible, one blocked: IP should still be listenable
-            let listenable = directory.listenable();
-            assert!(
-                listenable.contains(&shared_ip),
-                "IP should be listenable when at least one peer is eligible"
-            );
-
-            // Block the other peer
-            directory.block(&pk_2);
-
-            // Both blocked: IP should NOT be in listenable set
-            let listenable = directory.listenable();
-            assert!(
-                !listenable.contains(&shared_ip),
-                "IP should not be listenable when all peers are blocked"
-            );
+            assert!(directory.eligible(&outbound_only_pk));
+            assert!(directory.acceptable(&outbound_only_pk));
+            assert_eq!(directory.dialable().peers, vec![dialable_pk]);
+            assert!(directory.dial(&outbound_only_pk).is_none());
         });
     }
 
@@ -1677,9 +1495,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -1698,17 +1513,11 @@ mod tests {
 
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // Block the peer
             directory.block(&pk_1);
-
-            // Verify peer is blocked and not listenable
-            assert!(
-                !directory.listenable().contains(&addr_1.ip()),
-                "Blocked peer should not be listenable"
-            );
 
             // Verify peer is blocked
             assert_eq!(directory.blocked(), 1, "Should have one blocked peer");
@@ -1730,12 +1539,6 @@ mod tests {
 
             // Now unblock_expired should unblock the peer
             assert!(directory.unblock_expired(), "Should have unblocked a peer");
-
-            // Verify peer is now listenable
-            assert!(
-                directory.listenable().contains(&addr_1.ip()),
-                "Unblocked peer should be listenable"
-            );
 
             // Verify no more blocked peers
             assert_eq!(directory.blocked(), 0, "No more blocked peers");
@@ -1762,9 +1565,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(1), // Only keep 1 set so we can evict peers
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -1792,7 +1592,7 @@ mod tests {
             // Add pk_1 and block it
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
             directory.block(&pk_1);
             assert!(directory.blocked.contains(&pk_1));
@@ -1805,7 +1605,7 @@ mod tests {
             // The blocked metric should remain since the block persists
             directory.track(
                 1,
-                primary([(pk_2.clone(), addr(addr_2))].try_into().unwrap()),
+                primary([(pk_2.clone(), dialable(addr_2))].try_into().unwrap()),
             );
             assert!(
                 !directory.peers.contains_key(&pk_1),
@@ -1819,7 +1619,7 @@ mod tests {
             // Re-add pk_1 - should still be blocked because block persists
             directory.track(
                 2,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
             assert!(
                 directory.blocked.contains(&pk_1),
@@ -1852,9 +1652,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -1880,9 +1677,9 @@ mod tests {
                 0,
                 primary(
                     [
-                        (pk_1.clone(), addr(addr_1)),
-                        (pk_2.clone(), addr(addr_2)),
-                        (pk_3.clone(), addr(addr_3)),
+                        (pk_1.clone(), dialable(addr_1)),
+                        (pk_2.clone(), dialable(addr_2)),
+                        (pk_3.clone(), dialable(addr_3)),
                     ]
                     .try_into()
                     .unwrap(),
@@ -1919,9 +1716,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -1963,9 +1757,6 @@ mod tests {
         let unknown_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9999);
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -2001,7 +1792,7 @@ mod tests {
             directory.track(
                 0,
                 primary(
-                    [(unknown_pk.clone(), addr(unknown_addr))]
+                    [(unknown_pk.clone(), dialable(unknown_addr))]
                         .try_into()
                         .unwrap(),
                 ),
@@ -2052,9 +1843,6 @@ mod tests {
         let registered_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5050);
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -2072,7 +1860,7 @@ mod tests {
             directory.track(
                 0,
                 primary(
-                    [(registered_pk.clone(), addr(registered_addr))]
+                    [(registered_pk.clone(), dialable(registered_addr))]
                         .try_into()
                         .unwrap(),
                 ),
@@ -2130,9 +1918,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1235);
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -2149,7 +1934,7 @@ mod tests {
             // Add peer to a set
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // Peer should be dialable before blocking
@@ -2187,9 +1972,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1235);
         let cooldown = Duration::from_secs(1);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: cooldown,
             block_duration: Duration::from_secs(100),
@@ -2204,7 +1986,7 @@ mod tests {
             );
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // First reservation succeeds.
@@ -2227,10 +2009,10 @@ mod tests {
             // After the jitter window (up to 2x interval), peer becomes dialable again.
             context.sleep(cooldown * 2).await;
             assert!(directory.dialable().peers.contains(&pk_1));
-            let (_reservation, ingress) = directory
+            let (_reservation, dial_advertisement) = directory
                 .dial(&pk_1)
                 .expect("should succeed after interval");
-            assert_eq!(ingress, Ingress::Socket(addr_1));
+            assert_eq!(dial_advertisement, advertisement(addr_1));
         });
     }
 
@@ -2242,9 +2024,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1235);
         let cooldown = Duration::from_secs(1);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: cooldown,
             block_duration: Duration::from_secs(100),
@@ -2259,7 +2038,7 @@ mod tests {
             );
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // Reserve and release.
@@ -2284,9 +2063,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let cooldown = Duration::from_millis(200);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: cooldown,
             block_duration: Duration::from_secs(100),
@@ -2314,9 +2090,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1234);
         let cooldown = Duration::from_millis(200);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: cooldown,
             block_duration: Duration::from_secs(3600),
@@ -2331,7 +2104,7 @@ mod tests {
             );
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // Block the only peer. No peers are immediately dialable, but
@@ -2355,9 +2128,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1234);
         let block_duration = Duration::from_secs(1);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(200),
             block_duration,
@@ -2372,7 +2142,7 @@ mod tests {
             );
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             directory.block(&pk_1);
@@ -2407,9 +2177,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1234);
         let block_duration = Duration::from_secs(1);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(200),
             block_duration,
@@ -2424,7 +2191,7 @@ mod tests {
             );
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             directory.block(&pk_1);
@@ -2454,9 +2221,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1235);
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: true, // Bypass IP check to simplify test
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -2473,12 +2237,12 @@ mod tests {
             // Add peer to a set
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // Peer should be acceptable before blocking
             assert!(
-                directory.acceptable(&pk_1, addr_1.ip()),
+                directory.acceptable(&pk_1),
                 "Peer should be acceptable before blocking"
             );
 
@@ -2487,7 +2251,7 @@ mod tests {
 
             // Peer should NOT be acceptable while blocked
             assert!(
-                !directory.acceptable(&pk_1, addr_1.ip()),
+                !directory.acceptable(&pk_1),
                 "Blocked peer should not be acceptable"
             );
 
@@ -2497,65 +2261,8 @@ mod tests {
 
             // Peer should be acceptable again after unblock
             assert!(
-                directory.acceptable(&pk_1, addr_1.ip()),
+                directory.acceptable(&pk_1),
                 "Peer should be acceptable after unblock"
-            );
-        });
-    }
-
-    #[test]
-    fn test_blocked_peer_not_listenable() {
-        let runtime = deterministic::Runner::default();
-        let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
-        let pk_1 = ed25519::PrivateKey::from_seed(1).public_key();
-        let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1235);
-        let block_duration = Duration::from_secs(100);
-        let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
-            max_sets: NZUsize!(3),
-            peer_connection_cooldown: Duration::from_millis(100),
-            block_duration,
-        };
-
-        runtime.start(|context| async move {
-            let mut directory = Directory::init(
-                context.child("directory"),
-                my_pk,
-                config,
-                new_releaser(context.child("releaser")),
-            );
-
-            // Add peer to a set
-            directory.track(
-                0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
-            );
-
-            // Peer's IP should be listenable before blocking
-            assert!(
-                directory.listenable().contains(&addr_1.ip()),
-                "Peer's IP should be listenable before blocking"
-            );
-
-            // Block the peer
-            directory.block(&pk_1);
-
-            // Peer's IP should NOT be listenable while blocked
-            assert!(
-                !directory.listenable().contains(&addr_1.ip()),
-                "Blocked peer's IP should not be listenable"
-            );
-
-            // Advance time and unblock
-            context.sleep(block_duration + Duration::from_secs(1)).await;
-            directory.unblock_expired();
-
-            // Peer's IP should be listenable again after unblock
-            assert!(
-                directory.listenable().contains(&addr_1.ip()),
-                "Peer's IP should be listenable after unblock"
             );
         });
     }
@@ -2568,9 +2275,6 @@ mod tests {
         let addr_1 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1235);
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -2587,7 +2291,7 @@ mod tests {
             // Add peer to a set
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             // Peer should be eligible before blocking
@@ -2622,9 +2326,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -2640,19 +2341,19 @@ mod tests {
 
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
             assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_1))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_1))
             );
 
-            let success = directory.overwrite(&pk_1, addr(addr_2));
+            let success = directory.overwrite(&pk_1, dialable(addr_2));
             assert!(success);
             assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_2))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_2))
             );
         });
     }
@@ -2662,9 +2363,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -2677,7 +2375,7 @@ mod tests {
             let releaser = new_releaser(context.child("releaser"));
             let mut directory = Directory::init(context, my_pk, config, releaser);
 
-            let success = directory.overwrite(&pk_1, addr(addr_1));
+            let success = directory.overwrite(&pk_1, dialable(addr_1));
             assert!(!success);
         });
     }
@@ -2687,9 +2385,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(1),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -2707,14 +2402,14 @@ mod tests {
 
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
             directory.track(
                 1,
-                primary([(pk_2.clone(), addr(addr_2))].try_into().unwrap()),
+                primary([(pk_2.clone(), dialable(addr_2))].try_into().unwrap()),
             );
 
-            let success = directory.overwrite(&pk_1, addr(addr_3));
+            let success = directory.overwrite(&pk_1, dialable(addr_3));
             assert!(!success);
         });
     }
@@ -2725,9 +2420,6 @@ mod tests {
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let block_duration = Duration::from_secs(100);
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration,
@@ -2747,23 +2439,23 @@ mod tests {
 
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
             directory.block(&pk_1);
 
-            let success = directory.overwrite(&pk_1, addr(addr_2));
+            let success = directory.overwrite(&pk_1, dialable(addr_2));
             assert!(success);
             assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_2))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_2))
             );
 
             context.sleep(block_duration + Duration::from_secs(1)).await;
             directory.unblock_expired();
 
             assert_eq!(
-                directory.peers.get(&pk_1).unwrap().ingress(),
-                Some(Ingress::Socket(addr_2))
+                directory.peers.get(&pk_1).unwrap().advertisement(),
+                Some(advertisement(addr_2))
             );
             assert!(directory.dialable().peers.contains(&pk_1));
         });
@@ -2774,9 +2466,6 @@ mod tests {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -2788,19 +2477,16 @@ mod tests {
             let releaser = new_releaser(context.child("releaser"));
             let mut directory = Directory::init(context, my_pk.clone(), config, releaser);
 
-            let success = directory.overwrite(&my_pk, addr(addr_1));
+            let success = directory.overwrite(&my_pk, dialable(addr_1));
             assert!(!success);
         });
     }
 
     #[test]
-    fn test_overwrite_same_address() {
+    fn test_overwrite_same_reachability() {
         let runtime = deterministic::Runner::default();
         let my_pk = ed25519::PrivateKey::from_seed(0).public_key();
         let config = super::Config {
-            allow_private_ips: true,
-            allow_dns: true,
-            bypass_ip_check: false,
             max_sets: NZUsize!(3),
             peer_connection_cooldown: Duration::from_millis(100),
             block_duration: Duration::from_secs(100),
@@ -2815,19 +2501,19 @@ mod tests {
 
             directory.track(
                 0,
-                primary([(pk_1.clone(), addr(addr_1))].try_into().unwrap()),
+                primary([(pk_1.clone(), dialable(addr_1))].try_into().unwrap()),
             );
 
-            // First update with different address should succeed
+            // First update with different reachability should succeed
             let addr_2 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(9, 9, 9, 9)), 1236);
-            assert!(directory.overwrite(&pk_1, addr(addr_2)));
+            assert!(directory.overwrite(&pk_1, dialable(addr_2)));
 
-            // Update with same address should return false (no change)
-            assert!(!directory.overwrite(&pk_1, addr(addr_2)));
+            // Update with same reachability should return false (no change)
+            assert!(!directory.overwrite(&pk_1, dialable(addr_2)));
 
-            // Update with different address should succeed again
+            // Update with different reachability should succeed again
             let addr_3 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(10, 10, 10, 10)), 1237);
-            assert!(directory.overwrite(&pk_1, addr(addr_3)));
+            assert!(directory.overwrite(&pk_1, dialable(addr_3)));
         });
     }
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/ingress.rs
@@ -1,35 +1,39 @@
 use super::Reservation;
 use crate::{
-    AddressableTrackedPeers, Ingress, PeerSetSubscription, TrackedPeers,
+    Advertisement, PeerEndpoint, PeerSetSubscription, Reachability, ReachableTrackedPeers,
+    TrackedPeers,
     authenticated::{
         dialing::Dialable,
         lookup::actors::{peer, tracker::Metadata},
     },
-    types::Address,
 };
 use commonware_actor::{
     Feedback,
     mailbox::{self, Policy},
 };
 use commonware_cryptography::PublicKey;
+use commonware_macros::stability;
 use commonware_utils::{
+    PlatformSend,
     channel::{mpsc, oneshot},
     ordered::Map,
 };
-use std::{collections::VecDeque, net::IpAddr};
+use std::collections::VecDeque;
+
+type DialReservation<C, E> = Option<(Reservation<C, E>, Advertisement<E>)>;
 
 /// Messages that can be sent to the tracker actor.
 #[derive(Debug)]
-pub enum Message<C: PublicKey> {
+pub enum Message<C: PublicKey, E: PeerEndpoint = crate::Ingress> {
     // ---------- Used by oracle ----------
     /// Register a peer set at a given index.
     Register {
         index: u64,
-        peers: AddressableTrackedPeers<C>,
+        peers: ReachableTrackedPeers<C, E>,
     },
 
     /// Update addresses for multiple peers without creating a new peer set.
-    Overwrite { peers: Map<C, Address> },
+    Overwrite { peers: Map<C, Reachability<E>> },
 
     // ---------- Used by peer set provider ----------
     /// Fetch primary and secondary peers for a given ID.
@@ -77,7 +81,17 @@ pub enum Message<C: PublicKey> {
         public_key: C,
 
         /// Sender to respond with the reservation and ingress address.
-        reservation: oneshot::Sender<Option<(Reservation<C>, Ingress)>>,
+        reservation: oneshot::Sender<DialReservation<C, E>>,
+    },
+
+    /// Reserve a connection established outside the autonomous transport actors.
+    Attach {
+        /// Authenticated peer identity.
+        public_key: C,
+        /// Whether the connection was accepted inbound.
+        inbound: bool,
+        /// Sender to respond with a reservation.
+        reservation: oneshot::Sender<Option<Reservation<C, E>>>,
     },
 
     // ---------- Used by listener ----------
@@ -85,9 +99,6 @@ pub enum Message<C: PublicKey> {
     Acceptable {
         /// The public key of the peer to check.
         public_key: C,
-
-        /// The IP address the peer connected from.
-        source_ip: IpAddr,
 
         /// The sender to respond with whether the peer is acceptable.
         responder: oneshot::Sender<bool>,
@@ -102,11 +113,8 @@ pub enum Message<C: PublicKey> {
         /// The public key of the peer to reserve.
         public_key: C,
 
-        /// The IP address the peer connected from.
-        source_ip: IpAddr,
-
         /// The sender to respond with the reservation.
-        reservation: oneshot::Sender<Option<Reservation<C>>>,
+        reservation: oneshot::Sender<Option<Reservation<C, E>>>,
     },
 
     // ---------- Used by reservation ----------
@@ -117,7 +125,7 @@ pub enum Message<C: PublicKey> {
     },
 }
 
-impl<C: PublicKey> Policy for Message<C> {
+impl<C: PublicKey, E: PeerEndpoint> Policy for Message<C, E> {
     type Overflow = VecDeque<Self>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
@@ -127,10 +135,10 @@ impl<C: PublicKey> Policy for Message<C> {
 
 /// Mailbox for sending messages to the tracker actor.
 #[derive(Clone, Debug)]
-pub struct Mailbox<C: PublicKey>(mailbox::Sender<Message<C>>);
+pub struct Mailbox<C: PublicKey, E: PeerEndpoint = crate::Ingress>(mailbox::Sender<Message<C, E>>);
 
-impl<C: PublicKey> Mailbox<C> {
-    pub(crate) const fn new(sender: mailbox::Sender<Message<C>>) -> Self {
+impl<C: PublicKey, E: PeerEndpoint> Mailbox<C, E> {
+    pub(crate) const fn new(sender: mailbox::Sender<Message<C, E>>) -> Self {
         Self(sender)
     }
 
@@ -151,7 +159,10 @@ impl<C: PublicKey> Mailbox<C> {
     /// Send a `Dial` message to the tracker.
     ///
     /// Returns `None` if the tracker is shut down.
-    pub(crate) async fn dial(&self, public_key: C) -> Option<(Reservation<C>, Ingress)> {
+    pub(crate) async fn dial(
+        &self,
+        public_key: C,
+    ) -> Option<(Reservation<C, E>, Advertisement<E>)> {
         let (reservation, receiver) = oneshot::channel();
         let _ = self.0.enqueue(Message::Dial {
             public_key,
@@ -160,14 +171,24 @@ impl<C: PublicKey> Mailbox<C> {
         receiver.await.ok().flatten()
     }
 
+    /// Reserve an externally established connection.
+    pub(crate) async fn attach(&self, public_key: C, inbound: bool) -> Option<Reservation<C, E>> {
+        let (reservation, receiver) = oneshot::channel();
+        let _ = self.0.enqueue(Message::Attach {
+            public_key,
+            inbound,
+            reservation,
+        });
+        receiver.await.ok().flatten()
+    }
+
     /// Send an `Acceptable` message to the tracker.
     ///
     /// Returns `false` if the tracker is shut down.
-    pub(crate) async fn acceptable(&self, public_key: C, source_ip: IpAddr) -> bool {
+    pub(crate) async fn acceptable(&self, public_key: C) -> bool {
         let (responder, receiver) = oneshot::channel();
         let _ = self.0.enqueue(Message::Acceptable {
             public_key,
-            source_ip,
             responder,
         });
         receiver.await.unwrap_or(false)
@@ -176,11 +197,10 @@ impl<C: PublicKey> Mailbox<C> {
     /// Send a `Listen` message to the tracker.
     ///
     /// Returns `None` if the tracker is shut down.
-    pub(crate) async fn listen(&self, public_key: C, source_ip: IpAddr) -> Option<Reservation<C>> {
+    pub(crate) async fn listen(&self, public_key: C) -> Option<Reservation<C, E>> {
         let (reservation, receiver) = oneshot::channel();
         let _ = self.0.enqueue(Message::Listen {
             public_key,
-            source_ip,
             reservation,
         });
         receiver.await.ok().flatten()
@@ -189,13 +209,13 @@ impl<C: PublicKey> Mailbox<C> {
 
 /// Allows releasing reservations
 #[derive(Clone, Debug)]
-pub struct Releaser<C: PublicKey> {
-    sender: mailbox::Sender<Message<C>>,
+pub struct Releaser<C: PublicKey, E: PeerEndpoint = crate::Ingress> {
+    sender: mailbox::Sender<Message<C, E>>,
 }
 
-impl<C: PublicKey> Releaser<C> {
+impl<C: PublicKey, E: PeerEndpoint> Releaser<C, E> {
     /// Create a new releaser.
-    pub(crate) const fn new(sender: mailbox::Sender<Message<C>>) -> Self {
+    pub(crate) const fn new(sender: mailbox::Sender<Message<C, E>>) -> Self {
         Self { sender }
     }
 
@@ -210,17 +230,17 @@ impl<C: PublicKey> Releaser<C> {
 /// Peers that are not explicitly authorized
 /// will be blocked by commonware-p2p.
 #[derive(Debug, Clone)]
-pub struct Oracle<C: PublicKey> {
-    sender: mailbox::Sender<Message<C>>,
+pub struct Oracle<C: PublicKey, E: PeerEndpoint = crate::Ingress> {
+    sender: mailbox::Sender<Message<C, E>>,
 }
 
-impl<C: PublicKey> Oracle<C> {
-    pub(super) const fn new(sender: mailbox::Sender<Message<C>>) -> Self {
+impl<C: PublicKey, E: PeerEndpoint> Oracle<C, E> {
+    pub(super) const fn new(sender: mailbox::Sender<Message<C, E>>) -> Self {
         Self { sender }
     }
 }
 
-impl<C: PublicKey> crate::Provider for Oracle<C> {
+impl<C: PublicKey, E: PeerEndpoint> crate::Provider for Oracle<C, E> {
     type PublicKey = C;
 
     async fn peer_set(&mut self, id: u64) -> Option<TrackedPeers<Self::PublicKey>> {
@@ -242,10 +262,13 @@ impl<C: PublicKey> crate::Provider for Oracle<C> {
     }
 }
 
-impl<C: PublicKey> crate::AddressableManager for Oracle<C> {
+#[stability(ALPHA)]
+impl<C: PublicKey, E: PeerEndpoint> crate::ReachabilityManager for Oracle<C, E> {
+    type Endpoint = E;
+
     fn track<R>(&mut self, index: u64, peers: R) -> Feedback
     where
-        R: Into<AddressableTrackedPeers<Self::PublicKey>> + Send,
+        R: Into<ReachableTrackedPeers<Self::PublicKey, E>> + PlatformSend,
     {
         self.sender.enqueue(Message::Register {
             index,
@@ -253,12 +276,44 @@ impl<C: PublicKey> crate::AddressableManager for Oracle<C> {
         })
     }
 
-    fn overwrite(&mut self, peers: Map<Self::PublicKey, Address>) -> Feedback {
+    fn overwrite(&mut self, peers: Map<Self::PublicKey, Reachability<E>>) -> Feedback {
         self.sender.enqueue(Message::Overwrite { peers })
     }
 }
 
-impl<C: PublicKey> crate::Blocker for Oracle<C> {
+impl<C: PublicKey> crate::AddressableManager for Oracle<C, crate::Ingress> {
+    fn track<R>(&mut self, index: u64, peers: R) -> Feedback
+    where
+        R: Into<crate::AddressableTrackedPeers<Self::PublicKey>> + PlatformSend,
+    {
+        let peers = peers.into();
+        self.sender.enqueue(Message::Register {
+            index,
+            peers: ReachableTrackedPeers::new(
+                legacy_reachability(peers.primary),
+                legacy_reachability(peers.secondary),
+            ),
+        })
+    }
+
+    fn overwrite(&mut self, peers: Map<Self::PublicKey, crate::Address>) -> Feedback {
+        self.sender.enqueue(Message::Overwrite {
+            peers: legacy_reachability(peers),
+        })
+    }
+}
+
+fn legacy_reachability<C: PublicKey>(
+    peers: Map<C, crate::Address>,
+) -> Map<C, Reachability<crate::Ingress>> {
+    Map::from_iter_dedup(peers.into_iter().map(|(peer, address)| {
+        let advertisement = Advertisement::new(vec![address.ingress()])
+            .expect("a single endpoint is a valid advertisement");
+        (peer, Reachability::Dialable(advertisement))
+    }))
+}
+
+impl<C: PublicKey, E: PeerEndpoint> crate::Blocker for Oracle<C, E> {
     type PublicKey = C;
 
     fn block(&mut self, public_key: Self::PublicKey) -> Feedback {

--- a/p2p/src/authenticated/lookup/actors/tracker/mod.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/mod.rs
@@ -1,6 +1,5 @@
 //! Tracker
 
-use crate::authenticated::lookup::actors::listener;
 use commonware_cryptography::Signer;
 use std::{num::NonZeroUsize, time::Duration};
 
@@ -25,9 +24,5 @@ pub struct Config<C: Signer> {
     pub mailbox_size: NonZeroUsize,
     pub tracked_peer_sets: NonZeroUsize,
     pub peer_connection_cooldown: Duration,
-    pub allow_private_ips: bool,
-    pub allow_dns: bool,
-    pub bypass_ip_check: bool,
-    pub listener: listener::Mailbox,
     pub block_duration: Duration,
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/record.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/record.rs
@@ -1,23 +1,23 @@
 use crate::{
+    Advertisement, PeerEndpoint, Reachability,
     authenticated::dialing::{DialStatus, ReserveResult},
-    types::{self, Ingress},
 };
 use commonware_runtime::Clock;
 use commonware_utils::SystemTimeExt;
 use rand_core::Rng;
-use std::{
-    net::IpAddr,
-    time::{Duration, SystemTime},
-};
+use std::time::{Duration, SystemTime};
 
 /// Represents information known about a peer's address.
 #[derive(Clone, Debug)]
-pub enum Address {
+pub enum Address<E: PeerEndpoint> {
     /// Peer is the local node.
     Myself,
 
     /// Address is provided when peer is tracked.
-    Known(types::Address),
+    Known(Reachability<E>),
+
+    /// Peer is authorized for an attached connection but has no dial endpoint.
+    Undialable,
 }
 
 /// Represents the connection status of a peer.
@@ -38,9 +38,9 @@ pub enum Status {
 
 /// Represents a record of a peer's address and associated information.
 #[derive(Clone, Debug)]
-pub struct Record {
+pub struct Record<E: PeerEndpoint> {
     /// Address state of the peer.
-    address: Address,
+    address: Address<E>,
 
     /// Connection status of the peer.
     status: Status,
@@ -64,13 +64,13 @@ pub struct Record {
     next_dial_at: SystemTime,
 }
 
-impl Record {
+impl<E: PeerEndpoint> Record<E> {
     // ---------- Constructors ----------
 
     /// Create a new record with a known address.
-    pub const fn known(addr: types::Address) -> Self {
+    pub const fn known(reachability: Reachability<E>) -> Self {
         Self {
-            address: Address::Known(addr),
+            address: Address::Known(reachability),
             status: Status::Inert,
             stale_connection: false,
             primary_sets: 0,
@@ -95,19 +95,40 @@ impl Record {
         }
     }
 
+    /// Create a provisional record for a peer reached through an attached connection.
+    pub const fn undialable() -> Self {
+        Self {
+            address: Address::Undialable,
+            status: Status::Inert,
+            stale_connection: false,
+            primary_sets: 0,
+            secondary_sets: 0,
+            persistent: false,
+            next_reservable_at: SystemTime::UNIX_EPOCH,
+            next_dial_at: SystemTime::UNIX_EPOCH,
+        }
+    }
+
     // ---------- Setters ----------
 
     /// Update the record with a new address.
     ///
     /// Returns `true` if the address was changed, `false` if unchanged or self.
-    pub fn update(&mut self, addr: types::Address) -> bool {
+    pub fn update(&mut self, reachability: Reachability<E>) -> bool {
         match &mut self.address {
             Address::Myself => false,
+            Address::Undialable => {
+                self.address = Address::Known(reachability);
+                if self.is_reserved_or_connected() {
+                    self.stale_connection = true;
+                }
+                true
+            }
             Address::Known(existing) => {
-                if *existing == addr {
+                if *existing == reachability {
                     return false;
                 }
-                *existing = addr;
+                *existing = reachability;
                 if self.is_reserved_or_connected() {
                     self.stale_connection = true;
                 }
@@ -171,6 +192,9 @@ impl Record {
             return false;
         }
         self.status = Status::Active;
+        if matches!(self.address, Address::Undialable) {
+            self.persistent = true;
+        }
         true
     }
 
@@ -225,21 +249,14 @@ impl Record {
     /// Returns [DialStatus::Now] if the peer can be dialed immediately,
     /// [DialStatus::After] if it will become dialable at a future time,
     /// or [DialStatus::Unavailable] if it is not dialable at all.
-    pub fn dialable(
-        &self,
-        now: SystemTime,
-        allow_private_ips: bool,
-        allow_dns: bool,
-    ) -> DialStatus {
+    pub fn dialable(&self, now: SystemTime) -> DialStatus {
         if self.status != Status::Inert || !self.is_outbound_target() {
             return DialStatus::Unavailable;
         }
-        let ingress = match &self.address {
-            Address::Known(addr) => addr.ingress(),
-            Address::Myself => return DialStatus::Unavailable,
-        };
-        if !ingress.is_valid(allow_private_ips, allow_dns) {
-            return DialStatus::Unavailable;
+        match &self.address {
+            Address::Known(Reachability::Dialable(_)) => {}
+            Address::Known(Reachability::OutboundOnly) => return DialStatus::Unavailable,
+            Address::Myself | Address::Undialable => return DialStatus::Unavailable,
         }
         if self.next_dial_at > now {
             DialStatus::After(self.next_dial_at)
@@ -248,38 +265,18 @@ impl Record {
         }
     }
 
-    /// Returns `true` if this peer is acceptable (can accept an incoming connection from them).
-    ///
-    /// A peer is acceptable if:
-    /// - The peer is eligible (in a peer set, not ourselves)
-    /// - The source IP matches the expected egress IP for this peer (if not bypass_ip_check)
-    /// - We are not already connected or reserved
-    pub fn acceptable(&self, source_ip: IpAddr, bypass_ip_check: bool) -> bool {
-        if !self.eligible() || self.status != Status::Inert {
-            return false;
-        }
-        if bypass_ip_check {
-            return true;
-        }
-        match &self.address {
-            Address::Known(addr) => addr.egress_ip() == source_ip,
-            Address::Myself => false,
-        }
+    /// Returns `true` if this peer is eligible and has no active reservation or connection.
+    pub const fn acceptable(&self) -> bool {
+        self.eligible() && matches!(self.status, Status::Inert)
     }
 
-    /// Return the ingress address for dialing, if known.
-    pub fn ingress(&self) -> Option<Ingress> {
+    /// Returns the peer's advertised endpoints, if it can be dialed.
+    pub fn advertisement(&self) -> Option<Advertisement<E>> {
         match &self.address {
-            Address::Myself => None,
-            Address::Known(addr) => Some(addr.ingress()),
-        }
-    }
-
-    /// Return the egress IP for filtering, if known.
-    pub const fn egress_ip(&self) -> Option<IpAddr> {
-        match &self.address {
-            Address::Myself => None,
-            Address::Known(addr) => Some(addr.egress_ip()),
+            Address::Known(Reachability::Dialable(advertisement)) => Some(advertisement.clone()),
+            Address::Known(Reachability::OutboundOnly) | Address::Myself | Address::Undialable => {
+                None
+            }
         }
     }
 
@@ -303,6 +300,12 @@ impl Record {
             Address::Known(_) => {
                 self.primary_sets > 0 || self.secondary_sets > 0 || self.persistent
             }
+            Address::Undialable => {
+                self.primary_sets > 0
+                    || self.secondary_sets > 0
+                    || self.persistent
+                    || matches!(self.status, Status::Reserved | Status::Active)
+            }
         }
     }
 }
@@ -310,64 +313,99 @@ impl Record {
 mod tests {
     use super::*;
     use commonware_runtime::{Runner, deterministic};
-    use std::{net::SocketAddr, time::Duration};
 
-    fn test_socket() -> SocketAddr {
-        SocketAddr::from(([54, 12, 1, 9], 8080))
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct Endpoint(&'static str);
+
+    impl PeerEndpoint for Endpoint {}
+
+    type TestRecord = Record<Endpoint>;
+
+    fn dialable(endpoints: &[&'static str]) -> Reachability<Endpoint> {
+        Reachability::Dialable(
+            Advertisement::new(endpoints.iter().copied().map(Endpoint).collect()).unwrap(),
+        )
     }
 
-    fn test_address() -> types::Address {
-        types::Address::Symmetric(test_socket())
+    fn known() -> TestRecord {
+        Record::known(dialable(&["primary"]))
     }
 
     #[test]
     fn test_myself_initial_state() {
-        let record = Record::myself();
+        let record = TestRecord::myself();
         assert!(matches!(record.address, Address::Myself));
         assert_eq!(record.status, Status::Inert);
         assert_eq!(record.primary_sets, 0);
+        assert_eq!(record.secondary_sets, 0);
         assert!(record.persistent);
-        assert!(record.ingress().is_none());
+        assert!(record.advertisement().is_none());
         assert!(!record.is_blockable());
-        assert_eq!(record.status, Status::Inert);
         assert!(!record.deletable());
         assert!(!record.eligible());
     }
 
     #[test]
     fn test_known_initial_state() {
-        let record = Record::known(test_address());
+        let record = known();
         assert!(matches!(record.address, Address::Known(_)));
         assert_eq!(record.status, Status::Inert);
         assert_eq!(record.primary_sets, 0);
+        assert_eq!(record.secondary_sets, 0);
         assert!(!record.persistent);
-        assert!(record.ingress().is_some());
+        assert_eq!(
+            record.advertisement().unwrap().endpoints(),
+            &[Endpoint("primary")]
+        );
         assert!(record.is_blockable());
         assert!(record.deletable());
         assert!(!record.eligible());
     }
 
     #[test]
+    fn test_attached_peer_can_gain_reachability() {
+        let mut record = TestRecord::undialable();
+        let reachability = dialable(&["first", "second"]);
+        assert!(record.update(reachability.clone()));
+        assert_eq!(
+            record.advertisement(),
+            match reachability {
+                Reachability::Dialable(advertisement) => Some(advertisement),
+                Reachability::OutboundOnly => unreachable!(),
+            }
+        );
+        assert!(!record.is_outbound_target());
+    }
+
+    #[test]
     fn test_is_blockable() {
-        // Myself is not blockable
-        let record_myself = Record::myself();
+        let record_myself = TestRecord::myself();
         assert!(!record_myself.is_blockable());
 
-        // Known peers are blockable
-        let record_known = Record::known(test_address());
+        let record_known = known();
         assert!(record_known.is_blockable());
+
+        let record_undialable = TestRecord::undialable();
+        assert!(record_undialable.is_blockable());
     }
 
     #[test]
     fn test_increment_decrement_and_deletable() {
-        let mut record_known = Record::known(test_address());
+        let mut record_known = known();
         assert!(record_known.deletable());
         record_known.increment_primary();
+        assert_eq!(record_known.primary_sets(), 1);
         assert!(!record_known.deletable());
         record_known.decrement_primary();
         assert!(record_known.deletable());
 
-        let mut record_myself = Record::myself();
+        record_known.increment_secondary();
+        assert_eq!(record_known.secondary_sets(), 1);
+        assert!(!record_known.deletable());
+        record_known.decrement_secondary();
+        assert!(record_known.deletable());
+
+        let mut record_myself = TestRecord::myself();
         assert!(!record_myself.deletable());
         record_myself.increment_primary();
         assert!(!record_myself.deletable());
@@ -378,7 +416,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_decrement_panics_at_zero() {
-        let mut record = Record::known(test_address());
+        let mut record = known();
         assert_eq!(record.primary_sets, 0);
         record.decrement_primary();
     }
@@ -386,7 +424,7 @@ mod tests {
     #[test]
     fn test_status_transitions_reserve_connect_release() {
         deterministic::Runner::default().start(|mut context| async move {
-            let mut record = Record::known(test_address());
+            let mut record = known();
 
             assert_eq!(record.status, Status::Inert);
             assert_eq!(
@@ -402,7 +440,7 @@ mod tests {
             );
             assert_eq!(record.status, Status::Reserved);
 
-            record.connect();
+            assert!(record.connect());
             assert_eq!(record.status, Status::Active);
 
             assert_eq!(
@@ -428,7 +466,7 @@ mod tests {
     #[test]
     fn test_needs_teardown_after_losing_eligibility() {
         deterministic::Runner::default().start(|mut context| async move {
-            let mut record = Record::known(test_address());
+            let mut record = known();
             record.increment_primary();
 
             assert!(!record.needs_teardown());
@@ -444,7 +482,7 @@ mod tests {
             assert!(record.needs_teardown());
             assert!(record.is_reserved_or_connected());
 
-            record.connect();
+            assert!(record.connect());
             assert!(record.needs_teardown());
             assert!(record.is_reserved_or_connected());
 
@@ -457,17 +495,14 @@ mod tests {
     #[test]
     fn test_reserved_connect_rejected_after_address_change() {
         deterministic::Runner::default().start(|mut context| async move {
-            let mut record = Record::known(test_address());
+            let mut record = known();
             record.increment_primary();
             assert_eq!(
                 record.reserve(&mut context, Duration::ZERO),
                 ReserveResult::Reserved
             );
 
-            assert!(record.update(types::Address::Symmetric(SocketAddr::from((
-                [54, 12, 1, 10],
-                8081,
-            )))));
+            assert!(record.update(dialable(&["replacement"])));
             assert!(record.needs_teardown());
             assert!(!record.connect());
             assert_eq!(record.status, Status::Reserved);
@@ -480,7 +515,7 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_connect_when_not_reserved_panics_from_inert() {
-        let mut record = Record::known(test_address());
+        let mut record = known();
         record.connect();
     }
 
@@ -488,12 +523,12 @@ mod tests {
     #[should_panic]
     fn test_connect_when_active_panics() {
         deterministic::Runner::default().start(|mut context| async move {
-            let mut record = Record::known(test_address());
+            let mut record = known();
             assert_eq!(
                 record.reserve(&mut context, Duration::ZERO),
                 ReserveResult::Reserved
             );
-            record.connect();
+            assert!(record.connect());
             record.connect();
         });
     }
@@ -501,16 +536,16 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_release_when_inert_panics() {
-        let mut record = Record::known(test_address());
+        let mut record = known();
         record.release();
     }
 
     #[test]
     fn test_deletable_logic_detailed() {
         deterministic::Runner::default().start(|mut context| async move {
-            assert!(!Record::myself().deletable());
+            assert!(!TestRecord::myself().deletable());
 
-            let mut record = Record::known(test_address());
+            let mut record = known();
             assert_eq!(record.primary_sets, 0);
             assert_eq!(record.status, Status::Inert);
             assert!(record.deletable());
@@ -524,7 +559,7 @@ mod tests {
             );
             assert!(!record.deletable());
 
-            record.connect();
+            assert!(record.connect());
             assert!(!record.deletable());
 
             record.release();
@@ -537,86 +572,56 @@ mod tests {
 
     #[test]
     fn test_eligible_logic() {
-        // Myself is never eligible
-        assert!(!Record::myself().eligible());
+        assert!(!TestRecord::myself().eligible());
 
-        // Known records are only eligible when in a peer set
-        let mut record_known = Record::known(test_address());
+        let mut record_known = known();
         assert!(!record_known.eligible(), "Not eligible when sets=0");
         record_known.increment_primary();
         assert!(record_known.eligible(), "Eligible when sets>0");
         record_known.decrement_primary();
         assert!(!record_known.eligible(), "Not eligible when sets=0 again");
+
+        record_known.increment_secondary();
+        assert!(record_known.eligible(), "Eligible when in a secondary set");
+
+        let record_undialable = TestRecord::undialable();
+        assert!(!record_undialable.eligible());
+        assert!(!record_undialable.acceptable());
+        assert!(record_undialable.advertisement().is_none());
     }
 
     #[test]
-    fn test_acceptable_checks_eligibility_status_and_ip() {
+    fn test_acceptable_checks_eligibility_and_status() {
         deterministic::Runner::default().start(|mut context| async move {
-            use std::net::IpAddr;
-
-            let egress_ip: IpAddr = [8, 8, 8, 8].into();
-            let wrong_ip: IpAddr = [1, 2, 3, 4].into();
-            let public_socket = SocketAddr::from(([8, 8, 8, 8], 8080));
-
-            let mut record = Record::known(types::Address::Symmetric(public_socket));
+            let mut record = known();
             record.increment_primary();
-            assert!(record.acceptable(egress_ip, false));
-            assert!(!record.acceptable(wrong_ip, false));
+            assert!(record.acceptable());
 
-            let record_not_eligible = Record::known(types::Address::Symmetric(public_socket));
-            assert!(!record_not_eligible.acceptable(egress_ip, false));
+            let record_not_eligible = known();
+            assert!(!record_not_eligible.acceptable());
 
-            let mut record_reserved = Record::known(types::Address::Symmetric(public_socket));
+            let mut record_reserved = known();
             record_reserved.increment_primary();
             record_reserved.reserve(&mut context, Duration::ZERO);
-            assert!(!record_reserved.acceptable(egress_ip, false));
+            assert!(!record_reserved.acceptable());
 
-            let mut record_connected = Record::known(types::Address::Symmetric(public_socket));
+            let mut record_connected = known();
             record_connected.increment_primary();
             record_connected.reserve(&mut context, Duration::ZERO);
             record_connected.connect();
-            assert!(!record_connected.acceptable(egress_ip, false));
-        });
-    }
+            assert!(!record_connected.acceptable());
 
-    #[test]
-    fn test_acceptable_bypass_ip_check() {
-        deterministic::Runner::default().start(|mut context| async move {
-            use std::net::IpAddr;
-
-            let egress_ip: IpAddr = [8, 8, 8, 8].into();
-            let wrong_ip: IpAddr = [1, 2, 3, 4].into();
-            let public_socket = SocketAddr::from(([8, 8, 8, 8], 8080));
-
-            let mut record = Record::known(types::Address::Symmetric(public_socket));
-            record.increment_primary();
-            assert!(record.acceptable(wrong_ip, true));
-
-            let record_not_eligible = Record::known(types::Address::Symmetric(public_socket));
-            assert!(!record_not_eligible.acceptable(egress_ip, true));
-
-            let mut record_reserved = Record::known(types::Address::Symmetric(public_socket));
-            record_reserved.increment_primary();
-            record_reserved.reserve(&mut context, Duration::ZERO);
-            assert!(!record_reserved.acceptable(egress_ip, true));
-
-            let mut record_connected = Record::known(types::Address::Symmetric(public_socket));
-            record_connected.increment_primary();
-            record_connected.reserve(&mut context, Duration::ZERO);
-            record_connected.connect();
-            assert!(!record_connected.acceptable(egress_ip, true));
-
-            assert!(!Record::myself().acceptable(egress_ip, true));
+            assert!(!TestRecord::myself().acceptable());
         });
     }
 
     #[test]
     fn test_reserve_sets_next_dial() {
         deterministic::Runner::default().start(|mut context| async move {
-            let mut record = Record::known(test_address());
+            let mut record = known();
             record.increment_primary();
             let now = context.current();
-            assert_eq!(record.dialable(now, true, true), DialStatus::Now);
+            assert_eq!(record.dialable(now), DialStatus::Now);
 
             let interval = Duration::from_secs(1);
             assert_eq!(
@@ -625,8 +630,7 @@ mod tests {
             );
             record.release();
 
-            // Immediately after release, dialable returns After with jittered time.
-            let status = record.dialable(now, true, true);
+            let status = record.dialable(now);
             match status {
                 DialStatus::After(t) => {
                     assert!(t >= now + interval);
@@ -640,7 +644,7 @@ mod tests {
     #[test]
     fn test_reserve_rate_limited() {
         deterministic::Runner::default().start(|mut context| async move {
-            let mut record = Record::known(test_address());
+            let mut record = known();
             let interval = Duration::from_secs(5);
 
             assert_eq!(
@@ -649,13 +653,11 @@ mod tests {
             );
             record.release();
 
-            // Immediate re-reserve is rate-limited.
             assert_eq!(
                 record.reserve(&mut context, interval),
                 ReserveResult::RateLimited
             );
 
-            // After interval elapses, reserve succeeds again.
             context.sleep(interval).await;
             assert_eq!(
                 record.reserve(&mut context, interval),
@@ -665,66 +667,31 @@ mod tests {
     }
 
     #[test]
-    fn test_dialable_checks_ingress_ip() {
-        use Ingress;
-        use std::net::IpAddr;
-
+    fn test_dialable_requires_outbound_target_and_advertisement() {
         let now = SystemTime::UNIX_EPOCH;
 
-        // Public ingress, public egress - dialable
-        let public_socket = SocketAddr::from(([8, 8, 8, 8], 8080));
-        let mut record_public = Record::known(types::Address::Symmetric(public_socket));
-        record_public.increment_primary();
-        assert_eq!(record_public.dialable(now, false, true), DialStatus::Now);
-
-        // Private ingress (Socket), public egress - NOT dialable when allow_private_ips=false
-        let private_ingress =
-            SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)), 8080);
-        let public_egress = SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8)), 9090);
-        let asymmetric_private_ingress = types::Address::Asymmetric {
-            ingress: Ingress::Socket(private_ingress),
-            egress: public_egress,
-        };
-        let mut record_private_ingress = Record::known(asymmetric_private_ingress);
-        record_private_ingress.increment_primary();
+        let mut secondary = Record::known(dialable(&["first", "second"]));
+        secondary.increment_secondary();
+        assert_eq!(secondary.dialable(now), DialStatus::Unavailable);
         assert_eq!(
-            record_private_ingress.dialable(now, false, true),
-            DialStatus::Unavailable
-        );
-        assert_eq!(
-            record_private_ingress.dialable(now, true, true),
-            DialStatus::Now
+            secondary.advertisement().unwrap().endpoints(),
+            &[Endpoint("first"), Endpoint("second")]
         );
 
-        // Public ingress (Socket), private egress - dialable (egress not checked for dialing)
-        let public_ingress = SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8)), 8080);
-        let private_egress =
-            SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)), 9090);
-        let asymmetric_private_egress = types::Address::Asymmetric {
-            ingress: Ingress::Socket(public_ingress),
-            egress: private_egress,
-        };
-        let mut record_private_egress = Record::known(asymmetric_private_egress);
-        record_private_egress.increment_primary();
-        assert_eq!(
-            record_private_egress.dialable(now, false, true),
-            DialStatus::Now
-        );
+        secondary.increment_primary();
+        assert_eq!(secondary.dialable(now), DialStatus::Now);
 
-        // DNS ingress (no IP to check) - dialable (DNS private check happens at dial time)
-        let dns_ingress = types::Address::Asymmetric {
-            ingress: Ingress::Dns {
-                host: commonware_utils::hostname!("example.com"),
-                port: 8080,
-            },
-            egress: public_egress,
-        };
-        let mut record_dns = Record::known(dns_ingress);
-        record_dns.increment_primary();
-        assert_eq!(record_dns.dialable(now, false, true), DialStatus::Now);
+        let mut outbound_only = Record::known(Reachability::<Endpoint>::OutboundOnly);
+        outbound_only.increment_primary();
+        assert!(outbound_only.acceptable());
+        assert_eq!(outbound_only.dialable(now), DialStatus::Unavailable);
+        assert!(outbound_only.advertisement().is_none());
+
+        assert!(outbound_only.update(dialable(&["replacement", "fallback"])));
+        assert_eq!(outbound_only.dialable(now), DialStatus::Now);
         assert_eq!(
-            record_dns.dialable(now, false, false),
-            DialStatus::Unavailable
+            outbound_only.advertisement().unwrap().endpoints(),
+            &[Endpoint("replacement"), Endpoint("fallback")]
         );
     }
 }

--- a/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
+++ b/p2p/src/authenticated/lookup/actors/tracker/reservation.rs
@@ -1,23 +1,23 @@
 use super::Metadata;
-use crate::authenticated::lookup::actors::tracker::ingress::Releaser;
+use crate::{PeerEndpoint, authenticated::lookup::actors::tracker::ingress::Releaser};
 use commonware_cryptography::PublicKey;
 
 /// Reservation for a peer in the network. This is used to ensure that the peer is reserved only
 /// once, and that the reservation is released when the peer connection fails or is closed.
 #[derive(Debug)]
-pub struct Reservation<P: PublicKey> {
+pub struct Reservation<P: PublicKey, E: PeerEndpoint = crate::Ingress> {
     /// Metadata about the reservation.
     metadata: Metadata<P>,
 
     /// Used to automatically notify the completion of the reservation when it is dropped.
     ///
     /// Stored as an `Option` to avoid unnecessary cloning by `take`ing the value.
-    releaser: Option<Releaser<P>>,
+    releaser: Option<Releaser<P, E>>,
 }
 
-impl<P: PublicKey> Reservation<P> {
+impl<P: PublicKey, E: PeerEndpoint> Reservation<P, E> {
     /// Create a new reservation for a peer.
-    pub const fn new(metadata: Metadata<P>, releaser: Releaser<P>) -> Self {
+    pub const fn new(metadata: Metadata<P>, releaser: Releaser<P, E>) -> Self {
         Self {
             metadata,
             releaser: Some(releaser),
@@ -25,14 +25,14 @@ impl<P: PublicKey> Reservation<P> {
     }
 }
 
-impl<P: PublicKey> Reservation<P> {
+impl<P: PublicKey, E: PeerEndpoint> Reservation<P, E> {
     /// Returns the metadata associated with this reservation.
     pub const fn metadata(&self) -> &Metadata<P> {
         &self.metadata
     }
 }
 
-impl<P: PublicKey> Drop for Reservation<P> {
+impl<P: PublicKey, E: PeerEndpoint> Drop for Reservation<P, E> {
     fn drop(&mut self) {
         let mut releaser = self
             .releaser

--- a/p2p/src/authenticated/lookup/config.rs
+++ b/p2p/src/authenticated/lookup/config.rs
@@ -1,5 +1,8 @@
 use commonware_cryptography::Signer;
+use commonware_macros::stability;
 use commonware_runtime::Quota;
+#[stability(ALPHA)]
+use commonware_stream::encrypted;
 use commonware_utils::{NZU32, NZUsize};
 use std::{
     net::SocketAddr,
@@ -111,6 +114,90 @@ pub struct Config<C: Signer> {
 
     /// Duration after which a blocked peer is allowed to reconnect.
     pub block_duration: Duration,
+}
+
+/// Configuration for an authenticated network using explicitly attached connections.
+#[stability(ALPHA)]
+pub struct AttachmentConfig<C: Signer, A> {
+    /// Configuration for encrypted streams.
+    ///
+    /// `max_message_size` includes authenticated-network framing overhead. The maximum application
+    /// message size is derived from it.
+    pub stream: encrypted::Config<C>,
+
+    /// Application policy for admitting inbound connections.
+    pub admission: A,
+
+    /// Message backlog allowed for internal actors.
+    pub mailbox_size: NonZeroUsize,
+
+    /// Maximum number of connection handshakes in progress.
+    pub max_concurrent_handshakes: NonZeroU32,
+
+    /// Maximum number of queued outbound messages combined into one write.
+    pub send_batch_size: NonZeroUsize,
+
+    /// Frequency at which connected peers are pinged.
+    pub ping_frequency: Duration,
+
+    /// Number of peer sets retained by the tracker.
+    pub tracked_peer_sets: NonZeroUsize,
+
+    /// Minimum time between reservations for a single peer.
+    pub peer_connection_cooldown: Duration,
+
+    /// Duration after which a blocked peer may reconnect.
+    pub block_duration: Duration,
+}
+
+/// Transport-neutral configuration for endpoint-generic lookup networks.
+#[stability(ALPHA)]
+#[derive(Clone)]
+pub struct GenericConfig<C: Signer> {
+    /// Configuration for authenticated streams.
+    pub stream: encrypted::Config<C>,
+    /// Message backlog allowed for internal actors.
+    pub mailbox_size: NonZeroUsize,
+    /// Maximum queued messages combined into one write.
+    pub send_batch_size: NonZeroUsize,
+    /// Maximum duration for trying all endpoints advertised by one peer.
+    pub dial_timeout: Duration,
+    /// Minimum time between connection reservations for one peer.
+    pub peer_connection_cooldown: Duration,
+    /// Frequency at which one peer is selected for dialing.
+    pub dial_frequency: Duration,
+    /// Frequency at which connected peers are pinged.
+    pub ping_frequency: Duration,
+    /// Number of peer sets retained by the tracker.
+    pub tracked_peer_sets: NonZeroUsize,
+    /// Duration after which a blocked peer may reconnect.
+    pub block_duration: Duration,
+}
+
+#[stability(ALPHA)]
+impl<C: Signer> From<Config<C>> for GenericConfig<C> {
+    fn from(cfg: Config<C>) -> Self {
+        Self {
+            stream: encrypted::Config {
+                signing_key: cfg.crypto,
+                namespace: commonware_utils::union(&cfg.namespace, b"_STREAM"),
+                max_message_size: cfg
+                    .max_message_size
+                    .saturating_add(crate::authenticated::data::MAX_PAYLOAD_DATA_OVERHEAD),
+                synchrony_bound: cfg.synchrony_bound,
+                max_handshake_age: cfg.max_handshake_age,
+                handshake_timeout: cfg.handshake_timeout,
+            },
+            mailbox_size: cfg.mailbox_size,
+            send_batch_size: cfg.send_batch_size,
+            dial_timeout: cfg.dial_timeout,
+            peer_connection_cooldown: cfg.peer_connection_cooldown,
+            dial_frequency: cfg.dial_frequency,
+            ping_frequency: cfg.ping_frequency,
+            tracked_peer_sets: cfg.tracked_peer_sets,
+            block_duration: cfg.block_duration,
+        }
+    }
 }
 
 impl<C: Signer> Config<C> {

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -1,9 +1,10 @@
-//! Communicate with a fixed set of authenticated peers with known addresses over encrypted connections.
+//! Communicate with authenticated peers over encrypted connections.
 //!
-//! `lookup` provides multiplexed communication between fully-connected peers
-//! identified by a developer-specified cryptographic identity (i.e. BLS, ed25519, etc.).
-//! Unlike `discovery`, peers in `lookup` don't use a discovery mechanism to find each other;
-//! each peer's address is supplied by the application layer.
+//! `lookup` provides multiplexed communication between peers identified by cryptographic
+//! identities (for example, BLS or Ed25519 keys). Applications may either provide a tracked set
+//! of TCP addresses through [`Network`] or supply already-established transport connections
+//! through [`AttachmentNetwork`]. The attachment path supports outbound-only transports and
+//! peers whose identity is learned during an authenticated inbound handshake.
 //!
 //! # Features
 //!
@@ -12,9 +13,9 @@
 //!
 //! # Design
 //!
-//! ## Discovery
+//! ## Address-tracked network
 //!
-//! This module operates under the assumption that all peers are aware of and synchronized on
+//! [`Network`] operates under the assumption that all peers are aware of and synchronized on
 //! the composition of peer sets at specific, user-provided indices (`u64`). Each index maps to a
 //! list of peer `PublicKey`/`SocketAddr` pairs (`(u64, Vec<(PublicKey, SocketAddr)>)`).
 //!
@@ -110,7 +111,7 @@
 //! ```rust
 //! use commonware_p2p::{authenticated::lookup::{self, Network}, Address, AddressableManager, Sender, Recipients};
 //! use commonware_cryptography::{ed25519, Signer, PrivateKey as _, PublicKey as _, };
-//! use commonware_runtime::{deterministic, IoBuf, Metrics, Quota, Runner, Spawner, Supervisor};
+//! use commonware_runtime::{deterministic, IoBuf, Metrics, Quota, Runner, Scheduler, Supervisor};
 //! use commonware_utils::{NZU32, ordered::Map};
 //! use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 //!
@@ -194,17 +195,29 @@ mod network;
 mod types;
 
 pub use crate::authenticated::channels::{Error, Receiver, Sender};
-pub use actors::tracker::Oracle;
+#[stability(ALPHA)]
+pub use actors::attachment::{
+    Attachments, Error as AttachmentError, ExactPeerAdmission, PeerAdmission, Rejected,
+};
+#[stability(ALPHA)]
+pub use actors::tracker::Oracle as ReachabilityOracle;
+use commonware_macros::stability;
 pub use config::Config;
-pub use network::Network;
+#[stability(ALPHA)]
+pub use config::{AttachmentConfig, GenericConfig};
+#[stability(ALPHA)]
+pub use network::{AcceptingNetwork, AttachmentNetwork, DialOnlyNetwork};
+pub use network::{Network, Oracle};
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::{
-        Address, AddressableManager, CheckedSender as _, Ingress, LimitedSender as _, Provider,
+        Address, AddressableManager, Advertisement, CheckedSender as _, Ingress,
+        LimitedSender as _, PeerEndpoint, Provider, Reachability, ReachabilityManager as _,
         Receiver, Recipients, Sender,
         authenticated::{
+            admission::{ExactPeerAdmission, InboundAdmission, Rejection},
             channels,
             relay::Relay,
             router::{Actor as RouterActor, Config as RouterConfig},
@@ -214,19 +227,25 @@ mod tests {
     use commonware_cryptography::{Signer as _, ed25519};
     use commonware_macros::{select, test_group, test_traced};
     use commonware_runtime::{
-        BufferPooler, Clock, IoBuf, Metrics, Network as RNetwork, Quota, Resolver, Runner, Spawner,
-        Supervisor as _, deterministic, telemetry::metrics::count_running_tasks, tokio,
+        Acceptor, BufferPooler, Clock, Connection, ConnectionInfo, Dialer, IoBuf, Listener, Metrics,
+        Quota, Resolver, Runner, Scheduler, Spawner, Supervisor as _, TcpEndpoint, TcpOrigin,
+        deterministic, mocks, telemetry::metrics::count_running_tasks, tokio,
     };
     use commonware_utils::{
         Hostname, NZU32, NZUsize, TryCollect,
         channel::mpsc,
         hostname,
         ordered::{Map, Set},
+        sync::Mutex,
     };
     use rand_core::{CryptoRng, Rng};
     use std::{
-        collections::HashSet,
+        collections::{HashSet, VecDeque},
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
         time::Duration,
     };
 
@@ -239,6 +258,423 @@ mod tests {
 
     const MAX_MESSAGE_SIZE: u32 = 1_024 * 1_024; // 1MB
     const DEFAULT_MESSAGE_BACKLOG: usize = 128;
+
+    struct AttachedConnection {
+        sink: mocks::Sink,
+        stream: mocks::Stream,
+        origin: u8,
+    }
+
+    impl Connection for AttachedConnection {
+        type Sink = mocks::Sink;
+        type Stream = mocks::Stream;
+        type Origin = u8;
+
+        fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>) {
+            (
+                self.sink,
+                self.stream,
+                ConnectionInfo {
+                    origin: Some(self.origin),
+                    transport: "test_attachment",
+                },
+            )
+        }
+    }
+
+    fn attached_pair() -> (AttachedConnection, AttachedConnection) {
+        let (sink_0, stream_1) = mocks::Channel::init();
+        let (sink_1, stream_0) = mocks::Channel::init();
+        (
+            AttachedConnection {
+                sink: sink_0,
+                stream: stream_0,
+                origin: 1,
+            },
+            AttachedConnection {
+                sink: sink_1,
+                stream: stream_1,
+                origin: 0,
+            },
+        )
+    }
+
+    fn attachment_config(
+        signer: ed25519::PrivateKey,
+        expected_peer: ed25519::PublicKey,
+    ) -> AttachmentConfig<ed25519::PrivateKey, ExactPeerAdmission<ed25519::PublicKey>> {
+        let tcp = Config::test(
+            signer,
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            MAX_MESSAGE_SIZE,
+        );
+        let generic = GenericConfig::from(tcp);
+        AttachmentConfig {
+            stream: generic.stream,
+            admission: ExactPeerAdmission::new(expected_peer),
+            mailbox_size: generic.mailbox_size,
+            max_concurrent_handshakes: NZU32!(8),
+            send_batch_size: generic.send_batch_size,
+            ping_frequency: generic.ping_frequency,
+            tracked_peer_sets: generic.tracked_peer_sets,
+            peer_connection_cooldown: generic.peer_connection_cooldown,
+            block_duration: generic.block_duration,
+        }
+    }
+
+    #[test]
+    fn test_tcp_dialer_respects_endpoint_policy() {
+        deterministic::Runner::default().start(|context| async move {
+            let private = Ingress::Socket(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1));
+            let dns = Ingress::Dns {
+                host: hostname!("example.com"),
+                port: 443,
+            };
+
+            let restricted =
+                super::network::TcpDialer::new(context.child("restricted"), false, false);
+            assert!(!restricted.supports(&private));
+            assert!(!restricted.supports(&dns));
+
+            let permissive =
+                super::network::TcpDialer::new(context.child("permissive"), true, true);
+            assert!(permissive.supports(&private));
+            assert!(permissive.supports(&dns));
+        });
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    enum TestEndpoint {
+        Unsupported,
+        First,
+        Second,
+    }
+
+    impl PeerEndpoint for TestEndpoint {}
+
+    struct DialOnlyTransport {
+        attempts: Arc<Mutex<Vec<TestEndpoint>>>,
+    }
+
+    impl Dialer for DialOnlyTransport {
+        type Endpoint = TestEndpoint;
+        type Connection = AttachedConnection;
+
+        fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+            *endpoint != TestEndpoint::Unsupported
+        }
+
+        async fn dial(
+            &self,
+            endpoint: &Self::Endpoint,
+        ) -> Result<Self::Connection, commonware_runtime::Error> {
+            self.attempts.lock().push(endpoint.clone());
+            Err(commonware_runtime::Error::ConnectionFailed)
+        }
+    }
+
+    struct BurstAcceptor {
+        connections: Arc<Mutex<Option<VecDeque<AttachedConnection>>>>,
+        accepted: Arc<AtomicUsize>,
+    }
+
+    impl BurstAcceptor {
+        fn new(connections: VecDeque<AttachedConnection>) -> (Self, Arc<AtomicUsize>) {
+            let accepted = Arc::new(AtomicUsize::new(0));
+            (
+                Self {
+                    connections: Arc::new(Mutex::new(Some(connections))),
+                    accepted: accepted.clone(),
+                },
+                accepted,
+            )
+        }
+    }
+
+    impl Acceptor for BurstAcceptor {
+        type Bind = ();
+        type Connection = AttachedConnection;
+        type Listener = BurstListener;
+
+        async fn bind(&self, _bind: &Self::Bind) -> Result<Self::Listener, commonware_runtime::Error> {
+            Ok(BurstListener {
+                connections: self.connections.lock().take().unwrap(),
+                accepted: self.accepted.clone(),
+            })
+        }
+    }
+
+    struct BurstListener {
+        connections: VecDeque<AttachedConnection>,
+        accepted: Arc<AtomicUsize>,
+    }
+
+    impl Listener for BurstListener {
+        type Connection = AttachedConnection;
+
+        async fn accept(&mut self) -> Result<Self::Connection, commonware_runtime::Error> {
+            let Some(connection) = self.connections.pop_front() else {
+                return std::future::pending().await;
+            };
+            self.accepted.fetch_add(1, Ordering::Relaxed);
+            Ok(connection)
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    struct RejectZeroOrigin;
+
+    impl InboundAdmission<ed25519::PublicKey, u8> for RejectZeroOrigin {
+        type Permit = ();
+
+        fn pre_auth(
+            &self,
+            info: &ConnectionInfo<u8>,
+        ) -> Result<Self::Permit, Rejection> {
+            if info.origin == Some(0) {
+                return Err(Rejection::Application);
+            }
+            Ok(())
+        }
+
+        async fn post_auth(
+            &self,
+            _permit: Self::Permit,
+            _peer: &ed25519::PublicKey,
+            _info: &ConnectionInfo<u8>,
+        ) -> Result<(), Rejection> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn test_attachment_network_authenticates_exact_keys_and_exchanges_message() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer_0 = ed25519::PrivateKey::from_seed(0);
+            let signer_1 = ed25519::PrivateKey::from_seed(1);
+            let key_0 = signer_0.public_key();
+            let key_1 = signer_1.public_key();
+
+            let (mut network_0, _oracle_0, attachments_0) = AttachmentNetwork::new(
+                context.child("peer_0"),
+                attachment_config(signer_0, key_1.clone()),
+            );
+            let (mut network_1, _oracle_1, attachments_1) = AttachmentNetwork::new(
+                context.child("peer_1"),
+                attachment_config(signer_1, key_0.clone()),
+            );
+            let (mut sender_0, _receiver_0) =
+                network_0.register(7, Quota::per_second(NZU32!(100)), DEFAULT_MESSAGE_BACKLOG);
+            let (_sender_1, mut receiver_1) =
+                network_1.register(7, Quota::per_second(NZU32!(100)), DEFAULT_MESSAGE_BACKLOG);
+            network_0.start();
+            network_1.start();
+
+            let (connection_0, connection_1) = attached_pair();
+            let expected_key = key_1.clone();
+            let outbound_attachments = attachments_0.clone();
+            let outbound = context.child("attach_outbound").spawn(move |_| async move {
+                outbound_attachments
+                    .attach_outbound(expected_key, connection_0)
+                    .await
+            });
+            let inbound_attachments = attachments_1.clone();
+            let inbound = context.child("attach_inbound").spawn(move |_| async move {
+                inbound_attachments.attach_inbound(connection_1).await
+            });
+            assert_eq!(outbound.await.unwrap(), Ok(()));
+            assert_eq!(inbound.await.unwrap(), Ok(()));
+
+            let message = IoBuf::from(b"attached lookup".to_vec());
+            loop {
+                let sent = sender_0.send(Recipients::One(key_1.clone()), message.clone(), true);
+                if sent.as_ref() == [key_1.clone()] {
+                    break;
+                }
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            let (authenticated_sender, received) = receiver_1.recv().await.unwrap();
+            assert_eq!(authenticated_sender, key_0);
+            assert_eq!(received, b"attached lookup".as_slice());
+        });
+    }
+
+    #[test]
+    fn test_attachment_network_rejects_expected_key_mismatch() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer_0 = ed25519::PrivateKey::from_seed(10);
+            let signer_1 = ed25519::PrivateKey::from_seed(11);
+            let wrong_key = ed25519::PrivateKey::from_seed(12).public_key();
+            let key_0 = signer_0.public_key();
+            let key_1 = signer_1.public_key();
+
+            let (network_0, _oracle_0, attachments_0) = AttachmentNetwork::new(
+                context.child("peer_0"),
+                attachment_config(signer_0, key_1.clone()),
+            );
+            let (network_1, _oracle_1, attachments_1) =
+                AttachmentNetwork::new(context.child("peer_1"), attachment_config(signer_1, key_0));
+            network_0.start();
+            network_1.start();
+
+            let (connection_0, connection_1) = attached_pair();
+            let outbound_attachments = attachments_0.clone();
+            let outbound = context.child("attach_outbound").spawn(move |_| async move {
+                outbound_attachments
+                    .attach_outbound(wrong_key, connection_0)
+                    .await
+            });
+            let inbound_attachments = attachments_1.clone();
+            let inbound = context.child("attach_inbound").spawn(move |_| async move {
+                inbound_attachments.attach_inbound(connection_1).await
+            });
+            assert_eq!(outbound.await.unwrap(), Err(AttachmentError::Handshake));
+            let _ = inbound.await;
+        });
+    }
+
+    #[test]
+    fn test_dial_only_network_skips_unsupported_endpoints_in_order_and_outbound_only_peers() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer = ed25519::PrivateKey::from_seed(20);
+            let dialable_peer = ed25519::PrivateKey::from_seed(21).public_key();
+            let outbound_only_peer = ed25519::PrivateKey::from_seed(22).public_key();
+            let attempts = Arc::new(Mutex::new(Vec::new()));
+            let transport = DialOnlyTransport {
+                attempts: attempts.clone(),
+            };
+            let tcp = Config::test(
+                signer,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                MAX_MESSAGE_SIZE,
+            );
+            let mut config = GenericConfig::from(tcp);
+            config.peer_connection_cooldown = Duration::from_hours(1);
+            let (network, mut oracle) =
+                DialOnlyNetwork::new(context.child("network"), transport, config);
+
+            let advertisement = Advertisement::new(vec![
+                TestEndpoint::Unsupported,
+                TestEndpoint::First,
+                TestEndpoint::Second,
+            ])
+            .unwrap();
+            oracle.track(
+                0,
+                Map::try_from(vec![
+                    (dialable_peer, Reachability::Dialable(advertisement)),
+                    (outbound_only_peer, Reachability::OutboundOnly),
+                ])
+                .unwrap(),
+            );
+            network.start();
+
+            context.sleep(Duration::from_secs(2)).await;
+            assert_eq!(
+                *attempts.lock(),
+                vec![TestEndpoint::First, TestEndpoint::Second]
+            );
+        });
+    }
+
+    #[test]
+    fn test_accepting_network_survives_attachment_mailbox_overflow() {
+        const BURST_SIZE: usize = 3;
+
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let signer = ed25519::PrivateKey::from_seed(30);
+            let expected_peer = ed25519::PrivateKey::from_seed(31).public_key();
+            let tcp = Config::test(
+                signer,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                MAX_MESSAGE_SIZE,
+            );
+            let mut config = GenericConfig::from(tcp);
+            config.mailbox_size = NZUsize!(1);
+
+            let connections = (0..BURST_SIZE)
+                .map(|_| attached_pair().0)
+                .collect::<VecDeque<_>>();
+            let (acceptor, accepted) = BurstAcceptor::new(connections);
+            let transport = DialOnlyTransport {
+                attempts: Arc::new(Mutex::new(Vec::new())),
+            };
+            let (network, _oracle) =
+                DialOnlyNetwork::new(context.child("network"), transport, config);
+            let network = network.accepting(
+                acceptor,
+                (),
+                ExactPeerAdmission::new(expected_peer),
+                NZU32!(1),
+            );
+            let mut network_task = network.start();
+
+            while accepted.load(Ordering::Relaxed) < BURST_SIZE {
+                select! {
+                    result = &mut network_task => {
+                        panic!(
+                            "accepting network stopped after accepting {} of {BURST_SIZE} connections: {result:?}",
+                            accepted.load(Ordering::Relaxed),
+                        );
+                    },
+                    _ = context.sleep(Duration::from_millis(1)) => {},
+                }
+            }
+
+            select! {
+                result = &mut network_task => {
+                    panic!("accepting network stopped after the connection burst: {result:?}");
+                },
+                _ = context.sleep(Duration::from_millis(1)) => {},
+            }
+
+            network_task.abort();
+            let _ = network_task.await;
+        });
+    }
+
+    #[test]
+    fn test_accepting_network_survives_pre_auth_rejection() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let signer = ed25519::PrivateKey::from_seed(32);
+            let tcp = Config::test(
+                signer,
+                SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                MAX_MESSAGE_SIZE,
+            );
+            let config = GenericConfig::from(tcp);
+
+            let (mut rejected, _) = attached_pair();
+            rejected.origin = 0;
+            let (mut accepted_connection, _) = attached_pair();
+            accepted_connection.origin = 1;
+            let (acceptor, accepted) =
+                BurstAcceptor::new(VecDeque::from([rejected, accepted_connection]));
+            let transport = DialOnlyTransport {
+                attempts: Arc::new(Mutex::new(Vec::new())),
+            };
+            let (network, _oracle) =
+                DialOnlyNetwork::new(context.child("network"), transport, config);
+            let network = network.accepting(acceptor, (), RejectZeroOrigin, NZU32!(1));
+            let mut network_task = network.start();
+
+            while accepted.load(Ordering::Relaxed) < 2 {
+                select! {
+                    result = &mut network_task => {
+                        panic!(
+                            "accepting network stopped after accepting {} of 2 connections: {result:?}",
+                            accepted.load(Ordering::Relaxed),
+                        );
+                    },
+                    _ = context.sleep(Duration::from_millis(1)) => {},
+                }
+            }
+
+            network_task.abort();
+            let _ = network_task.await;
+        });
+    }
 
     /// Ensure no message rate limiting occurred.
     ///
@@ -259,13 +695,19 @@ mod tests {
     ///
     /// We set a unique `base_port` for each test to avoid "address already in use"
     /// errors when tests are run immediately after each other.
-    async fn run_network(
-        context: impl Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics,
-        max_message_size: u32,
-        base_port: u16,
-        n: usize,
-        mode: Mode,
-    ) {
+    async fn run_network<E>(context: E, max_message_size: u32, base_port: u16, n: usize, mode: Mode)
+    where
+        E: Scheduler
+            + Spawner
+            + BufferPooler
+            + Clock
+            + CryptoRng
+            + Acceptor<Bind = SocketAddr>
+            + Dialer<Endpoint = TcpEndpoint, Connection = <E as Acceptor>::Connection>
+            + Resolver
+            + Metrics,
+        <E as Acceptor>::Connection: Connection<Origin = TcpOrigin>,
+    {
         // Create peers
         let mut peers_and_sks = Vec::new();
         for i in 0..n {

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -1,33 +1,639 @@
 //! Implementation of an `authenticated` network.
 
+#[stability(ALPHA)]
+use super::config::{AttachmentConfig, GenericConfig};
 use super::{
-    actors::{dialer, listener, spawner, tracker},
+    actors::{attachment, dialer, listener, spawner, tracker},
     config::Config,
 };
+#[stability(ALPHA)]
+use crate::PeerEndpoint;
 use crate::{
-    Channel,
+    Address, AddressableManager, AddressableTrackedPeers, Blocker, Channel, Ingress,
+    PeerSetSubscription, Provider, TrackedPeers,
     authenticated::{
+        admission::{TcpAdmission, TcpAdmissionConfig},
         channels::{self, Channels},
         data::MAX_PAYLOAD_DATA_OVERHEAD,
         router,
     },
 };
 use commonware_cryptography::Signer;
-use commonware_macros::select;
+use commonware_macros::{select, stability};
+#[stability(ALPHA)]
+use commonware_runtime::Scheduler;
 use commonware_runtime::{
-    BufferPooler, Clock, ContextCell, Handle, Metrics, Network as RNetwork, Quota, Resolver,
-    Spawner, spawn_cell,
+    Acceptor, BufferPooler, Clock, Connection, ContextCell, Dialer, Handle, Metrics, Quota,
+    Resolver, Spawner, TcpEndpoint, TcpOrigin, spawn_cell,
 };
 use commonware_stream::encrypted::Config as StreamConfig;
-use commonware_utils::union;
+use commonware_utils::{PlatformSend, ordered::Map, sync::Mutex, union};
+use rand::{SeedableRng, rngs::StdRng, seq::IndexedRandom};
 use rand_core::CryptoRng;
+use std::{
+    collections::{BTreeMap, HashMap, HashSet},
+    fmt,
+    sync::Arc,
+};
 use tracing::{debug, info};
+
+struct TcpOracleState<C: commonware_cryptography::PublicKey> {
+    sets: BTreeMap<u64, AddressableTrackedPeers<C>>,
+    max_sets: usize,
+}
+
+/// Legacy TCP oracle that keeps origin admission synchronized with peer addresses.
+pub struct Oracle<C: commonware_cryptography::PublicKey> {
+    inner: tracker::Oracle<C>,
+    updates: crate::authenticated::admission::TcpAdmissionUpdates<C>,
+    state: Arc<Mutex<TcpOracleState<C>>>,
+    #[cfg(test)]
+    after_tracker_update: Option<Arc<dyn Fn() + Send + Sync>>,
+}
+
+impl<C: commonware_cryptography::PublicKey> Clone for Oracle<C> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            updates: self.updates.clone(),
+            state: self.state.clone(),
+            #[cfg(test)]
+            after_tracker_update: self.after_tracker_update.clone(),
+        }
+    }
+}
+
+impl<C: commonware_cryptography::PublicKey> fmt::Debug for Oracle<C> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Oracle").finish_non_exhaustive()
+    }
+}
+
+impl<C: commonware_cryptography::PublicKey> Oracle<C> {
+    fn refresh_admission(&self, state: &TcpOracleState<C>) {
+        let mut latest_peer_ips = HashMap::new();
+        for peers in state.sets.values() {
+            for (peer, address) in &peers.secondary {
+                latest_peer_ips.insert(peer.clone(), address.egress_ip());
+            }
+            for (peer, address) in &peers.primary {
+                latest_peer_ips.insert(peer.clone(), address.egress_ip());
+            }
+        }
+
+        let peer_ips = latest_peer_ips
+            .into_iter()
+            .map(|(peer, ip)| (peer, HashSet::from([ip])))
+            .collect();
+        self.updates.set(peer_ips);
+    }
+}
+
+impl<C: commonware_cryptography::PublicKey> Provider for Oracle<C> {
+    type PublicKey = C;
+
+    async fn peer_set(&mut self, id: u64) -> Option<TrackedPeers<C>> {
+        self.inner.peer_set(id).await
+    }
+
+    async fn subscribe(&mut self) -> PeerSetSubscription<C> {
+        self.inner.subscribe().await
+    }
+}
+
+impl<C: commonware_cryptography::PublicKey> AddressableManager for Oracle<C> {
+    fn track<T>(&mut self, index: u64, peers: T) -> commonware_actor::Feedback
+    where
+        T: Into<AddressableTrackedPeers<C>> + PlatformSend,
+    {
+        let peers = peers.into();
+        let mut state = self.state.lock();
+        if state
+            .sets
+            .last_key_value()
+            .is_some_and(|(last, _)| index <= *last)
+        {
+            return self.inner.track(index, peers);
+        }
+
+        state.sets.insert(index, peers.clone());
+        while state.sets.len() > state.max_sets {
+            state.sets.pop_first();
+        }
+        self.refresh_admission(&state);
+
+        let feedback = self.inner.track(index, peers);
+        #[cfg(test)]
+        if let Some(hook) = &self.after_tracker_update {
+            hook();
+        }
+        feedback
+    }
+
+    fn overwrite(&mut self, peers: Map<C, Address>) -> commonware_actor::Feedback {
+        let mut state = self.state.lock();
+        for tracked in state.sets.values_mut() {
+            for (peer, address) in &peers {
+                if let Some(existing) = tracked.primary.get_value_mut(peer) {
+                    *existing = address.clone();
+                }
+                if let Some(existing) = tracked.secondary.get_value_mut(peer) {
+                    *existing = address.clone();
+                }
+            }
+        }
+        self.refresh_admission(&state);
+
+        let feedback = self.inner.overwrite(peers);
+        #[cfg(test)]
+        if let Some(hook) = &self.after_tracker_update {
+            hook();
+        }
+        feedback
+    }
+}
+
+impl<C: commonware_cryptography::PublicKey> Blocker for Oracle<C> {
+    type PublicKey = C;
+
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "facade forwards the Blocker implementation without adding a second log"
+    )]
+    fn block(&mut self, public_key: C) -> commonware_actor::Feedback {
+        self.inner.block(public_key)
+    }
+}
+
+/// Endpoint-generic lookup network that only establishes outbound connections.
+#[stability(ALPHA)]
+pub struct DialOnlyNetwork<R, C, D>
+where
+    R: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    D: Dialer,
+    D::Endpoint: PeerEndpoint,
+{
+    context: ContextCell<R>,
+    cfg: GenericConfig<C>,
+    dialer: D,
+    channels: Channels<C::PublicKey>,
+    tracker: tracker::Actor<R, C, D::Endpoint>,
+    tracker_mailbox: tracker::Mailbox<C::PublicKey, D::Endpoint>,
+    router: router::Actor<R, C::PublicKey>,
+    router_mailbox: router::Mailbox<C::PublicKey>,
+}
+
+#[stability(ALPHA)]
+impl<R, C, D> DialOnlyNetwork<R, C, D>
+where
+    R: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    D: Dialer,
+    D::Endpoint: PeerEndpoint,
+{
+    /// Creates a lookup network without requiring an inbound transport capability.
+    pub fn new(
+        context: R,
+        dialer: D,
+        cfg: GenericConfig<C>,
+    ) -> (Self, tracker::Oracle<C::PublicKey, D::Endpoint>) {
+        let (tracker, tracker_mailbox, oracle) = tracker::Actor::new(
+            context.child("tracker"),
+            tracker::Config {
+                crypto: cfg.stream.signing_key.clone(),
+                mailbox_size: cfg.mailbox_size,
+                tracked_peer_sets: cfg.tracked_peer_sets,
+                peer_connection_cooldown: cfg.peer_connection_cooldown,
+                block_duration: cfg.block_duration,
+            },
+        );
+        let (router, router_mailbox, messenger) = router::Actor::new(
+            context.child("router"),
+            router::Config {
+                mailbox_size: cfg.mailbox_size,
+            },
+        );
+        let channels = Channels::new(
+            messenger,
+            cfg.stream
+                .max_message_size
+                .saturating_sub(MAX_PAYLOAD_DATA_OVERHEAD),
+        );
+        (
+            Self {
+                context: ContextCell::new(context),
+                cfg,
+                dialer,
+                channels,
+                tracker,
+                tracker_mailbox,
+                router,
+                router_mailbox,
+            },
+            oracle,
+        )
+    }
+
+    /// Registers an application channel.
+    #[allow(clippy::type_complexity)]
+    pub fn register(
+        &mut self,
+        channel: Channel,
+        rate: Quota,
+        backlog: usize,
+    ) -> (
+        channels::Sender<C::PublicKey, R>,
+        channels::Receiver<C::PublicKey>,
+    ) {
+        let context = self
+            .context
+            .child("channel")
+            .with_attribute("index", channel);
+        self.channels.register(channel, rate, backlog, context)
+    }
+
+    /// Adds an explicitly supplied acceptor and inbound admission policy.
+    pub const fn accepting<A, I>(
+        self,
+        acceptor: A,
+        bind: A::Bind,
+        admission: I,
+        max_concurrent_handshakes: std::num::NonZeroU32,
+    ) -> AcceptingNetwork<R, C, D, A, I>
+    where
+        A: Acceptor<Connection = D::Connection>,
+        I: crate::authenticated::admission::InboundAdmission<
+                C::PublicKey,
+                <D::Connection as Connection>::Origin,
+            >,
+    {
+        AcceptingNetwork {
+            inner: self,
+            acceptor,
+            bind,
+            admission,
+            max_concurrent_handshakes,
+        }
+    }
+
+    /// Starts the dial-only network.
+    pub fn start(mut self) -> Handle<()> {
+        spawn_cell!(self.context, self.run())
+    }
+
+    async fn run(self) {
+        let mut tracker_task = self.tracker.start();
+        let mut router_task = self.router.start(self.channels);
+        let (spawner, spawner_mailbox) = spawner::Actor::new(
+            self.context.child("spawner"),
+            spawner::Config {
+                mailbox_size: self.cfg.mailbox_size,
+                send_batch_size: self.cfg.send_batch_size,
+                ping_frequency: self.cfg.ping_frequency,
+            },
+        );
+        let mut spawner_task = spawner.start(self.tracker_mailbox.clone(), self.router_mailbox);
+        let dialer = dialer::Actor::new(
+            self.context.child("dialer"),
+            self.dialer,
+            dialer::Config {
+                stream_cfg: self.cfg.stream,
+                dial_timeout: self.cfg.dial_timeout,
+                dial_frequency: self.cfg.dial_frequency,
+                peer_connection_cooldown: self.cfg.peer_connection_cooldown,
+            },
+        );
+        let mut dialer_task = dialer.start(self.tracker_mailbox, spawner_mailbox);
+        let mut shutdown = self.context.stopped();
+        select! {
+            _ = &mut shutdown => debug!("context shutdown, stopping dial-only network"),
+            result = &mut tracker_task => debug!(?result, "tracker stopped"),
+            result = &mut router_task => debug!(?result, "router stopped"),
+            result = &mut spawner_task => debug!(?result, "spawner stopped"),
+            result = &mut dialer_task => debug!(?result, "dialer stopped"),
+        }
+    }
+}
+
+/// Endpoint-generic lookup network with inbound and outbound transport capabilities.
+#[stability(ALPHA)]
+pub struct AcceptingNetwork<R, C, D, A, I>
+where
+    R: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    D: Dialer,
+    D::Endpoint: PeerEndpoint,
+    A: Acceptor<Connection = D::Connection>,
+    I: crate::authenticated::admission::InboundAdmission<
+            C::PublicKey,
+            <D::Connection as Connection>::Origin,
+        >,
+{
+    inner: DialOnlyNetwork<R, C, D>,
+    acceptor: A,
+    bind: A::Bind,
+    admission: I,
+    max_concurrent_handshakes: std::num::NonZeroU32,
+}
+
+#[stability(ALPHA)]
+impl<R, C, D, A, I> AcceptingNetwork<R, C, D, A, I>
+where
+    R: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    D: Dialer,
+    D::Endpoint: PeerEndpoint,
+    A: Acceptor<Connection = D::Connection>,
+    I: crate::authenticated::admission::InboundAdmission<
+            C::PublicKey,
+            <D::Connection as Connection>::Origin,
+        >,
+{
+    /// Registers an application channel.
+    #[allow(clippy::type_complexity)]
+    pub fn register(
+        &mut self,
+        channel: Channel,
+        rate: Quota,
+        backlog: usize,
+    ) -> (
+        channels::Sender<C::PublicKey, R>,
+        channels::Receiver<C::PublicKey>,
+    ) {
+        self.inner.register(channel, rate, backlog)
+    }
+
+    /// Starts the accepting network.
+    pub fn start(mut self) -> Handle<()> {
+        spawn_cell!(self.inner.context, self.run())
+    }
+
+    async fn run(self) {
+        let mut tracker_task = self.inner.tracker.start();
+        let mut router_task = self.inner.router.start(self.inner.channels);
+        let (spawner, spawner_mailbox) = spawner::Actor::new(
+            self.inner.context.child("spawner"),
+            spawner::Config {
+                mailbox_size: self.inner.cfg.mailbox_size,
+                send_batch_size: self.inner.cfg.send_batch_size,
+                ping_frequency: self.inner.cfg.ping_frequency,
+            },
+        );
+        let mut spawner_task = spawner.start(
+            self.inner.tracker_mailbox.clone(),
+            self.inner.router_mailbox,
+        );
+        let (attachment, attachments) = attachment::Actor::new(
+            self.inner.context.child("attachment"),
+            self.inner.cfg.stream.clone(),
+            self.admission,
+            self.inner.cfg.mailbox_size,
+            self.max_concurrent_handshakes,
+        );
+        let mut attachment_task =
+            attachment.start_listener(self.inner.tracker_mailbox.clone(), spawner_mailbox.clone());
+        let listener = listener::Actor::new(
+            self.inner.context.child("listener"),
+            self.acceptor,
+            listener::Config { bind: self.bind },
+        );
+        let mut listener_task = listener.start(attachments);
+        let dialer = dialer::Actor::new(
+            self.inner.context.child("dialer"),
+            self.inner.dialer,
+            dialer::Config {
+                stream_cfg: self.inner.cfg.stream,
+                dial_timeout: self.inner.cfg.dial_timeout,
+                dial_frequency: self.inner.cfg.dial_frequency,
+                peer_connection_cooldown: self.inner.cfg.peer_connection_cooldown,
+            },
+        );
+        let mut dialer_task = dialer.start(self.inner.tracker_mailbox, spawner_mailbox);
+        let mut shutdown = self.inner.context.stopped();
+        select! {
+            _ = &mut shutdown => debug!("context shutdown, stopping accepting network"),
+            result = &mut tracker_task => debug!(?result, "tracker stopped"),
+            result = &mut router_task => debug!(?result, "router stopped"),
+            result = &mut spawner_task => debug!(?result, "spawner stopped"),
+            result = &mut attachment_task => debug!(?result, "attachment stopped"),
+            result = &mut listener_task => debug!(?result, "listener stopped"),
+            result = &mut dialer_task => debug!(?result, "dialer stopped"),
+        }
+    }
+}
+
+/// Authenticated network whose transport connections are supplied explicitly.
+#[stability(ALPHA)]
+pub struct AttachmentNetwork<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+    A: crate::authenticated::admission::InboundAdmission<C::PublicKey, N::Origin>,
+> {
+    context: ContextCell<E>,
+    mailbox_size: std::num::NonZeroUsize,
+    send_batch_size: std::num::NonZeroUsize,
+    ping_frequency: std::time::Duration,
+    channels: Channels<C::PublicKey>,
+    tracker: tracker::Actor<E, C>,
+    tracker_mailbox: tracker::Mailbox<C::PublicKey>,
+    router: router::Actor<E, C::PublicKey>,
+    router_mailbox: router::Mailbox<C::PublicKey>,
+    attachment: attachment::Actor<E, C, N, A>,
+}
+
+#[stability(ALPHA)]
+impl<
+    E: Scheduler + BufferPooler + Clock + CryptoRng + Metrics,
+    C: Signer,
+    N: Connection,
+    A: crate::authenticated::admission::InboundAdmission<C::PublicKey, N::Origin>,
+> AttachmentNetwork<E, C, N, A>
+{
+    /// Creates a network and a handle for supplying transport connections.
+    #[allow(
+        clippy::type_complexity,
+        reason = "the network, reachability oracle, and attachment handle are its construction interface"
+    )]
+    pub fn new(
+        context: E,
+        cfg: AttachmentConfig<C, A>,
+    ) -> (
+        Self,
+        tracker::Oracle<C::PublicKey>,
+        crate::authenticated::attachment::Attachments<N, C::PublicKey, A>,
+    ) {
+        let (tracker, tracker_mailbox, oracle) = tracker::Actor::new(
+            context.child("tracker"),
+            tracker::Config {
+                crypto: cfg.stream.signing_key.clone(),
+                mailbox_size: cfg.mailbox_size,
+                tracked_peer_sets: cfg.tracked_peer_sets,
+                peer_connection_cooldown: cfg.peer_connection_cooldown,
+                block_duration: cfg.block_duration,
+            },
+        );
+        let (router, router_mailbox, messenger) = router::Actor::new(
+            context.child("router"),
+            router::Config {
+                mailbox_size: cfg.mailbox_size,
+            },
+        );
+        let channels = Channels::new(
+            messenger,
+            cfg.stream
+                .max_message_size
+                .saturating_sub(MAX_PAYLOAD_DATA_OVERHEAD),
+        );
+        let (attachment, attachments) = attachment::Actor::new(
+            context.child("attachment"),
+            cfg.stream.clone(),
+            cfg.admission,
+            cfg.mailbox_size,
+            cfg.max_concurrent_handshakes,
+        );
+
+        (
+            Self {
+                context: ContextCell::new(context),
+                mailbox_size: cfg.mailbox_size,
+                send_batch_size: cfg.send_batch_size,
+                ping_frequency: cfg.ping_frequency,
+                channels,
+                tracker,
+                tracker_mailbox,
+                router,
+                router_mailbox,
+                attachment,
+            },
+            oracle,
+            attachments,
+        )
+    }
+
+    /// Registers an application channel.
+    #[allow(clippy::type_complexity)]
+    pub fn register(
+        &mut self,
+        channel: Channel,
+        rate: Quota,
+        backlog: usize,
+    ) -> (
+        channels::Sender<C::PublicKey, E>,
+        channels::Receiver<C::PublicKey>,
+    ) {
+        let context = self
+            .context
+            .child("channel")
+            .with_attribute("index", channel);
+        self.channels.register(channel, rate, backlog, context)
+    }
+
+    /// Starts the tracker, router, peer spawner, and attachment actors.
+    pub fn start(mut self) -> Handle<()> {
+        spawn_cell!(self.context, self.run())
+    }
+
+    async fn run(self) {
+        let mut tracker_task = self.tracker.start();
+        let mut router_task = self.router.start(self.channels);
+        let (spawner, spawner_mailbox) = spawner::Actor::new(
+            self.context.child("spawner"),
+            spawner::Config {
+                mailbox_size: self.mailbox_size,
+                send_batch_size: self.send_batch_size,
+                ping_frequency: self.ping_frequency,
+            },
+        );
+        let mut spawner_task =
+            spawner.start(self.tracker_mailbox.clone(), self.router_mailbox.clone());
+        let mut attachment_task = self.attachment.start(self.tracker_mailbox, spawner_mailbox);
+        let mut shutdown = self.context.stopped();
+
+        info!("attachment network started");
+        select! {
+            _ = &mut shutdown => debug!("context shutdown, stopping network"),
+            tracker = &mut tracker_task => debug!(?tracker, "tracker stopped, shutting down network"),
+            router = &mut router_task => debug!(?router, "router stopped, shutting down network"),
+            spawner = &mut spawner_task => debug!(?spawner, "spawner stopped, shutting down network"),
+            attachment = &mut attachment_task => debug!(?attachment, "attachment actor stopped, shutting down network"),
+        }
+    }
+}
 
 /// Unique suffix for all messages signed in a stream.
 const STREAM_SUFFIX: &[u8] = b"_STREAM";
 
+pub(super) struct TcpDialer<D> {
+    inner: D,
+    selector: Mutex<StdRng>,
+    allow_private_ips: bool,
+    allow_dns: bool,
+}
+
+impl<D: CryptoRng> TcpDialer<D> {
+    pub(super) fn new(mut inner: D, allow_private_ips: bool, allow_dns: bool) -> Self {
+        let selector = Mutex::new(StdRng::from_rng(&mut inner));
+        Self {
+            inner,
+            selector,
+            allow_private_ips,
+            allow_dns,
+        }
+    }
+}
+
+impl<D> Dialer for TcpDialer<D>
+where
+    D: Dialer<Endpoint = TcpEndpoint> + Resolver + CryptoRng,
+{
+    type Endpoint = Ingress;
+    type Connection = D::Connection;
+
+    fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+        if !endpoint.is_valid(self.allow_private_ips, self.allow_dns) {
+            return false;
+        }
+        match endpoint {
+            Ingress::Socket(_) => self
+                .inner
+                .supports(&endpoint.tcp_endpoint(self.allow_private_ips)),
+            Ingress::Dns { .. } => true,
+        }
+    }
+
+    async fn dial(
+        &self,
+        endpoint: &Self::Endpoint,
+    ) -> Result<Self::Connection, commonware_runtime::Error> {
+        let addresses: Vec<_> = endpoint
+            .resolve_filtered(&self.inner, self.allow_private_ips)
+            .await
+            .map(Iterator::collect)
+            .unwrap_or_default();
+        let address = addresses
+            .choose(&mut *self.selector.lock())
+            .copied()
+            .ok_or(commonware_runtime::Error::ConnectionFailed)?;
+        self.inner.dial(&TcpEndpoint::Socket(address)).await
+    }
+}
+
 /// Implementation of an `authenticated` network.
-pub struct Network<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Metrics, C: Signer> {
+pub struct Network<
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + CryptoRng
+        + Resolver
+        + Acceptor<Bind = std::net::SocketAddr>
+        + Dialer<Endpoint = TcpEndpoint, Connection = <E as Acceptor>::Connection>
+        + Metrics,
+    C: Signer,
+> where
+    <E as Acceptor>::Connection: Connection<Origin = TcpOrigin>,
+{
     context: ContextCell<E>,
     cfg: Config<C>,
 
@@ -36,11 +642,22 @@ pub struct Network<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Me
     tracker_mailbox: tracker::Mailbox<C::PublicKey>,
     router: router::Actor<E, C::PublicKey>,
     router_mailbox: router::Mailbox<C::PublicKey>,
-    listener: listener::Updates,
+    admission: TcpAdmission<E, C::PublicKey>,
 }
 
-impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metrics, C: Signer>
-    Network<E, C>
+impl<
+    E: Spawner
+        + BufferPooler
+        + Clock
+        + CryptoRng
+        + Resolver
+        + Acceptor<Bind = std::net::SocketAddr>
+        + Dialer<Endpoint = TcpEndpoint, Connection = <E as Acceptor>::Connection>
+        + Metrics,
+    C: Signer,
+> Network<E, C>
+where
+    <E as Acceptor>::Connection: Connection<Origin = TcpOrigin>,
 {
     /// Create a new instance of an `authenticated` network.
     ///
@@ -52,22 +669,19 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
     ///
     /// * A tuple containing the network instance and the oracle that
     ///   can be used by a developer to configure which peers are authorized.
-    pub fn new(context: E, cfg: Config<C>) -> (Self, tracker::Oracle<C::PublicKey>) {
-        let (listener_mailbox, listener) = listener::Mailbox::new();
-        let (tracker, tracker_mailbox, oracle) = tracker::Actor::new(
-            context.child("tracker"),
-            tracker::Config {
-                crypto: cfg.crypto.clone(),
-                mailbox_size: cfg.mailbox_size,
-                tracked_peer_sets: cfg.tracked_peer_sets,
-                peer_connection_cooldown: cfg.peer_connection_cooldown,
-                allow_private_ips: cfg.allow_private_ips,
-                allow_dns: cfg.allow_dns,
-                bypass_ip_check: cfg.bypass_ip_check,
-                listener: listener_mailbox,
-                block_duration: cfg.block_duration,
-            },
-        );
+    pub fn new(context: E, cfg: Config<C>) -> (Self, Oracle<C::PublicKey>) {
+        let max_sets = cfg.tracked_peer_sets.get();
+        let (tracker, tracker_mailbox, tracker_oracle, eligibility) =
+            tracker::Actor::with_eligibility(
+                context.child("tracker"),
+                tracker::Config {
+                    crypto: cfg.crypto.clone(),
+                    mailbox_size: cfg.mailbox_size,
+                    tracked_peer_sets: cfg.tracked_peer_sets,
+                    peer_connection_cooldown: cfg.peer_connection_cooldown,
+                    block_duration: cfg.block_duration,
+                },
+            );
         let (router, router_mailbox, messenger) = router::Actor::new(
             context.child("router"),
             router::Config {
@@ -75,6 +689,26 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
             },
         );
         let channels = Channels::new(messenger, cfg.max_message_size);
+        let (admission, updates) = TcpAdmission::with_eligibility(
+            context.child("admission"),
+            TcpAdmissionConfig {
+                allow_private_ips: cfg.allow_private_ips,
+                require_registered_ip: !cfg.bypass_ip_check,
+                allowed_handshake_rate_per_ip: cfg.allowed_handshake_rate_per_ip,
+                allowed_handshake_rate_per_subnet: cfg.allowed_handshake_rate_per_subnet,
+            },
+            eligibility,
+        );
+        let oracle = Oracle {
+            inner: tracker_oracle,
+            updates,
+            state: Arc::new(Mutex::new(TcpOracleState {
+                sets: BTreeMap::new(),
+                max_sets,
+            })),
+            #[cfg(test)]
+            after_tracker_update: None,
+        };
 
         (
             Self {
@@ -86,7 +720,7 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
                 tracker_mailbox,
                 router,
                 router_mailbox,
-                listener,
+                admission,
             },
             oracle,
         )
@@ -148,7 +782,6 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
         let mut spawner_task =
             spawner.start(self.tracker_mailbox.clone(), self.router_mailbox.clone());
 
-        // Start listener
         let stream_cfg = StreamConfig {
             signing_key: self.cfg.crypto,
             namespace: union(&self.cfg.namespace, STREAM_SUFFIX),
@@ -160,31 +793,39 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
             max_handshake_age: self.cfg.max_handshake_age,
             handshake_timeout: self.cfg.handshake_timeout,
         };
+        let (attachment, attachments) = attachment::Actor::new(
+            self.context.child("attachment"),
+            stream_cfg.clone(),
+            self.admission,
+            self.cfg.mailbox_size,
+            self.cfg.max_concurrent_handshakes,
+        );
+        let mut attachment_task =
+            attachment.start_listener(self.tracker_mailbox.clone(), spawner_mailbox.clone());
+
+        // Start listener
         let listener = listener::Actor::new(
             self.context.child("listener"),
+            self.context.child("acceptor"),
             listener::Config {
-                address: self.cfg.listen,
-                stream_cfg: stream_cfg.clone(),
-                allow_private_ips: self.cfg.allow_private_ips,
-                bypass_ip_check: self.cfg.bypass_ip_check,
-                max_concurrent_handshakes: self.cfg.max_concurrent_handshakes,
-                allowed_handshake_rate_per_ip: self.cfg.allowed_handshake_rate_per_ip,
-                allowed_handshake_rate_per_subnet: self.cfg.allowed_handshake_rate_per_subnet,
+                bind: self.cfg.listen,
             },
-            self.listener,
         );
-        let mut listener_task =
-            listener.start(self.tracker_mailbox.clone(), spawner_mailbox.clone());
+        let mut listener_task = listener.start(attachments);
 
         // Start dialer
         let dialer = dialer::Actor::new(
             self.context.child("dialer"),
+            TcpDialer::new(
+                self.context.child("transport_dialer"),
+                self.cfg.allow_private_ips,
+                self.cfg.allow_dns,
+            ),
             dialer::Config {
                 stream_cfg,
                 dial_timeout: self.cfg.dial_timeout,
                 dial_frequency: self.cfg.dial_frequency,
                 peer_connection_cooldown: self.cfg.peer_connection_cooldown,
-                allow_private_ips: self.cfg.allow_private_ips,
             },
         );
         let mut dialer_task = dialer.start(self.tracker_mailbox, spawner_mailbox);
@@ -209,9 +850,291 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
             listener = &mut listener_task => {
                 debug!(?listener, "listener stopped, shutting down network");
             },
+            attachment = &mut attachment_task => {
+                debug!(?attachment, "attachment stopped, shutting down network");
+            },
             dialer = &mut dialer_task => {
                 debug!(?dialer, "dialer stopped, shutting down network");
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::authenticated::admission::{InboundAdmission, Rejection};
+    use commonware_cryptography::ed25519::{PrivateKey, PublicKey};
+    use commonware_runtime::{
+        ConnectionInfo, Resolver, Runner as _, Supervisor as _, deterministic,
+    };
+    use commonware_utils::{NZUsize, hostname, sync::Mutex as TestMutex};
+    use rand_core::{TryCryptoRng, TryRng};
+    use std::{
+        convert::Infallible,
+        net::{IpAddr, Ipv4Addr, SocketAddr},
+        sync::{Arc as StdArc, Barrier},
+        time::Duration,
+    };
+
+    struct RecordingTcpDialer {
+        context: deterministic::Context,
+        attempts: StdArc<TestMutex<Vec<TcpEndpoint>>>,
+    }
+
+    impl TryRng for RecordingTcpDialer {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            self.context.try_next_u32()
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            self.context.try_next_u64()
+        }
+
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+            self.context.try_fill_bytes(dest)
+        }
+    }
+
+    impl TryCryptoRng for RecordingTcpDialer {}
+
+    impl Resolver for RecordingTcpDialer {
+        async fn resolve(
+            &self,
+            _host: &str,
+        ) -> Result<Vec<IpAddr>, commonware_runtime::Error> {
+            Ok(vec![
+                Ipv4Addr::new(8, 8, 8, 8).into(),
+                Ipv4Addr::new(1, 1, 1, 1).into(),
+            ])
+        }
+    }
+
+    impl Dialer for RecordingTcpDialer {
+        type Endpoint = TcpEndpoint;
+        type Connection = <deterministic::Context as Dialer>::Connection;
+
+        async fn dial(
+            &self,
+            endpoint: &Self::Endpoint,
+        ) -> Result<Self::Connection, commonware_runtime::Error> {
+            self.attempts.lock().push(endpoint.clone());
+            Err(commonware_runtime::Error::ConnectionFailed)
+        }
+    }
+
+    fn connection_info(remote: SocketAddr) -> ConnectionInfo<TcpOrigin> {
+        ConnectionInfo {
+            origin: Some(TcpOrigin { remote }),
+            transport: "tcp",
+        }
+    }
+
+    async fn assert_origin_accepted<E>(
+        admission: &TcpAdmission<E, PublicKey>,
+        peer: &PublicKey,
+        remote: SocketAddr,
+    ) where
+        E: Clock + Metrics,
+    {
+        let info = connection_info(remote);
+        let permit = admission
+            .pre_auth(&info)
+            .expect("registered origin should begin authentication");
+        assert_eq!(admission.post_auth(permit, peer, &info).await, Ok(()));
+    }
+
+    fn assert_origin_rejected<E>(admission: &TcpAdmission<E, PublicKey>, remote: SocketAddr)
+    where
+        E: Clock + Metrics,
+    {
+        assert_eq!(
+            admission.pre_auth(&connection_info(remote)),
+            Err(Rejection::UnregisteredIp)
+        );
+    }
+
+    #[test]
+    fn tcp_dialer_selects_one_resolved_address_per_attempt() {
+        deterministic::Runner::default().start(|context| async move {
+            let attempts = StdArc::new(TestMutex::new(Vec::new()));
+            let transport = RecordingTcpDialer {
+                context: context.child("transport"),
+                attempts: attempts.clone(),
+            };
+            let dialer = TcpDialer::new(transport, false, true);
+            let endpoint = Ingress::Dns {
+                host: hostname!("example.com"),
+                port: 443,
+            };
+
+            assert!(matches!(
+                dialer.dial(&endpoint).await,
+                Err(commonware_runtime::Error::ConnectionFailed)
+            ));
+            let attempts = attempts.lock();
+            assert_eq!(attempts.len(), 1);
+            assert!(matches!(attempts[0], TcpEndpoint::Socket(_)));
+        });
+    }
+
+    #[test]
+    fn oracle_admission_uses_latest_address_across_retained_sets() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer = PrivateKey::from_seed(0);
+            let peer = PrivateKey::from_seed(1).public_key();
+            let listen = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+            let old_origin = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1000));
+            let new_origin = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 2), 1000));
+            let mut config = Config::test(signer, listen, 1024);
+            config.tracked_peer_sets = NZUsize!(2);
+
+            let (network, mut oracle) = Network::new(context.child("network"), config);
+            let tracker_mailbox = network.tracker_mailbox.clone();
+            network.tracker.start();
+            let old_set = Map::try_from([(peer.clone(), Address::from(old_origin))]).unwrap();
+            let new_set = Map::try_from([(peer.clone(), Address::from(new_origin))]).unwrap();
+            oracle.track(0, old_set);
+            oracle.track(1, new_set);
+            assert!(tracker_mailbox.acceptable(peer.clone()).await);
+
+            assert_origin_rejected(&network.admission, old_origin);
+            assert_origin_accepted(&network.admission, &peer, new_origin).await;
+        });
+    }
+
+    #[test]
+    fn oracle_updates_admission_before_publishing_tracker_changes() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer = PrivateKey::from_seed(3);
+            let peer = PrivateKey::from_seed(4).public_key();
+            let listen = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+            let old_origin = SocketAddr::from((Ipv4Addr::new(8, 8, 8, 8), 1000));
+            let new_origin = SocketAddr::from((Ipv4Addr::new(1, 1, 1, 1), 1000));
+            let config = Config::test(signer, listen, 1024);
+
+            let (network, mut oracle) = Network::new(context.child("network"), config);
+            let tracker_mailbox = network.tracker_mailbox.clone();
+            network.tracker.start();
+            oracle.track(
+                0,
+                Map::try_from([(peer.clone(), Address::from(old_origin))]).unwrap(),
+            );
+            assert!(tracker_mailbox.acceptable(peer.clone()).await);
+
+            let published = StdArc::new(Barrier::new(2));
+            let release = StdArc::new(Barrier::new(2));
+            oracle.after_tracker_update = Some(StdArc::new({
+                let published = published.clone();
+                let release = release.clone();
+                move || {
+                    published.wait();
+                    release.wait();
+                }
+            }));
+            let update = std::thread::spawn(move || {
+                oracle.overwrite(
+                    Map::try_from([(peer.clone(), Address::from(new_origin))]).unwrap(),
+                )
+            });
+
+            published.wait();
+            let reservation = tracker_mailbox
+                .listen(PrivateKey::from_seed(4).public_key())
+                .await;
+            let old_origin_result = network.admission.pre_auth(&connection_info(old_origin));
+            release.wait();
+            assert!(update.join().unwrap().accepted());
+
+            assert!(reservation.is_some());
+            assert_eq!(old_origin_result, Err(Rejection::UnregisteredIp));
+        });
+    }
+
+    #[test]
+    fn oracle_admission_prefers_primary_address_within_set() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer = PrivateKey::from_seed(0);
+            let peer = PrivateKey::from_seed(1).public_key();
+            let listen = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+            let primary_origin = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1000));
+            let secondary_origin = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 2), 1000));
+            let config = Config::test(signer, listen, 1024);
+
+            let primary =
+                Map::try_from([(peer.clone(), Address::from(primary_origin))]).unwrap();
+            let secondary =
+                Map::try_from([(peer.clone(), Address::from(secondary_origin))]).unwrap();
+            let (network, mut oracle) = Network::new(context.child("network"), config);
+            let tracker_mailbox = network.tracker_mailbox.clone();
+            network.tracker.start();
+            oracle.track(0, AddressableTrackedPeers::new(primary, secondary));
+            assert!(tracker_mailbox.acceptable(peer.clone()).await);
+
+            assert_origin_accepted(&network.admission, &peer, primary_origin).await;
+            assert_origin_rejected(&network.admission, secondary_origin);
+        });
+    }
+
+    #[test]
+    fn oracle_admission_removes_unique_origin_while_peer_is_blocked() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer = PrivateKey::from_seed(0);
+            let peer = PrivateKey::from_seed(1).public_key();
+            let listen = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+            let origin = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1000));
+            let mut config = Config::test(signer, listen, 1024);
+            config.block_duration = Duration::from_millis(100);
+            let block_duration = config.block_duration;
+
+            let (network, mut oracle) = Network::new(context.child("network"), config);
+            let tracker_mailbox = network.tracker_mailbox.clone();
+            network.tracker.start();
+            let peers = Map::try_from([(peer.clone(), Address::from(origin))]).unwrap();
+            oracle.track(0, peers);
+            assert!(tracker_mailbox.acceptable(peer.clone()).await);
+            assert_origin_accepted(&network.admission, &peer, origin).await;
+
+            crate::block_peer(&mut oracle, peer.clone());
+            assert!(!tracker_mailbox.acceptable(peer.clone()).await);
+            assert_origin_rejected(&network.admission, origin);
+
+            context
+                .sleep(block_duration + Duration::from_millis(1))
+                .await;
+            assert!(tracker_mailbox.acceptable(peer.clone()).await);
+            assert_origin_accepted(&network.admission, &peer, origin).await;
+        });
+    }
+
+    #[test]
+    fn oracle_admission_keeps_origin_shared_with_unblocked_peer() {
+        deterministic::Runner::default().start(|context| async move {
+            let signer = PrivateKey::from_seed(0);
+            let blocked_peer = PrivateKey::from_seed(1).public_key();
+            let eligible_peer = PrivateKey::from_seed(2).public_key();
+            let listen = SocketAddr::from((Ipv4Addr::LOCALHOST, 0));
+            let origin = SocketAddr::from((Ipv4Addr::new(192, 0, 2, 1), 1000));
+            let config = Config::test(signer, listen, 1024);
+
+            let (network, mut oracle) = Network::new(context.child("network"), config);
+            let tracker_mailbox = network.tracker_mailbox.clone();
+            network.tracker.start();
+            let peers = Map::try_from([
+                (blocked_peer.clone(), Address::from(origin)),
+                (eligible_peer.clone(), Address::from(origin)),
+            ])
+            .unwrap();
+            oracle.track(0, peers);
+            assert!(tracker_mailbox.acceptable(blocked_peer.clone()).await);
+            assert!(tracker_mailbox.acceptable(eligible_peer.clone()).await);
+
+            crate::block_peer(&mut oracle, blocked_peer.clone());
+            assert!(!tracker_mailbox.acceptable(blocked_peer).await);
+            assert!(tracker_mailbox.acceptable(eligible_peer.clone()).await);
+            assert_origin_accepted(&network.admission, &eligible_peer, origin).await;
+        });
     }
 }

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -7,6 +7,8 @@
 //! [lookup] operates under the assumption that peer addresses are known in advance,
 //! and that they can be looked up by their identifiers.
 
+mod admission;
+mod attachment;
 mod channels;
 mod data;
 pub(crate) mod dialing;

--- a/p2p/src/authenticated/relay.rs
+++ b/p2p/src/authenticated/relay.rs
@@ -4,6 +4,7 @@ use commonware_actor::{
 };
 use commonware_macros::select;
 use commonware_runtime::Metrics;
+use commonware_utils::PlatformSend;
 use std::{collections::VecDeque, num::NonZeroUsize};
 
 pub(crate) struct Message<T>(T);
@@ -14,7 +15,7 @@ impl<T> Message<T> {
     }
 }
 
-impl<T> UnreliablePolicy for Message<T> {
+impl<T: PlatformSend> UnreliablePolicy for Message<T> {
     type Overflow = VecDeque<Self>;
 
     fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
@@ -22,18 +23,18 @@ impl<T> UnreliablePolicy for Message<T> {
     }
 }
 
-pub(crate) struct Receivers<T> {
+pub(crate) struct Receivers<T: PlatformSend> {
     pub(crate) low: mailbox::UnreliableReceiver<Message<T>>,
     pub(crate) high: mailbox::UnreliableReceiver<Message<T>>,
 }
 
 #[derive(Clone, Debug)]
-pub struct Relay<T> {
+pub struct Relay<T: PlatformSend> {
     low: mailbox::UnreliableSender<Message<T>>,
     high: mailbox::UnreliableSender<Message<T>>,
 }
 
-impl<T> Relay<T> {
+impl<T: PlatformSend> Relay<T> {
     /// Creates a prioritized relay backed by bounded low and high priority mailboxes.
     pub fn new(metrics: impl Metrics, size: NonZeroUsize) -> (Self, Receivers<T>) {
         let (low_sender, low_receiver) = mailbox::new_unreliable(metrics.child("low"), size);
@@ -71,7 +72,7 @@ pub enum Prioritized<C, D> {
 }
 
 /// Awaits a message from control, high, or low priority receivers.
-pub async fn recv_prioritized<C: UnreliablePolicy, D>(
+pub async fn recv_prioritized<C: UnreliablePolicy, D: PlatformSend>(
     control: &mut mailbox::UnreliableReceiver<C>,
     high: &mut mailbox::UnreliableReceiver<Message<D>>,
     low: &mut mailbox::UnreliableReceiver<Message<D>>,
@@ -88,7 +89,9 @@ pub async fn recv_prioritized<C: UnreliablePolicy, D>(
 }
 
 /// Attempts to receive one data message from a relay receiver.
-pub(crate) fn try_recv<T>(receiver: &mut mailbox::UnreliableReceiver<Message<T>>) -> Option<T> {
+pub(crate) fn try_recv<T: PlatformSend>(
+    receiver: &mut mailbox::UnreliableReceiver<Message<T>>,
+) -> Option<T> {
     receiver.try_recv().ok().map(Message::into_inner)
 }
 

--- a/p2p/src/authenticated/router/actor.rs
+++ b/p2p/src/authenticated/router/actor.rs
@@ -9,14 +9,14 @@ use crate::{
 use commonware_actor::mailbox;
 use commonware_cryptography::PublicKey;
 use commonware_macros::select_loop;
-use commonware_runtime::{BufferPooler, ContextCell, Handle, Metrics, Spawner, spawn_cell};
+use commonware_runtime::{BufferPooler, ContextCell, Handle, Metrics, Scheduler, spawn_cell};
 use commonware_utils::channel::ring;
 use futures::Sink;
 use std::{collections::BTreeMap, pin::Pin};
 use tracing::debug;
 
 /// Router actor that manages peer connections and routing messages.
-pub struct Actor<E: Spawner + BufferPooler + Metrics, P: PublicKey> {
+pub struct Actor<E: Scheduler + BufferPooler + Metrics, P: PublicKey> {
     context: ContextCell<E>,
 
     control: mailbox::UnreliableReceiver<Message<P>>,
@@ -24,7 +24,7 @@ pub struct Actor<E: Spawner + BufferPooler + Metrics, P: PublicKey> {
     open_subscriptions: Vec<ring::Sender<Vec<P>>>,
 }
 
-impl<E: Spawner + BufferPooler + Metrics, P: PublicKey> Actor<E, P> {
+impl<E: Scheduler + BufferPooler + Metrics, P: PublicKey> Actor<E, P> {
     /// Returns a new [Actor] along with a [Mailbox] and [Messenger]
     /// that can be used to send messages to the router.
     pub fn new(context: E, cfg: Config) -> (Self, Mailbox<P>, Messenger<P>) {

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -9,7 +9,11 @@
     html_favicon_url = "https://commonware.xyz/favicon.ico"
 )]
 
-use commonware_macros::{stability_mod, stability_scope};
+#[allow(
+    unused_imports,
+    reason = "stability is only used by APIs below the selected stability level"
+)]
+use commonware_macros::{stability, stability_mod, stability_scope};
 
 stability_mod!(ALPHA, pub mod simulated);
 
@@ -18,16 +22,26 @@ stability_scope!(BETA {
     use commonware_cryptography::PublicKey;
     use commonware_runtime::{IoBuf, IoBufs};
     use commonware_utils::{
+        PlatformSend, PlatformSync,
         channel::mpsc,
         ordered::{Map, Set},
     };
     use std::{error::Error as StdError, fmt::Debug, future::Future, time::SystemTime};
 
     pub mod authenticated;
+    mod reachability;
     pub mod types;
     pub mod utils;
 
     pub use types::{Address, Ingress};
+    #[stability(ALPHA)]
+    pub use reachability::{
+        Advertisement, PeerEndpoint, Reachability, ReachabilityManager, ReachableTrackedPeers,
+    };
+    #[cfg(commonware_stability_BETA)]
+    pub(crate) use reachability::{
+        Advertisement, PeerEndpoint, Reachability, ReachableTrackedPeers,
+    };
 
     /// Tuple representing a message received from a given public key.
     ///
@@ -47,7 +61,7 @@ stability_scope!(BETA {
     }
 
     /// Interface for sending messages to a set of recipients without rate-limiting restrictions.
-    pub trait UnlimitedSender: Clone + Send + Sync + 'static {
+    pub trait UnlimitedSender: Clone + PlatformSend + PlatformSync + 'static {
         /// Public key type used to identify recipients.
         type PublicKey: PublicKey;
 
@@ -67,19 +81,19 @@ stability_scope!(BETA {
         fn send(
             &mut self,
             recipients: Recipients<Self::PublicKey>,
-            message: impl Into<IoBufs> + Send,
+            message: impl Into<IoBufs> + PlatformSend,
             priority: bool,
         ) -> Unreliable<Feedback>;
     }
 
     /// Interface for constructing a [`CheckedSender`] from a set of [`Recipients`],
     /// filtering out any that are currently rate-limited.
-    pub trait LimitedSender: Clone + Send + Sync + 'static {
+    pub trait LimitedSender: Clone + PlatformSend + PlatformSync + 'static {
         /// Public key type used to identify recipients.
         type PublicKey: PublicKey;
 
         /// The type of [`CheckedSender`] returned after checking recipients.
-        type Checked<'a>: CheckedSender<PublicKey = Self::PublicKey> + Send
+        type Checked<'a>: CheckedSender<PublicKey = Self::PublicKey> + PlatformSend
         where
             Self: 'a;
 
@@ -103,7 +117,7 @@ stability_scope!(BETA {
     }
 
     /// Interface for sending messages to [`Recipients`] that are not currently rate-limited.
-    pub trait CheckedSender: Send {
+    pub trait CheckedSender: PlatformSend {
         /// Public key type used to identify [`Recipients`].
         type PublicKey: PublicKey;
 
@@ -123,7 +137,11 @@ stability_scope!(BETA {
         /// Feedback from submitting the message for delivery.
         /// [`Unreliable`] indicates that local submission may be rejected under backpressure.
         /// [`Feedback::accepted`] does not guarantee that the recipient will receive the message.
-        fn send(self, message: impl Into<IoBufs> + Send, priority: bool) -> Unreliable<Feedback>;
+        fn send(
+            self,
+            message: impl Into<IoBufs> + PlatformSend,
+            priority: bool,
+        ) -> Unreliable<Feedback>;
     }
 
     /// Interface for sending messages to a set of recipients.
@@ -149,7 +167,7 @@ stability_scope!(BETA {
         fn send(
             &mut self,
             recipients: Recipients<Self::PublicKey>,
-            message: impl Into<IoBufs> + Send,
+            message: impl Into<IoBufs> + PlatformSend,
             priority: bool,
         ) -> Vec<Self::PublicKey> {
             self.check(recipients).map_or_else(
@@ -171,9 +189,9 @@ stability_scope!(BETA {
     impl<S: LimitedSender> Sender for S {}
 
     /// Interface for receiving messages from arbitrary recipients.
-    pub trait Receiver: Debug + Send + 'static {
+    pub trait Receiver: Debug + PlatformSend + 'static {
         /// Error that can occur when receiving a message.
-        type Error: Debug + StdError + Send + Sync;
+        type Error: Debug + StdError + PlatformSend + PlatformSync;
 
         /// Public key type used to identify recipients.
         type PublicKey: PublicKey;
@@ -181,7 +199,7 @@ stability_scope!(BETA {
         /// Receive a message from an arbitrary recipient.
         fn recv(
             &mut self,
-        ) -> impl Future<Output = Result<Message<Self::PublicKey>, Self::Error>> + Send;
+        ) -> impl Future<Output = Result<Message<Self::PublicKey>, Self::Error>> + PlatformSend;
     }
 
     /// Notification sent to subscribers when a peer set changes.
@@ -266,7 +284,7 @@ stability_scope!(BETA {
     }
 
     /// Interface for reading peer set information.
-    pub trait Provider: Debug + Clone + Send + 'static {
+    pub trait Provider: Debug + Clone + PlatformSend + 'static {
         /// Public key type used to identify peers.
         type PublicKey: PublicKey;
 
@@ -274,7 +292,7 @@ stability_scope!(BETA {
         fn peer_set(
             &mut self,
             id: u64,
-        ) -> impl Future<Output = Option<TrackedPeers<Self::PublicKey>>> + Send;
+        ) -> impl Future<Output = Option<TrackedPeers<Self::PublicKey>>> + PlatformSend;
 
         /// Subscribe to notifications when new peer sets are added.
         ///
@@ -284,7 +302,7 @@ stability_scope!(BETA {
         /// across tracked sets with the same rule (secondary excludes keys present as primary).
         fn subscribe(
             &mut self,
-        ) -> impl Future<Output = PeerSetSubscription<Self::PublicKey>> + Send;
+        ) -> impl Future<Output = PeerSetSubscription<Self::PublicKey>> + PlatformSend;
     }
 
     /// Interface for managing peer set membership (where peer addresses are not known).
@@ -315,7 +333,7 @@ stability_scope!(BETA {
         /// often both gossiping data to them and answering requests from them).
         fn track<R>(&mut self, id: u64, peers: R) -> Feedback
         where
-            R: Into<TrackedPeers<Self::PublicKey>> + Send;
+            R: Into<TrackedPeers<Self::PublicKey>> + PlatformSend;
     }
 
     /// Interface for managing peer set membership (where peer addresses are known).
@@ -347,7 +365,7 @@ stability_scope!(BETA {
         /// often both gossiping data to them and answering requests from them).
         fn track<R>(&mut self, id: u64, peers: R) -> Feedback
         where
-            R: Into<AddressableTrackedPeers<Self::PublicKey>> + Send;
+            R: Into<AddressableTrackedPeers<Self::PublicKey>> + PlatformSend;
 
         /// Update addresses for multiple peers without creating a new peer set.
         ///
@@ -359,7 +377,7 @@ stability_scope!(BETA {
     }
 
     /// Interface for blocking other peers.
-    pub trait Blocker: Clone + Send + 'static {
+    pub trait Blocker: Clone + PlatformSend + 'static {
         /// Public key type used to identify peers.
         type PublicKey: PublicKey;
 

--- a/p2p/src/reachability.rs
+++ b/p2p/src/reachability.rs
@@ -1,0 +1,292 @@
+//! Transport-neutral peer reachability.
+
+#[stability(ALPHA)]
+use crate::Provider;
+#[stability(ALPHA)]
+use commonware_actor::Feedback;
+use commonware_codec::{
+    EncodeSize, Error as CodecError, FixedSize, Read, ReadExt, Write, config::RangeCfg,
+};
+use commonware_cryptography::PublicKey;
+use commonware_macros::stability;
+use commonware_runtime::{Buf, BufMut};
+use commonware_utils::{
+    PlatformSend, PlatformSync,
+    ordered::Map,
+};
+use std::{collections::HashSet, fmt::Debug, hash::Hash};
+
+const DIALABLE_PREFIX: u8 = 0;
+const OUTBOUND_ONLY_PREFIX: u8 = 1;
+
+/// An endpoint that can be advertised to and dialed by peers.
+///
+/// Endpoint codecs are intentionally not part of this trait. Protocols that exchange endpoints
+/// add the codec bounds required by their wire format.
+pub trait PeerEndpoint: Clone + Debug + Eq + Hash + PlatformSend + PlatformSync + 'static {}
+
+/// An ordered, non-empty list of unique endpoints.
+///
+/// Earlier entries are preferred when attempting to reach a peer. At most
+/// [`MAX_ENDPOINTS`](Self::MAX_ENDPOINTS) endpoints may be advertised.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Advertisement<E: PeerEndpoint> {
+    endpoints: Vec<E>,
+}
+
+impl<E: PeerEndpoint> Advertisement<E> {
+    /// Maximum number of endpoints in an advertisement.
+    pub const MAX_ENDPOINTS: usize = 8;
+
+    /// Maximum encoded size of one endpoint.
+    pub const MAX_ENDPOINT_SIZE: usize = 2_048;
+
+    /// Maximum encoded size of an advertisement, including its length prefix.
+    pub const MAX_SIZE: usize = 8_192;
+
+    /// Creates an advertisement, preserving the order of `endpoints`.
+    ///
+    /// Returns an error if no endpoints are supplied, the maximum is exceeded, or an endpoint
+    /// occurs more than once.
+    pub fn new(endpoints: Vec<E>) -> Result<Self, CodecError> {
+        if endpoints.is_empty() || endpoints.len() > Self::MAX_ENDPOINTS {
+            return Err(CodecError::InvalidLength(endpoints.len()));
+        }
+
+        let mut unique = HashSet::with_capacity(endpoints.len());
+        if endpoints.iter().any(|endpoint| !unique.insert(endpoint)) {
+            return Err(CodecError::Invalid("Advertisement", "duplicate endpoint"));
+        }
+
+        Ok(Self { endpoints })
+    }
+
+    /// Returns endpoints in dialing preference order.
+    pub fn endpoints(&self) -> &[E] {
+        &self.endpoints
+    }
+
+    /// Consumes the advertisement and returns endpoints in dialing preference order.
+    #[stability(ALPHA)]
+    pub fn into_endpoints(self) -> Vec<E> {
+        self.endpoints
+    }
+}
+
+#[stability(ALPHA)]
+impl<E: PeerEndpoint + EncodeSize> Advertisement<E> {
+    /// Creates an advertisement and validates its encoded size.
+    ///
+    /// In addition to the identity checks performed by [`new`](Self::new), this rejects endpoints
+    /// and advertisements that exceed their encoded-size limits.
+    pub fn new_encoded(endpoints: Vec<E>) -> Result<Self, CodecError> {
+        let advertisement = Self::new(endpoints)?;
+        advertisement.validate_encoded()?;
+        Ok(advertisement)
+    }
+
+    /// Validates the encoded size of this advertisement and each of its endpoints.
+    pub fn validate_encoded(&self) -> Result<(), CodecError> {
+        if self
+            .endpoints
+            .iter()
+            .any(|endpoint| endpoint.encode_size() > Self::MAX_ENDPOINT_SIZE)
+        {
+            return Err(CodecError::Invalid(
+                "Advertisement",
+                "endpoint exceeds maximum encoded size",
+            ));
+        }
+
+        if self.encode_size() > Self::MAX_SIZE {
+            return Err(CodecError::Invalid(
+                "Advertisement",
+                "advertisement exceeds maximum encoded size",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl<E: PeerEndpoint + Write> Write for Advertisement<E> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.endpoints.write(buf);
+    }
+}
+
+impl<E: PeerEndpoint + EncodeSize> EncodeSize for Advertisement<E> {
+    fn encode_size(&self) -> usize {
+        self.endpoints.encode_size()
+    }
+}
+
+impl<E: PeerEndpoint + Read<Cfg = ()>> Read for Advertisement<E> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, CodecError> {
+        let advertisement_start = buf.remaining();
+        let len = usize::read_cfg(buf, &RangeCfg::new(1..=Self::MAX_ENDPOINTS))?;
+        let mut endpoints = Vec::with_capacity(len);
+
+        for _ in 0..len {
+            let endpoint_start = buf.remaining();
+            let endpoint = E::read(&mut (&mut *buf).take(Self::MAX_ENDPOINT_SIZE))?;
+            let endpoint_size = endpoint_start - buf.remaining();
+            if endpoint_size > Self::MAX_ENDPOINT_SIZE {
+                return Err(CodecError::Invalid(
+                    "Advertisement",
+                    "endpoint exceeds maximum encoded size",
+                ));
+            }
+
+            if advertisement_start - buf.remaining() > Self::MAX_SIZE {
+                return Err(CodecError::Invalid(
+                    "Advertisement",
+                    "advertisement exceeds maximum encoded size",
+                ));
+            }
+
+            endpoints.push(endpoint);
+        }
+
+        Self::new(endpoints)
+    }
+}
+
+/// Whether and how a peer can be reached.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Reachability<E: PeerEndpoint> {
+    /// The peer can be dialed using the advertised endpoints.
+    Dialable(Advertisement<E>),
+    /// The peer cannot be dialed and must establish outbound connections to participate.
+    OutboundOnly,
+}
+
+impl<E: PeerEndpoint + Write> Write for Reachability<E> {
+    fn write(&self, buf: &mut impl BufMut) {
+        match self {
+            Self::Dialable(advertisement) => {
+                DIALABLE_PREFIX.write(buf);
+                advertisement.write(buf);
+            }
+            Self::OutboundOnly => OUTBOUND_ONLY_PREFIX.write(buf),
+        }
+    }
+}
+
+impl<E: PeerEndpoint + EncodeSize> EncodeSize for Reachability<E> {
+    fn encode_size(&self) -> usize {
+        u8::SIZE
+            + match self {
+                Self::Dialable(advertisement) => advertisement.encode_size(),
+                Self::OutboundOnly => 0,
+            }
+    }
+}
+
+impl<E: PeerEndpoint + Read<Cfg = ()>> Read for Reachability<E> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, CodecError> {
+        match u8::read(buf)? {
+            DIALABLE_PREFIX => Ok(Self::Dialable(Advertisement::<E>::read(buf)?)),
+            OUTBOUND_ONLY_PREFIX => Ok(Self::OutboundOnly),
+            other => Err(CodecError::InvalidEnum(other)),
+        }
+    }
+}
+
+/// Primary and secondary peers with transport-neutral reachability information.
+///
+/// The same public key may appear in both maps. Tracking deduplicates overlapping keys, storing
+/// them as primary only.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReachableTrackedPeers<P: PublicKey, E: PeerEndpoint> {
+    /// Reachability for peers eligible for primary-only policies.
+    pub primary: Map<P, Reachability<E>>,
+    /// Reachability for peers eligible for secondary-only policies.
+    pub secondary: Map<P, Reachability<E>>,
+}
+
+impl<P: PublicKey, E: PeerEndpoint> ReachableTrackedPeers<P, E> {
+    /// Creates a tracked peer set with primary and secondary peers.
+    pub const fn new(
+        primary: Map<P, Reachability<E>>,
+        secondary: Map<P, Reachability<E>>,
+    ) -> Self {
+        Self { primary, secondary }
+    }
+
+    /// Creates a tracked peer set containing only primary peers.
+    pub fn primary(primary: Map<P, Reachability<E>>) -> Self {
+        Self::new(primary, Map::default())
+    }
+}
+
+impl<P: PublicKey, E: PeerEndpoint> From<Map<P, Reachability<E>>>
+    for ReachableTrackedPeers<P, E>
+{
+    fn from(primary: Map<P, Reachability<E>>) -> Self {
+        Self::primary(primary)
+    }
+}
+
+/// Interface for managing peers with transport-neutral reachability information.
+///
+/// Implementations use [`Reachability::Dialable`] advertisements to connect to peers and retain
+/// [`Reachability::OutboundOnly`] peers without attempting to dial them.
+#[stability(ALPHA)]
+pub trait ReachabilityManager: Provider {
+    /// Endpoint type understood by the network transport.
+    type Endpoint: PeerEndpoint;
+
+    /// Tracks primary and secondary peers with the given ID.
+    ///
+    /// IDs must increase monotonically. The highest ID is the active peer set, which implementations
+    /// use to decide which connections to maintain. Peers present in both maps are stored as primary
+    /// only.
+    fn track<R>(&mut self, id: u64, peers: R) -> Feedback
+    where
+        R: Into<ReachableTrackedPeers<Self::PublicKey, Self::Endpoint>> + PlatformSend;
+
+    /// Updates reachability for tracked peers without creating a new peer set.
+    ///
+    /// Implementations should discard connections made using stale reachability information and
+    /// apply the new information to future connection attempts.
+    fn overwrite(
+        &mut self,
+        peers: Map<Self::PublicKey, Reachability<Self::Endpoint>>,
+    ) -> Feedback;
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, E> arbitrary::Arbitrary<'a> for Advertisement<E>
+where
+    E: PeerEndpoint + arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let len = u.int_in_range(1..=Self::MAX_ENDPOINTS)?;
+        let mut endpoints = Vec::with_capacity(len);
+
+        for _ in 0..len {
+            endpoints.push(E::arbitrary(u)?);
+        }
+
+        Self::new(endpoints).map_err(|_| arbitrary::Error::IncorrectFormat)
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, E> arbitrary::Arbitrary<'a> for Reachability<E>
+where
+    E: PeerEndpoint + arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        if u.arbitrary::<bool>()? {
+            return Ok(Self::OutboundOnly);
+        }
+
+        Ok(Self::Dialable(u.arbitrary::<Advertisement<E>>()?))
+    }
+}

--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -6,6 +6,7 @@ use commonware_actor::Feedback;
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, IoBuf, Quota};
 use commonware_utils::{
+    PlatformSend,
     channel::{fallible::FallibleExt, mpsc, oneshot, ring},
     ordered::Map,
 };
@@ -120,8 +121,8 @@ async fn request<P, E, R, F>(
 where
     P: PublicKey,
     E: Clock,
-    R: Send,
-    F: FnOnce(oneshot::Sender<R>) -> Message<P, E> + Send,
+    R: PlatformSend,
+    F: FnOnce(oneshot::Sender<R>) -> Message<P, E> + PlatformSend,
 {
     sender.request(make_msg).await
 }
@@ -334,7 +335,7 @@ impl<P: PublicKey, E: Clock> crate::Provider for Manager<P, E> {
 impl<P: PublicKey, E: Clock> crate::Manager for Manager<P, E> {
     fn track<R>(&mut self, id: u64, peers: R) -> Feedback
     where
-        R: Into<TrackedPeers<Self::PublicKey>> + Send,
+        R: Into<TrackedPeers<Self::PublicKey>> + PlatformSend,
     {
         self.oracle.track(id, peers.into())
     }
@@ -383,7 +384,7 @@ impl<P: PublicKey, E: Clock> crate::Provider for SocketManager<P, E> {
 impl<P: PublicKey, E: Clock> crate::AddressableManager for SocketManager<P, E> {
     fn track<R>(&mut self, id: u64, peers: R) -> Feedback
     where
-        R: Into<AddressableTrackedPeers<Self::PublicKey>> + Send,
+        R: Into<AddressableTrackedPeers<Self::PublicKey>> + PlatformSend,
     {
         // Ignore all addresses (simulated network doesn't use them)
         let peers = peers.into();

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -61,7 +61,7 @@
 //! ```rust
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{ed25519, PrivateKey, Signer as _, PublicKey as _, };
-//! use commonware_runtime::{deterministic, Metrics, Quota, Runner, Spawner, Supervisor};
+//! use commonware_runtime::{deterministic, Metrics, Quota, Runner, Scheduler, Supervisor};
 //! use commonware_utils::{NZU32, NZUsize};
 //! use std::time::Duration;
 //!
@@ -192,7 +192,7 @@ mod tests {
     };
     use commonware_macros::{select, test_group};
     use commonware_runtime::{
-        Clock, IoBuf, Quota, Runner, Spawner, Supervisor as _, deterministic, reschedule,
+        Clock, IoBuf, Quota, Runner, Scheduler as _, Supervisor as _, deterministic, reschedule,
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -19,13 +19,13 @@ use commonware_codec::{DecodeExt, FixedSize};
 use commonware_cryptography::PublicKey;
 use commonware_macros::select_loop;
 use commonware_runtime::{
-    Clock, ContextCell, Handle, IoBuf, IoBufs, Listener as _, Metrics, Network as RNetwork, Quota,
-    Spawner, spawn_cell,
+    Acceptor, Clock, Connection, ContextCell, Dialer, Handle, IoBuf, IoBufs, Listener as _,
+    Metrics, Quota, Spawner, TcpEndpoint, spawn_cell,
     telemetry::metrics::{CounterFamily, MetricsExt as _},
 };
 use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_utils::{
-    NZUsize, TryCollect,
+    NZUsize, PlatformSend, PlatformSync, TryCollect,
     channel::{fallible::FallibleExt, mpsc, oneshot, ring},
     ordered::Set,
 };
@@ -83,14 +83,18 @@ pub enum SplitOrigin {
 
 /// A function that forwards messages from [SplitOrigin] to [Recipients].
 pub trait SplitForwarder<P: PublicKey>:
-    Fn(SplitOrigin, &Recipients<P>, &IoBuf) -> Option<Recipients<P>> + Send + Sync + Clone + 'static
+    Fn(SplitOrigin, &Recipients<P>, &IoBuf) -> Option<Recipients<P>>
+    + PlatformSend
+    + PlatformSync
+    + Clone
+    + 'static
 {
 }
 
 impl<P: PublicKey, F> SplitForwarder<P> for F where
     F: Fn(SplitOrigin, &Recipients<P>, &IoBuf) -> Option<Recipients<P>>
-        + Send
-        + Sync
+        + PlatformSend
+        + PlatformSync
         + Clone
         + 'static
 {
@@ -98,12 +102,12 @@ impl<P: PublicKey, F> SplitForwarder<P> for F where
 
 /// A function that routes incoming [NetworkMessage]s to a [SplitTarget].
 pub trait SplitRouter<P: PublicKey>:
-    Fn(&NetworkMessage<P>) -> SplitTarget + Send + Sync + 'static
+    Fn(&NetworkMessage<P>) -> SplitTarget + PlatformSend + PlatformSync + 'static
 {
 }
 
 impl<P: PublicKey, F> SplitRouter<P> for F where
-    F: Fn(&NetworkMessage<P>) -> SplitTarget + Send + Sync + 'static
+    F: Fn(&NetworkMessage<P>) -> SplitTarget + PlatformSend + PlatformSync + 'static
 {
 }
 
@@ -132,7 +136,15 @@ pub struct Config {
 }
 
 /// Implementation of a simulated network.
-pub struct Network<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> {
+pub struct Network<
+    E: Acceptor<Bind = SocketAddr, Connection: Connection>
+        + Dialer<Endpoint = TcpEndpoint, Connection: Connection>
+        + Spawner
+        + Rng
+        + Clock
+        + Metrics,
+    P: PublicKey,
+> {
     context: ContextCell<E>,
 
     // Maximum size of a message that can be sent over the network
@@ -185,7 +197,16 @@ pub struct Network<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> 
     sent_messages: CounterFamily<metrics::Message>,
 }
 
-impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> {
+impl<
+    E: Acceptor<Bind = SocketAddr, Connection: Connection>
+        + Dialer<Endpoint = TcpEndpoint, Connection: Connection>
+        + Spawner
+        + Rng
+        + Clock
+        + Metrics,
+    P: PublicKey,
+> Network<E, P>
+{
     /// Create a new simulated network with a given runtime and configuration.
     ///
     /// Returns a tuple containing the network instance and the oracle that can
@@ -667,7 +688,16 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
     }
 }
 
-impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> {
+impl<
+    E: Acceptor<Bind = SocketAddr, Connection: Connection>
+        + Dialer<Endpoint = TcpEndpoint, Connection: Connection>
+        + Spawner
+        + Rng
+        + Clock
+        + Metrics,
+    P: PublicKey,
+> Network<E, P>
+{
     /// Process completions from the transmitter.
     fn process_completions(&mut self, completions: Vec<Completion<P>>) {
         for completion in completions {
@@ -957,7 +987,7 @@ impl<P: PublicKey, E: Clock> crate::UnlimitedSender for UnlimitedSender<P, E> {
     fn send(
         &mut self,
         recipients: Recipients<P>,
-        message: impl Into<IoBufs> + Send,
+        message: impl Into<IoBufs> + PlatformSend,
         priority: bool,
     ) -> Unreliable<Feedback> {
         let message = message.into().coalesce();
@@ -1140,7 +1170,11 @@ impl<'a, P: PublicKey, E: Clock, F: SplitForwarder<P>> crate::CheckedSender
         crate::CheckedSender::recipients(&self.checked)
     }
 
-    fn send(self, message: impl Into<IoBufs> + Send, priority: bool) -> Unreliable<Feedback> {
+    fn send(
+        self,
+        message: impl Into<IoBufs> + PlatformSend,
+        priority: bool,
+    ) -> Unreliable<Feedback> {
         // Convert to IoBuf here since forwarder needs to inspect the message
         let message = message.into().coalesce();
 
@@ -1252,7 +1286,12 @@ impl<P: PublicKey> Peer<P> {
     ///
     /// The peer will listen for incoming connections on the given `socket` address.
     /// `max_size` is the maximum size of a message that can be sent to the peer.
-    async fn new<E: Spawner + RNetwork + Metrics + Clock>(
+    async fn new<
+        E: Spawner
+            + Acceptor<Bind = SocketAddr, Connection: Connection>
+            + Metrics
+            + Clock,
+    >(
         context: E,
         public_key: P,
         socket: SocketAddr,
@@ -1313,11 +1352,13 @@ impl<P: PublicKey> Peer<P> {
         let (ready_tx, ready_rx) = oneshot::channel();
         context.child("listener").spawn(move |context| async move {
             // Initialize listener
-            let mut listener = context.bind(socket).await.unwrap();
+            let mut listener = context.bind(&socket).await.unwrap();
             let _ = ready_tx.send(());
 
             // Continually accept new connections
-            while let Ok((_, _, mut stream)) = listener.accept().await {
+            while let Ok(connection) = listener.accept().await {
+                let (_, mut stream, _) = connection.split();
+
                 // New connection accepted. Spawn a task for this connection
                 context.child("receiver").spawn({
                     let inbox_sender = inbox_sender.clone();
@@ -1393,7 +1434,13 @@ struct Link {
 /// Buffered payload waiting for earlier messages on the same link to complete.
 impl Link {
     #[allow(clippy::too_many_arguments)]
-    fn new<E: Spawner + RNetwork + Clock + Metrics, P: PublicKey>(
+    fn new<
+        E: Spawner
+            + Dialer<Endpoint = TcpEndpoint, Connection: Connection>
+            + Clock
+            + Metrics,
+        P: PublicKey,
+    >(
         context: &mut E,
         dialer: P,
         receiver: P,
@@ -1408,7 +1455,9 @@ impl Link {
         let (inbox, mut outbox) = mpsc::unbounded_channel::<(Channel, IoBuf, SystemTime)>();
         context.child("link").spawn(move |context| async move {
             // Dial the peer and handshake by sending it the dialer's public key
-            let (mut sink, _) = context.dial(socket).await.unwrap();
+            let endpoint = TcpEndpoint::Socket(socket);
+            let connection = context.dial(&endpoint).await.unwrap();
+            let (mut sink, _, _) = connection.split();
             if let Err(err) = send_frame(&mut sink, dialer.as_ref().to_vec(), max_size).await {
                 error!(?err, "failed to send public key to listener");
                 return;

--- a/p2p/src/types.rs
+++ b/p2p/src/types.rs
@@ -1,7 +1,10 @@
 //! Shared address types for p2p networking.
 
+#[stability(ALPHA)]
+pub use crate::reachability::{Advertisement, PeerEndpoint, Reachability};
 use commonware_codec::{EncodeSize, Error as CodecError, FixedSize, Read, ReadExt, Write};
-use commonware_runtime::{Buf, BufMut, Error as RuntimeError, Resolver};
+use commonware_macros::stability;
+use commonware_runtime::{Buf, BufMut, Error as RuntimeError, Resolver, TcpEndpoint};
 use commonware_utils::{Hostname, IpAddrExt};
 use std::net::{IpAddr, SocketAddr};
 
@@ -12,7 +15,7 @@ const ADDRESS_SYMMETRIC_PREFIX: u8 = 0;
 const ADDRESS_ASYMMETRIC_PREFIX: u8 = 1;
 
 /// What we dial to connect to a peer.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Ingress {
     /// IP-based ingress address.
     Socket(SocketAddr),
@@ -24,6 +27,8 @@ pub enum Ingress {
         port: u16,
     },
 }
+
+impl crate::reachability::PeerEndpoint for Ingress {}
 
 impl Ingress {
     /// Returns the port number for this ingress address.
@@ -47,47 +52,60 @@ impl Ingress {
     /// - `Socket` addresses must have a global IP (or `allow_private_ips` must be true).
     /// - `Dns` addresses are allowed only if `allow_dns` is `true`.
     ///
-    /// Note: For `Dns` addresses, private IP checks are performed after resolution in
-    /// [`resolve_filtered`](Self::resolve_filtered).
+    /// For `Dns` addresses, the TCP transport checks resolved addresses before connecting.
     pub fn is_valid(&self, allow_private_ips: bool, allow_dns: bool) -> bool {
         match self {
             Self::Socket(addr) => allow_private_ips || IpAddrExt::is_global(&addr.ip()),
             Self::Dns { .. } => allow_dns,
         }
     }
+}
 
-    /// Resolve this ingress address to socket addresses.
-    ///
-    /// For `Socket` variants, returns a single-element iterator.
-    /// For `Dns` variants, performs DNS resolution and returns all resolved addresses.
+impl Ingress {
+    /// Resolves this ingress address to socket addresses.
     pub async fn resolve(
         &self,
         resolver: &impl Resolver,
     ) -> Result<impl Iterator<Item = SocketAddr>, RuntimeError> {
         match self {
-            Self::Socket(addr) => Ok(vec![*addr].into_iter()),
+            Self::Socket(address) => Ok(vec![*address].into_iter()),
             Self::Dns { host, port } => {
-                let ips = resolver.resolve(host.as_str()).await?;
-                if ips.is_empty() {
+                let addresses = resolver.resolve(host.as_str()).await?;
+                if addresses.is_empty() {
                     return Err(RuntimeError::ResolveFailed(host.to_string()));
                 }
-                Ok(ips
+                Ok(addresses
                     .into_iter()
-                    .map(move |ip| SocketAddr::new(ip, *port))
+                    .map(|ip| SocketAddr::new(ip, *port))
                     .collect::<Vec<_>>()
                     .into_iter())
             }
         }
     }
 
-    /// [`resolve`](Self::resolve) and filter by private IP policy.
+    /// Resolves this ingress and filters addresses according to the private-IP policy.
     pub async fn resolve_filtered(
         &self,
         resolver: &impl Resolver,
         allow_private_ips: bool,
     ) -> Option<impl Iterator<Item = SocketAddr>> {
-        let addrs = self.resolve(resolver).await.ok()?;
-        Some(addrs.filter(move |addr| allow_private_ips || IpAddrExt::is_global(&addr.ip())))
+        let addresses = self.resolve(resolver).await.ok()?;
+        Some(
+            addresses
+                .filter(move |address| allow_private_ips || IpAddrExt::is_global(&address.ip())),
+        )
+    }
+
+    /// Converts this advertised ingress into a TCP dial attempt.
+    pub(crate) fn tcp_endpoint(&self, allow_private_ips: bool) -> TcpEndpoint {
+        match self {
+            Self::Socket(address) => TcpEndpoint::Socket(*address),
+            Self::Dns { host, port } => TcpEndpoint::Dns {
+                host: host.to_string(),
+                port: *port,
+                allow_private_ips,
+            },
+        }
     }
 }
 
@@ -267,10 +285,212 @@ impl arbitrary::Arbitrary<'_> for Address {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_codec::{DecodeExt, Encode};
-    use commonware_runtime::IoBuf;
+    use commonware_codec::{DecodeExt, Encode, config::RangeCfg};
+    use commonware_runtime::{IoBuf, Runner as _, deterministic};
     use commonware_utils::hostname;
-    use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::{
+        net::{Ipv4Addr, Ipv6Addr},
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct TestEndpoint(Vec<u8>);
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct IdentityOnlyEndpoint(u8);
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct RemainingEndpoint;
+
+    #[cfg(feature = "arbitrary")]
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    struct SingletonEndpoint;
+
+    static ENDPOINT_REMAINING: AtomicUsize = AtomicUsize::new(usize::MAX);
+
+    #[cfg(feature = "arbitrary")]
+    static SINGLETON_ENDPOINT_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    #[cfg(feature = "arbitrary")]
+    const SINGLETON_ENDPOINT_CALL_LIMIT: usize = 32;
+
+    impl PeerEndpoint for IdentityOnlyEndpoint {}
+
+    impl PeerEndpoint for RemainingEndpoint {}
+
+    impl Read for RemainingEndpoint {
+        type Cfg = ();
+
+        fn read_cfg(buf: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, CodecError> {
+            ENDPOINT_REMAINING.store(buf.remaining(), Ordering::Relaxed);
+            Ok(Self)
+        }
+    }
+
+    #[cfg(feature = "arbitrary")]
+    impl PeerEndpoint for SingletonEndpoint {}
+
+    #[cfg(feature = "arbitrary")]
+    impl arbitrary::Arbitrary<'_> for SingletonEndpoint {
+        fn arbitrary(_u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+            let calls = SINGLETON_ENDPOINT_CALLS.fetch_add(1, Ordering::Relaxed);
+            if calls >= SINGLETON_ENDPOINT_CALL_LIMIT {
+                return Err(arbitrary::Error::NotEnoughData);
+            }
+
+            Ok(Self)
+        }
+    }
+
+    impl Write for TestEndpoint {
+        fn write(&self, buf: &mut impl BufMut) {
+            self.0.write(buf);
+        }
+    }
+
+    impl EncodeSize for TestEndpoint {
+        fn encode_size(&self) -> usize {
+            self.0.encode_size()
+        }
+    }
+
+    impl Read for TestEndpoint {
+        type Cfg = ();
+
+        fn read_cfg(buf: &mut impl Buf, _cfg: &Self::Cfg) -> Result<Self, CodecError> {
+            Vec::<u8>::read_cfg(buf, &(RangeCfg::new(..), ())).map(Self)
+        }
+    }
+
+    impl PeerEndpoint for TestEndpoint {}
+
+    fn assert_invalid_advertisement(endpoints: Vec<TestEndpoint>) {
+        assert!(Advertisement::new(endpoints.clone()).is_err());
+        assert!(Advertisement::<TestEndpoint>::decode(endpoints.encode()).is_err());
+    }
+
+    fn assert_invalid_encoded_advertisement(endpoints: Vec<TestEndpoint>) {
+        let advertisement = Advertisement::new(endpoints.clone()).unwrap();
+        assert!(advertisement.validate_encoded().is_err());
+        assert!(Advertisement::new_encoded(endpoints.clone()).is_err());
+        assert!(Advertisement::<TestEndpoint>::decode(endpoints.encode()).is_err());
+    }
+
+    #[test]
+    fn test_advertisement_does_not_require_endpoint_codec() {
+        let advertisement =
+            Advertisement::new(vec![IdentityOnlyEndpoint(1), IdentityOnlyEndpoint(2)]).unwrap();
+
+        assert_eq!(
+            advertisement.endpoints(),
+            &[IdentityOnlyEndpoint(1), IdentityOnlyEndpoint(2)]
+        );
+    }
+
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn test_advertisement_arbitrary_rejects_insufficient_unique_endpoints() {
+        use arbitrary::Arbitrary;
+
+        SINGLETON_ENDPOINT_CALLS.store(0, Ordering::Relaxed);
+        // Select two endpoints, leaving no input for the endpoint generator to consume.
+        let mut input = arbitrary::Unstructured::new(&[1]);
+
+        let result = Advertisement::<SingletonEndpoint>::arbitrary(&mut input);
+
+        assert_eq!(result, Err(arbitrary::Error::IncorrectFormat));
+        assert!(SINGLETON_ENDPOINT_CALLS.load(Ordering::Relaxed) < SINGLETON_ENDPOINT_CALL_LIMIT);
+    }
+
+    #[test]
+    fn test_advertisement_roundtrip_preserves_preference() {
+        let preferred = Ingress::Socket(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080));
+        let fallback = Ingress::Dns {
+            host: hostname!("fallback.example.com"),
+            port: 443,
+        };
+        let advertisement = Advertisement::new(vec![preferred.clone(), fallback.clone()]).unwrap();
+
+        let decoded = Advertisement::<Ingress>::decode(advertisement.encode()).unwrap();
+        assert_eq!(decoded.endpoints(), &[preferred, fallback]);
+        assert_eq!(decoded, advertisement);
+    }
+
+    #[test]
+    fn test_advertisement_rejects_invalid_endpoints() {
+        assert_invalid_advertisement(Vec::new());
+        assert_invalid_advertisement(vec![TestEndpoint(vec![0]); 2]);
+        assert_invalid_advertisement(
+            (0..=Advertisement::<TestEndpoint>::MAX_ENDPOINTS)
+                .map(|value| TestEndpoint(vec![value as u8]))
+                .collect(),
+        );
+    }
+
+    #[test]
+    fn test_advertisement_rejects_oversized_encoded_endpoint() {
+        let endpoint = TestEndpoint(vec![0; Advertisement::<TestEndpoint>::MAX_ENDPOINT_SIZE]);
+        assert!(endpoint.encode_size() > Advertisement::<TestEndpoint>::MAX_ENDPOINT_SIZE);
+
+        assert_invalid_encoded_advertisement(vec![endpoint]);
+    }
+
+    #[test]
+    fn test_advertisement_limits_endpoint_decoder_input() {
+        let mut payload = 1usize.encode().to_vec();
+        payload.resize(
+            payload.len() + Advertisement::<RemainingEndpoint>::MAX_ENDPOINT_SIZE + 1,
+            0,
+        );
+
+        let _ = Advertisement::<RemainingEndpoint>::decode(payload.as_slice());
+
+        let remaining = ENDPOINT_REMAINING.load(Ordering::Relaxed);
+        assert!(
+            remaining <= Advertisement::<RemainingEndpoint>::MAX_ENDPOINT_SIZE,
+            "endpoint decoder saw {remaining} bytes, maximum is {}",
+            Advertisement::<RemainingEndpoint>::MAX_ENDPOINT_SIZE,
+        );
+    }
+
+    #[test]
+    fn test_advertisement_rejects_oversized_encoded_payload() {
+        let endpoints = (0..5)
+            .map(|value| {
+                let mut bytes = vec![0; 2_045];
+                bytes[0] = value;
+                TestEndpoint(bytes)
+            })
+            .collect::<Vec<_>>();
+        assert!(endpoints.iter().all(|endpoint| {
+            endpoint.encode_size() <= Advertisement::<TestEndpoint>::MAX_ENDPOINT_SIZE
+        }));
+        assert!(endpoints.encode_size() > Advertisement::<TestEndpoint>::MAX_SIZE);
+
+        assert_invalid_encoded_advertisement(endpoints);
+    }
+
+    #[test]
+    fn test_reachability_roundtrip() {
+        let endpoint = Ingress::Socket(SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 8080));
+        let cases = [
+            Reachability::Dialable(Advertisement::new(vec![endpoint]).unwrap()),
+            Reachability::OutboundOnly,
+        ];
+
+        for reachability in cases {
+            let decoded = Reachability::<Ingress>::decode(reachability.encode()).unwrap();
+            assert_eq!(decoded, reachability);
+        }
+    }
+
+    #[test]
+    fn test_reachability_rejects_invalid_prefix() {
+        assert!(matches!(
+            Reachability::<Ingress>::decode([2].as_slice()),
+            Err(CodecError::InvalidEnum(2))
+        ));
+    }
 
     #[test]
     fn test_ingress_socket_roundtrip() {
@@ -460,6 +680,32 @@ mod tests {
         assert!(dns.is_valid(true, true));
     }
 
+    #[test]
+    fn test_ingress_resolve_compatibility() {
+        deterministic::Runner::default().start(|context| async move {
+            let public = IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8));
+            let private = IpAddr::V4(Ipv4Addr::LOCALHOST);
+            context.resolver_register("example.com", Some(vec![public, private]));
+            let ingress = Ingress::Dns {
+                host: hostname!("example.com"),
+                port: 443,
+            };
+
+            let resolved = ingress.resolve(&context).await.unwrap().collect::<Vec<_>>();
+            assert_eq!(
+                resolved,
+                vec![SocketAddr::new(public, 443), SocketAddr::new(private, 443)]
+            );
+
+            let filtered = ingress
+                .resolve_filtered(&context, false)
+                .await
+                .unwrap()
+                .collect::<Vec<_>>();
+            assert_eq!(filtered, vec![SocketAddr::new(public, 443)]);
+        });
+    }
+
     #[cfg(feature = "arbitrary")]
     mod conformance {
         use super::*;
@@ -468,6 +714,8 @@ mod tests {
         commonware_conformance::conformance_tests! {
             CodecConformance<Ingress>,
             CodecConformance<Address>,
+            CodecConformance<Advertisement<Ingress>>,
+            CodecConformance<Reachability<Ingress>>,
         }
     }
 }

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -1,16 +1,26 @@
 //! Codec wrapper for [Sender] and [Receiver].
 
-use crate::{Blocker, CheckedSender, Receiver, Recipients, Sender};
-use commonware_actor::{Feedback, Unreliable, mailbox};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::Blocker;
+use crate::{CheckedSender, Receiver, Recipients, Sender};
+#[cfg(not(target_arch = "wasm32"))]
+use commonware_actor::mailbox;
+use commonware_actor::{Feedback, Unreliable};
 use commonware_codec::{Codec, Error};
+#[cfg(not(target_arch = "wasm32"))]
 use commonware_cryptography::PublicKey;
+#[cfg(not(target_arch = "wasm32"))]
 use commonware_macros::select_loop;
+#[cfg(not(target_arch = "wasm32"))]
 use commonware_parallel::Strategy;
-use commonware_runtime::{
-    BufferPool, ContextCell, Handle, Metrics, Spawner, iobuf::EncodeExt, spawn_cell,
-};
-use commonware_utils::futures::Pool;
-use std::{collections::VecDeque, num::NonZeroUsize, time::SystemTime};
+use commonware_runtime::{BufferPool, iobuf::EncodeExt};
+#[cfg(not(target_arch = "wasm32"))]
+use commonware_runtime::{ContextCell, Handle, Metrics, Spawner, spawn_cell};
+#[cfg(not(target_arch = "wasm32"))]
+use commonware_utils::{PlatformSend, futures::Pool};
+use std::time::SystemTime;
+#[cfg(not(target_arch = "wasm32"))]
+use std::{collections::VecDeque, num::NonZeroUsize};
 
 /// Wrap a [Sender] and [Receiver] with some [Codec].
 pub const fn wrap<S: Sender, R: Receiver, V: Codec>(
@@ -141,9 +151,11 @@ impl<R: Receiver, V: Codec> WrappedReceiver<R, V> {
 /// reading more bytes. Successfully decoded messages are forwarded through a bounded mailbox; if
 /// the consumer falls behind and the mailbox fills, additional decoded messages are dropped (they
 /// would likely no longer be useful by the time we get back to them).
+#[cfg(not(target_arch = "wasm32"))]
 struct Decoded<P: PublicKey, V>(P, V);
 
-impl<P: PublicKey, V> mailbox::UnreliablePolicy for Decoded<P, V> {
+#[cfg(not(target_arch = "wasm32"))]
+impl<P: PublicKey, V: PlatformSend> mailbox::UnreliablePolicy for Decoded<P, V> {
     type Overflow = VecDeque<Self>;
 
     fn handle(_overflow: &mut Self::Overflow, _message: Self) -> bool {
@@ -152,11 +164,13 @@ impl<P: PublicKey, V> mailbox::UnreliablePolicy for Decoded<P, V> {
 }
 
 /// Receiver half for successfully decoded messages from a [`WrappedBackgroundReceiver`].
-pub struct BackgroundReceiver<P: PublicKey, V> {
+#[cfg(not(target_arch = "wasm32"))]
+pub struct BackgroundReceiver<P: PublicKey, V: PlatformSend> {
     receiver: mailbox::UnreliableReceiver<Decoded<P, V>>,
 }
 
-impl<P: PublicKey, V> BackgroundReceiver<P, V> {
+#[cfg(not(target_arch = "wasm32"))]
+impl<P: PublicKey, V: PlatformSend> BackgroundReceiver<P, V> {
     /// Receive the next successfully decoded message.
     pub async fn recv(&mut self) -> Option<(P, V)> {
         self.receiver
@@ -166,13 +180,14 @@ impl<P: PublicKey, V> BackgroundReceiver<P, V> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub struct WrappedBackgroundReceiver<E, P, B, R, V, T>
 where
     E: Spawner,
     P: PublicKey,
     B: Blocker<PublicKey = P>,
     R: Receiver<PublicKey = P>,
-    V: Codec + Send,
+    V: Codec + PlatformSend,
     T: Strategy,
 {
     context: ContextCell<E>,
@@ -183,13 +198,14 @@ where
     strategy: T,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<E, P, B, R, V, T> WrappedBackgroundReceiver<E, P, B, R, V, T>
 where
     E: Spawner + Metrics,
     P: PublicKey,
     B: Blocker<PublicKey = P>,
     R: Receiver<PublicKey = P>,
-    V: Codec + Send + 'static,
+    V: Codec + PlatformSend + 'static,
     T: Strategy,
 {
     /// Create a new [`WrappedBackgroundReceiver`].

--- a/p2p/src/utils/limited.rs
+++ b/p2p/src/utils/limited.rs
@@ -4,12 +4,12 @@ use crate::{Recipients, UnlimitedSender};
 use commonware_actor::{Feedback, Unreliable};
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, IoBufs, KeyedRateLimiter, Quota};
-use commonware_utils::{channel::ring, sync::Mutex};
+use commonware_utils::{PlatformSend, PlatformSync, channel::ring, sync::Mutex};
 use futures::{FutureExt, StreamExt};
 use std::{cmp, fmt, sync::Arc, time::SystemTime};
 
 /// Provides peer snapshots for resolving [`Recipients::All`].
-pub trait Connected: Clone + Send + Sync + 'static {
+pub trait Connected: Clone + PlatformSend + PlatformSync + 'static {
     type PublicKey: PublicKey;
 
     /// Return the current peer snapshot.
@@ -210,7 +210,11 @@ impl<'a, S: UnlimitedSender> crate::CheckedSender for CheckedSender<'a, S> {
         }
     }
 
-    fn send(self, message: impl Into<IoBufs> + Send, priority: bool) -> Unreliable<Feedback> {
+    fn send(
+        self,
+        message: impl Into<IoBufs> + PlatformSend,
+        priority: bool,
+    ) -> Unreliable<Feedback> {
         self.sender.send(self.recipients, message, priority)
     }
 }
@@ -258,7 +262,7 @@ mod tests {
         fn send(
             &mut self,
             recipients: Recipients<Self::PublicKey>,
-            message: impl Into<IoBufs> + Send,
+            message: impl Into<IoBufs> + PlatformSend,
             priority: bool,
         ) -> Unreliable<Feedback> {
             let message = message.into().coalesce();

--- a/p2p/src/utils/mocks/mod.rs
+++ b/p2p/src/utils/mocks/mod.rs
@@ -7,6 +7,7 @@ use commonware_runtime::{
     IoBuf, IoBufs, Metrics as RuntimeMetrics, Name, Supervisor,
     telemetry::metrics::{Metric, Registered, Registration},
 };
+use commonware_utils::PlatformSend;
 use core::future;
 use std::{convert::Infallible, marker::PhantomData, sync::Arc, time::SystemTime};
 
@@ -92,7 +93,7 @@ impl<P: PublicKey> CheckedSender for InertCheckedSender<P> {
         self.recipients.clone()
     }
 
-    fn send(self, _: impl Into<IoBufs> + Send, _: bool) -> Unreliable<Feedback> {
+    fn send(self, _: impl Into<IoBufs> + PlatformSend, _: bool) -> Unreliable<Feedback> {
         Unreliable::new(Feedback::Ok)
     }
 }
@@ -153,7 +154,11 @@ mod tests {
             vec![self.peer.clone()]
         }
 
-        fn send(self, _message: impl Into<IoBufs> + Send, _priority: bool) -> Unreliable<Feedback> {
+        fn send(
+            self,
+            _message: impl Into<IoBufs> + PlatformSend,
+            _priority: bool,
+        ) -> Unreliable<Feedback> {
             Unreliable::Rejected
         }
     }

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -12,11 +12,14 @@ use crate::{Channel, CheckedSender, LimitedSender, Message, Receiver, Recipients
 use commonware_actor::{Feedback, Unreliable};
 use commonware_codec::{Encode, Error as CodecError, ReadExt, varint::UInt};
 use commonware_macros::select_loop;
-use commonware_runtime::{ContextCell, Handle, IoBuf, IoBufs, Spawner, spawn_cell};
-use commonware_utils::channel::{
-    fallible::FallibleExt,
-    mpsc::{self, error::TrySendError},
-    oneshot,
+use commonware_runtime::{ContextCell, Handle, IoBuf, IoBufs, Scheduler, spawn_cell};
+use commonware_utils::{
+    PlatformSend,
+    channel::{
+        fallible::FallibleExt,
+        mpsc::{self, error::TrySendError},
+        oneshot,
+    },
 };
 use std::{collections::HashMap, fmt::Debug, time::SystemTime};
 use thiserror::Error;
@@ -58,7 +61,7 @@ type Routes<P> = HashMap<Channel, mpsc::Sender<Message<P>>>;
 type BackupResponse<P> = (Channel, Message<P>);
 
 /// A multiplexer of p2p channels into subchannels.
-pub struct Muxer<E: Spawner, S: Sender, R: Receiver> {
+pub struct Muxer<E: Scheduler, S: Sender, R: Receiver> {
     context: ContextCell<E>,
     sender: S,
     receiver: R,
@@ -68,7 +71,7 @@ pub struct Muxer<E: Spawner, S: Sender, R: Receiver> {
     backup: Option<mpsc::Sender<BackupResponse<R::PublicKey>>>,
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> Muxer<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> Muxer<E, S, R> {
     /// Create a multiplexed wrapper around a [Sender] and [Receiver] pair, and return a ([Muxer],
     /// [MuxHandle]) pair that can be used to register routes dynamically.
     pub fn new(context: E, sender: S, receiver: R, mailbox_size: usize) -> (Self, MuxHandle<S, R>) {
@@ -299,7 +302,7 @@ impl<S: Sender> GlobalSender<S> {
         &mut self,
         subchannel: Channel,
         recipients: Recipients<S::PublicKey>,
-        payload: impl Into<IoBufs> + Send,
+        payload: impl Into<IoBufs> + PlatformSend,
         priority: bool,
     ) -> Unreliable<Feedback> {
         self.check(recipients).map_or_else(
@@ -347,7 +350,11 @@ impl<'a, S: Sender> CheckedSender for CheckedGlobalSender<'a, S> {
         self.inner.recipients()
     }
 
-    fn send(self, message: impl Into<IoBufs> + Send, priority: bool) -> Unreliable<Feedback> {
+    fn send(
+        self,
+        message: impl Into<IoBufs> + PlatformSend,
+        priority: bool,
+    ) -> Unreliable<Feedback> {
         let subchannel = UInt(self.subchannel.expect("subchannel not set"));
         let mut message = message.into();
         message.prepend(subchannel.encode().into());
@@ -365,12 +372,12 @@ pub trait Builder {
 }
 
 /// A builder that constructs a [Muxer].
-pub struct MuxerBuilder<E: Spawner, S: Sender, R: Receiver> {
+pub struct MuxerBuilder<E: Scheduler, S: Sender, R: Receiver> {
     mux: Muxer<E, S, R>,
     mux_handle: MuxHandle<S, R>,
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilder<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> Builder for MuxerBuilder<E, S, R> {
     type Output = (Muxer<E, S, R>, MuxHandle<S, R>);
 
     fn build(self) -> Self::Output {
@@ -378,7 +385,7 @@ impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilder<E, S, R> {
     }
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilder<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> MuxerBuilder<E, S, R> {
     /// Registers a backup channel with the muxer.
     pub fn with_backup(mut self) -> MuxerBuilderWithBackup<E, S, R> {
         let (tx, rx) = mpsc::channel(self.mux.mailbox_size);
@@ -404,13 +411,13 @@ impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilder<E, S, R> {
 }
 
 /// A builder that constructs a [Muxer] with a backup channel.
-pub struct MuxerBuilderWithBackup<E: Spawner, S: Sender, R: Receiver> {
+pub struct MuxerBuilderWithBackup<E: Scheduler, S: Sender, R: Receiver> {
     mux: Muxer<E, S, R>,
     mux_handle: MuxHandle<S, R>,
     backup_rx: mpsc::Receiver<BackupResponse<R::PublicKey>>,
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilderWithBackup<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> MuxerBuilderWithBackup<E, S, R> {
     /// Registers a global sender with the muxer.
     pub fn with_global_sender(self) -> MuxerBuilderAllOpts<E, S, R> {
         let global_sender = GlobalSender::new(self.mux.sender.clone());
@@ -424,7 +431,7 @@ impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilderWithBackup<E, S, R> {
     }
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderWithBackup<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> Builder for MuxerBuilderWithBackup<E, S, R> {
     type Output = (
         Muxer<E, S, R>,
         MuxHandle<S, R>,
@@ -437,13 +444,13 @@ impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderWithBackup<E, S
 }
 
 /// A builder that constructs a [Muxer] with a [GlobalSender].
-pub struct MuxerBuilderWithGlobalSender<E: Spawner, S: Sender, R: Receiver> {
+pub struct MuxerBuilderWithGlobalSender<E: Scheduler, S: Sender, R: Receiver> {
     mux: Muxer<E, S, R>,
     mux_handle: MuxHandle<S, R>,
     global_sender: GlobalSender<S>,
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilderWithGlobalSender<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> MuxerBuilderWithGlobalSender<E, S, R> {
     /// Registers a backup channel with the muxer.
     pub fn with_backup(mut self) -> MuxerBuilderAllOpts<E, S, R> {
         let (tx, rx) = mpsc::channel(self.mux.mailbox_size);
@@ -458,7 +465,7 @@ impl<E: Spawner, S: Sender, R: Receiver> MuxerBuilderWithGlobalSender<E, S, R> {
     }
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderWithGlobalSender<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> Builder for MuxerBuilderWithGlobalSender<E, S, R> {
     type Output = (Muxer<E, S, R>, MuxHandle<S, R>, GlobalSender<S>);
 
     fn build(self) -> Self::Output {
@@ -467,14 +474,14 @@ impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderWithGlobalSende
 }
 
 /// A builder that constructs a [Muxer] with a [GlobalSender] and backup channel.
-pub struct MuxerBuilderAllOpts<E: Spawner, S: Sender, R: Receiver> {
+pub struct MuxerBuilderAllOpts<E: Scheduler, S: Sender, R: Receiver> {
     mux: Muxer<E, S, R>,
     mux_handle: MuxHandle<S, R>,
     backup_rx: mpsc::Receiver<BackupResponse<R::PublicKey>>,
     global_sender: GlobalSender<S>,
 }
 
-impl<E: Spawner, S: Sender, R: Receiver> Builder for MuxerBuilderAllOpts<E, S, R> {
+impl<E: Scheduler, S: Sender, R: Receiver> Builder for MuxerBuilderAllOpts<E, S, R> {
     type Output = (
         Muxer<E, S, R>,
         MuxHandle<S, R>,
@@ -680,7 +687,7 @@ mod tests {
             unreachable!("rate-limited sender should not produce a checked sender");
         }
 
-        fn send(self, _: impl Into<IoBufs> + Send, _: bool) -> Unreliable<Feedback> {
+        fn send(self, _: impl Into<IoBufs> + PlatformSend, _: bool) -> Unreliable<Feedback> {
             unreachable!("rate-limited sender should not send");
         }
     }

--- a/resolver/src/ingress.rs
+++ b/resolver/src/ingress.rs
@@ -5,14 +5,14 @@
 
 use crate::Fetch;
 use commonware_actor::mailbox::{Overflow, Policy};
-use commonware_utils::vec::NonEmptyVec;
+use commonware_utils::{PlatformSend, vec::NonEmptyVec};
 use std::collections::VecDeque;
 
 /// Predicate used to retain subscribers for resolver keys.
 pub type Predicate<K, S> = Box<dyn Fn(&K, &S) -> bool + Send>;
 
 /// Metadata carried by a coalesced fetch.
-pub(crate) trait Metadata {
+pub(crate) trait Metadata: PlatformSend {
     /// Merge metadata from a duplicate fetch into the retained fetch.
     fn merge(&mut self, incoming: Self);
 }
@@ -21,7 +21,7 @@ impl Metadata for () {
     fn merge(&mut self, _incoming: Self) {}
 }
 
-impl<T: Eq> Metadata for Option<NonEmptyVec<T>> {
+impl<T: Eq + PlatformSend> Metadata for Option<NonEmptyVec<T>> {
     fn merge(&mut self, incoming: Self) {
         // `None` means unrestricted. It dominates targeted metadata because a
         // non-targeted fetch should clear existing target restrictions.
@@ -95,7 +95,12 @@ impl<K, S, M> Default for Pending<K, S, M> {
     }
 }
 
-impl<K, S, M> Overflow<Message<K, S, M>> for Pending<K, S, M> {
+impl<K, S, M> Overflow<Message<K, S, M>> for Pending<K, S, M>
+where
+    K: PlatformSend,
+    S: PlatformSend,
+    M: PlatformSend,
+{
     fn is_empty(&self) -> bool {
         self.modifications.is_empty() && self.fetches.is_empty()
     }
@@ -164,8 +169,8 @@ fn merge_subscribers<S: Eq>(
 
 impl<K, S, M> Policy for Message<K, S, M>
 where
-    K: Clone + Eq,
-    S: Eq,
+    K: Clone + Eq + PlatformSend,
+    S: Eq + PlatformSend,
     M: Metadata,
 {
     type Overflow = Pending<K, S, M>;

--- a/resolver/src/p2p/ingress.rs
+++ b/resolver/src/p2p/ingress.rs
@@ -1,7 +1,7 @@
 use crate::{Fetch, Resolver, TargetedResolver, ingress};
 use commonware_actor::{Feedback, mailbox::Sender};
 use commonware_cryptography::PublicKey;
-use commonware_utils::{Span, vec::NonEmptyVec};
+use commonware_utils::{PlatformSend, Span, vec::NonEmptyVec};
 
 /// A key to fetch data for, optionally with target peers.
 pub type FetchKey<K, P, S> = ingress::FetchKey<K, S, Option<NonEmptyVec<P>>>;
@@ -19,12 +19,12 @@ fn fetch_key<K, P, S>(fetch: Fetch<K, S>, targets: Option<NonEmptyVec<P>>) -> Fe
 
 /// A way to send messages to the peer actor.
 #[derive(Clone)]
-pub struct Mailbox<K: Span, P: Eq, S: Eq = ()> {
+pub struct Mailbox<K: Span, P: Eq + PlatformSend, S: Eq + PlatformSend = ()> {
     /// The channel that delivers messages to the peer actor.
     sender: Sender<Message<K, P, S>>,
 }
 
-impl<K: Span, P: Eq, S: Eq> Mailbox<K, P, S> {
+impl<K: Span, P: Eq + PlatformSend, S: Eq + PlatformSend> Mailbox<K, P, S> {
     /// Create a new mailbox.
     pub(super) const fn new(sender: Sender<Message<K, P, S>>) -> Self {
         Self { sender }

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -107,7 +107,7 @@ mod tests {
         simulated::{Link, Network, Oracle, Receiver, Sender},
     };
     use commonware_runtime::{
-        Clock, Metrics as _, Quota, Runner, Spawner as _, Supervisor as _, deterministic,
+        Clock, Metrics as _, Quota, Runner, Scheduler as _, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -23,26 +23,19 @@ commonware-conformance = { workspace = true, optional = true }
 commonware-cryptography = { workspace = true, features = ["std"] }
 commonware-formatting = { workspace = true, features = ["std"] }
 commonware-macros = { workspace = true, features = ["std"] }
-commonware-parallel = { workspace = true, features = ["std"] }
 commonware-runtime-macros.workspace = true
 commonware-utils = { workspace = true, features = ["std"] }
 crossbeam-utils.workspace = true
 futures.workspace = true
 governor.workspace = true
 io-uring = { workspace = true, optional = true }
-libc.workspace = true
 loom = { workspace = true, optional = true }
-opentelemetry.workspace = true
 pin-project = { workspace = true, optional = true }
 prometheus-client.workspace = true
 rand = { workspace = true, features = ["std_rng"] }
 rand_core.workspace = true
-rayon.workspace = true
-sha2.workspace = true
-sysinfo.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-tracing-opentelemetry.workspace = true
 tracing-subscriber = { workspace = true, features = ["fmt", "json", "env-filter"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies.getrandom]
@@ -58,12 +51,19 @@ features = ["js"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum.workspace = true
+commonware-parallel = { workspace = true, features = ["std"] }
 console-subscriber = { workspace = true, features = ["parking_lot"], optional = true }
 criterion = { workspace = true, features = ["async"] }
 crossbeam-queue = { workspace = true, optional = true }
+libc.workspace = true
+opentelemetry.workspace = true
 opentelemetry-otlp = { workspace = true, features = ["http-proto"] }
 opentelemetry_sdk = { workspace = true, features = ["rt-tokio"] }
+rayon.workspace = true
+sha2.workspace = true
+sysinfo.workspace = true
 tokio = { workspace = true, features = ["full"] }
+tracing-opentelemetry.workspace = true
 
 [dev-dependencies]
 clap = { workspace = true, features = ["derive"] }

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -27,7 +27,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, deterministic, Metrics, Supervisor};
+//! use commonware_runtime::{Scheduler, Runner, deterministic, Metrics, Supervisor};
 //!
 //! let executor =  deterministic::Runner::default();
 //! executor.start(|context| async move {
@@ -43,11 +43,9 @@
 //! ```
 
 pub use crate::storage::faulty::Config as FaultConfig;
-#[cfg(feature = "external")]
-use crate::{Blocker, Pacer};
 use crate::{
-    BufferPool, BufferPoolConfig, Clock, Error, Execution, Handle, IoBufs, ListenerOf,
-    METRICS_PREFIX, Name, Panicked, child_label,
+    Acceptor, BufferPool, BufferPoolConfig, Clock, ConnectionOf, Dialer, Error, Execution, Handle,
+    IoBufs, METRICS_PREFIX, Name, Panicked, TcpEndpoint, child_label,
     network::{
         audited::Network as AuditedNetwork, deterministic::Network as DeterministicNetwork,
         metered::Network as MeteredNetwork,
@@ -67,6 +65,8 @@ use crate::{
         supervision::Tree,
     },
 };
+#[cfg(feature = "external")]
+use crate::{Blocker, Pacer};
 use commonware_codec::Encode;
 use commonware_formatting::hex;
 use commonware_macros::select;
@@ -897,9 +897,8 @@ impl Tasks {
 type Network = MeteredNetwork<AuditedNetwork<DeterministicNetwork>>;
 type Storage = MeteredStorage<AuditedStorage<FaultyStorage<MemStorage>>>;
 
-/// Implementation of [crate::Spawner], [crate::Clock],
-/// [crate::Network], and [crate::Storage] for the `deterministic`
-/// runtime.
+/// Implementation of [crate::Scheduler], [crate::Clock], [crate::Dialer],
+/// [crate::Acceptor], and [crate::Storage] for the `deterministic` runtime.
 pub struct Context {
     name: String,
     attributes: Vec<(String, String)>,
@@ -1116,17 +1115,7 @@ impl Context {
     }
 }
 
-impl crate::Spawner for Context {
-    fn dedicated(mut self) -> Self {
-        self.execution = Execution::Dedicated;
-        self
-    }
-
-    fn shared(mut self, blocking: bool) -> Self {
-        self.execution = Execution::Shared(blocking);
-        self
-    }
-
+impl crate::Scheduler for Context {
     fn spawn<F, Fut, T>(mut self, f: F) -> Handle<T>
     where
         F: FnOnce(Self) -> Fut + Send + 'static,
@@ -1193,6 +1182,18 @@ impl crate::Spawner for Context {
         executor.auditor.event(b"stopped", |_| {});
 
         executor.shutdown.lock().stopped()
+    }
+}
+
+impl crate::Spawner for Context {
+    fn dedicated(mut self) -> Self {
+        self.execution = Execution::Dedicated;
+        self
+    }
+
+    fn shared(mut self, blocking: bool) -> Self {
+        self.execution = Execution::Shared(blocking);
+        self
     }
 }
 
@@ -1498,35 +1499,78 @@ impl GClock for Context {
 
 impl ReasonablyRealtime for Context {}
 
-impl crate::Network for Context {
-    type Listener = ListenerOf<Network>;
-
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, Error> {
-        self.network.bind(socket).await
-    }
-
-    async fn dial(
-        &self,
-        socket: SocketAddr,
-    ) -> Result<(crate::SinkOf<Self>, crate::StreamOf<Self>), Error> {
-        self.network.dial(socket).await
-    }
-}
-
 impl crate::Resolver for Context {
     async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, Error> {
-        // Get the record
         let executor = self.executor();
-        let dns = executor.dns.lock();
-        let result = dns.get(host).cloned();
-        drop(dns);
-
-        // Update the auditor
+        let result = executor.dns.lock().get(host).cloned();
         executor.auditor.event(b"resolve", |hasher| {
             hasher.update(host.as_bytes());
             hasher.update(result.encode());
         });
         result.ok_or_else(|| Error::ResolveFailed(host.to_string()))
+    }
+}
+
+impl Dialer for Context {
+    type Endpoint = TcpEndpoint;
+    type Connection = ConnectionOf<Network>;
+
+    fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+        matches!(endpoint, TcpEndpoint::Socket(_) | TcpEndpoint::Dns { .. })
+    }
+
+    async fn dial(&self, endpoint: &Self::Endpoint) -> Result<Self::Connection, Error> {
+        let sockets = match endpoint {
+            TcpEndpoint::Socket(socket) => vec![*socket],
+            TcpEndpoint::Dns {
+                host,
+                port,
+                allow_private_ips,
+            } => {
+                let executor = self.executor();
+                let result = executor.dns.lock().get(host).cloned();
+                executor.auditor.event(b"resolve", |hasher| {
+                    hasher.update(host.as_bytes());
+                    hasher.update(result.encode());
+                });
+                let mut addresses = result.ok_or_else(|| Error::ResolveFailed(host.clone()))?;
+                if addresses.is_empty() {
+                    return Err(Error::ResolveFailed(host.clone()));
+                }
+                executor.auditor.event(b"rand", |hasher| {
+                    hasher.update(b"dns_shuffle");
+                });
+                addresses.shuffle(&mut **executor.rng.lock());
+                let addresses: Vec<_> = addresses
+                    .into_iter()
+                    .filter(|ip| *allow_private_ips || commonware_utils::IpAddrExt::is_global(ip))
+                    .map(|ip| SocketAddr::new(ip, *port))
+                    .collect();
+                if addresses.is_empty() {
+                    return Err(Error::ResolveFailed(host.clone()));
+                }
+                addresses
+            }
+        };
+
+        let mut last_error = Error::ConnectionFailed;
+        for socket in sockets {
+            match self.network.dial(&TcpEndpoint::Socket(socket)).await {
+                Ok(connection) => return Ok(connection),
+                Err(error) => last_error = error,
+            }
+        }
+        Err(last_error)
+    }
+}
+
+impl Acceptor for Context {
+    type Bind = SocketAddr;
+    type Connection = <Network as Acceptor>::Connection;
+    type Listener = <Network as Acceptor>::Listener;
+
+    async fn bind(&self, bind: &Self::Bind) -> Result<Self::Listener, Error> {
+        self.network.bind(bind).await
     }
 }
 
@@ -1600,8 +1644,8 @@ mod tests {
     #[cfg(feature = "external")]
     use crate::FutureExt;
     use crate::{
-        Blob, Metrics as _, Resolver, Runner as _, Spawner as _, Storage, Strategizer,
-        Supervisor as _, deterministic, reschedule,
+        Blob, Connection as _, Listener as _, Metrics as _, Runner as _, Scheduler as _, Storage,
+        Strategizer, Supervisor as _, deterministic, reschedule,
     };
     use commonware_macros::test_traced;
     use commonware_parallel::Strategy;
@@ -1853,8 +1897,17 @@ mod tests {
         // Check that DNS mappings persist after recovery
         let executor = Runner::from(checkpoint);
         executor.start(move |context| async move {
-            let resolved = context.resolve(host).await.unwrap();
-            assert_eq!(resolved, addrs);
+            let socket = SocketAddr::new(addrs[0], 1234);
+            let mut listener = context.bind(&socket).await.unwrap();
+            let endpoint = TcpEndpoint::Dns {
+                host: host.to_string(),
+                port: socket.port(),
+                allow_private_ips: true,
+            };
+
+            let (dialed, accepted) = futures::join!(context.dial(&endpoint), listener.accept());
+            dialed.unwrap().split();
+            accepted.unwrap().split();
         });
     }
 
@@ -2336,17 +2389,49 @@ mod tests {
             let ip2: IpAddr = "192.168.1.2".parse().unwrap();
             context.resolver_register("example.com", Some(vec![ip1, ip2]));
 
-            // Resolve registered hostname
-            let addrs = context.resolve("example.com").await.unwrap();
-            assert_eq!(addrs, vec![ip1, ip2]);
+            // Dial a registered hostname.
+            let socket = SocketAddr::new(ip1, 1234);
+            let mut listener = context.bind(&socket).await.unwrap();
+            let endpoint = TcpEndpoint::Dns {
+                host: "example.com".to_string(),
+                port: socket.port(),
+                allow_private_ips: true,
+            };
+            let (dialed, accepted) = futures::join!(context.dial(&endpoint), listener.accept());
+            dialed.unwrap().split();
+            accepted.unwrap().split();
 
-            // Resolve unregistered hostname
-            let result = context.resolve("unknown.com").await;
+            // Dial an unregistered hostname.
+            let unknown = TcpEndpoint::Dns {
+                host: "unknown.com".to_string(),
+                port: socket.port(),
+                allow_private_ips: true,
+            };
+            let result = context.dial(&unknown).await;
+            assert!(matches!(result, Err(Error::ResolveFailed(_))));
+
+            // An empty successful response is also a resolution failure.
+            context.resolver_register("empty.com", Some(Vec::new()));
+            let empty = TcpEndpoint::Dns {
+                host: "empty.com".to_string(),
+                port: socket.port(),
+                allow_private_ips: true,
+            };
+            let result = context.dial(&empty).await;
+            assert!(matches!(result, Err(Error::ResolveFailed(_))));
+
+            // Private DNS results are rejected before a connection is attempted.
+            let private = TcpEndpoint::Dns {
+                host: "example.com".to_string(),
+                port: socket.port(),
+                allow_private_ips: false,
+            };
+            let result = context.dial(&private).await;
             assert!(matches!(result, Err(Error::ResolveFailed(_))));
 
             // Remove mapping
             context.resolver_register("example.com", None);
-            let result = context.resolve("example.com").await;
+            let result = context.dial(&endpoint).await;
             assert!(matches!(result, Err(Error::ResolveFailed(_))));
         });
     }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -116,13 +116,9 @@
 //! a slot outside the freelist may access that slot's parking cell.
 use super::buffer::PooledBuffer;
 use crossbeam_utils::CachePadded;
-use std::{
-    alloc::Layout,
-    cell::Cell,
-    mem::MaybeUninit,
-    num::{NonZeroU32, NonZeroUsize},
-    sync::atomic::Ordering,
-};
+#[cfg(not(target_arch = "wasm32"))]
+use std::num::{NonZeroU32, NonZeroUsize};
+use std::{alloc::Layout, cell::Cell, mem::MaybeUninit, sync::atomic::Ordering};
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "loom")] {
@@ -201,6 +197,7 @@ impl Freelist {
     ///
     /// If `prefill` is true, creates `capacity` buffers and makes them
     /// immediately available in the freelist.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(
         capacity: NonZeroU32,
         parallelism: NonZeroUsize,

--- a/runtime/src/iobuf/mod.rs
+++ b/runtime/src/iobuf/mod.rs
@@ -1798,6 +1798,7 @@ impl IoBufsMut {
     /// # Panics
     ///
     /// Panics if `len` exceeds total capacity.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) unsafe fn set_len(&mut self, len: usize) {
         // SAFETY: The caller guarantees that all bytes in `0..len` are initialized.
         unsafe {

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -53,22 +53,25 @@
 //! batch back to the global freelist if needed.
 
 use super::{IoBufMut, freelist::Freelist, page_size};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::telemetry::metrics::{Register, raw};
 use crate::{
     iobuf::buffer::{PooledBufMut, PooledBuffer},
-    telemetry::metrics::{Counter, CounterFamily, EncodeLabelSet, GaugeFamily, Register, raw},
+    telemetry::metrics::{Counter, CounterFamily, EncodeLabelSet, GaugeFamily},
 };
 use commonware_utils::{NZU32, NZUsize};
+#[cfg(not(target_arch = "wasm32"))]
 use std::{
     alloc::Layout,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+use std::{
     cell::{Cell, UnsafeCell},
     collections::BTreeMap,
     mem::MaybeUninit,
     num::{NonZeroU32, NonZeroUsize},
     ptr,
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
+    sync::Arc,
 };
 
 /// Minimum thread-local cache capacity required before refill/spill batches.
@@ -606,6 +609,7 @@ impl BufferPoolConfig {
     /// - `alignment` is not a power of two
     /// - the smallest enabled class is smaller than `alignment`
     /// - `pool_min_size` is larger than the smallest enabled class
+    #[cfg(not(target_arch = "wasm32"))]
     fn validate(&self) {
         assert!(
             self.alignment.is_power_of_two(),
@@ -632,6 +636,7 @@ impl BufferPoolConfig {
     /// parallelism so cross-thread reuse remains effective. Small class limits
     /// may resolve to zero. An explicit capacity replaces the derivation and
     /// clamps to the class limit.
+    #[cfg(not(target_arch = "wasm32"))]
     fn resolve_thread_cache_capacity(&self, class_limit: NonZeroU32) -> usize {
         let class_limit = class_limit.get() as usize;
         match self.thread_cache_config {
@@ -662,6 +667,7 @@ struct PoolMetrics {
 }
 
 impl PoolMetrics {
+    #[cfg(not(target_arch = "wasm32"))]
     fn new(registry: &mut impl Register) -> Self {
         Self {
             created: registry.register(
@@ -794,6 +800,7 @@ impl SizeClassToken {
     /// still represents one strong reference. The caller must wrap it in an
     /// owning type, such as [`SizeClassHandle`], or otherwise arrange for that
     /// strong reference to be released.
+    #[cfg(not(target_arch = "wasm32"))]
     fn new(class: SizeClass) -> Self {
         let ptr = Arc::into_raw(Arc::new(class)).cast_mut();
         // SAFETY: `Arc::into_raw` never returns null.
@@ -865,6 +872,7 @@ impl SizeClassHandle {
     ///
     /// If `prefill` is true, the global freelist creates `max` buffers upfront
     /// and makes them immediately available for reuse.
+    #[cfg(not(target_arch = "wasm32"))]
     fn new(
         class_id: usize,
         size: usize,
@@ -1737,6 +1745,7 @@ impl std::fmt::Debug for BufferPool {
 ///
 /// Relaxed ordering is sufficient: the atomic operation is only used to assign
 /// unique ids, not to publish any associated size-class state.
+#[cfg(not(target_arch = "wasm32"))]
 static NEXT_SIZE_CLASS_ID: AtomicUsize = AtomicUsize::new(0);
 
 impl BufferPool {
@@ -1745,6 +1754,7 @@ impl BufferPool {
     /// # Panics
     ///
     /// Panics if the configuration is invalid.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn new(config: BufferPoolConfig, registry: &mut impl Register) -> Self {
         config.validate();
         let metrics = PoolMetrics::new(registry);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -33,6 +33,8 @@ mod storage;
 stability_scope!(ALPHA {
     #[cfg(feature = "arbitrary")]
     pub mod conformance;
+});
+stability_scope!(ALPHA, cfg(not(target_arch = "wasm32")) {
     pub mod deterministic;
     pub mod mocks;
 });
@@ -49,18 +51,22 @@ stability_scope!(BETA {
     /// Re-export of `Buf` and `BufMut` traits for usage with [I/O buffers](iobuf).
     pub use bytes::{Buf, BufMut};
     use commonware_macros::select;
+    #[cfg(not(target_arch = "wasm32"))]
     use commonware_parallel::Rayon;
     /// Re-export of [governor::Quota] for rate limiting configuration.
     pub use governor::Quota;
+    pub use commonware_utils::{PlatformSend, PlatformSync};
     use iobuf::PoolError;
     use std::{
         future::Future,
         io::Error as IoError,
         net::SocketAddr,
-        num::NonZeroUsize,
         sync::Arc,
         time::{Duration, SystemTime},
     };
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::num::NonZeroUsize;
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) use telemetry::metrics::{METRICS_PREFIX, child_label, prefixed_name};
     use thiserror::Error;
 
@@ -101,6 +107,14 @@ stability_scope!(BETA {
         SendFailed,
         #[error("recv failed")]
         RecvFailed,
+        #[error("transport failed: {0}")]
+        TransportFailed(String),
+        #[error("unsupported endpoint")]
+        UnsupportedEndpoint,
+        #[error("protocol violation: {0}")]
+        ProtocolViolation(String),
+        #[error("incoming buffer limit exceeded")]
+        IncomingBufferExceeded,
         #[error("dns resolution failed: {0}")]
         ResolveFailed(String),
         #[error(
@@ -155,8 +169,8 @@ stability_scope!(BETA {
         /// Start running a root task.
         ///
         /// When this function returns, all spawned tasks will be canceled. If clean
-        /// shutdown cannot be implemented via `Drop`, consider using [Spawner::stop] and
-        /// [Spawner::stopped] to coordinate clean shutdown.
+        /// shutdown cannot be implemented via `Drop`, consider using [Scheduler::stop] and
+        /// [Scheduler::stopped] to coordinate clean shutdown.
         fn start<F, Fut>(self, f: F) -> Fut::Output
         where
             F: FnOnce(Self::Context) -> Fut,
@@ -173,7 +187,7 @@ stability_scope!(BETA {
     }
 
     /// Interface to track task hierarchy and identity.
-    pub trait Supervisor: Send + Sync + 'static {
+    pub trait Supervisor: PlatformSend + PlatformSync + 'static {
         /// Return the current label prefix and attributes.
         fn name(&self) -> Name;
 
@@ -258,27 +272,7 @@ stability_scope!(BETA {
     }
 
     /// Interface that any task scheduler must implement to spawn tasks.
-    pub trait Spawner: Supervisor {
-        /// Return a [`Spawner`] that schedules the next task onto the runtime's shared executor.
-        ///
-        /// Set `blocking` to `true` when the task may hold the thread for a short, blocking operation.
-        /// Runtimes can use this hint to move the work to a blocking-friendly pool so asynchronous
-        /// tasks on a work-stealing executor are not starved. For long-lived, blocking work, use
-        /// [`Spawner::dedicated`] instead.
-        ///
-        /// The shared executor with `blocking == false` is the default spawn mode.
-        #[must_use]
-        fn shared(self, blocking: bool) -> Self;
-
-        /// Return a [`Spawner`] that runs the next task on a dedicated thread when the runtime supports it.
-        ///
-        /// Reserve this for long-lived or prioritized tasks that should not compete for resources in the
-        /// shared executor.
-        ///
-        /// This is not the default behavior. See [`Spawner::shared`] for more information.
-        #[must_use]
-        fn dedicated(self) -> Self;
-
+    pub trait Scheduler: Supervisor {
         /// Spawn a task with the current context.
         ///
         /// Unlike directly awaiting a future, the task starts running immediately even if the caller
@@ -308,7 +302,7 @@ stability_scope!(BETA {
         /// # Spawn Configuration
         ///
         /// [`Spawner::dedicated`] and [`Spawner::shared`] only affect the
-        /// handle they return. [`Supervisor::child`] and [`Spawner::spawn`]
+        /// handle they return. [`Supervisor::child`] and [`Scheduler::spawn`]
         /// both start child task contexts from a clean spawn configuration.
         ///
         /// Child tasks should assume they start from a clean configuration without needing to inspect how their
@@ -316,15 +310,15 @@ stability_scope!(BETA {
         fn spawn<F, Fut, T>(self, f: F) -> Handle<T>
         where
             Self: Sized,
-            F: FnOnce(Self) -> Fut + Send + 'static,
-            Fut: Future<Output = T> + Send + 'static,
-            T: Send + 'static;
+            F: FnOnce(Self) -> Fut + PlatformSend + 'static,
+            Fut: Future<Output = T> + PlatformSend + 'static,
+            T: PlatformSend + 'static;
 
         /// Signals the runtime to stop execution and waits for all outstanding tasks
         /// to perform any required cleanup and exit.
         ///
         /// This method does not actually kill any tasks but rather signals to them, using
-        /// the [signal::Signal] returned by [Spawner::stopped], that they should exit.
+        /// the [signal::Signal] returned by [Scheduler::stopped], that they should exit.
         /// It then waits for all [signal::Signal] references to be dropped before returning.
         ///
         /// ## Multiple Stop Calls
@@ -343,18 +337,35 @@ stability_scope!(BETA {
             self,
             value: i32,
             timeout: Option<Duration>,
-        ) -> impl Future<Output = Result<(), Error>> + Send;
+        ) -> impl Future<Output = Result<(), Error>> + PlatformSend;
 
-        /// Returns an instance of a [signal::Signal] that resolves when [Spawner::stop] is called by
+        /// Returns an instance of a [signal::Signal] that resolves when [Scheduler::stop] is called by
         /// any task.
         ///
-        /// If [Spawner::stop] has already been called, the [signal::Signal] returned will resolve
+        /// If [Scheduler::stop] has already been called, the [signal::Signal] returned will resolve
         /// immediately. The [signal::Signal] returned will always resolve to the value of the
-        /// first [Spawner::stop] call.
+        /// first [Scheduler::stop] call.
         fn stopped(&self) -> signal::Signal;
     }
 
+    /// Scheduling hints for runtimes that support thread placement.
+    ///
+    /// A runtime may treat these as placement hints when it cannot provide a distinct executor or
+    /// thread. Single-threaded runtimes implement [`Scheduler`] without implementing this trait.
+    pub trait Spawner: Scheduler {
+        /// Return a spawner that schedules the next task on the shared executor.
+        ///
+        /// Set `blocking` when the task may briefly block its executor thread.
+        #[must_use]
+        fn shared(self, blocking: bool) -> Self;
+
+        /// Return a spawner that requests dedicated placement for the next task.
+        #[must_use]
+        fn dedicated(self) -> Self;
+    }
+
     /// Interface that runtimes implement to provide parallel execution strategies.
+    #[cfg(not(target_arch = "wasm32"))]
     pub trait Strategizer: Spawner {
         /// Returns a new [Rayon] strategy with the requested parallelism.
         ///
@@ -428,18 +439,21 @@ stability_scope!(BETA {
     pub trait Clock:
         governor::clock::Clock<Instant = SystemTime>
         + governor::clock::ReasonablyRealtime
-        + Send
-        + Sync
+        + PlatformSend
+        + PlatformSync
         + 'static
     {
         /// Returns the current time.
         fn current(&self) -> SystemTime;
 
         /// Sleep for the given duration.
-        fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + Send + 'static;
+        fn sleep(&self, duration: Duration) -> impl Future<Output = ()> + PlatformSend + 'static;
 
         /// Sleep until the given deadline.
-        fn sleep_until(&self, deadline: SystemTime) -> impl Future<Output = ()> + Send + 'static;
+        fn sleep_until(
+            &self,
+            deadline: SystemTime,
+        ) -> impl Future<Output = ()> + PlatformSend + 'static;
 
         /// Await a future with a timeout, returning `Error::Timeout` if it expires.
         ///
@@ -465,10 +479,10 @@ stability_scope!(BETA {
             &self,
             duration: Duration,
             future: F,
-        ) -> impl Future<Output = Result<T, Error>> + Send + '_
+        ) -> impl Future<Output = Result<T, Error>> + PlatformSend + '_
         where
-            F: Future<Output = T> + Send + 'static,
-            T: Send + 'static,
+            F: Future<Output = T> + PlatformSend + 'static,
+            T: PlatformSend + 'static,
         {
             async move {
                 select! {
@@ -479,69 +493,135 @@ stability_scope!(BETA {
         }
     }
 
-    /// Syntactic sugar for the type of [Sink] used by a given [Network] N.
-    pub type SinkOf<N> = <<N as Network>::Listener as Listener>::Sink;
-
-    /// Syntactic sugar for the type of [Stream] used by a given [Network] N.
-    pub type StreamOf<N> = <<N as Network>::Listener as Listener>::Stream;
-
-    /// Syntactic sugar for the type of [Listener] used by a given [Network] N.
-    pub type ListenerOf<N> = <N as crate::Network>::Listener;
-
-    /// Interface that any runtime must implement to create
-    /// network connections.
-    pub trait Network: Send + Sync + 'static {
-        /// The type of [Listener] that's returned when binding to a socket.
-        /// Accepting a connection returns a [Sink] and [Stream] which are defined
-        /// by the [Listener] and used to send and receive data over the connection.
-        type Listener: Listener;
-
-        /// Bind to the given socket address.
-        fn bind(
-            &self,
-            socket: SocketAddr,
-        ) -> impl Future<Output = Result<Self::Listener, Error>> + Send;
-
-        /// Dial the given socket address.
-        fn dial(
-            &self,
-            socket: SocketAddr,
-        ) -> impl Future<Output = Result<(SinkOf<Self>, StreamOf<Self>), Error>> + Send;
-    }
-
-    /// Interface for DNS resolution.
-    pub trait Resolver: Send + Sync + 'static {
-        /// Resolve a hostname to IP addresses.
-        ///
-        /// Returns a list of IP addresses that the hostname resolves to.
+    /// Interface for resolving hostnames to IP addresses.
+    ///
+    /// New transports should resolve their own endpoints while dialing. This trait remains
+    /// available for callers that resolve legacy host-based addresses explicitly.
+    pub trait Resolver: PlatformSend + PlatformSync + 'static {
+        /// Resolves `host` to its IP addresses.
         fn resolve(
             &self,
             host: &str,
-        ) -> impl Future<Output = Result<Vec<std::net::IpAddr>, Error>> + Send;
+        ) -> impl Future<Output = Result<Vec<std::net::IpAddr>, Error>> + PlatformSend;
     }
 
-    /// Interface that any runtime must implement to handle
-    /// incoming network connections.
-    pub trait Listener: Sync + Send + 'static {
-        /// The type of [Sink] that's returned when accepting a connection.
-        /// This is used to send data to the remote connection.
-        type Sink: Sink;
-        /// The type of [Stream] that's returned when accepting a connection.
-        /// This is used to receive data from the remote connection.
-        type Stream: Stream;
+    /// Transport-observed metadata for an established connection.
+    #[derive(Clone, Debug)]
+    pub struct ConnectionInfo<O> {
+        /// Remote peer metadata observed by the transport, if available.
+        ///
+        /// This describes the other end of the transport and is not an authenticated peer identity.
+        pub origin: Option<O>,
+        /// Stable, low-cardinality transport name for logs and metrics.
+        pub transport: &'static str,
+    }
 
-        /// Accept an incoming connection.
+    /// An established reliable byte stream.
+    pub trait Connection: PlatformSend + PlatformSync + 'static {
+        /// Write half of the reliable byte stream.
+        type Sink: Sink;
+        /// Read half of the reliable byte stream.
+        type Stream: Stream;
+        /// Transport-observed remote peer metadata.
+        type Origin: Clone + std::fmt::Debug + PlatformSend + PlatformSync + 'static;
+
+        /// Separates the connection into independent byte-stream halves and transport metadata.
+        fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>);
+    }
+
+    /// Outbound connection capability.
+    pub trait Dialer: PlatformSend + PlatformSync + 'static {
+        /// Transport-specific instructions for establishing a connection.
+        type Endpoint: Clone + std::fmt::Debug + PlatformSend + PlatformSync + 'static;
+        /// Connection returned after transport establishment.
+        type Connection: Connection;
+
+        /// Returns whether this dialer understands an endpoint without performing I/O.
+        fn supports(&self, _endpoint: &Self::Endpoint) -> bool {
+            true
+        }
+
+        /// Establishes a connection to `endpoint`.
+        fn dial<'a>(
+            &'a self,
+            endpoint: &'a Self::Endpoint,
+        ) -> impl Future<Output = Result<Self::Connection, Error>> + PlatformSend + 'a;
+    }
+
+    /// Inbound connection capability.
+    pub trait Acceptor: PlatformSend + PlatformSync + 'static {
+        /// Transport-specific local binding instructions.
+        type Bind: Clone + std::fmt::Debug + PlatformSend + PlatformSync + 'static;
+        /// Connection produced by this acceptor.
+        type Connection: Connection;
+        /// Bound listener that accepts connections.
+        type Listener: Listener<Connection = Self::Connection>;
+
+        /// Binds a listener according to `bind`.
+        fn bind<'a>(
+            &'a self,
+            bind: &'a Self::Bind,
+        ) -> impl Future<Output = Result<Self::Listener, Error>> + PlatformSend + 'a;
+    }
+
+    /// Accepts established connections from a bound transport.
+    pub trait Listener: PlatformSend + PlatformSync + 'static {
+        /// Connection returned by [`Self::accept`].
+        type Connection: Connection;
+
+        /// Waits for the next established inbound connection.
         fn accept(
             &mut self,
-        ) -> impl Future<Output = Result<(SocketAddr, Self::Sink, Self::Stream), Error>> + Send;
+        ) -> impl Future<Output = Result<Self::Connection, Error>> + PlatformSend;
+    }
 
-        /// Returns the local address of the listener.
+    /// Socket-specific metadata exposed by TCP listeners.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub trait TcpListener: Listener {
         fn local_addr(&self) -> Result<SocketAddr, std::io::Error>;
+    }
+
+    /// Connection returned by a [`Dialer`].
+    pub type ConnectionOf<D> = <D as Dialer>::Connection;
+    /// Write half returned by a dialer's connection.
+    pub type SinkOf<D> = <<D as Dialer>::Connection as Connection>::Sink;
+    /// Read half returned by a dialer's connection.
+    pub type StreamOf<D> = <<D as Dialer>::Connection as Connection>::Stream;
+    /// Origin metadata returned by a dialer's connection.
+    pub type OriginOf<D> = <<D as Dialer>::Connection as Connection>::Origin;
+
+    /// TCP dial location.
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    pub enum TcpEndpoint {
+        /// Connect directly to a socket address.
+        Socket(SocketAddr),
+        /// Resolve a hostname and try the resulting addresses in randomized order.
+        Dns {
+            /// Hostname to resolve.
+            host: String,
+            /// Destination port.
+            port: u16,
+            /// Whether resolved private addresses may be contacted.
+            allow_private_ips: bool,
+        },
+    }
+
+    impl From<SocketAddr> for TcpEndpoint {
+        fn from(value: SocketAddr) -> Self {
+            Self::Socket(value)
+        }
+    }
+
+    /// Remote endpoint observed by a TCP connection.
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    pub struct TcpOrigin {
+        /// Remote socket observed by the transport.
+        pub remote: SocketAddr,
     }
 
     /// Interface that any runtime must implement to send
     /// messages over a network connection.
-    pub trait Sink: Sync + Send + 'static {
+    pub trait Sink: PlatformSend + PlatformSync + 'static {
         /// Send a message to the sink.
         ///
         /// # Warning
@@ -554,13 +634,13 @@ stability_scope!(BETA {
         /// partial write may have occurred.
         fn send(
             &mut self,
-            bufs: impl Into<IoBufs> + Send,
-        ) -> impl Future<Output = Result<(), Error>> + Send;
+            bufs: impl Into<IoBufs> + PlatformSend,
+        ) -> impl Future<Output = Result<(), Error>> + PlatformSend;
     }
 
     /// Interface that any runtime must implement to receive
     /// messages over a network connection.
-    pub trait Stream: Sync + Send + 'static {
+    pub trait Stream: PlatformSend + PlatformSync + 'static {
         /// Receive exactly `len` bytes from the stream.
         ///
         /// The runtime allocates the buffer and returns it as `IoBufs`.
@@ -573,7 +653,10 @@ stability_scope!(BETA {
         ///
         /// Dropping the future (e.g. via `select!`) also poisons the stream, since
         /// partially read data may be lost.
-        fn recv(&mut self, len: usize) -> impl Future<Output = Result<IoBufs, Error>> + Send;
+        fn recv(
+            &mut self,
+            len: usize,
+        ) -> impl Future<Output = Result<IoBufs, Error>> + PlatformSend;
 
         /// Peek at buffered data without consuming.
         ///
@@ -766,7 +849,7 @@ stability_scope!(BETA {
     }
 
     /// Interface that any runtime must implement to provide buffer pools.
-    pub trait BufferPooler: Send + Sync + 'static {
+    pub trait BufferPooler: PlatformSend + PlatformSync + 'static {
         /// Returns the network [BufferPool].
         fn network_buffer_pool(&self) -> &BufferPool;
 
@@ -776,7 +859,7 @@ stability_scope!(BETA {
 });
 stability_scope!(BETA, cfg(feature = "external") {
     /// Interface that runtimes can implement to constrain the execution latency of a future.
-    pub trait Pacer: Clock + Send + Sync + 'static {
+    pub trait Pacer: Clock + PlatformSend + PlatformSync + 'static {
         /// Defer completion of a future until a specified `latency` has elapsed. If the future is
         /// not yet ready at the desired time of completion, the runtime will block until the future
         /// is ready.
@@ -800,33 +883,33 @@ stability_scope!(BETA, cfg(feature = "external") {
             &'a self,
             latency: Duration,
             future: F,
-        ) -> impl Future<Output = T> + Send + 'a
+        ) -> impl Future<Output = T> + PlatformSend + 'a
         where
-            F: Future<Output = T> + Send + 'a,
-            T: Send + 'a;
+            F: Future<Output = T> + PlatformSend + 'a,
+            T: PlatformSend + 'a;
     }
 
     /// Extension trait that makes it more ergonomic to use [Pacer].
     ///
     /// This inverts the call-site of [`Pacer::pace`] by letting the future itself request how the
     /// runtime should delay completion relative to the clock.
-    pub trait FutureExt: Future + Send + Sized {
+    pub trait FutureExt: Future + PlatformSend + Sized {
         /// Delay completion of the future until a specified `latency` on `pacer`.
         fn pace<'a, E>(
             self,
             pacer: &'a E,
             latency: Duration,
-        ) -> impl Future<Output = Self::Output> + Send + 'a
+        ) -> impl Future<Output = Self::Output> + PlatformSend + 'a
         where
             E: Pacer + 'a,
-            Self: Send + 'a,
-            Self::Output: Send + 'a,
+            Self: PlatformSend + 'a,
+            Self::Output: PlatformSend + 'a,
         {
             pacer.pace(latency, self)
         }
     }
 
-    impl<F> FutureExt for F where F: Future + Send {}
+    impl<F> FutureExt for F where F: Future + PlatformSend {}
 });
 
 #[cfg(test)]

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     Blob, BufMut, BufferPool, BufferPooler, Clock, Error, Handle, IoBufs, IoBufsMut, Metrics, Name,
-    Spawner, Storage, Supervisor,
+    Scheduler, Spawner, Storage, Supervisor,
     signal::Signal,
     telemetry::metrics::{Metric, Registered},
 };
@@ -510,17 +510,7 @@ pub struct DelayedSyncContext<E> {
 
 forward_context!(DelayedSyncContext, pending);
 
-impl<E: Spawner> Spawner for DelayedSyncContext<E> {
-    fn shared(mut self, blocking: bool) -> Self {
-        self.inner = self.inner.shared(blocking);
-        self
-    }
-
-    fn dedicated(mut self) -> Self {
-        self.inner = self.inner.dedicated();
-        self
-    }
-
+impl<E: Scheduler> Scheduler for DelayedSyncContext<E> {
     fn spawn<F, Fut, T>(self, f: F) -> Handle<T>
     where
         F: FnOnce(Self) -> Fut + Send + 'static,
@@ -537,6 +527,18 @@ impl<E: Spawner> Spawner for DelayedSyncContext<E> {
 
     fn stopped(&self) -> Signal {
         self.inner.stopped()
+    }
+}
+
+impl<E: Spawner> Spawner for DelayedSyncContext<E> {
+    fn shared(mut self, blocking: bool) -> Self {
+        self.inner = self.inner.shared(blocking);
+        self
+    }
+
+    fn dedicated(mut self) -> Self {
+        self.inner = self.inner.dedicated();
+        self
     }
 }
 
@@ -1047,7 +1049,7 @@ impl<B: Blob> Blob for SyncFaultBlob<B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Clock, Runner, Sink, Spawner, Stream, deterministic};
+    use crate::{Clock, Runner, Scheduler, Sink, Stream, deterministic};
     use commonware_macros::select;
     use std::{thread::sleep, time::Duration};
 

--- a/runtime/src/network/audited.rs
+++ b/runtime/src/network/audited.rs
@@ -1,30 +1,30 @@
-use crate::{Error, IoBufs, SinkOf, StreamOf, deterministic::Auditor};
+use crate::{Acceptor, Connection as _, Dialer, Error, IoBufs, deterministic::Auditor};
 use std::{net::SocketAddr, sync::Arc};
 
 /// A sink that audits network operations.
 pub struct Sink<S: crate::Sink> {
     auditor: Arc<Auditor>,
     inner: S,
-    remote_addr: SocketAddr,
+    remote: String,
 }
 
 impl<S: crate::Sink> crate::Sink for Sink<S> {
     async fn send(&mut self, bufs: impl Into<IoBufs> + Send) -> Result<(), Error> {
         let bufs = bufs.into();
         self.auditor.event(b"send_attempt", |hasher| {
-            hasher.update(self.remote_addr.to_string().as_bytes());
+            hasher.update(self.remote.as_bytes());
             hasher.update_bufs(&bufs);
         });
 
         self.inner.send(bufs).await.inspect_err(|e| {
             self.auditor.event(b"send_failure", |hasher| {
-                hasher.update(self.remote_addr.to_string().as_bytes());
+                hasher.update(self.remote.as_bytes());
                 hasher.update(e.to_string().as_bytes());
             });
         })?;
 
         self.auditor.event(b"send_success", |hasher| {
-            hasher.update(self.remote_addr.to_string().as_bytes());
+            hasher.update(self.remote.as_bytes());
         });
         Ok(())
     }
@@ -34,25 +34,25 @@ impl<S: crate::Sink> crate::Sink for Sink<S> {
 pub struct Stream<S: crate::Stream> {
     auditor: Arc<Auditor>,
     inner: S,
-    remote_addr: SocketAddr,
+    remote: String,
 }
 
 impl<S: crate::Stream> crate::Stream for Stream<S> {
     async fn recv(&mut self, len: usize) -> Result<IoBufs, Error> {
         self.auditor.event(b"recv_attempt", |hasher| {
-            hasher.update(self.remote_addr.to_string().as_bytes());
+            hasher.update(self.remote.as_bytes());
             hasher.update(len.to_be_bytes());
         });
 
         let bufs = self.inner.recv(len).await.inspect_err(|e| {
             self.auditor.event(b"recv_failure", |hasher| {
-                hasher.update(self.remote_addr.to_string().as_bytes());
+                hasher.update(self.remote.as_bytes());
                 hasher.update(e.to_string().as_bytes());
             });
         })?;
 
         self.auditor.event(b"recv_success", |hasher| {
-            hasher.update(self.remote_addr.to_string().as_bytes());
+            hasher.update(self.remote.as_bytes());
             hasher.update_bufs(&bufs);
         });
 
@@ -64,130 +64,190 @@ impl<S: crate::Stream> crate::Stream for Stream<S> {
     }
 }
 
+pub struct Connection<S, St, O> {
+    auditor: Arc<Auditor>,
+    sink: S,
+    stream: St,
+    info: crate::ConnectionInfo<O>,
+    remote: String,
+}
+
+impl<S, St, O> crate::Connection for Connection<S, St, O>
+where
+    S: crate::Sink,
+    St: crate::Stream,
+    O: Clone + std::fmt::Debug + crate::PlatformSend + crate::PlatformSync + 'static,
+{
+    type Sink = Sink<S>;
+    type Stream = Stream<St>;
+    type Origin = O;
+
+    fn split(
+        self,
+    ) -> (
+        Self::Sink,
+        Self::Stream,
+        crate::ConnectionInfo<Self::Origin>,
+    ) {
+        (
+            Sink {
+                auditor: Arc::clone(&self.auditor),
+                inner: self.sink,
+                remote: self.remote.clone(),
+            },
+            Stream {
+                auditor: self.auditor,
+                inner: self.stream,
+                remote: self.remote,
+            },
+            self.info,
+        )
+    }
+}
+
 /// A listener that audits network operations.
 pub struct Listener<L: crate::Listener> {
     auditor: Arc<Auditor>,
     inner: L,
-    local_addr: SocketAddr,
+    bind: String,
 }
 
 impl<L: crate::Listener> crate::Listener for Listener<L> {
-    type Sink = Sink<L::Sink>;
-    type Stream = Stream<L::Stream>;
+    type Connection = Connection<
+        <L::Connection as crate::Connection>::Sink,
+        <L::Connection as crate::Connection>::Stream,
+        <L::Connection as crate::Connection>::Origin,
+    >;
 
-    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
+    async fn accept(&mut self) -> Result<Self::Connection, Error> {
         self.auditor.event(b"accept_attempt", |hasher| {
-            hasher.update(self.local_addr.to_string().as_bytes());
+            hasher.update(self.bind.as_bytes());
         });
 
-        let (addr, sink, stream) = self.inner.accept().await.inspect_err(|e| {
+        let inner = self.inner.accept().await.inspect_err(|e| {
             self.auditor.event(b"accept_failure", |hasher| {
-                hasher.update(self.local_addr.to_string().as_bytes());
+                hasher.update(self.bind.as_bytes());
                 hasher.update(e.to_string().as_bytes());
             });
         })?;
-
+        let (sink, stream, info) = inner.split();
+        let remote = format!("{:?}", info.origin);
         self.auditor.event(b"accept_success", |hasher| {
-            hasher.update(self.local_addr.to_string().as_bytes());
-            hasher.update(addr.to_string().as_bytes());
+            hasher.update(self.bind.as_bytes());
+            hasher.update(info.transport.as_bytes());
+            hasher.update(remote.as_bytes());
         });
 
-        Ok((
-            addr,
-            Sink {
-                auditor: self.auditor.clone(),
-                inner: sink,
-                remote_addr: addr,
-            },
-            Stream {
-                auditor: self.auditor.clone(),
-                inner: stream,
-                remote_addr: addr,
-            },
-        ))
+        Ok(Connection {
+            auditor: Arc::clone(&self.auditor),
+            sink,
+            stream,
+            info,
+            remote,
+        })
     }
+}
 
+impl<L: crate::TcpListener> crate::TcpListener for Listener<L> {
     fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
         self.inner.local_addr()
     }
 }
 
 /// An audited network implementation which wraps another
-/// [crate::Network] and records audit events for network operations.
+/// transport and records audit events for network operations.
 #[derive(Clone)]
-pub struct Network<N: crate::Network> {
+pub struct Network<N> {
     auditor: Arc<Auditor>,
     inner: N,
 }
 
-impl<N: crate::Network> Network<N> {
+impl<N> Network<N> {
     /// Creates a new audited network that wraps the provided network implementation.
     pub const fn new(inner: N, auditor: Arc<Auditor>) -> Self {
         Self { auditor, inner }
     }
 }
 
-impl<N: crate::Network> crate::Network for Network<N> {
+impl<N: Acceptor> Acceptor for Network<N> {
+    type Bind = N::Bind;
+    type Connection = Connection<
+        <N::Connection as crate::Connection>::Sink,
+        <N::Connection as crate::Connection>::Stream,
+        <N::Connection as crate::Connection>::Origin,
+    >;
     type Listener = Listener<N::Listener>;
 
-    async fn bind(&self, local_addr: SocketAddr) -> Result<Self::Listener, Error> {
+    async fn bind(&self, bind: &Self::Bind) -> Result<Self::Listener, Error> {
+        let bind_label = format!("{bind:?}");
         self.auditor.event(b"bind_attempt", |hasher| {
-            hasher.update(local_addr.to_string().as_bytes());
+            hasher.update(bind_label.as_bytes());
         });
 
-        let inner = self.inner.bind(local_addr).await.inspect_err(|e| {
+        let inner = self.inner.bind(bind).await.inspect_err(|e| {
             self.auditor.event(b"bind_failure", |hasher| {
-                hasher.update(local_addr.to_string().as_bytes());
+                hasher.update(bind_label.as_bytes());
                 hasher.update(e.to_string().as_bytes());
             });
         })?;
 
         self.auditor.event(b"bind_success", |hasher| {
-            hasher.update(local_addr.to_string().as_bytes());
+            hasher.update(bind_label.as_bytes());
         });
 
         Ok(Listener {
-            auditor: self.auditor.clone(),
+            auditor: Arc::clone(&self.auditor),
             inner,
-            local_addr,
+            bind: bind_label,
         })
     }
+}
 
-    async fn dial(&self, remote_addr: SocketAddr) -> Result<(SinkOf<Self>, StreamOf<Self>), Error> {
+impl<N: Dialer> Dialer for Network<N> {
+    type Endpoint = N::Endpoint;
+    type Connection = Connection<
+        <N::Connection as crate::Connection>::Sink,
+        <N::Connection as crate::Connection>::Stream,
+        <N::Connection as crate::Connection>::Origin,
+    >;
+
+    fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+        self.inner.supports(endpoint)
+    }
+
+    async fn dial(&self, endpoint: &Self::Endpoint) -> Result<Self::Connection, Error> {
+        let remote = format!("{endpoint:?}");
         self.auditor.event(b"dial_attempt", |hasher| {
-            hasher.update(remote_addr.to_string().as_bytes());
+            hasher.update(remote.as_bytes());
         });
 
-        let (sink, stream) = self.inner.dial(remote_addr).await.inspect_err(|e| {
+        let inner = self.inner.dial(endpoint).await.inspect_err(|e| {
             self.auditor.event(b"dial_failure", |hasher| {
-                hasher.update(remote_addr.to_string().as_bytes());
+                hasher.update(remote.as_bytes());
                 hasher.update(e.to_string().as_bytes());
             });
         })?;
 
         self.auditor.event(b"dial_success", |hasher| {
-            hasher.update(remote_addr.to_string().as_bytes());
+            hasher.update(remote.as_bytes());
         });
 
-        Ok((
-            Sink {
-                auditor: self.auditor.clone(),
-                inner: sink,
-                remote_addr,
-            },
-            Stream {
-                auditor: self.auditor.clone(),
-                inner: stream,
-                remote_addr,
-            },
-        ))
+        let (sink, stream, info) = inner.split();
+        Ok(Connection {
+            auditor: Arc::clone(&self.auditor),
+            sink,
+            stream,
+            info,
+            remote,
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        Error, IoBuf, IoBufs, Listener as _, Network as _, Sink as _, Stream as _,
+        Acceptor as _, Connection as _, Dialer as _, Error, IoBuf, IoBufs, Listener as _,
+        Sink as _, Stream as _, TcpEndpoint,
         deterministic::Auditor,
         network::{
             audited::Network as AuditedNetwork, deterministic::Network as DeterministicNetwork,
@@ -223,6 +283,74 @@ mod tests {
         fn peek(&self, _max_len: usize) -> &[u8] {
             &[]
         }
+    }
+
+    struct OriginConnection {
+        origin: u64,
+        sink: RecordingSink,
+        stream: RecordingStream,
+    }
+
+    impl crate::Connection for OriginConnection {
+        type Sink = RecordingSink;
+        type Stream = RecordingStream;
+        type Origin = u64;
+
+        fn split(
+            self,
+        ) -> (
+            Self::Sink,
+            Self::Stream,
+            crate::ConnectionInfo<Self::Origin>,
+        ) {
+            (
+                self.sink,
+                self.stream,
+                crate::ConnectionInfo {
+                    origin: Some(self.origin),
+                    transport: "test",
+                },
+            )
+        }
+    }
+
+    struct OriginListener(Option<OriginConnection>);
+
+    impl crate::Listener for OriginListener {
+        type Connection = OriginConnection;
+
+        async fn accept(&mut self) -> Result<Self::Connection, Error> {
+            self.0.take().ok_or(Error::Closed)
+        }
+    }
+
+    fn origin_listener(origin: u64, auditor: Arc<Auditor>) -> super::Listener<OriginListener> {
+        super::Listener {
+            auditor,
+            inner: OriginListener(Some(OriginConnection {
+                origin,
+                sink: RecordingSink {
+                    chunk_counts: Arc::new(Mutex::new(Vec::new())),
+                },
+                stream: RecordingStream {
+                    bufs: Arc::new(Mutex::new(None)),
+                },
+            })),
+            bind: "test".into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn accepted_origin_is_audited_before_split() {
+        let first = Arc::new(Auditor::default());
+        let second = Arc::new(Auditor::default());
+        let mut first_listener = origin_listener(1, first.clone());
+        let mut second_listener = origin_listener(2, second.clone());
+
+        let _first_connection = first_listener.accept().await.unwrap();
+        let _second_connection = second_listener.accept().await.unwrap();
+
+        assert_ne!(first.state(), second.state());
     }
 
     #[tokio::test]
@@ -277,8 +405,8 @@ mod tests {
         // the same address because we're not actually binding to it.
         let listener_addr = SocketAddr::from(([127, 0, 0, 1], 1234));
         let listeners = [
-            networks[0].bind(listener_addr).await.unwrap(),
-            networks[1].bind(listener_addr).await.unwrap(),
+            networks[0].bind(&listener_addr).await.unwrap(),
+            networks[1].bind(&listener_addr).await.unwrap(),
         ];
         verify_auditors("after binding");
 
@@ -286,7 +414,7 @@ mod tests {
         let mut server_handles = Vec::new();
         for mut listener in listeners {
             let handle = tokio::spawn(async move {
-                let (_, mut sink, mut stream) = listener.accept().await.unwrap();
+                let (mut sink, mut stream, _) = listener.accept().await.unwrap().split();
 
                 // Receive data from client
                 let received = stream.recv(CLIENT_MSG.len()).await.unwrap();
@@ -304,7 +432,11 @@ mod tests {
         for network in &networks {
             let network = network.clone();
             let handle = tokio::spawn(async move {
-                let (mut sink, mut stream) = network.dial(listener_addr).await.unwrap();
+                let (mut sink, mut stream, _) = network
+                    .dial(&TcpEndpoint::Socket(listener_addr))
+                    .await
+                    .unwrap()
+                    .split();
 
                 // Send data to server
                 sink.send(CLIENT_MSG.as_bytes()).await.unwrap();
@@ -323,7 +455,7 @@ mod tests {
 
         // Step 4: Test error conditions (attempting to bind to same address again)
         for network in &networks {
-            let result = network.bind(listener_addr).await;
+            let result = network.bind(&listener_addr).await;
             assert!(result.is_err());
         }
         verify_auditors("after bind error");
@@ -331,7 +463,7 @@ mod tests {
         // Step 5: Test dialing to non-existent server
         let bad_addr = SocketAddr::from(([127, 0, 0, 1], 9999));
         for network in &networks {
-            let result = network.dial(bad_addr).await;
+            let result = network.dial(&TcpEndpoint::Socket(bad_addr)).await;
             assert!(result.is_err());
         }
         verify_auditors("after failed dial attempts");
@@ -345,7 +477,7 @@ mod tests {
             inner: RecordingSink {
                 chunk_counts: chunk_counts.clone(),
             },
-            remote_addr: SocketAddr::from(([127, 0, 0, 1], 1234)),
+            remote: SocketAddr::from(([127, 0, 0, 1], 1234)).to_string(),
         };
 
         sink.send(IoBufs::from(vec![
@@ -372,7 +504,7 @@ mod tests {
                     IoBuf::from(b"d".to_vec()),
                 ])))),
             },
-            remote_addr: SocketAddr::from(([127, 0, 0, 1], 1234)),
+            remote: SocketAddr::from(([127, 0, 0, 1], 1234)).to_string(),
         };
 
         let received = stream.recv(4).await.unwrap();

--- a/runtime/src/network/deterministic.rs
+++ b/runtime/src/network/deterministic.rs
@@ -1,4 +1,4 @@
-use crate::{Error, mocks};
+use crate::{Acceptor, ConnectionInfo, Dialer, Error, TcpEndpoint, TcpOrigin, mocks};
 use commonware_utils::{channel::mpsc, sync::Mutex};
 use std::{
     collections::HashMap,
@@ -16,6 +16,29 @@ pub type Sink = mocks::Sink;
 /// Implementation of [crate::Stream] for a deterministic [Network].
 pub type Stream = mocks::Stream;
 
+pub struct Connection {
+    sink: Sink,
+    stream: Stream,
+    origin: TcpOrigin,
+}
+
+impl crate::Connection for Connection {
+    type Sink = Sink;
+    type Stream = Stream;
+    type Origin = TcpOrigin;
+
+    fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>) {
+        (
+            self.sink,
+            self.stream,
+            ConnectionInfo {
+                origin: Some(self.origin),
+                transport: "deterministic_tcp",
+            },
+        )
+    }
+}
+
 /// Implementation of [crate::Listener] for a deterministic [Network].
 pub struct Listener {
     address: SocketAddr,
@@ -23,14 +46,19 @@ pub struct Listener {
 }
 
 impl crate::Listener for Listener {
-    type Sink = Sink;
-    type Stream = Stream;
+    type Connection = Connection;
 
-    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
+    async fn accept(&mut self) -> Result<Self::Connection, Error> {
         let (socket, sender, receiver) = self.listener.recv().await.ok_or(Error::ReadFailed)?;
-        Ok((socket, sender, receiver))
+        Ok(Connection {
+            sink: sender,
+            stream: receiver,
+            origin: TcpOrigin { remote: socket },
+        })
     }
+}
 
+impl crate::TcpListener for Listener {
     fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
         Ok(self.address)
     }
@@ -42,7 +70,7 @@ type Dialable = mpsc::UnboundedSender<(
     mocks::Stream, // Dialer -> Listener
 )>;
 
-/// Deterministic implementation of [crate::Network].
+/// Deterministic TCP transport.
 ///
 /// When a dialer connects to a listener, the listener is given a new ephemeral port
 /// from the range `32768..61000`. To keep things simple, it is not possible to
@@ -63,10 +91,13 @@ impl Default for Network {
     }
 }
 
-impl crate::Network for Network {
+impl Acceptor for Network {
+    type Bind = SocketAddr;
+    type Connection = Connection;
     type Listener = Listener;
 
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, Error> {
+    async fn bind(&self, socket: &SocketAddr) -> Result<Self::Listener, Error> {
+        let socket = *socket;
         // If the IP is localhost, ensure the port is not in the ephemeral range
         // so that it can be used for binding in the dial method
         if socket.ip() == IpAddr::V4(Ipv4Addr::LOCALHOST)
@@ -89,8 +120,21 @@ impl crate::Network for Network {
             listener: receiver,
         })
     }
+}
 
-    async fn dial(&self, socket: SocketAddr) -> Result<(Sink, Stream), Error> {
+impl Dialer for Network {
+    type Endpoint = TcpEndpoint;
+    type Connection = Connection;
+
+    fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+        matches!(endpoint, TcpEndpoint::Socket(_))
+    }
+
+    async fn dial(&self, endpoint: &TcpEndpoint) -> Result<Self::Connection, Error> {
+        let TcpEndpoint::Socket(socket) = endpoint else {
+            return Err(Error::UnsupportedEndpoint);
+        };
+        let socket = *socket;
         // Assign dialer a port from the ephemeral range
         let dialer = {
             let mut ephemeral = self.ephemeral.lock();
@@ -114,7 +158,11 @@ impl crate::Network for Network {
         sender
             .send((dialer, dialer_sender, listener_receiver))
             .map_err(|_| Error::ConnectionFailed)?;
-        Ok((listener_sender, dialer_receiver))
+        Ok(Connection {
+            sink: listener_sender,
+            stream: dialer_receiver,
+            origin: TcpOrigin { remote: socket },
+        })
     }
 }
 

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -1,5 +1,4 @@
-//! This module provides an io_uring-based implementation of the [crate::Network] trait,
-//! offering fast, high-throughput network operations on Linux systems.
+//! This module provides an io_uring-based TCP transport for Linux systems.
 //!
 //! ## Architecture
 //!
@@ -22,7 +21,8 @@
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
 use crate::{
-    Buf, BufferPool, Error, IoBufMut, IoBufs,
+    Acceptor, Buf, BufferPool, ConnectionInfo, Dialer, Error, IoBufMut, IoBufs, TcpEndpoint,
+    TcpOrigin,
     iouring::{self},
     telemetry::metrics::Register,
     utils,
@@ -91,7 +91,7 @@ impl Default for Config {
     }
 }
 
-/// [crate::Network] implementation that uses io_uring to do async I/O.
+/// TCP transport that uses io_uring for asynchronous I/O.
 #[derive(Clone)]
 pub struct Network {
     /// If Some, explicitly sets TCP_NODELAY on the socket.
@@ -162,11 +162,13 @@ impl Network {
     }
 }
 
-impl crate::Network for Network {
+impl Acceptor for Network {
+    type Bind = SocketAddr;
+    type Connection = Connection;
     type Listener = Listener;
 
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, Error> {
-        let listener = TcpListener::bind(socket)
+    async fn bind(&self, socket: &SocketAddr) -> Result<Self::Listener, Error> {
+        let listener = TcpListener::bind(*socket)
             .await
             .map_err(|_| Error::BindFailed)?;
         Ok(Listener {
@@ -180,15 +182,23 @@ impl crate::Network for Network {
             pool: self.pool.clone(),
         })
     }
+}
 
-    async fn dial(
-        &self,
-        socket: SocketAddr,
-    ) -> Result<(crate::SinkOf<Self>, crate::StreamOf<Self>), Error> {
-        let stream = timeout(self.connect_timeout, TcpStream::connect(socket))
+impl Dialer for Network {
+    type Endpoint = TcpEndpoint;
+    type Connection = Connection;
+
+    async fn dial(&self, endpoint: &TcpEndpoint) -> Result<Self::Connection, Error> {
+        let connect = async {
+            let addresses = super::resolve_tcp_endpoint(endpoint).await?;
+
+            TcpStream::connect(addresses.as_slice())
+                .await
+                .map_err(|_| Error::ConnectionFailed)
+        };
+        let stream = timeout(self.connect_timeout, connect)
             .await
-            .map_err(|_| Error::Timeout)?
-            .map_err(|_| Error::ConnectionFailed)?;
+            .map_err(|_| Error::Timeout)??;
 
         // Set TCP_NODELAY if configured
         if let Some(tcp_nodelay) = self.tcp_nodelay
@@ -204,6 +214,8 @@ impl crate::Network for Network {
             warn!(?err, "failed to set SO_LINGER");
         }
 
+        let remote = stream.peer_addr().map_err(|_| Error::ConnectionFailed)?;
+
         // Convert the stream to a std::net::TcpStream
         let stream = stream.into_std().map_err(|_| Error::ConnectionFailed)?;
 
@@ -213,20 +225,45 @@ impl crate::Network for Network {
             .map_err(|_| Error::ConnectionFailed)?;
 
         let fd = Arc::new(OwnedFd::from(stream));
-        Ok((
-            Sink::new(
+        Ok(Connection {
+            origin: TcpOrigin { remote },
+            sink: Sink::new(
                 fd.clone(),
                 self.send_handle.clone(),
                 self.read_write_timeout,
             ),
-            Stream::new(
+            stream: Stream::new(
                 fd,
                 self.recv_handle.clone(),
                 self.read_write_timeout,
                 self.read_buffer_size,
                 self.pool.clone(),
             ),
-        ))
+        })
+    }
+}
+
+/// An established io_uring TCP connection.
+pub struct Connection {
+    origin: TcpOrigin,
+    sink: Sink,
+    stream: Stream,
+}
+
+impl crate::Connection for Connection {
+    type Sink = Sink;
+    type Stream = Stream;
+    type Origin = TcpOrigin;
+
+    fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>) {
+        (
+            self.sink,
+            self.stream,
+            ConnectionInfo {
+                origin: Some(self.origin),
+                transport: "tcp",
+            },
+        )
     }
 }
 
@@ -251,10 +288,9 @@ pub struct Listener {
 }
 
 impl crate::Listener for Listener {
-    type Stream = Stream;
-    type Sink = Sink;
+    type Connection = Connection;
 
-    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
+    async fn accept(&mut self) -> Result<Self::Connection, Error> {
         let (stream, remote_addr) = self
             .inner
             .accept()
@@ -285,23 +321,27 @@ impl crate::Listener for Listener {
 
         let fd = Arc::new(OwnedFd::from(stream));
 
-        Ok((
-            remote_addr,
-            Sink::new(
+        Ok(Connection {
+            origin: TcpOrigin {
+                remote: remote_addr,
+            },
+            sink: Sink::new(
                 fd.clone(),
                 self.send_handle.clone(),
                 self.read_write_timeout,
             ),
-            Stream::new(
+            stream: Stream::new(
                 fd,
                 self.recv_handle.clone(),
                 self.read_write_timeout,
                 self.read_buffer_size,
                 self.pool.clone(),
             ),
-        ))
+        })
     }
+}
 
+impl crate::TcpListener for Listener {
     fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
         self.inner.local_addr()
     }
@@ -573,8 +613,9 @@ impl crate::Stream for Stream {
 mod tests {
     use super::{Sink, Stream};
     use crate::{
-        BufferPool, BufferPoolConfig, Error, IoBuf, IoBufMut, IoBufs, Listener as _, Network as _,
-        Sink as _, Stream as _, iouring,
+        Acceptor as _, BufferPool, BufferPoolConfig, Connection as _, Dialer as _, Error, IoBuf,
+        IoBufMut, IoBufs, Listener as _, Sink as _, Stream as _, TcpEndpoint, TcpListener as _,
+        iouring,
         network::{
             iouring::{Config, Network},
             tests,
@@ -659,19 +700,21 @@ mod tests {
         let network = test_network(Config::default()).expect("Failed to start io_uring");
 
         // Bind a listener
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         // Spawn a task to accept and read
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = connection.split();
 
             // Read a small message (much smaller than the 64KB buffer)
             stream.recv(10).await.unwrap()
         });
 
         // Connect and send a small message
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (mut sink, _stream, _) = connection.split();
         let msg = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         sink.send(msg.clone()).await.unwrap();
 
@@ -694,11 +737,12 @@ mod tests {
         .expect("Failed to start io_uring");
 
         // Bind a listener
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = connection.split();
 
             // Try to read 100 bytes, but only 5 will be sent
             let start = Instant::now();
@@ -709,7 +753,8 @@ mod tests {
         });
 
         // Connect and send only partial data
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (mut sink, _stream, _) = connection.split();
         sink.send([1u8, 2, 3, 4, 5].as_slice()).await.unwrap();
 
         // Wait for the reader to complete
@@ -733,13 +778,14 @@ mod tests {
         .expect("Failed to start io_uring");
 
         // Bind a listener
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         // Accept one connection and verify that peeking never observes buffered
         // bytes because the wrapper should not retain any internal read state.
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = connection.split();
 
             // In unbuffered mode, peek should always return empty
             assert!(stream.peek(100).is_empty());
@@ -757,7 +803,8 @@ mod tests {
         });
 
         // Send two independent messages so the reader exercises repeated direct recvs.
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (mut sink, _stream, _) = connection.split();
         sink.send([1u8, 2, 3, 4, 5].as_slice()).await.unwrap();
         sink.send([6u8, 7, 8, 9, 10].as_slice()).await.unwrap();
 
@@ -782,11 +829,13 @@ mod tests {
         })
         .expect("Failed to start io_uring");
 
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
-        let (client_sink, mut client_stream) = network.dial(addr).await.unwrap();
-        let (_addr, _server_sink, _server_stream) = listener.accept().await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (client_sink, mut client_stream, _) = connection.split();
+        let connection = listener.accept().await.unwrap();
+        let (_server_sink, _server_stream, _) = connection.split();
 
         // Sink + stream + our clone.
         let fd = client_stream.fd.clone();
@@ -817,11 +866,12 @@ mod tests {
         // Use default buffer size to enable buffering
         let network = test_network(Config::default()).expect("Failed to start io_uring");
 
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = connection.split();
 
             // Initially peek should be empty (no data received yet)
             assert!(stream.peek(100).is_empty());
@@ -850,7 +900,8 @@ mod tests {
         });
 
         // Connect and send data
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (mut sink, _stream, _) = connection.split();
         sink.send(b"hello world").await.unwrap();
 
         reader.await.unwrap();
@@ -956,20 +1007,22 @@ mod tests {
         })
         .expect("Failed to start io_uring");
 
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
         let expected = *b"abcdefgh";
 
         // Accept one connection and issue a recv that exactly matches the
         // internal buffer size, forcing the direct-recv branch.
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = connection.split();
             let received = stream.recv(expected.len()).await.unwrap();
             assert!(stream.peek(1).is_empty());
             received
         });
 
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (mut sink, _stream, _) = connection.split();
         sink.send(expected.to_vec()).await.unwrap();
 
         assert_eq!(reader.await.unwrap().coalesce(), expected);
@@ -985,16 +1038,18 @@ mod tests {
         })
         .expect("Failed to start io_uring");
 
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         // Accepting the connection covers the listener-side option setters.
         let accepter = tokio::spawn(async move {
-            let (_addr, _sink, _stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, _stream, _) = connection.split();
         });
 
         // Dialing the listener covers the client-side option setters.
-        let (_sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (_sink, _stream, _) = connection.split();
         accepter.await.unwrap();
     }
 
@@ -1008,14 +1063,16 @@ mod tests {
         })
         .expect("Failed to start io_uring");
 
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         let accepter = tokio::spawn(async move {
-            let (_addr, _sink, _stream) = listener.accept().await.unwrap();
+            let connection = listener.accept().await.unwrap();
+            let (_sink, _stream, _) = connection.split();
         });
 
-        let (_sink, _stream) = network.dial(addr).await.unwrap();
+        let connection = network.dial(&TcpEndpoint::from(addr)).await.unwrap();
+        let (_sink, _stream, _) = connection.split();
         accepter.await.unwrap();
     }
 

--- a/runtime/src/network/metered.rs
+++ b/runtime/src/network/metered.rs
@@ -1,5 +1,5 @@
 use crate::{
-    IoBufs, SinkOf, StreamOf,
+    Acceptor, Dialer, IoBufs, PlatformSend,
     telemetry::metrics::{Counter, Register, raw},
 };
 use std::{net::SocketAddr, sync::Arc};
@@ -51,7 +51,7 @@ pub struct Sink<S: crate::Sink> {
 }
 
 impl<S: crate::Sink> crate::Sink for Sink<S> {
-    async fn send(&mut self, bufs: impl Into<IoBufs> + Send) -> Result<(), crate::Error> {
+    async fn send(&mut self, bufs: impl Into<IoBufs> + PlatformSend) -> Result<(), crate::Error> {
         let bufs = bufs.into();
         let len = bufs.len();
         self.inner.send(bufs).await?;
@@ -64,6 +64,39 @@ impl<S: crate::Sink> crate::Sink for Sink<S> {
 pub struct Stream<S: crate::Stream> {
     inner: S,
     metrics: Arc<Metrics>,
+}
+
+/// Adds byte counters to an established connection.
+pub struct Connection<C: crate::Connection> {
+    inner: C,
+    metrics: Arc<Metrics>,
+}
+
+impl<C: crate::Connection> crate::Connection for Connection<C> {
+    type Sink = Sink<C::Sink>;
+    type Stream = Stream<C::Stream>;
+    type Origin = C::Origin;
+
+    fn split(
+        self,
+    ) -> (
+        Self::Sink,
+        Self::Stream,
+        crate::ConnectionInfo<Self::Origin>,
+    ) {
+        let (sink, stream, info) = self.inner.split();
+        (
+            Sink {
+                inner: sink,
+                metrics: Arc::clone(&self.metrics),
+            },
+            Stream {
+                inner: stream,
+                metrics: self.metrics,
+            },
+            info,
+        )
+    }
 }
 
 impl<S: crate::Stream> crate::Stream for Stream<S> {
@@ -86,34 +119,27 @@ pub struct Listener<L: crate::Listener> {
 }
 
 impl<L: crate::Listener> crate::Listener for Listener<L> {
-    type Sink = Sink<L::Sink>;
-    type Stream = Stream<L::Stream>;
+    type Connection = Connection<L::Connection>;
 
-    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), crate::Error> {
-        let (addr, sink, stream) = self.inner.accept().await?;
+    async fn accept(&mut self) -> Result<Self::Connection, crate::Error> {
+        let inner = self.inner.accept().await?;
         self.metrics.inbound_connections.inc();
-        Ok((
-            addr,
-            Sink {
-                inner: sink,
-                metrics: self.metrics.clone(),
-            },
-            Stream {
-                inner: stream,
-                metrics: self.metrics.clone(),
-            },
-        ))
+        Ok(Connection {
+            inner,
+            metrics: Arc::clone(&self.metrics),
+        })
     }
+}
 
+impl<L: crate::TcpListener> crate::TcpListener for Listener<L> {
     fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
         self.inner.local_addr()
     }
 }
 
-/// A metered network implementation which wraps another
-/// [crate::Network] and tracks metrics for it.
+/// A metered transport that wraps another transport and tracks metrics for it.
 #[derive(Debug, Clone)]
-pub struct Network<N: crate::Network> {
+pub struct Network<N> {
     inner: N,
     /// Metrics for the network.
     /// Note these are not tracked on a per-connection basis.
@@ -122,7 +148,7 @@ pub struct Network<N: crate::Network> {
     metrics: Arc<Metrics>,
 }
 
-impl<N: crate::Network> Network<N> {
+impl<N> Network<N> {
     /// Wraps `inner` to make it metered.
     /// The `registry` is used to register the metrics.
     pub(crate) fn new(inner: N, registry: &mut impl Register) -> Self {
@@ -134,40 +160,43 @@ impl<N: crate::Network> Network<N> {
     }
 }
 
-impl<N: crate::Network> crate::Network for Network<N> {
-    type Listener = Listener<N::Listener>;
+impl<N: Dialer> Dialer for Network<N> {
+    type Endpoint = N::Endpoint;
+    type Connection = Connection<N::Connection>;
 
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, crate::Error> {
-        let inner = self.inner.bind(socket).await?;
-        Ok(Listener {
-            inner,
-            metrics: self.metrics.clone(),
-        })
+    fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+        self.inner.supports(endpoint)
     }
 
-    async fn dial(
-        &self,
-        socket: SocketAddr,
-    ) -> Result<(SinkOf<Self>, StreamOf<Self>), crate::Error> {
-        let (sink, stream) = self.inner.dial(socket).await?;
+    async fn dial(&self, endpoint: &Self::Endpoint) -> Result<Self::Connection, crate::Error> {
+        let inner = self.inner.dial(endpoint).await?;
         self.metrics.outbound_connections.inc();
-        Ok((
-            Sink {
-                inner: sink,
-                metrics: self.metrics.clone(),
-            },
-            Stream {
-                inner: stream,
-                metrics: self.metrics.clone(),
-            },
-        ))
+        Ok(Connection {
+            inner,
+            metrics: Arc::clone(&self.metrics),
+        })
+    }
+}
+
+impl<N: Acceptor> Acceptor for Network<N> {
+    type Bind = N::Bind;
+    type Connection = Connection<N::Connection>;
+    type Listener = Listener<N::Listener>;
+
+    async fn bind(&self, bind: &Self::Bind) -> Result<Self::Listener, crate::Error> {
+        let inner = self.inner.bind(bind).await?;
+        Ok(Listener {
+            inner,
+            metrics: Arc::clone(&self.metrics),
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        Listener as _, Network as _, Sink as _, Stream as _,
+        Acceptor as _, Connection as _, Dialer as _, Listener as _, Sink as _, Stream as _,
+        TcpEndpoint,
         network::{
             deterministic::Network as DeterministicNetwork, metered::Network as MeteredNetwork,
             tests,
@@ -175,7 +204,6 @@ mod tests {
     };
     use commonware_macros::test_group;
     use std::net::SocketAddr;
-
     #[tokio::test]
     async fn test_trait() {
         tests::test_network_trait(|| {
@@ -207,17 +235,21 @@ mod tests {
         // Note this is a deterministic network, so we can use any address
         // since we're not actually binding to a real socket.
         let addr = SocketAddr::from(([127, 0, 0, 1], 1234));
-        let mut listener = network.bind(addr).await.unwrap();
+        let mut listener = network.bind(&addr).await.unwrap();
 
         // Create a server task that accepts one connection and echoes data
         let server = tokio::spawn(async move {
-            let (_, mut sink, mut stream) = listener.accept().await.unwrap();
+            let (mut sink, mut stream, _) = listener.accept().await.unwrap().split();
             let received = stream.recv(MSG_SIZE).await.unwrap();
             sink.send(received).await.unwrap();
         });
 
         // Send and receive data as client
-        let (mut client_sink, mut client_stream) = network.dial(addr).await.unwrap();
+        let (mut client_sink, mut client_stream, _) = network
+            .dial(&TcpEndpoint::Socket(addr))
+            .await
+            .unwrap()
+            .split();
 
         // Send fixed-size data and receive response
         let msg = vec![42u8; MSG_SIZE];

--- a/runtime/src/network/mod.rs
+++ b/runtime/src/network/mod.rs
@@ -1,10 +1,39 @@
 use commonware_macros::stability_scope;
 
-stability_scope!(ALPHA {
+stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
+    async fn resolve_tcp_endpoint(
+        endpoint: &crate::TcpEndpoint,
+    ) -> Result<Vec<std::net::SocketAddr>, crate::Error> {
+        use commonware_utils::IpAddrExt;
+        use rand::seq::SliceRandom as _;
+
+        let (host, port, allow_private_ips) = match endpoint {
+            crate::TcpEndpoint::Socket(address) => return Ok(vec![*address]),
+            crate::TcpEndpoint::Dns {
+                host,
+                port,
+                allow_private_ips,
+            } => (host, port, allow_private_ips),
+        };
+
+        let mut addresses: Vec<_> = ::tokio::net::lookup_host((host.as_str(), *port))
+            .await
+            .map_err(|error| crate::Error::ResolveFailed(error.to_string()))?
+            .filter(|address| *allow_private_ips || IpAddrExt::is_global(&address.ip()))
+            .collect();
+        if addresses.is_empty() {
+            return Err(crate::Error::ResolveFailed("no addresses returned".into()));
+        }
+        addresses.shuffle(&mut commonware_utils::sys_rng());
+        Ok(addresses)
+    }
+});
+
+stability_scope!(ALPHA, cfg(not(target_arch = "wasm32")) {
     pub(crate) mod audited;
     pub(crate) mod deterministic;
 });
-stability_scope!(BETA {
+stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
     pub(crate) mod metered;
 });
 stability_scope!(BETA, cfg(all(not(target_arch = "wasm32"), not(feature = "iouring-network"))) {
@@ -16,7 +45,10 @@ stability_scope!(ALPHA, cfg(all(not(target_arch = "wasm32"), feature = "iouring-
 
 #[cfg(test)]
 mod tests {
-    use crate::{IoBuf, IoBufs, Listener, Sink, Stream};
+    use crate::{
+        Acceptor, Connection, Dialer, IoBuf, IoBufs, Listener, Sink, Stream, TcpEndpoint,
+        TcpListener,
+    };
     use commonware_macros::select;
     use commonware_utils::sync::Barrier;
     use futures::{FutureExt, join};
@@ -26,10 +58,45 @@ mod tests {
     const CLIENT_SEND_DATA: &[u8] = b"client_send_data";
     const SERVER_SEND_DATA: &[u8] = b"server_send_data";
 
+    #[cfg(not(feature = "iouring-network"))]
+    fn assert_send<T: Send>(_: &T) {}
+
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[cfg(not(feature = "iouring-network"))]
+    #[test]
+    fn native_network_types_remain_thread_safe() {
+        assert_send_sync::<super::tokio::Network>();
+        assert_send_sync::<super::tokio::Connection>();
+        assert_send_sync::<super::tokio::Sink>();
+        assert_send_sync::<super::tokio::Stream>();
+
+        let mut registry = crate::telemetry::metrics::Registry::default();
+        let pool = crate::BufferPool::new(crate::BufferPoolConfig::for_network(), &mut registry);
+        let network = super::tokio::Network::new(super::tokio::Config::default(), pool);
+        let endpoint = TcpEndpoint::Socket(SocketAddr::from(([127, 0, 0, 1], 1)));
+        let dial = network.dial(&endpoint);
+        assert_send(&dial);
+
+        let address = SocketAddr::from(([127, 0, 0, 1], 0));
+        let bind = network.bind(&address);
+        assert_send(&bind);
+    }
+
+    #[cfg(feature = "iouring-network")]
+    #[test]
+    fn native_iouring_network_types_remain_thread_safe() {
+        assert_send_sync::<super::iouring::Network>();
+        assert_send_sync::<super::iouring::Connection>();
+        assert_send_sync::<super::iouring::Sink>();
+        assert_send_sync::<super::iouring::Stream>();
+    }
+
     pub(super) async fn test_network_trait<N, F>(new_network: F)
     where
         F: Fn() -> N,
-        N: crate::Network,
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
     {
         test_network_bind_and_dial(new_network()).await;
         test_network_vectored_send(new_network()).await;
@@ -44,10 +111,14 @@ mod tests {
     }
 
     // Basic network connectivity test
-    async fn test_network_bind_and_dial<N: crate::Network>(network: N) {
+    async fn test_network_bind_and_dial<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         // Start a server
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
 
@@ -58,7 +129,8 @@ mod tests {
         // join handles are awaited below.
         let server = tokio::spawn(async move {
             // Server accepts a client, verifies the payload, and sends a reply.
-            let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, mut stream, _) =
+                listener.accept().await.expect("Failed to accept").split();
             let received = stream
                 .recv(CLIENT_SEND_DATA.len())
                 .await
@@ -76,10 +148,11 @@ mod tests {
         let client = tokio::spawn(async move {
             // Client connects to the server, sends a payload, and reads the reply.
             // Connect to the server
-            let (mut sink, mut stream) = network
-                .dial(listener_addr)
+            let (mut sink, mut stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             sink.send(IoBuf::from(CLIENT_SEND_DATA))
                 .await
@@ -99,10 +172,14 @@ mod tests {
     }
 
     // Test sending a multi-buffer payload.
-    async fn test_network_vectored_send<N: crate::Network>(network: N) {
+    async fn test_network_vectored_send<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         // Start a server
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
 
@@ -122,7 +199,7 @@ mod tests {
         // side should observe the same byte stream regardless of send chunking.
         let server = tokio::spawn(async move {
             // Server receives the vectored payload as one logical byte stream.
-            let (_, sink, mut stream) = listener.accept().await.expect("Failed to accept");
+            let (sink, mut stream, _) = listener.accept().await.expect("Failed to accept").split();
             let received = stream
                 .recv(expected.len())
                 .await
@@ -135,10 +212,11 @@ mod tests {
         let client = tokio::spawn(async move {
             // Client connects and sends the pre-built vectored message.
             // Connect to the server
-            let (mut sink, stream) = network
-                .dial(listener_addr)
+            let (mut sink, stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             // Send the pre-built vectored message.
             sink.send(message).await.expect("Failed to send data");
@@ -152,13 +230,17 @@ mod tests {
     }
 
     // Test handling multiple clients
-    async fn test_network_multiple_clients<N: crate::Network>(network: N) {
+    async fn test_network_multiple_clients<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         const NUM_CLIENTS: usize = 3;
 
         // Start a server
         let network = Arc::new(network);
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
@@ -172,7 +254,8 @@ mod tests {
             // Handle multiple clients
             let mut set = JoinSet::new();
             for _ in 0..NUM_CLIENTS {
-                let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
+                let (mut sink, mut stream, _) =
+                    listener.accept().await.expect("Failed to accept").split();
                 let barrier = server_barrier.clone();
                 set.spawn(async move {
                     let received = stream
@@ -200,10 +283,11 @@ mod tests {
             let barrier = barrier.clone();
             set.spawn(async move {
                 // Connect to the server
-                let (mut sink, mut stream) = network
-                    .dial(listener_addr)
+                let (mut sink, mut stream, _) = network
+                    .dial(&TcpEndpoint::Socket(listener_addr))
                     .await
-                    .expect("Failed to dial server");
+                    .expect("Failed to dial server")
+                    .split();
 
                 // Send a message to the server
                 sink.send(IoBuf::from(CLIENT_SEND_DATA))
@@ -232,13 +316,17 @@ mod tests {
     }
 
     // Test large data transfer
-    async fn test_network_large_data<N: crate::Network>(network: N) {
+    async fn test_network_large_data<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         const NUM_CHUNKS: usize = 1_000;
         const CHUNK_SIZE: usize = 8 * 1024; // 8 KB
 
         // Start a server
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
@@ -246,7 +334,8 @@ mod tests {
         // Spawn server. Returning the socket halves keeps them alive until both
         // join handles are awaited below.
         let server = tokio::spawn(async move {
-            let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, mut stream, _) =
+                listener.accept().await.expect("Failed to accept").split();
 
             // Receive and echo large data in chunks
             for _ in 0..NUM_CHUNKS {
@@ -263,10 +352,11 @@ mod tests {
         // join handles are awaited below.
         let client = tokio::spawn(async move {
             // Connect to the server
-            let (mut sink, mut stream) = network
-                .dial(listener_addr)
+            let (mut sink, mut stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             // Create a pattern of data
             let pattern = (0..CHUNK_SIZE).map(|i| (i % 256) as u8).collect::<Vec<_>>();
@@ -292,37 +382,45 @@ mod tests {
     }
 
     // Tests dialing and binding errors
-    async fn test_network_connection_errors<N: crate::Network>(network: N) {
+    async fn test_network_connection_errors<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         // Test dialing an invalid address
         let invalid_addr = SocketAddr::from(([127, 0, 0, 1], 1));
-        let result = network.dial(invalid_addr).await;
+        let result = network.dial(&TcpEndpoint::Socket(invalid_addr)).await;
         assert!(matches!(result, Err(crate::Error::ConnectionFailed)));
 
         // Test binding to an already bound address
         let listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
 
         // Try to bind to the same address
-        let result = network.bind(listener_addr).await;
+        let result = network.bind(&listener_addr).await;
         assert!(matches!(result, Err(crate::Error::BindFailed)));
     }
 
     // Tests peek functionality
-    async fn test_network_peek<N: crate::Network>(network: N) {
+    async fn test_network_peek<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         const DATA: &[u8] = b"hello world - peek test data";
 
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
 
         // Server sends data
         let server = tokio::spawn(async move {
-            let (_, mut sink, stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, stream, _) = listener.accept().await.expect("Failed to accept").split();
             sink.send(IoBuf::from(DATA)).await.expect("Failed to send");
             (sink, stream)
         });
@@ -330,10 +428,11 @@ mod tests {
         // Client receives and tests peek
         let client = tokio::spawn(async move {
             // Connect to the server
-            let (sink, mut stream) = network
-                .dial(listener_addr)
+            let (sink, mut stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             // Receive partial data to fill the buffer
             let first = stream.recv(5).await.expect("Failed to receive");
@@ -371,15 +470,20 @@ mod tests {
         client_result.expect("Client task failed");
     }
 
-    async fn test_network_canceled_recv_poisons_stream<N: crate::Network>(network: N) {
+    async fn test_network_canceled_recv_poisons_stream<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
 
         let server = tokio::spawn(async move {
-            let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, mut stream, _) =
+                listener.accept().await.expect("Failed to accept").split();
 
             // Cancel a recv mid-flight
             select! {
@@ -401,10 +505,11 @@ mod tests {
         });
 
         let client = tokio::spawn(async move {
-            let (sink, mut stream) = network
-                .dial(listener_addr)
+            let (sink, mut stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             let received = stream.recv(2).await.expect("Failed to receive response");
             assert_eq!(received.coalesce(), b"ok");
@@ -418,7 +523,11 @@ mod tests {
         client_result.expect("Client task failed");
     }
 
-    async fn test_network_canceled_send_poisons_sink<N: crate::Network>(network: N) {
+    async fn test_network_canceled_send_poisons_sink<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         // Windows IOCP completes TCP writes without yielding, so send
         // cancellation cannot be easily triggered on that platform.
         if cfg!(target_os = "windows") {
@@ -426,14 +535,15 @@ mod tests {
         }
 
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
         let (canceled_sender, canceled_receiver) = oneshot::channel();
 
         let server = tokio::spawn(async move {
-            let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, mut stream, _) =
+                listener.accept().await.expect("Failed to accept").split();
 
             // Poll multiple sends until backpressure makes one pending, then
             // drop that pending future to simulate cancellation.
@@ -467,10 +577,11 @@ mod tests {
         });
 
         let client = tokio::spawn(async move {
-            let (mut sink, stream) = network
-                .dial(listener_addr)
+            let (mut sink, stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             canceled_receiver
                 .await
@@ -487,9 +598,13 @@ mod tests {
         client_result.expect("Client task failed");
     }
 
-    async fn test_network_recv_error_poisons_stream<N: crate::Network>(network: N) {
+    async fn test_network_recv_error_poisons_stream<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
@@ -497,7 +612,8 @@ mod tests {
         // Server triggers a recv error after a partial read, then verifies the
         // stream is poisoned while the sink remains usable.
         let server = tokio::spawn(async move {
-            let (_, mut sink, mut stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, mut stream, _) =
+                listener.accept().await.expect("Failed to accept").split();
 
             let err = stream
                 .recv(100)
@@ -516,10 +632,11 @@ mod tests {
         // Client sends a partial payload, half-closes its write direction, and
         // still receives the server's response on the read half.
         let client = tokio::spawn(async move {
-            let (mut sink, mut stream) = network
-                .dial(listener_addr)
+            let (mut sink, mut stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             sink.send(vec![1u8; 50])
                 .await
@@ -538,11 +655,15 @@ mod tests {
         client_result.expect("Client task failed");
     }
 
-    async fn test_network_send_error_poisons_sink<N: crate::Network>(network: N) {
+    async fn test_network_send_error_poisons_sink<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         const DATA: &[u8] = b"okay";
 
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .expect("Failed to bind");
         let listener_addr = listener.local_addr().expect("Failed to get local address");
@@ -552,7 +673,7 @@ mod tests {
         // Server sends a response, waits for the client to buffer it, then
         // closes the connection so the client's next send eventually fails.
         let server = tokio::spawn(async move {
-            let (_, mut sink, stream) = listener.accept().await.expect("Failed to accept");
+            let (mut sink, stream, _) = listener.accept().await.expect("Failed to accept").split();
 
             sink.send(IoBuf::from(DATA))
                 .await
@@ -573,10 +694,11 @@ mod tests {
         // Client confirms the read half remains usable after the server closes,
         // then verifies the sink is poisoned after the first send error.
         let client = tokio::spawn(async move {
-            let (mut sink, mut stream) = network
-                .dial(listener_addr)
+            let (mut sink, mut stream, _) = network
+                .dial(&TcpEndpoint::Socket(listener_addr))
                 .await
-                .expect("Failed to dial server");
+                .expect("Failed to dial server")
+                .split();
 
             let prefix = stream.recv(2).await.expect("Failed to receive response");
             assert_eq!(prefix.coalesce(), &DATA[..2]);
@@ -630,10 +752,10 @@ mod tests {
     /// pending rather than completing. Other operating systems may clamp the backlog to a
     /// different value or handle an overflowing accept queue differently.
     #[cfg(target_os = "linux")]
-    pub(super) async fn test_network_connect_timeout<N: crate::Network>(
-        network: N,
-        connect_timeout: Duration,
-    ) {
+    pub(super) async fn test_network_connect_timeout<N>(network: N, connect_timeout: Duration)
+    where
+        N: Dialer<Endpoint = TcpEndpoint>,
+    {
         // Create a loopback listener with the smallest possible accept queue.
         let socket = tokio::net::TcpSocket::new_v4().expect("Failed to create TCP socket");
         socket
@@ -650,9 +772,12 @@ mod tests {
             .expect("Failed to fill listener accept queue");
 
         let start = std::time::Instant::now();
-        let result = tokio::time::timeout(connect_timeout * 2, network.dial(listener_addr))
-            .await
-            .expect("Dial did not honor connect timeout");
+        let result = tokio::time::timeout(
+            connect_timeout * 2,
+            network.dial(&TcpEndpoint::Socket(listener_addr)),
+        )
+        .await
+        .expect("Dial did not honor connect timeout");
 
         assert!(matches!(result, Err(crate::Error::Timeout)));
 
@@ -664,21 +789,26 @@ mod tests {
     pub(super) async fn stress_test_network_trait<N, F>(new_network: F)
     where
         F: Fn() -> N,
-        N: crate::Network,
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
     {
         stress_concurrent_streams(new_network()).await;
     }
 
     /// Creates a large number of concurrent streams and sends messages
     /// back and forth between them.
-    async fn stress_concurrent_streams<N: crate::Network>(network: N) {
+    async fn stress_concurrent_streams<N>(network: N)
+    where
+        N: Dialer<Endpoint = TcpEndpoint> + Acceptor<Bind = SocketAddr>,
+        <N as Acceptor>::Listener: TcpListener,
+    {
         const NUM_CLIENTS: usize = 96;
         const NUM_MESSAGES: usize = 16_384;
         const MESSAGE_SIZE: usize = 4096;
 
         let network = Arc::new(network);
         let mut listener = network
-            .bind(SocketAddr::from(([127, 0, 0, 1], 0)))
+            .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .unwrap();
         let addr = listener.local_addr().unwrap();
@@ -691,7 +821,7 @@ mod tests {
         let server = tokio::spawn(async move {
             let mut set = JoinSet::new();
             for _ in 0..NUM_CLIENTS {
-                let (_, mut sink, mut stream) = listener.accept().await.unwrap();
+                let (mut sink, mut stream, _) = listener.accept().await.unwrap().split();
                 let barrier = server_barrier.clone();
                 set.spawn(async move {
                     // Echo every message back to the connected client.
@@ -716,7 +846,11 @@ mod tests {
             let barrier = barrier.clone();
             set.spawn(async move {
                 // Dial the server and repeatedly verify the echoed payload.
-                let (mut sink, mut stream) = network.dial(addr).await.unwrap();
+                let (mut sink, mut stream, _) = network
+                    .dial(&TcpEndpoint::Socket(addr))
+                    .await
+                    .unwrap()
+                    .split();
                 let payload = vec![42u8; MESSAGE_SIZE];
                 for _ in 0..NUM_MESSAGES {
                     sink.send(payload.clone()).await.unwrap();

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -1,9 +1,9 @@
-use crate::{BufferPool, Error, IoBufs};
+use crate::{Acceptor, BufferPool, ConnectionInfo, Dialer, Error, IoBufs, TcpEndpoint, TcpOrigin};
 use std::{convert::identity, net::SocketAddr, time::Duration};
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _, BufReader},
     net::{
-        TcpListener, TcpStream,
+        TcpListener as TokioTcpListener, TcpStream,
         tcp::{OwnedReadHalf, OwnedWriteHalf},
     },
     time::timeout,
@@ -143,18 +143,40 @@ impl crate::Stream for Stream {
     }
 }
 
-/// Implementation of [crate::Listener] using the [tokio] runtime.
+pub struct Connection {
+    sink: Sink,
+    stream: Stream,
+    origin: TcpOrigin,
+}
+
+impl crate::Connection for Connection {
+    type Sink = Sink;
+    type Stream = Stream;
+    type Origin = TcpOrigin;
+
+    fn split(self) -> (Self::Sink, Self::Stream, ConnectionInfo<Self::Origin>) {
+        (
+            self.sink,
+            self.stream,
+            ConnectionInfo {
+                origin: Some(self.origin),
+                transport: "tcp",
+            },
+        )
+    }
+}
+
+/// Implementation of [crate::Listener] using the Tokio runtime.
 pub struct Listener {
     cfg: Config,
-    listener: TcpListener,
+    listener: TokioTcpListener,
     pool: BufferPool,
 }
 
 impl crate::Listener for Listener {
-    type Sink = Sink;
-    type Stream = Stream;
+    type Connection = Connection;
 
-    async fn accept(&mut self) -> Result<(SocketAddr, Self::Sink, Self::Stream), Error> {
+    async fn accept(&mut self) -> Result<Self::Connection, Error> {
         // Accept a new TCP stream
         let (stream, addr) = self.listener.accept().await.map_err(|_| Error::Closed)?;
 
@@ -174,28 +196,30 @@ impl crate::Listener for Listener {
 
         // Return the sink and stream
         let (stream, sink) = stream.into_split();
-        Ok((
-            addr,
-            Sink {
+        Ok(Connection {
+            origin: TcpOrigin { remote: addr },
+            sink: Sink {
                 write_timeout: self.cfg.write_timeout,
                 sink,
                 state: SinkState::Open,
             },
-            Stream {
+            stream: Stream {
                 read_timeout: self.cfg.read_timeout,
                 stream: BufReader::with_capacity(self.cfg.read_buffer_size, stream),
                 pool: self.pool.clone(),
                 poisoned: false,
             },
-        ))
+        })
     }
+}
 
+impl crate::TcpListener for Listener {
     fn local_addr(&self) -> Result<SocketAddr, std::io::Error> {
         self.listener.local_addr()
     }
 }
 
-/// Configuration for the tokio [Network] implementation of the [crate::Network] trait.
+/// Configuration for the tokio TCP transport.
 #[derive(Clone, Debug)]
 pub struct Config {
     /// Whether or not to disable Nagle's algorithm.
@@ -312,7 +336,7 @@ impl Default for Config {
 }
 
 #[derive(Clone)]
-/// [crate::Network] implementation that uses the [tokio] runtime.
+/// TCP transport that uses the [tokio] runtime.
 pub struct Network {
     cfg: Config,
     pool: BufferPool,
@@ -325,11 +349,13 @@ impl Network {
     }
 }
 
-impl crate::Network for Network {
+impl Acceptor for Network {
+    type Bind = SocketAddr;
+    type Connection = Connection;
     type Listener = Listener;
 
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, crate::Error> {
-        TcpListener::bind(socket)
+    async fn bind(&self, socket: &SocketAddr) -> Result<Self::Listener, crate::Error> {
+        TokioTcpListener::bind(*socket)
             .await
             .map_err(|_| Error::BindFailed)
             .map(|listener| Listener {
@@ -338,16 +364,25 @@ impl crate::Network for Network {
                 pool: self.pool.clone(),
             })
     }
+}
 
-    async fn dial(
-        &self,
-        socket: SocketAddr,
-    ) -> Result<(crate::SinkOf<Self>, crate::StreamOf<Self>), crate::Error> {
+impl Dialer for Network {
+    type Endpoint = TcpEndpoint;
+    type Connection = Connection;
+
+    async fn dial(&self, endpoint: &TcpEndpoint) -> Result<Self::Connection, crate::Error> {
+        let connect = async {
+            let addresses = super::resolve_tcp_endpoint(endpoint).await?;
+
+            TcpStream::connect(addresses.as_slice())
+                .await
+                .map_err(|_| Error::ConnectionFailed)
+        };
+
         // Create a new TCP stream
-        let stream = timeout(self.cfg.connect_timeout, TcpStream::connect(socket))
+        let stream = timeout(self.cfg.connect_timeout, connect)
             .await
-            .map_err(|_| Error::Timeout)?
-            .map_err(|_| Error::ConnectionFailed)?;
+            .map_err(|_| Error::Timeout)??;
 
         // Set TCP_NODELAY if configured
         if let Some(tcp_nodelay) = self.cfg.tcp_nodelay
@@ -364,27 +399,30 @@ impl crate::Network for Network {
         }
 
         // Return the sink and stream
+        let remote = stream.peer_addr().map_err(|_| Error::ConnectionFailed)?;
         let (stream, sink) = stream.into_split();
-        Ok((
-            Sink {
+        Ok(Connection {
+            origin: TcpOrigin { remote },
+            sink: Sink {
                 write_timeout: self.cfg.write_timeout,
                 sink,
                 state: SinkState::Open,
             },
-            Stream {
+            stream: Stream {
                 read_timeout: self.cfg.read_timeout,
                 stream: BufReader::with_capacity(self.cfg.read_buffer_size, stream),
                 pool: self.pool.clone(),
                 poisoned: false,
             },
-        ))
+        })
     }
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        BufferPool, BufferPoolConfig, Listener as _, Network as _, Sink as _, Stream as _,
+        Acceptor as _, BufferPool, BufferPoolConfig, Connection as _, Dialer as _, Listener as _,
+        Sink as _, Stream as _, TcpEndpoint, TcpListener as _,
         network::{tests, tokio as TokioNetwork},
         telemetry::metrics::Registry,
     };
@@ -447,12 +485,12 @@ mod tests {
         );
 
         // Bind a listener
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         // Spawn a task to accept and read
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = listener.accept().await.unwrap().split();
 
             // Read a small message (much smaller than the 64KB buffer)
             let start = Instant::now();
@@ -463,7 +501,11 @@ mod tests {
         });
 
         // Connect and send a small message
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let (mut sink, _stream, _) = network
+            .dial(&TcpEndpoint::Socket(addr))
+            .await
+            .unwrap()
+            .split();
         let msg = vec![1u8, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         sink.send(msg.clone()).await.unwrap();
 
@@ -490,11 +532,11 @@ mod tests {
         );
 
         // Bind a listener
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = listener.accept().await.unwrap().split();
 
             // Try to read 100 bytes, but only 5 will be sent
             let start = Instant::now();
@@ -505,7 +547,11 @@ mod tests {
         });
 
         // Connect and send only partial data
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let (mut sink, _stream, _) = network
+            .dial(&TcpEndpoint::Socket(addr))
+            .await
+            .unwrap()
+            .split();
         sink.send([1u8, 2, 3, 4, 5].as_slice()).await.unwrap();
 
         // Wait for the reader to complete
@@ -530,12 +576,12 @@ mod tests {
         );
 
         // Bind a listener
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         // Spawn a task to accept and read
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = listener.accept().await.unwrap().split();
 
             // In unbuffered mode, peek should always return empty
             assert!(stream.peek(100).is_empty());
@@ -553,7 +599,11 @@ mod tests {
         });
 
         // Connect and send two messages
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let (mut sink, _stream, _) = network
+            .dial(&TcpEndpoint::Socket(addr))
+            .await
+            .unwrap()
+            .split();
         sink.send([1u8, 2, 3, 4, 5].as_slice()).await.unwrap();
         sink.send([6u8, 7, 8, 9, 10].as_slice()).await.unwrap();
 
@@ -575,11 +625,11 @@ mod tests {
             test_pool(),
         );
 
-        let mut listener = network.bind("127.0.0.1:0".parse().unwrap()).await.unwrap();
+        let mut listener = network.bind(&"127.0.0.1:0".parse().unwrap()).await.unwrap();
         let addr = listener.local_addr().unwrap();
 
         let reader = tokio::spawn(async move {
-            let (_addr, _sink, mut stream) = listener.accept().await.unwrap();
+            let (_sink, mut stream, _) = listener.accept().await.unwrap().split();
 
             // Initially peek should be empty (no data received yet)
             assert!(stream.peek(100).is_empty());
@@ -608,7 +658,11 @@ mod tests {
         });
 
         // Connect and send data
-        let (mut sink, _stream) = network.dial(addr).await.unwrap();
+        let (mut sink, _stream, _) = network
+            .dial(&TcpEndpoint::Socket(addr))
+            .await
+            .unwrap()
+            .split();
         sink.send(b"hello world").await.unwrap();
 
         reader.await.unwrap();

--- a/runtime/src/storage/header.rs
+++ b/runtime/src/storage/header.rs
@@ -149,7 +149,7 @@ stability_scope!(BETA {
         pub(crate) const fn data_offset(self) -> u64 {
             match self {
                 Self::V0 => Header::PRELUDE_SIZE as u64,
-                Self::V1 => 4096,
+                Self::V1 => super::V1_BLOB_DATA_OFFSET,
             }
         }
 

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -91,27 +91,36 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
     }
 });
 
-stability_scope!(ALPHA {
+stability_scope!(ALPHA, cfg(not(target_arch = "wasm32")) {
     pub mod audited;
     pub mod faulty;
     pub mod memory;
 });
-stability_scope!(ALPHA, cfg(feature = "iouring-storage") {
+stability_scope!(ALPHA, cfg(all(not(target_arch = "wasm32"), feature = "iouring-storage")) {
     pub mod iouring;
 });
 stability_scope!(BETA, cfg(all(not(target_arch = "wasm32"), not(feature = "iouring-storage"))) {
     pub mod tokio;
 });
 stability_scope!(BETA {
+    /// Offset where V1 blob data begins after its header.
+    pub(crate) const V1_BLOB_DATA_OFFSET: u64 = 4096;
+
+    #[cfg(not(target_arch = "wasm32"))]
     pub mod metered;
 
+    #[cfg(not(target_arch = "wasm32"))]
     mod header;
-    pub(crate) use header::{Header, Layout};
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) use header::Header;
+    #[cfg(all(test, not(target_arch = "wasm32")))]
+    pub(crate) use header::Layout;
 
     /// Validate that a partition name contains only allowed characters.
     ///
     /// Partition names must only contain alphanumeric characters, dashes ('-'),
     /// or underscores ('_').
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn validate_partition_name(partition: &str) -> Result<(), crate::Error> {
         if partition.is_empty()
             || partition

--- a/runtime/src/telemetry/metrics/mod.rs
+++ b/runtime/src/telemetry/metrics/mod.rs
@@ -3,9 +3,11 @@
 pub mod histogram;
 mod registration;
 pub mod status;
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod task;
 
 /// Prefix for runtime metrics.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) const METRICS_PREFIX: &str = "runtime";
 
 pub use commonware_runtime_macros::{EncodeLabelSet, EncodeLabelValue, EncodeStruct};
@@ -34,18 +36,24 @@ pub mod raw {
     };
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 use commonware_utils::sync::Mutex;
+#[cfg(not(target_arch = "wasm32"))]
 use prometheus_client::encoding::{
     MetricEncoder as PromMetricEncoder,
     text::{encode, encode_eof},
 };
 pub use registration::Registration;
+#[cfg(not(target_arch = "wasm32"))]
 use std::{
     any::Any,
     borrow::Cow,
     collections::{BTreeMap, HashMap},
+    sync::Weak,
+};
+use std::{
     ops::Deref,
-    sync::{Arc, Weak, atomic::Ordering},
+    sync::{Arc, atomic::Ordering},
 };
 
 /// Native integer width used by [`raw::Gauge`] on this target.
@@ -229,7 +237,7 @@ pub fn has_metric_value(metrics: &str, name: &str, value: impl std::fmt::Display
 ///
 /// ```rust
 /// use commonware_runtime::{
-///     deterministic, telemetry::metrics::count_running_tasks, Clock, Metrics, Runner, Spawner,
+///     deterministic, telemetry::metrics::count_running_tasks, Clock, Metrics, Runner, Scheduler,
 ///     Supervisor,
 /// };
 /// use std::time::Duration;
@@ -280,6 +288,7 @@ pub fn count_running_tasks(metrics: &impl crate::Metrics, prefix: &str) -> usize
 //
 // Source:
 // https://github.com/prometheus/client_rust/blob/4a6d40a55443d5b18f5be311d246c03e56f417d6/src/encoding/text.rs#L218-L275
+#[cfg(not(target_arch = "wasm32"))]
 fn encode_descriptor<W>(
     writer: &mut W,
     name: &str,
@@ -302,6 +311,7 @@ where
 }
 
 /// Join a metric or label prefix with a child name using Prometheus' `_` separator.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn prefixed_name(prefix: &str, name: &str) -> String {
     if prefix.is_empty() {
         name.to_string()
@@ -312,6 +322,7 @@ pub(crate) fn prefixed_name(prefix: &str, name: &str) -> String {
 
 /// Build a child context label by appending `label` to `prefix`, asserting that
 /// `label` is valid and does not shadow the reserved runtime metric prefix.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn child_label(prefix: &str, label: &str) -> String {
     validate_label(label);
     let name = prefixed_name(prefix, label);
@@ -322,11 +333,13 @@ pub(crate) fn child_label(prefix: &str, label: &str) -> String {
     name
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 struct RegistryGuard {
     id: usize,
     registry: Weak<Mutex<RegistryInner>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Drop for RegistryGuard {
     fn drop(&mut self) {
         let Some(registry) = self.registry.upgrade() else {
@@ -422,10 +435,14 @@ impl<M: std::fmt::Debug> std::fmt::Debug for Registered<M> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 type MetricAttributes = Vec<(Cow<'static, str>, Cow<'static, str>)>;
+#[cfg(not(target_arch = "wasm32"))]
 type MetricKey = (String, MetricAttributes);
+#[cfg(not(target_arch = "wasm32"))]
 type SampleEncoder = dyn Fn(&mut String) -> Result<(), std::fmt::Error> + Send + Sync;
 
+#[cfg(not(target_arch = "wasm32"))]
 struct PendingMetricEntry {
     family_name: String,
     attributes: MetricAttributes,
@@ -433,14 +450,17 @@ struct PendingMetricEntry {
     metric_any: Arc<dyn Any + Send + Sync>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct SharedMetric<M>(pub(crate) Arc<M>);
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<M: std::fmt::Debug> std::fmt::Debug for SharedMetric<M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<M: EncodeMetric> EncodeMetric for SharedMetric<M> {
     fn encode(&self, encoder: PromMetricEncoder<'_>) -> Result<(), std::fmt::Error> {
         self.0.encode(encoder)
@@ -451,6 +471,7 @@ impl<M: EncodeMetric> EncodeMetric for SharedMetric<M> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn create_sample_encoder<M>(
     name: String,
     labels: MetricAttributes,
@@ -479,6 +500,7 @@ where
     })
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn owned_attributes(attributes: Vec<(String, String)>) -> MetricAttributes {
     attributes
         .into_iter()
@@ -490,10 +512,12 @@ fn owned_attributes(attributes: Vec<(String, String)>) -> MetricAttributes {
 //
 // Source:
 // https://github.com/prometheus/client_rust/blob/4a6d40a55443d5b18f5be311d246c03e56f417d6/src/registry.rs#L340-L348
+#[cfg(not(target_arch = "wasm32"))]
 fn normalize_help(help: String) -> String {
     help + "."
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 struct MetricEntry {
     family_name: String,
     attributes: MetricAttributes,
@@ -504,6 +528,7 @@ struct MetricEntry {
 }
 
 #[derive(Debug)]
+#[cfg(not(target_arch = "wasm32"))]
 struct MetricFamily {
     help: String,
     metric_type: MetricType,
@@ -514,9 +539,11 @@ struct MetricFamily {
 /// Manages metrics with explicit lifetimes.
 #[derive(Clone)]
 pub struct Registry {
+    #[cfg(not(target_arch = "wasm32"))]
     inner: Arc<Mutex<RegistryInner>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 struct RegistryInner {
     /// Dense metric storage indexed by stable metric id.
     metrics: Vec<Option<MetricEntry>>,
@@ -539,10 +566,12 @@ impl Default for Registry {
 impl Registry {
     pub fn new() -> Self {
         Self {
+            #[cfg(not(target_arch = "wasm32"))]
             inner: Arc::new(Mutex::new(RegistryInner::new())),
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn register<M>(
         &self,
         name: String,
@@ -558,10 +587,18 @@ impl Registry {
     }
 
     pub fn encode(&self) -> String {
-        self.inner.lock().encode()
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            self.inner.lock().encode()
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            "# EOF\n".to_string()
+        }
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl RegistryInner {
     fn new() -> Self {
         Self {
@@ -808,11 +845,13 @@ impl RegistryInner {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct Scope {
     registry: Registry,
     prefix: String,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) trait Register {
     /// Register a metric under this scope's prefix.
     fn register<M: Metric>(&mut self, name: &str, help: &str, metric: M) -> Registered<M>;
@@ -821,6 +860,7 @@ pub(crate) trait Register {
     fn sub_registry(&mut self, prefix: &str) -> Scope;
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Register for Registry {
     fn register<M: Metric>(&mut self, name: &str, help: &str, metric: M) -> Registered<M> {
         validate_label(name);
@@ -842,6 +882,7 @@ impl Register for Registry {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Register for Scope {
     fn register<M: Metric>(&mut self, name: &str, help: &str, metric: M) -> Registered<M> {
         validate_label(name);
@@ -863,7 +904,7 @@ impl Register for Scope {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Metrics as _, Runner, Spawner, Supervisor as _, deterministic};
+    use crate::{Metrics as _, Runner, Scheduler, Supervisor as _, deterministic};
     use commonware_macros::test_traced;
     use futures::future;
     use std::sync::mpsc::{self, TryRecvError};

--- a/runtime/src/telemetry/traces/mod.rs
+++ b/runtime/src/telemetry/traces/mod.rs
@@ -1,5 +1,6 @@
 //! Utility functions for traces
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod status;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/runtime/src/tokio/mod.rs
+++ b/runtime/src/tokio/mod.rs
@@ -8,7 +8,7 @@
 //! # Example
 //!
 //! ```rust
-//! use commonware_runtime::{Spawner, Runner, Supervisor, tokio, Metrics};
+//! use commonware_runtime::{Scheduler, Runner, Supervisor, tokio, Metrics};
 //!
 //! let executor = tokio::Runner::default();
 //! executor.start(|context| async move {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -7,8 +7,8 @@ use crate::storage::iouring::{Config as IoUringConfig, Storage as IoUringStorage
 #[cfg(not(feature = "iouring-storage"))]
 use crate::storage::tokio::{Config as TokioStorageConfig, Storage as TokioStorage};
 use crate::{
-    BufferPool, BufferPoolConfig, Clock, Error, Execution, Handle, METRICS_PREFIX, Name, SinkOf,
-    Spawner as _, StreamOf, Supervisor as _, child_label,
+    Acceptor, BufferPool, BufferPoolConfig, Clock, ConnectionOf, Dialer, Error, Execution, Handle,
+    METRICS_PREFIX, Name, Scheduler as _, Spawner as _, Supervisor as _, TcpEndpoint, child_label,
     network::metered::Network as MeteredNetwork,
     prefixed_name,
     process::metered::Metrics as MeteredProcess,
@@ -538,9 +538,8 @@ cfg_if::cfg_if! {
     }
 }
 
-/// Implementation of [crate::Spawner], [crate::Clock],
-/// [crate::Network], and [crate::Storage] for the `tokio`
-/// runtime.
+/// Implementation of [crate::Scheduler], [crate::Clock], [crate::Dialer],
+/// [crate::Acceptor], and [crate::Storage] for the `tokio` runtime.
 pub struct Context {
     name: String,
     attributes: Vec<(String, String)>,
@@ -560,17 +559,7 @@ impl Context {
     }
 }
 
-impl crate::Spawner for Context {
-    fn dedicated(mut self) -> Self {
-        self.execution = Execution::Dedicated;
-        self
-    }
-
-    fn shared(mut self, blocking: bool) -> Self {
-        self.execution = Execution::Shared(blocking);
-        self
-    }
-
+impl crate::Scheduler for Context {
     fn spawn<F, Fut, T>(mut self, f: F) -> Handle<T>
     where
         F: FnOnce(Self) -> Fut + Send + 'static,
@@ -650,6 +639,18 @@ impl crate::Spawner for Context {
 
     fn stopped(&self) -> Signal {
         self.executor.shutdown.lock().stopped()
+    }
+}
+
+impl crate::Spawner for Context {
+    fn dedicated(mut self) -> Self {
+        self.execution = Execution::Dedicated;
+        self
+    }
+
+    fn shared(mut self, blocking: bool) -> Self {
+        self.execution = Execution::Shared(blocking);
+        self
     }
 }
 
@@ -769,29 +770,35 @@ impl GClock for Context {
 
 impl ReasonablyRealtime for Context {}
 
-impl crate::Network for Context {
-    type Listener = <Network as crate::Network>::Listener;
-
-    async fn bind(&self, socket: SocketAddr) -> Result<Self::Listener, Error> {
-        self.network.bind(socket).await
-    }
-
-    async fn dial(&self, socket: SocketAddr) -> Result<(SinkOf<Self>, StreamOf<Self>), Error> {
-        self.network.dial(socket).await
+impl crate::Resolver for Context {
+    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, Error> {
+        let addresses = tokio::net::lookup_host(format!("{host}:0"))
+            .await
+            .map_err(|error| Error::ResolveFailed(error.to_string()))?;
+        Ok(addresses.map(|address| address.ip()).collect())
     }
 }
 
-impl crate::Resolver for Context {
-    async fn resolve(&self, host: &str) -> Result<Vec<IpAddr>, Error> {
-        // Uses the host's DNS configuration (e.g. /etc/resolv.conf on Unix,
-        // registry on Windows). This delegates to the system's libc resolver.
-        //
-        // The `:0` port is required by lookup_host's API but is not used
-        // for DNS resolution.
-        let addrs = tokio::net::lookup_host(format!("{host}:0"))
-            .await
-            .map_err(|e| Error::ResolveFailed(e.to_string()))?;
-        Ok(addrs.map(|addr| addr.ip()).collect())
+impl Dialer for Context {
+    type Endpoint = TcpEndpoint;
+    type Connection = ConnectionOf<Network>;
+
+    fn supports(&self, endpoint: &Self::Endpoint) -> bool {
+        self.network.supports(endpoint)
+    }
+
+    async fn dial(&self, endpoint: &Self::Endpoint) -> Result<Self::Connection, Error> {
+        self.network.dial(endpoint).await
+    }
+}
+
+impl Acceptor for Context {
+    type Bind = SocketAddr;
+    type Connection = <Network as Acceptor>::Connection;
+    type Listener = <Network as Acceptor>::Listener;
+
+    async fn bind(&self, bind: &Self::Bind) -> Result<Self::Listener, Error> {
+        self.network.bind(bind).await
     }
 }
 
@@ -849,16 +856,11 @@ impl crate::BufferPooler for Context {
 mod tests {
     use super::*;
     use crate::{
-        Metrics, Network, Resolver, Runner as _, Sink, Stream, telemetry::metrics::raw::Counter,
-        tokio::telemetry,
+        Connection as _, Listener as _, Metrics, Runner as _, Sink, Stream, TcpListener as _,
+        telemetry::metrics::raw::Counter, tokio::telemetry,
     };
     use bytes::Bytes;
-    use std::{
-        self,
-        collections::HashMap,
-        net::{IpAddr, Ipv4Addr, Ipv6Addr},
-        str::FromStr,
-    };
+    use std::{self, collections::HashMap, str::FromStr};
     use tracing::{Level, error};
 
     #[test]
@@ -1048,9 +1050,10 @@ mod tests {
 
             // Simulate a client connecting to the server
             let client_handle = context.child("client").spawn(move |context| async move {
-                let (mut sink, mut stream) = loop {
-                    match context.dial(address).await {
-                        Ok((sink, stream)) => break (sink, stream),
+                let endpoint = TcpEndpoint::Socket(address);
+                let (mut sink, mut stream, _) = loop {
+                    match context.dial(&endpoint).await {
+                        Ok(connection) => break connection.split(),
                         Err(e) => {
                             // The client may be polled before the server is ready, that's alright!
                             error!(err =?e, "failed to connect");
@@ -1092,14 +1095,30 @@ mod tests {
     fn test_resolver() {
         let executor = Runner::default();
         executor.start(|context| async move {
-            let addrs = context.resolve("localhost").await.unwrap();
-            assert!(!addrs.is_empty());
-            for addr in addrs {
-                assert!(
-                    addr == IpAddr::V4(Ipv4Addr::LOCALHOST)
-                        || addr == IpAddr::V6(Ipv6Addr::LOCALHOST)
-                );
-            }
+            let mut listener = context
+                .bind(&SocketAddr::from(([127, 0, 0, 1], 0)))
+                .await
+                .unwrap();
+            let port = listener.local_addr().unwrap().port();
+            let endpoint = TcpEndpoint::Dns {
+                host: "127.0.0.1".to_string(),
+                port,
+                allow_private_ips: true,
+            };
+
+            let (dialed, accepted) = futures::join!(context.dial(&endpoint), listener.accept());
+            dialed.unwrap().split();
+            accepted.unwrap().split();
+
+            let endpoint = TcpEndpoint::Dns {
+                host: "127.0.0.1".to_string(),
+                port,
+                allow_private_ips: false,
+            };
+            assert!(matches!(
+                context.dial(&endpoint).await,
+                Err(Error::ResolveFailed(_))
+            ));
         });
     }
 }

--- a/runtime/src/tokio/telemetry.rs
+++ b/runtime/src/tokio/telemetry.rs
@@ -4,7 +4,7 @@ use super::{
     Context,
     tracing::{Config, export},
 };
-use crate::{Metrics as _, Spawner, Supervisor as _};
+use crate::{Metrics as _, Scheduler, Supervisor as _};
 use axum::{
     Extension, Router,
     body::Body,
@@ -115,7 +115,7 @@ pub fn init(context: Context, logs: Logs, metrics: Option<SocketAddr>, traces: O
             // Serve the metrics over HTTP.
             //
             // `serve` will spawn its own tasks using `tokio::spawn` (and there is no way to specify
-            // it to do otherwise). These tasks will not be tracked like metrics spawned using `Spawner`.
+            // it to do otherwise). These tasks will not be tracked like metrics spawned using `Scheduler`.
             serve(listener, app.into_make_service())
                 .await
                 .expect("Could not serve metrics");

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -1,6 +1,12 @@
 //! Buffers for reading and writing to [crate::Blob]s.
 
-use futures::future::{BoxFuture, FutureExt as _, Shared};
+use futures::{FutureExt as _, future::Shared};
+
+#[cfg(not(target_arch = "wasm32"))]
+type CompletionFuture = futures::future::BoxFuture<'static, Result<(), crate::Error>>;
+
+#[cfg(target_arch = "wasm32")]
+type CompletionFuture = futures::future::LocalBoxFuture<'static, Result<(), crate::Error>>;
 
 pub mod paged;
 mod read;
@@ -16,7 +22,7 @@ pub use write::Write;
 /// dropping one neither cancels the underlying sync nor consumes its result, and every
 /// observer sees the same outcome.
 #[derive(Clone)]
-struct Completion(Shared<BoxFuture<'static, Result<(), crate::Error>>>);
+struct Completion(Shared<CompletionFuture>);
 
 impl Completion {
     /// Return a handle for the sync result.
@@ -32,7 +38,11 @@ impl Completion {
 
 impl From<crate::Handle<()>> for Completion {
     fn from(handle: crate::Handle<()>) -> Self {
-        Self(handle.boxed().shared())
+        #[cfg(not(target_arch = "wasm32"))]
+        let handle = handle.boxed();
+        #[cfg(target_arch = "wasm32")]
+        let handle = handle.boxed_local();
+        Self(handle.shared())
     }
 }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -20,7 +20,11 @@ use tracing::{error, trace, warn};
 
 /// Shared future for one logical page fetch. The output uses `Arc<Error>` because `Shared`
 /// requires cloneable results. The `IoBuf` contains only the logical, validated page bytes.
+#[cfg(not(target_arch = "wasm32"))]
 type PageFetchFuture = Shared<Pin<Box<dyn Future<Output = Result<IoBuf, Arc<Error>>> + Send>>>;
+
+#[cfg(target_arch = "wasm32")]
+type PageFetchFuture = Shared<Pin<Box<dyn Future<Output = Result<IoBuf, Arc<Error>>>>>>;
 
 /// Shared handle to one in-flight fetch generation. The cache keeps one copy in `page_fetches`,
 /// and each waiter clones the `Arc` while it is still interested in the result.
@@ -400,7 +404,10 @@ impl CacheRef {
                     };
 
                     // Make the future shareable and insert it into the map.
+                    #[cfg(not(target_arch = "wasm32"))]
                     let fetch_future = future.boxed().shared();
+                    #[cfg(target_arch = "wasm32")]
+                    let fetch_future = future.boxed_local().shared();
                     let fetch = Arc::new(fetch_future.clone());
                     v.insert(PageFetchEntry {
                         fetch: Arc::clone(&fetch),
@@ -603,7 +610,7 @@ mod tests {
     use super::{super::Checksum, *};
     use crate::{
         Buf, BufferPool, BufferPoolConfig, Clock as _, Handle, IoBufs, IoBufsMut, Runner as _,
-        Spawner as _, Storage as _, Supervisor as _, buffer::paged::CHECKSUM_SIZE, deterministic,
+        Scheduler as _, Storage as _, Supervisor as _, buffer::paged::CHECKSUM_SIZE, deterministic,
         telemetry::metrics::Registry,
     };
     use commonware_cryptography::Crc32;

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -63,11 +63,7 @@ const CHECKSUM_SIZE: u64 = Checksum::SIZE as u64;
 pub(crate) const STORAGE_PAGE_SIZE: u64 = 4096;
 // The alignment reasoning above assumes newly created blobs place their data on a
 // storage-page boundary.
-const _: () = assert!(
-    crate::storage::Layout::V1
-        .data_offset()
-        .is_multiple_of(STORAGE_PAGE_SIZE)
-);
+const _: () = assert!(crate::storage::V1_BLOB_DATA_OFFSET.is_multiple_of(STORAGE_PAGE_SIZE));
 
 const CHECKSUM_SLOT_LEN_SIZE: usize = u16::SIZE;
 const CHECKSUM_SLOT_SIZE: usize = CHECKSUM_SLOT_LEN_SIZE + crc32::Digest::SIZE;

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1182,7 +1182,7 @@ impl<B: Blob> Writer<B> {
 mod tests {
     use super::*;
     use crate::{
-        Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
+        Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Scheduler as _,
         Storage as _, Supervisor as _,
         buffer::{paged::CHECKSUM_SLOT_LEN_SIZE, tests::SyncTrackingBlob},
         deterministic,

--- a/runtime/src/utils/cell.rs
+++ b/runtime/src/utils/cell.rs
@@ -13,7 +13,7 @@ const DUPLICATE_CONTEXT: &str = "runtime context already present";
 macro_rules! spawn_cell {
     ($cell:expr, $body:expr $(,)?) => {{
         let __commonware_context = $cell.take();
-        $crate::Spawner::spawn(__commonware_context, move |context| {
+        $crate::Scheduler::spawn(__commonware_context, move |context| {
             $cell.restore(context);
             $body
         })

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -1,36 +1,44 @@
-use crate::{
-    Error,
-    telemetry::metrics::raw::Gauge,
-    utils::{extract_panic_message, supervision::Tree},
-};
-use commonware_utils::{
-    channel::oneshot,
-    sync::{Mutex, Once},
-};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::utils::extract_panic_message;
+use crate::{Error, PlatformSend};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::{telemetry::metrics::raw::Gauge, utils::supervision::Tree};
+use commonware_utils::channel::oneshot;
+#[cfg(not(target_arch = "wasm32"))]
+use commonware_utils::sync::Mutex;
+#[cfg(not(target_arch = "wasm32"))]
+use commonware_utils::sync::Once;
+use futures::stream::{AbortHandle, Abortable};
+#[cfg(not(target_arch = "wasm32"))]
 use futures::{
     FutureExt as _,
     future::{Either, select},
     pin_mut,
-    stream::{AbortHandle, Abortable, Aborted},
+    stream::Aborted,
 };
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::{
     any::Any,
-    future::Future,
     panic::{AssertUnwindSafe, resume_unwind},
+};
+use std::{
+    future::Future,
     pin::Pin,
-    sync::Arc,
     task::{Context, Poll},
 };
+#[cfg(not(target_arch = "wasm32"))]
 use tracing::error;
 
 /// Handle to an asynchronous result.
 ///
-/// Handles returned by [`crate::Spawner::spawn`] abort the spawned task. Completion handles only
+/// Handles returned by [`crate::Scheduler::spawn`] abort the spawned task. Completion handles only
 /// stop waiting when aborted, resolving to [`Error::Aborted`]; they do not cancel the underlying
 /// work.
 pub struct Handle<T>
 where
-    T: Send + 'static,
+    T: PlatformSend + 'static,
 {
     state: HandleState<T>,
 }
@@ -38,8 +46,9 @@ where
 /// Distinguishes handles that own spawned work from handles that only wait on completion.
 enum HandleState<T>
 where
-    T: Send + 'static,
+    T: PlatformSend + 'static,
 {
+    #[cfg(not(target_arch = "wasm32"))]
     Task {
         receiver: oneshot::Receiver<Result<T, Error>>,
         abort_handle: AbortHandle,
@@ -54,17 +63,23 @@ where
 /// Normalizes receiver-backed and future-backed completions behind one abortable future.
 enum Completion<T>
 where
-    T: Send + 'static,
+    T: PlatformSend + 'static,
 {
     Receiver(oneshot::Receiver<Result<T, Error>>),
-    Future(Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'static>>),
+    Future(BoxedCompletion<T>),
 }
 
-impl<T> Unpin for Completion<T> where T: Send + 'static {}
+#[cfg(not(target_arch = "wasm32"))]
+type BoxedCompletion<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + Send + 'static>>;
+
+#[cfg(target_arch = "wasm32")]
+type BoxedCompletion<T> = Pin<Box<dyn Future<Output = Result<T, Error>> + 'static>>;
+
+impl<T> Unpin for Completion<T> where T: PlatformSend + 'static {}
 
 impl<T> Future for Completion<T>
 where
-    T: Send + 'static,
+    T: PlatformSend + 'static,
 {
     type Output = Result<T, Error>;
 
@@ -80,9 +95,10 @@ where
 
 impl<T> Handle<T>
 where
-    T: Send + 'static,
+    T: PlatformSend + 'static,
 {
     #[inline(always)]
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn init<F>(
         f: F,
         metric: MetricHandle,
@@ -90,7 +106,7 @@ where
         tree: Arc<Tree>,
     ) -> (impl Future<Output = ()>, Self)
     where
-        F: Future<Output = T> + Send + 'static,
+        F: Future<Output = T> + PlatformSend + 'static,
     {
         // Initialize channels to handle result/abort
         let (sender, receiver) = oneshot::channel();
@@ -152,7 +168,7 @@ where
     /// Returns a handle backed by a completion future.
     pub fn from_future<F>(future: F) -> Self
     where
-        F: Future<Output = Result<T, Error>> + Send + 'static,
+        F: Future<Output = Result<T, Error>> + PlatformSend + 'static,
     {
         let (abort_handle, abort_registration) = AbortHandle::new_pair();
         Self {
@@ -171,6 +187,7 @@ where
     }
 
     /// Returns a handle that resolves to [`Error::Closed`] without spawning work.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn closed(metric: MetricHandle) -> Self {
         // Mark the task as finished immediately so gauges remain accurate.
         metric.finish();
@@ -185,6 +202,7 @@ where
     /// Abort the spawned task or stop waiting for a completion.
     pub fn abort(&self) {
         match &self.state {
+            #[cfg(not(target_arch = "wasm32"))]
             HandleState::Task {
                 abort_handle,
                 metric,
@@ -203,8 +221,10 @@ where
     }
 
     /// Returns a helper that aborts the task and updates metrics consistently.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn aborter(&self) -> Option<Aborter> {
         match &self.state {
+            #[cfg(not(target_arch = "wasm32"))]
             HandleState::Task {
                 abort_handle,
                 metric,
@@ -217,12 +237,13 @@ where
 
 impl<T> Future for Handle<T>
 where
-    T: Send + 'static,
+    T: PlatformSend + 'static,
 {
     type Output = Result<T, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         match &mut self.state {
+            #[cfg(not(target_arch = "wasm32"))]
             HandleState::Task { receiver, .. } => Pin::new(receiver)
                 .poll(cx)
                 .map(|result| result.unwrap_or_else(|_| Err(Error::Closed))),
@@ -235,11 +256,13 @@ where
 
 /// Tracks the metric state associated with a spawned task handle.
 #[derive(Clone)]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct MetricHandle {
     gauge: Gauge,
     finished: Arc<Once>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl MetricHandle {
     /// Increments the supplied gauge and returns a handle responsible for
     /// eventually decrementing it.
@@ -265,15 +288,18 @@ impl MetricHandle {
 }
 
 /// A panic emitted by a spawned task.
+#[cfg(not(target_arch = "wasm32"))]
 pub type Panic = Box<dyn Any + Send + 'static>;
 
 /// Notifies the runtime when a spawned task panics, so it can propagate the failure.
 #[derive(Clone)]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct Panicker {
     catch: bool,
     sender: Arc<Mutex<Option<oneshot::Sender<Panic>>>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Panicker {
     /// Creates a new [Panicker].
     pub(crate) fn new(catch: bool) -> (Self, Panicked) {
@@ -315,10 +341,12 @@ impl Panicker {
 }
 
 /// A handle that will be notified when a panic occurs.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct Panicked {
     receiver: oneshot::Receiver<Panic>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Panicked {
     /// Polls a task that should be interrupted by a panic.
     pub(crate) async fn interrupt<Fut>(self, task: Fut) -> Fut::Output
@@ -348,11 +376,13 @@ impl Panicked {
 }
 
 /// Couples an [`AbortHandle`] with its metric handle so aborted tasks clean up gauges.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct Aborter {
     inner: AbortHandle,
     metric: MetricHandle,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Aborter {
     /// Creates a new [`Aborter`] for the provided abort handle and metric handle.
     pub(crate) const fn new(inner: AbortHandle, metric: MetricHandle) -> Self {
@@ -372,7 +402,9 @@ impl Aborter {
 #[cfg(test)]
 mod tests {
     use super::Handle;
-    use crate::{Error, Metrics as _, Runner, Spawner, Supervisor as _, deterministic};
+    use crate::{
+        Error, Metrics as _, Runner, Scheduler, Spawner as _, Supervisor as _, deterministic,
+    };
     use commonware_utils::channel::oneshot;
     use futures::future;
 

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -3,7 +3,6 @@
 use commonware_utils::sync::{Condvar, Mutex};
 use futures::task::ArcWake;
 use std::{
-    any::Any,
     future::Future,
     pin::Pin,
     sync::Arc,
@@ -17,13 +16,18 @@ pub(crate) mod thread;
 
 mod handle;
 pub use handle::Handle;
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use handle::MetricHandle;
 #[commonware_macros::stability(ALPHA)]
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) use handle::Panicked;
-pub(crate) use handle::{Aborter, MetricHandle, Panicker};
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use handle::Panicker;
 
 mod cell;
 pub use cell::Cell as ContextCell;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) mod supervision;
 
 /// The execution mode of a task.
@@ -65,7 +69,8 @@ pub async fn reschedule() {
     Reschedule { yielded: false }.await
 }
 
-pub(crate) fn extract_panic_message(err: &(dyn Any + Send)) -> String {
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn extract_panic_message(err: &(dyn std::any::Any + Send)) -> String {
     err.downcast_ref::<&str>().map_or_else(
         || {
             err.downcast_ref::<String>()

--- a/runtime/src/utils/signal.rs
+++ b/runtime/src/utils/signal.rs
@@ -21,7 +21,7 @@ use std::{
 /// ## Basic Usage
 ///
 /// ```rust
-/// use commonware_runtime::{Spawner, Runner, deterministic, signal::Signaler};
+/// use commonware_runtime::{Scheduler, Runner, deterministic, signal::Signaler};
 ///
 /// let executor = deterministic::Runner::default();
 /// executor.start(|context| async move {
@@ -50,7 +50,7 @@ use std::{
 ///
 /// ```rust
 /// use commonware_macros::select;
-/// use commonware_runtime::{Clock, Spawner, Runner, Supervisor, deterministic, Metrics, signal::Signaler};
+/// use commonware_runtime::{Clock, Scheduler, Runner, Supervisor, deterministic, Metrics, signal::Signaler};
 /// use commonware_utils::channel::oneshot;
 /// use std::time::Duration;
 ///

--- a/runtime/src/utils/supervision.rs
+++ b/runtime/src/utils/supervision.rs
@@ -1,4 +1,4 @@
-use super::Aborter;
+use super::handle::Aborter;
 use commonware_utils::sync::Mutex;
 use std::{
     mem,

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -223,7 +223,7 @@ mod tests {
     use commonware_codec::{DecodeExt, Error as CodecError};
     use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{
-        BufferPooler, Error as RError, Metrics as _, Runner, Spawner as _, Supervisor as _,
+        BufferPooler, Error as RError, Metrics as _, Runner, Scheduler as _, Supervisor as _,
         deterministic,
         mocks::{
             DelayedSyncContext, PendingSyncs, fail_pending_syncs, release_next_pending_syncs,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -1048,7 +1048,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::{Manual, Rayon, Sequential};
     use commonware_runtime::{
-        BufferPooler, Runner as _, Spawner as _, Strategizer as _, Supervisor as _,
+        BufferPooler, Runner as _, Scheduler as _, Strategizer as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic::{self, Context},
         mocks::{

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1745,7 +1745,7 @@ mod tests {
     use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        Blob, BufferPooler, Error as RuntimeError, Metrics as _, Runner, Spawner as _, Storage,
+        Blob, BufferPooler, Error as RuntimeError, Metrics as _, Runner, Scheduler as _, Storage,
         Supervisor as _,
         buffer::paged::Writer,
         deterministic::{self, Context},

--- a/storage/src/journal/contiguous/tests.rs
+++ b/storage/src/journal/contiguous/tests.rs
@@ -4,7 +4,7 @@ use super::{Contiguous, Many, fixed, variable};
 use crate::journal::{Error, contiguous::Mutable};
 use commonware_macros::boxed;
 use commonware_runtime::{
-    Blob as _, Runner as _, Spawner as _, Storage as _, Supervisor as _,
+    Blob as _, Runner as _, Scheduler as _, Storage as _, Supervisor as _,
     buffer::paged::CacheRef,
     deterministic,
     mocks::{DelayedSyncContext, PendingSyncs},

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2570,7 +2570,7 @@ mod tests {
     use crate::journal::contiguous::tests::{corrupt_page, run_contiguous_tests};
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        Metrics as _, Runner, Spawner as _, Storage, Supervisor as _,
+        Metrics as _, Runner, Scheduler as _, Storage, Supervisor as _,
         buffer::paged::{CacheRef, Writer},
         deterministic,
         mocks::{

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -593,7 +593,7 @@ mod tests {
     use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        BufferPooler, Error as RError, Runner, Spawner as _, Supervisor as _,
+        BufferPooler, Error as RError, Runner, Scheduler as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, fail_pending_syncs, release_pending_syncs},

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -536,7 +536,7 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_runtime::{Runner as _, Spawner as _, Supervisor as _, deterministic};
+    use commonware_runtime::{Runner as _, Scheduler as _, Supervisor as _, deterministic};
     use commonware_utils::{channel::oneshot, sync::Mutex};
     use futures::{
         FutureExt as _,

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -155,7 +155,7 @@ pub(crate) mod test {
     use commonware_math::algebra::Random;
     use commonware_parallel::{Rayon, Sequential};
     use commonware_runtime::{
-        Clock as _, Metrics as _, Runner as _, Strategizer as _, Supervisor as _,
+        Clock as _, Metrics as _, Runner as _, Scheduler as _, Strategizer as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic::{self, Context},
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},

--- a/storage/src/qmdb/benches/scale.rs
+++ b/storage/src/qmdb/benches/scale.rs
@@ -63,7 +63,7 @@ use common::{
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_runtime::{
-    Runner as _, Spawner as _, Supervisor as _,
+    Runner as _, Scheduler as _, Supervisor as _,
     tokio::{Config, Context, Runner},
 };
 use commonware_storage::{merkle::mmr::Family as Mmr, qmdb::any::traits::DbAny};

--- a/storage/src/queue/shared.rs
+++ b/storage/src/queue/shared.rs
@@ -303,7 +303,7 @@ mod tests {
     use commonware_codec::RangeCfg;
     use commonware_macros::{select, test_traced};
     use commonware_runtime::{
-        BufferPooler, Clock, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef,
+        BufferPooler, Clock, Runner, Scheduler, Supervisor as _, buffer::paged::CacheRef,
         deterministic,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};

--- a/stream/Cargo.toml
+++ b/stream/Cargo.toml
@@ -15,7 +15,7 @@ workspace = true
 
 [dependencies]
 commonware-codec.workspace = true
-commonware-cryptography = { workspace = true, features = ["std"] }
+commonware-cryptography.workspace = true
 commonware-formatting.workspace = true
 commonware-macros = { workspace = true, features = ["std"] }
 commonware-runtime.workspace = true
@@ -25,6 +25,9 @@ rand_core.workspace = true
 thiserror.workspace = true
 x25519-dalek.workspace = true
 zeroize.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+commonware-cryptography = { workspace = true, features = ["std"] }
 
 [target.'cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))'.dependencies.chacha20poly1305]
 workspace = true

--- a/stream/fuzz/fuzz_targets/connection.rs
+++ b/stream/fuzz/fuzz_targets/connection.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use commonware_cryptography::{Signer, ed25519::PrivateKey};
-use commonware_runtime::{Runner, Spawner, Supervisor as _, deterministic, mocks};
+use commonware_runtime::{Runner, Scheduler as _, Supervisor as _, deterministic, mocks};
 use commonware_stream::encrypted::{Config, dial, listen};
 use futures::join;
 use libfuzzer_sys::fuzz_target;

--- a/stream/fuzz/fuzz_targets/e2e.rs
+++ b/stream/fuzz/fuzz_targets/e2e.rs
@@ -1,7 +1,9 @@
 #![no_main]
 
 use commonware_cryptography::{Signer, ed25519::PrivateKey, handshake::TAG_SIZE};
-use commonware_runtime::{Handle, Runner as _, Spawner, Supervisor as _, deterministic, mocks};
+use commonware_runtime::{
+    Handle, Runner as _, Scheduler as _, Supervisor as _, deterministic, mocks,
+};
 use commonware_stream::{
     encrypted::{Config, Error, Receiver, Sender, dial, listen},
     utils::codec::{recv_frame, send_frame},

--- a/stream/fuzz/fuzz_targets/lazy_transport.rs
+++ b/stream/fuzz/fuzz_targets/lazy_transport.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use commonware_cryptography::{Signer, ed25519::PrivateKey};
-use commonware_runtime::{Runner, Spawner, Supervisor as _, deterministic, mocks};
+use commonware_runtime::{Runner, Scheduler as _, Supervisor as _, deterministic, mocks};
 use commonware_stream::encrypted::{Config, Receiver, Sender, dial, listen};
 use futures::executor::block_on;
 use libfuzzer_sys::fuzz_target;

--- a/stream/fuzz/fuzz_targets/transport.rs
+++ b/stream/fuzz/fuzz_targets/transport.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use commonware_cryptography::{Signer, ed25519::PrivateKey};
-use commonware_runtime::{Runner, Spawner, Supervisor as _, deterministic, mocks};
+use commonware_runtime::{Runner, Scheduler as _, Supervisor as _, deterministic, mocks};
 use commonware_stream::encrypted::{Config, dial, listen};
 use libfuzzer_sys::fuzz_target;
 use std::time::Duration;

--- a/stream/src/encrypted.rs
+++ b/stream/src/encrypted.rs
@@ -531,10 +531,10 @@ mod test {
     use commonware_codec::varint::UInt;
     use commonware_cryptography::{Signer, ed25519::PrivateKey};
     use commonware_runtime::{
-        BufferPoolConfig, Error as RuntimeError, IoBuf, IoBufs, Runner as _, Spawner as _,
+        BufferPoolConfig, Error as RuntimeError, IoBuf, IoBufs, Runner as _, Scheduler as _,
         Supervisor as _, deterministic, mocks,
     };
-    use commonware_utils::{NZU32, NZUsize, sync::Mutex};
+    use commonware_utils::{NZU32, NZUsize, PlatformSend, sync::Mutex};
     use std::{
         sync::{
             Arc,
@@ -579,7 +579,10 @@ mod test {
     }
 
     impl<S: commonware_runtime::Sink> commonware_runtime::Sink for CountingSink<S> {
-        async fn send(&mut self, bufs: impl Into<IoBufs> + Send) -> Result<(), RuntimeError> {
+        async fn send(
+            &mut self,
+            bufs: impl Into<IoBufs> + PlatformSend,
+        ) -> Result<(), RuntimeError> {
             let bufs = bufs.into();
             self.sends.fetch_add(1, Ordering::Relaxed);
             self.chunk_counts.lock().push(bufs.chunk_count());

--- a/stream/src/utils/codec.rs
+++ b/stream/src/utils/codec.rs
@@ -4,6 +4,7 @@ use commonware_codec::{
     varint::{Decoder, MAX_U32_VARINT_SIZE, UInt},
 };
 use commonware_runtime::{Buf, IoBuf, IoBufMut, IoBufs, Sink, Stream};
+use commonware_utils::PlatformSend;
 
 /// Validates the frame size and assembles the frame via the caller's closure.
 ///
@@ -60,7 +61,7 @@ pub(crate) fn append_frame(
 /// Returns an error if the message is too large or the sink is closed.
 pub async fn send_frame<S: Sink>(
     sink: &mut S,
-    bufs: impl Into<IoBufs> + Send,
+    bufs: impl Into<IoBufs> + PlatformSend,
     max_message_size: u32,
 ) -> Result<(), Error> {
     let mut bufs = bufs.into();
@@ -129,7 +130,7 @@ async fn recv_length<T: Stream>(stream: &mut T) -> Result<(usize, usize), Error>
 mod tests {
     use super::*;
     use commonware_runtime::{
-        BufMut, IoBufMut, Runner, Spawner, Supervisor as _, deterministic, mocks,
+        BufMut, IoBufMut, Runner, Scheduler as _, Supervisor as _, deterministic, mocks,
     };
     use rand::RngExt as _;
 

--- a/utils/src/channel/fallible.rs
+++ b/utils/src/channel/fallible.rs
@@ -20,6 +20,7 @@ use super::{
     mpsc, oneshot,
     reservation::{Reservation, ReservationExt},
 };
+use crate::PlatformSend;
 use std::future::Future;
 
 /// Extension trait for channel operations that may fail due to disconnection.
@@ -48,39 +49,39 @@ pub trait FallibleExt<T> {
     ///     .request(|tx| Message::Dialable { responder: tx })
     ///     .await;
     /// ```
-    fn request<R, F>(&self, make_msg: F) -> impl Future<Output = Option<R>> + Send
+    fn request<R, F>(&self, make_msg: F) -> impl Future<Output = Option<R>> + PlatformSend
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send;
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend;
 
     /// Send a request and return the provided default on failure.
     ///
     /// This is a convenience wrapper around [`request`](Self::request) for cases
     /// where you have a sensible default value.
-    fn request_or<R, F>(&self, make_msg: F, default: R) -> impl Future<Output = R> + Send
+    fn request_or<R, F>(&self, make_msg: F, default: R) -> impl Future<Output = R> + PlatformSend
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send;
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend;
 
     /// Send a request and return `R::default()` on failure.
     ///
     /// This is a convenience wrapper around [`request`](Self::request) for types
     /// that implement [`Default`].
-    fn request_or_default<R, F>(&self, make_msg: F) -> impl Future<Output = R> + Send
+    fn request_or_default<R, F>(&self, make_msg: F) -> impl Future<Output = R> + PlatformSend
     where
-        R: Default + Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send;
+        R: Default + PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend;
 }
 
-impl<T: Send> FallibleExt<T> for mpsc::UnboundedSender<T> {
+impl<T: PlatformSend> FallibleExt<T> for mpsc::UnboundedSender<T> {
     fn send_lossy(&self, msg: T) -> bool {
         self.send(msg).is_ok()
     }
 
     async fn request<R, F>(&self, make_msg: F) -> Option<R>
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send,
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend,
     {
         let (tx, rx) = oneshot::channel();
         if self.send(make_msg(tx)).is_err() {
@@ -91,16 +92,16 @@ impl<T: Send> FallibleExt<T> for mpsc::UnboundedSender<T> {
 
     async fn request_or<R, F>(&self, make_msg: F, default: R) -> R
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send,
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend,
     {
         self.request(make_msg).await.unwrap_or(default)
     }
 
     async fn request_or_default<R, F>(&self, make_msg: F) -> R
     where
-        R: Default + Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send,
+        R: Default + PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend,
     {
         self.request(make_msg).await.unwrap_or_default()
     }
@@ -116,7 +117,7 @@ pub trait AsyncFallibleExt<T> {
     /// may have been dropped during shutdown. The return value can
     /// be ignored if the caller doesn't need to know whether the
     /// send succeeded.
-    fn send_lossy(&self, msg: T) -> impl Future<Output = bool> + Send;
+    fn send_lossy(&self, msg: T) -> impl Future<Output = bool> + PlatformSend;
 
     /// Try to send a message without blocking, returning `true` if successful.
     ///
@@ -138,25 +139,25 @@ pub trait AsyncFallibleExt<T> {
     /// Returns `None` if:
     /// - The receiver has been dropped (send fails)
     /// - The responder is dropped without sending (receive fails)
-    fn request<R, F>(&self, make_msg: F) -> impl Future<Output = Option<R>> + Send
+    fn request<R, F>(&self, make_msg: F) -> impl Future<Output = Option<R>> + PlatformSend
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send;
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend;
 
     /// Send a request and return the provided default on failure.
-    fn request_or<R, F>(&self, make_msg: F, default: R) -> impl Future<Output = R> + Send
+    fn request_or<R, F>(&self, make_msg: F, default: R) -> impl Future<Output = R> + PlatformSend
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send;
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend;
 
     /// Send a request and return `R::default()` on failure.
-    fn request_or_default<R, F>(&self, make_msg: F) -> impl Future<Output = R> + Send
+    fn request_or_default<R, F>(&self, make_msg: F) -> impl Future<Output = R> + PlatformSend
     where
-        R: Default + Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send;
+        R: Default + PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend;
 }
 
-impl<T: Send> AsyncFallibleExt<T> for mpsc::Sender<T> {
+impl<T: PlatformSend> AsyncFallibleExt<T> for mpsc::Sender<T> {
     async fn send_lossy(&self, msg: T) -> bool {
         self.send(msg).await.is_ok()
     }
@@ -174,8 +175,8 @@ impl<T: Send> AsyncFallibleExt<T> for mpsc::Sender<T> {
 
     async fn request<R, F>(&self, make_msg: F) -> Option<R>
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send,
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend,
     {
         let (tx, rx) = oneshot::channel();
         if self.send(make_msg(tx)).await.is_err() {
@@ -186,16 +187,16 @@ impl<T: Send> AsyncFallibleExt<T> for mpsc::Sender<T> {
 
     async fn request_or<R, F>(&self, make_msg: F, default: R) -> R
     where
-        R: Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send,
+        R: PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend,
     {
         self.request(make_msg).await.unwrap_or(default)
     }
 
     async fn request_or_default<R, F>(&self, make_msg: F) -> R
     where
-        R: Default + Send,
-        F: FnOnce(oneshot::Sender<R>) -> T + Send,
+        R: Default + PlatformSend,
+        F: FnOnce(oneshot::Sender<R>) -> T + PlatformSend,
     {
         self.request(make_msg).await.unwrap_or_default()
     }

--- a/utils/src/channel/reservation.rs
+++ b/utils/src/channel/reservation.rs
@@ -4,6 +4,7 @@ use super::mpsc::{
     self, OwnedPermit,
     error::{SendError, TrySendError},
 };
+use crate::PlatformSend;
 use std::{
     future::Future,
     pin::Pin,
@@ -14,7 +15,11 @@ use std::{
 type ReserveResult<T> = Result<OwnedPermit<T>, SendError<()>>;
 
 // Tokio's `reserve_owned` future is not nameable, so box it instead of exposing a future parameter.
+#[cfg(not(target_arch = "wasm32"))]
 type ReserveFuture<T> = Pin<Box<dyn Future<Output = ReserveResult<T>> + Send>>;
+
+#[cfg(target_arch = "wasm32")]
+type ReserveFuture<T> = Pin<Box<dyn Future<Output = ReserveResult<T>>>>;
 
 /// A reserved channel slot bundled with the value to send.
 #[must_use = "call send to deliver the reserved message"]
@@ -38,7 +43,10 @@ pub struct Reservation<T> {
 }
 
 impl<T> Reservation<T> {
-    fn new(future: impl Future<Output = ReserveResult<T>> + Send + 'static, value: T) -> Self {
+    fn new(
+        future: impl Future<Output = ReserveResult<T>> + PlatformSend + 'static,
+        value: T,
+    ) -> Self {
         Self {
             future: Box::pin(future),
             value: Some(value),
@@ -82,7 +90,7 @@ pub trait ReservationExt<T> {
         T: 'static;
 }
 
-impl<T: Send> ReservationExt<T> for mpsc::Sender<T> {
+impl<T: PlatformSend> ReservationExt<T> for mpsc::Sender<T> {
     fn send_or_reserve(&self, value: T) -> Result<Option<Reservation<T>>, SendError<T>>
     where
         T: 'static,

--- a/utils/src/channel/ring.rs
+++ b/utils/src/channel/ring.rs
@@ -27,7 +27,7 @@
 //! });
 //! ```
 
-use crate::sync::Mutex;
+use crate::{PlatformSend, PlatformSync, sync::Mutex};
 use core::num::NonZeroUsize;
 use futures::{Sink, Stream, stream::FusedStream};
 use std::{
@@ -55,7 +55,7 @@ pub enum TryRecvError {
 }
 
 #[derive(Debug)]
-struct Shared<T: Send + Sync> {
+struct Shared<T: PlatformSend + PlatformSync> {
     buffer: VecDeque<T>,
     capacity: usize,
     receiver_waker: Option<Waker>,
@@ -70,11 +70,11 @@ struct Shared<T: Send + Sync> {
 ///
 /// This type can be cloned to create multiple producers for the same channel.
 /// The channel remains open until all senders are dropped.
-pub struct Sender<T: Send + Sync> {
+pub struct Sender<T: PlatformSend + PlatformSync> {
     shared: Arc<Mutex<Shared<T>>>,
 }
 
-impl<T: Send + Sync> Sender<T> {
+impl<T: PlatformSend + PlatformSync> Sender<T> {
     /// Returns whether the receiver has been dropped.
     ///
     /// If this returns `true`, subsequent sends will fail with [`ChannelClosed`].
@@ -84,7 +84,7 @@ impl<T: Send + Sync> Sender<T> {
     }
 }
 
-impl<T: Send + Sync> Clone for Sender<T> {
+impl<T: PlatformSend + PlatformSync> Clone for Sender<T> {
     fn clone(&self) -> Self {
         let mut shared = self.shared.lock();
         shared.sender_count += 1;
@@ -96,7 +96,7 @@ impl<T: Send + Sync> Clone for Sender<T> {
     }
 }
 
-impl<T: Send + Sync> Drop for Sender<T> {
+impl<T: PlatformSend + PlatformSync> Drop for Sender<T> {
     fn drop(&mut self) {
         let mut shared = self.shared.lock();
         shared.sender_count -= 1;
@@ -113,7 +113,7 @@ impl<T: Send + Sync> Drop for Sender<T> {
     }
 }
 
-impl<T: Send + Sync> Sink<T> for Sender<T> {
+impl<T: PlatformSend + PlatformSync> Sink<T> for Sender<T> {
     type Error = ChannelClosed;
 
     fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -171,11 +171,11 @@ impl<T: Send + Sync> Sink<T> for Sender<T> {
 /// The stream terminates (returns `None`) when all senders have been dropped
 /// and all buffered items have been consumed.
 #[derive(Debug)]
-pub struct Receiver<T: Send + Sync> {
+pub struct Receiver<T: PlatformSend + PlatformSync> {
     shared: Arc<Mutex<Shared<T>>>,
 }
 
-impl<T: Send + Sync> Receiver<T> {
+impl<T: PlatformSend + PlatformSync> Receiver<T> {
     /// Receives the next item from the channel.
     pub async fn recv(&mut self) -> Option<T> {
         futures::future::poll_fn(|cx| Pin::new(&mut *self).poll_next(cx)).await
@@ -194,7 +194,7 @@ impl<T: Send + Sync> Receiver<T> {
     }
 }
 
-impl<T: Send + Sync> Stream for Receiver<T> {
+impl<T: PlatformSend + PlatformSync> Stream for Receiver<T> {
     type Item = T;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -219,14 +219,14 @@ impl<T: Send + Sync> Stream for Receiver<T> {
     }
 }
 
-impl<T: Send + Sync> FusedStream for Receiver<T> {
+impl<T: PlatformSend + PlatformSync> FusedStream for Receiver<T> {
     fn is_terminated(&self) -> bool {
         let shared = self.shared.lock();
         shared.sender_count == 0 && shared.buffer.is_empty()
     }
 }
 
-impl<T: Send + Sync> Drop for Receiver<T> {
+impl<T: PlatformSend + PlatformSync> Drop for Receiver<T> {
     fn drop(&mut self) {
         let mut shared = self.shared.lock();
         shared.receiver_dropped = true;
@@ -237,7 +237,7 @@ impl<T: Send + Sync> Drop for Receiver<T> {
 ///
 /// Returns a ([`Sender`], [`Receiver`]) pair. The sender can be cloned to create
 /// multiple producers.
-pub fn channel<T: Send + Sync>(capacity: NonZeroUsize) -> (Sender<T>, Receiver<T>) {
+pub fn channel<T: PlatformSend + PlatformSync>(capacity: NonZeroUsize) -> (Sender<T>, Receiver<T>) {
     let shared = Arc::new(Mutex::new(Shared {
         buffer: VecDeque::with_capacity(capacity.get()),
         capacity: capacity.get(),

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -17,6 +17,8 @@ commonware_macros::stability_scope!(BETA {
     use alloc::{boxed::Box, vec::Vec};
     use bytes::{BufMut, BytesMut};
     use core::time::Duration;
+    mod platform;
+    pub use platform::{PlatformSend, PlatformSync};
     pub mod faults;
     pub use faults::{Faults, N3f1, N5f1};
 

--- a/utils/src/platform.rs
+++ b/utils/src/platform.rs
@@ -1,0 +1,61 @@
+//! Target-dependent thread-safety bounds.
+
+/// A value that may cross a platform scheduling boundary.
+///
+/// Native targets may move work to another thread, so this requires [`Send`].
+/// Browser WASM stays on one event-loop thread and does not.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait PlatformSend: Send {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Send + ?Sized> PlatformSend for T {}
+
+/// A value that may cross a platform scheduling boundary.
+///
+/// Browser tasks remain on the current event-loop thread.
+#[cfg(target_arch = "wasm32")]
+pub trait PlatformSend {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T: ?Sized> PlatformSend for T {}
+
+/// A value that may be shared across a platform scheduling boundary.
+///
+/// Native targets may access shared state from multiple threads, so this
+/// requires [`Sync`]. Browser WASM stays on one event-loop thread and does not.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait PlatformSync: Sync {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<T: Sync + ?Sized> PlatformSync for T {}
+
+/// A value that may be shared across a platform scheduling boundary.
+///
+/// Browser tasks remain on the current event-loop thread.
+#[cfg(target_arch = "wasm32")]
+pub trait PlatformSync {}
+
+#[cfg(target_arch = "wasm32")]
+impl<T: ?Sized> PlatformSync for T {}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::{PlatformSend, PlatformSync};
+
+    const fn assert_send<T: Send + ?Sized>() {}
+    const fn assert_sync<T: Sync + ?Sized>() {}
+
+    #[test]
+    fn native_platform_bounds_imply_thread_safety() {
+        fn assert_platform_send<T: PlatformSend + ?Sized>() {
+            assert_send::<T>();
+        }
+
+        fn assert_platform_sync<T: PlatformSync + ?Sized>() {
+            assert_sync::<T>();
+        }
+
+        assert_platform_send::<usize>();
+        assert_platform_sync::<usize>();
+    }
+}


### PR DESCRIPTION
## Overview

Introduces portable runtime and authenticated lookup abstractions for reliable transports. Platform-aware send/sync markers preserve native thread-safety while allowing browser-local futures, and the runtime now separates scheduling, dialing, accepting, connections, origins, sinks, and streams.

Authenticated lookup gains transport-neutral endpoints, dial-only participation, explicit connection attachment, and pluggable admission while preserving existing TCP discovery and its wire format. These traits also make it possible to replace `p2p::simulated` with a deterministic runtime network instead of maintaining a second P2P implementation.

Related to #491.