### PR TITLE
[consensus/simplex] Make Vote Reporting Durable and Bound Batcher Memory

### DIFF
--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -405,7 +405,7 @@ where
         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
         strategy: Sequential,
         forwarding: ForwardingPolicy::Disabled,
-        historical_conflict_reporting: false,
+        track_historical_votes: false,
     };
     let engine = Engine::new(context.child("engine"), engine_cfg);
     engine.start(pending, recovered, resolver);
@@ -651,7 +651,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 page_cache: CacheRef::from_pooler(&primary_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 strategy: Sequential,
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             };
             let engine = Engine::new(primary_context.child("engine"), engine_cfg);
             engine.start(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -405,6 +405,7 @@ where
         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
         strategy: Sequential,
         forwarding: ForwardingPolicy::Disabled,
+        report_conflicting_votes: false,
     };
     let engine = Engine::new(context.child("engine"), engine_cfg);
     engine.start(pending, recovered, resolver);
@@ -650,6 +651,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 page_cache: CacheRef::from_pooler(&primary_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 strategy: Sequential,
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             };
             let engine = Engine::new(primary_context.child("engine"), engine_cfg);
             engine.start(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -405,7 +405,7 @@ where
         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
         strategy: Sequential,
         forwarding: ForwardingPolicy::Disabled,
-        report_conflicting_votes: false,
+        retain_votes_after_certification: false,
     };
     let engine = Engine::new(context.child("engine"), engine_cfg);
     engine.start(pending, recovered, resolver);
@@ -651,7 +651,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 page_cache: CacheRef::from_pooler(&primary_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 strategy: Sequential,
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             };
             let engine = Engine::new(primary_context.child("engine"), engine_cfg);
             engine.start(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -405,7 +405,7 @@ where
         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
         strategy: Sequential,
         forwarding: ForwardingPolicy::Disabled,
-        extended_conflict_reporting: false,
+        historical_conflict_reporting: false,
     };
     let engine = Engine::new(context.child("engine"), engine_cfg);
     engine.start(pending, recovered, resolver);
@@ -651,7 +651,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 page_cache: CacheRef::from_pooler(&primary_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 strategy: Sequential,
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             };
             let engine = Engine::new(primary_context.child("engine"), engine_cfg);
             engine.start(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -405,7 +405,7 @@ where
         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
         strategy: Sequential,
         forwarding: ForwardingPolicy::Disabled,
-        retain_votes_after_certification: false,
+        extended_conflict_reporting: false,
     };
     let engine = Engine::new(context.child("engine"), engine_cfg);
     engine.start(pending, recovered, resolver);
@@ -651,7 +651,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
                 page_cache: CacheRef::from_pooler(&primary_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 strategy: Sequential,
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             };
             let engine = Engine::new(primary_context.child("engine"), engine_cfg);
             engine.start(

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2115,6 +2115,7 @@ mod tests {
                     fetch_timeout: Duration::from_secs(1),
                     fetch_concurrent: NZUsize!(3),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 },
             );
             let _engine = engine.start(vote_network, certificate_network, resolver_network);

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2115,7 +2115,7 @@ mod tests {
                     fetch_timeout: Duration::from_secs(1),
                     fetch_concurrent: NZUsize!(3),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 },
             );
             let _engine = engine.start(vote_network, certificate_network, resolver_network);

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2115,7 +2115,7 @@ mod tests {
                     fetch_timeout: Duration::from_secs(1),
                     fetch_concurrent: NZUsize!(3),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 },
             );
             let _engine = engine.start(vote_network, certificate_network, resolver_network);

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2115,7 +2115,7 @@ mod tests {
                     fetch_timeout: Duration::from_secs(1),
                     fetch_concurrent: NZUsize!(3),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 },
             );
             let _engine = engine.start(vote_network, certificate_network, resolver_network);

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2115,7 +2115,7 @@ mod tests {
                     fetch_timeout: Duration::from_secs(1),
                     fetch_concurrent: NZUsize!(3),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 },
             );
             let _engine = engine.start(vote_network, certificate_network, resolver_network);

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -59,7 +59,7 @@ where
 
     blocker: B,
     reporter: Re,
-    retain_recovered_votes: bool,
+    historical_conflict_reporting: bool,
     relay: Rl,
     strategy: T,
 
@@ -145,7 +145,7 @@ where
 
                 blocker: cfg.blocker,
                 reporter: cfg.reporter,
-                retain_recovered_votes: cfg.retain_recovered_votes,
+                historical_conflict_reporting: cfg.historical_conflict_reporting,
                 relay: cfg.relay,
                 strategy: cfg.strategy,
 
@@ -176,7 +176,7 @@ where
             Arc::clone(&self.scheme),
             self.blocker.clone(),
             self.reporter.clone(),
-            self.retain_recovered_votes,
+            self.historical_conflict_reporting,
         )
     }
 
@@ -428,7 +428,7 @@ where
                         let round = work.entry(view).or_insert_with(|| self.new_round(view));
                         let process = process_span(round.span());
                         let _guard = process.entered();
-                        round.accept_vote(message, true);
+                        round.add_constructed(message);
                         self.added.inc();
                         updated_view = view;
                     }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -59,6 +59,7 @@ where
 
     blocker: B,
     reporter: Re,
+    report_conflicting_votes: bool,
     relay: Rl,
     strategy: T,
 
@@ -144,6 +145,7 @@ where
 
                 blocker: cfg.blocker,
                 reporter: cfg.reporter,
+                report_conflicting_votes: cfg.report_conflicting_votes,
                 relay: cfg.relay,
                 strategy: cfg.strategy,
 
@@ -174,6 +176,7 @@ where
             Arc::clone(&self.scheme),
             self.blocker.clone(),
             self.reporter.clone(),
+            self.report_conflicting_votes,
         )
     }
 

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -283,7 +283,7 @@ where
             return false;
         };
         work.get(&current.view)
-            .is_some_and(|round| round.has_retained_nullify(leader))
+            .is_some_and(|round| round.has_nullify(leader))
     }
 
     pub fn start(

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -59,7 +59,7 @@ where
 
     blocker: B,
     reporter: Re,
-    historical_conflict_reporting: bool,
+    track_historical_votes: bool,
     relay: Rl,
     strategy: T,
 
@@ -145,7 +145,7 @@ where
 
                 blocker: cfg.blocker,
                 reporter: cfg.reporter,
-                historical_conflict_reporting: cfg.historical_conflict_reporting,
+                track_historical_votes: cfg.track_historical_votes,
                 relay: cfg.relay,
                 strategy: cfg.strategy,
 
@@ -176,7 +176,7 @@ where
             Arc::clone(&self.scheme),
             self.blocker.clone(),
             self.reporter.clone(),
-            self.historical_conflict_reporting,
+            self.track_historical_votes,
         )
     }
 

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -428,7 +428,7 @@ where
                         let round = work.entry(view).or_insert_with(|| self.new_round(view));
                         let process = process_span(round.span());
                         let _guard = process.entered();
-                        round.add_constructed(message);
+                        round.accept_vote(message, true);
                         self.added.inc();
                         updated_view = view;
                     }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -59,7 +59,7 @@ where
 
     blocker: B,
     reporter: Re,
-    report_conflicting_votes: bool,
+    retain_votes_after_certification: bool,
     relay: Rl,
     strategy: T,
 
@@ -145,7 +145,7 @@ where
 
                 blocker: cfg.blocker,
                 reporter: cfg.reporter,
-                report_conflicting_votes: cfg.report_conflicting_votes,
+                retain_votes_after_certification: cfg.retain_votes_after_certification,
                 relay: cfg.relay,
                 strategy: cfg.strategy,
 
@@ -176,7 +176,7 @@ where
             Arc::clone(&self.scheme),
             self.blocker.clone(),
             self.reporter.clone(),
-            self.report_conflicting_votes,
+            self.retain_votes_after_certification,
         )
     }
 

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -283,7 +283,7 @@ where
             return false;
         };
         work.get(&current.view)
-            .is_some_and(|round| round.has_nullify(leader))
+            .is_some_and(|round| round.has_retained_nullify(leader))
     }
 
     pub fn start(

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -59,7 +59,7 @@ where
 
     blocker: B,
     reporter: Re,
-    retain_votes_after_certification: bool,
+    retain_recovered_votes: bool,
     relay: Rl,
     strategy: T,
 
@@ -145,7 +145,7 @@ where
 
                 blocker: cfg.blocker,
                 reporter: cfg.reporter,
-                retain_votes_after_certification: cfg.retain_votes_after_certification,
+                retain_recovered_votes: cfg.retain_recovered_votes,
                 relay: cfg.relay,
                 strategy: cfg.strategy,
 
@@ -176,7 +176,7 @@ where
             Arc::clone(&self.scheme),
             self.blocker.clone(),
             self.reporter.clone(),
-            self.retain_votes_after_certification,
+            self.retain_recovered_votes,
         )
     }
 

--- a/consensus/src/simplex/actors/batcher/ingress.rs
+++ b/consensus/src/simplex/actors/batcher/ingress.rs
@@ -18,7 +18,7 @@ pub enum Message<S: Scheme, D: Digest> {
         finalized: View,
         certified_proposal: Option<Proposal<D>>,
     },
-    /// A durable locally constructed vote (needed for quorum).
+    /// A durable locally constructed vote for certificate assembly.
     Constructed(Vote<S, D>),
 }
 
@@ -188,7 +188,7 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
         });
     }
 
-    /// Send a locally constructed vote after it is durable.
+    /// Sends a locally constructed vote after its journal entry is durable.
     pub fn constructed(&mut self, message: Vote<S, D>) {
         let _ = self.sender.enqueue(Message::Constructed(message));
     }

--- a/consensus/src/simplex/actors/batcher/ingress.rs
+++ b/consensus/src/simplex/actors/batcher/ingress.rs
@@ -18,7 +18,7 @@ pub enum Message<S: Scheme, D: Digest> {
         finalized: View,
         certified_proposal: Option<Proposal<D>>,
     },
-    /// A constructed vote (needed for quorum).
+    /// A durable locally constructed vote (needed for quorum).
     Constructed(Vote<S, D>),
 }
 
@@ -188,7 +188,7 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
         });
     }
 
-    /// Send a constructed vote.
+    /// Send a locally constructed vote after it is durable.
     pub fn constructed(&mut self, message: Vote<S, D>) {
         let _ = self.sender.enqueue(Message::Constructed(message));
     }

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -22,7 +22,7 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
     pub blocker: B,
     pub reporter: Re,
-    pub historical_conflict_reporting: bool,
+    pub track_historical_votes: bool,
     pub relay: Rl,
 
     /// Strategy for parallel operations.
@@ -184,7 +184,7 @@ mod tests {
         skip_timeout: Duration,
         term_length: TermLength,
         forwarding: ForwardingPolicy,
-        historical_conflict_reporting: bool,
+        track_historical_votes: bool,
         floor: View,
     }
 
@@ -195,7 +195,7 @@ mod tests {
                 skip_timeout: Duration::from_secs(5),
                 term_length: TermLength::ONE,
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
                 floor: View::zero(),
             }
         }
@@ -215,7 +215,7 @@ mod tests {
             scheme,
             blocker,
             reporter,
-            historical_conflict_reporting: options.historical_conflict_reporting,
+            track_historical_votes: options.track_historical_votes,
             relay,
             strategy: Sequential,
             view_retention: options.view_retention,
@@ -480,7 +480,7 @@ mod tests {
     }
 
     fn certified_conflict_outcome(
-        historical_conflict_reporting: bool,
+        track_historical_votes: bool,
         kind: Kind,
         first_matches: bool,
     ) -> (bool, bool) {
@@ -505,7 +505,7 @@ mod tests {
             Arc::new(schemes[0].clone()),
             RecordingBlocker(blocked.clone()),
             RecordingReporter(activities.clone()),
-            historical_conflict_reporting,
+            track_historical_votes,
         );
 
         match kind {

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -22,7 +22,7 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
     pub blocker: B,
     pub reporter: Re,
-    pub report_conflicting_votes: bool,
+    pub retain_votes_after_certification: bool,
     pub relay: Rl,
 
     /// Strategy for parallel operations.
@@ -184,7 +184,7 @@ mod tests {
         skip_timeout: Duration,
         term_length: TermLength,
         forwarding: ForwardingPolicy,
-        report_conflicting_votes: bool,
+        retain_votes_after_certification: bool,
         floor: View,
     }
 
@@ -195,7 +195,7 @@ mod tests {
                 skip_timeout: Duration::from_secs(5),
                 term_length: TermLength::ONE,
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
                 floor: View::zero(),
             }
         }
@@ -215,7 +215,7 @@ mod tests {
             scheme,
             blocker,
             reporter,
-            report_conflicting_votes: options.report_conflicting_votes,
+            retain_votes_after_certification: options.retain_votes_after_certification,
             relay,
             strategy: Sequential,
             view_retention: options.view_retention,
@@ -467,7 +467,7 @@ mod tests {
         );
     }
 
-    fn retains_certified_vote(report_conflicting_votes: bool) -> bool {
+    fn certified_vote_outcome(retain_votes_after_certification: bool) -> (bool, bool) {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -477,12 +477,13 @@ mod tests {
         let round_id = Round::new(Epoch::new(0), View::new(1));
         let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
         let signer = Participant::from_usize(0);
+        let activities = Arc::new(Mutex::new(Vec::new()));
         let mut round = super::Round::new(
             round_id,
             Arc::new(schemes[0].clone()),
             NoopBlocker,
-            NoopReporter(PhantomData),
-            report_conflicting_votes,
+            RecordingReporter(activities.clone()),
+            retain_votes_after_certification,
         );
 
         let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
@@ -491,57 +492,32 @@ mod tests {
 
         let notarization = build_notarization(&schemes, &proposal, quorum(5) as usize);
         assert!(round.record_certificate(&Certificate::Notarization(notarization)));
-        round.has_notarize(signer)
-    }
+        let retained = round.has_notarize(signer);
 
-    #[test]
-    fn test_certificate_releases_votes_without_conflict_checking() {
-        assert!(!retains_certified_vote(false));
-    }
-
-    #[test]
-    fn test_certificate_retains_votes_for_conflict_checking() {
-        assert!(retains_certified_vote(true));
-    }
-
-    #[test]
-    fn test_conflicting_votes_not_reported_when_disabled() {
-        let mut rng = test_rng();
-        let Fixture {
-            participants,
-            schemes,
-            ..
-        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
-        let round_id = Round::new(Epoch::new(0), View::new(1));
-        let activities = Arc::new(Mutex::new(Vec::new()));
-        let mut round = super::Round::new(
-            round_id,
-            Arc::new(schemes[0].clone()),
-            NoopBlocker,
-            RecordingReporter(activities.clone()),
-            false,
-        );
-        let first = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"first"]));
-        let second = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"second"]));
-
-        assert!(round.add_network(
-            participants[1].clone(),
-            Vote::Notarize(Notarize::sign(&schemes[1], first).unwrap()),
-        ));
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
         assert!(!round.add_network(
-            participants[1].clone(),
-            Vote::Notarize(Notarize::sign(&schemes[1], second).unwrap()),
+            participants[0].clone(),
+            Vote::Notarize(Notarize::sign(&schemes[0], conflicting).unwrap()),
         ));
-        assert!(
-            activities
-                .lock()
-                .iter()
-                .all(|activity| !matches!(activity, Activity::ConflictingNotarize(_)))
-        );
+        let conflict_reported = activities
+            .lock()
+            .iter()
+            .any(|activity| matches!(activity, Activity::ConflictingNotarize(_)));
+        (retained, conflict_reported)
     }
 
     #[test]
-    fn test_nullify_finalize_conflicts_reported_when_enabled() {
+    fn test_certificate_releases_votes_without_retention() {
+        assert_eq!(certified_vote_outcome(false), (false, false));
+    }
+
+    #[test]
+    fn test_certificate_retains_votes_when_configured() {
+        assert_eq!(certified_vote_outcome(true), (true, true));
+    }
+
+    #[test]
+    fn test_nullify_finalize_conflicts_reported_while_evidence_available() {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -556,7 +532,7 @@ mod tests {
             Arc::new(schemes[0].clone()),
             NoopBlocker,
             RecordingReporter(activities.clone()),
-            true,
+            false,
         );
 
         assert!(round.add_network(
@@ -577,13 +553,56 @@ mod tests {
             Vote::Finalize(Finalize::sign(&schemes[2], proposal).unwrap()),
         ));
 
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            RecordingReporter(activities.clone()),
+            false,
+        );
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
+        assert!(round.add_network(
+            participants[1].clone(),
+            Vote::Finalize(Finalize::sign(&schemes[1], proposal.clone()).unwrap()),
+        ));
+        round.record_certificate(&Certificate::Nullification(build_nullification(
+            &schemes,
+            round_id,
+            quorum(5) as usize,
+        )));
+        assert!(!round.add_network(
+            participants[1].clone(),
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[1], round_id).unwrap()),
+        ));
+
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            RecordingReporter(activities.clone()),
+            false,
+        );
+        assert!(round.add_network(
+            participants[2].clone(),
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[2], round_id).unwrap()),
+        ));
+        round.record_certificate(&Certificate::Finalization(build_finalization(
+            &schemes,
+            &proposal,
+            quorum(5) as usize,
+        )));
+        assert!(!round.add_network(
+            participants[2].clone(),
+            Vote::Finalize(Finalize::sign(&schemes[2], proposal).unwrap()),
+        ));
+
         assert_eq!(
             activities
                 .lock()
                 .iter()
                 .filter(|activity| matches!(activity, Activity::NullifyFinalize(_)))
                 .count(),
-            2
+            4
         );
     }
 
@@ -5356,10 +5375,7 @@ mod tests {
                 reporter.clone(),
                 MockRelay::new(),
                 epoch,
-                BatcherOptions {
-                    report_conflicting_votes: true,
-                    ..Default::default()
-                },
+                BatcherOptions::default(),
             );
             let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
 

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -22,7 +22,6 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
     pub blocker: B,
     pub reporter: Re,
-    /// Whether to retain full votes after recovering their certificate.
     pub retain_recovered_votes: bool,
     pub relay: Rl,
 

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -866,62 +866,86 @@ mod tests {
         );
     }
 
-    /// A durable local finalize preserves certificate-backed proposal authority
-    /// after the batcher has already compacted the finalize phase.
+    /// A locally recovered certificate makes its proposal authoritative before
+    /// compacting the corresponding vote phase.
     #[test_async]
-    async fn test_constructed_finalize_after_local_finalization_preserves_authority() {
-        let mut rng = test_rng();
-        let Fixture {
-            participants,
-            schemes,
-            verifier,
-            ..
-        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
-        let quorum_size = quorum(5) as usize;
-        let round_id = Round::new(Epoch::new(0), View::new(1));
-        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"finalized"]));
-        let mut round = super::Round::new(
-            round_id,
-            Arc::new(verifier),
-            NoopBlocker,
-            NoopReporter(PhantomData),
-            false,
-        );
+    async fn test_local_certificate_preserves_proposal_authority() {
+        for kind in [Kind::Notarization, Kind::Finalization] {
+            let mut rng = test_rng();
+            let Fixture {
+                participants,
+                schemes,
+                verifier,
+                ..
+            } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+            let quorum_size = quorum(5) as usize;
+            let round_id = Round::new(Epoch::new(0), View::new(1));
+            let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"certified"]));
+            let mut round = super::Round::new(
+                round_id,
+                Arc::new(verifier),
+                NoopBlocker,
+                NoopReporter(PhantomData),
+                false,
+            );
 
-        // Learn the proposal only from the leader, then locally recover a
-        // finalization without using a constructed vote.
-        let leader = Participant::from_usize(0);
-        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
-        assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
-        round.set_leader(leader);
-        for i in 0..quorum_size {
-            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
-            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+            let leader = Participant::from_usize(0);
+            let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
+            round.set_leader(leader);
+            match kind {
+                Kind::Notarization => {
+                    for i in 1..quorum_size {
+                        let notarize = Notarize::sign(&schemes[i], proposal.clone()).unwrap();
+                        assert!(
+                            round.add_network(participants[i].clone(), Vote::Notarize(notarize))
+                        );
+                    }
+                }
+                Kind::Finalization => {
+                    for i in 0..quorum_size {
+                        let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+                        assert!(
+                            round.add_network(participants[i].clone(), Vote::Finalize(finalize))
+                        );
+                    }
+                }
+                Kind::Nullification => unreachable!(),
+            }
+
+            let (batch, invalid) = round
+                .try_verify(&mut rng, &Sequential)
+                .await
+                .expect("certificate quorum must be ready");
+            assert_eq!(batch, quorum_size);
+            assert!(invalid.is_empty());
+            let certificate = round
+                .try_construct_certificate(&Sequential)
+                .await
+                .expect("verified quorum must construct a certificate");
+            assert_eq!(certificate.kind(), kind);
+
+            let conflicting =
+                Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+            let conflicting = match kind {
+                Kind::Notarization => Certificate::Finalization(build_finalization(
+                    &schemes,
+                    &conflicting,
+                    quorum_size,
+                )),
+                Kind::Finalization => Certificate::Notarization(build_notarization(
+                    &schemes,
+                    &conflicting,
+                    quorum_size,
+                )),
+                Kind::Nullification => unreachable!(),
+            };
+            assert!(!round.record_certificate(&conflicting));
+            assert_eq!(
+                round.try_forward_proposal(Participant::from_usize(1)),
+                Some(proposal)
+            );
         }
-        let (batch, invalid) = round
-            .try_verify(&mut rng, &Sequential)
-            .await
-            .expect("finalize quorum must be ready");
-        assert_eq!(batch, quorum_size);
-        assert!(invalid.is_empty());
-        assert!(matches!(
-            round.try_construct_certificate(&Sequential).await,
-            Some(Certificate::Finalization(finalization)) if finalization.proposal == proposal
-        ));
-
-        // The voter's durable finalize may arrive after certificate recovery.
-        let finalize = Finalize::sign(&schemes[quorum_size], proposal.clone()).unwrap();
-        round.add_constructed(Vote::Finalize(finalize));
-
-        // Certificate-backed proposal state is immutable even if conflicting
-        // certificate evidence is presented later.
-        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
-        let notarization = build_notarization(&schemes, &conflicting, quorum_size);
-        assert!(!round.record_certificate(&Certificate::Notarization(notarization)));
-        assert_eq!(
-            round.try_forward_proposal(Participant::from_usize(1)),
-            Some(proposal)
-        );
     }
 
     /// A constructed finalize is added as verified while restoring only

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -770,6 +770,64 @@ mod tests {
         );
     }
 
+    /// A durable local finalize preserves certificate-backed proposal authority
+    /// after the batcher has already compacted the finalize phase.
+    #[test_async]
+    async fn test_constructed_finalize_after_local_finalization_preserves_authority() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            verifier,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let quorum_size = quorum(5) as usize;
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"finalized"]));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(verifier),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+            false,
+        );
+
+        // Learn the proposal only from the leader, then locally recover a
+        // finalization without using a constructed vote.
+        let leader = Participant::from_usize(0);
+        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
+        assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
+        round.set_leader(leader);
+        for i in 0..quorum_size {
+            let finalize = Finalize::sign(&schemes[i], proposal.clone()).unwrap();
+            assert!(round.add_network(participants[i].clone(), Vote::Finalize(finalize)));
+        }
+        let (batch, invalid) = round
+            .try_verify(&mut rng, &Sequential)
+            .await
+            .expect("finalize quorum must be ready");
+        assert_eq!(batch, quorum_size);
+        assert!(invalid.is_empty());
+        assert!(matches!(
+            round.try_construct_certificate(&Sequential).await,
+            Some(Certificate::Finalization(finalization)) if finalization.proposal == proposal
+        ));
+
+        // The voter's durable finalize may arrive after certificate recovery.
+        let finalize = Finalize::sign(&schemes[quorum_size], proposal.clone()).unwrap();
+        round.add_constructed(Vote::Finalize(finalize));
+
+        // Certificate-backed proposal state is immutable even if conflicting
+        // certificate evidence is presented later.
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+        let notarization = build_notarization(&schemes, &conflicting, quorum_size);
+        assert!(!round.record_certificate(&Certificate::Notarization(notarization)));
+        assert_eq!(
+            round.try_forward_proposal(Participant::from_usize(1)),
+            Some(proposal)
+        );
+    }
+
     /// A constructed finalize is added as verified while restoring only
     /// matching network votes after replacing a conflicting leader proposal.
     #[test_async]

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -467,7 +467,7 @@ mod tests {
         );
     }
 
-    fn certified_vote_outcome(retain_votes_after_certification: bool) -> (bool, bool) {
+    fn certified_conflict_reported(retain_votes_after_certification: bool) -> bool {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -492,28 +492,26 @@ mod tests {
 
         let notarization = build_notarization(&schemes, &proposal, quorum(5) as usize);
         assert!(round.record_certificate(&Certificate::Notarization(notarization)));
-        let retained = round.has_notarize(signer);
 
         let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
         assert!(!round.add_network(
             participants[0].clone(),
             Vote::Notarize(Notarize::sign(&schemes[0], conflicting).unwrap()),
         ));
-        let conflict_reported = activities
+        activities
             .lock()
             .iter()
-            .any(|activity| matches!(activity, Activity::ConflictingNotarize(_)));
-        (retained, conflict_reported)
+            .any(|activity| matches!(activity, Activity::ConflictingNotarize(_)))
     }
 
     #[test]
     fn test_certificate_releases_votes_without_retention() {
-        assert_eq!(certified_vote_outcome(false), (false, false));
+        assert!(!certified_conflict_reported(false));
     }
 
     #[test]
     fn test_certificate_retains_votes_when_configured() {
-        assert_eq!(certified_vote_outcome(true), (true, true));
+        assert!(certified_conflict_reported(true));
     }
 
     #[test]

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -22,6 +22,7 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
     pub blocker: B,
     pub reporter: Re,
+    pub report_conflicting_votes: bool,
     pub relay: Rl,
 
     /// Strategy for parallel operations.
@@ -183,6 +184,7 @@ mod tests {
         skip_timeout: Duration,
         term_length: TermLength,
         forwarding: ForwardingPolicy,
+        report_conflicting_votes: bool,
         floor: View,
     }
 
@@ -193,6 +195,7 @@ mod tests {
                 skip_timeout: Duration::from_secs(5),
                 term_length: TermLength::ONE,
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
                 floor: View::zero(),
             }
         }
@@ -212,6 +215,7 @@ mod tests {
             scheme,
             blocker,
             reporter,
+            report_conflicting_votes: options.report_conflicting_votes,
             relay,
             strategy: Sequential,
             view_retention: options.view_retention,
@@ -340,6 +344,25 @@ mod tests {
         }
     }
 
+    struct RecordingReporter<S: Scheme<Sha256Digest>>(
+        Arc<Mutex<Vec<Activity<S, Sha256Digest>>>>,
+    );
+
+    impl<S: Scheme<Sha256Digest>> Clone for RecordingReporter<S> {
+        fn clone(&self) -> Self {
+            Self(self.0.clone())
+        }
+    }
+
+    impl<S: Scheme<Sha256Digest>> crate::Reporter for RecordingReporter<S> {
+        type Activity = Activity<S, Sha256Digest>;
+
+        fn report(&mut self, activity: Self::Activity) -> Feedback {
+            self.0.lock().push(activity);
+            Feedback::Ok
+        }
+    }
+
     /// Drives a full quorum of network votes through a [Round]'s batch-verify and
     /// certificate-recovery offloads using `strategy`.
     async fn verify_and_construct<S, F>(mut fixture: F, strategy: impl Strategy)
@@ -360,6 +383,7 @@ mod tests {
             Arc::new(schemes[0].clone()),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
 
         // Route a quorum of notarizes through the round as network votes.
@@ -429,6 +453,7 @@ mod tests {
             Arc::new(schemes[1].clone()),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
 
         // The leader's notarize arrives before the leader is known
@@ -449,6 +474,173 @@ mod tests {
         );
     }
 
+    fn retains_certified_vote(report_conflicting_votes: bool) -> bool {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
+        let signer = Participant::from_usize(0);
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+            report_conflicting_votes,
+        );
+
+        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
+        assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
+        assert!(!round.is_missing_voter(&proposal, signer));
+
+        let notarization = build_notarization(&schemes, &proposal, quorum(5) as usize);
+        assert!(round.record_certificate(&Certificate::Notarization(notarization)));
+        round.has_notarize(signer)
+    }
+
+    #[test]
+    fn test_certificate_releases_votes_without_conflict_checking() {
+        assert!(!retains_certified_vote(false));
+    }
+
+    #[test]
+    fn test_certificate_retains_votes_for_conflict_checking() {
+        assert!(retains_certified_vote(true));
+    }
+
+    #[test]
+    fn test_conflicting_votes_not_reported_when_disabled() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            RecordingReporter(activities.clone()),
+            false,
+        );
+        let first = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"first"]));
+        let second = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"second"]));
+
+        assert!(round.add_network(
+            participants[1].clone(),
+            Vote::Notarize(Notarize::sign(&schemes[1], first).unwrap()),
+        ));
+        assert!(!round.add_network(
+            participants[1].clone(),
+            Vote::Notarize(Notarize::sign(&schemes[1], second).unwrap()),
+        ));
+        assert!(
+            activities
+                .lock()
+                .iter()
+                .all(|activity| !matches!(activity, Activity::ConflictingNotarize(_)))
+        );
+    }
+
+    #[test]
+    fn test_constructed_votes_reported_after_existing_certificates() {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            RecordingReporter(activities.clone()),
+            false,
+        );
+        let quorum = quorum(5) as usize;
+
+        round.record_certificate(&Certificate::Notarization(build_notarization(
+            &schemes, &proposal, quorum,
+        )));
+        round.add_constructed(Vote::Notarize(
+            Notarize::sign(&schemes[0], proposal.clone()).unwrap(),
+        ));
+
+        round.record_certificate(&Certificate::Nullification(build_nullification(
+            &schemes, round_id, quorum,
+        )));
+        round.add_constructed(Vote::Nullify(
+            Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap(),
+        ));
+
+        round.record_certificate(&Certificate::Finalization(build_finalization(
+            &schemes, &proposal, quorum,
+        )));
+        round.add_constructed(Vote::Finalize(
+            Finalize::sign(&schemes[0], proposal).unwrap(),
+        ));
+
+        let activities = activities.lock();
+        assert_eq!(
+            activities
+                .iter()
+                .filter(|activity| matches!(activity, Activity::Notarize(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            activities
+                .iter()
+                .filter(|activity| matches!(activity, Activity::Nullify(_)))
+                .count(),
+            1
+        );
+        assert_eq!(
+            activities
+                .iter()
+                .filter(|activity| matches!(activity, Activity::Finalize(_)))
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_nullify_retry_after_certificate_is_not_reported_twice() {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            RecordingReporter(activities.clone()),
+            false,
+        );
+        let nullify = Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap();
+
+        round.add_constructed(Vote::Nullify(nullify.clone()));
+        round.record_certificate(&Certificate::Nullification(build_nullification(
+            &schemes,
+            round_id,
+            quorum(5) as usize,
+        )));
+        round.add_constructed(Vote::Nullify(nullify));
+
+        assert_eq!(
+            activities
+                .lock()
+                .iter()
+                .filter(|activity| matches!(activity, Activity::Nullify(_)))
+                .count(),
+            1
+        );
+    }
+
     /// A finalization replaces a conflicting leader-selected proposal and
     /// makes its proposal authoritative.
     #[test]
@@ -465,6 +657,7 @@ mod tests {
             Arc::new(schemes[1].clone()),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
 
         // The leader's notarize arrives before the leader is known.
@@ -505,6 +698,7 @@ mod tests {
             Arc::new(schemes[0].clone()),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
 
         // The constructed finalize establishes the proposal without relying
@@ -535,6 +729,7 @@ mod tests {
             Arc::new(verifier),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
         let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"notarized"]));
 
@@ -590,6 +785,7 @@ mod tests {
             Arc::new(verifier),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
         let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"notarized"]));
 
@@ -647,6 +843,7 @@ mod tests {
             Arc::new(schemes[0].clone()),
             NoopBlocker,
             NoopReporter(PhantomData),
+            false,
         );
 
         // A quorum of notarizes and a nullify from every participant
@@ -5119,7 +5316,10 @@ mod tests {
                 reporter.clone(),
                 MockRelay::new(),
                 epoch,
-                BatcherOptions::default(),
+                BatcherOptions {
+                    report_conflicting_votes: true,
+                    ..Default::default()
+                },
             );
             let (batcher, mut batcher_mailbox) = Actor::new(context.child("actor"), batcher_cfg);
 

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -607,6 +607,60 @@ mod tests {
     }
 
     #[test]
+    fn test_compacted_votes_still_block_nullify_finalize_conflicts() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
+
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+            false,
+        );
+        assert!(round.add_network(
+            participants[1].clone(),
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[1], round_id).unwrap()),
+        ));
+        round.record_certificate(&Certificate::Nullification(build_nullification(
+            &schemes,
+            round_id,
+            quorum(5) as usize,
+        )));
+        assert!(!round.add_network(
+            participants[1].clone(),
+            Vote::Finalize(Finalize::sign(&schemes[1], proposal.clone()).unwrap()),
+        ));
+
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            NoopReporter(PhantomData),
+            false,
+        );
+        assert!(round.add_network(
+            participants[2].clone(),
+            Vote::Finalize(Finalize::sign(&schemes[2], proposal.clone()).unwrap()),
+        ));
+        round.record_certificate(&Certificate::Finalization(build_finalization(
+            &schemes,
+            &proposal,
+            quorum(5) as usize,
+        )));
+        assert!(!round.add_network(
+            participants[2].clone(),
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[2], round_id).unwrap()),
+        ));
+    }
+
+    #[test]
     fn test_constructed_votes_reported_after_existing_certificates() {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = ed25519::fixture(&mut rng, b"batcher_test", 5);
@@ -625,23 +679,26 @@ mod tests {
         round.record_certificate(&Certificate::Notarization(build_notarization(
             &schemes, &proposal, quorum,
         )));
-        round.add_constructed(Vote::Notarize(
-            Notarize::sign(&schemes[0], proposal.clone()).unwrap(),
-        ));
+        round.accept_vote(
+            Vote::Notarize(Notarize::sign(&schemes[0], proposal.clone()).unwrap()),
+            true,
+        );
 
         round.record_certificate(&Certificate::Nullification(build_nullification(
             &schemes, round_id, quorum,
         )));
-        round.add_constructed(Vote::Nullify(
-            Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap(),
-        ));
+        round.accept_vote(
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap()),
+            true,
+        );
 
         round.record_certificate(&Certificate::Finalization(build_finalization(
             &schemes, &proposal, quorum,
         )));
-        round.add_constructed(Vote::Finalize(
-            Finalize::sign(&schemes[0], proposal).unwrap(),
-        ));
+        round.accept_vote(
+            Vote::Finalize(Finalize::sign(&schemes[0], proposal).unwrap()),
+            true,
+        );
 
         let activities = activities.lock();
         assert_eq!(
@@ -682,13 +739,13 @@ mod tests {
         );
         let nullify = Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap();
 
-        round.add_constructed(Vote::Nullify(nullify.clone()));
+        round.accept_vote(Vote::Nullify(nullify.clone()), true);
         round.record_certificate(&Certificate::Nullification(build_nullification(
             &schemes,
             round_id,
             quorum(5) as usize,
         )));
-        round.add_constructed(Vote::Nullify(nullify));
+        round.accept_vote(Vote::Nullify(nullify), true);
 
         assert_eq!(
             activities
@@ -763,7 +820,7 @@ mod tests {
         // The constructed finalize establishes the proposal without relying
         // on a leader vote.
         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-        round.add_constructed(Vote::Finalize(finalize));
+        round.accept_vote(Vote::Finalize(finalize), true);
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(0)),
             Some(proposal)
@@ -815,7 +872,7 @@ mod tests {
 
         // The voter's durable finalize may arrive after certificate recovery.
         let finalize = Finalize::sign(&schemes[quorum_size], proposal.clone()).unwrap();
-        round.add_constructed(Vote::Finalize(finalize));
+        round.accept_vote(Vote::Finalize(finalize), true);
 
         // Certificate-backed proposal state is immutable even if conflicting
         // certificate evidence is presented later.
@@ -866,7 +923,7 @@ mod tests {
         // The constructed finalize replaces the proposal and restores the
         // matching network votes before it enters the tracker itself.
         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-        round.add_constructed(Vote::Finalize(finalize));
+        round.accept_vote(Vote::Finalize(finalize), true);
 
         // Only the network votes require verification.
         let (batch, invalid) = round

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -344,15 +344,8 @@ mod tests {
         }
     }
 
-    struct RecordingReporter<S: Scheme<Sha256Digest>>(
-        Arc<Mutex<Vec<Activity<S, Sha256Digest>>>>,
-    );
-
-    impl<S: Scheme<Sha256Digest>> Clone for RecordingReporter<S> {
-        fn clone(&self) -> Self {
-            Self(self.0.clone())
-        }
-    }
+    #[derive(Clone)]
+    struct RecordingReporter<S: Scheme<Sha256Digest>>(Arc<Mutex<Vec<Activity<S, Sha256Digest>>>>);
 
     impl<S: Scheme<Sha256Digest>> crate::Reporter for RecordingReporter<S> {
         type Activity = Activity<S, Sha256Digest>;
@@ -544,6 +537,53 @@ mod tests {
                 .lock()
                 .iter()
                 .all(|activity| !matches!(activity, Activity::ConflictingNotarize(_)))
+        );
+    }
+
+    #[test]
+    fn test_nullify_finalize_conflicts_reported_when_enabled() {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            schemes,
+            ..
+        } = ed25519::fixture(&mut rng, b"batcher_test", 5);
+        let round_id = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
+        let activities = Arc::new(Mutex::new(Vec::new()));
+        let mut round = super::Round::new(
+            round_id,
+            Arc::new(schemes[0].clone()),
+            NoopBlocker,
+            RecordingReporter(activities.clone()),
+            true,
+        );
+
+        assert!(round.add_network(
+            participants[1].clone(),
+            Vote::Finalize(Finalize::sign(&schemes[1], proposal.clone()).unwrap()),
+        ));
+        assert!(!round.add_network(
+            participants[1].clone(),
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[1], round_id).unwrap()),
+        ));
+
+        assert!(round.add_network(
+            participants[2].clone(),
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[2], round_id).unwrap()),
+        ));
+        assert!(!round.add_network(
+            participants[2].clone(),
+            Vote::Finalize(Finalize::sign(&schemes[2], proposal).unwrap()),
+        ));
+
+        assert_eq!(
+            activities
+                .lock()
+                .iter()
+                .filter(|activity| matches!(activity, Activity::NullifyFinalize(_)))
+                .count(),
+            2
         );
     }
 

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -22,7 +22,8 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
     pub blocker: B,
     pub reporter: Re,
-    pub retain_votes_after_certification: bool,
+    /// Whether to retain full votes after recovering their certificate.
+    pub retain_recovered_votes: bool,
     pub relay: Rl,
 
     /// Strategy for parallel operations.
@@ -184,7 +185,7 @@ mod tests {
         skip_timeout: Duration,
         term_length: TermLength,
         forwarding: ForwardingPolicy,
-        retain_votes_after_certification: bool,
+        retain_recovered_votes: bool,
         floor: View,
     }
 
@@ -195,7 +196,7 @@ mod tests {
                 skip_timeout: Duration::from_secs(5),
                 term_length: TermLength::ONE,
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                retain_recovered_votes: false,
                 floor: View::zero(),
             }
         }
@@ -215,7 +216,7 @@ mod tests {
             scheme,
             blocker,
             reporter,
-            retain_votes_after_certification: options.retain_votes_after_certification,
+            retain_recovered_votes: options.retain_recovered_votes,
             relay,
             strategy: Sequential,
             view_retention: options.view_retention,
@@ -467,7 +468,7 @@ mod tests {
         );
     }
 
-    fn certified_conflict_reported(retain_votes_after_certification: bool) -> bool {
+    fn certified_conflict_reported(retain_recovered_votes: bool) -> bool {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -483,7 +484,7 @@ mod tests {
             Arc::new(schemes[0].clone()),
             NoopBlocker,
             RecordingReporter(activities.clone()),
-            retain_votes_after_certification,
+            retain_recovered_votes,
         );
 
         let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -721,23 +721,26 @@ mod tests {
         round.record_certificate(&Certificate::Notarization(build_notarization(
             &schemes, &proposal, quorum,
         )));
-        round.add_constructed(Vote::Notarize(
-            Notarize::sign(&schemes[0], proposal.clone()).unwrap(),
-        ));
+        round.accept_vote(
+            Vote::Notarize(Notarize::sign(&schemes[0], proposal.clone()).unwrap()),
+            true,
+        );
 
         round.record_certificate(&Certificate::Nullification(build_nullification(
             &schemes, round_id, quorum,
         )));
-        round.add_constructed(Vote::Nullify(
-            Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap(),
-        ));
+        round.accept_vote(
+            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap()),
+            true,
+        );
 
         round.record_certificate(&Certificate::Finalization(build_finalization(
             &schemes, &proposal, quorum,
         )));
-        round.add_constructed(Vote::Finalize(
-            Finalize::sign(&schemes[0], proposal).unwrap(),
-        ));
+        round.accept_vote(
+            Vote::Finalize(Finalize::sign(&schemes[0], proposal).unwrap()),
+            true,
+        );
 
         let activities = activities.lock();
         assert_eq!(
@@ -778,13 +781,13 @@ mod tests {
         );
         let nullify = Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap();
 
-        round.add_constructed(Vote::Nullify(nullify.clone()));
+        round.accept_vote(Vote::Nullify(nullify.clone()), true);
         round.record_certificate(&Certificate::Nullification(build_nullification(
             &schemes,
             round_id,
             quorum(5) as usize,
         )));
-        round.add_constructed(Vote::Nullify(nullify));
+        round.accept_vote(Vote::Nullify(nullify), true);
 
         assert_eq!(
             activities
@@ -859,7 +862,7 @@ mod tests {
         // The constructed finalize establishes the proposal without relying
         // on a leader vote.
         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-        round.add_constructed(Vote::Finalize(finalize));
+        round.accept_vote(Vote::Finalize(finalize), true);
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(0)),
             Some(proposal)
@@ -986,7 +989,7 @@ mod tests {
         // The constructed finalize replaces the proposal and restores the
         // matching network votes before it enters the tracker itself.
         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-        round.add_constructed(Vote::Finalize(finalize));
+        round.accept_vote(Vote::Finalize(finalize), true);
 
         // Only the network votes require verification.
         let (batch, invalid) = round

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -22,7 +22,7 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
     pub blocker: B,
     pub reporter: Re,
-    pub retain_recovered_votes: bool,
+    pub historical_conflict_reporting: bool,
     pub relay: Rl,
 
     /// Strategy for parallel operations.
@@ -184,7 +184,7 @@ mod tests {
         skip_timeout: Duration,
         term_length: TermLength,
         forwarding: ForwardingPolicy,
-        retain_recovered_votes: bool,
+        historical_conflict_reporting: bool,
         floor: View,
     }
 
@@ -195,7 +195,7 @@ mod tests {
                 skip_timeout: Duration::from_secs(5),
                 term_length: TermLength::ONE,
                 forwarding: ForwardingPolicy::Disabled,
-                retain_recovered_votes: false,
+                historical_conflict_reporting: false,
                 floor: View::zero(),
             }
         }
@@ -215,7 +215,7 @@ mod tests {
             scheme,
             blocker,
             reporter,
-            retain_recovered_votes: options.retain_recovered_votes,
+            historical_conflict_reporting: options.historical_conflict_reporting,
             relay,
             strategy: Sequential,
             view_retention: options.view_retention,
@@ -323,6 +323,18 @@ mod tests {
         type PublicKey = PublicKey;
 
         fn block(&mut self, _peer: Self::PublicKey) -> Feedback {
+            Feedback::Ok
+        }
+    }
+
+    #[derive(Clone)]
+    struct RecordingBlocker(Arc<Mutex<Vec<PublicKey>>>);
+
+    impl commonware_p2p::Blocker for RecordingBlocker {
+        type PublicKey = PublicKey;
+
+        fn block(&mut self, peer: Self::PublicKey) -> Feedback {
+            self.0.lock().push(peer);
             Feedback::Ok
         }
     }
@@ -467,7 +479,11 @@ mod tests {
         );
     }
 
-    fn certified_conflict_reported(retain_recovered_votes: bool) -> bool {
+    fn certified_conflict_outcome(
+        historical_conflict_reporting: bool,
+        kind: Kind,
+        first_matches: bool,
+    ) -> (bool, bool) {
         let mut rng = test_rng();
         let Fixture {
             participants,
@@ -476,42 +492,70 @@ mod tests {
         } = ed25519::fixture(&mut rng, b"batcher_test", 5);
         let round_id = Round::new(Epoch::new(0), View::new(1));
         let proposal = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"payload"]));
-        let signer = Participant::from_usize(0);
+        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
+        let (first, second) = if first_matches {
+            (&proposal, &conflicting)
+        } else {
+            (&conflicting, &proposal)
+        };
         let activities = Arc::new(Mutex::new(Vec::new()));
+        let blocked = Arc::new(Mutex::new(Vec::new()));
         let mut round = super::Round::new(
             round_id,
             Arc::new(schemes[0].clone()),
-            NoopBlocker,
+            RecordingBlocker(blocked.clone()),
             RecordingReporter(activities.clone()),
-            retain_recovered_votes,
+            historical_conflict_reporting,
         );
 
-        let notarize = Notarize::sign(&schemes[0], proposal.clone()).unwrap();
-        assert!(round.add_network(participants[0].clone(), Vote::Notarize(notarize)));
-        assert!(!round.is_missing_voter(&proposal, signer));
-
-        let notarization = build_notarization(&schemes, &proposal, quorum(5) as usize);
-        assert!(round.record_certificate(&Certificate::Notarization(notarization)));
-
-        let conflicting = Proposal::new(round_id, View::zero(), Sha256::hash(&[b"conflicting"]));
-        assert!(!round.add_network(
-            participants[0].clone(),
-            Vote::Notarize(Notarize::sign(&schemes[0], conflicting).unwrap()),
-        ));
-        activities
-            .lock()
-            .iter()
-            .any(|activity| matches!(activity, Activity::ConflictingNotarize(_)))
+        match kind {
+            Kind::Notarization => {
+                let vote = Notarize::sign(&schemes[0], first.clone()).unwrap();
+                assert!(round.add_network(participants[0].clone(), Vote::Notarize(vote)));
+                let certificate = build_notarization(&schemes, &proposal, quorum(5) as usize);
+                assert!(round.record_certificate(&Certificate::Notarization(certificate)));
+                let vote = Notarize::sign(&schemes[0], second.clone()).unwrap();
+                assert!(!round.add_network(participants[0].clone(), Vote::Notarize(vote)));
+            }
+            Kind::Finalization => {
+                let vote = Finalize::sign(&schemes[0], first.clone()).unwrap();
+                assert!(round.add_network(participants[0].clone(), Vote::Finalize(vote)));
+                let certificate = build_finalization(&schemes, &proposal, quorum(5) as usize);
+                assert!(!round.record_certificate(&Certificate::Finalization(certificate)));
+                let vote = Finalize::sign(&schemes[0], second.clone()).unwrap();
+                assert!(!round.add_network(participants[0].clone(), Vote::Finalize(vote)));
+            }
+            Kind::Nullification => unreachable!("nullify votes do not carry proposals"),
+        }
+        let reported = activities.lock().iter().any(|activity| match kind {
+            Kind::Notarization => matches!(activity, Activity::ConflictingNotarize(_)),
+            Kind::Finalization => matches!(activity, Activity::ConflictingFinalize(_)),
+            Kind::Nullification => false,
+        });
+        let blocked = blocked.lock().contains(&participants[0]);
+        (reported, blocked)
     }
 
     #[test]
     fn test_certificate_releases_votes_without_retention() {
-        assert!(!certified_conflict_reported(false));
+        for kind in [Kind::Notarization, Kind::Finalization] {
+            for first_matches in [false, true] {
+                let (reported, blocked) = certified_conflict_outcome(false, kind, first_matches);
+                assert!(!reported);
+                assert!(blocked, "compact proposal conflict should block its signer");
+            }
+        }
     }
 
     #[test]
     fn test_certificate_retains_votes_when_configured() {
-        assert!(certified_conflict_reported(true));
+        for kind in [Kind::Notarization, Kind::Finalization] {
+            for first_matches in [false, true] {
+                let (reported, blocked) = certified_conflict_outcome(true, kind, first_matches);
+                assert!(reported);
+                assert!(blocked);
+            }
+        }
     }
 
     #[test]
@@ -677,26 +721,23 @@ mod tests {
         round.record_certificate(&Certificate::Notarization(build_notarization(
             &schemes, &proposal, quorum,
         )));
-        round.accept_vote(
-            Vote::Notarize(Notarize::sign(&schemes[0], proposal.clone()).unwrap()),
-            true,
-        );
+        round.add_constructed(Vote::Notarize(
+            Notarize::sign(&schemes[0], proposal.clone()).unwrap(),
+        ));
 
         round.record_certificate(&Certificate::Nullification(build_nullification(
             &schemes, round_id, quorum,
         )));
-        round.accept_vote(
-            Vote::Nullify(Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap()),
-            true,
-        );
+        round.add_constructed(Vote::Nullify(
+            Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap(),
+        ));
 
         round.record_certificate(&Certificate::Finalization(build_finalization(
             &schemes, &proposal, quorum,
         )));
-        round.accept_vote(
-            Vote::Finalize(Finalize::sign(&schemes[0], proposal).unwrap()),
-            true,
-        );
+        round.add_constructed(Vote::Finalize(
+            Finalize::sign(&schemes[0], proposal).unwrap(),
+        ));
 
         let activities = activities.lock();
         assert_eq!(
@@ -737,13 +778,13 @@ mod tests {
         );
         let nullify = Nullify::sign::<Sha256Digest>(&schemes[0], round_id).unwrap();
 
-        round.accept_vote(Vote::Nullify(nullify.clone()), true);
+        round.add_constructed(Vote::Nullify(nullify.clone()));
         round.record_certificate(&Certificate::Nullification(build_nullification(
             &schemes,
             round_id,
             quorum(5) as usize,
         )));
-        round.accept_vote(Vote::Nullify(nullify), true);
+        round.add_constructed(Vote::Nullify(nullify));
 
         assert_eq!(
             activities
@@ -818,7 +859,7 @@ mod tests {
         // The constructed finalize establishes the proposal without relying
         // on a leader vote.
         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-        round.accept_vote(Vote::Finalize(finalize), true);
+        round.add_constructed(Vote::Finalize(finalize));
         assert_eq!(
             round.try_forward_proposal(Participant::from_usize(0)),
             Some(proposal)
@@ -870,7 +911,7 @@ mod tests {
 
         // The voter's durable finalize may arrive after certificate recovery.
         let finalize = Finalize::sign(&schemes[quorum_size], proposal.clone()).unwrap();
-        round.accept_vote(Vote::Finalize(finalize), true);
+        round.add_constructed(Vote::Finalize(finalize));
 
         // Certificate-backed proposal state is immutable even if conflicting
         // certificate evidence is presented later.
@@ -921,7 +962,7 @@ mod tests {
         // The constructed finalize replaces the proposal and restores the
         // matching network votes before it enters the tracker itself.
         let finalize = Finalize::sign(&schemes[0], proposal.clone()).unwrap();
-        round.accept_vote(Vote::Finalize(finalize), true);
+        round.add_constructed(Vote::Finalize(finalize));
 
         // Only the network votes require verification.
         let (batch, invalid) = round

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -103,10 +103,10 @@ impl<
 
     /// Records a verified certificate.
     ///
-    /// Marks its verifier phase complete and releases full votes no longer needed
-    /// for certificate assembly. A notarization or finalization may also establish
-    /// authoritative proposal evidence. Returns `true` when a notarization selects
-    /// a new proposal, making its buffered finalize votes eligible for processing.
+    /// Completes its verifier phase and applies the configured vote retention
+    /// policy. A notarization or finalization also establishes authoritative
+    /// proposal evidence. Returns `true` when a notarization selects a new proposal,
+    /// making buffered finalize votes eligible for processing.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
         let process_votes = match certificate {
             Certificate::Notarization(notarization) => {
@@ -126,7 +126,7 @@ impl<
         process_votes
     }
 
-    /// Releases full votes that are no longer needed for certificate assembly.
+    /// Applies the configured retention policy to a certified vote phase.
     fn release_votes(&mut self, kind: Kind) {
         match kind {
             Kind::Notarization => {
@@ -147,12 +147,11 @@ impl<
         }
     }
 
-    /// Accepts and reports a vote after sender and conflict checks.
+    /// Records and reports a vote after source-specific admission checks.
     ///
-    /// Full votes are forwarded to the verifier and retained while needed for
-    /// certification. When extended conflict reporting is disabled, compact
-    /// state preserves duplicate suppression and proposal forwarding without
-    /// reallocating the released vote map.
+    /// Retained votes are forwarded to the verifier for certificate assembly.
+    /// Compacted phases preserve duplicate suppression and proposal forwarding
+    /// without recreating their released vote maps.
     pub(super) fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> Outcome {
         if constructed && let Vote::Finalize(finalize) = &message {
             // The voter only constructs a finalize after independently
@@ -180,8 +179,8 @@ impl<
             }
         };
 
-        // A compacted phase already has its certificate. Report newly observed signer
-        // evidence, but only retained full votes can contribute to certificate assembly.
+        // Completed phases report new signer evidence without forwarding votes
+        // to the verifier.
         let verifier_message = retained.then(|| message.clone());
         let activity = match message {
             Vote::Notarize(notarize) => Activity::Notarize(notarize),
@@ -382,18 +381,16 @@ impl<
 
     /// Returns whether `signer` has a retained nullify vote.
     ///
-    /// Compact state is reached only after the corresponding certificate has
-    /// been forwarded to the voter, so it does not drive the leader fast path.
+    /// Compact state exists only after certification, which supersedes the
+    /// leader-nullify fast path.
     pub fn has_retained_nullify(&self, signer: Participant) -> bool {
         self.votes.has_nullify(signer)
     }
 
     /// Returns whether `participant` has not voted for `proposal` locally.
     ///
-    /// Uses the vote tracker and compact post-certificate membership rather
-    /// than the verified vote vectors because we only verify the first quorum
-    /// of votes. A peer whose matching vote arrived after quorum is still
-    /// tracked for forwarding.
+    /// Uses tracker membership, including compact state, because verification stops
+    /// after the first quorum. Matching votes received later still inform forwarding.
     ///
     /// Both notarize and finalize votes are checked: a participant who sent
     /// either for the same proposal already has the block and does not need
@@ -407,18 +404,7 @@ impl<
         !self.votes.has_finalize_for(participant, proposal)
     }
 
-    /// Returns participant indices whose matching vote for `proposal` was not
-    /// observed locally.
-    ///
-    /// Uses the vote tracker and compact post-certificate membership rather
-    /// than the verified vote vectors because we only verify the first quorum
-    /// of votes. A peer whose matching vote arrived after quorum is still
-    /// tracked for forwarding.
-    ///
-    /// Both notarize and finalize votes are checked: a participant who sent
-    /// either for the same proposal already has the block and does not need
-    /// it forwarded. Votes for a conflicting proposal are treated as missing
-    /// because those peers still need the winning block forwarded.
+    /// Returns participant indices for which [`Self::is_missing_voter`] is true.
     pub fn missing_voters(&self, proposal: &Proposal<D>) -> Vec<Participant> {
         (0..self.verifier.participants().len())
             .map(Participant::from_usize)

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -6,7 +6,7 @@ use crate::{
         scheme::Scheme,
         types::{
             Activity, Attributable, Certificate, ConflictingFinalize, ConflictingNotarize, Kind,
-            NullifyFinalize, Proposal, Vote, VoteTracker,
+            NullifyFinalize, Proposal, Vote, VoteRecord, VoteTracker,
         },
     },
     types::{Participant, Round as Rnd},
@@ -18,6 +18,16 @@ use commonware_utils::{N3f1, ordered::Quorum};
 use rand_core::CryptoRng;
 use std::sync::Arc;
 use tracing::Span;
+
+/// Outcome of recording a vote after preliminary conflict checks.
+enum VoteAcceptance {
+    /// The vote was newly recorded and reported.
+    Added,
+    /// The signer was already recorded with the same known vote state.
+    Duplicate,
+    /// Compact state proves the signer changed its relation to the authoritative proposal.
+    ConflictingProposal,
+}
 
 /// Per-view state for vote accumulation and certificate tracking.
 pub struct Round<
@@ -61,7 +71,7 @@ impl<
         scheme: Arc<S>,
         blocker: B,
         reporter: R,
-        retain_recovered_votes: bool,
+        historical_conflict_reporting: bool,
     ) -> Self {
         let quorum = scheme.participants().quorum::<N3f1>();
         let len = scheme.participants().len();
@@ -70,7 +80,7 @@ impl<
             reporter,
             verifier: Verifier::new(round, scheme, quorum),
 
-            votes: VoteTracker::new(len, retain_recovered_votes),
+            votes: VoteTracker::new(len, historical_conflict_reporting),
 
             proposal_sent: false,
 
@@ -153,7 +163,7 @@ impl<
     /// certification. When extended conflict reporting is disabled, compact
     /// state preserves duplicate suppression and proposal forwarding without
     /// reallocating the released vote map.
-    pub(super) fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> bool {
+    fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> VoteAcceptance {
         if constructed && let Vote::Finalize(finalize) = &message {
             // The voter only constructs a finalize after independently
             // authenticating the proposal.
@@ -161,18 +171,24 @@ impl<
         }
 
         let record = self.votes.record(&message, self.verifier.proposal());
-        if !record.inserted && record.retained && constructed {
-            match &message {
-                Vote::Notarize(_) => panic!("duplicate notarize"),
-                Vote::Nullify(_) => {}
-                Vote::Finalize(_) => panic!("duplicate finalize"),
+        let retained = match record {
+            VoteRecord::NewRetained => true,
+            VoteRecord::NewCompacted => false,
+            VoteRecord::DuplicateRetained => {
+                if constructed {
+                    match &message {
+                        Vote::Notarize(_) => panic!("duplicate notarize"),
+                        Vote::Nullify(_) => {}
+                        Vote::Finalize(_) => panic!("duplicate finalize"),
+                    }
+                }
+                return VoteAcceptance::Duplicate;
             }
-        }
-        if !record.inserted {
-            return false;
-        }
+            VoteRecord::DuplicateCompacted => return VoteAcceptance::Duplicate,
+            VoteRecord::ConflictingProposal => return VoteAcceptance::ConflictingProposal,
+        };
 
-        let verifier_message = record.retained.then(|| message.clone());
+        let verifier_message = retained.then(|| message.clone());
         let activity = match message {
             Vote::Notarize(notarize) => Activity::Notarize(notarize),
             Vote::Nullify(nullify) => Activity::Nullify(nullify),
@@ -182,7 +198,18 @@ impl<
         if let Some(message) = verifier_message {
             self.verifier.add(message, constructed);
         }
-        true
+        VoteAcceptance::Added
+    }
+
+    /// Adds a durable locally constructed vote.
+    pub fn add_constructed(&mut self, message: Vote<S, D>) {
+        assert!(
+            !matches!(
+                self.accept_vote(message, true),
+                VoteAcceptance::ConflictingProposal
+            ),
+            "conflicting constructed vote"
+        );
     }
 
     /// Makes an independently authenticated proposal authoritative, restoring
@@ -238,7 +265,14 @@ impl<
                         }
                         false
                     }
-                    None => self.accept_vote(Vote::Notarize(notarize), false),
+                    None => match self.accept_vote(Vote::Notarize(notarize), false) {
+                        VoteAcceptance::Added => true,
+                        VoteAcceptance::Duplicate => false,
+                        VoteAcceptance::ConflictingProposal => {
+                            commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
+                            false
+                        }
+                    },
                 }
             }
             Vote::Nullify(nullify) => {
@@ -266,7 +300,13 @@ impl<
                         }
                         false
                     }
-                    None => self.accept_vote(Vote::Nullify(nullify), false),
+                    None => match self.accept_vote(Vote::Nullify(nullify), false) {
+                        VoteAcceptance::Added => true,
+                        VoteAcceptance::Duplicate => false,
+                        VoteAcceptance::ConflictingProposal => {
+                            unreachable!("nullify votes do not carry proposals")
+                        }
+                    },
                 }
             }
             Vote::Finalize(finalize) => {
@@ -299,7 +339,14 @@ impl<
                         }
                         false
                     }
-                    None => self.accept_vote(Vote::Finalize(finalize), false),
+                    None => match self.accept_vote(Vote::Finalize(finalize), false) {
+                        VoteAcceptance::Added => true,
+                        VoteAcceptance::Duplicate => false,
+                        VoteAcceptance::ConflictingProposal => {
+                            commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
+                            false
+                        }
+                    },
                 }
             }
         }
@@ -358,8 +405,7 @@ impl<
         self.votes.has_nullify(signer)
     }
 
-    /// Returns participant indices whose matching vote for `proposal` was not
-    /// observed locally.
+    /// Returns whether `participant` has not voted for `proposal` locally.
     ///
     /// Uses the vote tracker and compact post-certificate membership rather
     /// than the verified vote vectors because we only verify the first quorum

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -61,7 +61,7 @@ impl<
         scheme: Arc<S>,
         blocker: B,
         reporter: R,
-        retain_votes_after_certification: bool,
+        retain_recovered_votes: bool,
     ) -> Self {
         let quorum = scheme.participants().quorum::<N3f1>();
         let len = scheme.participants().len();
@@ -70,7 +70,7 @@ impl<
             reporter,
             verifier: Verifier::new(round, scheme, quorum),
 
-            votes: VoteTracker::new(len, retain_votes_after_certification),
+            votes: VoteTracker::new(len, retain_recovered_votes),
 
             proposal_sent: false,
 

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -61,7 +61,7 @@ impl<
         scheme: Arc<S>,
         blocker: B,
         reporter: R,
-        historical_conflict_reporting: bool,
+        track_historical_votes: bool,
     ) -> Self {
         let quorum = scheme.participants().quorum::<N3f1>();
         let len = scheme.participants().len();
@@ -70,7 +70,7 @@ impl<
             reporter,
             verifier: Verifier::new(round, scheme, quorum),
 
-            votes: VoteTracker::new(len, historical_conflict_reporting),
+            votes: VoteTracker::new(len, track_historical_votes),
 
             proposal_sent: false,
 

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -150,31 +150,29 @@ impl<
     /// Accepts and reports a vote after sender and conflict checks.
     ///
     /// Full votes are forwarded to the verifier and retained while needed for
-    /// certification. When post-certification retention is disabled, compact
+    /// certification. When extended conflict reporting is disabled, compact
     /// state preserves duplicate suppression and proposal forwarding without
     /// reallocating the released vote map.
-    fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> bool {
-        let retain_full = self.votes.retains_full(&message);
-
+    pub(super) fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> bool {
         if constructed && let Vote::Finalize(finalize) = &message {
             // The voter only constructs a finalize after independently
             // authenticating the proposal.
             self.set_authoritative_proposal(&finalize.proposal);
         }
 
-        let inserted = self.votes.record(&message, self.verifier.proposal());
-        if !inserted {
-            if retain_full && constructed {
-                match message {
-                    Vote::Notarize(_) => panic!("duplicate notarize"),
-                    Vote::Nullify(_) => {}
-                    Vote::Finalize(_) => panic!("duplicate finalize"),
-                }
+        let record = self.votes.record(&message, self.verifier.proposal());
+        if !record.inserted && record.retained && constructed {
+            match &message {
+                Vote::Notarize(_) => panic!("duplicate notarize"),
+                Vote::Nullify(_) => {}
+                Vote::Finalize(_) => panic!("duplicate finalize"),
             }
+        }
+        if !record.inserted {
             return false;
         }
 
-        let verifier_message = retain_full.then(|| message.clone());
+        let verifier_message = record.retained.then(|| message.clone());
         let activity = match message {
             Vote::Notarize(notarize) => Activity::Notarize(notarize),
             Vote::Nullify(nullify) => Activity::Nullify(nullify),
@@ -251,9 +249,11 @@ impl<
                 }
 
                 // Check if finalized
-                if let Some(previous) = self.votes.finalize(index) {
-                    let activity = NullifyFinalize::new(nullify, previous.clone());
-                    self.reporter.report(Activity::NullifyFinalize(activity));
+                if self.votes.saw_finalize(index) {
+                    if let Some(previous) = self.votes.finalize(index) {
+                        let activity = NullifyFinalize::new(nullify, previous.clone());
+                        self.reporter.report(Activity::NullifyFinalize(activity));
+                    }
                     commonware_p2p::block!(self.blocker, sender, "nullify after finalize");
                     return false;
                 }
@@ -277,9 +277,11 @@ impl<
                 }
 
                 // Check if nullified
-                if let Some(previous) = self.votes.nullify(index) {
-                    let activity = NullifyFinalize::new(previous.clone(), finalize);
-                    self.reporter.report(Activity::NullifyFinalize(activity));
+                if self.votes.saw_nullify(index) {
+                    if let Some(previous) = self.votes.nullify(index) {
+                        let activity = NullifyFinalize::new(previous.clone(), finalize);
+                        self.reporter.report(Activity::NullifyFinalize(activity));
+                    }
                     commonware_p2p::block!(self.blocker, sender, "finalize after nullify");
                     return false;
                 }
@@ -301,18 +303,6 @@ impl<
                 }
             }
         }
-    }
-
-    /// Adds a durable locally constructed vote to the verifier and reporter.
-    ///
-    /// Duplicate nullifies are ignored (the voter re-sends its nullify vote on
-    /// every timeout retry).
-    ///
-    /// # Panics
-    ///
-    /// Panics if a notarize or finalize vote is added more than once.
-    pub fn add_constructed(&mut self, message: Vote<S, D>) {
-        self.accept_vote(message, true);
     }
 
     /// Sets the leader for this view. If the leader's notarize has already

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use tracing::Span;
 
 /// Outcome of recording a vote after preliminary conflict checks.
-enum VoteAcceptance {
+enum Outcome {
     /// The vote was newly recorded and reported.
     Added,
     /// The signer was already recorded with the same known vote state.
@@ -118,7 +118,18 @@ impl<
     /// `true` when a notarization selects a new proposal, making its buffered
     /// finalize votes eligible for processing.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
-        let process_votes = match certificate {
+        let process_votes = self.adopt_certificate_proposal(certificate);
+        self.verifier.record_certificate(certificate.kind());
+        self.release_votes(certificate.kind());
+        process_votes
+    }
+
+    /// Makes a certificate's proposal authoritative.
+    ///
+    /// Returns whether a notarization made buffered finalize votes eligible
+    /// for processing.
+    fn adopt_certificate_proposal(&mut self, certificate: &Certificate<S, D>) -> bool {
+        match certificate {
             Certificate::Notarization(notarization) => {
                 self.set_authoritative_proposal(&notarization.proposal)
             }
@@ -130,10 +141,7 @@ impl<
                 false
             }
             Certificate::Nullification(_) => false,
-        };
-        self.verifier.record_certificate(certificate.kind());
-        self.release_votes(certificate.kind());
-        process_votes
+        }
     }
 
     /// Releases full votes that are no longer needed for certificate assembly.
@@ -163,7 +171,7 @@ impl<
     /// certification. When extended conflict reporting is disabled, compact
     /// state preserves duplicate suppression and proposal forwarding without
     /// reallocating the released vote map.
-    fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> VoteAcceptance {
+    fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> Outcome {
         if constructed && let Vote::Finalize(finalize) = &message {
             // The voter only constructs a finalize after independently
             // authenticating the proposal.
@@ -182,10 +190,10 @@ impl<
                         Vote::Finalize(_) => panic!("duplicate finalize"),
                     }
                 }
-                return VoteAcceptance::Duplicate;
+                return Outcome::Duplicate;
             }
-            VoteRecord::DuplicateCompacted => return VoteAcceptance::Duplicate,
-            VoteRecord::ConflictingProposal => return VoteAcceptance::ConflictingProposal,
+            VoteRecord::DuplicateCompacted => return Outcome::Duplicate,
+            VoteRecord::ConflictingProposal => return Outcome::ConflictingProposal,
         };
 
         let verifier_message = retained.then(|| message.clone());
@@ -198,7 +206,7 @@ impl<
         if let Some(message) = verifier_message {
             self.verifier.add(message, constructed);
         }
-        VoteAcceptance::Added
+        Outcome::Added
     }
 
     /// Adds a durable locally constructed vote.
@@ -206,7 +214,7 @@ impl<
         assert!(
             !matches!(
                 self.accept_vote(message, true),
-                VoteAcceptance::ConflictingProposal
+                Outcome::ConflictingProposal
             ),
             "conflicting constructed vote"
         );
@@ -266,9 +274,9 @@ impl<
                         false
                     }
                     None => match self.accept_vote(Vote::Notarize(notarize), false) {
-                        VoteAcceptance::Added => true,
-                        VoteAcceptance::Duplicate => false,
-                        VoteAcceptance::ConflictingProposal => {
+                        Outcome::Added => true,
+                        Outcome::Duplicate => false,
+                        Outcome::ConflictingProposal => {
                             commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
                             false
                         }
@@ -301,9 +309,9 @@ impl<
                         false
                     }
                     None => match self.accept_vote(Vote::Nullify(nullify), false) {
-                        VoteAcceptance::Added => true,
-                        VoteAcceptance::Duplicate => false,
-                        VoteAcceptance::ConflictingProposal => {
+                        Outcome::Added => true,
+                        Outcome::Duplicate => false,
+                        Outcome::ConflictingProposal => {
                             unreachable!("nullify votes do not carry proposals")
                         }
                     },
@@ -340,9 +348,9 @@ impl<
                         false
                     }
                     None => match self.accept_vote(Vote::Finalize(finalize), false) {
-                        VoteAcceptance::Added => true,
-                        VoteAcceptance::Duplicate => false,
-                        VoteAcceptance::ConflictingProposal => {
+                        Outcome::Added => true,
+                        Outcome::Duplicate => false,
+                        Outcome::ConflictingProposal => {
                             commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
                             false
                         }
@@ -454,6 +462,7 @@ impl<
         strategy: &impl Strategy,
     ) -> Option<Certificate<S, D>> {
         let certificate = self.verifier.try_construct_certificate(strategy).await?;
+        self.adopt_certificate_proposal(&certificate);
         self.release_votes(certificate.kind());
         Some(certificate)
     }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -156,10 +156,7 @@ impl<
     fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> bool {
         let retain_full = self.votes.retains_full(&message);
 
-        if retain_full
-            && constructed
-            && let Vote::Finalize(finalize) = &message
-        {
+        if constructed && let Vote::Finalize(finalize) = &message {
             // The voter only constructs a finalize after independently
             // authenticating the proposal.
             self.set_authoritative_proposal(&finalize.proposal);

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -39,8 +39,6 @@ pub struct Round<
     /// verified. Used for duplicate detection, conflict reporting, and
     /// proposal-switch recovery.
     votes: VoteTracker<S, D>,
-    /// Whether to retain full votes for conflict evidence after certification.
-    report_conflicting_votes: bool,
 
     /// Whether we've already sent the selected proposal to the voter.
     proposal_sent: bool,
@@ -63,7 +61,7 @@ impl<
         scheme: Arc<S>,
         blocker: B,
         reporter: R,
-        report_conflicting_votes: bool,
+        retain_votes_after_certification: bool,
     ) -> Self {
         let quorum = scheme.participants().quorum::<N3f1>();
         let len = scheme.participants().len();
@@ -72,8 +70,7 @@ impl<
             reporter,
             verifier: Verifier::new(round, scheme, quorum),
 
-            votes: VoteTracker::new(len),
-            report_conflicting_votes,
+            votes: VoteTracker::new(len, retain_votes_after_certification),
 
             proposal_sent: false,
 
@@ -131,10 +128,6 @@ impl<
 
     /// Releases full votes that are no longer needed for certificate assembly.
     fn release_votes(&mut self, kind: Kind) {
-        if self.report_conflicting_votes {
-            return;
-        }
-
         match kind {
             Kind::Notarization => {
                 let proposal = self
@@ -152,6 +145,49 @@ impl<
                 self.votes.release_finalizes(proposal);
             }
         }
+    }
+
+    /// Accepts and reports a vote after sender and conflict checks.
+    ///
+    /// Full votes are forwarded to the verifier and retained while needed for
+    /// certification. When post-certification retention is disabled, compact
+    /// state preserves duplicate suppression and proposal forwarding without
+    /// reallocating the released vote map.
+    fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> bool {
+        let retain_full = self.votes.retains_full(&message);
+
+        if retain_full
+            && constructed
+            && let Vote::Finalize(finalize) = &message
+        {
+            // The voter only constructs a finalize after independently
+            // authenticating the proposal.
+            self.set_authoritative_proposal(&finalize.proposal);
+        }
+
+        let inserted = self.votes.record(&message, self.verifier.proposal());
+        if !inserted {
+            if retain_full && constructed {
+                match message {
+                    Vote::Notarize(_) => panic!("duplicate notarize"),
+                    Vote::Nullify(_) => {}
+                    Vote::Finalize(_) => panic!("duplicate finalize"),
+                }
+            }
+            return false;
+        }
+
+        let verifier_message = retain_full.then(|| message.clone());
+        let activity = match message {
+            Vote::Notarize(notarize) => Activity::Notarize(notarize),
+            Vote::Nullify(nullify) => Activity::Nullify(nullify),
+            Vote::Finalize(finalize) => Activity::Finalize(finalize),
+        };
+        self.reporter.report(activity);
+        if let Some(message) = verifier_message {
+            self.verifier.add(message, constructed);
+        }
+        true
     }
 
     /// Makes an independently authenticated proposal authoritative, restoring
@@ -194,37 +230,20 @@ impl<
                     return false;
                 }
 
-                // Once certified, the vote is useful only for activity and
-                // proposal-forwarding hints unless conflict checking is enabled.
-                if !self.report_conflicting_votes && self.has_certificate(Kind::Notarization) {
-                    let matching = self.verifier.proposal() == Some(&notarize.proposal);
-                    if !self.votes.remember_notarize(index, matching) {
-                        return false;
-                    }
-                    self.reporter.report(Activity::Notarize(notarize));
-                    return true;
-                }
-
                 // Try to reserve
-                match (self.report_conflicting_votes, self.votes.notarize(index)) {
-                    (true, Some(previous)) if previous.proposal != notarize.proposal => {
-                        let activity = ConflictingNotarize::new(previous.clone(), notarize);
-                        self.reporter
-                            .report(Activity::ConflictingNotarize(activity));
-                        commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
+                match self.votes.notarize(index) {
+                    Some(previous) => {
+                        if previous.proposal != notarize.proposal {
+                            let activity = ConflictingNotarize::new(previous.clone(), notarize);
+                            self.reporter
+                                .report(Activity::ConflictingNotarize(activity));
+                            commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
+                        } else if previous != &notarize {
+                            commonware_p2p::block!(self.blocker, sender, "invalid signature");
+                        }
                         false
                     }
-                    (true, Some(previous)) if previous != &notarize => {
-                        commonware_p2p::block!(self.blocker, sender, "invalid signature");
-                        false
-                    }
-                    (_, Some(_)) => false,
-                    (_, None) => {
-                        self.reporter.report(Activity::Notarize(notarize.clone()));
-                        self.votes.insert_notarize(notarize.clone());
-                        self.verifier.add(Vote::Notarize(notarize), false);
-                        true
-                    }
+                    None => self.accept_vote(Vote::Notarize(notarize), false),
                 }
             }
             Vote::Nullify(nullify) => {
@@ -234,20 +253,8 @@ impl<
                     return false;
                 }
 
-                // Once certified, retain only the signer for duplicate suppression.
-                // The full vote is only needed when conflict reporting is enabled.
-                if !self.report_conflicting_votes && self.has_certificate(Kind::Nullification) {
-                    if !self.votes.remember_nullify(index) {
-                        return false;
-                    }
-                    self.reporter.report(Activity::Nullify(nullify));
-                    return true;
-                }
-
                 // Check if finalized
-                if self.report_conflicting_votes
-                    && let Some(previous) = self.votes.finalize(index)
-                {
+                if let Some(previous) = self.votes.finalize(index) {
                     let activity = NullifyFinalize::new(nullify, previous.clone());
                     self.reporter.report(Activity::NullifyFinalize(activity));
                     commonware_p2p::block!(self.blocker, sender, "nullify after finalize");
@@ -255,18 +262,14 @@ impl<
                 }
 
                 // Try to reserve
-                match (self.report_conflicting_votes, self.votes.nullify(index)) {
-                    (true, Some(previous)) if previous != &nullify => {
-                        commonware_p2p::block!(self.blocker, sender, "conflicting nullify");
+                match self.votes.nullify(index) {
+                    Some(previous) => {
+                        if previous != &nullify {
+                            commonware_p2p::block!(self.blocker, sender, "conflicting nullify");
+                        }
                         false
                     }
-                    (_, Some(_)) => false,
-                    (_, None) => {
-                        self.reporter.report(Activity::Nullify(nullify.clone()));
-                        self.votes.insert_nullify(nullify.clone());
-                        self.verifier.add(Vote::Nullify(nullify), false);
-                        true
-                    }
+                    None => self.accept_vote(Vote::Nullify(nullify), false),
                 }
             }
             Vote::Finalize(finalize) => {
@@ -276,22 +279,8 @@ impl<
                     return false;
                 }
 
-                // Once certified, retain only compact state for duplicate suppression
-                // and proposal forwarding. The full vote is only needed when conflict
-                // reporting is enabled.
-                if !self.report_conflicting_votes && self.has_certificate(Kind::Finalization) {
-                    let matching = self.verifier.proposal() == Some(&finalize.proposal);
-                    if !self.votes.remember_finalize(index, matching) {
-                        return false;
-                    }
-                    self.reporter.report(Activity::Finalize(finalize));
-                    return true;
-                }
-
                 // Check if nullified
-                if self.report_conflicting_votes
-                    && let Some(previous) = self.votes.nullify(index)
-                {
+                if let Some(previous) = self.votes.nullify(index) {
                     let activity = NullifyFinalize::new(previous.clone(), finalize);
                     self.reporter.report(Activity::NullifyFinalize(activity));
                     commonware_p2p::block!(self.blocker, sender, "finalize after nullify");
@@ -299,25 +288,19 @@ impl<
                 }
 
                 // Try to reserve
-                match (self.report_conflicting_votes, self.votes.finalize(index)) {
-                    (true, Some(previous)) if previous.proposal != finalize.proposal => {
-                        let activity = ConflictingFinalize::new(previous.clone(), finalize);
-                        self.reporter
-                            .report(Activity::ConflictingFinalize(activity));
-                        commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
+                match self.votes.finalize(index) {
+                    Some(previous) => {
+                        if previous.proposal != finalize.proposal {
+                            let activity = ConflictingFinalize::new(previous.clone(), finalize);
+                            self.reporter
+                                .report(Activity::ConflictingFinalize(activity));
+                            commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
+                        } else if previous != &finalize {
+                            commonware_p2p::block!(self.blocker, sender, "invalid signature");
+                        }
                         false
                     }
-                    (true, Some(previous)) if previous != &finalize => {
-                        commonware_p2p::block!(self.blocker, sender, "invalid signature");
-                        false
-                    }
-                    (_, Some(_)) => false,
-                    (_, None) => {
-                        self.reporter.report(Activity::Finalize(finalize.clone()));
-                        self.votes.insert_finalize(finalize.clone());
-                        self.verifier.add(Vote::Finalize(finalize), false);
-                        true
-                    }
+                    None => self.accept_vote(Vote::Finalize(finalize), false),
                 }
             }
         }
@@ -332,70 +315,7 @@ impl<
     ///
     /// Panics if a notarize or finalize vote is added more than once.
     pub fn add_constructed(&mut self, message: Vote<S, D>) {
-        match &message {
-            Vote::Notarize(notarize) => {
-                if !self.report_conflicting_votes && self.has_certificate(Kind::Notarization) {
-                    let matching = self.verifier.proposal() == Some(&notarize.proposal);
-                    if !self.votes.remember_notarize(notarize.signer(), matching) {
-                        return;
-                    }
-                    self.reporter.report(Activity::Notarize(notarize.clone()));
-                    return;
-                }
-
-                // Our own votes are already verified
-                assert!(
-                    self.votes.insert_notarize(notarize.clone()),
-                    "duplicate notarize"
-                );
-
-                // Report activity
-                self.reporter.report(Activity::Notarize(notarize.clone()));
-            }
-            Vote::Nullify(nullify) => {
-                if !self.report_conflicting_votes && self.has_certificate(Kind::Nullification) {
-                    if !self.votes.remember_nullify(nullify.signer()) {
-                        return;
-                    }
-                    self.reporter.report(Activity::Nullify(nullify.clone()));
-                    return;
-                }
-
-                // The voter re-sends its nullify on every timeout retry (the
-                // batcher's state does not survive a restart), so duplicates
-                // are expected and ignored.
-                if !self.votes.insert_nullify(nullify.clone()) {
-                    return;
-                }
-
-                // Report activity
-                self.reporter.report(Activity::Nullify(nullify.clone()));
-            }
-            Vote::Finalize(finalize) => {
-                if !self.report_conflicting_votes && self.has_certificate(Kind::Finalization) {
-                    let matching = self.verifier.proposal() == Some(&finalize.proposal);
-                    if !self.votes.remember_finalize(finalize.signer(), matching) {
-                        return;
-                    }
-                    self.reporter.report(Activity::Finalize(finalize.clone()));
-                    return;
-                }
-
-                // The voter only constructs a finalize after independently
-                // authenticating the proposal.
-                self.set_authoritative_proposal(&finalize.proposal);
-                assert!(
-                    self.votes.insert_finalize(finalize.clone()),
-                    "duplicate finalize"
-                );
-
-                // Report activity
-                self.reporter.report(Activity::Finalize(finalize.clone()));
-            }
-        }
-
-        // The verifier drops votes for a different proposal than the selected one.
-        self.verifier.add(message, true);
+        self.accept_vote(message, true);
     }
 
     /// Sets the leader for this view. If the leader's notarize has already

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -6,7 +6,7 @@ use crate::{
         scheme::Scheme,
         types::{
             Activity, Attributable, Certificate, ConflictingFinalize, ConflictingNotarize, Kind,
-            NullifyFinalize, Outcome, Proposal, Vote, VoteTracker,
+            NullifyFinalize, ObservedVote, Outcome, Proposal, Vote, VoteTracker,
         },
     },
     types::{Participant, Round as Rnd},
@@ -153,7 +153,7 @@ impl<
     /// certification. When extended conflict reporting is disabled, compact
     /// state preserves duplicate suppression and proposal forwarding without
     /// reallocating the released vote map.
-    fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> Outcome {
+    pub(super) fn accept_vote(&mut self, message: Vote<S, D>, constructed: bool) -> Outcome {
         if constructed && let Vote::Finalize(finalize) = &message {
             // The voter only constructs a finalize after independently
             // authenticating the proposal.
@@ -174,7 +174,10 @@ impl<
                 }
                 return Outcome::Duplicate { retained };
             }
-            Outcome::Conflicting => return Outcome::Conflicting,
+            Outcome::Conflicting => {
+                assert!(!constructed, "conflicting constructed vote");
+                return Outcome::Conflicting;
+            }
         };
 
         // A compacted phase already has its certificate. Report newly observed signer
@@ -190,14 +193,6 @@ impl<
             self.verifier.add(message, constructed);
         }
         Outcome::Added { retained }
-    }
-
-    /// Adds a durable locally constructed vote.
-    pub fn add_constructed(&mut self, message: Vote<S, D>) {
-        assert!(
-            !matches!(self.accept_vote(message, true), Outcome::Conflicting),
-            "conflicting constructed vote"
-        );
     }
 
     /// Makes an independently authenticated proposal authoritative, restoring
@@ -271,8 +266,8 @@ impl<
                 }
 
                 // Check if finalized
-                if self.votes.saw_finalize(index) {
-                    if let Some(previous) = self.votes.finalize(index) {
+                if let Some(previous) = self.votes.saw_finalize(index) {
+                    if let ObservedVote::Retained(previous) = previous {
                         let activity = NullifyFinalize::new(nullify, previous.clone());
                         self.reporter.report(Activity::NullifyFinalize(activity));
                     }
@@ -305,8 +300,8 @@ impl<
                 }
 
                 // Check if nullified
-                if self.votes.saw_nullify(index) {
-                    if let Some(previous) = self.votes.nullify(index) {
+                if let Some(previous) = self.votes.saw_nullify(index) {
+                    if let ObservedVote::Retained(previous) = previous {
                         let activity = NullifyFinalize::new(previous.clone(), finalize);
                         self.reporter.report(Activity::NullifyFinalize(activity));
                     }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -103,23 +103,12 @@ impl<
 
     /// Records a verified certificate.
     ///
-    /// The first notarization or finalization establishes an authoritative
-    /// proposal and may replace one learned from the leader's vote. Returns
-    /// `true` when a notarization selects a new proposal, making its buffered
-    /// finalize votes eligible for processing.
+    /// Marks its verifier phase complete and releases full votes no longer needed
+    /// for certificate assembly. A notarization or finalization may also establish
+    /// authoritative proposal evidence. Returns `true` when a notarization selects
+    /// a new proposal, making its buffered finalize votes eligible for processing.
     pub fn record_certificate(&mut self, certificate: &Certificate<S, D>) -> bool {
-        let process_votes = self.adopt_certificate_proposal(certificate);
-        self.verifier.record_certificate(certificate.kind());
-        self.release_votes(certificate.kind());
-        process_votes
-    }
-
-    /// Makes a certificate's proposal authoritative.
-    ///
-    /// Returns whether a notarization made buffered finalize votes eligible
-    /// for processing.
-    fn adopt_certificate_proposal(&mut self, certificate: &Certificate<S, D>) -> bool {
-        match certificate {
+        let process_votes = match certificate {
             Certificate::Notarization(notarization) => {
                 self.set_authoritative_proposal(&notarization.proposal)
             }
@@ -131,7 +120,10 @@ impl<
                 false
             }
             Certificate::Nullification(_) => false,
-        }
+        };
+        self.verifier.record_certificate(certificate.kind());
+        self.release_votes(certificate.kind());
+        process_votes
     }
 
     /// Releases full votes that are no longer needed for certificate assembly.
@@ -450,8 +442,7 @@ impl<
         strategy: &impl Strategy,
     ) -> Option<Certificate<S, D>> {
         let certificate = self.verifier.try_construct_certificate(strategy).await?;
-        self.adopt_certificate_proposal(&certificate);
-        self.release_votes(certificate.kind());
+        self.record_certificate(&certificate);
         Some(certificate)
     }
 }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -6,7 +6,7 @@ use crate::{
         scheme::Scheme,
         types::{
             Activity, Attributable, Certificate, ConflictingFinalize, ConflictingNotarize, Kind,
-            NullifyFinalize, Proposal, Vote, VoteRecord, VoteTracker,
+            NullifyFinalize, Outcome, Proposal, Vote, VoteTracker,
         },
     },
     types::{Participant, Round as Rnd},
@@ -18,16 +18,6 @@ use commonware_utils::{N3f1, ordered::Quorum};
 use rand_core::CryptoRng;
 use std::sync::Arc;
 use tracing::Span;
-
-/// Outcome of recording a vote after preliminary conflict checks.
-enum Outcome {
-    /// The vote was newly recorded and reported.
-    Added,
-    /// The signer was already recorded with the same known vote state.
-    Duplicate,
-    /// Compact state proves the signer changed its relation to the authoritative proposal.
-    Conflicting,
-}
 
 /// Per-view state for vote accumulation and certificate tracking.
 pub struct Round<
@@ -178,12 +168,10 @@ impl<
             self.set_authoritative_proposal(&finalize.proposal);
         }
 
-        let record = self.votes.record(&message, self.verifier.proposal());
-        let retained = match record {
-            VoteRecord::NewRetained => true,
-            VoteRecord::NewCompacted => false,
-            VoteRecord::DuplicateRetained => {
-                if constructed {
+        let retained = match self.votes.record(&message, self.verifier.proposal()) {
+            Outcome::Added { retained } => retained,
+            Outcome::Duplicate { retained } => {
+                if constructed && retained {
                     // Nullify is reconstructed for each retry. Notarize and finalize
                     // are one-shot local actions, so constructing either twice is a bug.
                     match &message {
@@ -192,10 +180,9 @@ impl<
                         Vote::Finalize(_) => panic!("duplicate finalize"),
                     }
                 }
-                return Outcome::Duplicate;
+                return Outcome::Duplicate { retained };
             }
-            VoteRecord::DuplicateCompacted => return Outcome::Duplicate,
-            VoteRecord::ConflictingProposal => return Outcome::Conflicting,
+            Outcome::Conflicting => return Outcome::Conflicting,
         };
 
         // A compacted phase already has its certificate. Report newly observed signer
@@ -210,7 +197,7 @@ impl<
         if let Some(message) = verifier_message {
             self.verifier.add(message, constructed);
         }
-        Outcome::Added
+        Outcome::Added { retained }
     }
 
     /// Adds a durable locally constructed vote.
@@ -275,8 +262,8 @@ impl<
                         false
                     }
                     None => match self.accept_vote(Vote::Notarize(notarize), false) {
-                        Outcome::Added => true,
-                        Outcome::Duplicate => false,
+                        Outcome::Added { .. } => true,
+                        Outcome::Duplicate { .. } => false,
                         Outcome::Conflicting => {
                             commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
                             false
@@ -310,8 +297,8 @@ impl<
                         false
                     }
                     None => match self.accept_vote(Vote::Nullify(nullify), false) {
-                        Outcome::Added => true,
-                        Outcome::Duplicate => false,
+                        Outcome::Added { .. } => true,
+                        Outcome::Duplicate { .. } => false,
                         Outcome::Conflicting => {
                             unreachable!("nullify votes do not carry proposals")
                         }
@@ -349,8 +336,8 @@ impl<
                         false
                     }
                     None => match self.accept_vote(Vote::Finalize(finalize), false) {
-                        Outcome::Added => true,
-                        Outcome::Duplicate => false,
+                        Outcome::Added { .. } => true,
+                        Outcome::Duplicate { .. } => false,
                         Outcome::Conflicting => {
                             commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
                             false

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -355,11 +355,6 @@ impl<
         self.votes.has_nullify(signer)
     }
 
-    #[cfg(test)]
-    pub(super) fn has_notarize(&self, signer: Participant) -> bool {
-        self.votes.has_notarize(signer)
-    }
-
     /// Returns participant indices whose matching vote for `proposal` was not
     /// observed locally.
     ///

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -196,9 +196,7 @@ impl<
 
                 // Once certified, the vote is useful only for activity and
                 // proposal-forwarding hints unless conflict checking is enabled.
-                if !self.report_conflicting_votes
-                    && self.has_certificate(Kind::Notarization)
-                {
+                if !self.report_conflicting_votes && self.has_certificate(Kind::Notarization) {
                     let matching = self.verifier.proposal() == Some(&notarize.proposal);
                     if !self.votes.remember_notarize(index, matching) {
                         return false;
@@ -208,10 +206,7 @@ impl<
                 }
 
                 // Try to reserve
-                match (
-                    self.report_conflicting_votes,
-                    self.votes.notarize(index),
-                ) {
+                match (self.report_conflicting_votes, self.votes.notarize(index)) {
                     (true, Some(previous)) if previous.proposal != notarize.proposal => {
                         let activity = ConflictingNotarize::new(previous.clone(), notarize);
                         self.reporter
@@ -239,9 +234,7 @@ impl<
                     return false;
                 }
 
-                if !self.report_conflicting_votes
-                    && self.has_certificate(Kind::Nullification)
-                {
+                if !self.report_conflicting_votes && self.has_certificate(Kind::Nullification) {
                     if !self.votes.remember_nullify(index) {
                         return false;
                     }
@@ -281,9 +274,7 @@ impl<
                     return false;
                 }
 
-                if !self.report_conflicting_votes
-                    && self.has_certificate(Kind::Finalization)
-                {
+                if !self.report_conflicting_votes && self.has_certificate(Kind::Finalization) {
                     let matching = self.verifier.proposal() == Some(&finalize.proposal);
                     if !self.votes.remember_finalize(index, matching) {
                         return false;
@@ -303,10 +294,7 @@ impl<
                 }
 
                 // Try to reserve
-                match (
-                    self.report_conflicting_votes,
-                    self.votes.finalize(index),
-                ) {
+                match (self.report_conflicting_votes, self.votes.finalize(index)) {
                     (true, Some(previous)) if previous.proposal != finalize.proposal => {
                         let activity = ConflictingFinalize::new(previous.clone(), finalize);
                         self.reporter
@@ -341,9 +329,7 @@ impl<
     pub fn add_constructed(&mut self, message: Vote<S, D>) {
         match &message {
             Vote::Notarize(notarize) => {
-                if !self.report_conflicting_votes
-                    && self.has_certificate(Kind::Notarization)
-                {
+                if !self.report_conflicting_votes && self.has_certificate(Kind::Notarization) {
                     let matching = self.verifier.proposal() == Some(&notarize.proposal);
                     if !self.votes.remember_notarize(notarize.signer(), matching) {
                         return;
@@ -362,9 +348,7 @@ impl<
                 self.reporter.report(Activity::Notarize(notarize.clone()));
             }
             Vote::Nullify(nullify) => {
-                if !self.report_conflicting_votes
-                    && self.has_certificate(Kind::Nullification)
-                {
+                if !self.report_conflicting_votes && self.has_certificate(Kind::Nullification) {
                     if !self.votes.remember_nullify(nullify.signer()) {
                         return;
                     }
@@ -383,9 +367,7 @@ impl<
                 self.reporter.report(Activity::Nullify(nullify.clone()));
             }
             Vote::Finalize(finalize) => {
-                if !self.report_conflicting_votes
-                    && self.has_certificate(Kind::Finalization)
-                {
+                if !self.report_conflicting_votes && self.has_certificate(Kind::Finalization) {
                     let matching = self.verifier.proposal() == Some(&finalize.proposal);
                     if !self.votes.remember_finalize(finalize.signer(), matching) {
                         return;

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -234,6 +234,8 @@ impl<
                     return false;
                 }
 
+                // Once certified, retain only the signer for duplicate suppression.
+                // The full vote is only needed when conflict reporting is enabled.
                 if !self.report_conflicting_votes && self.has_certificate(Kind::Nullification) {
                     if !self.votes.remember_nullify(index) {
                         return false;
@@ -274,6 +276,9 @@ impl<
                     return false;
                 }
 
+                // Once certified, retain only compact state for duplicate suppression
+                // and proposal forwarding. The full vote is only needed when conflict
+                // reporting is enabled.
                 if !self.report_conflicting_votes && self.has_certificate(Kind::Finalization) {
                     let matching = self.verifier.proposal() == Some(&finalize.proposal);
                     if !self.votes.remember_finalize(index, matching) {

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -379,11 +379,8 @@ impl<
         self.verifier.try_verify_finalizes(rng, strategy).await
     }
 
-    /// Returns whether `signer` has a retained nullify vote.
-    ///
-    /// Compact state exists only after certification, which supersedes the
-    /// leader-nullify fast path.
-    pub fn has_retained_nullify(&self, signer: Participant) -> bool {
+    /// Returns whether `signer` has a nullify vote.
+    pub fn has_nullify(&self, signer: Participant) -> bool {
         self.votes.has_nullify(signer)
     }
 

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -39,6 +39,8 @@ pub struct Round<
     /// verified. Used for duplicate detection, conflict reporting, and
     /// proposal-switch recovery.
     votes: VoteTracker<S, D>,
+    /// Whether to retain full votes for conflict evidence after certification.
+    report_conflicting_votes: bool,
 
     /// Whether we've already sent the selected proposal to the voter.
     proposal_sent: bool,
@@ -56,7 +58,13 @@ impl<
     R: Reporter<Activity = Activity<S, D>>,
 > Round<S, B, D, R>
 {
-    pub fn new(round: Rnd, scheme: Arc<S>, blocker: B, reporter: R) -> Self {
+    pub fn new(
+        round: Rnd,
+        scheme: Arc<S>,
+        blocker: B,
+        reporter: R,
+        report_conflicting_votes: bool,
+    ) -> Self {
         let quorum = scheme.participants().quorum::<N3f1>();
         let len = scheme.participants().len();
         Self {
@@ -65,6 +73,7 @@ impl<
             verifier: Verifier::new(round, scheme, quorum),
 
             votes: VoteTracker::new(len),
+            report_conflicting_votes,
 
             proposal_sent: false,
 
@@ -116,7 +125,33 @@ impl<
             Certificate::Nullification(_) => false,
         };
         self.verifier.record_certificate(certificate.kind());
+        self.release_votes(certificate.kind());
         process_votes
+    }
+
+    /// Releases full votes that are no longer needed for certificate assembly.
+    fn release_votes(&mut self, kind: Kind) {
+        if self.report_conflicting_votes {
+            return;
+        }
+
+        match kind {
+            Kind::Notarization => {
+                let proposal = self
+                    .verifier
+                    .proposal()
+                    .expect("notarization must establish a proposal");
+                self.votes.release_notarizes(proposal);
+            }
+            Kind::Nullification => self.votes.release_nullifies(),
+            Kind::Finalization => {
+                let proposal = self
+                    .verifier
+                    .proposal()
+                    .expect("finalization must establish a proposal");
+                self.votes.release_finalizes(proposal);
+            }
+        }
     }
 
     /// Makes an independently authenticated proposal authoritative, restoring
@@ -159,20 +194,37 @@ impl<
                     return false;
                 }
 
+                // Once certified, the vote is useful only for activity and
+                // proposal-forwarding hints unless conflict checking is enabled.
+                if !self.report_conflicting_votes
+                    && self.has_certificate(Kind::Notarization)
+                {
+                    let matching = self.verifier.proposal() == Some(&notarize.proposal);
+                    if !self.votes.remember_notarize(index, matching) {
+                        return false;
+                    }
+                    self.reporter.report(Activity::Notarize(notarize));
+                    return true;
+                }
+
                 // Try to reserve
-                match self.votes.notarize(index) {
-                    Some(previous) => {
-                        if previous.proposal != notarize.proposal {
-                            let activity = ConflictingNotarize::new(previous.clone(), notarize);
-                            self.reporter
-                                .report(Activity::ConflictingNotarize(activity));
-                            commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
-                        } else if previous != &notarize {
-                            commonware_p2p::block!(self.blocker, sender, "invalid signature");
-                        }
+                match (
+                    self.report_conflicting_votes,
+                    self.votes.notarize(index),
+                ) {
+                    (true, Some(previous)) if previous.proposal != notarize.proposal => {
+                        let activity = ConflictingNotarize::new(previous.clone(), notarize);
+                        self.reporter
+                            .report(Activity::ConflictingNotarize(activity));
+                        commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
                         false
                     }
-                    None => {
+                    (true, Some(previous)) if previous != &notarize => {
+                        commonware_p2p::block!(self.blocker, sender, "invalid signature");
+                        false
+                    }
+                    (_, Some(_)) => false,
+                    (_, None) => {
                         self.reporter.report(Activity::Notarize(notarize.clone()));
                         self.votes.insert_notarize(notarize.clone());
                         self.verifier.add(Vote::Notarize(notarize), false);
@@ -187,8 +239,20 @@ impl<
                     return false;
                 }
 
+                if !self.report_conflicting_votes
+                    && self.has_certificate(Kind::Nullification)
+                {
+                    if !self.votes.remember_nullify(index) {
+                        return false;
+                    }
+                    self.reporter.report(Activity::Nullify(nullify));
+                    return true;
+                }
+
                 // Check if finalized
-                if let Some(previous) = self.votes.finalize(index) {
+                if self.report_conflicting_votes
+                    && let Some(previous) = self.votes.finalize(index)
+                {
                     let activity = NullifyFinalize::new(nullify, previous.clone());
                     self.reporter.report(Activity::NullifyFinalize(activity));
                     commonware_p2p::block!(self.blocker, sender, "nullify after finalize");
@@ -196,14 +260,13 @@ impl<
                 }
 
                 // Try to reserve
-                match self.votes.nullify(index) {
-                    Some(previous) => {
-                        if previous != &nullify {
-                            commonware_p2p::block!(self.blocker, sender, "conflicting nullify");
-                        }
+                match (self.report_conflicting_votes, self.votes.nullify(index)) {
+                    (true, Some(previous)) if previous != &nullify => {
+                        commonware_p2p::block!(self.blocker, sender, "conflicting nullify");
                         false
                     }
-                    None => {
+                    (_, Some(_)) => false,
+                    (_, None) => {
                         self.reporter.report(Activity::Nullify(nullify.clone()));
                         self.votes.insert_nullify(nullify.clone());
                         self.verifier.add(Vote::Nullify(nullify), false);
@@ -218,8 +281,21 @@ impl<
                     return false;
                 }
 
+                if !self.report_conflicting_votes
+                    && self.has_certificate(Kind::Finalization)
+                {
+                    let matching = self.verifier.proposal() == Some(&finalize.proposal);
+                    if !self.votes.remember_finalize(index, matching) {
+                        return false;
+                    }
+                    self.reporter.report(Activity::Finalize(finalize));
+                    return true;
+                }
+
                 // Check if nullified
-                if let Some(previous) = self.votes.nullify(index) {
+                if self.report_conflicting_votes
+                    && let Some(previous) = self.votes.nullify(index)
+                {
                     let activity = NullifyFinalize::new(previous.clone(), finalize);
                     self.reporter.report(Activity::NullifyFinalize(activity));
                     commonware_p2p::block!(self.blocker, sender, "finalize after nullify");
@@ -227,19 +303,23 @@ impl<
                 }
 
                 // Try to reserve
-                match self.votes.finalize(index) {
-                    Some(previous) => {
-                        if previous.proposal != finalize.proposal {
-                            let activity = ConflictingFinalize::new(previous.clone(), finalize);
-                            self.reporter
-                                .report(Activity::ConflictingFinalize(activity));
-                            commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
-                        } else if previous != &finalize {
-                            commonware_p2p::block!(self.blocker, sender, "invalid signature");
-                        }
+                match (
+                    self.report_conflicting_votes,
+                    self.votes.finalize(index),
+                ) {
+                    (true, Some(previous)) if previous.proposal != finalize.proposal => {
+                        let activity = ConflictingFinalize::new(previous.clone(), finalize);
+                        self.reporter
+                            .report(Activity::ConflictingFinalize(activity));
+                        commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
                         false
                     }
-                    None => {
+                    (true, Some(previous)) if previous != &finalize => {
+                        commonware_p2p::block!(self.blocker, sender, "invalid signature");
+                        false
+                    }
+                    (_, Some(_)) => false,
+                    (_, None) => {
                         self.reporter.report(Activity::Finalize(finalize.clone()));
                         self.votes.insert_finalize(finalize.clone());
                         self.verifier.add(Vote::Finalize(finalize), false);
@@ -250,7 +330,7 @@ impl<
         }
     }
 
-    /// Adds a vote that we constructed ourselves to the verifier.
+    /// Adds a durable locally constructed vote to the verifier and reporter.
     ///
     /// Duplicate nullifies are ignored (the voter re-sends its nullify vote on
     /// every timeout retry).
@@ -261,6 +341,17 @@ impl<
     pub fn add_constructed(&mut self, message: Vote<S, D>) {
         match &message {
             Vote::Notarize(notarize) => {
+                if !self.report_conflicting_votes
+                    && self.has_certificate(Kind::Notarization)
+                {
+                    let matching = self.verifier.proposal() == Some(&notarize.proposal);
+                    if !self.votes.remember_notarize(notarize.signer(), matching) {
+                        return;
+                    }
+                    self.reporter.report(Activity::Notarize(notarize.clone()));
+                    return;
+                }
+
                 // Our own votes are already verified
                 assert!(
                     self.votes.insert_notarize(notarize.clone()),
@@ -271,6 +362,16 @@ impl<
                 self.reporter.report(Activity::Notarize(notarize.clone()));
             }
             Vote::Nullify(nullify) => {
+                if !self.report_conflicting_votes
+                    && self.has_certificate(Kind::Nullification)
+                {
+                    if !self.votes.remember_nullify(nullify.signer()) {
+                        return;
+                    }
+                    self.reporter.report(Activity::Nullify(nullify.clone()));
+                    return;
+                }
+
                 // The voter re-sends its nullify on every timeout retry (the
                 // batcher's state does not survive a restart), so duplicates
                 // are expected and ignored.
@@ -282,6 +383,17 @@ impl<
                 self.reporter.report(Activity::Nullify(nullify.clone()));
             }
             Vote::Finalize(finalize) => {
+                if !self.report_conflicting_votes
+                    && self.has_certificate(Kind::Finalization)
+                {
+                    let matching = self.verifier.proposal() == Some(&finalize.proposal);
+                    if !self.votes.remember_finalize(finalize.signer(), matching) {
+                        return;
+                    }
+                    self.reporter.report(Activity::Finalize(finalize.clone()));
+                    return;
+                }
+
                 // The voter only constructs a finalize after independently
                 // authenticating the proposal.
                 self.set_authoritative_proposal(&finalize.proposal);
@@ -303,8 +415,8 @@ impl<
     /// been received, this will also set the leader's proposal (filtering out
     /// votes for other proposals).
     pub fn set_leader(&mut self, leader: Participant) {
-        // Certification drops the verifier's buffered notarizes, so read the
-        // leader's vote from the tracker, which holds it for the round's lifetime.
+        // Certification drops the verifier's buffered notarizes, so read an
+        // uncertified leader vote from the tracker.
         self.verifier
             .set_leader(leader, self.votes.notarize(leader));
     }
@@ -349,37 +461,38 @@ impl<
         self.votes.has_nullify(signer)
     }
 
+    #[cfg(test)]
+    pub(super) fn has_notarize(&self, signer: Participant) -> bool {
+        self.votes.has_notarize(signer)
+    }
+
     /// Returns participant indices whose matching vote for `proposal` was not
     /// observed locally.
     ///
-    /// Uses `votes` rather than the verified vote vectors because we only
-    /// verify the first quorum of votes. A peer whose matching vote arrived
-    /// after quorum but before the certificate is still tracked in pending.
+    /// Uses the vote tracker and compact post-certificate membership rather
+    /// than the verified vote vectors because we only verify the first quorum
+    /// of votes. A peer whose matching vote arrived after quorum is still
+    /// tracked for forwarding.
     ///
     /// Both notarize and finalize votes are checked: a participant who sent
     /// either for the same proposal already has the block and does not need
     /// it forwarded. Votes for a conflicting proposal are treated as missing
     /// because those peers still need the winning block forwarded.
     pub fn is_missing_voter(&self, proposal: &Proposal<D>, participant: Participant) -> bool {
-        if self
-            .votes
-            .notarize(participant)
-            .is_some_and(|vote| &vote.proposal == proposal)
-        {
+        if self.votes.has_notarize_for(participant, proposal) {
             return false;
         }
 
-        self.votes
-            .finalize(participant)
-            .is_none_or(|vote| &vote.proposal != proposal)
+        !self.votes.has_finalize_for(participant, proposal)
     }
 
     /// Returns participant indices whose matching vote for `proposal` was not
     /// observed locally.
     ///
-    /// Uses `votes` rather than the verified vote vectors because we only
-    /// verify the first quorum of votes. A peer whose matching vote arrived
-    /// after quorum but before the certificate is still tracked in pending.
+    /// Uses the vote tracker and compact post-certificate membership rather
+    /// than the verified vote vectors because we only verify the first quorum
+    /// of votes. A peer whose matching vote arrived after quorum is still
+    /// tracked for forwarding.
     ///
     /// Both notarize and finalize votes are checked: a participant who sent
     /// either for the same proposal already has the block and does not need
@@ -402,6 +515,8 @@ impl<
         &mut self,
         strategy: &impl Strategy,
     ) -> Option<Certificate<S, D>> {
-        self.verifier.try_construct_certificate(strategy).await
+        let certificate = self.verifier.try_construct_certificate(strategy).await?;
+        self.release_votes(certificate.kind());
+        Some(certificate)
     }
 }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -350,8 +350,11 @@ impl<
         self.verifier.try_verify_finalizes(rng, strategy).await
     }
 
-    /// Returns true if `signer` has a nullify vote in this round.
-    pub fn has_nullify(&self, signer: Participant) -> bool {
+    /// Returns whether `signer` has a retained nullify vote.
+    ///
+    /// Compact state is reached only after the corresponding certificate has
+    /// been forwarded to the voter, so it does not drive the leader fast path.
+    pub fn has_retained_nullify(&self, signer: Participant) -> bool {
         self.votes.has_nullify(signer)
     }
 

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -26,7 +26,7 @@ enum Outcome {
     /// The signer was already recorded with the same known vote state.
     Duplicate,
     /// Compact state proves the signer changed its relation to the authoritative proposal.
-    ConflictingProposal,
+    Conflicting,
 }
 
 /// Per-view state for vote accumulation and certificate tracking.
@@ -184,6 +184,8 @@ impl<
             VoteRecord::NewCompacted => false,
             VoteRecord::DuplicateRetained => {
                 if constructed {
+                    // Nullify is reconstructed for each retry. Notarize and finalize
+                    // are one-shot local actions, so constructing either twice is a bug.
                     match &message {
                         Vote::Notarize(_) => panic!("duplicate notarize"),
                         Vote::Nullify(_) => {}
@@ -193,9 +195,11 @@ impl<
                 return Outcome::Duplicate;
             }
             VoteRecord::DuplicateCompacted => return Outcome::Duplicate,
-            VoteRecord::ConflictingProposal => return Outcome::ConflictingProposal,
+            VoteRecord::ConflictingProposal => return Outcome::Conflicting,
         };
 
+        // A compacted phase already has its certificate. Report newly observed signer
+        // evidence, but only retained full votes can contribute to certificate assembly.
         let verifier_message = retained.then(|| message.clone());
         let activity = match message {
             Vote::Notarize(notarize) => Activity::Notarize(notarize),
@@ -212,10 +216,7 @@ impl<
     /// Adds a durable locally constructed vote.
     pub fn add_constructed(&mut self, message: Vote<S, D>) {
         assert!(
-            !matches!(
-                self.accept_vote(message, true),
-                Outcome::ConflictingProposal
-            ),
+            !matches!(self.accept_vote(message, true), Outcome::Conflicting),
             "conflicting constructed vote"
         );
     }
@@ -276,7 +277,7 @@ impl<
                     None => match self.accept_vote(Vote::Notarize(notarize), false) {
                         Outcome::Added => true,
                         Outcome::Duplicate => false,
-                        Outcome::ConflictingProposal => {
+                        Outcome::Conflicting => {
                             commonware_p2p::block!(self.blocker, sender, "conflicting notarize");
                             false
                         }
@@ -311,7 +312,7 @@ impl<
                     None => match self.accept_vote(Vote::Nullify(nullify), false) {
                         Outcome::Added => true,
                         Outcome::Duplicate => false,
-                        Outcome::ConflictingProposal => {
+                        Outcome::Conflicting => {
                             unreachable!("nullify votes do not carry proposals")
                         }
                     },
@@ -350,7 +351,7 @@ impl<
                     None => match self.accept_vote(Vote::Finalize(finalize), false) {
                         Outcome::Added => true,
                         Outcome::Duplicate => false,
-                        Outcome::ConflictingProposal => {
+                        Outcome::Conflicting => {
                             commonware_p2p::block!(self.blocker, sender, "conflicting finalize");
                             false
                         }

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -74,12 +74,15 @@ impl<V> Certification<V> {
     /// Buffers a vote for verification (or, if already verified, for
     /// certificate recovery). Dropped once complete.
     fn add(&mut self, vote: V, is_verified: bool) {
+        // Verified votes and pending votes for batchable schemes may accumulate to
+        // quorum. A non-batchable pending buffer is consumed after each vote.
         let initial_capacity = if is_verified || self.batchable {
             self.quorum
         } else {
-            // Eager verification consumes pending storage after every vote.
             1
         };
+
+        // Completed certifications drop subsequent votes without allocating.
         if let State::Incomplete { pending, verified } = &mut self.state {
             let votes = if is_verified { verified } else { pending };
             if votes.capacity() == 0 {
@@ -685,6 +688,7 @@ mod tests {
             }
         }
 
+        /// Returns the capacities of the pending and verified vote buffers.
         fn capacities(&self) -> (usize, usize) {
             match &self.state {
                 State::Incomplete { pending, verified } => {

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -74,10 +74,16 @@ impl<V> Certification<V> {
     /// Buffers a vote for verification (or, if already verified, for
     /// certificate recovery). Dropped once complete.
     fn add(&mut self, vote: V, is_verified: bool) {
+        let initial_capacity = if is_verified || self.batchable {
+            self.quorum
+        } else {
+            // Eager verification consumes pending storage after every vote.
+            1
+        };
         if let State::Incomplete { pending, verified } = &mut self.state {
             let votes = if is_verified { verified } else { pending };
             if votes.capacity() == 0 {
-                votes.reserve_exact(self.quorum);
+                votes.reserve_exact(initial_capacity);
             }
             votes.push(vote);
         }
@@ -701,6 +707,27 @@ mod tests {
 
         certification.complete();
         assert_eq!(certification.capacities(), (0, 0));
+    }
+
+    #[test_async]
+    async fn test_non_batchable_certification_avoids_repeated_quorum_reservations() {
+        let quorum = 64;
+        let mut certification = Certification::new(quorum, false);
+        certification.add(1u8, false);
+        certification
+            .try_verify(|pending, mut verified| async move {
+                verified.extend(pending);
+                (verified, Vec::new())
+            })
+            .await
+            .expect("non-batchable pending votes must verify eagerly");
+
+        certification.add(2u8, false);
+        let (pending, _) = certification.capacities();
+        assert!(
+            pending < quorum,
+            "a single eagerly verified vote should not reserve a quorum-sized buffer"
+        );
     }
 
     // Helper function to create a sample digest

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -74,16 +74,16 @@ impl<V> Certification<V> {
     /// Buffers a vote for verification (or, if already verified, for
     /// certificate recovery). Dropped once complete.
     fn add(&mut self, vote: V, is_verified: bool) {
-        // Verified votes and pending votes for batchable schemes may accumulate to
-        // quorum. A non-batchable pending buffer is consumed after each vote.
-        let initial_capacity = if is_verified || self.batchable {
-            self.quorum
-        } else {
-            1
-        };
-
         // Completed certifications drop subsequent votes without allocating.
         if let State::Incomplete { pending, verified } = &mut self.state {
+            // Verified votes may accumulate to quorum. A batchable pending buffer
+            // only needs the remaining unverified slots, while a non-batchable
+            // pending buffer is consumed after each vote.
+            let initial_capacity = if is_verified || self.batchable {
+                self.quorum.saturating_sub(verified.len()).max(1)
+            } else {
+                1
+            };
             let votes = if is_verified { verified } else { pending };
             if votes.capacity() == 0 {
                 votes.reserve_exact(initial_capacity);
@@ -731,6 +731,29 @@ mod tests {
         assert!(
             pending < quorum,
             "a single eagerly verified vote should not reserve a quorum-sized buffer"
+        );
+    }
+
+    #[test_async]
+    async fn test_batchable_certification_reserves_only_remaining_quorum() {
+        let quorum = 64;
+        let mut certification = Certification::new(quorum, true);
+        for vote in 0..quorum {
+            certification.add(vote, false);
+        }
+        certification
+            .try_verify(|mut pending, _| async move {
+                pending.pop().expect("quorum batch must be non-empty");
+                (pending, Vec::new())
+            })
+            .await
+            .expect("a quorum of pending votes must trigger batch verification");
+
+        certification.add(quorum, false);
+        let (pending, _) = certification.capacities();
+        assert!(
+            pending < quorum,
+            "one replacement vote should not reserve a quorum-sized buffer"
         );
     }
 

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -59,14 +59,14 @@ enum State<V> {
 }
 
 impl<V> Certification<V> {
-    /// Creates an empty [State::Incomplete] with buffers sized for `quorum` votes.
-    fn new(quorum: usize, batchable: bool) -> Self {
+    /// Creates an empty [State::Incomplete] whose vote buffers allocate lazily.
+    const fn new(quorum: usize, batchable: bool) -> Self {
         Self {
             quorum,
             batchable,
             state: State::Incomplete {
-                pending: Vec::with_capacity(quorum),
-                verified: Vec::with_capacity(quorum),
+                pending: Vec::new(),
+                verified: Vec::new(),
             },
         }
     }
@@ -75,7 +75,11 @@ impl<V> Certification<V> {
     /// certificate recovery). Dropped once complete.
     fn add(&mut self, vote: V, is_verified: bool) {
         if let State::Incomplete { pending, verified } = &mut self.state {
-            if is_verified { verified } else { pending }.push(vote);
+            let votes = if is_verified { verified } else { pending };
+            if votes.capacity() == 0 {
+                votes.reserve_exact(self.quorum);
+            }
+            votes.push(vote);
         }
     }
 
@@ -674,6 +678,29 @@ mod tests {
                 State::Complete => &[],
             }
         }
+
+        fn capacities(&self) -> (usize, usize) {
+            match &self.state {
+                State::Incomplete { pending, verified } => {
+                    (pending.capacity(), verified.capacity())
+                }
+                State::Complete => (0, 0),
+            }
+        }
+    }
+
+    #[test]
+    fn test_certification_allocates_vote_buffers_lazily() {
+        let mut certification = Certification::new(4, true);
+        assert_eq!(certification.capacities(), (0, 0));
+
+        certification.add(1u8, false);
+        let (pending, verified) = certification.capacities();
+        assert!(pending >= 4);
+        assert_eq!(verified, 0);
+
+        certification.complete();
+        assert_eq!(certification.capacities(), (0, 0));
     }
 
     // Helper function to create a sample digest

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -405,7 +405,6 @@ impl<
     #[allow(clippy::type_complexity)]
     async fn timeout(
         mut self,
-        batcher: &mut batcher::Mailbox<S, D>,
         reason: TimeoutReason,
     ) -> (Self, Option<(Nullify<S>, Option<Certificate<S, D>>)>) {
         // Construct a nullify vote for the current view
@@ -413,11 +412,6 @@ impl<
         let Some((retry, nullify)) = self.state.construct_nullify(view, reason) else {
             return (self, None);
         };
-
-        // Inform the batcher on every attempt (it ignores duplicate nullifies):
-        // after a restart, the first attempt for a replayed nullify is a retry,
-        // and the batcher (whose state is not persisted) has not seen the vote yet.
-        batcher.constructed(Vote::Nullify(nullify.clone()));
 
         // Persist the nullify if it is a first attempt
         if !retry {
@@ -512,7 +506,6 @@ impl<
     /// Builds and records a notarize vote when this view is ready.
     async fn prepare_notarize(
         mut self,
-        batcher: &mut batcher::Mailbox<S, D>,
         view: View,
     ) -> (Self, Option<Notarize<S, D>>) {
         // Construct a notarize vote
@@ -520,8 +513,6 @@ impl<
             return (self, None);
         };
 
-        // Inform the batcher so it can aggregate our vote with others.
-        batcher.constructed(Vote::Notarize(notarize.clone()));
         // Record the vote locally before sharing it.
         self = self.handle_notarize(notarize.clone()).await;
         (self, Some(notarize))
@@ -590,7 +581,6 @@ impl<
     /// Builds and records a finalize vote if the round provides a candidate.
     async fn prepare_finalize(
         mut self,
-        batcher: &mut batcher::Mailbox<S, D>,
         view: View,
     ) -> (Self, Option<Finalize<S, D>>) {
         // Construct the finalize vote.
@@ -598,8 +588,6 @@ impl<
             return (self, None);
         };
 
-        // Provide the vote to the batcher pipeline.
-        batcher.constructed(Vote::Finalize(finalize.clone()));
         // Record the vote locally before sharing it.
         self = self.handle_finalize(finalize.clone()).await;
         (self, Some(finalize))
@@ -815,7 +803,7 @@ impl<
     /// Builds and records any votes or certificates that became available for `view`.
     ///
     /// Everything returned must be synced to the journal (via [Self::sync_journal])
-    /// before it is broadcast (via [Self::notify]).
+    /// before it reaches the batcher, reporter, or network (via [Self::notify]).
     ///
     /// We don't need to iterate over all views to check for new actions because messages we receive
     /// only affect a single view. In particular, healing the same-term finalize gate does not
@@ -824,16 +812,15 @@ impl<
     /// same-term vote safety for the consequences when none arrives).
     async fn construct(
         mut self,
-        batcher: &mut batcher::Mailbox<S, D>,
         resolver: &mut resolver::Mailbox<S, D>,
         view: View,
         resolved: Resolved,
     ) -> (Self, Staged<S, D>) {
         let (notarize, notarization, nullification, finalize, finalization);
-        (self, notarize) = self.prepare_notarize(batcher, view).await;
+        (self, notarize) = self.prepare_notarize(view).await;
         (self, notarization) = self.prepare_notarization(resolver, view, resolved).await;
         (self, nullification) = self.prepare_nullification(resolver, view, resolved).await;
-        (self, finalize) = self.prepare_finalize(batcher, view).await;
+        (self, finalize) = self.prepare_finalize(view).await;
         (self, finalization) = self.prepare_finalization(resolver, view, resolved).await;
         (
             self,
@@ -847,13 +834,14 @@ impl<
         )
     }
 
-    /// Broadcasts everything constructed this iteration and reports it to the application.
+    /// Publishes everything constructed this iteration to the batcher and network.
     ///
     /// Callers must sync pending journal appends first (via [Self::sync_journal])
-    /// so no vote or certificate reaches the network before it is durable.
-    #[allow(clippy::type_complexity)]
+    /// so no locally constructed vote is reported or broadcast before it is durable.
+    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     fn notify<Sp: Sender, Sr: Sender>(
         &mut self,
+        batcher: &mut batcher::Mailbox<S, D>,
         resolver: &mut resolver::Mailbox<S, D>,
         vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
         certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
@@ -875,6 +863,9 @@ impl<
         }
 
         if let Some((nullify, entry)) = nullify {
+            // The batcher reports locally constructed votes, so do not hand
+            // one over until the journal sync above has made it durable.
+            batcher.constructed(Vote::Nullify(nullify.clone()));
             debug!(round=?nullify.round(), "broadcasting nullify");
             self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
 
@@ -884,6 +875,7 @@ impl<
             }
         }
         if let Some(notarize) = staged.notarize {
+            batcher.constructed(Vote::Notarize(notarize.clone()));
             debug!(proposal=?notarize.proposal, "broadcasting notarize");
             self.broadcast_vote(vote_sender, Vote::Notarize(notarize));
         }
@@ -908,6 +900,7 @@ impl<
             self.reporter.report(Activity::Nullification(nullification));
         }
         if let Some(finalize) = staged.finalize {
+            batcher.constructed(Vote::Finalize(finalize.clone()));
             debug!(proposal=?finalize.proposal, "broadcasting finalize");
             self.broadcast_vote(vote_sender, Vote::Finalize(finalize));
         }
@@ -1167,7 +1160,7 @@ impl<
                     view = current_view.traced(),
                     reason = reason.as_str()
                 );
-                (self, nullify) = self.timeout(&mut batcher, reason).instrument(span).await;
+                (self, nullify) = self.timeout(reason).instrument(span).await;
                 view = self.state.current_view();
             },
             (context, span, proposed) = propose_wait => {
@@ -1238,7 +1231,7 @@ impl<
                     // Build and record everything that became available for `view`.
                     let staged;
                     (self, staged) = self
-                        .construct(&mut batcher, &mut resolver, view, resolved)
+                        .construct(&mut resolver, view, resolved)
                         .await;
 
                     // Sync everything appended this iteration (during message
@@ -1250,6 +1243,7 @@ impl<
 
                     // Broadcast everything we built (and report it to the application).
                     self.notify(
+                        &mut batcher,
                         &mut resolver,
                         &mut vote_sender,
                         &mut certificate_sender,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -64,6 +64,8 @@ enum Resolved {
 /// [Actor::notify]).
 #[allow(clippy::type_complexity)]
 struct Staged<S: Scheme<D>, D: Digest> {
+    nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
+    certification: Option<(bool, Notarization<S, D>)>,
     notarize: Option<Notarize<S, D>>,
     notarization: Option<Notarization<S, D>>,
     /// A nullification certificate, with the parent certificate of our proposal
@@ -134,7 +136,7 @@ pub struct Actor<
     write_buffer: NonZeroUsize,
     page_cache: CacheRef,
     journal: Option<Journal<E, Artifact<S, D>>>,
-    dirty: bool,
+    dirty_section: Option<View>,
 
     mailbox_receiver: mailbox::Receiver<Message<S, D>>,
 
@@ -195,7 +197,7 @@ impl<
                 write_buffer: cfg.write_buffer,
                 page_cache: cfg.page_cache,
                 journal: None,
-                dirty: false,
+                dirty_section: None,
 
                 mailbox_receiver,
 
@@ -258,13 +260,18 @@ impl<
             })
             .await
             .expect("unable to append to journal");
-            self.dirty = true;
+            match self.dirty_section {
+                Some(dirty) => assert_eq!(
+                    dirty, view,
+                    "one voter iteration must append to a single journal section"
+                ),
+                None => self.dirty_section = Some(view),
+            }
         }
         self
     }
 
-    /// Syncs the journal section for `view` (the view being processed) if the
-    /// iteration appended anything.
+    /// Syncs the journal section written by this iteration, if any.
     ///
     /// Invoked once per event loop iteration, after [Self::construct] and before
     /// [Self::notify] (regardless of whether anything will be broadcast), so
@@ -272,10 +279,10 @@ impl<
     /// a restart. Deferring syncs to this boundary (rather than syncing after
     /// each append) coalesces all appends in the same loop iteration into a
     /// single sync.
-    async fn sync_journal(mut self, view: View) -> Self {
-        if !self.dirty {
+    async fn sync_journal(mut self) -> Self {
+        let Some(view) = self.dirty_section else {
             return self;
-        }
+        };
         let span = info_span!(
             "simplex.voter.journal.sync",
             epoch = self.state.epoch().traced(),
@@ -286,22 +293,25 @@ impl<
         })
         .await
         .expect("unable to sync journal");
-        self.dirty = false;
+        self.dirty_section = None;
         self
     }
 
-    /// Send a vote to every peer.
+    /// Publishes a durable local vote to the batcher and every peer.
     ///
     /// Callers must sync pending journal appends first (via [Self::sync_journal]).
-    /// A vote must be durable before it reaches the network: a restart that
-    /// forgets a sent vote can sign a conflicting one, and conflicting votes
-    /// from the same signer allow conflicting certificates to form (a safety
-    /// failure).
-    fn broadcast_vote<T: Sender>(
+    /// A vote must be durable before it reaches either destination: a restart
+    /// that forgets a published vote can sign a conflicting one, and conflicting
+    /// votes from the same signer allow conflicting certificates to form (a
+    /// safety failure).
+    fn publish_vote<T: Sender>(
         &mut self,
+        batcher: &mut batcher::Mailbox<S, D>,
         sender: &mut WrappedSender<T, Vote<S, D>>,
         vote: Vote<S, D>,
     ) {
+        batcher.constructed(vote.clone());
+
         // Update outbound metrics
         let metric = match &vote {
             Vote::Notarize(_) => metrics::Outbound::notarize(),
@@ -819,6 +829,8 @@ impl<
         (
             self,
             Staged {
+                nullify: None,
+                certification: None,
                 notarize,
                 notarization,
                 nullification,
@@ -832,7 +844,6 @@ impl<
     ///
     /// Callers must sync pending journal appends first (via [Self::sync_journal])
     /// so no locally constructed vote is reported or broadcast before it is durable.
-    #[allow(clippy::too_many_arguments, clippy::type_complexity)]
     fn notify<Sp: Sender, Sr: Sender>(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
@@ -840,12 +851,13 @@ impl<
         vote_sender: &mut WrappedSender<Sp, Vote<S, D>>,
         certificate_sender: &mut WrappedSender<Sr, Certificate<S, D>>,
         staged: Staged<S, D>,
-        nullify: Option<(Nullify<S>, Option<Certificate<S, D>>)>,
-        certification: Option<(bool, Notarization<S, D>)>,
     ) {
-        assert!(!self.dirty, "journal must be synced before broadcast");
+        assert!(
+            self.dirty_section.is_none(),
+            "journal must be synced before broadcast"
+        );
 
-        if let Some((certified, notarization)) = certification {
+        if let Some((certified, notarization)) = staged.certification {
             // Always forward certification outcomes to resolver. This can happen
             // after a nullification for the same view because certification is
             // asynchronous; finalization is the boundary that cancels in-flight
@@ -856,10 +868,9 @@ impl<
             }
         }
 
-        if let Some((nullify, entry)) = nullify {
-            batcher.constructed(Vote::Nullify(nullify.clone()));
+        if let Some((nullify, entry)) = staged.nullify {
             debug!(round=?nullify.round(), "broadcasting nullify");
-            self.broadcast_vote(vote_sender, Vote::Nullify(nullify));
+            self.publish_vote(batcher, vote_sender, Vote::Nullify(nullify));
 
             // Broadcast entry to help others enter the view (if on retry).
             if let Some(entry) = entry {
@@ -867,9 +878,8 @@ impl<
             }
         }
         if let Some(notarize) = staged.notarize {
-            batcher.constructed(Vote::Notarize(notarize.clone()));
             debug!(proposal=?notarize.proposal, "broadcasting notarize");
-            self.broadcast_vote(vote_sender, Vote::Notarize(notarize));
+            self.publish_vote(batcher, vote_sender, Vote::Notarize(notarize));
         }
         if let Some(notarization) = staged.notarization {
             debug!(proposal=?notarization.proposal, "broadcasting notarization");
@@ -892,9 +902,8 @@ impl<
             self.reporter.report(Activity::Nullification(nullification));
         }
         if let Some(finalize) = staged.finalize {
-            batcher.constructed(Vote::Finalize(finalize.clone()));
             debug!(proposal=?finalize.proposal, "broadcasting finalize");
-            self.broadcast_vote(vote_sender, Vote::Finalize(finalize));
+            self.publish_vote(batcher, vote_sender, Vote::Finalize(finalize));
         }
         if let Some(finalization) = staged.finalization {
             debug!(proposal=?finalization.proposal, "broadcasting finalization");
@@ -1221,17 +1230,19 @@ impl<
                 );
                 self = async {
                     // Build and record everything that became available for `view`.
-                    let staged;
+                    let mut staged;
                     (self, staged) = self
                         .construct(&mut resolver, view, resolved)
                         .await;
+                    staged.nullify = nullify;
+                    staged.certification = certification;
 
                     // Sync everything appended this iteration (during message
                     // processing and construction) in a single coalesced sync.
                     // This runs even if there is nothing to broadcast (e.g. a
                     // certification result was recorded) so every artifact is
                     // durable by the end of the iteration that appended it.
-                    self = self.sync_journal(view).await;
+                    self = self.sync_journal().await;
 
                     // Broadcast everything we built (and report it to the application).
                     self.notify(
@@ -1240,8 +1251,6 @@ impl<
                         &mut vote_sender,
                         &mut certificate_sender,
                         staged,
-                        nullify,
-                        certification,
                     );
                     self
                 }

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -273,12 +273,8 @@ impl<
 
     /// Syncs the journal section written by this iteration, if any.
     ///
-    /// Invoked once per event loop iteration, after [Self::construct] and before
-    /// [Self::notify] (regardless of whether anything will be broadcast), so
-    /// every vote and certificate we tell the network about is recoverable after
-    /// a restart. Deferring syncs to this boundary (rather than syncing after
-    /// each append) coalesces all appends in the same loop iteration into a
-    /// single sync.
+    /// Called after construction and before publication so every appended artifact
+    /// is durable by the end of the iteration. A single sync coalesces all appends.
     async fn sync_journal(mut self) -> Self {
         let Some(view) = self.dirty_section else {
             return self;
@@ -299,19 +295,16 @@ impl<
 
     /// Publishes a durable local vote to the batcher and every peer.
     ///
-    /// Callers must sync pending journal appends first (via [Self::sync_journal]).
-    /// A vote must be durable before it reaches either destination: a restart
-    /// that forgets a published vote can sign a conflicting one, and conflicting
-    /// votes from the same signer allow conflicting certificates to form (a
-    /// safety failure).
+    /// Callers must first sync pending journal appends. Otherwise a restart may
+    /// forget the vote and sign a conflicting one, allowing conflicting certificates.
     fn publish_vote<T: Sender>(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,
         sender: &mut WrappedSender<T, Vote<S, D>>,
         vote: Vote<S, D>,
     ) {
-        // Do not suppress retries here: batcher state is not persisted, so the first
-        // retry of a replayed nullify may be its first copy of that vote.
+        // Every nullify retry refreshes volatile batcher state. The first retry after
+        // replay may be the batcher's first copy of the vote.
         batcher.constructed(vote.clone());
 
         // Update outbound metrics
@@ -808,8 +801,8 @@ impl<
 
     /// Builds and records any votes or certificates that became available for `view`.
     ///
-    /// Everything returned must be synced to the journal (via [Self::sync_journal])
-    /// before it reaches the batcher, reporter, or network (via [Self::notify]).
+    /// Returned artifacts must be synced through [Self::sync_journal] before
+    /// [Self::notify] publishes them.
     ///
     /// We don't need to iterate over all views to check for new actions because messages we receive
     /// only affect a single view. In particular, healing the same-term finalize gate does not
@@ -842,10 +835,10 @@ impl<
         )
     }
 
-    /// Publishes everything constructed this iteration to the batcher and network.
+    /// Publishes the staged votes and certificates.
     ///
-    /// Callers must sync pending journal appends first (via [Self::sync_journal])
-    /// so no locally constructed vote is reported or broadcast before it is durable.
+    /// Callers must first sync pending journal appends so locally constructed votes
+    /// are durable before reaching the batcher, reporter, or network.
     fn notify<Sp: Sender, Sr: Sender>(
         &mut self,
         batcher: &mut batcher::Mailbox<S, D>,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -857,8 +857,6 @@ impl<
         }
 
         if let Some((nullify, entry)) = nullify {
-            // The batcher reports locally constructed votes, so do not hand
-            // one over until the journal sync above has made it durable.
             batcher.constructed(Vote::Nullify(nullify.clone()));
             debug!(round=?nullify.round(), "broadcasting nullify");
             self.broadcast_vote(vote_sender, Vote::Nullify(nullify));

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -504,10 +504,7 @@ impl<
     }
 
     /// Builds and records a notarize vote when this view is ready.
-    async fn prepare_notarize(
-        mut self,
-        view: View,
-    ) -> (Self, Option<Notarize<S, D>>) {
+    async fn prepare_notarize(mut self, view: View) -> (Self, Option<Notarize<S, D>>) {
         // Construct a notarize vote
         let Some(notarize) = self.state.construct_notarize(view) else {
             return (self, None);
@@ -579,10 +576,7 @@ impl<
     }
 
     /// Builds and records a finalize vote if the round provides a candidate.
-    async fn prepare_finalize(
-        mut self,
-        view: View,
-    ) -> (Self, Option<Finalize<S, D>>) {
+    async fn prepare_finalize(mut self, view: View) -> (Self, Option<Finalize<S, D>>) {
         // Construct the finalize vote.
         let Some(finalize) = self.state.construct_finalize(view) else {
             return (self, None);

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -310,6 +310,8 @@ impl<
         sender: &mut WrappedSender<T, Vote<S, D>>,
         vote: Vote<S, D>,
     ) {
+        // Do not suppress retries here: batcher state is not persisted, so the first
+        // retry of a replayed nullify may be its first copy of that vote.
         batcher.constructed(vote.clone());
 
         // Update outbound metrics

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -8484,12 +8484,11 @@ mod tests {
         first_view_progress_without_timeout::<_, _, RoundRobin>(secp256r1::fixture);
     }
 
-    /// Tests that certification and finalize are coalesced into one durable section sync.
+    /// Certification and the finalize vote share one durable section sync.
     ///
-    /// 1. First run: gate the section sync after certification and verify finalize is neither
-    ///    handed to the batcher nor broadcast.
-    /// 2. Release the only section sync, observe the finalize reach both, and abort the voter.
-    /// 3. Second run: replay both artifacts and advance without re-certifying.
+    /// 1. Gate the sync and verify the finalize reaches neither batcher nor network.
+    /// 2. Release the sync, observe both deliveries, and abort the voter.
+    /// 3. Restart, replay both artifacts, and advance without re-certifying.
     fn successful_certification_replayed_after_restart<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -8486,9 +8486,9 @@ mod tests {
 
     /// Tests that certification and finalize are coalesced into one durable section sync.
     ///
-    /// 1. First run: gate the section sync after certification and verify finalize is staged but
-    ///    not broadcast.
-    /// 2. Release the only section sync, observe the finalize broadcast, and abort the voter.
+    /// 1. First run: gate the section sync after certification and verify finalize is neither
+    ///    handed to the batcher nor broadcast.
+    /// 2. Release the only section sync, observe the finalize reach both, and abort the voter.
     /// 3. Second run: replay both artifacts and advance without re-certifying.
     fn successful_certification_replayed_after_restart<S, F>(mut fixture: F)
     where
@@ -8691,8 +8691,8 @@ mod tests {
                 }
             }
             assert!(
-                finalize_constructed,
-                "finalize was not constructed before the section sync"
+                !finalize_constructed,
+                "finalize reached the batcher before the section sync completed"
             );
             assert_eq!(
                 pending_syncs.calls(),
@@ -8720,6 +8720,26 @@ mod tests {
             }
 
             deferred.release.send(Ok(())).unwrap();
+
+            // The batcher may report our vote, so it must only receive the
+            // finalize after the vote is durable.
+            let deadline = context.current() + Duration::from_secs(5);
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if matches!(
+                            msg.unwrap(),
+                            batcher::Message::Constructed(Vote::Finalize(ref finalize))
+                                if finalize.view() == target_view
+                        ) {
+                            break;
+                        }
+                    },
+                    _ = context.sleep_until(deadline) => {
+                        panic!("timed out waiting for durable finalize in view {target_view}");
+                    },
+                }
+            }
 
             // The resolver should observe certification only after the section sync completes.
             let mut certified = false;
@@ -9182,6 +9202,11 @@ mod tests {
             let reporter = mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
             let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
             let epoch = Epoch::new(333);
+            let pending_syncs = PendingSyncs::default();
+            let voter_context = DelayedSyncContext {
+                inner: context.child("voter"),
+                pending: pending_syncs.clone(),
+            };
 
             // First run: trigger timeout and nullification.
             let app_cfg = mocks::application::Config::<Sha256, _> {
@@ -9207,15 +9232,19 @@ mod tests {
                 epoch,
                 floor: Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
                 mailbox_size: NZUsize!(128),
-                leader_timeout: Duration::from_secs(1),
-                certification_timeout: Duration::from_secs(1),
+                leader_timeout: Duration::from_secs(100),
+                certification_timeout: Duration::from_secs(100),
                 timeout_retry: Duration::from_mins(60),
                 view_retention: ViewDelta::new(10),
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                page_cache: CacheRef::from_pooler(
+                    &voter_context,
+                    PAGE_SIZE,
+                    PAGE_CACHE_SIZE,
+                ),
             };
-            let (voter, mut mailbox) = Actor::new(context.child("voter"), voter_cfg);
+            let (voter, mut mailbox) = Actor::new(voter_context, voter_cfg);
             let (resolver_sender, _resolver_receiver) =
                 mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
             let (batcher_sender, mut batcher_receiver) =
@@ -9250,7 +9279,35 @@ mod tests {
             )
             .await;
 
-            // Wait for the timeout-driven nullify vote.
+            // Gate the first-attempt nullify's journal sync.
+            pending_syncs.arm();
+            mailbox.timeout(
+                Round::new(epoch, target_view),
+                TimeoutReason::LeaderTimeout,
+            );
+            while pending_syncs.lock().is_empty() {
+                reschedule().await;
+            }
+            let deferred = next_pending_sync(&pending_syncs);
+            deferred
+                .blocked
+                .await
+                .expect("gated nullify section sync was dropped");
+
+            while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
+                assert!(
+                    !matches!(
+                        msg,
+                        batcher::Message::Constructed(Vote::Nullify(ref nullify))
+                            if nullify.view() == target_view
+                    ),
+                    "nullify reached the batcher before the section sync completed"
+                );
+            }
+
+            deferred.release.send(Ok(())).unwrap();
+
+            // Wait for the durable timeout-driven nullify vote.
             loop {
                 select! {
                     msg = batcher_receiver.recv() => match msg.unwrap() {

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -9238,11 +9238,7 @@ mod tests {
                 view_retention: ViewDelta::new(10),
                 replay_buffer: NZUsize!(1024 * 1024),
                 write_buffer: NZUsize!(1024 * 1024),
-                page_cache: CacheRef::from_pooler(
-                    &voter_context,
-                    PAGE_SIZE,
-                    PAGE_CACHE_SIZE,
-                ),
+                page_cache: CacheRef::from_pooler(&voter_context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let (voter, mut mailbox) = Actor::new(voter_context, voter_cfg);
             let (resolver_sender, _resolver_receiver) =
@@ -9281,10 +9277,7 @@ mod tests {
 
             // Gate the first-attempt nullify's journal sync.
             pending_syncs.arm();
-            mailbox.timeout(
-                Round::new(epoch, target_view),
-                TimeoutReason::LeaderTimeout,
-            );
+            mailbox.timeout(Round::new(epoch, target_view), TimeoutReason::LeaderTimeout);
             while pending_syncs.lock().is_empty() {
                 reschedule().await;
             }

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -149,17 +149,17 @@ where
     /// may differ from the one exported before the crash.
     pub reporter: F,
 
-    /// Extend conflict reporting beyond certification.
+    /// Report historical conflicts after certification.
     ///
-    /// Enabling this retains full votes after their corresponding certificate is
-    /// recovered. Otherwise, conflict evidence that requires a released vote can
-    /// no longer be constructed. Compact signer data remains available for
-    /// forwarding and duplicate suppression.
+    /// By default, conflicts that require full vote evidence can be reported only
+    /// until the corresponding certificate is constructed or received. Enabling
+    /// this retains those votes so the conflicts can still be reported. Compact
+    /// signer data remains available for forwarding and duplicate suppression
+    /// either way.
     ///
-    /// This is disabled by default in provided configurations because retaining
-    /// full signed votes for every tracked view can consume substantial memory,
-    /// especially when certificates arrive far ahead of the current view.
-    pub extended_conflict_reporting: bool,
+    /// Historical conflict reporting increases per-view memory usage, especially
+    /// when certificates arrive far ahead of the current view.
+    pub historical_conflict_reporting: bool,
 
     /// Strategy for parallel operations.
     pub strategy: T,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -148,14 +148,13 @@ where
     /// different votes exported before and after a restart.
     pub reporter: F,
 
-    /// Report historical conflicts after certification.
+    /// Track individual votes after certification.
     ///
     /// By default, full vote evidence is released when the corresponding certificate
     /// is constructed or received, making later conflict reporting and peer blocking
     /// best effort. Enabling this retains each recorded vote until its round is
-    /// pruned, increasing memory usage. Forwarding and duplicate suppression remain
-    /// available either way.
-    pub historical_conflict_reporting: bool,
+    /// pruned, increasing memory usage.
+    pub track_historical_votes: bool,
 
     /// Strategy for parallel operations.
     pub strategy: T,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -145,24 +145,18 @@ where
     /// may differ from the one exported before the crash.
     pub reporter: F,
 
-    /// Retain votes after certification to detect and report conflicting votes.
+    /// Retain full votes after their corresponding certificate is recovered.
+    ///
+    /// The batcher detects and reports conflicts while the required full votes
+    /// remain in memory. When this is disabled, those votes are released once
+    /// certified, so conflict evidence that requires a released vote can no longer
+    /// be constructed. Compact signer data remains available for forwarding and
+    /// duplicate suppression.
     ///
     /// This is disabled by default in provided configurations because retaining
     /// full signed votes for every tracked view can consume substantial memory,
-    /// especially when certificates arrive far ahead of the current view. When
-    /// disabled, votes needed for certificate assembly are released as soon as
-    /// the corresponding certificate exists. Compact signer data is retained for
-    /// forwarding and duplicate suppression.
-    ///
-    /// Individual votes are still exported through `reporter`, so a downstream
-    /// application may independently observe conflicting activity. This option
-    /// controls the batcher's retention, comparison, and emission of explicit
-    /// conflict-evidence activities.
-    ///
-    /// Enabling this currently requires deterministic signatures: signing the
-    /// same subject twice must produce equal signature encodings (see
-    /// [`super::scheme::Scheme`]).
-    pub report_conflicting_votes: bool,
+    /// especially when certificates arrive far ahead of the current view.
+    pub retain_votes_after_certification: bool,
 
     /// Strategy for parallel operations.
     pub strategy: T,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -144,21 +144,17 @@ where
     /// and verify activities based on scheme attributability.
     ///
     /// Locally constructed votes are exported only after their journal entries are
-    /// durable. Votes received from the network are not persisted and may be exported
-    /// again after a restart. If the sender equivocates, a vote exported after restart
-    /// may differ from the one exported before the crash.
+    /// durable. Network votes are not persisted, so an equivocating sender may have
+    /// different votes exported before and after a restart.
     pub reporter: F,
 
     /// Report historical conflicts after certification.
     ///
-    /// By default, conflicts that require full vote evidence can be reported only
-    /// until the corresponding certificate is constructed or received. Enabling
-    /// this retains those votes so the conflicts can still be reported. Compact
-    /// signer data remains available for forwarding and duplicate suppression
-    /// either way.
-    ///
-    /// Historical conflict reporting increases per-view memory usage, especially
-    /// when certificates arrive far ahead of the current view.
+    /// By default, full vote evidence is released when the corresponding certificate
+    /// is constructed or received, making later conflict reporting and peer blocking
+    /// best effort. Enabling this retains each recorded vote until its round is
+    /// pruned, increasing memory usage. Forwarding and duplicate suppression remain
+    /// available either way.
     pub historical_conflict_reporting: bool,
 
     /// Strategy for parallel operations.

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -109,6 +109,10 @@ where
     /// responsible for reusing the exact participant ordering carried by `participants` so that signer indices
     /// remain stable across both key spaces; if the order diverges, validators will reject votes as coming from
     /// the wrong validator.
+    ///
+    /// Simplex compares complete signed votes when checking duplicates and
+    /// conflicts. Signing the same subject more than once for the same participant
+    /// must therefore produce the same signature encoding.
     pub scheme: S,
 
     /// Leader election configuration.
@@ -145,18 +149,17 @@ where
     /// may differ from the one exported before the crash.
     pub reporter: F,
 
-    /// Retain full votes after their corresponding certificate is recovered.
+    /// Extend conflict reporting beyond certification.
     ///
-    /// The batcher detects and reports conflicts while the required full votes
-    /// remain in memory. When this is disabled, those votes are released once
-    /// certified, so conflict evidence that requires a released vote can no longer
-    /// be constructed. Compact signer data remains available for forwarding and
-    /// duplicate suppression.
+    /// Enabling this retains full votes after their corresponding certificate is
+    /// recovered. Otherwise, conflict evidence that requires a released vote can
+    /// no longer be constructed. Compact signer data remains available for
+    /// forwarding and duplicate suppression.
     ///
     /// This is disabled by default in provided configurations because retaining
     /// full signed votes for every tracked view can consume substantial memory,
     /// especially when certificates arrive far ahead of the current view.
-    pub retain_votes_after_certification: bool,
+    pub extended_conflict_reporting: bool,
 
     /// Strategy for parallel operations.
     pub strategy: T,

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -138,7 +138,31 @@ where
     /// verified (see [`crate::simplex::types::Activity`]). Consider wrapping with
     /// [`crate::simplex::scheme::reporter::AttributableReporter`] to automatically filter
     /// and verify activities based on scheme attributability.
+    ///
+    /// Locally constructed votes are exported only after their journal entries are
+    /// durable. Votes received from the network are not persisted and may be exported
+    /// again after a restart. If the sender equivocates, a vote exported after restart
+    /// may differ from the one exported before the crash.
     pub reporter: F,
+
+    /// Retain votes after certification to detect and report conflicting votes.
+    ///
+    /// This is disabled by default in provided configurations because retaining
+    /// full signed votes for every tracked view can consume substantial memory,
+    /// especially when certificates arrive far ahead of the current view. When
+    /// disabled, votes needed for certificate assembly are released as soon as
+    /// the corresponding certificate exists. Compact signer data is retained for
+    /// forwarding and duplicate suppression.
+    ///
+    /// Individual votes are still exported through `reporter`, so a downstream
+    /// application may independently observe conflicting activity. This option
+    /// controls the batcher's retention, comparison, and emission of explicit
+    /// conflict-evidence activities.
+    ///
+    /// Enabling this currently requires deterministic signatures: signing the
+    /// same subject twice must produce equal signature encodings (see
+    /// [`super::scheme::Scheme`]).
+    pub report_conflicting_votes: bool,
 
     /// Strategy for parallel operations.
     pub strategy: T,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -75,7 +75,7 @@ impl<
                 scheme: cfg.scheme.clone(),
                 blocker: cfg.blocker.clone(),
                 reporter: cfg.reporter.clone(),
-                historical_conflict_reporting: cfg.historical_conflict_reporting,
+                track_historical_votes: cfg.track_historical_votes,
                 relay: cfg.relay.clone(),
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -75,6 +75,7 @@ impl<
                 scheme: cfg.scheme.clone(),
                 blocker: cfg.blocker.clone(),
                 reporter: cfg.reporter.clone(),
+                report_conflicting_votes: cfg.report_conflicting_votes,
                 relay: cfg.relay.clone(),
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -75,7 +75,7 @@ impl<
                 scheme: cfg.scheme.clone(),
                 blocker: cfg.blocker.clone(),
                 reporter: cfg.reporter.clone(),
-                retain_votes_after_certification: cfg.extended_conflict_reporting,
+                retain_recovered_votes: cfg.historical_conflict_reporting,
                 relay: cfg.relay.clone(),
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -75,7 +75,7 @@ impl<
                 scheme: cfg.scheme.clone(),
                 blocker: cfg.blocker.clone(),
                 reporter: cfg.reporter.clone(),
-                retain_recovered_votes: cfg.historical_conflict_reporting,
+                historical_conflict_reporting: cfg.historical_conflict_reporting,
                 relay: cfg.relay.clone(),
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -75,7 +75,7 @@ impl<
                 scheme: cfg.scheme.clone(),
                 blocker: cfg.blocker.clone(),
                 reporter: cfg.reporter.clone(),
-                report_conflicting_votes: cfg.report_conflicting_votes,
+                retain_votes_after_certification: cfg.retain_votes_after_certification,
                 relay: cfg.relay.clone(),
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -75,7 +75,7 @@ impl<
                 scheme: cfg.scheme.clone(),
                 blocker: cfg.blocker.clone(),
                 reporter: cfg.reporter.clone(),
-                retain_votes_after_certification: cfg.retain_votes_after_certification,
+                retain_votes_after_certification: cfg.extended_conflict_reporting,
                 relay: cfg.relay.clone(),
                 strategy: cfg.strategy.clone(),
                 epoch: cfg.epoch,

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -136,10 +136,10 @@
 //!   entered in the current term.
 //! * Votes are tracked down to `view_retention` views below the highest finalized view: late
 //!   votes in that window are still reported, even though they are no longer verified or used
-//!   for certificate construction. Explicit conflict evidence is emitted only when
-//!   [`Config::report_conflicting_votes`] is enabled. Votes below the window are ignored on
-//!   arrival, so downstream systems consuming per-vote activity (rewards, slashing) never
-//!   observe them.
+//!   for certificate construction. Explicit conflict evidence is best effort once full votes are
+//!   released; [`Config::retain_votes_after_certification`] preserves them for continued conflict
+//!   reporting. Votes below the window are ignored on arrival, so downstream systems consuming
+//!   per-vote activity (rewards, slashing) never observe them.
 //!
 //! ## Protocol Properties
 //!
@@ -927,7 +927,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1190,7 +1190,7 @@ mod tests {
                         PAGE_CACHE_SIZE,
                     ),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(validator_context.child("engine"), cfg);
                 let (pending, recovered, resolver) =
@@ -1307,7 +1307,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&joiner_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             };
             let engine = Engine::new(joiner_context.child("engine"), cfg);
             let (pending, recovered, resolver) = register_validator(&mut oracle, joiner).await;
@@ -1451,7 +1451,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -1613,7 +1613,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1769,7 +1769,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1945,7 +1945,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2067,7 +2067,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2204,7 +2204,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2439,7 +2439,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2601,7 +2601,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2795,7 +2795,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2913,7 +2913,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3033,7 +3033,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3221,7 +3221,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3417,7 +3417,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: true,
+                        retain_votes_after_certification: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3586,7 +3586,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3751,7 +3751,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3938,7 +3938,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4060,7 +4060,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4213,7 +4213,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engines.push(engine.start(pending, recovered, resolver));
@@ -4307,7 +4307,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4460,7 +4460,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4606,7 +4606,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: true,
+                        retain_votes_after_certification: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4769,7 +4769,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4898,7 +4898,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5021,7 +5021,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 16),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5197,7 +5197,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5534,7 +5534,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(
                         context
@@ -5740,7 +5740,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5886,7 +5886,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5988,7 +5988,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 engine_handlers.insert(idx, engine.start(pending, recovered, resolver));
@@ -6409,7 +6409,7 @@ mod tests {
                             write_buffer: NZUsize!(1024 * 1024),
                             page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                             forwarding: ForwardingPolicy::Disabled,
-                            report_conflicting_votes: false,
+                            retain_votes_after_certification: false,
                         };
                         let engine = Engine::new(context.child("engine"), cfg);
                         engine_handlers.push(engine.start(
@@ -6479,7 +6479,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        report_conflicting_votes: false,
+                        retain_votes_after_certification: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -138,7 +138,7 @@
 //!   votes in that window are still reported, even though they are no longer verified or used
 //!   for certificate construction. By default, certification releases full vote evidence, making
 //!   later conflict reporting and peer blocking best effort.
-//!   [`Config::historical_conflict_reporting`] instead retains each recorded vote until its round
+//!   [`Config::track_historical_votes`] instead retains each recorded vote until its round
 //!   is pruned. Votes below the window are ignored on arrival, so downstream systems consuming
 //!   per-vote activity (rewards, slashing) never observe them.
 //!
@@ -928,7 +928,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1191,7 +1191,7 @@ mod tests {
                         PAGE_CACHE_SIZE,
                     ),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(validator_context.child("engine"), cfg);
                 let (pending, recovered, resolver) =
@@ -1308,7 +1308,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&joiner_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             };
             let engine = Engine::new(joiner_context.child("engine"), cfg);
             let (pending, recovered, resolver) = register_validator(&mut oracle, joiner).await;
@@ -1452,7 +1452,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -1614,7 +1614,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1770,7 +1770,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1946,7 +1946,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2068,7 +2068,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2205,7 +2205,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2440,7 +2440,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2602,7 +2602,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2796,7 +2796,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2914,7 +2914,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3034,7 +3034,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3222,7 +3222,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3418,7 +3418,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: true,
+                        track_historical_votes: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3587,7 +3587,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3752,7 +3752,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3939,7 +3939,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4061,7 +4061,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4214,7 +4214,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engines.push(engine.start(pending, recovered, resolver));
@@ -4308,7 +4308,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4461,7 +4461,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4607,7 +4607,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: true,
+                        track_historical_votes: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4770,7 +4770,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4899,7 +4899,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5022,7 +5022,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 16),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5198,7 +5198,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5535,7 +5535,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(
                         context
@@ -5741,7 +5741,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5887,7 +5887,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5989,7 +5989,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 engine_handlers.insert(idx, engine.start(pending, recovered, resolver));
@@ -6410,7 +6410,7 @@ mod tests {
                             write_buffer: NZUsize!(1024 * 1024),
                             page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                             forwarding: ForwardingPolicy::Disabled,
-                            historical_conflict_reporting: false,
+                            track_historical_votes: false,
                         };
                         let engine = Engine::new(context.child("engine"), cfg);
                         engine_handlers.push(engine.start(
@@ -6480,7 +6480,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        historical_conflict_reporting: false,
+                        track_historical_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -136,11 +136,11 @@
 //!   entered in the current term.
 //! * Votes are tracked down to `view_retention` views below the highest finalized view: late
 //!   votes in that window are still reported, even though they are no longer verified or used
-//!   for certificate construction. By default, full vote evidence is released when its certificate
-//!   is constructed or received. Later conflict reporting is best effort.
-//!   [`Config::historical_conflict_reporting`] preserves the evidence. Votes below the window are
-//!   ignored on arrival, so downstream systems consuming per-vote activity (rewards, slashing)
-//!   never observe them.
+//!   for certificate construction. By default, certification releases full vote evidence, making
+//!   later conflict reporting and peer blocking best effort.
+//!   [`Config::historical_conflict_reporting`] instead retains each recorded vote until its round
+//!   is pruned. Votes below the window are ignored on arrival, so downstream systems consuming
+//!   per-vote activity (rewards, slashing) never observe them.
 //!
 //! ## Protocol Properties
 //!

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -137,7 +137,7 @@
 //! * Votes are tracked down to `view_retention` views below the highest finalized view: late
 //!   votes in that window are still reported, even though they are no longer verified or used
 //!   for certificate construction. Explicit conflict evidence is best effort once full votes are
-//!   released; [`Config::retain_votes_after_certification`] preserves them for continued conflict
+//!   released; [`Config::extended_conflict_reporting`] preserves them for continued conflict
 //!   reporting. Votes below the window are ignored on arrival, so downstream systems consuming
 //!   per-vote activity (rewards, slashing) never observe them.
 //!
@@ -927,7 +927,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1190,7 +1190,7 @@ mod tests {
                         PAGE_CACHE_SIZE,
                     ),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(validator_context.child("engine"), cfg);
                 let (pending, recovered, resolver) =
@@ -1307,7 +1307,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&joiner_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             };
             let engine = Engine::new(joiner_context.child("engine"), cfg);
             let (pending, recovered, resolver) = register_validator(&mut oracle, joiner).await;
@@ -1451,7 +1451,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -1613,7 +1613,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1769,7 +1769,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1945,7 +1945,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2067,7 +2067,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2204,7 +2204,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2439,7 +2439,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2601,7 +2601,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2795,7 +2795,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2913,7 +2913,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3033,7 +3033,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3221,7 +3221,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3417,7 +3417,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: true,
+                        extended_conflict_reporting: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3586,7 +3586,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3751,7 +3751,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3938,7 +3938,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4060,7 +4060,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4213,7 +4213,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engines.push(engine.start(pending, recovered, resolver));
@@ -4307,7 +4307,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4460,7 +4460,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4606,7 +4606,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: true,
+                        extended_conflict_reporting: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4769,7 +4769,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4898,7 +4898,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5021,7 +5021,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 16),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5197,7 +5197,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5534,7 +5534,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(
                         context
@@ -5740,7 +5740,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5886,7 +5886,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5988,7 +5988,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 engine_handlers.insert(idx, engine.start(pending, recovered, resolver));
@@ -6409,7 +6409,7 @@ mod tests {
                             write_buffer: NZUsize!(1024 * 1024),
                             page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                             forwarding: ForwardingPolicy::Disabled,
-                            retain_votes_after_certification: false,
+                            extended_conflict_reporting: false,
                         };
                         let engine = Engine::new(context.child("engine"), cfg);
                         engine_handlers.push(engine.start(
@@ -6479,7 +6479,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        retain_votes_after_certification: false,
+                        extended_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -135,10 +135,11 @@
 //!   current view and vote `nullify`. In practice, this tracks the oldest unfinalized view we have
 //!   entered in the current term.
 //! * Votes are tracked down to `view_retention` views below the highest finalized view: late
-//!   votes in that window are still reported (and equivocation there is still detected), even
-//!   though they are no longer verified or used for certificate construction. Votes below the
-//!   window are ignored on arrival, so downstream systems consuming per-vote activity (rewards,
-//!   slashing) never observe them.
+//!   votes in that window are still reported, even though they are no longer verified or used
+//!   for certificate construction. Explicit conflict evidence is emitted only when
+//!   [`Config::report_conflicting_votes`] is enabled. Votes below the window are ignored on
+//!   arrival, so downstream systems consuming per-vote activity (rewards, slashing) never
+//!   observe them.
 //!
 //! ## Protocol Properties
 //!
@@ -926,6 +927,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1188,6 +1190,7 @@ mod tests {
                         PAGE_CACHE_SIZE,
                     ),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(validator_context.child("engine"), cfg);
                 let (pending, recovered, resolver) =
@@ -1304,6 +1307,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&joiner_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             };
             let engine = Engine::new(joiner_context.child("engine"), cfg);
             let (pending, recovered, resolver) = register_validator(&mut oracle, joiner).await;
@@ -1447,6 +1451,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -1608,6 +1613,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1763,6 +1769,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1938,6 +1945,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2059,6 +2067,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2195,6 +2204,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2429,6 +2439,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2590,6 +2601,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2783,6 +2795,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2900,6 +2913,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3019,6 +3033,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3206,6 +3221,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3401,6 +3417,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3569,6 +3586,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3733,6 +3751,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3919,6 +3938,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4040,6 +4060,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4192,6 +4213,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engines.push(engine.start(pending, recovered, resolver));
@@ -4285,6 +4307,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4437,6 +4460,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4582,6 +4606,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4744,6 +4769,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4872,6 +4898,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -4994,6 +5021,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 16),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5169,6 +5197,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5505,6 +5534,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(
                         context
@@ -5710,6 +5740,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5855,6 +5886,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5956,6 +5988,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 engine_handlers.insert(idx, engine.start(pending, recovered, resolver));
@@ -6376,6 +6409,7 @@ mod tests {
                             write_buffer: NZUsize!(1024 * 1024),
                             page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                             forwarding: ForwardingPolicy::Disabled,
+                            report_conflicting_votes: false,
                         };
                         let engine = Engine::new(context.child("engine"), cfg);
                         engine_handlers.push(engine.start(
@@ -6445,6 +6479,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
+                        report_conflicting_votes: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -136,10 +136,11 @@
 //!   entered in the current term.
 //! * Votes are tracked down to `view_retention` views below the highest finalized view: late
 //!   votes in that window are still reported, even though they are no longer verified or used
-//!   for certificate construction. Explicit conflict evidence is best effort once full votes are
-//!   released; [`Config::extended_conflict_reporting`] preserves them for continued conflict
-//!   reporting. Votes below the window are ignored on arrival, so downstream systems consuming
-//!   per-vote activity (rewards, slashing) never observe them.
+//!   for certificate construction. By default, full vote evidence is released when its certificate
+//!   is constructed or received, so later conflict reporting is best effort;
+//!   [`Config::historical_conflict_reporting`] preserves the evidence. Votes below the window are
+//!   ignored on arrival, so downstream systems consuming per-vote activity (rewards, slashing)
+//!   never observe them.
 //!
 //! ## Protocol Properties
 //!
@@ -927,7 +928,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1190,7 +1191,7 @@ mod tests {
                         PAGE_CACHE_SIZE,
                     ),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(validator_context.child("engine"), cfg);
                 let (pending, recovered, resolver) =
@@ -1307,7 +1308,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&joiner_context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             };
             let engine = Engine::new(joiner_context.child("engine"), cfg);
             let (pending, recovered, resolver) = register_validator(&mut oracle, joiner).await;
@@ -1451,7 +1452,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -1613,7 +1614,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1769,7 +1770,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 
@@ -1945,7 +1946,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2067,7 +2068,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2204,7 +2205,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2439,7 +2440,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2601,7 +2602,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2795,7 +2796,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -2913,7 +2914,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3033,7 +3034,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3221,7 +3222,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -3417,7 +3418,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: true,
+                        historical_conflict_reporting: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -3586,7 +3587,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3751,7 +3752,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 let (pending, recovered, resolver) = registrations
@@ -3938,7 +3939,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4060,7 +4061,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4213,7 +4214,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engines.push(engine.start(pending, recovered, resolver));
@@ -4307,7 +4308,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 1024),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
             engine.start(pending, recovered, resolver);
@@ -4460,7 +4461,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4606,7 +4607,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: true,
+                        historical_conflict_reporting: true,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4769,7 +4770,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
                     engine.start(pending, recovered, resolver);
@@ -4898,7 +4899,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5021,7 +5022,7 @@ mod tests {
                 write_buffer: NZUsize!(1024 * 16),
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             };
             let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5197,7 +5198,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5534,7 +5535,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(
                         context
@@ -5740,7 +5741,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5886,7 +5887,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
 
@@ -5988,7 +5989,7 @@ mod tests {
                     write_buffer: NZUsize!(1024 * 1024),
                     page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 };
                 let engine = Engine::new(context.child("engine"), cfg);
                 engine_handlers.insert(idx, engine.start(pending, recovered, resolver));
@@ -6409,7 +6410,7 @@ mod tests {
                             write_buffer: NZUsize!(1024 * 1024),
                             page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                             forwarding: ForwardingPolicy::Disabled,
-                            extended_conflict_reporting: false,
+                            historical_conflict_reporting: false,
                         };
                         let engine = Engine::new(context.child("engine"), cfg);
                         engine_handlers.push(engine.start(
@@ -6479,7 +6480,7 @@ mod tests {
                         write_buffer: NZUsize!(1024 * 1024),
                         page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                         forwarding: ForwardingPolicy::Disabled,
-                        extended_conflict_reporting: false,
+                        historical_conflict_reporting: false,
                     };
                     let engine = Engine::new(context.child("engine"), cfg);
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -137,7 +137,7 @@
 //! * Votes are tracked down to `view_retention` views below the highest finalized view: late
 //!   votes in that window are still reported, even though they are no longer verified or used
 //!   for certificate construction. By default, full vote evidence is released when its certificate
-//!   is constructed or received, so later conflict reporting is best effort;
+//!   is constructed or received. Later conflict reporting is best effort.
 //!   [`Config::historical_conflict_reporting`] preserves the evidence. Votes below the window are
 //!   ignored on arrival, so downstream systems consuming per-vote activity (rewards, slashing)
 //!   never observe them.

--- a/consensus/src/simplex/scheme/mod.rs
+++ b/consensus/src/simplex/scheme/mod.rs
@@ -135,12 +135,6 @@ impl<D: Digest, S> CertificateVerifier<D> for S where
 /// This trait binds a [`CertificateScheme`] to the [`Subject`] subject type and
 /// [`N3f1`] fault model used by the simplex protocol. It is automatically
 /// implemented for any compatible scheme.
-///
-/// # Deterministic Signatures
-///
-/// Conflict checking currently compares complete signed votes. Schemes must
-/// produce equal signature encodings whenever the same participant signs the
-/// same [`Subject`] more than once.
 pub trait Scheme<D: Digest>:
     CertificateVerifier<D> + for<'a> CertificateScheme<Subject<'a, D> = Subject<'a, D>>
 {

--- a/consensus/src/simplex/scheme/mod.rs
+++ b/consensus/src/simplex/scheme/mod.rs
@@ -135,6 +135,14 @@ impl<D: Digest, S> CertificateVerifier<D> for S where
 /// This trait binds a [`CertificateScheme`] to the [`Subject`] subject type and
 /// [`N3f1`] fault model used by the simplex protocol. It is automatically
 /// implemented for any compatible scheme.
+///
+/// # Deterministic Signatures
+///
+/// Conflict checking (see
+/// [`crate::simplex::Config::report_conflicting_votes`]) currently compares
+/// complete signed votes. Schemes used with that option must produce equal
+/// signature encodings whenever the same participant signs the same
+/// [`Subject`] more than once.
 pub trait Scheme<D: Digest>:
     CertificateVerifier<D> + for<'a> CertificateScheme<Subject<'a, D> = Subject<'a, D>>
 {

--- a/consensus/src/simplex/scheme/mod.rs
+++ b/consensus/src/simplex/scheme/mod.rs
@@ -138,11 +138,9 @@ impl<D: Digest, S> CertificateVerifier<D> for S where
 ///
 /// # Deterministic Signatures
 ///
-/// Conflict checking (see
-/// [`crate::simplex::Config::report_conflicting_votes`]) currently compares
-/// complete signed votes. Schemes used with that option must produce equal
-/// signature encodings whenever the same participant signs the same
-/// [`Subject`] more than once.
+/// Conflict checking currently compares complete signed votes. Schemes must
+/// produce equal signature encodings whenever the same participant signs the
+/// same [`Subject`] more than once.
 pub trait Scheme<D: Digest>:
     CertificateVerifier<D> + for<'a> CertificateScheme<Subject<'a, D> = Subject<'a, D>>
 {

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -176,11 +176,9 @@ impl<T: Attributable> AttributableMap<T> {
 /// validator can only contribute one vote per phase. Unless historical conflict reporting
 /// is enabled, full votes are released once their certificate exists. Compact signer state
 /// remains available for forwarding and duplicate suppression.
-#[cfg(not(target_arch = "wasm32"))]
 pub struct VoteTracker<S: Scheme, D: Digest> {
-    /// Number of validators represented by the vote maps and compact signer table.
     participants: usize,
-    /// Whether full votes remain available after their certificate is recovered.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     retain_recovered_votes: bool,
     /// Compact state records whether a signer voted and whether the vote carried the
     /// authoritative proposal. The former suppresses duplicates and cross-phase
@@ -197,8 +195,11 @@ pub struct VoteTracker<S: Scheme, D: Digest> {
     finalizes: Option<AttributableMap<Finalize<S, D>>>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 /// Outcome of recording a vote in its phase-specific lifecycle state.
+///
+/// A vote can be newly observed without being retained after its phase has
+/// certified, so callers need these states independently.
+#[cfg(not(target_arch = "wasm32"))]
 pub(crate) struct VoteRecord {
     /// Whether the signer was newly recorded in this phase.
     pub inserted: bool,
@@ -206,7 +207,6 @@ pub(crate) struct VoteRecord {
     pub retained: bool,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     const NOTARIZE_SEEN: u8 = 1 << 0;
     const NOTARIZE_HAS_PROPOSAL: u8 = 1 << 1;
@@ -228,7 +228,10 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
             finalizes: Some(AttributableMap::new(participants)),
         }
     }
+}
 
+#[cfg(not(target_arch = "wasm32"))]
+impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     /// Records signer facts after the phase's full vote map has been released.
     ///
     /// The facts are monotonic until the phase is cleared. In particular, a matching
@@ -294,7 +297,6 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
-    /// Returns whether compact post-certificate state contains `flag` for `signer`.
     fn remembered(&self, signer: Participant, flag: u8) -> bool {
         self.compacted
             .get(usize::from(signer))
@@ -440,7 +442,9 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
             |vote: &Finalize<S, D>| &vote.proposal == proposal,
         );
     }
+}
 
+impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     fn clear_compacted(&mut self, cleared: u8) {
         for flags in &mut self.compacted {
             *flags &= !cleared;

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -173,10 +173,15 @@ impl<T: Attributable> AttributableMap<T> {
 /// Tracks notarize/nullify/finalize votes for a view.
 ///
 /// Each vote type is stored in its own lazily allocated [`AttributableMap`] so a
-/// validator can only contribute one vote per phase. Full votes are released once
-/// their certificate exists. Compact signer state remains available for forwarding
-/// and duplicate suppression.
+/// validator can only contribute one vote per phase. Unless configured for retention,
+/// full votes are released once their certificate exists. Compact signer state remains
+/// available for forwarding and duplicate suppression.
 pub struct VoteTracker<S: Scheme, D: Digest> {
+    /// Whether full votes remain available after their phase is certified.
+    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    retain_votes_after_certification: bool,
+    /// Vote phases that have transitioned to compact storage.
+    compacted_phases: u8,
     /// Per-phase signer and proposal-match flags retained after full votes are released.
     compacted: Vec<u8>,
     /// Per-signer notarize votes keyed by validator index.
@@ -191,6 +196,10 @@ pub struct VoteTracker<S: Scheme, D: Digest> {
 }
 
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
+    const NOTARIZATION_COMPACTED: u8 = 1 << 0;
+    const NULLIFICATION_COMPACTED: u8 = 1 << 1;
+    const FINALIZATION_COMPACTED: u8 = 1 << 2;
+
     const NOTARIZE_SEEN: u8 = 1 << 0;
     const NOTARIZE_MATCHING: u8 = 1 << 1;
     const NULLIFY_SEEN: u8 = 1 << 2;
@@ -198,8 +207,13 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     const FINALIZE_MATCHING: u8 = 1 << 4;
 
     /// Creates a tracker sized for `participants` validators.
-    pub const fn new(participants: usize) -> Self {
+    ///
+    /// When `retain_votes_after_certification` is `false`, each phase transitions to
+    /// compact storage once its certificate is recorded.
+    pub const fn new(participants: usize, retain_votes_after_certification: bool) -> Self {
         Self {
+            retain_votes_after_certification,
+            compacted_phases: 0,
             compacted: Vec::new(),
             notarizes: AttributableMap::new(participants),
             nullifies: AttributableMap::new(participants),
@@ -210,6 +224,28 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
+    const fn compacted_phase(vote: &Vote<S, D>) -> u8 {
+        match vote {
+            Vote::Notarize(_) => Self::NOTARIZATION_COMPACTED,
+            Vote::Nullify(_) => Self::NULLIFICATION_COMPACTED,
+            Vote::Finalize(_) => Self::FINALIZATION_COMPACTED,
+        }
+    }
+
+    /// Returns whether the full vote will be retained.
+    pub(crate) const fn retains_full(&self, vote: &Vote<S, D>) -> bool {
+        self.retain_votes_after_certification
+            || self.compacted_phases & Self::compacted_phase(vote) == 0
+    }
+
+    const fn compact_phase(&mut self, phase: u8) -> bool {
+        if self.retain_votes_after_certification {
+            return false;
+        }
+        self.compacted_phases |= phase;
+        true
+    }
+
     fn remember(&mut self, signer: Participant, seen: u8, matching: Option<u8>) -> bool {
         let index = usize::from(signer);
         let participants = self.notarizes.participants;
@@ -233,6 +269,26 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         self.compacted
             .get(usize::from(signer))
             .is_some_and(|flags| flags & flag != 0)
+    }
+
+    /// Records a vote in full or as compact post-certificate state.
+    ///
+    /// `proposal` is the authoritative proposal, when known, and preserves
+    /// proposal-match state when the full vote is not retained.
+    pub(crate) fn record(&mut self, vote: &Vote<S, D>, proposal: Option<&Proposal<D>>) -> bool {
+        let retain_full = self.retains_full(vote);
+        match vote {
+            Vote::Notarize(notarize) if retain_full => self.insert_notarize(notarize.clone()),
+            Vote::Notarize(notarize) => {
+                self.remember_notarize(notarize.signer(), proposal == Some(&notarize.proposal))
+            }
+            Vote::Nullify(nullify) if retain_full => self.insert_nullify(nullify.clone()),
+            Vote::Nullify(nullify) => self.remember_nullify(nullify.signer()),
+            Vote::Finalize(finalize) if retain_full => self.insert_finalize(finalize.clone()),
+            Vote::Finalize(finalize) => {
+                self.remember_finalize(finalize.signer(), proposal == Some(&finalize.proposal))
+            }
+        }
     }
 
     fn release<T: Attributable>(
@@ -297,6 +353,9 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases notarize votes while retaining compact signer state.
     pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
+        if !self.compact_phase(Self::NOTARIZATION_COMPACTED) {
+            return;
+        }
         let participants = self.notarizes.participants;
         Self::release(
             participants,
@@ -310,6 +369,9 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases nullify votes while retaining compact signer state.
     pub(crate) fn release_nullifies(&mut self) {
+        if !self.compact_phase(Self::NULLIFICATION_COMPACTED) {
+            return;
+        }
         let participants = self.nullifies.participants;
         Self::release(
             participants,
@@ -323,6 +385,9 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases finalize votes while retaining compact signer state.
     pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
+        if !self.compact_phase(Self::FINALIZATION_COMPACTED) {
+            return;
+        }
         let participants = self.finalizes.participants;
         Self::release(
             participants,
@@ -420,18 +485,21 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     /// Clears all notarize votes and releases their storage.
     pub fn clear_notarizes(&mut self) {
         self.notarizes.clear();
+        self.compacted_phases &= !Self::NOTARIZATION_COMPACTED;
         self.clear_compacted(Self::NOTARIZE_SEEN | Self::NOTARIZE_MATCHING);
     }
 
     /// Clears all nullify votes and releases their storage.
     pub fn clear_nullifies(&mut self) {
         self.nullifies.clear();
+        self.compacted_phases &= !Self::NULLIFICATION_COMPACTED;
         self.clear_compacted(Self::NULLIFY_SEEN);
     }
 
     /// Clears all finalize votes and releases their storage.
     pub fn clear_finalizes(&mut self) {
         self.finalizes.clear();
+        self.compacted_phases &= !Self::FINALIZATION_COMPACTED;
         self.clear_compacted(Self::FINALIZE_SEEN | Self::FINALIZE_MATCHING);
     }
 }
@@ -3647,7 +3715,7 @@ mod tests {
 
     #[test]
     fn test_vote_tracker_clears_compacted_state() {
-        let mut tracker = VoteTracker::<ed25519::Scheme, Sha256>::new(2);
+        let mut tracker = VoteTracker::<ed25519::Scheme, Sha256>::new(2, false);
         let signer = Participant::new(1);
         let proposal = Proposal::new(
             Round::new(Epoch::new(0), View::new(1)),
@@ -3671,6 +3739,45 @@ mod tests {
 
         tracker.clear_finalizes();
         assert!(!tracker.has_finalize_for(signer, &proposal));
+    }
+
+    #[test]
+    fn test_vote_tracker_retention_policy() {
+        let mut rng = test_rng();
+        let fixture = ed25519::fixture(&mut rng, NAMESPACE, 2);
+        let proposal = Proposal::new(
+            Round::new(Epoch::new(0), View::new(1)),
+            View::zero(),
+            sample_digest(1),
+        );
+        let notarize = Notarize::sign(&fixture.schemes[0], proposal.clone()).unwrap();
+        let signer = notarize.signer();
+        let vote = Vote::Notarize(notarize);
+
+        let mut releasing = VoteTracker::new(2, false);
+        assert!(releasing.record(&vote, Some(&proposal)));
+        assert!(releasing.notarizes.data.capacity() >= 2);
+        releasing.release_notarizes(&proposal);
+        assert_eq!(releasing.notarizes.data.capacity(), 0);
+        assert!(!releasing.retains_full(&vote));
+        assert!(!releasing.record(&vote, Some(&proposal)));
+
+        // A certificate can arrive before any individual votes. Subsequent votes
+        // must use compact storage instead of recreating the released full map.
+        let mut certificate_first = VoteTracker::new(2, false);
+        certificate_first.release_notarizes(&proposal);
+        assert!(!certificate_first.retains_full(&vote));
+        assert!(certificate_first.record(&vote, Some(&proposal)));
+        assert_eq!(certificate_first.notarizes.data.capacity(), 0);
+        assert!(!certificate_first.record(&vote, Some(&proposal)));
+
+        let mut retaining = VoteTracker::new(2, true);
+        assert!(retaining.record(&vote, Some(&proposal)));
+        let retained_capacity = retaining.notarizes.data.capacity();
+        retaining.release_notarizes(&proposal);
+        assert!(retaining.retains_full(&vote));
+        assert_eq!(retaining.notarizes.data.capacity(), retained_capacity);
+        assert!(retaining.notarize(signer).is_some());
     }
 
     #[test]

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -614,12 +614,6 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         self.clear_compacted(Self::NOTARIZE_SEEN | Self::NOTARIZE_HAS_PROPOSAL);
     }
 
-    /// Clears all nullify votes and releases their storage.
-    pub fn clear_nullifies(&mut self) {
-        self.nullifies.reset(self.participants);
-        self.clear_compacted(Self::NULLIFY_SEEN);
-    }
-
     /// Clears all finalize votes and releases their storage.
     pub fn clear_finalizes(&mut self) {
         self.finalizes.reset(self.participants);
@@ -3846,18 +3840,12 @@ mod tests {
         let scheme = &fixture.schemes[usize::from(signer)];
         let proposal = Proposal::new(round, View::zero(), sample_digest(1));
         let notarize = Vote::Notarize(Notarize::sign(scheme, proposal.clone()).unwrap());
-        let nullify = Vote::Nullify(Nullify::sign::<Sha256>(scheme, round).unwrap());
         let finalize = Vote::Finalize(Finalize::sign(scheme, proposal.clone()).unwrap());
 
         tracker.release_notarizes(&proposal);
-        tracker.release_nullifies();
         tracker.release_finalizes(&proposal);
         assert!(matches!(
             tracker.record(&notarize, Some(&proposal)),
-            Outcome::Added { retained: false }
-        ));
-        assert!(matches!(
-            tracker.record(&nullify, Some(&proposal)),
             Outcome::Added { retained: false }
         ));
         assert!(matches!(
@@ -3865,23 +3853,12 @@ mod tests {
             Outcome::Added { retained: false }
         ));
         assert!(tracker.has_notarize_for(signer, &proposal));
-        assert!(matches!(
-            tracker.saw_nullify(signer),
-            Some(ObservedVote::Compacted)
-        ));
         assert!(tracker.has_finalize_for(signer, &proposal));
 
         tracker.clear_notarizes();
         assert!(!tracker.has_notarize_for(signer, &proposal));
         assert!(matches!(
             tracker.record(&notarize, Some(&proposal)),
-            Outcome::Added { retained: true }
-        ));
-
-        tracker.clear_nullifies();
-        assert!(tracker.saw_nullify(signer).is_none());
-        assert!(matches!(
-            tracker.record(&nullify, Some(&proposal)),
             Outcome::Added { retained: true }
         ));
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -177,7 +177,6 @@ impl<T: Attributable> AttributableMap<T> {
 /// their certificate exists. Compact signer state remains available for forwarding
 /// and duplicate suppression.
 pub struct VoteTracker<S: Scheme, D: Digest> {
-    participants: usize,
     /// Per-phase signer and proposal-match flags retained after full votes are released.
     compacted: Vec<u8>,
     /// Per-signer notarize votes keyed by validator index.
@@ -201,21 +200,24 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     /// Creates a tracker sized for `participants` validators.
     pub const fn new(participants: usize) -> Self {
         Self {
-            participants,
             compacted: Vec::new(),
             notarizes: AttributableMap::new(participants),
             nullifies: AttributableMap::new(participants),
             finalizes: AttributableMap::new(participants),
         }
     }
+}
 
+#[cfg(not(target_arch = "wasm32"))]
+impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     fn remember(&mut self, signer: Participant, seen: u8, matching: Option<u8>) -> bool {
         let index = usize::from(signer);
-        if index >= self.participants {
+        let participants = self.notarizes.participants;
+        if index >= participants {
             return false;
         }
         if self.compacted.is_empty() {
-            self.compacted.resize(self.participants, 0);
+            self.compacted.resize(participants, 0);
         }
 
         let flags = &mut self.compacted[index];
@@ -278,11 +280,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     }
 
     /// Returns whether `signer` is known to have notarized `proposal`.
-    pub(crate) fn has_notarize_for(
-        &self,
-        signer: Participant,
-        proposal: &Proposal<D>,
-    ) -> bool {
+    pub(crate) fn has_notarize_for(&self, signer: Participant, proposal: &Proposal<D>) -> bool {
         self.remembered(signer, Self::NOTARIZE_MATCHING)
             || self
                 .notarize(signer)
@@ -290,11 +288,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     }
 
     /// Returns whether `signer` is known to have finalized `proposal`.
-    pub(crate) fn has_finalize_for(
-        &self,
-        signer: Participant,
-        proposal: &Proposal<D>,
-    ) -> bool {
+    pub(crate) fn has_finalize_for(&self, signer: Participant, proposal: &Proposal<D>) -> bool {
         self.remembered(signer, Self::FINALIZE_MATCHING)
             || self
                 .finalize(signer)
@@ -303,22 +297,22 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases notarize votes while retaining compact signer state.
     pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
+        let participants = self.notarizes.participants;
         Self::release(
-            self.participants,
+            participants,
             &mut self.compacted,
             &mut self.notarizes,
             Self::NOTARIZE_SEEN,
             Self::NOTARIZE_MATCHING,
-            |vote: &Notarize<S, D>| {
-                &vote.proposal == proposal
-            },
+            |vote: &Notarize<S, D>| &vote.proposal == proposal,
         );
     }
 
     /// Releases nullify votes while retaining compact signer state.
     pub(crate) fn release_nullifies(&mut self) {
+        let participants = self.nullifies.participants;
         Self::release(
-            self.participants,
+            participants,
             &mut self.compacted,
             &mut self.nullifies,
             Self::NULLIFY_SEEN,
@@ -329,16 +323,23 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases finalize votes while retaining compact signer state.
     pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
+        let participants = self.finalizes.participants;
         Self::release(
-            self.participants,
+            participants,
             &mut self.compacted,
             &mut self.finalizes,
             Self::FINALIZE_SEEN,
             Self::FINALIZE_MATCHING,
-            |vote: &Finalize<S, D>| {
-                &vote.proposal == proposal
-            },
+            |vote: &Finalize<S, D>| &vote.proposal == proposal,
         );
+    }
+}
+
+impl<S: Scheme, D: Digest> VoteTracker<S, D> {
+    fn clear_compacted(&mut self, phases: u8) {
+        for flags in &mut self.compacted {
+            *flags &= !phases;
+        }
     }
 
     /// Inserts a notarize vote if the signer has not already voted.
@@ -419,25 +420,19 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     /// Clears all notarize votes and releases their storage.
     pub fn clear_notarizes(&mut self) {
         self.notarizes.clear();
-        for flags in &mut self.compacted {
-            *flags &= !(Self::NOTARIZE_SEEN | Self::NOTARIZE_MATCHING);
-        }
+        self.clear_compacted(Self::NOTARIZE_SEEN | Self::NOTARIZE_MATCHING);
     }
 
     /// Clears all nullify votes and releases their storage.
     pub fn clear_nullifies(&mut self) {
         self.nullifies.clear();
-        for flags in &mut self.compacted {
-            *flags &= !Self::NULLIFY_SEEN;
-        }
+        self.clear_compacted(Self::NULLIFY_SEEN);
     }
 
     /// Clears all finalize votes and releases their storage.
     pub fn clear_finalizes(&mut self) {
         self.finalizes.clear();
-        for flags in &mut self.compacted {
-            *flags &= !(Self::FINALIZE_SEEN | Self::FINALIZE_MATCHING);
-        }
+        self.clear_compacted(Self::FINALIZE_SEEN | Self::FINALIZE_MATCHING);
     }
 }
 
@@ -3648,6 +3643,34 @@ mod tests {
         let mut iter = map.iter();
         assert!(matches!(iter.next(), Some(a) if a.signer() == Participant::new(2)));
         assert!(iter.next().is_none());
+    }
+
+    #[test]
+    fn test_vote_tracker_clears_compacted_state() {
+        let mut tracker = VoteTracker::<ed25519::Scheme, Sha256>::new(2);
+        let signer = Participant::new(1);
+        let proposal = Proposal::new(
+            Round::new(Epoch::new(0), View::new(1)),
+            View::zero(),
+            sample_digest(1),
+        );
+
+        assert!(tracker.remember_notarize(signer, true));
+        assert!(tracker.remember_nullify(signer));
+        assert!(tracker.remember_finalize(signer, true));
+        assert!(!tracker.remember_notarize(Participant::new(2), true));
+        assert!(tracker.has_notarize_for(signer, &proposal));
+        assert!(tracker.has_finalize_for(signer, &proposal));
+
+        tracker.clear_notarizes();
+        assert!(!tracker.has_notarize_for(signer, &proposal));
+
+        assert!(!tracker.remember_nullify(signer));
+        tracker.clear_nullifies();
+        assert!(tracker.remember_nullify(signer));
+
+        tracker.clear_finalizes();
+        assert!(!tracker.has_finalize_for(signer, &proposal));
     }
 
     #[test]

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -170,7 +170,7 @@ impl<T: Attributable> AttributableMap<T> {
     }
 }
 
-/// Full vote storage for a phase, or its compacted lifecycle marker.
+/// Full vote storage for a phase, or a marker that its certificate was recorded.
 #[cfg(not(target_arch = "wasm32"))]
 enum Phase<T: Attributable> {
     Full(AttributableMap<T>),
@@ -228,22 +228,19 @@ impl<T: Attributable> Phase<T> {
 /// Tracks notarize/nullify/finalize votes for a view.
 ///
 /// Each vote type is stored in its own lazily allocated phase so a validator can
-/// contribute at most one vote per phase. Once certified, a phase can drop its full
-/// votes while compact signer facts preserve forwarding and duplicate suppression.
+/// contribute at most one vote per phase. After certification, compact signer facts
+/// can replace full votes while preserving forwarding, duplicate suppression, and
+/// compact conflict detection.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct VoteTracker<S: Scheme, D: Digest> {
     participants: usize,
     retain_votes_after_certification: bool,
     /// Compact state records whether a signer voted and whether the vote carried the
-    /// authoritative proposal. The former suppresses duplicates and cross-phase
-    /// conflicts; the latter avoids forwarding blocks to validators that already have them.
+    /// authoritative proposal. The first fact suppresses duplicates and cross-phase
+    /// conflicts. The second avoids forwarding a block to validators that already have it.
     compacted: Vec<u8>,
-    /// Per-signer notarize phase.
     notarizes: Phase<Notarize<S, D>>,
-    /// Per-signer nullify phase.
     nullifies: Phase<Nullify<S>>,
-    /// Per-signer finalize phase.
-    ///
     /// Finalize votes include the proposal digest so the entire certificate can be
     /// reconstructed once the quorum threshold is hit.
     finalizes: Phase<Finalize<S, D>>,
@@ -260,12 +257,10 @@ pub(crate) enum Outcome {
     Conflicting,
 }
 
-/// A recorded vote that may no longer be retained in full.
+/// A recorded vote retained in full or represented by compact signer state.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) enum ObservedVote<'a, T> {
-    /// The full vote remains available.
     Retained(&'a T),
-    /// Only compact signer state remains.
     Compacted,
 }
 
@@ -279,8 +274,9 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Creates a tracker sized for `participants` validators.
     ///
-    /// If `retain_votes_after_certification` is false, full votes are released
-    /// once their phase certifies.
+    /// When `retain_votes_after_certification` is false, full votes are released
+    /// once their phase certifies. Otherwise they remain until explicitly cleared
+    /// or the tracker is dropped.
     pub const fn new(participants: usize, retain_votes_after_certification: bool) -> Self {
         Self {
             participants,
@@ -295,11 +291,10 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
-    /// Records signer facts after the phase's full vote map has been released.
+    /// Records monotonic signer facts after a phase releases its full vote map.
     ///
-    /// The facts are monotonic until the phase is cleared. In particular, a matching
-    /// vote may establish that the signer has the authoritative proposal even when a
-    /// vote from that signer was already observed.
+    /// A later matching vote can record that the signer has the authoritative
+    /// proposal even when the signer was already observed.
     fn remember(
         participants: usize,
         compacted: &mut Vec<u8>,
@@ -373,8 +368,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Records a vote in full or as compact post-certificate state.
     ///
-    /// `proposal` is the authoritative proposal, when known, and preserves
-    /// proposal-match state when the full vote is not retained.
+    /// `proposal` identifies the authoritative proposal used for compact match state.
     pub(crate) fn record(&mut self, vote: &Vote<S, D>, proposal: Option<&Proposal<D>>) -> Outcome {
         match vote {
             Vote::Notarize(notarize) => Self::record_phase(
@@ -408,8 +402,8 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Moves a phase from full vote storage to compact signer state.
     ///
-    /// Taking the map makes the transition idempotent. Empty phases stay
-    /// allocation-free, while existing signer and proposal-ownership facts survive.
+    /// Taking the map makes the transition idempotent. Empty phases remain
+    /// allocation-free, while existing signer and proposal-match facts survive.
     fn release<T: Attributable>(
         participants: usize,
         compacted: &mut Vec<u8>,
@@ -428,7 +422,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
             compacted.resize(participants, 0);
         }
 
-        // Proposal bits are relative to the certificate-backed authoritative proposal.
+        // Proposal-match bits are relative to the certificate-backed proposal.
         for vote in votes.iter() {
             let flags = &mut compacted[usize::from(vote.signer())];
             *flags |= seen;
@@ -438,7 +432,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
-    /// Returns a previously observed nullify vote, including compact state.
+    /// Returns the retained or compact state for a previously observed nullify vote.
     pub(crate) fn saw_nullify(&self, signer: Participant) -> Option<ObservedVote<'_, Nullify<S>>> {
         self.nullify(signer)
             .map(ObservedVote::Retained)
@@ -448,7 +442,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
             })
     }
 
-    /// Returns a previously observed finalize vote, including compact state.
+    /// Returns the retained or compact state for a previously observed finalize vote.
     pub(crate) fn saw_finalize(
         &self,
         signer: Participant,
@@ -461,7 +455,8 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
             })
     }
 
-    /// Returns whether `signer` is known to have the authoritative proposal from notarizing it.
+    /// Returns whether `signer` is known to have the authoritative proposal
+    /// from notarizing it.
     pub(crate) fn has_notarize_for(&self, signer: Participant, proposal: &Proposal<D>) -> bool {
         self.remembered(signer, Self::NOTARIZE_HAS_PROPOSAL)
             || self
@@ -469,7 +464,8 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
                 .is_some_and(|vote| &vote.proposal == proposal)
     }
 
-    /// Returns whether `signer` is known to have the authoritative proposal from finalizing it.
+    /// Returns whether `signer` is known to have the authoritative proposal
+    /// from finalizing it.
     pub(crate) fn has_finalize_for(&self, signer: Participant, proposal: &Proposal<D>) -> bool {
         self.remembered(signer, Self::FINALIZE_HAS_PROPOSAL)
             || self
@@ -477,7 +473,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
                 .is_some_and(|vote| &vote.proposal == proposal)
     }
 
-    /// Releases notarize votes while retaining compact signer state.
+    /// Releases notarize votes unless full evidence is configured for retention.
     pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
         if self.retain_votes_after_certification {
             return;
@@ -492,7 +488,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         );
     }
 
-    /// Releases nullify votes while retaining compact signer state.
+    /// Releases nullify votes unless full evidence is configured for retention.
     pub(crate) fn release_nullifies(&mut self) {
         if self.retain_votes_after_certification {
             return;
@@ -507,7 +503,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         );
     }
 
-    /// Releases finalize votes while retaining compact signer state.
+    /// Releases finalize votes unless full evidence is configured for retention.
     pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
         if self.retain_votes_after_certification {
             return;

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -341,39 +341,6 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
-    #[cfg(test)]
-    fn remember_notarize(&mut self, signer: Participant, has_proposal: bool) -> bool {
-        Self::remember(
-            self.participants,
-            &mut self.compacted,
-            signer,
-            Self::NOTARIZE_SEEN,
-            has_proposal.then_some(Self::NOTARIZE_HAS_PROPOSAL),
-        )
-    }
-
-    #[cfg(test)]
-    fn remember_nullify(&mut self, signer: Participant) -> bool {
-        Self::remember(
-            self.participants,
-            &mut self.compacted,
-            signer,
-            Self::NULLIFY_SEEN,
-            None,
-        )
-    }
-
-    #[cfg(test)]
-    fn remember_finalize(&mut self, signer: Participant, has_proposal: bool) -> bool {
-        Self::remember(
-            self.participants,
-            &mut self.compacted,
-            signer,
-            Self::FINALIZE_SEEN,
-            has_proposal.then_some(Self::FINALIZE_HAS_PROPOSAL),
-        )
-    }
-
     /// Returns whether `signer` previously nullified, including compact state.
     pub(crate) fn saw_nullify(&self, signer: Participant) -> bool {
         self.nullify(signer).is_some() || self.remembered(signer, Self::NULLIFY_SEEN)
@@ -3766,30 +3733,38 @@ mod tests {
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_vote_tracker_clears_compacted_state() {
+        let mut rng = test_rng();
+        let fixture = ed25519::fixture(&mut rng, NAMESPACE, 2);
+        let round = Round::new(Epoch::new(0), View::new(1));
         let mut tracker = VoteTracker::<ed25519::Scheme, Sha256>::new(2, false);
         let signer = Participant::new(1);
-        let proposal = Proposal::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            View::zero(),
-            sample_digest(1),
-        );
+        let scheme = &fixture.schemes[usize::from(signer)];
+        let proposal = Proposal::new(round, View::zero(), sample_digest(1));
+        let notarize = Vote::Notarize(Notarize::sign(scheme, proposal.clone()).unwrap());
+        let nullify = Vote::Nullify(Nullify::sign::<Sha256>(scheme, round).unwrap());
+        let finalize = Vote::Finalize(Finalize::sign(scheme, proposal.clone()).unwrap());
 
-        assert!(tracker.remember_notarize(signer, true));
-        assert!(tracker.remember_nullify(signer));
-        assert!(tracker.remember_finalize(signer, true));
-        assert!(!tracker.remember_notarize(Participant::new(2), true));
+        tracker.release_notarizes(&proposal);
+        tracker.release_nullifies();
+        tracker.release_finalizes(&proposal);
+        assert!(tracker.record(&notarize, Some(&proposal)).inserted);
+        assert!(tracker.record(&nullify, Some(&proposal)).inserted);
+        assert!(tracker.record(&finalize, Some(&proposal)).inserted);
         assert!(tracker.has_notarize_for(signer, &proposal));
+        assert!(tracker.saw_nullify(signer));
         assert!(tracker.has_finalize_for(signer, &proposal));
 
         tracker.clear_notarizes();
         assert!(!tracker.has_notarize_for(signer, &proposal));
+        assert!(tracker.record(&notarize, Some(&proposal)).inserted);
 
-        assert!(!tracker.remember_nullify(signer));
         tracker.clear_nullifies();
-        assert!(tracker.remember_nullify(signer));
+        assert!(!tracker.saw_nullify(signer));
+        assert!(tracker.record(&nullify, Some(&proposal)).inserted);
 
         tracker.clear_finalizes();
         assert!(!tracker.has_finalize_for(signer, &proposal));
+        assert!(tracker.record(&finalize, Some(&proposal)).inserted);
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -173,96 +173,106 @@ impl<T: Attributable> AttributableMap<T> {
 /// Tracks notarize/nullify/finalize votes for a view.
 ///
 /// Each vote type is stored in its own lazily allocated [`AttributableMap`] so a
-/// validator can only contribute one vote per phase. Unless configured for retention,
-/// full votes are released once their certificate exists. Compact signer state remains
-/// available for forwarding and duplicate suppression.
+/// validator can only contribute one vote per phase. Unless extended conflict reporting
+/// is enabled, full votes are released once their certificate exists. Compact signer
+/// state remains available for forwarding and duplicate suppression.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct VoteTracker<S: Scheme, D: Digest> {
-    /// Whether full votes remain available after their phase is certified.
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
+    participants: usize,
     retain_votes_after_certification: bool,
-    /// Vote phases that have transitioned to compact storage.
-    compacted_phases: u8,
-    /// Per-phase signer and proposal-match flags retained after full votes are released.
+    /// Compact state records whether a signer voted and whether the vote carried the
+    /// authoritative proposal. The former suppresses duplicates and cross-phase
+    /// conflicts; the latter avoids forwarding blocks to validators that already have them.
     compacted: Vec<u8>,
-    /// Per-signer notarize votes keyed by validator index.
-    notarizes: AttributableMap<Notarize<S, D>>,
-    /// Per-signer nullify votes keyed by validator index.
-    nullifies: AttributableMap<Nullify<S>>,
-    /// Per-signer finalize votes keyed by validator index.
+    /// Per-signer notarize votes, or `None` after compaction.
+    notarizes: Option<AttributableMap<Notarize<S, D>>>,
+    /// Per-signer nullify votes, or `None` after compaction.
+    nullifies: Option<AttributableMap<Nullify<S>>>,
+    /// Per-signer finalize votes, or `None` after compaction.
     ///
     /// Finalize votes include the proposal digest so the entire certificate can be
     /// reconstructed once the quorum threshold is hit.
-    finalizes: AttributableMap<Finalize<S, D>>,
+    finalizes: Option<AttributableMap<Finalize<S, D>>>,
 }
 
-impl<S: Scheme, D: Digest> VoteTracker<S, D> {
-    const NOTARIZATION_COMPACTED: u8 = 1 << 0;
-    const NULLIFICATION_COMPACTED: u8 = 1 << 1;
-    const FINALIZATION_COMPACTED: u8 = 1 << 2;
-
-    const NOTARIZE_SEEN: u8 = 1 << 0;
-    const NOTARIZE_MATCHING: u8 = 1 << 1;
-    const NULLIFY_SEEN: u8 = 1 << 2;
-    const FINALIZE_SEEN: u8 = 1 << 3;
-    const FINALIZE_MATCHING: u8 = 1 << 4;
-
-    /// Creates a tracker sized for `participants` validators.
-    ///
-    /// When `retain_votes_after_certification` is `false`, each phase transitions to
-    /// compact storage once its certificate is recorded.
-    pub const fn new(participants: usize, retain_votes_after_certification: bool) -> Self {
-        Self {
-            retain_votes_after_certification,
-            compacted_phases: 0,
-            compacted: Vec::new(),
-            notarizes: AttributableMap::new(participants),
-            nullifies: AttributableMap::new(participants),
-            finalizes: AttributableMap::new(participants),
-        }
-    }
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) struct VoteRecord {
+    pub inserted: bool,
+    pub retained: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
-    const fn compacted_phase(vote: &Vote<S, D>) -> u8 {
-        match vote {
-            Vote::Notarize(_) => Self::NOTARIZATION_COMPACTED,
-            Vote::Nullify(_) => Self::NULLIFICATION_COMPACTED,
-            Vote::Finalize(_) => Self::FINALIZATION_COMPACTED,
+    const NOTARIZE_SEEN: u8 = 1 << 0;
+    const NOTARIZE_HAS_PROPOSAL: u8 = 1 << 1;
+    const NULLIFY_SEEN: u8 = 1 << 2;
+    const FINALIZE_SEEN: u8 = 1 << 3;
+    const FINALIZE_HAS_PROPOSAL: u8 = 1 << 4;
+
+    /// Creates a tracker sized for `participants` validators.
+    ///
+    /// Unless `retain_votes_after_certification` is enabled, each vote map transitions
+    /// to compact storage once its certificate is recorded.
+    pub const fn new(participants: usize, retain_votes_after_certification: bool) -> Self {
+        Self {
+            participants,
+            retain_votes_after_certification,
+            compacted: Vec::new(),
+            notarizes: Some(AttributableMap::new(participants)),
+            nullifies: Some(AttributableMap::new(participants)),
+            finalizes: Some(AttributableMap::new(participants)),
         }
     }
 
-    /// Returns whether the full vote will be retained.
-    pub(crate) const fn retains_full(&self, vote: &Vote<S, D>) -> bool {
-        self.retain_votes_after_certification
-            || self.compacted_phases & Self::compacted_phase(vote) == 0
-    }
-
-    const fn compact_phase(&mut self, phase: u8) -> bool {
-        if self.retain_votes_after_certification {
-            return false;
-        }
-        self.compacted_phases |= phase;
-        true
-    }
-
-    fn remember(&mut self, signer: Participant, seen: u8, matching: Option<u8>) -> bool {
+    fn remember(
+        participants: usize,
+        compacted: &mut Vec<u8>,
+        signer: Participant,
+        seen: u8,
+        has_proposal: Option<u8>,
+    ) -> bool {
         let index = usize::from(signer);
-        let participants = self.notarizes.participants;
         if index >= participants {
             return false;
         }
-        if self.compacted.is_empty() {
-            self.compacted.resize(participants, 0);
+        if compacted.is_empty() {
+            compacted.resize(participants, 0);
         }
 
-        let flags = &mut self.compacted[index];
+        let flags = &mut compacted[index];
         let inserted = *flags & seen == 0;
         *flags |= seen;
-        if let Some(matching) = matching {
-            *flags |= matching;
+        if let Some(has_proposal) = has_proposal {
+            *flags |= has_proposal;
         }
         inserted
+    }
+
+    fn record_phase<T: Attributable>(
+        participants: usize,
+        compacted: &mut Vec<u8>,
+        votes: &mut Option<AttributableMap<T>>,
+        vote: T,
+        seen: u8,
+        has_proposal: Option<u8>,
+    ) -> VoteRecord {
+        let Some(votes) = votes else {
+            return VoteRecord {
+                inserted: Self::remember(
+                    participants,
+                    compacted,
+                    vote.signer(),
+                    seen,
+                    has_proposal,
+                ),
+                retained: false,
+            };
+        };
+
+        VoteRecord {
+            inserted: votes.insert(vote),
+            retained: true,
+        }
     }
 
     fn remembered(&self, signer: Participant, flag: u8) -> bool {
@@ -275,77 +285,116 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     ///
     /// `proposal` is the authoritative proposal, when known, and preserves
     /// proposal-match state when the full vote is not retained.
-    pub(crate) fn record(&mut self, vote: &Vote<S, D>, proposal: Option<&Proposal<D>>) -> bool {
-        let retain_full = self.retains_full(vote);
+    pub(crate) fn record(
+        &mut self,
+        vote: &Vote<S, D>,
+        proposal: Option<&Proposal<D>>,
+    ) -> VoteRecord {
         match vote {
-            Vote::Notarize(notarize) if retain_full => self.insert_notarize(notarize.clone()),
-            Vote::Notarize(notarize) => {
-                self.remember_notarize(notarize.signer(), proposal == Some(&notarize.proposal))
-            }
-            Vote::Nullify(nullify) if retain_full => self.insert_nullify(nullify.clone()),
-            Vote::Nullify(nullify) => self.remember_nullify(nullify.signer()),
-            Vote::Finalize(finalize) if retain_full => self.insert_finalize(finalize.clone()),
-            Vote::Finalize(finalize) => {
-                self.remember_finalize(finalize.signer(), proposal == Some(&finalize.proposal))
-            }
+            Vote::Notarize(notarize) => Self::record_phase(
+                self.participants,
+                &mut self.compacted,
+                &mut self.notarizes,
+                notarize.clone(),
+                Self::NOTARIZE_SEEN,
+                (proposal == Some(&notarize.proposal)).then_some(Self::NOTARIZE_HAS_PROPOSAL),
+            ),
+            Vote::Nullify(nullify) => Self::record_phase(
+                self.participants,
+                &mut self.compacted,
+                &mut self.nullifies,
+                nullify.clone(),
+                Self::NULLIFY_SEEN,
+                None,
+            ),
+            Vote::Finalize(finalize) => Self::record_phase(
+                self.participants,
+                &mut self.compacted,
+                &mut self.finalizes,
+                finalize.clone(),
+                Self::FINALIZE_SEEN,
+                (proposal == Some(&finalize.proposal)).then_some(Self::FINALIZE_HAS_PROPOSAL),
+            ),
         }
     }
 
     fn release<T: Attributable>(
         participants: usize,
         compacted: &mut Vec<u8>,
-        votes: &mut AttributableMap<T>,
+        votes: &mut Option<AttributableMap<T>>,
         seen: u8,
-        matching: u8,
-        is_matching: impl Fn(&T) -> bool,
+        has_proposal: u8,
+        carries_proposal: impl Fn(&T) -> bool,
     ) {
+        let Some(votes) = votes.take() else {
+            return;
+        };
         if !votes.is_empty() && compacted.is_empty() {
             compacted.resize(participants, 0);
         }
         for vote in votes.iter() {
             let flags = &mut compacted[usize::from(vote.signer())];
             *flags |= seen;
-            if is_matching(vote) {
-                *flags |= matching;
+            if carries_proposal(vote) {
+                *flags |= has_proposal;
             }
         }
-        votes.clear();
     }
 
-    /// Remembers a notarize signer without retaining the full vote.
-    pub(crate) fn remember_notarize(&mut self, signer: Participant, matching: bool) -> bool {
-        self.remember(
+    #[cfg(test)]
+    fn remember_notarize(&mut self, signer: Participant, has_proposal: bool) -> bool {
+        Self::remember(
+            self.participants,
+            &mut self.compacted,
             signer,
             Self::NOTARIZE_SEEN,
-            matching.then_some(Self::NOTARIZE_MATCHING),
+            has_proposal.then_some(Self::NOTARIZE_HAS_PROPOSAL),
         )
     }
 
-    /// Remembers a nullify signer without retaining the full vote.
-    pub(crate) fn remember_nullify(&mut self, signer: Participant) -> bool {
-        self.remember(signer, Self::NULLIFY_SEEN, None)
+    #[cfg(test)]
+    fn remember_nullify(&mut self, signer: Participant) -> bool {
+        Self::remember(
+            self.participants,
+            &mut self.compacted,
+            signer,
+            Self::NULLIFY_SEEN,
+            None,
+        )
     }
 
-    /// Remembers a finalize signer without retaining the full vote.
-    pub(crate) fn remember_finalize(&mut self, signer: Participant, matching: bool) -> bool {
-        self.remember(
+    #[cfg(test)]
+    fn remember_finalize(&mut self, signer: Participant, has_proposal: bool) -> bool {
+        Self::remember(
+            self.participants,
+            &mut self.compacted,
             signer,
             Self::FINALIZE_SEEN,
-            matching.then_some(Self::FINALIZE_MATCHING),
+            has_proposal.then_some(Self::FINALIZE_HAS_PROPOSAL),
         )
     }
 
-    /// Returns whether `signer` is known to have notarized `proposal`.
+    /// Returns whether `signer` previously nullified, including compact state.
+    pub(crate) fn saw_nullify(&self, signer: Participant) -> bool {
+        self.nullify(signer).is_some() || self.remembered(signer, Self::NULLIFY_SEEN)
+    }
+
+    /// Returns whether `signer` previously finalized, including compact state.
+    pub(crate) fn saw_finalize(&self, signer: Participant) -> bool {
+        self.finalize(signer).is_some() || self.remembered(signer, Self::FINALIZE_SEEN)
+    }
+
+    /// Returns whether `signer` is known to have the authoritative proposal from notarizing it.
     pub(crate) fn has_notarize_for(&self, signer: Participant, proposal: &Proposal<D>) -> bool {
-        self.remembered(signer, Self::NOTARIZE_MATCHING)
+        self.remembered(signer, Self::NOTARIZE_HAS_PROPOSAL)
             || self
                 .notarize(signer)
                 .is_some_and(|vote| &vote.proposal == proposal)
     }
 
-    /// Returns whether `signer` is known to have finalized `proposal`.
+    /// Returns whether `signer` is known to have the authoritative proposal from finalizing it.
     pub(crate) fn has_finalize_for(&self, signer: Participant, proposal: &Proposal<D>) -> bool {
-        self.remembered(signer, Self::FINALIZE_MATCHING)
+        self.remembered(signer, Self::FINALIZE_HAS_PROPOSAL)
             || self
                 .finalize(signer)
                 .is_some_and(|vote| &vote.proposal == proposal)
@@ -353,28 +402,26 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases notarize votes while retaining compact signer state.
     pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
-        if !self.compact_phase(Self::NOTARIZATION_COMPACTED) {
+        if self.retain_votes_after_certification {
             return;
         }
-        let participants = self.notarizes.participants;
         Self::release(
-            participants,
+            self.participants,
             &mut self.compacted,
             &mut self.notarizes,
             Self::NOTARIZE_SEEN,
-            Self::NOTARIZE_MATCHING,
+            Self::NOTARIZE_HAS_PROPOSAL,
             |vote: &Notarize<S, D>| &vote.proposal == proposal,
         );
     }
 
     /// Releases nullify votes while retaining compact signer state.
     pub(crate) fn release_nullifies(&mut self) {
-        if !self.compact_phase(Self::NULLIFICATION_COMPACTED) {
+        if self.retain_votes_after_certification {
             return;
         }
-        let participants = self.nullifies.participants;
         Self::release(
-            participants,
+            self.participants,
             &mut self.compacted,
             &mut self.nullifies,
             Self::NULLIFY_SEEN,
@@ -385,122 +432,125 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases finalize votes while retaining compact signer state.
     pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
-        if !self.compact_phase(Self::FINALIZATION_COMPACTED) {
+        if self.retain_votes_after_certification {
             return;
         }
-        let participants = self.finalizes.participants;
         Self::release(
-            participants,
+            self.participants,
             &mut self.compacted,
             &mut self.finalizes,
             Self::FINALIZE_SEEN,
-            Self::FINALIZE_MATCHING,
+            Self::FINALIZE_HAS_PROPOSAL,
             |vote: &Finalize<S, D>| &vote.proposal == proposal,
         );
     }
-}
 
-impl<S: Scheme, D: Digest> VoteTracker<S, D> {
-    fn clear_compacted(&mut self, phases: u8) {
+    fn clear_compacted(&mut self, cleared: u8) {
         for flags in &mut self.compacted {
-            *flags &= !phases;
+            *flags &= !cleared;
         }
     }
 
     /// Inserts a notarize vote if the signer has not already voted.
     pub fn insert_notarize(&mut self, vote: Notarize<S, D>) -> bool {
-        self.notarizes.insert(vote)
+        self.notarizes
+            .as_mut()
+            .is_some_and(|votes| votes.insert(vote))
     }
 
     /// Inserts a nullify vote if the signer has not already voted.
     pub fn insert_nullify(&mut self, vote: Nullify<S>) -> bool {
-        self.nullifies.insert(vote)
+        self.nullifies
+            .as_mut()
+            .is_some_and(|votes| votes.insert(vote))
     }
 
     /// Inserts a finalize vote if the signer has not already voted.
     pub fn insert_finalize(&mut self, vote: Finalize<S, D>) -> bool {
-        self.finalizes.insert(vote)
+        self.finalizes
+            .as_mut()
+            .is_some_and(|votes| votes.insert(vote))
     }
 
     /// Returns the notarize vote for `signer`, if present.
     pub fn notarize(&self, signer: Participant) -> Option<&Notarize<S, D>> {
-        self.notarizes.get(signer)
+        self.notarizes.as_ref()?.get(signer)
     }
 
     /// Returns the nullify vote for `signer`, if present.
     pub fn nullify(&self, signer: Participant) -> Option<&Nullify<S>> {
-        self.nullifies.get(signer)
+        self.nullifies.as_ref()?.get(signer)
     }
 
     /// Returns the finalize vote for `signer`, if present.
     pub fn finalize(&self, signer: Participant) -> Option<&Finalize<S, D>> {
-        self.finalizes.get(signer)
+        self.finalizes.as_ref()?.get(signer)
     }
 
     /// Iterates over notarize votes in signer order.
     pub fn iter_notarizes(&self) -> impl Iterator<Item = &Notarize<S, D>> {
-        self.notarizes.iter()
+        self.notarizes.iter().flat_map(|votes| votes.iter())
     }
 
     /// Iterates over nullify votes in signer order.
     pub fn iter_nullifies(&self) -> impl Iterator<Item = &Nullify<S>> {
-        self.nullifies.iter()
+        self.nullifies.iter().flat_map(|votes| votes.iter())
     }
 
     /// Iterates over finalize votes in signer order.
     pub fn iter_finalizes(&self) -> impl Iterator<Item = &Finalize<S, D>> {
-        self.finalizes.iter()
+        self.finalizes.iter().flat_map(|votes| votes.iter())
     }
 
     /// Returns how many notarize votes have been recorded.
     pub fn len_notarizes(&self) -> u32 {
-        u32::try_from(self.notarizes.len()).expect("too many notarize votes")
+        let len = self.notarizes.as_ref().map_or(0, AttributableMap::len);
+        u32::try_from(len).expect("too many notarize votes")
     }
 
     /// Returns how many nullify votes have been recorded.
     pub fn len_nullifies(&self) -> u32 {
-        u32::try_from(self.nullifies.len()).expect("too many nullify votes")
+        let len = self.nullifies.as_ref().map_or(0, AttributableMap::len);
+        u32::try_from(len).expect("too many nullify votes")
     }
 
     /// Returns how many finalize votes have been recorded.
     pub fn len_finalizes(&self) -> u32 {
-        u32::try_from(self.finalizes.len()).expect("too many finalize votes")
+        let len = self.finalizes.as_ref().map_or(0, AttributableMap::len);
+        u32::try_from(len).expect("too many finalize votes")
     }
 
     /// Returns `true` if the given signer has a notarize vote recorded.
     pub fn has_notarize(&self, signer: Participant) -> bool {
-        self.notarizes.get(signer).is_some()
+        self.notarize(signer).is_some()
     }
 
     /// Returns `true` if a nullify vote has been recorded for `signer`.
     pub fn has_nullify(&self, signer: Participant) -> bool {
-        self.nullifies.get(signer).is_some()
+        self.nullify(signer).is_some()
     }
 
     /// Returns `true` if a finalize vote has been recorded for `signer`.
     pub fn has_finalize(&self, signer: Participant) -> bool {
-        self.finalizes.get(signer).is_some()
+        self.finalize(signer).is_some()
     }
 
     /// Clears all notarize votes and releases their storage.
     pub fn clear_notarizes(&mut self) {
-        self.notarizes.clear();
-        self.compacted_phases &= !Self::NOTARIZATION_COMPACTED;
-        self.clear_compacted(Self::NOTARIZE_SEEN | Self::NOTARIZE_MATCHING);
+        self.notarizes = Some(AttributableMap::new(self.participants));
+        self.clear_compacted(Self::NOTARIZE_SEEN | Self::NOTARIZE_HAS_PROPOSAL);
     }
 
     /// Clears all nullify votes and releases their storage.
     pub fn clear_nullifies(&mut self) {
-        self.nullifies.clear();
-        self.compacted_phases &= !Self::NULLIFICATION_COMPACTED;
+        self.nullifies = Some(AttributableMap::new(self.participants));
         self.clear_compacted(Self::NULLIFY_SEEN);
     }
 
     /// Clears all finalize votes and releases their storage.
     pub fn clear_finalizes(&mut self) {
-        self.finalizes.clear();
-        self.compacted_phases &= !Self::FINALIZATION_COMPACTED;
-        self.clear_compacted(Self::FINALIZE_SEEN | Self::FINALIZE_MATCHING);
+        self.finalizes = Some(AttributableMap::new(self.participants));
+        self.clear_compacted(Self::FINALIZE_SEEN | Self::FINALIZE_HAS_PROPOSAL);
     }
 }
 
@@ -3713,6 +3763,7 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_vote_tracker_clears_compacted_state() {
         let mut tracker = VoteTracker::<ed25519::Scheme, Sha256>::new(2, false);
@@ -3741,6 +3792,7 @@ mod tests {
         assert!(!tracker.has_finalize_for(signer, &proposal));
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_vote_tracker_retention_policy() {
         let mut rng = test_rng();
@@ -3755,28 +3807,36 @@ mod tests {
         let vote = Vote::Notarize(notarize);
 
         let mut releasing = VoteTracker::new(2, false);
-        assert!(releasing.record(&vote, Some(&proposal)));
-        assert!(releasing.notarizes.data.capacity() >= 2);
+        let record = releasing.record(&vote, Some(&proposal));
+        assert!(record.inserted);
+        assert!(record.retained);
+        assert!(releasing.notarizes.as_ref().unwrap().data.capacity() >= 2);
         releasing.release_notarizes(&proposal);
-        assert_eq!(releasing.notarizes.data.capacity(), 0);
-        assert!(!releasing.retains_full(&vote));
-        assert!(!releasing.record(&vote, Some(&proposal)));
+        assert!(releasing.notarizes.is_none());
+        let record = releasing.record(&vote, Some(&proposal));
+        assert!(!record.inserted);
+        assert!(!record.retained);
 
         // A certificate can arrive before any individual votes. Subsequent votes
         // must use compact storage instead of recreating the released full map.
         let mut certificate_first = VoteTracker::new(2, false);
         certificate_first.release_notarizes(&proposal);
-        assert!(!certificate_first.retains_full(&vote));
-        assert!(certificate_first.record(&vote, Some(&proposal)));
-        assert_eq!(certificate_first.notarizes.data.capacity(), 0);
-        assert!(!certificate_first.record(&vote, Some(&proposal)));
+        let record = certificate_first.record(&vote, Some(&proposal));
+        assert!(record.inserted);
+        assert!(!record.retained);
+        assert!(certificate_first.notarizes.is_none());
+        assert!(!certificate_first.record(&vote, Some(&proposal)).inserted);
 
         let mut retaining = VoteTracker::new(2, true);
-        assert!(retaining.record(&vote, Some(&proposal)));
-        let retained_capacity = retaining.notarizes.data.capacity();
+        let record = retaining.record(&vote, Some(&proposal));
+        assert!(record.inserted);
+        assert!(record.retained);
+        let retained_capacity = retaining.notarizes.as_ref().unwrap().data.capacity();
         retaining.release_notarizes(&proposal);
-        assert!(retaining.retains_full(&vote));
-        assert_eq!(retaining.notarizes.data.capacity(), retained_capacity);
+        assert_eq!(
+            retaining.notarizes.as_ref().unwrap().data.capacity(),
+            retained_capacity
+        );
         assert!(retaining.notarize(signer).is_some());
     }
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -170,41 +170,96 @@ impl<T: Attributable> AttributableMap<T> {
     }
 }
 
+/// Full vote storage for a phase, or its compacted lifecycle marker.
+enum Phase<T: Attributable> {
+    Full(AttributableMap<T>),
+    Compacted,
+}
+
+impl<T: Attributable> Phase<T> {
+    const fn new(participants: usize) -> Self {
+        Self::Full(AttributableMap::new(participants))
+    }
+
+    fn insert(&mut self, vote: T) -> bool {
+        match self {
+            Self::Full(votes) => votes.insert(vote),
+            Self::Compacted => false,
+        }
+    }
+
+    fn get(&self, signer: Participant) -> Option<&T> {
+        match self {
+            Self::Full(votes) => votes.get(signer),
+            Self::Compacted => None,
+        }
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &T> {
+        match self {
+            Self::Full(votes) => Some(votes),
+            Self::Compacted => None,
+        }
+        .into_iter()
+        .flat_map(AttributableMap::iter)
+    }
+
+    const fn len(&self) -> usize {
+        match self {
+            Self::Full(votes) => votes.len(),
+            Self::Compacted => 0,
+        }
+    }
+
+    fn compact(&mut self) -> Option<AttributableMap<T>> {
+        match std::mem::replace(self, Self::Compacted) {
+            Self::Full(votes) => Some(votes),
+            Self::Compacted => None,
+        }
+    }
+
+    fn reset(&mut self, participants: usize) {
+        *self = Self::new(participants);
+    }
+}
+
 /// Tracks notarize/nullify/finalize votes for a view.
 ///
-/// Each vote type is stored in its own lazily allocated [`AttributableMap`] so a
-/// validator can only contribute one vote per phase. Unless historical conflict reporting
-/// is enabled, full votes are released once their certificate exists. Compact signer state
-/// remains available for forwarding and duplicate suppression.
+/// Each vote type is stored in its own lazily allocated phase so a validator can
+/// contribute at most one vote per phase. Once certified, a phase can drop its full
+/// votes while compact signer facts preserve forwarding and duplicate suppression.
 pub struct VoteTracker<S: Scheme, D: Digest> {
     participants: usize,
     #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
-    retain_recovered_votes: bool,
+    retain_votes_after_certification: bool,
     /// Compact state records whether a signer voted and whether the vote carried the
     /// authoritative proposal. The former suppresses duplicates and cross-phase
     /// conflicts; the latter avoids forwarding blocks to validators that already have them.
     compacted: Vec<u8>,
-    /// Per-signer notarize votes, or `None` after compaction.
-    notarizes: Option<AttributableMap<Notarize<S, D>>>,
-    /// Per-signer nullify votes, or `None` after compaction.
-    nullifies: Option<AttributableMap<Nullify<S>>>,
-    /// Per-signer finalize votes, or `None` after compaction.
+    /// Per-signer notarize phase.
+    notarizes: Phase<Notarize<S, D>>,
+    /// Per-signer nullify phase.
+    nullifies: Phase<Nullify<S>>,
+    /// Per-signer finalize phase.
     ///
     /// Finalize votes include the proposal digest so the entire certificate can be
     /// reconstructed once the quorum threshold is hit.
-    finalizes: Option<AttributableMap<Finalize<S, D>>>,
+    finalizes: Phase<Finalize<S, D>>,
 }
 
 /// Outcome of recording a vote in its phase-specific lifecycle state.
-///
-/// A vote can be newly observed without being retained after its phase has
-/// certified, so callers need these states independently.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) struct VoteRecord {
-    /// Whether the signer was newly recorded in this phase.
-    pub inserted: bool,
-    /// Whether the phase still stores full votes for recovery and conflict evidence.
-    pub retained: bool,
+pub(crate) enum VoteRecord {
+    /// Newly inserted with the full vote retained.
+    NewRetained,
+    /// Newly inserted as compact signer facts.
+    NewCompacted,
+    /// A duplicate while the full vote remains available.
+    DuplicateRetained,
+    /// A duplicate consistent with the compact signer facts.
+    DuplicateCompacted,
+    /// The compact proposal relation proves a same-phase conflict.
+    ConflictingProposal,
 }
 
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
@@ -216,16 +271,16 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Creates a tracker sized for `participants` validators.
     ///
-    /// Unless `retain_recovered_votes` is enabled, each vote map transitions
-    /// to compact storage once its certificate is recorded.
-    pub const fn new(participants: usize, retain_recovered_votes: bool) -> Self {
+    /// If `retain_votes_after_certification` is false, full votes are released
+    /// once their phase certifies.
+    pub const fn new(participants: usize, retain_votes_after_certification: bool) -> Self {
         Self {
             participants,
-            retain_recovered_votes,
+            retain_votes_after_certification,
             compacted: Vec::new(),
-            notarizes: Some(AttributableMap::new(participants)),
-            nullifies: Some(AttributableMap::new(participants)),
-            finalizes: Some(AttributableMap::new(participants)),
+            notarizes: Phase::new(participants),
+            nullifies: Phase::new(participants),
+            finalizes: Phase::new(participants),
         }
     }
 }
@@ -242,11 +297,11 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         compacted: &mut Vec<u8>,
         signer: Participant,
         seen: u8,
-        has_proposal: Option<u8>,
-    ) -> bool {
+        proposal_relation: Option<(u8, bool)>,
+    ) -> VoteRecord {
         let index = usize::from(signer);
         if index >= participants {
-            return false;
+            return VoteRecord::DuplicateCompacted;
         }
 
         // Certificate-first rounds remain allocation-free until a vote arrives.
@@ -255,45 +310,50 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
 
         let flags = &mut compacted[index];
-        let inserted = *flags & seen == 0;
+        let previously_seen = *flags & seen != 0;
+        let proposal_conflict = proposal_relation.is_some_and(|(has_proposal, matches)| {
+            previously_seen && (*flags & has_proposal != 0) != matches
+        });
         *flags |= seen;
-        if let Some(has_proposal) = has_proposal {
+        if let Some((has_proposal, true)) = proposal_relation {
             *flags |= has_proposal;
         }
-        inserted
+        if !previously_seen {
+            VoteRecord::NewCompacted
+        } else if proposal_conflict {
+            VoteRecord::ConflictingProposal
+        } else {
+            VoteRecord::DuplicateCompacted
+        }
     }
 
     /// Records one phase according to its full-to-compact storage lifecycle.
     ///
-    /// A present map owns duplicate detection and full-vote storage. An absent map is
-    /// the post-certificate marker until the phase is explicitly cleared, so only
-    /// compact signer facts are kept.
-    fn record_phase<T: Attributable>(
+    /// A full phase owns duplicate detection and full-vote storage. A compacted
+    /// phase retains only signer facts until explicitly cleared.
+    fn record_phase<T: Attributable + Clone>(
         participants: usize,
         compacted: &mut Vec<u8>,
-        votes: &mut Option<AttributableMap<T>>,
-        vote: T,
+        phase: &mut Phase<T>,
+        vote: &T,
         seen: u8,
-        has_proposal: Option<u8>,
+        proposal_relation: Option<(u8, bool)>,
     ) -> VoteRecord {
-        // Never recreate a released map: doing so would lose the compact state's
-        // duplicate history and make retention depend on message arrival order.
-        let Some(votes) = votes else {
-            return VoteRecord {
-                inserted: Self::remember(
-                    participants,
-                    compacted,
-                    vote.signer(),
-                    seen,
-                    has_proposal,
-                ),
-                retained: false,
-            };
-        };
-
-        VoteRecord {
-            inserted: votes.insert(vote),
-            retained: true,
+        match phase {
+            Phase::Full(votes) => {
+                if votes.insert(vote.clone()) {
+                    VoteRecord::NewRetained
+                } else {
+                    VoteRecord::DuplicateRetained
+                }
+            }
+            Phase::Compacted => Self::remember(
+                participants,
+                compacted,
+                vote.signer(),
+                seen,
+                proposal_relation,
+            ),
         }
     }
 
@@ -317,15 +377,16 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
                 self.participants,
                 &mut self.compacted,
                 &mut self.notarizes,
-                notarize.clone(),
+                notarize,
                 Self::NOTARIZE_SEEN,
-                (proposal == Some(&notarize.proposal)).then_some(Self::NOTARIZE_HAS_PROPOSAL),
+                proposal
+                    .map(|proposal| (Self::NOTARIZE_HAS_PROPOSAL, proposal == &notarize.proposal)),
             ),
             Vote::Nullify(nullify) => Self::record_phase(
                 self.participants,
                 &mut self.compacted,
                 &mut self.nullifies,
-                nullify.clone(),
+                nullify,
                 Self::NULLIFY_SEEN,
                 None,
             ),
@@ -333,9 +394,10 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
                 self.participants,
                 &mut self.compacted,
                 &mut self.finalizes,
-                finalize.clone(),
+                finalize,
                 Self::FINALIZE_SEEN,
-                (proposal == Some(&finalize.proposal)).then_some(Self::FINALIZE_HAS_PROPOSAL),
+                proposal
+                    .map(|proposal| (Self::FINALIZE_HAS_PROPOSAL, proposal == &finalize.proposal)),
             ),
         }
     }
@@ -347,12 +409,12 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     fn release<T: Attributable>(
         participants: usize,
         compacted: &mut Vec<u8>,
-        votes: &mut Option<AttributableMap<T>>,
+        phase: &mut Phase<T>,
         seen: u8,
         has_proposal: u8,
         carries_proposal: impl Fn(&T) -> bool,
     ) {
-        let Some(votes) = votes.take() else {
+        let Some(votes) = phase.compact() else {
             return;
         };
 
@@ -400,7 +462,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases notarize votes while retaining compact signer state.
     pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
-        if self.retain_recovered_votes {
+        if self.retain_votes_after_certification {
             return;
         }
         Self::release(
@@ -415,7 +477,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases nullify votes while retaining compact signer state.
     pub(crate) fn release_nullifies(&mut self) {
-        if self.retain_recovered_votes {
+        if self.retain_votes_after_certification {
             return;
         }
         Self::release(
@@ -430,7 +492,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases finalize votes while retaining compact signer state.
     pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
-        if self.retain_recovered_votes {
+        if self.retain_votes_after_certification {
             return;
         }
         Self::release(
@@ -449,74 +511,71 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         for flags in &mut self.compacted {
             *flags &= !cleared;
         }
+        if self.compacted.iter().all(|&flags| flags == 0) {
+            self.compacted = Vec::new();
+        }
     }
 
     /// Inserts a notarize vote if the signer has not already voted.
     pub fn insert_notarize(&mut self, vote: Notarize<S, D>) -> bool {
-        self.notarizes
-            .as_mut()
-            .is_some_and(|votes| votes.insert(vote))
+        self.notarizes.insert(vote)
     }
 
     /// Inserts a nullify vote if the signer has not already voted.
     pub fn insert_nullify(&mut self, vote: Nullify<S>) -> bool {
-        self.nullifies
-            .as_mut()
-            .is_some_and(|votes| votes.insert(vote))
+        self.nullifies.insert(vote)
     }
 
     /// Inserts a finalize vote if the signer has not already voted.
     pub fn insert_finalize(&mut self, vote: Finalize<S, D>) -> bool {
-        self.finalizes
-            .as_mut()
-            .is_some_and(|votes| votes.insert(vote))
+        self.finalizes.insert(vote)
     }
 
     /// Returns the notarize vote for `signer`, if present.
     pub fn notarize(&self, signer: Participant) -> Option<&Notarize<S, D>> {
-        self.notarizes.as_ref()?.get(signer)
+        self.notarizes.get(signer)
     }
 
     /// Returns the nullify vote for `signer`, if present.
     pub fn nullify(&self, signer: Participant) -> Option<&Nullify<S>> {
-        self.nullifies.as_ref()?.get(signer)
+        self.nullifies.get(signer)
     }
 
     /// Returns the finalize vote for `signer`, if present.
     pub fn finalize(&self, signer: Participant) -> Option<&Finalize<S, D>> {
-        self.finalizes.as_ref()?.get(signer)
+        self.finalizes.get(signer)
     }
 
     /// Iterates over notarize votes in signer order.
     pub fn iter_notarizes(&self) -> impl Iterator<Item = &Notarize<S, D>> {
-        self.notarizes.iter().flat_map(|votes| votes.iter())
+        self.notarizes.iter()
     }
 
     /// Iterates over nullify votes in signer order.
     pub fn iter_nullifies(&self) -> impl Iterator<Item = &Nullify<S>> {
-        self.nullifies.iter().flat_map(|votes| votes.iter())
+        self.nullifies.iter()
     }
 
     /// Iterates over finalize votes in signer order.
     pub fn iter_finalizes(&self) -> impl Iterator<Item = &Finalize<S, D>> {
-        self.finalizes.iter().flat_map(|votes| votes.iter())
+        self.finalizes.iter()
     }
 
     /// Returns how many notarize votes have been recorded.
     pub fn len_notarizes(&self) -> u32 {
-        let len = self.notarizes.as_ref().map_or(0, AttributableMap::len);
+        let len = self.notarizes.len();
         u32::try_from(len).expect("too many notarize votes")
     }
 
     /// Returns how many nullify votes have been recorded.
     pub fn len_nullifies(&self) -> u32 {
-        let len = self.nullifies.as_ref().map_or(0, AttributableMap::len);
+        let len = self.nullifies.len();
         u32::try_from(len).expect("too many nullify votes")
     }
 
     /// Returns how many finalize votes have been recorded.
     pub fn len_finalizes(&self) -> u32 {
-        let len = self.finalizes.as_ref().map_or(0, AttributableMap::len);
+        let len = self.finalizes.len();
         u32::try_from(len).expect("too many finalize votes")
     }
 
@@ -537,19 +596,19 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Clears all notarize votes and releases their storage.
     pub fn clear_notarizes(&mut self) {
-        self.notarizes = Some(AttributableMap::new(self.participants));
+        self.notarizes.reset(self.participants);
         self.clear_compacted(Self::NOTARIZE_SEEN | Self::NOTARIZE_HAS_PROPOSAL);
     }
 
     /// Clears all nullify votes and releases their storage.
     pub fn clear_nullifies(&mut self) {
-        self.nullifies = Some(AttributableMap::new(self.participants));
+        self.nullifies.reset(self.participants);
         self.clear_compacted(Self::NULLIFY_SEEN);
     }
 
     /// Clears all finalize votes and releases their storage.
     pub fn clear_finalizes(&mut self) {
-        self.finalizes = Some(AttributableMap::new(self.participants));
+        self.finalizes.reset(self.participants);
         self.clear_compacted(Self::FINALIZE_SEEN | Self::FINALIZE_HAS_PROPOSAL);
     }
 }
@@ -3780,24 +3839,43 @@ mod tests {
         tracker.release_notarizes(&proposal);
         tracker.release_nullifies();
         tracker.release_finalizes(&proposal);
-        assert!(tracker.record(&notarize, Some(&proposal)).inserted);
-        assert!(tracker.record(&nullify, Some(&proposal)).inserted);
-        assert!(tracker.record(&finalize, Some(&proposal)).inserted);
+        assert!(matches!(
+            tracker.record(&notarize, Some(&proposal)),
+            VoteRecord::NewCompacted
+        ));
+        assert!(matches!(
+            tracker.record(&nullify, Some(&proposal)),
+            VoteRecord::NewCompacted
+        ));
+        assert!(matches!(
+            tracker.record(&finalize, Some(&proposal)),
+            VoteRecord::NewCompacted
+        ));
         assert!(tracker.has_notarize_for(signer, &proposal));
         assert!(tracker.saw_nullify(signer));
         assert!(tracker.has_finalize_for(signer, &proposal));
 
         tracker.clear_notarizes();
         assert!(!tracker.has_notarize_for(signer, &proposal));
-        assert!(tracker.record(&notarize, Some(&proposal)).inserted);
+        assert!(matches!(
+            tracker.record(&notarize, Some(&proposal)),
+            VoteRecord::NewRetained
+        ));
 
         tracker.clear_nullifies();
         assert!(!tracker.saw_nullify(signer));
-        assert!(tracker.record(&nullify, Some(&proposal)).inserted);
+        assert!(matches!(
+            tracker.record(&nullify, Some(&proposal)),
+            VoteRecord::NewRetained
+        ));
 
         tracker.clear_finalizes();
         assert!(!tracker.has_finalize_for(signer, &proposal));
-        assert!(tracker.record(&finalize, Some(&proposal)).inserted);
+        assert_eq!(tracker.compacted.capacity(), 0);
+        assert!(matches!(
+            tracker.record(&finalize, Some(&proposal)),
+            VoteRecord::NewRetained
+        ));
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -3815,36 +3893,49 @@ mod tests {
         let vote = Vote::Notarize(notarize);
 
         let mut releasing = VoteTracker::new(2, false);
-        let record = releasing.record(&vote, Some(&proposal));
-        assert!(record.inserted);
-        assert!(record.retained);
-        assert!(releasing.notarizes.as_ref().unwrap().data.capacity() >= 2);
+        assert!(matches!(
+            releasing.record(&vote, Some(&proposal)),
+            VoteRecord::NewRetained
+        ));
+        let Phase::Full(votes) = &releasing.notarizes else {
+            panic!("notarize phase compacted before certification");
+        };
+        assert!(votes.data.capacity() >= 2);
         releasing.release_notarizes(&proposal);
-        assert!(releasing.notarizes.is_none());
-        let record = releasing.record(&vote, Some(&proposal));
-        assert!(!record.inserted);
-        assert!(!record.retained);
+        assert!(matches!(&releasing.notarizes, Phase::Compacted));
+        assert!(matches!(
+            releasing.record(&vote, Some(&proposal)),
+            VoteRecord::DuplicateCompacted
+        ));
 
         // A certificate can arrive before any individual votes. Subsequent votes
         // must use compact storage instead of recreating the released full map.
         let mut certificate_first = VoteTracker::new(2, false);
         certificate_first.release_notarizes(&proposal);
-        let record = certificate_first.record(&vote, Some(&proposal));
-        assert!(record.inserted);
-        assert!(!record.retained);
-        assert!(certificate_first.notarizes.is_none());
-        assert!(!certificate_first.record(&vote, Some(&proposal)).inserted);
+        assert!(matches!(
+            certificate_first.record(&vote, Some(&proposal)),
+            VoteRecord::NewCompacted
+        ));
+        assert!(matches!(&certificate_first.notarizes, Phase::Compacted));
+        assert!(matches!(
+            certificate_first.record(&vote, Some(&proposal)),
+            VoteRecord::DuplicateCompacted
+        ));
 
         let mut retaining = VoteTracker::new(2, true);
-        let record = retaining.record(&vote, Some(&proposal));
-        assert!(record.inserted);
-        assert!(record.retained);
-        let retained_capacity = retaining.notarizes.as_ref().unwrap().data.capacity();
+        assert!(matches!(
+            retaining.record(&vote, Some(&proposal)),
+            VoteRecord::NewRetained
+        ));
+        let Phase::Full(votes) = &retaining.notarizes else {
+            panic!("retained notarize phase compacted");
+        };
+        let retained_capacity = votes.data.capacity();
         retaining.release_notarizes(&proposal);
-        assert_eq!(
-            retaining.notarizes.as_ref().unwrap().data.capacity(),
-            retained_capacity
-        );
+        let Phase::Full(votes) = &retaining.notarizes else {
+            panic!("retained notarize phase compacted");
+        };
+        assert_eq!(votes.data.capacity(), retained_capacity);
         assert!(retaining.notarize(signer).is_some());
     }
 

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -104,23 +104,24 @@ pub trait Attributable {
 /// The key for each item is automatically inferred from [Attributable::signer()].
 /// Each signer can insert at most one item.
 pub struct AttributableMap<T: Attributable> {
+    participants: usize,
     data: Vec<Option<T>>,
     added: usize,
 }
 
 impl<T: Attributable> AttributableMap<T> {
     /// Creates a new [AttributableMap] with the given number of participants.
-    pub fn new(participants: usize) -> Self {
-        // `resize_with` avoids requiring `T: Clone` while pre-filling with `None`.
-        let mut data = Vec::with_capacity(participants);
-        data.resize_with(participants, || None);
-
-        Self { data, added: 0 }
+    pub const fn new(participants: usize) -> Self {
+        Self {
+            participants,
+            data: Vec::new(),
+            added: 0,
+        }
     }
 
-    /// Clears all existing items from the [AttributableMap].
+    /// Clears all existing items and releases their storage.
     pub fn clear(&mut self) {
-        self.data.fill_with(|| None);
+        self.data = Vec::new();
         self.added = 0;
     }
 
@@ -131,8 +132,13 @@ impl<T: Attributable> AttributableMap<T> {
     /// signer already exists or if the signer index is out of bounds.
     pub fn insert(&mut self, item: T) -> bool {
         let index: usize = item.signer().into();
-        if index >= self.data.len() {
+        if index >= self.participants {
             return false;
+        }
+        if self.data.is_empty() {
+            // `resize_with` avoids requiring `T: Clone` while pre-filling with `None`.
+            self.data.reserve_exact(self.participants);
+            self.data.resize_with(self.participants, || None);
         }
         if self.data[index].is_some() {
             return false;
@@ -166,10 +172,14 @@ impl<T: Attributable> AttributableMap<T> {
 
 /// Tracks notarize/nullify/finalize votes for a view.
 ///
-/// Each vote type is stored in its own [`AttributableMap`] so a validator can only
-/// contribute one vote per phase. The tracker is reused across rounds/views to keep
-/// allocations stable.
+/// Each vote type is stored in its own lazily allocated [`AttributableMap`] so a
+/// validator can only contribute one vote per phase. Full votes are released once
+/// their certificate exists. Compact signer state remains available for forwarding
+/// and duplicate suppression.
 pub struct VoteTracker<S: Scheme, D: Digest> {
+    participants: usize,
+    /// Per-phase signer and proposal-match flags retained after full votes are released.
+    compacted: Vec<u8>,
     /// Per-signer notarize votes keyed by validator index.
     notarizes: AttributableMap<Notarize<S, D>>,
     /// Per-signer nullify votes keyed by validator index.
@@ -182,13 +192,153 @@ pub struct VoteTracker<S: Scheme, D: Digest> {
 }
 
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
+    const NOTARIZE_SEEN: u8 = 1 << 0;
+    const NOTARIZE_MATCHING: u8 = 1 << 1;
+    const NULLIFY_SEEN: u8 = 1 << 2;
+    const FINALIZE_SEEN: u8 = 1 << 3;
+    const FINALIZE_MATCHING: u8 = 1 << 4;
+
     /// Creates a tracker sized for `participants` validators.
-    pub fn new(participants: usize) -> Self {
+    pub const fn new(participants: usize) -> Self {
         Self {
+            participants,
+            compacted: Vec::new(),
             notarizes: AttributableMap::new(participants),
             nullifies: AttributableMap::new(participants),
             finalizes: AttributableMap::new(participants),
         }
+    }
+
+    fn remember(&mut self, signer: Participant, seen: u8, matching: Option<u8>) -> bool {
+        let index = usize::from(signer);
+        if index >= self.participants {
+            return false;
+        }
+        if self.compacted.is_empty() {
+            self.compacted.resize(self.participants, 0);
+        }
+
+        let flags = &mut self.compacted[index];
+        let inserted = *flags & seen == 0;
+        *flags |= seen;
+        if let Some(matching) = matching {
+            *flags |= matching;
+        }
+        inserted
+    }
+
+    fn remembered(&self, signer: Participant, flag: u8) -> bool {
+        self.compacted
+            .get(usize::from(signer))
+            .is_some_and(|flags| flags & flag != 0)
+    }
+
+    fn release<T: Attributable>(
+        participants: usize,
+        compacted: &mut Vec<u8>,
+        votes: &mut AttributableMap<T>,
+        seen: u8,
+        matching: u8,
+        is_matching: impl Fn(&T) -> bool,
+    ) {
+        if !votes.is_empty() && compacted.is_empty() {
+            compacted.resize(participants, 0);
+        }
+        for vote in votes.iter() {
+            let flags = &mut compacted[usize::from(vote.signer())];
+            *flags |= seen;
+            if is_matching(vote) {
+                *flags |= matching;
+            }
+        }
+        votes.clear();
+    }
+
+    /// Remembers a notarize signer without retaining the full vote.
+    pub(crate) fn remember_notarize(&mut self, signer: Participant, matching: bool) -> bool {
+        self.remember(
+            signer,
+            Self::NOTARIZE_SEEN,
+            matching.then_some(Self::NOTARIZE_MATCHING),
+        )
+    }
+
+    /// Remembers a nullify signer without retaining the full vote.
+    pub(crate) fn remember_nullify(&mut self, signer: Participant) -> bool {
+        self.remember(signer, Self::NULLIFY_SEEN, None)
+    }
+
+    /// Remembers a finalize signer without retaining the full vote.
+    pub(crate) fn remember_finalize(&mut self, signer: Participant, matching: bool) -> bool {
+        self.remember(
+            signer,
+            Self::FINALIZE_SEEN,
+            matching.then_some(Self::FINALIZE_MATCHING),
+        )
+    }
+
+    /// Returns whether `signer` is known to have notarized `proposal`.
+    pub(crate) fn has_notarize_for(
+        &self,
+        signer: Participant,
+        proposal: &Proposal<D>,
+    ) -> bool {
+        self.remembered(signer, Self::NOTARIZE_MATCHING)
+            || self
+                .notarize(signer)
+                .is_some_and(|vote| &vote.proposal == proposal)
+    }
+
+    /// Returns whether `signer` is known to have finalized `proposal`.
+    pub(crate) fn has_finalize_for(
+        &self,
+        signer: Participant,
+        proposal: &Proposal<D>,
+    ) -> bool {
+        self.remembered(signer, Self::FINALIZE_MATCHING)
+            || self
+                .finalize(signer)
+                .is_some_and(|vote| &vote.proposal == proposal)
+    }
+
+    /// Releases notarize votes while retaining compact signer state.
+    pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
+        Self::release(
+            self.participants,
+            &mut self.compacted,
+            &mut self.notarizes,
+            Self::NOTARIZE_SEEN,
+            Self::NOTARIZE_MATCHING,
+            |vote: &Notarize<S, D>| {
+                &vote.proposal == proposal
+            },
+        );
+    }
+
+    /// Releases nullify votes while retaining compact signer state.
+    pub(crate) fn release_nullifies(&mut self) {
+        Self::release(
+            self.participants,
+            &mut self.compacted,
+            &mut self.nullifies,
+            Self::NULLIFY_SEEN,
+            0,
+            |_| false,
+        );
+    }
+
+    /// Releases finalize votes while retaining compact signer state.
+    pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
+        Self::release(
+            self.participants,
+            &mut self.compacted,
+            &mut self.finalizes,
+            Self::FINALIZE_SEEN,
+            Self::FINALIZE_MATCHING,
+            |vote: &Finalize<S, D>| {
+                &vote.proposal == proposal
+            },
+        );
     }
 
     /// Inserts a notarize vote if the signer has not already voted.
@@ -266,14 +416,28 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         self.finalizes.get(signer).is_some()
     }
 
-    /// Clears all notarize votes but keeps the allocations for reuse.
+    /// Clears all notarize votes and releases their storage.
     pub fn clear_notarizes(&mut self) {
         self.notarizes.clear();
+        for flags in &mut self.compacted {
+            *flags &= !(Self::NOTARIZE_SEEN | Self::NOTARIZE_MATCHING);
+        }
     }
 
-    /// Clears all finalize votes but keeps the allocations for reuse.
+    /// Clears all nullify votes and releases their storage.
+    pub fn clear_nullifies(&mut self) {
+        self.nullifies.clear();
+        for flags in &mut self.compacted {
+            *flags &= !Self::NULLIFY_SEEN;
+        }
+    }
+
+    /// Clears all finalize votes and releases their storage.
     pub fn clear_finalizes(&mut self) {
         self.finalizes.clear();
+        for flags in &mut self.compacted {
+            *flags &= !(Self::FINALIZE_SEEN | Self::FINALIZE_MATCHING);
+        }
     }
 }
 
@@ -3414,6 +3578,7 @@ mod tests {
         let mut map = AttributableMap::new(5);
         assert_eq!(map.len(), 0);
         assert!(map.is_empty());
+        assert_eq!(map.data.capacity(), 0, "empty maps should allocate lazily");
 
         // Test get on empty map
         for i in 0..5 {
@@ -3421,6 +3586,7 @@ mod tests {
         }
 
         assert!(map.insert(MockAttributable(Participant::new(3))));
+        assert!(map.data.capacity() >= 5);
         assert_eq!(map.len(), 1);
         assert!(!map.is_empty());
         let mut iter = map.iter();
@@ -3474,6 +3640,7 @@ mod tests {
         assert_eq!(map.len(), 0);
         assert!(map.is_empty());
         assert!(map.iter().next().is_none());
+        assert_eq!(map.data.capacity(), 0, "clear should release vote storage");
 
         // Verify can insert after clear
         assert!(map.insert(MockAttributable(Participant::new(2))));

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -260,6 +260,15 @@ pub(crate) enum Outcome {
     Conflicting,
 }
 
+/// A recorded vote that may no longer be retained in full.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) enum ObservedVote<'a, T> {
+    /// The full vote remains available.
+    Retained(&'a T),
+    /// Only compact signer state remains.
+    Compacted,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     const NOTARIZE_SEEN: u8 = 1 << 0;
@@ -429,14 +438,27 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
-    /// Returns whether `signer` previously nullified, including compact state.
-    pub(crate) fn saw_nullify(&self, signer: Participant) -> bool {
-        self.nullify(signer).is_some() || self.remembered(signer, Self::NULLIFY_SEEN)
+    /// Returns a previously observed nullify vote, including compact state.
+    pub(crate) fn saw_nullify(&self, signer: Participant) -> Option<ObservedVote<'_, Nullify<S>>> {
+        self.nullify(signer)
+            .map(ObservedVote::Retained)
+            .or_else(|| {
+                self.remembered(signer, Self::NULLIFY_SEEN)
+                    .then_some(ObservedVote::Compacted)
+            })
     }
 
-    /// Returns whether `signer` previously finalized, including compact state.
-    pub(crate) fn saw_finalize(&self, signer: Participant) -> bool {
-        self.finalize(signer).is_some() || self.remembered(signer, Self::FINALIZE_SEEN)
+    /// Returns a previously observed finalize vote, including compact state.
+    pub(crate) fn saw_finalize(
+        &self,
+        signer: Participant,
+    ) -> Option<ObservedVote<'_, Finalize<S, D>>> {
+        self.finalize(signer)
+            .map(ObservedVote::Retained)
+            .or_else(|| {
+                self.remembered(signer, Self::FINALIZE_SEEN)
+                    .then_some(ObservedVote::Compacted)
+            })
     }
 
     /// Returns whether `signer` is known to have the authoritative proposal from notarizing it.
@@ -3847,7 +3869,10 @@ mod tests {
             Outcome::Added { retained: false }
         ));
         assert!(tracker.has_notarize_for(signer, &proposal));
-        assert!(tracker.saw_nullify(signer));
+        assert!(matches!(
+            tracker.saw_nullify(signer),
+            Some(ObservedVote::Compacted)
+        ));
         assert!(tracker.has_finalize_for(signer, &proposal));
 
         tracker.clear_notarizes();
@@ -3858,7 +3883,7 @@ mod tests {
         ));
 
         tracker.clear_nullifies();
-        assert!(!tracker.saw_nullify(signer));
+        assert!(tracker.saw_nullify(signer).is_none());
         assert!(matches!(
             tracker.record(&nullify, Some(&proposal)),
             Outcome::Added { retained: true }

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -173,13 +173,15 @@ impl<T: Attributable> AttributableMap<T> {
 /// Tracks notarize/nullify/finalize votes for a view.
 ///
 /// Each vote type is stored in its own lazily allocated [`AttributableMap`] so a
-/// validator can only contribute one vote per phase. Unless extended conflict reporting
-/// is enabled, full votes are released once their certificate exists. Compact signer
-/// state remains available for forwarding and duplicate suppression.
+/// validator can only contribute one vote per phase. Unless historical conflict reporting
+/// is enabled, full votes are released once their certificate exists. Compact signer state
+/// remains available for forwarding and duplicate suppression.
 #[cfg(not(target_arch = "wasm32"))]
 pub struct VoteTracker<S: Scheme, D: Digest> {
+    /// Number of validators represented by the vote maps and compact signer table.
     participants: usize,
-    retain_votes_after_certification: bool,
+    /// Whether full votes remain available after their certificate is recovered.
+    retain_recovered_votes: bool,
     /// Compact state records whether a signer voted and whether the vote carried the
     /// authoritative proposal. The former suppresses duplicates and cross-phase
     /// conflicts; the latter avoids forwarding blocks to validators that already have them.
@@ -196,8 +198,11 @@ pub struct VoteTracker<S: Scheme, D: Digest> {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+/// Outcome of recording a vote in its phase-specific lifecycle state.
 pub(crate) struct VoteRecord {
+    /// Whether the signer was newly recorded in this phase.
     pub inserted: bool,
+    /// Whether the phase still stores full votes for recovery and conflict evidence.
     pub retained: bool,
 }
 
@@ -211,12 +216,12 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Creates a tracker sized for `participants` validators.
     ///
-    /// Unless `retain_votes_after_certification` is enabled, each vote map transitions
+    /// Unless `retain_recovered_votes` is enabled, each vote map transitions
     /// to compact storage once its certificate is recorded.
-    pub const fn new(participants: usize, retain_votes_after_certification: bool) -> Self {
+    pub const fn new(participants: usize, retain_recovered_votes: bool) -> Self {
         Self {
             participants,
-            retain_votes_after_certification,
+            retain_recovered_votes,
             compacted: Vec::new(),
             notarizes: Some(AttributableMap::new(participants)),
             nullifies: Some(AttributableMap::new(participants)),
@@ -224,6 +229,11 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
+    /// Records signer facts after the phase's full vote map has been released.
+    ///
+    /// The facts are monotonic until the phase is cleared. In particular, a matching
+    /// vote may establish that the signer has the authoritative proposal even when a
+    /// vote from that signer was already observed.
     fn remember(
         participants: usize,
         compacted: &mut Vec<u8>,
@@ -235,6 +245,8 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         if index >= participants {
             return false;
         }
+
+        // Certificate-first rounds remain allocation-free until a vote arrives.
         if compacted.is_empty() {
             compacted.resize(participants, 0);
         }
@@ -248,6 +260,11 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         inserted
     }
 
+    /// Records one phase according to its full-to-compact storage lifecycle.
+    ///
+    /// A present map owns duplicate detection and full-vote storage. An absent map is
+    /// the post-certificate marker until the phase is explicitly cleared, so only
+    /// compact signer facts are kept.
     fn record_phase<T: Attributable>(
         participants: usize,
         compacted: &mut Vec<u8>,
@@ -256,6 +273,8 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         seen: u8,
         has_proposal: Option<u8>,
     ) -> VoteRecord {
+        // Never recreate a released map: doing so would lose the compact state's
+        // duplicate history and make retention depend on message arrival order.
         let Some(votes) = votes else {
             return VoteRecord {
                 inserted: Self::remember(
@@ -275,6 +294,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
+    /// Returns whether compact post-certificate state contains `flag` for `signer`.
     fn remembered(&self, signer: Participant, flag: u8) -> bool {
         self.compacted
             .get(usize::from(signer))
@@ -318,6 +338,10 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         }
     }
 
+    /// Moves a phase from full vote storage to compact signer state.
+    ///
+    /// Taking the map makes the transition idempotent. Empty phases stay
+    /// allocation-free, while existing signer and proposal-ownership facts survive.
     fn release<T: Attributable>(
         participants: usize,
         compacted: &mut Vec<u8>,
@@ -329,9 +353,14 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         let Some(votes) = votes.take() else {
             return;
         };
+
+        // A certificate may arrive before any individual votes, in which case there
+        // are no signer facts worth allocating a table for.
         if !votes.is_empty() && compacted.is_empty() {
             compacted.resize(participants, 0);
         }
+
+        // Proposal bits are relative to the certificate-backed authoritative proposal.
         for vote in votes.iter() {
             let flags = &mut compacted[usize::from(vote.signer())];
             *flags |= seen;
@@ -369,7 +398,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases notarize votes while retaining compact signer state.
     pub(crate) fn release_notarizes(&mut self, proposal: &Proposal<D>) {
-        if self.retain_votes_after_certification {
+        if self.retain_recovered_votes {
             return;
         }
         Self::release(
@@ -384,7 +413,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases nullify votes while retaining compact signer state.
     pub(crate) fn release_nullifies(&mut self) {
-        if self.retain_votes_after_certification {
+        if self.retain_recovered_votes {
             return;
         }
         Self::release(
@@ -399,7 +428,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
 
     /// Releases finalize votes while retaining compact signer state.
     pub(crate) fn release_finalizes(&mut self, proposal: &Proposal<D>) {
-        if self.retain_votes_after_certification {
+        if self.retain_recovered_votes {
             return;
         }
         Self::release(

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -3826,7 +3826,6 @@ mod tests {
         assert!(iter.next().is_none());
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn test_vote_tracker_clears_compacted_state() {
         let mut rng = test_rng();
@@ -3882,7 +3881,49 @@ mod tests {
         ));
     }
 
-    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn test_vote_tracker_insert_and_accessors() {
+        let mut rng = test_rng();
+        let fixture = ed25519::fixture(&mut rng, NAMESPACE, 2);
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let proposal = Proposal::new(round, View::zero(), sample_digest(1));
+        let scheme = &fixture.schemes[0];
+        let signer = Participant::new(0);
+        let notarize = Notarize::sign(scheme, proposal.clone()).unwrap();
+        let nullify = Nullify::sign::<Sha256>(scheme, round).unwrap();
+        let finalize = Finalize::sign(scheme, proposal.clone()).unwrap();
+        let mut tracker = VoteTracker::new(2, false);
+
+        assert!(tracker.insert_notarize(notarize.clone()));
+        assert!(tracker.insert_nullify(nullify.clone()));
+        assert!(tracker.insert_finalize(finalize.clone()));
+        assert_eq!(tracker.len_notarizes(), 1);
+        assert_eq!(tracker.len_nullifies(), 1);
+        assert_eq!(tracker.len_finalizes(), 1);
+        assert!(tracker.has_notarize(signer));
+        assert!(tracker.has_nullify(signer));
+        assert!(tracker.has_finalize(signer));
+
+        tracker.release_notarizes(&proposal);
+        tracker.release_nullifies();
+        tracker.release_finalizes(&proposal);
+        assert_eq!(tracker.len_notarizes(), 0);
+        assert_eq!(tracker.len_nullifies(), 0);
+        assert_eq!(tracker.len_finalizes(), 0);
+        assert!(!tracker.has_notarize(signer));
+        assert!(!tracker.has_nullify(signer));
+        assert!(!tracker.has_finalize(signer));
+        assert!(tracker.iter_notarizes().next().is_none());
+        assert!(tracker.iter_nullifies().next().is_none());
+        assert!(tracker.iter_finalizes().next().is_none());
+        assert!(!tracker.insert_notarize(notarize));
+        assert!(!tracker.insert_nullify(nullify));
+        assert!(!tracker.insert_finalize(finalize));
+
+        // Releasing a compacted phase is idempotent.
+        tracker.release_notarizes(&proposal);
+    }
+
     #[test]
     fn test_vote_tracker_retention_policy() {
         let mut rng = test_rng();

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -251,17 +251,13 @@ pub struct VoteTracker<S: Scheme, D: Digest> {
 
 /// Outcome of recording a vote in its phase-specific lifecycle state.
 #[cfg(not(target_arch = "wasm32"))]
-pub(crate) enum VoteRecord {
-    /// Newly inserted with the full vote retained.
-    NewRetained,
-    /// Newly inserted as compact signer facts.
-    NewCompacted,
-    /// A duplicate while the full vote remains available.
-    DuplicateRetained,
-    /// A duplicate consistent with the compact signer facts.
-    DuplicateCompacted,
+pub(crate) enum Outcome {
+    /// Newly recorded, with the full vote retained when `retained` is true.
+    Added { retained: bool },
+    /// Not newly recorded, with full votes still retained when `retained` is true.
+    Duplicate { retained: bool },
     /// The compact proposal relation proves a same-phase conflict.
-    ConflictingProposal,
+    Conflicting,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -301,10 +297,10 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         signer: Participant,
         seen: u8,
         proposal_relation: Option<(u8, bool)>,
-    ) -> VoteRecord {
+    ) -> Outcome {
         let index = usize::from(signer);
         if index >= participants {
-            return VoteRecord::DuplicateCompacted;
+            return Outcome::Duplicate { retained: false };
         }
 
         // Certificate-first rounds remain allocation-free until a vote arrives.
@@ -322,11 +318,11 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
             *flags |= has_proposal;
         }
         if !previously_seen {
-            VoteRecord::NewCompacted
+            Outcome::Added { retained: false }
         } else if proposal_conflict {
-            VoteRecord::ConflictingProposal
+            Outcome::Conflicting
         } else {
-            VoteRecord::DuplicateCompacted
+            Outcome::Duplicate { retained: false }
         }
     }
 
@@ -341,13 +337,13 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
         vote: &T,
         seen: u8,
         proposal_relation: Option<(u8, bool)>,
-    ) -> VoteRecord {
+    ) -> Outcome {
         match phase {
             Phase::Full(votes) => {
                 if votes.insert(vote.clone()) {
-                    VoteRecord::NewRetained
+                    Outcome::Added { retained: true }
                 } else {
-                    VoteRecord::DuplicateRetained
+                    Outcome::Duplicate { retained: true }
                 }
             }
             Phase::Compacted => Self::remember(
@@ -370,11 +366,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     ///
     /// `proposal` is the authoritative proposal, when known, and preserves
     /// proposal-match state when the full vote is not retained.
-    pub(crate) fn record(
-        &mut self,
-        vote: &Vote<S, D>,
-        proposal: Option<&Proposal<D>>,
-    ) -> VoteRecord {
+    pub(crate) fn record(&mut self, vote: &Vote<S, D>, proposal: Option<&Proposal<D>>) -> Outcome {
         match vote {
             Vote::Notarize(notarize) => Self::record_phase(
                 self.participants,
@@ -3844,15 +3836,15 @@ mod tests {
         tracker.release_finalizes(&proposal);
         assert!(matches!(
             tracker.record(&notarize, Some(&proposal)),
-            VoteRecord::NewCompacted
+            Outcome::Added { retained: false }
         ));
         assert!(matches!(
             tracker.record(&nullify, Some(&proposal)),
-            VoteRecord::NewCompacted
+            Outcome::Added { retained: false }
         ));
         assert!(matches!(
             tracker.record(&finalize, Some(&proposal)),
-            VoteRecord::NewCompacted
+            Outcome::Added { retained: false }
         ));
         assert!(tracker.has_notarize_for(signer, &proposal));
         assert!(tracker.saw_nullify(signer));
@@ -3862,14 +3854,14 @@ mod tests {
         assert!(!tracker.has_notarize_for(signer, &proposal));
         assert!(matches!(
             tracker.record(&notarize, Some(&proposal)),
-            VoteRecord::NewRetained
+            Outcome::Added { retained: true }
         ));
 
         tracker.clear_nullifies();
         assert!(!tracker.saw_nullify(signer));
         assert!(matches!(
             tracker.record(&nullify, Some(&proposal)),
-            VoteRecord::NewRetained
+            Outcome::Added { retained: true }
         ));
 
         tracker.clear_finalizes();
@@ -3877,7 +3869,7 @@ mod tests {
         assert_eq!(tracker.compacted.capacity(), 0);
         assert!(matches!(
             tracker.record(&finalize, Some(&proposal)),
-            VoteRecord::NewRetained
+            Outcome::Added { retained: true }
         ));
     }
 
@@ -3940,7 +3932,7 @@ mod tests {
         let mut releasing = VoteTracker::new(2, false);
         assert!(matches!(
             releasing.record(&vote, Some(&proposal)),
-            VoteRecord::NewRetained
+            Outcome::Added { retained: true }
         ));
         let Phase::Full(votes) = &releasing.notarizes else {
             panic!("notarize phase compacted before certification");
@@ -3950,7 +3942,7 @@ mod tests {
         assert!(matches!(&releasing.notarizes, Phase::Compacted));
         assert!(matches!(
             releasing.record(&vote, Some(&proposal)),
-            VoteRecord::DuplicateCompacted
+            Outcome::Duplicate { retained: false }
         ));
 
         // A certificate can arrive before any individual votes. Subsequent votes
@@ -3959,18 +3951,18 @@ mod tests {
         certificate_first.release_notarizes(&proposal);
         assert!(matches!(
             certificate_first.record(&vote, Some(&proposal)),
-            VoteRecord::NewCompacted
+            Outcome::Added { retained: false }
         ));
         assert!(matches!(&certificate_first.notarizes, Phase::Compacted));
         assert!(matches!(
             certificate_first.record(&vote, Some(&proposal)),
-            VoteRecord::DuplicateCompacted
+            Outcome::Duplicate { retained: false }
         ));
 
         let mut retaining = VoteTracker::new(2, true);
         assert!(matches!(
             retaining.record(&vote, Some(&proposal)),
-            VoteRecord::NewRetained
+            Outcome::Added { retained: true }
         ));
         let Phase::Full(votes) = &retaining.notarizes else {
             panic!("retained notarize phase compacted");

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -171,11 +171,13 @@ impl<T: Attributable> AttributableMap<T> {
 }
 
 /// Full vote storage for a phase, or its compacted lifecycle marker.
+#[cfg(not(target_arch = "wasm32"))]
 enum Phase<T: Attributable> {
     Full(AttributableMap<T>),
     Compacted,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<T: Attributable> Phase<T> {
     const fn new(participants: usize) -> Self {
         Self::Full(AttributableMap::new(participants))
@@ -228,9 +230,9 @@ impl<T: Attributable> Phase<T> {
 /// Each vote type is stored in its own lazily allocated phase so a validator can
 /// contribute at most one vote per phase. Once certified, a phase can drop its full
 /// votes while compact signer facts preserve forwarding and duplicate suppression.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct VoteTracker<S: Scheme, D: Digest> {
     participants: usize,
-    #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
     retain_votes_after_certification: bool,
     /// Compact state records whether a signer voted and whether the vote carried the
     /// authoritative proposal. The former suppresses duplicates and cross-phase
@@ -262,6 +264,7 @@ pub(crate) enum VoteRecord {
     ConflictingProposal,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     const NOTARIZE_SEEN: u8 = 1 << 0;
     const NOTARIZE_HAS_PROPOSAL: u8 = 1 << 1;
@@ -506,6 +509,7 @@ impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl<S: Scheme, D: Digest> VoteTracker<S, D> {
     fn clear_compacted(&mut self, cleared: u8) {
         for flags in &mut self.compacted {

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -261,7 +261,7 @@ fn main() {
                 page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
                 strategy,
                 forwarding: simplex::ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             },
         );
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -261,6 +261,7 @@ fn main() {
                 page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
                 strategy,
                 forwarding: simplex::ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             },
         );
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -261,7 +261,7 @@ fn main() {
                 page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
                 strategy,
                 forwarding: simplex::ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             },
         );
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -261,7 +261,7 @@ fn main() {
                 page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
                 strategy,
                 forwarding: simplex::ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             },
         );
 

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -261,7 +261,7 @@ fn main() {
                 page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
                 strategy,
                 forwarding: simplex::ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             },
         );
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -226,7 +226,7 @@ fn main() {
             page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
             strategy: Sequential,
             forwarding: simplex::ForwardingPolicy::Disabled,
-            extended_conflict_reporting: false,
+            historical_conflict_reporting: false,
         };
         let engine = simplex::Engine::new(context.child("engine"), cfg);
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -226,7 +226,7 @@ fn main() {
             page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
             strategy: Sequential,
             forwarding: simplex::ForwardingPolicy::Disabled,
-            historical_conflict_reporting: false,
+            track_historical_votes: false,
         };
         let engine = simplex::Engine::new(context.child("engine"), cfg);
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -226,6 +226,7 @@ fn main() {
             page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
             strategy: Sequential,
             forwarding: simplex::ForwardingPolicy::Disabled,
+            report_conflicting_votes: false,
         };
         let engine = simplex::Engine::new(context.child("engine"), cfg);
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -226,7 +226,7 @@ fn main() {
             page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
             strategy: Sequential,
             forwarding: simplex::ForwardingPolicy::Disabled,
-            report_conflicting_votes: false,
+            retain_votes_after_certification: false,
         };
         let engine = simplex::Engine::new(context.child("engine"), cfg);
 

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -226,7 +226,7 @@ fn main() {
             page_cache: CacheRef::from_pooler(&context, NZU16!(16_384), NZUsize!(10_000)),
             strategy: Sequential,
             forwarding: simplex::ForwardingPolicy::Disabled,
-            retain_votes_after_certification: false,
+            extended_conflict_reporting: false,
         };
         let engine = simplex::Engine::new(context.child("engine"), cfg);
 

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -370,6 +370,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
                 view_retention: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             },
             gate,
             state_sync,

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -370,7 +370,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
                 view_retention: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             },
             gate,
             state_sync,

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -370,7 +370,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
                 view_retention: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             },
             gate,
             state_sync,

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -370,7 +370,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
                 view_retention: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             },
             gate,
             state_sync,

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -370,7 +370,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
                 view_retention: ViewDelta::new(10),
                 skip_timeout: Duration::from_secs(5),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             },
             gate,
             state_sync,

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -502,6 +502,7 @@ where
                 fetch_timeout: Duration::from_secs(2),
                 fetch_concurrent: NZUsize!(4),
                 forwarding: ForwardingPolicy::Disabled,
+                report_conflicting_votes: false,
             },
         );
 

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -502,7 +502,7 @@ where
                 fetch_timeout: Duration::from_secs(2),
                 fetch_concurrent: NZUsize!(4),
                 forwarding: ForwardingPolicy::Disabled,
-                retain_votes_after_certification: false,
+                extended_conflict_reporting: false,
             },
         );
 

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -502,7 +502,7 @@ where
                 fetch_timeout: Duration::from_secs(2),
                 fetch_concurrent: NZUsize!(4),
                 forwarding: ForwardingPolicy::Disabled,
-                historical_conflict_reporting: false,
+                track_historical_votes: false,
             },
         );
 

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -502,7 +502,7 @@ where
                 fetch_timeout: Duration::from_secs(2),
                 fetch_concurrent: NZUsize!(4),
                 forwarding: ForwardingPolicy::Disabled,
-                report_conflicting_votes: false,
+                retain_votes_after_certification: false,
             },
         );
 

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -502,7 +502,7 @@ where
                 fetch_timeout: Duration::from_secs(2),
                 fetch_concurrent: NZUsize!(4),
                 forwarding: ForwardingPolicy::Disabled,
-                extended_conflict_reporting: false,
+                historical_conflict_reporting: false,
             },
         );
 

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -127,11 +127,10 @@ pub struct SimplexConfig<L> {
     /// Time a leader may remain inactive before triggering immediate nullification.
     pub skip_timeout: Duration,
 
-    /// Retain signed votes after certification and report conflicts.
+    /// Retain signed votes after certification to extend conflict reporting.
     ///
-    /// Enabling this increases per-view memory usage and requires deterministic
-    /// signatures from the epoch signing scheme.
-    pub report_conflicting_votes: bool,
+    /// Enabling this increases per-view memory usage.
+    pub retain_votes_after_certification: bool,
 
     /// Policy for proactively forwarding certified blocks.
     pub forwarding: ForwardingPolicy,
@@ -724,7 +723,7 @@ where
                 view_retention: self.simplex.view_retention,
                 skip_timeout: self.simplex.skip_timeout,
                 forwarding: self.simplex.forwarding,
-                report_conflicting_votes: self.simplex.report_conflicting_votes,
+                retain_votes_after_certification: self.simplex.retain_votes_after_certification,
             },
         );
 

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -127,10 +127,12 @@ pub struct SimplexConfig<L> {
     /// Time a leader may remain inactive before triggering immediate nullification.
     pub skip_timeout: Duration,
 
-    /// Retain signed votes after certification to extend conflict reporting.
+    /// Report historical conflicts after certification.
     ///
-    /// Enabling this increases per-view memory usage.
-    pub extended_conflict_reporting: bool,
+    /// By default, conflicts that require full vote evidence can be reported only
+    /// until the corresponding certificate is constructed or received. Enabling
+    /// this retains those votes at the cost of higher per-view memory usage.
+    pub historical_conflict_reporting: bool,
 
     /// Policy for proactively forwarding certified blocks.
     pub forwarding: ForwardingPolicy,
@@ -723,7 +725,7 @@ where
                 view_retention: self.simplex.view_retention,
                 skip_timeout: self.simplex.skip_timeout,
                 forwarding: self.simplex.forwarding,
-                extended_conflict_reporting: self.simplex.extended_conflict_reporting,
+                historical_conflict_reporting: self.simplex.historical_conflict_reporting,
             },
         );
 

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -127,14 +127,13 @@ pub struct SimplexConfig<L> {
     /// Time a leader may remain inactive before triggering immediate nullification.
     pub skip_timeout: Duration,
 
-    /// Report historical conflicts after certification.
+    /// Track individual votes after certification.
     ///
     /// By default, full vote evidence is released when the corresponding certificate
     /// is constructed or received, making later conflict reporting and peer blocking
     /// best effort. Enabling this retains each recorded vote until its round is
-    /// pruned, increasing memory usage. Forwarding and duplicate suppression remain
-    /// available either way.
-    pub historical_conflict_reporting: bool,
+    /// pruned, increasing memory usage.
+    pub track_historical_votes: bool,
 
     /// Policy for proactively forwarding certified blocks.
     pub forwarding: ForwardingPolicy,
@@ -727,7 +726,7 @@ where
                 view_retention: self.simplex.view_retention,
                 skip_timeout: self.simplex.skip_timeout,
                 forwarding: self.simplex.forwarding,
-                historical_conflict_reporting: self.simplex.historical_conflict_reporting,
+                track_historical_votes: self.simplex.track_historical_votes,
             },
         );
 

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -130,7 +130,7 @@ pub struct SimplexConfig<L> {
     /// Retain signed votes after certification to extend conflict reporting.
     ///
     /// Enabling this increases per-view memory usage.
-    pub retain_votes_after_certification: bool,
+    pub extended_conflict_reporting: bool,
 
     /// Policy for proactively forwarding certified blocks.
     pub forwarding: ForwardingPolicy,
@@ -723,7 +723,7 @@ where
                 view_retention: self.simplex.view_retention,
                 skip_timeout: self.simplex.skip_timeout,
                 forwarding: self.simplex.forwarding,
-                retain_votes_after_certification: self.simplex.retain_votes_after_certification,
+                extended_conflict_reporting: self.simplex.extended_conflict_reporting,
             },
         );
 

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -129,9 +129,11 @@ pub struct SimplexConfig<L> {
 
     /// Report historical conflicts after certification.
     ///
-    /// By default, conflicts that require full vote evidence can be reported only
-    /// until the corresponding certificate is constructed or received. Enabling
-    /// this retains those votes at the cost of higher per-view memory usage.
+    /// By default, full vote evidence is released when the corresponding certificate
+    /// is constructed or received, making later conflict reporting and peer blocking
+    /// best effort. Enabling this retains each recorded vote until its round is
+    /// pruned, increasing memory usage. Forwarding and duplicate suppression remain
+    /// available either way.
     pub historical_conflict_reporting: bool,
 
     /// Policy for proactively forwarding certified blocks.

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -127,6 +127,12 @@ pub struct SimplexConfig<L> {
     /// Time a leader may remain inactive before triggering immediate nullification.
     pub skip_timeout: Duration,
 
+    /// Retain signed votes after certification and report conflicts.
+    ///
+    /// Enabling this increases per-view memory usage and requires deterministic
+    /// signatures from the epoch signing scheme.
+    pub report_conflicting_votes: bool,
+
     /// Policy for proactively forwarding certified blocks.
     pub forwarding: ForwardingPolicy,
 }
@@ -718,6 +724,7 @@ where
                 view_retention: self.simplex.view_retention,
                 skip_timeout: self.simplex.skip_timeout,
                 forwarding: self.simplex.forwarding,
+                report_conflicting_votes: self.simplex.report_conflicting_votes,
             },
         );
 

--- a/glue/src/dkg/tests/mocks.rs
+++ b/glue/src/dkg/tests/mocks.rs
@@ -501,7 +501,7 @@ pub(crate) fn simplex_config() -> orchestrator::SimplexConfig<TestElector> {
         view_retention: ViewDelta::new(8),
         skip_timeout: Duration::from_secs(1),
         forwarding: simplex::ForwardingPolicy::Disabled,
-        retain_votes_after_certification: false,
+        extended_conflict_reporting: false,
     }
 }
 

--- a/glue/src/dkg/tests/mocks.rs
+++ b/glue/src/dkg/tests/mocks.rs
@@ -501,7 +501,7 @@ pub(crate) fn simplex_config() -> orchestrator::SimplexConfig<TestElector> {
         view_retention: ViewDelta::new(8),
         skip_timeout: Duration::from_secs(1),
         forwarding: simplex::ForwardingPolicy::Disabled,
-        report_conflicting_votes: false,
+        retain_votes_after_certification: false,
     }
 }
 

--- a/glue/src/dkg/tests/mocks.rs
+++ b/glue/src/dkg/tests/mocks.rs
@@ -501,7 +501,7 @@ pub(crate) fn simplex_config() -> orchestrator::SimplexConfig<TestElector> {
         view_retention: ViewDelta::new(8),
         skip_timeout: Duration::from_secs(1),
         forwarding: simplex::ForwardingPolicy::Disabled,
-        extended_conflict_reporting: false,
+        historical_conflict_reporting: false,
     }
 }
 

--- a/glue/src/dkg/tests/mocks.rs
+++ b/glue/src/dkg/tests/mocks.rs
@@ -501,7 +501,7 @@ pub(crate) fn simplex_config() -> orchestrator::SimplexConfig<TestElector> {
         view_retention: ViewDelta::new(8),
         skip_timeout: Duration::from_secs(1),
         forwarding: simplex::ForwardingPolicy::Disabled,
-        historical_conflict_reporting: false,
+        track_historical_votes: false,
     }
 }
 

--- a/glue/src/dkg/tests/mocks.rs
+++ b/glue/src/dkg/tests/mocks.rs
@@ -501,6 +501,7 @@ pub(crate) fn simplex_config() -> orchestrator::SimplexConfig<TestElector> {
         view_retention: ViewDelta::new(8),
         skip_timeout: Duration::from_secs(1),
         forwarding: simplex::ForwardingPolicy::Disabled,
+        report_conflicting_votes: false,
     }
 }
 

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1027,7 +1027,7 @@ impl EngineDefinition for ReshareEngine {
                     view_retention: ViewDelta::new(10),
                     skip_timeout: Duration::from_secs(5),
                     forwarding: ForwardingPolicy::Disabled,
-                    retain_votes_after_certification: false,
+                    extended_conflict_reporting: false,
                 },
                 gate,
                 state_sync,

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1027,7 +1027,7 @@ impl EngineDefinition for ReshareEngine {
                     view_retention: ViewDelta::new(10),
                     skip_timeout: Duration::from_secs(5),
                     forwarding: ForwardingPolicy::Disabled,
-                    historical_conflict_reporting: false,
+                    track_historical_votes: false,
                 },
                 gate,
                 state_sync,

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1027,7 +1027,7 @@ impl EngineDefinition for ReshareEngine {
                     view_retention: ViewDelta::new(10),
                     skip_timeout: Duration::from_secs(5),
                     forwarding: ForwardingPolicy::Disabled,
-                    extended_conflict_reporting: false,
+                    historical_conflict_reporting: false,
                 },
                 gate,
                 state_sync,

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1027,7 +1027,7 @@ impl EngineDefinition for ReshareEngine {
                     view_retention: ViewDelta::new(10),
                     skip_timeout: Duration::from_secs(5),
                     forwarding: ForwardingPolicy::Disabled,
-                    report_conflicting_votes: false,
+                    retain_votes_after_certification: false,
                 },
                 gate,
                 state_sync,

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1027,6 +1027,7 @@ impl EngineDefinition for ReshareEngine {
                     view_retention: ViewDelta::new(10),
                     skip_timeout: Duration::from_secs(5),
                     forwarding: ForwardingPolicy::Disabled,
+                    report_conflicting_votes: false,
                 },
                 gate,
                 state_sync,

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -726,6 +726,7 @@ impl EngineDefinition for MultiDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
+            report_conflicting_votes: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -726,7 +726,7 @@ impl EngineDefinition for MultiDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            report_conflicting_votes: false,
+            retain_votes_after_certification: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -726,7 +726,7 @@ impl EngineDefinition for MultiDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            historical_conflict_reporting: false,
+            track_historical_votes: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -726,7 +726,7 @@ impl EngineDefinition for MultiDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            retain_votes_after_certification: false,
+            extended_conflict_reporting: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -726,7 +726,7 @@ impl EngineDefinition for MultiDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            extended_conflict_reporting: false,
+            historical_conflict_reporting: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -596,7 +596,7 @@ impl EngineDefinition for SingleDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            retain_votes_after_certification: false,
+            extended_conflict_reporting: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -596,7 +596,7 @@ impl EngineDefinition for SingleDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            extended_conflict_reporting: false,
+            historical_conflict_reporting: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -596,7 +596,7 @@ impl EngineDefinition for SingleDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            report_conflicting_votes: false,
+            retain_votes_after_certification: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -596,7 +596,7 @@ impl EngineDefinition for SingleDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
-            historical_conflict_reporting: false,
+            track_historical_votes: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -596,6 +596,7 @@ impl EngineDefinition for SingleDbEngine {
             fetch_timeout: Duration::from_secs(2),
             fetch_concurrent: NZUsize!(3),
             forwarding: ForwardingPolicy::Disabled,
+            report_conflicting_votes: false,
         };
 
         let engine = simplex::Engine::new(context, simplex_config);


### PR DESCRIPTION
Related: #2520

## Summary

Simplex previously handed a locally constructed vote to the Batcher before syncing the voter journal. If the process crashed after the Batcher reported that vote but before the sync completed, the application could observe one vote before the crash and a different vote after restart even though the voter never broadcast the first vote.

This PR stages locally constructed output for the event-loop iteration, appends it to the voter journal, performs one coalesced sync of the exact journal section written by that iteration, and only then publishes votes to the Batcher/reporter path and the network. Append or sync failure therefore terminates the voter before the vote becomes externally visible.

Votes received from the network remain unpersisted and may be exported again after restart. If a sender equivocates, the vote exported after restart may differ from the one exported before the crash.

## Bounded Batcher memory

Valid far-future certificates can leave many Batcher rounds retained. This PR reduces their per-view footprint by:

- lazily allocating per-phase vote maps and certificate-verification buffers;
- representing each vote phase explicitly as full or compacted;
- releasing full signed votes once the corresponding certificate exists when `historical_conflict_reporting` is disabled;
- retaining lazy compact signer and authoritative-proposal facts for duplicate suppression, targeted proposal forwarding, nullify/finalize cross-phase blocking, and blocking same-phase match/non-match relation flips; and
- releasing certificate-verification buffers after completion.

Compact state deliberately does not retain enough evidence to construct a conflict activity. Conflict reporting after certification is therefore best effort when `historical_conflict_reporting` is disabled. Enabling it retains every observed full vote for a certified phase, extending conflict reporting at the cost of substantially higher per-view memory.

Full-evidence conflict checks compare complete signed votes, so signing schemes must use deterministic signature encodings.

Coverage includes deterministic crash regressions around finalize and nullify durability; compact and retained notarize/finalize conflicts in both proposal-relation orders; and retention, forwarding, deduplication, certificate-first allocation, and verifier-buffer allocation cases.

## Memory impact

In a controlled RSS microprobe using 50 BLS VRF validators and 2,000 retained certificate-only Batcher rounds, average retained memory fell from 209.5 KiB per view to 0.55 KiB per view, a 99.74% reduction. This isolates the per-view Batcher allocation changed here and is not a whole-validator RSS measurement.