### PR TITLE
[p2p] Improve Mailbox Docs

### DIFF
--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -192,6 +192,13 @@ fn main() {
         let (mut network, mut oracle) =
             authenticated::discovery::Network::new(context.child("network"), p2p_cfg);
 
+        // Configure channel capacity
+        //
+        // The rate is enforced independently for each peer. All peers share each channel's inbound
+        // mailbox, so size its backlog for one full burst from every peer.
+        let message_rate = Quota::per_second(NZU32!(10));
+        let message_backlog = authenticated::burst_backlog(validators.len(), message_rate);
+
         // Provide authorized peers
         //
         // In a real-world scenario, this would be updated as new peer sets are created (like when
@@ -200,23 +207,13 @@ fn main() {
 
         // Register consensus channels
         //
-        // If you want to maximize the number of views per second, increase the rate limit
-        // for this channel.
-        let (vote_sender, vote_receiver) = network.register(
-            0,
-            Quota::per_second(NZU32!(10)),
-            256, // 256 messages in flight
-        );
-        let (certificate_sender, certificate_receiver) = network.register(
-            1,
-            Quota::per_second(NZU32!(10)),
-            256, // 256 messages in flight
-        );
-        let (resolver_sender, resolver_receiver) = network.register(
-            2,
-            Quota::per_second(NZU32!(10)),
-            256, // 256 messages in flight
-        );
+        // To support more views per second, increase the rate and retain enough backlog for every
+        // participant's full burst.
+        let (vote_sender, vote_receiver) = network.register(0, message_rate, message_backlog);
+        let (certificate_sender, certificate_receiver) =
+            network.register(1, message_rate, message_backlog);
+        let (resolver_sender, resolver_receiver) =
+            network.register(2, message_rate, message_backlog);
 
         // Initialize application
         let strategy = context.strategy(NZUsize!(2));

--- a/examples/bridge/src/bin/validator.rs
+++ b/examples/bridge/src/bin/validator.rs
@@ -197,7 +197,7 @@ fn main() {
         // The rate is enforced independently for each peer. All peers share each channel's inbound
         // mailbox, so size its backlog for one full burst from every peer.
         let message_rate = Quota::per_second(NZU32!(10));
-        let message_backlog = authenticated::burst_backlog(validators.len(), message_rate);
+        let message_backlog = authenticated::backlog(validators.len(), message_rate);
 
         // Provide authorized peers
         //

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -175,7 +175,7 @@ fn main() {
         // The rate is enforced independently for each peer. All peers share the channel's inbound
         // mailbox, so size its backlog for one full burst from every peer.
         let message_rate = Quota::per_second(NZU32!(128));
-        let message_backlog = authenticated::burst_backlog(recipients.len(), message_rate);
+        let message_backlog = authenticated::backlog(recipients.len(), message_rate);
 
         // Provide authorized peers
         //

--- a/examples/chat/src/main.rs
+++ b/examples/chat/src/main.rs
@@ -57,7 +57,10 @@ mod logger;
 
 use clap::{Arg, Command, value_parser};
 use commonware_cryptography::{Signer as _, ed25519};
-use commonware_p2p::{Manager as _, authenticated::discovery};
+use commonware_p2p::{
+    Manager as _,
+    authenticated::{self, discovery},
+};
 use commonware_runtime::{Quota, Runner as _, Supervisor as _, tokio};
 use commonware_utils::{NZU32, TryCollect, ordered::Set, sync::Mutex};
 use std::{
@@ -167,6 +170,13 @@ fn main() {
         // Initialize network
         let (mut network, mut oracle) = discovery::Network::new(context.child("network"), p2p_cfg);
 
+        // Configure channel capacity
+        //
+        // The rate is enforced independently for each peer. All peers share the channel's inbound
+        // mailbox, so size its backlog for one full burst from every peer.
+        let message_rate = Quota::per_second(NZU32!(128));
+        let message_backlog = authenticated::burst_backlog(recipients.len(), message_rate);
+
         // Provide authorized peers
         //
         // In a real-world scenario, this would be updated as new peer sets are created (like when
@@ -174,12 +184,8 @@ fn main() {
         oracle.track(0, recipients);
 
         // Initialize chat
-        const MAX_MESSAGE_BACKLOG: usize = 128;
-        let (chat_sender, chat_receiver) = network.register(
-            handler::CHANNEL,
-            Quota::per_second(NZU32!(128)),
-            MAX_MESSAGE_BACKLOG,
-        );
+        let (chat_sender, chat_receiver) =
+            network.register(handler::CHANNEL, message_rate, message_backlog);
 
         // Start network
         let network_handler = network.start();

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -142,7 +142,8 @@ fn main() {
         // Provide authorized peers
         oracle.track(0, peer_keys.clone());
 
-        // Register flood channel
+        // Keep the backlog operator-controlled because this benchmark intentionally saturates the
+        // receiver instead of provisioning for the aggregate peer burst.
         let (mut flood_sender, mut flood_receiver) = network.register(
             0,
             Quota::per_second(NZU32!(u32::MAX)),

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -172,7 +172,7 @@ fn main() {
         // The rate is enforced independently for each peer. All peers share each channel's inbound
         // mailbox, so size its backlog for one full burst from every peer.
         let message_rate = Quota::per_second(NZU32!(10));
-        let message_backlog = authenticated::burst_backlog(validators.len(), message_rate);
+        let message_backlog = authenticated::backlog(validators.len(), message_rate);
 
         // Provide authorized peers
         //

--- a/examples/log/src/main.rs
+++ b/examples/log/src/main.rs
@@ -53,7 +53,10 @@ use commonware_consensus::{
     types::{Epoch, ViewDelta},
 };
 use commonware_cryptography::{Sha256, Signer as _, ed25519};
-use commonware_p2p::{Manager as _, authenticated::discovery};
+use commonware_p2p::{
+    Manager as _,
+    authenticated::{self, discovery},
+};
 use commonware_parallel::Sequential;
 use commonware_runtime::{Quota, Runner, Supervisor as _, buffer::paged::CacheRef, tokio};
 use commonware_utils::{NZU16, NZU32, NZUsize, TryCollect, ordered::Set, union};
@@ -164,6 +167,13 @@ fn main() {
         // Initialize network
         let (mut network, mut oracle) = discovery::Network::new(context.child("network"), p2p_cfg);
 
+        // Configure channel capacity
+        //
+        // The rate is enforced independently for each peer. All peers share each channel's inbound
+        // mailbox, so size its backlog for one full burst from every peer.
+        let message_rate = Quota::per_second(NZU32!(10));
+        let message_backlog = authenticated::burst_backlog(validators.len(), message_rate);
+
         // Provide authorized peers
         //
         // In a real-world scenario, this would be updated as new peer sets are created (like when
@@ -172,23 +182,13 @@ fn main() {
 
         // Register consensus channels
         //
-        // If you want to maximize the number of views per second, increase the rate limit
-        // for this channel.
-        let (vote_sender, vote_receiver) = network.register(
-            0,
-            Quota::per_second(NZU32!(10)),
-            256, // 256 messages in flight
-        );
-        let (certificate_sender, certificate_receiver) = network.register(
-            1,
-            Quota::per_second(NZU32!(10)),
-            256, // 256 messages in flight
-        );
-        let (resolver_sender, resolver_receiver) = network.register(
-            2,
-            Quota::per_second(NZU32!(10)),
-            256, // 256 messages in flight
-        );
+        // To support more views per second, increase the rate and retain enough backlog for every
+        // participant's full burst.
+        let (vote_sender, vote_receiver) = network.register(0, message_rate, message_backlog);
+        let (certificate_sender, certificate_receiver) =
+            network.register(1, message_rate, message_backlog);
+        let (resolver_sender, resolver_receiver) =
+            network.register(2, message_rate, message_backlog);
 
         // Initialize application
         let namespace = union(APPLICATION_NAMESPACE, b"_CONSENSUS");

--- a/examples/reshare/src/dkg.rs
+++ b/examples/reshare/src/dkg.rs
@@ -5,7 +5,7 @@ use crate::{
     types::{
         self, BACKFILL_CHANNEL, BLOCKS_PER_EPOCH, BROADCAST_CHANNEL, CERTIFICATE_CHANNEL,
         DKG_CHANNEL, FileSecretStore, MAILBOX_SIZE, MAX_MESSAGE_SIZE, MAX_SUPPORTED_MODE,
-        MESSAGE_BACKLOG, NAMESPACE, Participants, RESOLVER_CHANNEL, SHARING_MODE, VOTE_CHANNEL,
+        MESSAGE_RATE, NAMESPACE, Participants, RESOLVER_CHANNEL, SHARING_MODE, VOTE_CHANNEL,
     },
 };
 use clap::Args;
@@ -15,9 +15,9 @@ use commonware_glue::dkg::{
     bootstrap,
     types::{EpochInfo, EpochOutcome},
 };
-use commonware_p2p::authenticated::discovery;
-use commonware_runtime::{Quota, Strategizer, Supervisor as _, tokio};
-use commonware_utils::{NZU32, NZUsize};
+use commonware_p2p::authenticated::{self, discovery};
+use commonware_runtime::{Strategizer, Supervisor as _, tokio};
+use commonware_utils::NZUsize;
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -53,32 +53,18 @@ pub async fn run(context: tokio::Context, args: Dkg) {
     p2p_config.mailbox_size = MAILBOX_SIZE;
     let (mut p2p, oracle) = discovery::Network::new(context.child("network"), p2p_config);
 
-    let vote = p2p.register(
-        VOTE_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let certificate = p2p.register(
-        CERTIFICATE_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let resolver = p2p.register(
-        RESOLVER_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let backfill = p2p.register(
-        BACKFILL_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let broadcast = p2p.register(
-        BROADCAST_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let dkg = p2p.register(DKG_CHANNEL, Quota::per_second(NZU32!(128)), MESSAGE_BACKLOG);
+    // Configure channel capacity
+    //
+    // The rate is enforced independently for each peer. All peers share each channel's inbound
+    // mailbox, so size its backlog for one full burst from every peer.
+    let message_backlog = authenticated::burst_backlog(network.participants.len(), MESSAGE_RATE);
+
+    let vote = p2p.register(VOTE_CHANNEL, MESSAGE_RATE, message_backlog);
+    let certificate = p2p.register(CERTIFICATE_CHANNEL, MESSAGE_RATE, message_backlog);
+    let resolver = p2p.register(RESOLVER_CHANNEL, MESSAGE_RATE, message_backlog);
+    let backfill = p2p.register(BACKFILL_CHANNEL, MESSAGE_RATE, message_backlog);
+    let broadcast = p2p.register(BROADCAST_CHANNEL, MESSAGE_RATE, message_backlog);
+    let dkg = p2p.register(DKG_CHANNEL, MESSAGE_RATE, message_backlog);
 
     let strategy = context.strategy(NZUsize!(2));
     let store = FileSecretStore::load(args.node_dir.join("secrets.json"))

--- a/examples/reshare/src/dkg.rs
+++ b/examples/reshare/src/dkg.rs
@@ -57,7 +57,7 @@ pub async fn run(context: tokio::Context, args: Dkg) {
     //
     // The rate is enforced independently for each peer. All peers share each channel's inbound
     // mailbox, so size its backlog for one full burst from every peer.
-    let message_backlog = authenticated::burst_backlog(network.participants.len(), MESSAGE_RATE);
+    let message_backlog = authenticated::backlog(network.participants.len(), MESSAGE_RATE);
 
     let vote = p2p.register(VOTE_CHANNEL, MESSAGE_RATE, message_backlog);
     let certificate = p2p.register(CERTIFICATE_CHANNEL, MESSAGE_RATE, message_backlog);

--- a/examples/reshare/src/types.rs
+++ b/examples/reshare/src/types.rs
@@ -31,7 +31,7 @@ use commonware_glue::{
     stateful::db::{Shared, SyncEngineConfig},
 };
 use commonware_parallel::Sequential;
-use commonware_runtime::{Buf, BufMut, buffer::paged::CacheRef};
+use commonware_runtime::{Buf, BufMut, Quota, buffer::paged::CacheRef};
 use commonware_storage::{
     journal::contiguous::fixed::Config as FixedLogConfig,
     mmr::{self, Location, full::Config as MmrJournalConfig},
@@ -42,7 +42,8 @@ use commonware_storage::{
     translator::TwoCap,
 };
 use commonware_utils::{
-    Acknowledgement, NZU64, NZUsize, ordered::Set, range::NonEmptyRange, sequence::U64, sync::Mutex,
+    Acknowledgement, NZU32, NZU64, NZUsize, ordered::Set, range::NonEmptyRange, sequence::U64,
+    sync::Mutex,
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error as _};
 use std::{
@@ -94,8 +95,8 @@ pub const DKG_CHANNEL: u64 = 6;
 pub const DKG_PROBE_CHANNEL: u64 = 7;
 /// Mailbox capacity for every actor.
 pub const MAILBOX_SIZE: std::num::NonZeroUsize = NZUsize!(100);
-/// Maximum queued messages per P2P channel.
-pub const MESSAGE_BACKLOG: usize = 128;
+/// Per-peer message quota for every P2P channel.
+pub const MESSAGE_RATE: Quota = Quota::per_second(NZU32!(128));
 /// Maximum P2P message size in bytes.
 pub const MAX_MESSAGE_SIZE: u32 = 1024 * 1024;
 

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -7,7 +7,7 @@ use crate::{
         self, BACKFILL_CHANNEL, BLOCKS_PER_EPOCH, BROADCAST_CHANNEL, Block, CERTIFICATE_CHANNEL,
         DKG_CHANNEL, DKG_PROBE_CHANNEL, DynamicProvider, FileSecretStore, IO_BUFFER_SIZE,
         LogReporter, MAILBOX_SIZE, MAX_MESSAGE_SIZE, MAX_PARTICIPANTS, MAX_SUPPORTED_MODE,
-        MESSAGE_BACKLOG, NAMESPACE, PAGE_CACHE_SIZE, PAGE_SIZE, Participants, QMDB_CHANNEL,
+        MESSAGE_RATE, NAMESPACE, PAGE_CACHE_SIZE, PAGE_SIZE, Participants, QMDB_CHANNEL,
         RESOLVER_CHANNEL, Registrar, SHARING_MODE, Scheme, VOTE_CHANNEL,
     },
 };
@@ -35,11 +35,11 @@ use commonware_glue::{
     },
 };
 use commonware_macros::boxed;
-use commonware_p2p::authenticated::discovery;
+use commonware_p2p::authenticated::{self, discovery};
 use commonware_parallel::Sequential;
-use commonware_runtime::{Quota, Supervisor as _, buffer::paged::CacheRef, tokio};
+use commonware_runtime::{Supervisor as _, buffer::paged::CacheRef, tokio};
 use commonware_storage::{archive::prunable, translator::TwoCap};
-use commonware_utils::{NZDuration, NZU32, NZU64, NZUsize};
+use commonware_utils::{NZDuration, NZU64, NZUsize};
 use futures::future::try_join_all;
 use std::{marker::PhantomData, path::PathBuf, time::Duration};
 use tracing::error;
@@ -79,42 +79,20 @@ pub async fn run(context: tokio::Context, args: Validator) {
     p2p_config.mailbox_size = MAILBOX_SIZE;
     let (mut p2p, oracle) = discovery::Network::new(context.child("network"), p2p_config);
 
-    let vote_network = p2p.register(
-        VOTE_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let certificate_network = p2p.register(
-        CERTIFICATE_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let resolver_network = p2p.register(
-        RESOLVER_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let backfill_network = p2p.register(
-        BACKFILL_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let broadcast_network = p2p.register(
-        BROADCAST_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let qmdb_network = p2p.register(
-        QMDB_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
-    let dkg_network = p2p.register(DKG_CHANNEL, Quota::per_second(NZU32!(128)), MESSAGE_BACKLOG);
-    let dkg_probe_network = p2p.register(
-        DKG_PROBE_CHANNEL,
-        Quota::per_second(NZU32!(128)),
-        MESSAGE_BACKLOG,
-    );
+    // Configure channel capacity
+    //
+    // The rate is enforced independently for each peer. All peers share each channel's inbound
+    // mailbox, so size its backlog for one full burst from every peer.
+    let message_backlog = authenticated::burst_backlog(network.participants.len(), MESSAGE_RATE);
+
+    let vote_network = p2p.register(VOTE_CHANNEL, MESSAGE_RATE, message_backlog);
+    let certificate_network = p2p.register(CERTIFICATE_CHANNEL, MESSAGE_RATE, message_backlog);
+    let resolver_network = p2p.register(RESOLVER_CHANNEL, MESSAGE_RATE, message_backlog);
+    let backfill_network = p2p.register(BACKFILL_CHANNEL, MESSAGE_RATE, message_backlog);
+    let broadcast_network = p2p.register(BROADCAST_CHANNEL, MESSAGE_RATE, message_backlog);
+    let qmdb_network = p2p.register(QMDB_CHANNEL, MESSAGE_RATE, message_backlog);
+    let dkg_network = p2p.register(DKG_CHANNEL, MESSAGE_RATE, message_backlog);
+    let dkg_probe_network = p2p.register(DKG_PROBE_CHANNEL, MESSAGE_RATE, message_backlog);
     let p2p_handle = p2p.start();
 
     let provider = DynamicProvider::default();

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -83,7 +83,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
     //
     // The rate is enforced independently for each peer. All peers share each channel's inbound
     // mailbox, so size its backlog for one full burst from every peer.
-    let message_backlog = authenticated::burst_backlog(network.participants.len(), MESSAGE_RATE);
+    let message_backlog = authenticated::backlog(network.participants.len(), MESSAGE_RATE);
 
     let vote_network = p2p.register(VOTE_CHANNEL, MESSAGE_RATE, message_backlog);
     let certificate_network = p2p.register(CERTIFICATE_CHANNEL, MESSAGE_RATE, message_backlog);

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -17,6 +17,20 @@ use std::{
 };
 use thiserror::Error;
 
+/// Returns the backlog required to hold one quota burst from every peer.
+///
+/// This covers a synchronized burst, including from honest peers, but does not account for
+/// receiver stalls or sustained ingress above the receiver's drain rate.
+///
+/// # Panics
+///
+/// Panics if the aggregate burst does not fit in a `usize`.
+pub const fn burst_backlog(peers: usize, rate: Quota) -> usize {
+    peers
+        .checked_mul(rate.burst_size().get() as usize)
+        .expect("message backlog overflow")
+}
+
 /// Errors that can occur when interacting with the network.
 #[derive(Error, Debug)]
 pub enum Error {
@@ -66,7 +80,9 @@ impl<P: PublicKey> crate::UnlimitedSender for UnlimitedSender<P> {
     }
 }
 
-/// Sender is the mechanism used to send arbitrary bytes to a set of recipients over a pre-defined channel.
+/// Sends arbitrary bytes over one registered channel.
+///
+/// The channel's quota is shared across clones and enforced independently for each recipient.
 pub struct Sender<P: PublicKey, C: Clock> {
     limited_sender: LimitedSender<C, UnlimitedSender<P>, Messenger<P>>,
 }
@@ -116,7 +132,12 @@ where
     }
 }
 
-/// Channel to asynchronously receive messages from a channel.
+/// Lossy receiver for one registered channel.
+///
+/// Every peer connection feeds the same bounded inbound mailbox after independent per-peer rate
+/// limiting. If the mailbox is full, the arriving message is dropped and queued messages remain.
+/// Configure its capacity through `Network::register` using the aggregate peer burst, expected
+/// receiver stalls, and memory budget.
 pub struct Receiver<P: PublicKey> {
     receiver: mailbox::UnreliableReceiver<Inbound<P>>,
 }
@@ -192,5 +213,26 @@ impl<P: PublicKey> Channels<P> {
 
     pub fn collect(self) -> BTreeMap<u64, (Quota, mailbox::UnreliableSender<Inbound<P>>)> {
         self.receivers
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_utils::NZU32;
+
+    #[test]
+    fn burst_backlog_aggregates_peers() {
+        let rate = Quota::per_second(NZU32!(128));
+
+        assert_eq!(burst_backlog(7, rate), 896);
+    }
+
+    #[test]
+    #[should_panic(expected = "message backlog overflow")]
+    fn burst_backlog_panics_on_overflow() {
+        let rate = Quota::per_second(NZU32!(2));
+
+        burst_backlog(usize::MAX, rate);
     }
 }

--- a/p2p/src/authenticated/channels.rs
+++ b/p2p/src/authenticated/channels.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 /// # Panics
 ///
 /// Panics if the aggregate burst does not fit in a `usize`.
-pub const fn burst_backlog(peers: usize, rate: Quota) -> usize {
+pub const fn backlog(peers: usize, rate: Quota) -> usize {
     peers
         .checked_mul(rate.burst_size().get() as usize)
         .expect("message backlog overflow")
@@ -222,17 +222,17 @@ mod tests {
     use commonware_utils::NZU32;
 
     #[test]
-    fn burst_backlog_aggregates_peers() {
+    fn backlog_aggregates_peers() {
         let rate = Quota::per_second(NZU32!(128));
 
-        assert_eq!(burst_backlog(7, rate), 896);
+        assert_eq!(backlog(7, rate), 896);
     }
 
     #[test]
     #[should_panic(expected = "message backlog overflow")]
-    fn burst_backlog_panics_on_overflow() {
+    fn backlog_panics_on_overflow() {
         let rate = Quota::per_second(NZU32!(2));
 
-        burst_backlog(usize::MAX, rate);
+        backlog(usize::MAX, rate);
     }
 }

--- a/p2p/src/authenticated/discovery/config.rs
+++ b/p2p/src/authenticated/discovery/config.rs
@@ -56,6 +56,9 @@ pub struct Config<C: Signer> {
     /// When there are more messages in a mailbox than this value, messages may be rejected before
     /// they are processed. Refer to [`commonware_actor::Feedback`] and/or metrics on
     /// [`commonware_actor::mailbox`] for a signal this is occurring.
+    ///
+    /// This does not control an application channel's inbound backlog. That capacity is passed to
+    /// [`Network::register`](super::Network::register).
     pub mailbox_size: NonZeroUsize,
 
     /// Maximum number of already-queued outbound messages to combine into one connection write.

--- a/p2p/src/authenticated/discovery/mod.rs
+++ b/p2p/src/authenticated/discovery/mod.rs
@@ -97,8 +97,10 @@
 //! The size of the `message` bytes must not exceed the configured
 //! `max_message_size`. If it does, the sending operation will panic. Messages can be sent with `priority`, allowing certain
 //! communications to potentially bypass lower-priority messages waiting in send queues across all
-//! channels. Each registered channel ([Sender], [Receiver]) handles its own message queuing
-//! and rate limiting.
+//! channels. Each registered logical channel has one bounded inbound mailbox shared by all peer
+//! connections. Inbound rate limiting is enforced independently for each peer.
+//! Authentication identifies the sender, but the network does not inspect application payload
+//! semantics before adding a message to this mailbox.
 //!
 //! ## Compression
 //!
@@ -126,7 +128,9 @@
 //! - `allowed_handshake_rate_per_ip`: The rate limit for handshake attempts originating from a single IP address.
 //! - `allowed_handshake_rate_per_subnet`: The rate limit for handshake attempts originating from a single IP subnet.
 //! - `peer_connection_cooldown`: The per-peer rate limit for inbound and outbound connection reservations, expressed as a minimum cooldown between attempts.
-//! - `rate` (per channel): The rate limit for messages sent on a single channel.
+//! - `rate` (per channel and peer): The same quota is enforced independently for inbound traffic
+//!   from each peer and outbound traffic to each recipient. Aggregate inbound traffic can scale
+//!   with the number of connected peers.
 //!
 //! _Users should consider these rate limits as best-effort protection against moderate abuse. Targeted abuse (e.g. DDoS)
 //! must be mitigated with an external proxy (that limits inbound connection attempts to authorized IPs)._
@@ -148,9 +152,11 @@
 //! ## Message Delivery
 //!
 //! Outgoing message submissions can be rejected when a peer's send buffer is full, preventing slow
-//! peers from blocking sends to other peers. Incoming messages are dropped when the application's
-//! receive buffer is full, ensuring protocol messages (BitVec, Peers) continue to flow and
-//! connections remain healthy.
+//! peers from blocking sends to other peers. Incoming application messages are enqueued without
+//! waiting. Each channel's registered `backlog` bounds one mailbox shared by all peers. When it is
+//! full, the arriving message is dropped and queued messages remain. This allows protocol messages
+//! (BitVec, Peers) to continue flowing, but provides no per-peer reservation or fairness. See
+//! [`Network::register`] for sizing guidance.
 //!
 //! # Example
 //!
@@ -216,7 +222,7 @@
 //!         Set::try_from([signer.public_key(), peer1, peer2, peer3]).unwrap(),
 //!     );
 //!
-//!     // Register some channel
+//!     // Register a channel with a shared backlog sized for the aggregate peer burst
 //!     const MAX_MESSAGE_BACKLOG: usize = 128;
 //!     let (mut sender, receiver) = network.register(
 //!         0,

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -108,8 +108,26 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
     /// # Parameters
     ///
     /// * `channel` - Unique identifier for the channel.
-    /// * `rate` - Rate at which messages can be received over the channel.
-    /// * `backlog` - Maximum number of messages that can be queued on the channel before blocking.
+    /// * `rate` - Per-peer message quota for the channel. Inbound traffic from each connected peer
+    ///   is paced independently. The returned sender applies the same quota independently to each
+    ///   recipient.
+    /// * `backlog` - Capacity of the channel's single bounded inbound mailbox.
+    ///
+    /// # Backpressure
+    ///
+    /// All peer connections share the inbound mailbox. Enqueueing never waits for capacity. When
+    /// the mailbox is full, the arriving message is dropped and queued messages remain. There is no
+    /// per-peer reservation or fairness.
+    ///
+    /// A synchronized burst can contribute up to `rate.burst_size()` messages per connected peer.
+    /// To absorb one full burst from every peer, use
+    /// [`burst_backlog`](crate::authenticated::burst_backlog) with the maximum number of connected
+    /// peers. This sizing includes honest traffic since protocol events can synchronize honest
+    /// senders. Also account for expected receiver stalls and ensure its drain rate can sustain
+    /// aggregate ingress. No finite backlog can absorb sustained ingress above the drain rate.
+    ///
+    /// The queued payloads can consume roughly `backlog * max_message_size` bytes, in addition to
+    /// queue and allocator overhead.
     ///
     /// # Returns
     ///

--- a/p2p/src/authenticated/discovery/network.rs
+++ b/p2p/src/authenticated/discovery/network.rs
@@ -121,10 +121,10 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
     ///
     /// A synchronized burst can contribute up to `rate.burst_size()` messages per connected peer.
     /// To absorb one full burst from every peer, use
-    /// [`burst_backlog`](crate::authenticated::burst_backlog) with the maximum number of connected
-    /// peers. This sizing includes honest traffic since protocol events can synchronize honest
-    /// senders. Also account for expected receiver stalls and ensure its drain rate can sustain
-    /// aggregate ingress. No finite backlog can absorb sustained ingress above the drain rate.
+    /// [`backlog`](crate::authenticated::backlog) with the maximum number of connected peers. This
+    /// sizing includes honest traffic since protocol events can synchronize honest senders. Also
+    /// account for expected receiver stalls and ensure its drain rate can sustain aggregate ingress.
+    /// No finite backlog can absorb sustained ingress above the drain rate.
     ///
     /// The queued payloads can consume roughly `backlog * max_message_size` bytes, in addition to
     /// queue and allocator overhead.

--- a/p2p/src/authenticated/lookup/config.rs
+++ b/p2p/src/authenticated/lookup/config.rs
@@ -50,6 +50,9 @@ pub struct Config<C: Signer> {
     /// When there are more messages in a mailbox than this value, messages may be rejected before
     /// they are processed. Refer to [`commonware_actor::Feedback`] and/or metrics on
     /// [`commonware_actor::mailbox`] for a signal this is occurring.
+    ///
+    /// This does not control an application channel's inbound backlog. That capacity is passed to
+    /// [`Network::register`](super::Network::register).
     pub mailbox_size: NonZeroUsize,
 
     /// Maximum number of already-queued outbound messages to combine into one connection write.

--- a/p2p/src/authenticated/lookup/mod.rs
+++ b/p2p/src/authenticated/lookup/mod.rs
@@ -48,8 +48,10 @@
 //! The size of the `message` bytes must not exceed the configured
 //! `max_message_size`. If it does, the sending operation will panic. Messages can be sent with `priority`, allowing certain
 //! communications to potentially bypass lower-priority messages waiting in send queues across all
-//! channels. Each registered channel ([Sender], [Receiver]) handles its own message queuing
-//! and rate limiting.
+//! channels. Each registered logical channel has one bounded inbound mailbox shared by all peer
+//! connections. Inbound rate limiting is enforced independently for each peer.
+//! Authentication identifies the sender, but the network does not inspect application payload
+//! semantics before adding a message to this mailbox.
 //!
 //! ## Compression
 //!
@@ -77,7 +79,9 @@
 //! - `allowed_handshake_rate_per_ip`: The rate limit for handshake attempts originating from a single IP address.
 //! - `allowed_handshake_rate_per_subnet`: The rate limit for handshake attempts originating from a single IP subnet.
 //! - `peer_connection_cooldown`: The per-peer rate limit for inbound and outbound connection reservations, expressed as a minimum cooldown between attempts.
-//! - `rate` (per channel): The rate limit for messages sent on a single channel.
+//! - `rate` (per channel and peer): The same quota is enforced independently for inbound traffic
+//!   from each peer and outbound traffic to each recipient. Aggregate inbound traffic can scale
+//!   with the number of connected peers.
 //!
 //! _Users should consider these rate limits as best-effort protection against moderate abuse. Targeted abuse (e.g. DDoS)
 //! must be mitigated with an external proxy (that limits inbound connection attempts to authorized IPs)._
@@ -102,8 +106,11 @@
 //! ## Message Delivery
 //!
 //! Outgoing message submissions can be rejected when a peer's send buffer is full, preventing slow
-//! peers from blocking sends to other peers. Incoming messages are dropped when the application's
-//! receive buffer is full, ensuring ping messages continue to flow and connections remain healthy.
+//! peers from blocking sends to other peers. Incoming application messages are enqueued without
+//! waiting. Each channel's registered `backlog` bounds one mailbox shared by all peers. When it is
+//! full, the arriving message is dropped and queued messages remain. This allows ping messages to
+//! continue flowing, but provides no per-peer reservation or fairness. See [`Network::register`]
+//! for sizing guidance.
 //!
 //! # Example
 //!
@@ -168,7 +175,7 @@
 //!     ].try_into().unwrap();
 //!     oracle.track(0, peers);
 //!
-//!     // Register some channel
+//!     // Register a channel with a shared backlog sized for the aggregate peer burst
 //!     const MAX_MESSAGE_BACKLOG: usize = 128;
 //!     let (mut sender, receiver) = network.register(
 //!         0,

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -110,10 +110,10 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
     ///
     /// A synchronized burst can contribute up to `rate.burst_size()` messages per connected peer.
     /// To absorb one full burst from every peer, use
-    /// [`burst_backlog`](crate::authenticated::burst_backlog) with the maximum number of connected
-    /// peers. This sizing includes honest traffic since protocol events can synchronize honest
-    /// senders. Also account for expected receiver stalls and ensure its drain rate can sustain
-    /// aggregate ingress. No finite backlog can absorb sustained ingress above the drain rate.
+    /// [`backlog`](crate::authenticated::backlog) with the maximum number of connected peers. This
+    /// sizing includes honest traffic since protocol events can synchronize honest senders. Also
+    /// account for expected receiver stalls and ensure its drain rate can sustain aggregate ingress.
+    /// No finite backlog can absorb sustained ingress above the drain rate.
     ///
     /// The queued payloads can consume roughly `backlog * max_message_size` bytes, in addition to
     /// queue and allocator overhead.

--- a/p2p/src/authenticated/lookup/network.rs
+++ b/p2p/src/authenticated/lookup/network.rs
@@ -97,8 +97,26 @@ impl<E: Spawner + BufferPooler + Clock + CryptoRng + RNetwork + Resolver + Metri
     /// # Parameters
     ///
     /// * `channel` - Unique identifier for the channel.
-    /// * `rate` - Rate at which messages can be received over the channel.
-    /// * `backlog` - Maximum number of messages that can be queued on the channel before blocking.
+    /// * `rate` - Per-peer message quota for the channel. Inbound traffic from each connected peer
+    ///   is paced independently. The returned sender applies the same quota independently to each
+    ///   recipient.
+    /// * `backlog` - Capacity of the channel's single bounded inbound mailbox.
+    ///
+    /// # Backpressure
+    ///
+    /// All peer connections share the inbound mailbox. Enqueueing never waits for capacity. When
+    /// the mailbox is full, the arriving message is dropped and queued messages remain. There is no
+    /// per-peer reservation or fairness.
+    ///
+    /// A synchronized burst can contribute up to `rate.burst_size()` messages per connected peer.
+    /// To absorb one full burst from every peer, use
+    /// [`burst_backlog`](crate::authenticated::burst_backlog) with the maximum number of connected
+    /// peers. This sizing includes honest traffic since protocol events can synchronize honest
+    /// senders. Also account for expected receiver stalls and ensure its drain rate can sustain
+    /// aggregate ingress. No finite backlog can absorb sustained ingress above the drain rate.
+    ///
+    /// The queued payloads can consume roughly `backlog * max_message_size` bytes, in addition to
+    /// queue and allocator overhead.
     ///
     /// # Returns
     ///

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -8,7 +8,7 @@
 //! and that they can be looked up by their identifiers.
 
 mod channels;
-pub use channels::burst_backlog;
+pub use channels::backlog;
 mod data;
 pub(crate) mod dialing;
 pub mod discovery;

--- a/p2p/src/authenticated/mod.rs
+++ b/p2p/src/authenticated/mod.rs
@@ -8,6 +8,7 @@
 //! and that they can be looked up by their identifiers.
 
 mod channels;
+pub use channels::burst_backlog;
 mod data;
 pub(crate) mod dialing;
 pub mod discovery;


### PR DESCRIPTION
## Summary

Makes authenticated P2P channel capacity easier to configure correctly.

Each registered logical channel has one bounded inbound mailbox shared by every authenticated peer connection. Rate limits are enforced independently per peer, so a synchronized burst can contribute `peer_count * rate.burst_size()` messages to that shared mailbox. When it fills, the newly arriving message is dropped without per-peer reservations or fairness.

This PR:

- documents the shared mailbox, drop-new overflow, per-peer rate limiting, semantic-filtering boundary, drain-rate limits, and memory implications for both discovery and lookup
- adds `authenticated::backlog` to calculate enough slots for one full quota burst from every peer, including synchronized honest senders
- distinguishes application channel backlogs from internal actor `mailbox_size`
- updates chat, log, bridge, and reshare configurations to use aggregate peer burst sizing
- keeps flood backlog operator-controlled because that benchmark intentionally saturates the receiver

The helper covers one synchronized aggregate burst. Applications must still account for receiver stalls and sustained ingress, since no finite backlog can absorb traffic above the receiver drain rate.