### PR TITLE
[storage/journal] Skip redundant partition rescan in fixed journal init

### DIFF
--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -73,12 +73,13 @@ impl<E: Context> Partition<E> {
         }
     }
 
-    /// Scan the partition and open every existing blob as a [`Writer`], keyed by blob index.
-    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
-        let stored = Self::scan_names(&self.context, &self.name).await?;
-
+    /// Open every blob in `names` as a [`Writer`], keyed by blob index.
+    pub(super) async fn open_many(
+        &self,
+        names: Vec<Vec<u8>>,
+    ) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
         let mut blobs = BTreeMap::new();
-        for name in stored {
+        for name in names {
             let hex_name = hex(&name);
             let bytes: [u8; 8] = name
                 .try_into()
@@ -89,6 +90,12 @@ impl<E: Context> Partition<E> {
             blobs.insert(index, writer);
         }
         Ok(blobs)
+    }
+
+    /// Scan the partition and open every existing blob as a [`Writer`], keyed by blob index.
+    pub(super) async fn open_all(&self) -> Result<BTreeMap<u64, Writer<E::Blob>>, Error> {
+        let names = Self::scan_names(&self.context, &self.name).await?;
+        self.open_many(names).await
     }
 
     /// Remove the given blob.
@@ -110,8 +117,11 @@ impl<E: Context> Partition<E> {
     /// Select the blob partition for `prefix` using legacy-first compatibility rules: the
     /// legacy partition (`prefix` itself) if it contains data, otherwise `{prefix}-blobs`.
     /// Both containing data is corruption.
+    ///
+    /// Returns the chosen partition's name together with the blob names found in it while
+    /// selecting, so the caller can open those blobs without listing the partition a second time.
     // TODO(#2941): Remove legacy partition support
-    pub(super) async fn select(context: &E, prefix: &str) -> Result<String, Error> {
+    pub(super) async fn select(context: &E, prefix: &str) -> Result<(String, Vec<Vec<u8>>), Error> {
         let new_partition = format!("{prefix}-blobs");
         let legacy_blobs = Self::scan_names(context, prefix).await?;
         let new_blobs = Self::scan_names(context, &new_partition).await?;
@@ -123,9 +133,9 @@ impl<E: Context> Partition<E> {
         }
 
         if !legacy_blobs.is_empty() {
-            Ok(prefix.into())
+            Ok((prefix.into(), legacy_blobs))
         } else {
-            Ok(new_partition)
+            Ok((new_partition, new_blobs))
         }
     }
 }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -432,14 +432,14 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             return Self::complete_staged_clear(context, cfg, checkpoint, clear_target).await;
         }
 
-        let blob_partition = Partition::select(&context, &cfg.partition).await?;
+        let (blob_partition, names) = Partition::select(&context, &cfg.partition).await?;
         let partition = Partition::new(
             context.child("blobs"),
             blob_partition,
             cfg.page_cache,
             cfg.write_buffer,
         );
-        let mut pending = partition.open_all().await?;
+        let mut pending = partition.open_many(names).await?;
 
         // Truncate any trailing non-chunk-aligned bytes on every blob before recovery. Items
         // are fixed size, so a blob ending in fewer than `CHUNK_SIZE` trailing bytes is junk
@@ -5287,7 +5287,7 @@ mod tests {
             let checkpoint = checkpoint.sync().await.unwrap();
             drop(checkpoint);
 
-            // This name would fail `Partition::open_all` if init tried to parse stale blobs before
+            // This name would fail `Partition::open_many` if init tried to parse stale blobs before
             // honoring the clear intent.
             let (blob, _) = context.open(&blob_part, b"not-u64").await.unwrap();
             blob.write_at_sync(0, vec![1, 2, 3]).await.unwrap();


### PR DESCRIPTION
`Partition::select` already lists both candidate partitions to choose the winner, but returned only the name — so the fixed journal's init then re-listed the winner via `open_all` before opening its blobs, scanning the winning directory a second time. `select` now returns the scan it already performed alongside the name, and init opens from it via a new `open_many`, listing the winner once.

Extracted from #4220 (its init half). #4220's destroy-crash-safety and removal-batching are superseded by the atomic-delete direction (#4361), so only this independent init optimization is carried forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
