### PR TITLE
[cryptography] Clarify SmallScalar Randomness

### DIFF
--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -287,7 +287,11 @@ pub struct SmallScalar {
 impl SmallScalar {
     /// Generates a random non-zero 128-bit scalar.
     pub fn random(mut rng: impl CryptoRng) -> Self {
+        // blst_scalar is 32 bytes.
         let mut bytes = [0u8; SCALAR_LENGTH];
+        // Fill the last 16 bytes (128 bits) with entropy.
+        // In big-endian, bytes[16..32] are the least significant.
+        // Leaving bytes[0..16] as zero ensures the scalar is < 2^128.
         let random_bytes = &mut bytes[(SCALAR_LENGTH - SMALL_SCALAR_LENGTH)..];
         while bool::from(all_zero(random_bytes)) {
             rng.fill_bytes(random_bytes);

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -285,14 +285,13 @@ pub struct SmallScalar {
 }
 
 impl SmallScalar {
-    /// Generates a random 128-bit scalar.
+    /// Generates a random non-zero 128-bit scalar.
     pub fn random(mut rng: impl CryptoRng) -> Self {
-        // blst_scalar is 32 bytes
-        let mut bytes = [0u8; 32];
-        // Fill the last 16 bytes (128 bits) with entropy.
-        // In big-endian, bytes[16..32] are the least significant.
-        // Leaving bytes[0..16] as zero ensures the scalar is < 2^128.
-        rng.fill_bytes(&mut bytes[SMALL_SCALAR_LENGTH..]);
+        let mut bytes = [0u8; SCALAR_LENGTH];
+        let random_bytes = &mut bytes[(SCALAR_LENGTH - SMALL_SCALAR_LENGTH)..];
+        while bool::from(all_zero(random_bytes)) {
+            rng.fill_bytes(random_bytes);
+        }
 
         let mut scalar = blst_scalar::default();
         // SAFETY: bytes is a valid 32-byte array.
@@ -1904,8 +1903,10 @@ mod tests {
     use commonware_math::algebra::{Random, test_suites};
     use commonware_parallel::{Rayon, Sequential};
     use commonware_utils::test_rng;
+    use rand_core::{TryCryptoRng, TryRng};
     use std::{
         collections::{BTreeSet, HashMap},
+        convert::Infallible,
         num::NonZeroUsize,
     };
 
@@ -2520,6 +2521,42 @@ mod tests {
         let scalar = Scalar::from(small.clone());
         let round_tripped = scalar.as_blst_scalar();
         assert_eq!(small.as_bytes(), round_tripped.b.as_slice());
+    }
+
+    #[test]
+    fn test_small_scalar_random_rejects_zero() {
+        struct ZeroThenOne {
+            fills: usize,
+        }
+
+        impl TryRng for ZeroThenOne {
+            type Error = Infallible;
+
+            fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+                Ok(0)
+            }
+
+            fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+                Ok(0)
+            }
+
+            fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+                dst.fill(0);
+                if self.fills > 0 {
+                    *dst.last_mut().expect("requested scalar bytes") = 1;
+                }
+                self.fills += 1;
+                Ok(())
+            }
+        }
+
+        impl TryCryptoRng for ZeroThenOne {}
+
+        let mut rng = ZeroThenOne { fills: 0 };
+        let scalar = SmallScalar::random(&mut rng);
+
+        assert_eq!(rng.fills, 2);
+        assert_ne!(scalar, SmallScalar::zero());
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -284,7 +284,13 @@ pub struct SmallScalar {
 }
 
 impl SmallScalar {
-    /// Generates a random scalar in `[0, 2^128)`.
+    /// Generates a uniformly random scalar in `[0, 2^128)`.
+    ///
+    /// Zero is intentionally included. Predictable challenges are unsafe regardless of their value,
+    /// but zero from uniform, independent sampling does not weaken the check. An invalid random
+    /// linear-combination check has at least one non-zero error term. Fixing every other challenge
+    /// leaves at most one value in this range for that term that can make the check pass, so the
+    /// soundness error remains at most `2^-128`.
     pub fn random(mut rng: impl CryptoRng) -> Self {
         // blst_scalar is 32 bytes.
         let mut bytes = [0u8; SCALAR_LENGTH];

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -260,8 +260,8 @@ const SCALAR_BITS: usize = 255;
 
 /// Number of scalar bits for SmallScalar (128 bits).
 ///
-/// 128 bits provides sufficient security (2^-128 collision probability)
-/// while roughly halving MSM computation time compared to full 255-bit scalars.
+/// 128 bits provides a soundness error of at most 2^-128 for random
+/// linear-combination checks while roughly halving MSM computation time.
 const SMALL_SCALAR_BITS: usize = 128;
 
 /// Number of bytes for SmallScalar (16 bytes = 128 bits).
@@ -273,11 +273,10 @@ const IKM_LENGTH: usize = 64;
 /// Minimum number of points required to use parallel MSM.
 const MIN_PARALLEL_POINTS: usize = 32;
 
-/// A 128-bit scalar for use in batch verification random challenges.
+/// A 128-bit scalar in `[0, 2^128)`.
 ///
-/// This provides 128-bit security which is sufficient for preventing
-/// forgery attacks in batch verification while reducing computational cost
-/// compared to full 255-bit scalars.
+/// Every `SmallScalar` can be converted to a valid [`Scalar`]. Its reduced width
+/// roughly halves MSM computation time compared to full 255-bit scalars.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct SmallScalar {
     /// Stored as blst_scalar with only lower 128 bits populated.
@@ -285,17 +284,14 @@ pub struct SmallScalar {
 }
 
 impl SmallScalar {
-    /// Generates a random non-zero 128-bit scalar.
+    /// Generates a random scalar in `[0, 2^128)`.
     pub fn random(mut rng: impl CryptoRng) -> Self {
-        // blst_scalar is 32 bytes.
-        let mut bytes = [0u8; SCALAR_LENGTH];
+        // blst_scalar is 32 bytes
+        let mut bytes = [0u8; 32];
         // Fill the last 16 bytes (128 bits) with entropy.
         // In big-endian, bytes[16..32] are the least significant.
         // Leaving bytes[0..16] as zero ensures the scalar is < 2^128.
-        let random_bytes = &mut bytes[(SCALAR_LENGTH - SMALL_SCALAR_LENGTH)..];
-        while bool::from(all_zero(random_bytes)) {
-            rng.fill_bytes(random_bytes);
-        }
+        rng.fill_bytes(&mut bytes[SMALL_SCALAR_LENGTH..]);
 
         let mut scalar = blst_scalar::default();
         // SAFETY: bytes is a valid 32-byte array.
@@ -1907,7 +1903,7 @@ mod tests {
     use commonware_math::algebra::{Random, test_suites};
     use commonware_parallel::{Rayon, Sequential};
     use commonware_utils::test_rng;
-    use rand_core::{TryCryptoRng, TryRng};
+    use rand_core::{TryCryptoRng, TryRng, utils::fill_bytes_via_next_word};
     use std::{
         collections::{BTreeSet, HashMap},
         convert::Infallible,
@@ -2528,12 +2524,10 @@ mod tests {
     }
 
     #[test]
-    fn test_small_scalar_random_rejects_zero() {
-        struct ZeroThenOne {
-            fills: usize,
-        }
+    fn test_small_scalar_random_includes_zero() {
+        struct ZeroOnce(bool);
 
-        impl TryRng for ZeroThenOne {
+        impl TryRng for ZeroOnce {
             type Error = Infallible;
 
             fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
@@ -2541,26 +2535,24 @@ mod tests {
             }
 
             fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-                Ok(0)
+                Ok(u64::from(self.try_next_u32()?))
             }
 
             fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
-                dst.fill(0);
-                if self.fills > 0 {
-                    *dst.last_mut().expect("requested scalar bytes") = 1;
-                }
-                self.fills += 1;
-                Ok(())
+                assert!(!self.0, "random sampled more than once");
+                self.0 = true;
+                fill_bytes_via_next_word(dst, || self.try_next_u64())
             }
         }
 
-        impl TryCryptoRng for ZeroThenOne {}
+        impl TryCryptoRng for ZeroOnce {}
 
-        let mut rng = ZeroThenOne { fills: 0 };
+        let mut rng = ZeroOnce(false);
         let scalar = SmallScalar::random(&mut rng);
 
-        assert_eq!(rng.fills, 2);
-        assert_ne!(scalar, SmallScalar::zero());
+        assert!(rng.0);
+        assert_eq!(scalar, SmallScalar::zero());
+        assert_eq!(Scalar::from(scalar), Scalar::zero());
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -286,12 +286,12 @@ pub struct SmallScalar {
 impl SmallScalar {
     /// Generates a random scalar in `[0, 2^128)`.
     pub fn random(mut rng: impl CryptoRng) -> Self {
-        // blst_scalar is 32 bytes
-        let mut bytes = [0u8; 32];
+        // blst_scalar is 32 bytes.
+        let mut bytes = [0u8; SCALAR_LENGTH];
         // Fill the last 16 bytes (128 bits) with entropy.
         // In big-endian, bytes[16..32] are the least significant.
         // Leaving bytes[0..16] as zero ensures the scalar is < 2^128.
-        rng.fill_bytes(&mut bytes[SMALL_SCALAR_LENGTH..]);
+        rng.fill_bytes(&mut bytes[(SCALAR_LENGTH - SMALL_SCALAR_LENGTH)..]);
 
         let mut scalar = blst_scalar::default();
         // SAFETY: bytes is a valid 32-byte array.

--- a/cryptography/src/bls12381/primitives/ops/batch.rs
+++ b/cryptography/src/bls12381/primitives/ops/batch.rs
@@ -10,9 +10,8 @@
 //! [`aggregate`](super::aggregate) verification. Without weights, an attacker could forge invalid
 //! signatures that cancel out when aggregated (e.g., one signature "too high" and another "too low"
 //! by the same amount). With random weights `r_i`, the errors must satisfy `sum(r_i * err_i) = 0`,
-//! which requires predicting the weights before they're generated (probability ~1/2^255 per invalid
-//! signature). Note, the weights must be unpredictable to the attacker for this to work (i.e. they
-//! must be generated securely).
+//! which an attacker cannot arrange without predicting the weights. The soundness error is at most
+//! `2^-128` per check.
 use super::{
     super::{Error, group::SmallScalar, variant::Variant},
     hash_with_namespace,

--- a/cryptography/src/bls12381/primitives/variant.rs
+++ b/cryptography/src/bls12381/primitives/variant.rs
@@ -103,9 +103,9 @@ impl Variant for MinPk {
     /// `e(hm_i,pk_i) == e(sig_i,G1::one())`,
     /// which is equivalent to checking if `e(hm_i,pk_i) * e(sig_i,-G1::one()) == 1`.
     ///
-    /// To batch verify `n` such equations, we introduce random non-zero scalars `r_i` (for `i=1..n`).
-    /// The batch verification checks if the product of these individual equations, each raised to the power
-    /// of its respective `r_i`, equals one:
+    /// To batch verify `n` such equations, we sample random 128-bit scalars `r_i` from
+    /// `[0, 2^128)` (for `i=1..n`). The batch verification checks if the product of these individual
+    /// equations, each raised to the power of its respective `r_i`, equals one:
     /// `prod_i((e(hm_i,pk_i) * e(sig_i,-G1::one()))^{r_i}) == 1`
     ///
     /// Using the bilinearity of pairings, this can be rewritten (by moving `r_i` inside the pairings,
@@ -206,9 +206,9 @@ impl Variant for MinSig {
     /// `e(pk_i,hm_i) == e(G2::one(),sig_i)`,
     /// which is equivalent to checking if `e(pk_i,hm_i) * e(-G2::one(),sig_i) == 1`.
     ///
-    /// To batch verify `n` such equations, we introduce random non-zero scalars `r_i` (for `i=1..n`).
-    /// The batch verification checks if the product of these individual equations, each effectively
-    /// raised to the power of its respective `r_i`, equals one:
+    /// To batch verify `n` such equations, we sample random 128-bit scalars `r_i` from
+    /// `[0, 2^128)` (for `i=1..n`). The batch verification checks if the product of these individual
+    /// equations, each effectively raised to the power of its respective `r_i`, equals one:
     /// `prod_i((e(pk_i,hm_i) * e(-G2::one(),sig_i))^{r_i}) == 1`
     ///
     /// Using the bilinearity of pairings, this can be rewritten (by moving `r_i` inside the pairings,

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -1,5 +1,11 @@
 //! Generate keys, sign arbitrary messages, and deterministically verify signatures.
 //!
+//! # Randomness
+//!
+//! Cryptographic operations that accept an RNG require a cryptographically secure and
+//! unpredictable source unless documented otherwise. A weak or predictable RNG may compromise
+//! security.
+//!
 //! # Status
 //!
 //! Stability varies by primitive. See [README](https://github.com/commonwarexyz/monorepo#stability) for details.


### PR DESCRIPTION
## Summary

- Define `SmallScalar` over its complete `[0, 2^128)` domain, including zero.
- Sample with a single uniform 128-bit draw and add regression coverage for an all-zero draw.
- Explain why uniformly sampled zero preserves the `2^-128` soundness bound, while predictable challenges are unsafe regardless of value.
- Correct the BLS batch-verification soundness documentation and centralize the crate-wide secure-RNG requirement.

## Rationale

For an invalid random linear-combination check, at least one error term is non-zero. After fixing every other challenge, at most one of the `2^128` values for that term can make the check pass. Zero is therefore a valid challenge: rejecting it neither improves the `2^-128` bound nor makes a predictable RNG secure.

`Scalar::random` remains intentionally non-zero because it follows IETF BLS KeyGen and backs private-key generation.

## Validation

- `just test -p commonware-cryptography` (655 passed)
- `just clippy -p commonware-cryptography`
- `just check-fmt`
- `just check-docs -p commonware-cryptography`
- `just check-stability -p commonware-cryptography`
- cryptography WASM release build