### PR TITLE
[storage/qmdb] Authenticate batch ancestry with Commitment

### DIFF
--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -79,7 +79,7 @@ where
             parent: parent.digest(),
             height,
             state_root: merkleized.root(),
-            range: non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size),
+            range: non_empty_range!(bounds.inactivity_floor, bounds.tip.size),
             payload,
         };
         Some(Proposed { block, merkleized })

--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -15,7 +15,7 @@ use commonware_glue::{
     },
 };
 use commonware_runtime::{BufferPooler, Clock, Metrics, Spawner, Storage};
-use commonware_storage::{mmr::Location, qmdb::sync::Target};
+use commonware_storage::qmdb::sync::Target;
 use commonware_utils::{non_empty_range, sequence::U64};
 use futures::StreamExt;
 use rand::Rng;
@@ -79,7 +79,7 @@ where
             parent: parent.digest(),
             height,
             state_root: merkleized.root(),
-            range: non_empty_range!(bounds.inactivity_floor, Location::new(bounds.total_size)),
+            range: non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size),
             payload,
         };
         Some(Proposed { block, merkleized })

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -267,7 +267,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
             parent: parent.digest(),
             height,
             state_root: merkleized.root(),
-            range: non_empty_range!(bounds.inactivity_floor, Location::new(bounds.total_size)),
+            range: non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size),
             payload,
         };
         Some(Proposed { block, merkleized })

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -267,7 +267,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
             parent: parent.digest(),
             height,
             state_root: merkleized.root(),
-            range: non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size),
+            range: non_empty_range!(bounds.inactivity_floor, bounds.tip.size),
             payload,
         };
         Some(Proposed { block, merkleized })

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1181,7 +1181,7 @@ mod tests {
                 state_root: merkleized.root(),
                 range: non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    Location::new(merkleized.bounds().total_size)
+                    merkleized.bounds().tip_commit.size
                 ),
             };
             Some(Proposed { block, merkleized })
@@ -1385,7 +1385,7 @@ mod tests {
                 state_root: merkleized.root(),
                 range: non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    Location::new(merkleized.bounds().total_size)
+                    merkleized.bounds().tip_commit.size
                 ),
             };
             let round = Round::new(Epoch::zero(), view);
@@ -1967,7 +1967,7 @@ mod tests {
                 state_root: merkleized.root(),
                 range: non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    Location::new(merkleized.bounds().total_size)
+                    merkleized.bounds().tip_commit.size
                 ),
             };
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1181,7 +1181,7 @@ mod tests {
                 state_root: merkleized.root(),
                 range: non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    merkleized.bounds().tip_commit.size
+                    merkleized.bounds().tip.size
                 ),
             };
             Some(Proposed { block, merkleized })
@@ -1385,7 +1385,7 @@ mod tests {
                 state_root: merkleized.root(),
                 range: non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    merkleized.bounds().tip_commit.size
+                    merkleized.bounds().tip.size
                 ),
             };
             let round = Round::new(Epoch::zero(), view);
@@ -1967,7 +1967,7 @@ mod tests {
                 state_root: merkleized.root(),
                 range: non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    merkleized.bounds().tip_commit.size
+                    merkleized.bounds().tip.size
                 ),
             };
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -528,7 +528,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -632,7 +632,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -528,7 +528,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -632,7 +632,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1487,10 +1487,8 @@ mod tests {
             ));
 
             let mut wrong_range = valid_target.clone();
-            wrong_range.range = non_empty_range!(
-                mmr::Location::new(*valid_target.range.start()),
-                mmr::Location::new(*valid_target.range.end() + 1)
-            );
+            wrong_range.range =
+                non_empty_range!(valid_target.range.start(), valid_target.range.end() + 1);
             assert!(!<OrderedFixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
                 &wrong_range,
@@ -1604,10 +1602,8 @@ mod tests {
             ));
 
             let mut wrong_range = valid_target.clone();
-            wrong_range.range = non_empty_range!(
-                mmr::Location::new(*valid_target.range.start()),
-                mmr::Location::new(*valid_target.range.end() + 1)
-            );
+            wrong_range.range =
+                non_empty_range!(valid_target.range.start(), valid_target.range.end() + 1);
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
                 &wrong_range,

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -526,7 +526,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -627,7 +627,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -806,7 +806,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -912,7 +912,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -526,7 +526,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -627,7 +627,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -806,7 +806,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -912,7 +912,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.ops_root() == target.root
             && *target.range.start() == batch.sync_boundary()
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -234,7 +234,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == Location::new(batch.bounds().total_size)
+        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -301,7 +301,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == Location::new(batch.bounds().total_size)
+        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -636,7 +636,7 @@ mod tests {
             // hangs so the test can observe the gauges while they diverge.
             let unservable_target = sync::CompactTarget {
                 root: Sha256::hash(&[&[0xFF]]),
-                size: Location::new(*target.size + 1),
+                size: target.size + 1,
             };
             let (stale_request_tx, mut stale_request_rx) = mpsc::channel(1);
             let superseding_source = SupersedingCompactSource {

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -234,7 +234,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
+        batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -301,7 +301,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
+        batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -307,7 +307,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -399,7 +399,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -307,7 +307,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -399,7 +399,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -735,7 +735,7 @@ mod tests {
             // hangs so the test can observe the gauges while they diverge.
             let unservable_target = sync::CompactTarget {
                 root: Sha256::hash(&[&[0xFF]]),
-                size: Location::new(*target.size + 1),
+                size: target.size + 1,
             };
             let (stale_request_tx, mut stale_request_rx) = mpsc::channel(1);
             let superseding_source = SupersedingCompactSource {

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -224,7 +224,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == Location::new(batch.bounds().total_size)
+        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -290,7 +290,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == Location::new(batch.bounds().total_size)
+        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -585,7 +585,7 @@ mod tests {
 
             let valid_target = sync::CompactTarget {
                 root: merkleized.root(),
-                size: mmr::Location::new(merkleized.bounds().total_size),
+                size: merkleized.bounds().tip_commit.size,
             };
             assert!(<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
@@ -594,7 +594,7 @@ mod tests {
 
             let wrong_size = sync::CompactTarget {
                 root: merkleized.root(),
-                size: mmr::Location::new(merkleized.bounds().total_size - 1),
+                size: merkleized.bounds().tip_commit.size - 1,
             };
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -224,7 +224,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
+        batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -290,7 +290,7 @@ where
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
-        batch.root() == target.root && target.size == batch.bounds().tip_commit.size
+        batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -585,7 +585,7 @@ mod tests {
 
             let valid_target = sync::CompactTarget {
                 root: merkleized.root(),
-                size: merkleized.bounds().tip_commit.size,
+                size: merkleized.bounds().tip.size,
             };
             assert!(<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
@@ -594,7 +594,7 @@ mod tests {
 
             let wrong_size = sync::CompactTarget {
                 root: merkleized.root(),
-                size: merkleized.bounds().tip_commit.size - 1,
+                size: merkleized.bounds().tip.size - 1,
             };
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -277,7 +277,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -362,7 +362,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == batch.bounds().tip_commit.size
+            && *target.range.end() == batch.bounds().tip.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -582,7 +582,7 @@ mod tests {
                 merkleized.root(),
                 non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    merkleized.bounds().tip_commit.size
+                    merkleized.bounds().tip.size
                 ),
             );
             assert!(<FixedDb as ManagedDb<_>>::matches_sync_target(
@@ -592,7 +592,7 @@ mod tests {
 
             let wrong_start = AnySyncTarget::new(
                 merkleized.root(),
-                non_empty_range!(mmr::Location::new(0), merkleized.bounds().tip_commit.size),
+                non_empty_range!(mmr::Location::new(0), merkleized.bounds().tip.size),
             );
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
@@ -603,7 +603,7 @@ mod tests {
                 merkleized.root(),
                 non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    merkleized.bounds().tip_commit.size - 1
+                    merkleized.bounds().tip.size - 1
                 ),
             );
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -277,7 +277,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -362,7 +362,7 @@ where
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
         batch.root() == target.root
             && *target.range.start() == batch.bounds().inactivity_floor
-            && *target.range.end() == Location::<F>::new(batch.bounds().total_size)
+            && *target.range.end() == batch.bounds().tip_commit.size
     }
 
     async fn finalize(self, batch: Self::Merkleized) -> Result<Self, Error<F>> {
@@ -582,7 +582,7 @@ mod tests {
                 merkleized.root(),
                 non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    mmr::Location::new(merkleized.bounds().total_size)
+                    merkleized.bounds().tip_commit.size
                 ),
             );
             assert!(<FixedDb as ManagedDb<_>>::matches_sync_target(
@@ -592,10 +592,7 @@ mod tests {
 
             let wrong_start = AnySyncTarget::new(
                 merkleized.root(),
-                non_empty_range!(
-                    mmr::Location::new(0),
-                    mmr::Location::new(merkleized.bounds().total_size)
-                ),
+                non_empty_range!(mmr::Location::new(0), merkleized.bounds().tip_commit.size),
             );
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(
                 &merkleized,
@@ -606,7 +603,7 @@ mod tests {
                 merkleized.root(),
                 non_empty_range!(
                     merkleized.bounds().inactivity_floor,
-                    mmr::Location::new(merkleized.bounds().total_size - 1)
+                    merkleized.bounds().tip_commit.size - 1
                 ),
             );
             assert!(!<FixedDb as ManagedDb<_>>::matches_sync_target(

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -265,9 +265,9 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
             parent: parent.digest(),
             height,
             root_a: merkleized_a.root(),
-            range_a: non_empty_range!(bounds_a.inactivity_floor, bounds_a.tip_commit.size),
+            range_a: non_empty_range!(bounds_a.inactivity_floor, bounds_a.tip.size),
             root_b: merkleized_b.root(),
-            range_b: non_empty_range!(bounds_b.inactivity_floor, bounds_b.tip_commit.size),
+            range_b: non_empty_range!(bounds_b.inactivity_floor, bounds_b.tip.size),
         };
         Some(Proposed {
             block,
@@ -287,9 +287,9 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         let bounds_a = merkleized_a.bounds();
         let bounds_b = merkleized_b.bounds();
         let matches_a = merkleized_a.root() == tip.root_a
-            && non_empty_range!(bounds_a.inactivity_floor, bounds_a.tip_commit.size) == tip.range_a;
+            && non_empty_range!(bounds_a.inactivity_floor, bounds_a.tip.size) == tip.range_a;
         let matches_b = merkleized_b.root() == tip.root_b
-            && non_empty_range!(bounds_b.inactivity_floor, bounds_b.tip_commit.size) == tip.range_b;
+            && non_empty_range!(bounds_b.inactivity_floor, bounds_b.tip.size) == tip.range_b;
         if !matches_a || !matches_b {
             return None;
         }

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -265,15 +265,9 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
             parent: parent.digest(),
             height,
             root_a: merkleized_a.root(),
-            range_a: non_empty_range!(
-                bounds_a.inactivity_floor,
-                Location::new(bounds_a.total_size)
-            ),
+            range_a: non_empty_range!(bounds_a.inactivity_floor, bounds_a.tip_commit.size),
             root_b: merkleized_b.root(),
-            range_b: non_empty_range!(
-                bounds_b.inactivity_floor,
-                Location::new(bounds_b.total_size)
-            ),
+            range_b: non_empty_range!(bounds_b.inactivity_floor, bounds_b.tip_commit.size),
         };
         Some(Proposed {
             block,
@@ -293,15 +287,9 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         let bounds_a = merkleized_a.bounds();
         let bounds_b = merkleized_b.bounds();
         let matches_a = merkleized_a.root() == tip.root_a
-            && non_empty_range!(
-                bounds_a.inactivity_floor,
-                Location::new(bounds_a.total_size)
-            ) == tip.range_a;
+            && non_empty_range!(bounds_a.inactivity_floor, bounds_a.tip_commit.size) == tip.range_a;
         let matches_b = merkleized_b.root() == tip.root_b
-            && non_empty_range!(
-                bounds_b.inactivity_floor,
-                Location::new(bounds_b.total_size)
-            ) == tip.range_b;
+            && non_empty_range!(bounds_b.inactivity_floor, bounds_b.tip_commit.size) == tip.range_b;
         if !matches_a || !matches_b {
             return None;
         }

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -215,7 +215,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
             parent: parent.digest(),
             height,
             state_root: merkleized.root(),
-            range: non_empty_range!(bounds.inactivity_floor, Location::new(bounds.total_size)),
+            range: non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size),
         };
         Some(Proposed { block, merkleized })
     }
@@ -231,8 +231,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         let merkleized = Self::execute(tip.height(), batches).await;
         let bounds = merkleized.bounds();
         if merkleized.root() != tip.state_root
-            || non_empty_range!(bounds.inactivity_floor, Location::new(bounds.total_size))
-                != tip.range
+            || non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size) != tip.range
         {
             return None;
         }

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -215,7 +215,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
             parent: parent.digest(),
             height,
             state_root: merkleized.root(),
-            range: non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size),
+            range: non_empty_range!(bounds.inactivity_floor, bounds.tip.size),
         };
         Some(Proposed { block, merkleized })
     }
@@ -231,7 +231,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         let merkleized = Self::execute(tip.height(), batches).await;
         let bounds = merkleized.bounds();
         if merkleized.root() != tip.state_root
-            || non_empty_range!(bounds.inactivity_floor, bounds.tip_commit.size) != tip.range
+            || non_empty_range!(bounds.inactivity_floor, bounds.tip.size) != tip.range
         {
             return None;
         }

--- a/storage/fuzz/fuzz_targets/qmdb_immutable.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable.rs
@@ -135,7 +135,7 @@ fn assign_pending_locations<F: MerkleFamily>(
     let mut sorted_keys: Vec<Digest> = pending.iter().map(|(k, _)| *k).collect();
     sorted_keys.sort();
     for (i, key) in sorted_keys.iter().enumerate() {
-        let loc = Location::new(base.as_u64() + i as u64);
+        let loc = base + i as u64;
         keys_set.push((*key, loc));
         set_locations.push((*key, loc));
     }
@@ -210,7 +210,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                             // Advance floor to the commit location (end of this batch).
                             // total_size = end + pending_count + 1 (commit op).
                             // Floor at the commit op is the maximum valid value.
-                            Location::new(*end + pending_count)
+                            end + pending_count
                         } else {
                             db.inactivity_floor_loc()
                         };

--- a/storage/src/merkle/mmb/iterator.rs
+++ b/storage/src/merkle/mmb/iterator.rs
@@ -115,10 +115,10 @@ impl Iterator for PeakIterator {
         let leaves_in_peak = 1u64 << height;
 
         // The last leaf in this peak's subtree.
-        let last_leaf = Location::new(self.start_leaf_cursor.as_u64() + leaves_in_peak - 1);
+        let last_leaf = self.start_leaf_cursor + leaves_in_peak - 1;
 
         // Advance the cursor rightward for the next (newer) peak.
-        self.start_leaf_cursor = Location::new(self.start_leaf_cursor.as_u64() + leaves_in_peak);
+        self.start_leaf_cursor += leaves_in_peak;
         self.current_i = self.current_i.wrapping_sub(1);
         self.remaining -= 1;
 

--- a/storage/src/merkle/mmb/mod.rs
+++ b/storage/src/merkle/mmb/mod.rs
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn test_inactive_peaks() {
-        let size = Family::location_to_position(Location::new(8));
+        let size = Location::new(8);
 
         // At 8 leaves (size 13 nodes), MMB has 3 peaks:
         // - Height 2 covering leaves 0..4 (capacity 4)

--- a/storage/src/merkle/mmb/proof.rs
+++ b/storage/src/merkle/mmb/proof.rs
@@ -71,7 +71,7 @@ mod tests {
 
             let loc = n - 1;
             let inactive_peaks =
-                crate::merkle::mmb::Family::inactive_peaks(mmb.size(), Location::new(0));
+                crate::merkle::mmb::Family::inactive_peaks(leaves, Location::new(0));
             let bp = Blueprint::new(
                 leaves,
                 inactive_peaks,

--- a/storage/src/merkle/mmr/mod.rs
+++ b/storage/src/merkle/mmr/mod.rs
@@ -895,7 +895,7 @@ mod tests {
 
     #[test]
     fn test_inactive_peaks() {
-        let size = Family::location_to_position(Location::new(11));
+        let size = Location::new(11);
 
         // At 11 leaves, MMR has 3 peaks:
         // - Height 3 covering leaves 0..8 (capacity 8)

--- a/storage/src/merkle/mmr/mod.rs
+++ b/storage/src/merkle/mmr/mod.rs
@@ -632,10 +632,10 @@ mod tests {
         assert!(Location::new(u64::MAX).checked_add(1).is_none());
         assert!(MAX_LEAVES.checked_add(1).is_none());
         // MAX_LEAVES - 10 + 10 = MAX_LEAVES, which IS valid (inclusive bound)
-        let loc = Location::new(*MAX_LEAVES - 10);
+        let loc = MAX_LEAVES - 10;
         assert_eq!(loc.checked_add(10).unwrap(), *MAX_LEAVES);
         // MAX_LEAVES - 11 + 10 = MAX_LEAVES - 1, also valid
-        let loc = Location::new(*MAX_LEAVES - 11);
+        let loc = MAX_LEAVES - 11;
         assert_eq!(loc.checked_add(10).unwrap(), *MAX_LEAVES - 1);
     }
 
@@ -707,7 +707,7 @@ mod tests {
         // MAX_LEAVES IS valid (inclusive bound)
         assert!(MAX_LEAVES.is_valid());
         assert!((MAX_LEAVES - 1).is_valid());
-        assert!(!Location::new(*MAX_LEAVES + 1).is_valid());
+        assert!(!(MAX_LEAVES + 1).is_valid());
         assert!(!Location::new(u64::MAX).is_valid());
     }
 
@@ -725,7 +725,7 @@ mod tests {
 
     #[test]
     fn test_overflow_location_returns_error() {
-        let over_loc = Location::new(*MAX_LEAVES + 1);
+        let over_loc = MAX_LEAVES + 1;
         assert!(!over_loc.is_valid());
         assert!(matches!(
             Position::try_from(over_loc).unwrap_err(),

--- a/storage/src/merkle/mmr/proof.rs
+++ b/storage/src/merkle/mmr/proof.rs
@@ -139,7 +139,7 @@ mod tests {
     fn test_max_location_is_provable() {
         // MAX_LEAVES is the largest valid leaf count.
         let max_loc = Family::MAX_LEAVES;
-        let max_loc_plus_1 = Location::new(*max_loc + 1);
+        let max_loc_plus_1 = max_loc + 1;
 
         let result = Blueprint::new(max_loc, 0, Bagging::ForwardFold, max_loc - 1..max_loc);
         assert!(

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -99,10 +99,10 @@ pub trait Family: Copy + Clone + Debug + Default + Send + Sync + 'static {
     ///
     /// A peak is considered entirely inactive if all of its leaves strictly precede the
     /// `inactivity_floor`. These peaks can be safely bagged forward into the `grafted_root`.
-    fn inactive_peaks(size: Position<Self>, inactivity_floor: Location<Self>) -> usize {
+    fn inactive_peaks(size: Location<Self>, inactivity_floor: Location<Self>) -> usize {
         let mut inactive_count = 0;
         let mut leaf_capacity_sum = 0u64;
-        for (_, height) in Self::peaks(size) {
+        for (_, height) in Self::peaks(Self::location_to_position(size)) {
             let capacity = 1u64.checked_shl(height).expect("height excessively large");
             leaf_capacity_sum = leaf_capacity_sum
                 .checked_add(capacity)

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -292,7 +292,7 @@ mod tests {
         ));
 
         // Leaf count beyond the family maximum.
-        let too_many = Location::new(mmr::Family::MAX_LEAVES.as_u64() + 1);
+        let too_many = mmr::Family::MAX_LEAVES + 1;
         assert!(matches!(
             merkle.reset_to(too_many, vec![]),
             Err(Error::LocationOverflow(loc)) if loc == too_many

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -1219,7 +1219,7 @@ mod tests {
         if start + width <= *leaves {
             return Location::new(start);
         }
-        Location::new(*leaves - width)
+        leaves - width
     }
 
     fn range_proofs_verify_for_supported_root_shapes<F: Family>() {
@@ -1930,7 +1930,7 @@ mod tests {
 
         // Verify mangling the location to something invalid should fail.
         let mut wrong_size_proof = multi_proof.clone();
-        wrong_size_proof.leaves = Location::new(*F::MAX_LEAVES + 2);
+        wrong_size_proof.leaves = F::MAX_LEAVES + 2;
         assert!(!wrong_size_proof.verify_multi_inclusion(
             &hasher,
             &[

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -170,7 +170,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
     /// from `size` and `inactivity_floor`.
     pub fn matches_canonical_inactive_peaks(
         &self,
-        size: Position<F>,
+        size: Location<F>,
         inactivity_floor: Location<F>,
     ) -> bool {
         self.inactive_peaks == F::inactive_peaks(size, inactivity_floor)

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -15,7 +15,7 @@ use crate::{
             operation::{Operation, update},
             ordered::{find_next_key, find_next_key_ascending, find_prev_key},
         },
-        batch_chain::{self, Bounds},
+        batch_chain::{self, Bounds, CommitId},
         bitmap::Shared,
         delete_known_loc,
         operation::{Key, Operation as OperationTrait},
@@ -202,7 +202,7 @@ where
 {
     /// Created from the DB via `db.new_batch()`.
     Db {
-        db_size: u64,
+        state: CommitId<F, D>,
         inactivity_floor_loc: Location<F>,
         active_keys: usize,
     },
@@ -214,22 +214,21 @@ impl<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy> Base<F,
 where
     Operation<F, U>: Send + Sync,
 {
-    /// Total operations before this batch (committed DB + ancestor batches).
-    fn base_size(&self) -> u64 {
+    /// The [CommitId] for the state off which this batch was created.
+    fn base_state(&self) -> CommitId<F, D> {
         match self {
-            Self::Db { db_size, .. } => *db_size,
-            Self::Child(parent) => parent.bounds.total_size,
+            Self::Db { state, .. } => *state,
+            Self::Child(parent) => parent.commit_id(),
         }
     }
 
-    /// Effective number of committed DB operations at the base of the batch chain.
-    /// For `Db`, this is the DB size when `new_batch()` was called.
-    /// For `Child`, this is inherited from the parent (which may be higher than
-    /// the original DB size if ancestors were dropped before merkleize).
-    fn db_size(&self) -> u64 {
+    /// The [CommitId] at the boundary between committed DB operations and the batch chain.
+    /// For `Db`, this is the committed DB state. For `Child`, it is inherited from the parent
+    /// (which may be higher than the original DB size if ancestors were dropped before merkleize).
+    fn db_commit(&self) -> CommitId<F, D> {
         match self {
-            Self::Db { db_size, .. } => *db_size,
-            Self::Child(parent) => parent.bounds.db_size,
+            Self::Db { state, .. } => *state,
+            Self::Child(parent) => parent.bounds.db_commit,
         }
     }
 
@@ -405,9 +404,6 @@ where
     /// Merkleized authenticated journal batch (provides the speculative Merkle root).
     pub(crate) journal_batch: Arc<authenticated::MerkleizedBatch<F, D, Operation<F, U>, S>>,
 
-    /// Cached operations root after applying this batch.
-    pub(crate) root: D,
-
     /// This batch's local key-level changes only (not accumulated from ancestors).
     /// Sorted by key with no duplicates; queried via `lookup_sorted` (binary search).
     pub(crate) diff: Arc<DiffVec<U::Key, F, U::Value>>,
@@ -424,7 +420,7 @@ where
     pub(crate) ancestor_diffs: Vec<Arc<DiffVec<U::Key, F, U::Value>>>,
 
     /// Position and floor bounds for this batch chain.
-    pub(crate) bounds: batch_chain::Bounds<F>,
+    pub(crate) bounds: batch_chain::Bounds<F, D>,
 }
 
 /// Strong ref to an ancestor [`MerkleizedBatch`] collected during merkleize.
@@ -444,8 +440,8 @@ where
 {
     journal_batch: authenticated::UnmerkleizedBatch<F, H, Operation<F, U>, S>,
     ancestors: Vec<AncestorBatch<F, H::Digest, U, S>>,
-    base_size: u64,
-    db_size: u64,
+    base_commit: CommitId<F, H::Digest>,
+    db_commit: CommitId<F, H::Digest>,
     base_inactivity_floor_loc: Location<F>,
     base_active_keys: usize,
 }
@@ -812,12 +808,14 @@ where
     ) -> Option<Operation<F, U>> {
         let loc = *loc;
 
-        if loc >= self.base_size {
-            return Some(batch_ops[(loc - self.base_size) as usize].clone());
+        if loc >= self.base_commit.size {
+            return Some(batch_ops[(loc - *self.base_commit.size) as usize].clone());
         }
 
-        if loc >= self.db_size {
-            return Some(read_op_from_ancestors(&self.ancestors, loc, self.db_size).clone());
+        if loc >= self.db_commit.size {
+            return Some(
+                read_op_from_ancestors(&self.ancestors, loc, *self.db_commit.size).clone(),
+            );
         }
 
         None
@@ -827,7 +825,9 @@ where
     /// the shape a single batched reader call serves with no in-memory resolution.
     fn all_committed_ascending(&self, locations: &[Location<F>]) -> bool {
         locations.is_sorted_by(|a, b| a < b)
-            && locations.last().is_some_and(|last| **last < self.db_size)
+            && locations
+                .last()
+                .is_some_and(|last| **last < self.db_commit.size)
     }
 
     /// Read multiple operations by location, preserving the caller's order and permitting
@@ -1055,7 +1055,7 @@ where
             // Floor raise: advance the inactivity floor by `total_steps` active operations.
             // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let strategy = db.strategy();
-            let fixed_tip = self.base_size + ops.len() as u64;
+            let fixed_tip = *self.base_commit.size + ops.len() as u64;
             let mut moved = 0u64;
             let mut scan_from = floor;
             floor_diff.reserve(total_steps as usize);
@@ -1233,7 +1233,7 @@ where
                     match outcome {
                         FloorOutcome::Inactive => continue,
                         FloorOutcome::MoveExisting { idx, base_old_loc } => {
-                            let new_loc = Location::new(self.base_size + ops.len() as u64);
+                            let new_loc = self.base_commit.size + ops.len() as u64;
                             let value = extract_update_value(&op);
                             ops.push(op);
                             diff[idx].1 = DiffEntry::Active {
@@ -1244,7 +1244,7 @@ where
                         }
                         FloorOutcome::MoveNew { base_old_loc } => {
                             let key = op.key().cloned().expect("moved op has a key");
-                            let new_loc = Location::new(self.base_size + ops.len() as u64);
+                            let new_loc = self.base_commit.size + ops.len() as u64;
                             let value = extract_update_value(&op);
                             ops.push(op);
                             floor_diff.push((
@@ -1265,7 +1265,7 @@ where
             }
         } else {
             // DB is empty after this batch; raise floor to tip.
-            floor = Location::new(self.base_size + ops.len() as u64);
+            floor = self.base_commit.size + ops.len() as u64;
             debug!(tip = ?floor, "db is empty, raising floor to tip");
         }
 
@@ -1294,7 +1294,7 @@ where
         }
 
         // CommitFloor operation.
-        let commit_loc = Location::<F>::new(self.base_size + ops.len() as u64);
+        let commit_loc = self.base_commit.size + ops.len() as u64;
         ops.push(Operation::CommitFloor(metadata, floor));
 
         // Merkleize the journal batch.
@@ -1302,7 +1302,7 @@ where
         // parent already contains all prior batches' Merkle state, so we only
         // add THIS batch's operations. Parent operations are never re-cloned,
         // re-encoded, or re-hashed.
-        let leaves = Location::new(self.base_size + ops.len() as u64);
+        let leaves = self.base_commit.size + ops.len() as u64;
         let inactive_peaks = db.inactive_peaks(leaves, floor);
 
         // Leaf and node hashing dominate merkleization, so run them as one job on the
@@ -1321,22 +1321,21 @@ where
             .iter()
             .map(|a| batch_chain::AncestorBounds {
                 floor: a.bounds.inactivity_floor,
-                end: a.bounds.total_size,
+                state: a.commit_id(),
             })
             .collect();
 
         assert!(total_active_keys >= 0, "active_keys underflow");
         Ok(Arc::new(MerkleizedBatch {
             journal_batch: journal,
-            root,
             diff: Arc::new(diff),
             parent: self.ancestors.first().map(Arc::downgrade),
             total_active_keys: total_active_keys as usize,
             ancestor_diffs,
             bounds: batch_chain::Bounds {
-                base_size: self.base_size,
-                db_size: self.db_size,
-                total_size: *commit_loc + 1,
+                base_commit: self.base_commit,
+                db_commit: self.db_commit,
+                tip_commit: CommitId::new(commit_loc + 1, root),
                 ancestors,
                 inactivity_floor: floor,
             },
@@ -1366,22 +1365,25 @@ where
             v.extend(parent.ancestors());
             v
         });
-        // If the Weak parent chain was truncated (an ancestor was committed and freed), the
-        // oldest alive ancestor's items don't start at db_size. Example: chain A -> B -> C,
-        // A committed and dropped. ancestors() yields [B] (A's Weak is dead). B's items start
-        // at A.size(), not db_size. We use the journal (strong Arcs, always intact) to compute
-        // the actual base so reads fall through to disk for locations in the gap.
-        let db_size = self.base.db_size();
-        let effective_db_size = ancestors.last().map_or(db_size, |oldest| {
-            let oldest_base =
-                oldest.journal_batch.size() - oldest.journal_batch.items().len() as u64;
-            db_size.max(oldest_base)
+        // The DB boundary is the inherited committed state, unless older ancestors were committed
+        // and freed (truncating the Weak parent chain): then the oldest live ancestor's base is the
+        // true boundary, and its recorded `base_commit` names that state directly. Example: chain
+        // A -> B -> C with A committed and dropped, `ancestors()` yields [B]; B's items start at A's
+        // size, so B's `base_commit` (== A's committed state) is the boundary.
+        let inherited = self.base.db_commit();
+        let db_commit = ancestors.last().map_or(inherited, |oldest| {
+            let oldest_base = oldest.bounds.base_commit;
+            if oldest_base.size > inherited.size {
+                oldest_base
+            } else {
+                inherited
+            }
         });
         let m = Merkleizer {
             journal_batch: self.journal_batch,
             ancestors,
-            base_size: self.base.base_size(),
-            db_size: effective_db_size,
+            base_commit: self.base.base_state(),
+            db_commit,
             base_inactivity_floor_loc: self.base.inactivity_floor_loc(),
             base_active_keys: self.base.active_keys(),
         };
@@ -2047,7 +2049,7 @@ where
         // Write a user mutation at the next batch location, preserving the previous committed
         // location of the key it supersedes.
         let mut emit = |key: K, base_old_loc: Option<Location<F>>, mutation: Option<V::Value>| {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            let new_loc = m.base_commit.size + ops.len() as u64;
             superseded_locs.extend(base_old_loc);
             match mutation {
                 Some(value) => {
@@ -2089,7 +2091,7 @@ where
         // key in the ancestor's traveling diff and supersedes its entry's location instead.
         let staged_base_old_loc = |sloc: StagedLoc<F>| match sloc {
             StagedLoc::Committed(loc) => Some(loc),
-            StagedLoc::Ancestor { loc, .. } if *loc < m.db_size => Some(loc),
+            StagedLoc::Ancestor { loc, .. } if *loc < m.db_commit.size => Some(loc),
             StagedLoc::Ancestor { base_old_loc, .. } => base_old_loc,
         };
         let mut cached = staged_updates.into_iter().peekable();
@@ -2149,7 +2151,7 @@ where
         db.strategy()
             .sort_by(&mut creates, |(a, _, _), (b, _, _)| a.cmp(b));
         for (key, value, base_old_loc) in creates {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            let new_loc = m.base_commit.size + ops.len() as u64;
             superseded_locs.extend(base_old_loc);
             ops.push(Operation::Update(update::Unordered(
                 key.clone(),
@@ -2487,7 +2489,7 @@ where
         let mut ancestors = DiffCursors::new(m.ancestors.iter().map(|a| a.diff.as_slice()));
         let mut next_idx = 0;
         for (key, value, old_loc) in &updated {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            let new_loc = m.base_commit.size + ops.len() as u64;
             let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
@@ -2513,7 +2515,7 @@ where
         // Process creates.
         let mut next_idx = 0;
         for (key, value, base_old_loc) in &created {
-            let new_loc = Location::new(m.base_size + ops.len() as u64);
+            let new_loc = m.base_commit.size + ops.len() as u64;
             let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
@@ -2560,7 +2562,7 @@ where
                 let prev_value = prev_value
                     .as_ref()
                     .expect("staged-resolved keys are skipped as updated");
-                let prev_new_loc = Location::new(m.base_size + ops.len() as u64);
+                let prev_new_loc = m.base_commit.size + ops.len() as u64;
                 let prev_next_key = find_next_key(prev_key, &next_candidates);
                 ops.push(Operation::Update(update::Ordered {
                     key: prev_key.clone(),
@@ -2612,11 +2614,11 @@ where
 {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
-        self.root
+        self.bounds.tip_commit.root
     }
 
     /// Return the [`Bounds`] of the batch.
-    pub const fn bounds(&self) -> &Bounds<F> {
+    pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
     }
 
@@ -2624,6 +2626,11 @@ where
     /// Weak ref fails to upgrade (ancestor was freed).
     pub(crate) fn ancestors(&self) -> impl Iterator<Item = Arc<Self>> + use<F, D, U, S> {
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
+    }
+
+    /// The [`CommitId`] this batch commits to.
+    pub(crate) const fn commit_id(&self) -> CommitId<F, D> {
+        self.bounds.tip_commit
     }
 }
 
@@ -2641,8 +2648,8 @@ where
         level = "debug",
         skip_all,
         fields(
-            base_size = self.bounds.base_size,
-            total_size = self.bounds.total_size,
+            base_size = *self.bounds.base_commit.size,
+            total_size = *self.bounds.tip_commit.size,
             ancestor_batches = self.ancestor_diffs.len() as u64,
         ),
     )]
@@ -2748,13 +2755,11 @@ where
         ),
     )]
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, H, U, S> {
-        // The DB is always committed, so journal size = last_commit_loc + 1.
-        let journal_size = *self.last_commit_loc + 1;
         UnmerkleizedBatch {
             journal_batch: self.log.new_batch(),
             mutations: BTreeMap::new(),
             base: Base::Db {
-                db_size: journal_size,
+                state: self.commit_id(),
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
@@ -2784,7 +2789,7 @@ where
     ) -> Result<(), crate::qmdb::Error<F>> {
         batch
             .bounds
-            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
     }
 
     /// Apply a batch to the database, returning the range of written operations.
@@ -2802,8 +2807,8 @@ where
         level = "info",
         skip_all,
         fields(
-            batch_total_size = batch.bounds.total_size,
-            batch_base_size = batch.bounds.base_size,
+            batch_total_size = *batch.bounds.tip_commit.size,
+            batch_base_size = *batch.bounds.base_commit.size,
             db_size = *self.last_commit_loc + 1,
             ancestor_batches = batch.ancestor_diffs.len() as u64,
         ),
@@ -2824,7 +2829,7 @@ where
         // Scoped so the bitmap guard drops before later `.await`s (guard is `!Send`).
         {
             let mut bitmap = self.bitmap.write();
-            bitmap.extend_to(batch.bounds.total_size);
+            bitmap.extend_to(*batch.bounds.tip_commit.size);
 
             if batch.ancestor_diffs.is_empty() {
                 // Fast path: no ancestors to merge, no fixups to look up.
@@ -2843,7 +2848,7 @@ where
                 let mut applied = Vec::with_capacity(batch.ancestor_diffs.len());
                 let mut pending = Vec::with_capacity(batch.ancestor_diffs.len());
                 for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
-                    if batch.bounds.ancestors[i].end <= db_size {
+                    if batch.bounds.ancestors[i].state.size <= db_size {
                         applied.push(ancestor_diff.as_slice());
                     } else {
                         pending.push(ancestor_diff.as_slice());
@@ -2866,14 +2871,14 @@ where
             // set the new; earlier ancestor commits between them are already 0 from
             // `extend_to`.
             bitmap.set_bit(*self.last_commit_loc, false);
-            bitmap.set_bit(batch.bounds.total_size - 1, true);
+            bitmap.set_bit(*batch.bounds.tip_commit.size - 1, true);
         }
 
         // Update DB metadata.
         self.active_keys = batch.total_active_keys;
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
-        self.root = batch.root;
+        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
+        self.root = batch.root();
 
         // Return range of operations that were written to the log.
         let end_loc = Location::new(*self.last_commit_loc + 1);
@@ -2910,22 +2915,13 @@ where
         ),
     )]
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, U, S>> {
-        // The DB is always committed, so journal size = last_commit_loc + 1.
-        let journal_size = *self.last_commit_loc + 1;
         Arc::new(MerkleizedBatch {
             journal_batch: self.log.to_merkleized_batch(),
-            root: self.root,
             diff: Arc::new(Vec::new()),
             parent: None,
             total_active_keys: self.active_keys,
             ancestor_diffs: Vec::new(),
-            bounds: batch_chain::Bounds {
-                base_size: journal_size,
-                db_size: journal_size,
-                total_size: journal_size,
-                ancestors: Vec::new(),
-                inactivity_floor: self.inactivity_floor_loc,
-            },
+            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
         })
     }
 }
@@ -4423,7 +4419,7 @@ mod tests {
                 .write(key_current, Some(value_current));
             let (_mutations, merkleizer) = child.into_parts();
 
-            let current_loc = Location::new(merkleizer.base_size);
+            let current_loc = merkleizer.base_commit.size;
             let batch_ops = vec![Operation::Update(update::Unordered(
                 key_current,
                 value_current,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -15,7 +15,7 @@ use crate::{
             operation::{Operation, update},
             ordered::{find_next_key, find_next_key_ascending, find_prev_key},
         },
-        batch_chain::{self, Bounds, CommitId},
+        batch_chain::{self, Bounds, Commitment},
         bitmap::Shared,
         delete_known_loc,
         operation::{Key, Operation as OperationTrait},
@@ -202,7 +202,7 @@ where
 {
     /// Created from the DB via `db.new_batch()`.
     Db {
-        state: CommitId<F, D>,
+        state: Commitment<F, D>,
         inactivity_floor_loc: Location<F>,
         active_keys: usize,
     },
@@ -214,18 +214,18 @@ impl<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy> Base<F,
 where
     Operation<F, U>: Send + Sync,
 {
-    /// The [CommitId] for the state off which this batch was created.
-    fn base_state(&self) -> CommitId<F, D> {
+    /// The [Commitment] for the state off which this batch was created.
+    fn base_state(&self) -> Commitment<F, D> {
         match self {
             Self::Db { state, .. } => *state,
-            Self::Child(parent) => parent.commit_id(),
+            Self::Child(parent) => parent.commitment(),
         }
     }
 
-    /// The [CommitId] at the boundary between committed DB operations and the batch chain.
+    /// The [Commitment] at the boundary between committed DB operations and the batch chain.
     /// For `Db`, this is the committed DB state. For `Child`, it is inherited from the parent
     /// (which may be higher than the original DB size if ancestors were dropped before merkleize).
-    fn db_commit(&self) -> CommitId<F, D> {
+    fn db_commit(&self) -> Commitment<F, D> {
         match self {
             Self::Db { state, .. } => *state,
             Self::Child(parent) => parent.bounds.db_commit,
@@ -440,8 +440,8 @@ where
 {
     journal_batch: authenticated::UnmerkleizedBatch<F, H, Operation<F, U>, S>,
     ancestors: Vec<AncestorBatch<F, H::Digest, U, S>>,
-    base_commit: CommitId<F, H::Digest>,
-    db_commit: CommitId<F, H::Digest>,
+    base_commit: Commitment<F, H::Digest>,
+    db_commit: Commitment<F, H::Digest>,
     base_inactivity_floor_loc: Location<F>,
     base_active_keys: usize,
 }
@@ -1321,7 +1321,7 @@ where
             .iter()
             .map(|a| batch_chain::AncestorBounds {
                 floor: a.bounds.inactivity_floor,
-                state: a.commit_id(),
+                state: a.commitment(),
             })
             .collect();
 
@@ -1335,7 +1335,7 @@ where
             bounds: batch_chain::Bounds {
                 base_commit: self.base_commit,
                 db_commit: self.db_commit,
-                tip_commit: CommitId::new(commit_loc + 1, root),
+                tip_commit: Commitment::new(commit_loc + 1, root),
                 ancestors,
                 inactivity_floor: floor,
             },
@@ -2628,8 +2628,8 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
-    /// The [`CommitId`] this batch commits to.
-    pub(crate) const fn commit_id(&self) -> CommitId<F, D> {
+    /// The [`Commitment`] this batch commits to.
+    pub(crate) const fn commitment(&self) -> Commitment<F, D> {
         self.bounds.tip_commit
     }
 }
@@ -2759,7 +2759,7 @@ where
             journal_batch: self.log.new_batch(),
             mutations: BTreeMap::new(),
             base: Base::Db {
-                state: self.commit_id(),
+                state: self.commitment(),
                 inactivity_floor_loc: self.inactivity_floor_loc,
                 active_keys: self.active_keys,
             },
@@ -2789,7 +2789,7 @@ where
     ) -> Result<(), crate::qmdb::Error<F>> {
         batch
             .bounds
-            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
+            .validate_apply_to(self.commitment(), self.inactivity_floor_loc)
     }
 
     /// Apply a batch to the database, returning the range of written operations.
@@ -2921,7 +2921,7 @@ where
             parent: None,
             total_active_keys: self.active_keys,
             ancestor_diffs: Vec::new(),
-            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
+            bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
         })
     }
 }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1224,7 +1224,7 @@ where
                 let mut reads = resolved.into_iter().flatten();
                 let mut pending = read_candidates.iter().peekable();
                 for candidate in candidates {
-                    floor = Location::new(*candidate + 1);
+                    floor = candidate + 1;
                     if pending.next_if(|&&pending| pending == candidate).is_none() {
                         continue;
                     }
@@ -2881,7 +2881,7 @@ where
         self.root = batch.root();
 
         // Return range of operations that were written to the log.
-        let end_loc = Location::new(*self.last_commit_loc + 1);
+        let end_loc = self.last_commit_loc + 1;
         let range = start_loc..end_loc;
         self.update_metrics();
         self.metrics

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -222,13 +222,14 @@ where
         }
     }
 
-    /// The [Commitment] at the boundary between committed DB operations and the batch chain.
-    /// For `Db`, this is the committed DB state. For `Child`, it is inherited from the parent
+    /// The database boundary for this batch chain.
+    ///
+    /// For `Db`, this is its state. For `Child`, it is inherited from the parent
     /// (which may be higher than the original DB size if ancestors were dropped before merkleize).
-    fn db_commit(&self) -> Commitment<F, D> {
+    fn db(&self) -> Commitment<F, D> {
         match self {
             Self::Db { state, .. } => *state,
-            Self::Child(parent) => parent.bounds.db_commit,
+            Self::Child(parent) => parent.bounds.db,
         }
     }
 
@@ -440,8 +441,8 @@ where
 {
     journal_batch: authenticated::UnmerkleizedBatch<F, H, Operation<F, U>, S>,
     ancestors: Vec<AncestorBatch<F, H::Digest, U, S>>,
-    base_commit: Commitment<F, H::Digest>,
-    db_commit: Commitment<F, H::Digest>,
+    base_state: Commitment<F, H::Digest>,
+    db_state: Commitment<F, H::Digest>,
     base_inactivity_floor_loc: Location<F>,
     base_active_keys: usize,
 }
@@ -808,14 +809,12 @@ where
     ) -> Option<Operation<F, U>> {
         let loc = *loc;
 
-        if loc >= self.base_commit.size {
-            return Some(batch_ops[(loc - *self.base_commit.size) as usize].clone());
+        if loc >= self.base_state.size {
+            return Some(batch_ops[(loc - *self.base_state.size) as usize].clone());
         }
 
-        if loc >= self.db_commit.size {
-            return Some(
-                read_op_from_ancestors(&self.ancestors, loc, *self.db_commit.size).clone(),
-            );
+        if loc >= self.db_state.size {
+            return Some(read_op_from_ancestors(&self.ancestors, loc, *self.db_state.size).clone());
         }
 
         None
@@ -827,7 +826,7 @@ where
         locations.is_sorted_by(|a, b| a < b)
             && locations
                 .last()
-                .is_some_and(|last| **last < self.db_commit.size)
+                .is_some_and(|last| **last < self.db_state.size)
     }
 
     /// Read multiple operations by location, preserving the caller's order and permitting
@@ -1055,7 +1054,7 @@ where
             // Floor raise: advance the inactivity floor by `total_steps` active operations.
             // `fixed_tip` prevents scanning into floor-raise moves just appended.
             let strategy = db.strategy();
-            let fixed_tip = *self.base_commit.size + ops.len() as u64;
+            let fixed_tip = *self.base_state.size + ops.len() as u64;
             let mut moved = 0u64;
             let mut scan_from = floor;
             floor_diff.reserve(total_steps as usize);
@@ -1233,7 +1232,7 @@ where
                     match outcome {
                         FloorOutcome::Inactive => continue,
                         FloorOutcome::MoveExisting { idx, base_old_loc } => {
-                            let new_loc = self.base_commit.size + ops.len() as u64;
+                            let new_loc = self.base_state.size + ops.len() as u64;
                             let value = extract_update_value(&op);
                             ops.push(op);
                             diff[idx].1 = DiffEntry::Active {
@@ -1244,7 +1243,7 @@ where
                         }
                         FloorOutcome::MoveNew { base_old_loc } => {
                             let key = op.key().cloned().expect("moved op has a key");
-                            let new_loc = self.base_commit.size + ops.len() as u64;
+                            let new_loc = self.base_state.size + ops.len() as u64;
                             let value = extract_update_value(&op);
                             ops.push(op);
                             floor_diff.push((
@@ -1265,7 +1264,7 @@ where
             }
         } else {
             // DB is empty after this batch; raise floor to tip.
-            floor = self.base_commit.size + ops.len() as u64;
+            floor = self.base_state.size + ops.len() as u64;
             debug!(tip = ?floor, "db is empty, raising floor to tip");
         }
 
@@ -1294,7 +1293,7 @@ where
         }
 
         // CommitFloor operation.
-        let commit_loc = self.base_commit.size + ops.len() as u64;
+        let commit_loc = self.base_state.size + ops.len() as u64;
         ops.push(Operation::CommitFloor(metadata, floor));
 
         // Merkleize the journal batch.
@@ -1302,7 +1301,7 @@ where
         // parent already contains all prior batches' Merkle state, so we only
         // add THIS batch's operations. Parent operations are never re-cloned,
         // re-encoded, or re-hashed.
-        let leaves = self.base_commit.size + ops.len() as u64;
+        let leaves = self.base_state.size + ops.len() as u64;
         let inactive_peaks = db.inactive_peaks(leaves, floor);
 
         // Leaf and node hashing dominate merkleization, so run them as one job on the
@@ -1333,9 +1332,9 @@ where
             total_active_keys: total_active_keys as usize,
             ancestor_diffs,
             bounds: batch_chain::Bounds {
-                base_commit: self.base_commit,
-                db_commit: self.db_commit,
-                tip_commit: Commitment::new(commit_loc + 1, root),
+                base: self.base_state,
+                db: self.db_state,
+                tip: Commitment::new(commit_loc + 1, root),
                 ancestors,
                 inactivity_floor: floor,
             },
@@ -1365,14 +1364,13 @@ where
             v.extend(parent.ancestors());
             v
         });
-        // The DB boundary is the inherited committed state, unless older ancestors were committed
-        // and freed (truncating the Weak parent chain): then the oldest live ancestor's base is the
-        // true boundary, and its recorded `base_commit` names that state directly. Example: chain
-        // A -> B -> C with A committed and dropped, `ancestors()` yields [B]; B's items start at A's
-        // size, so B's `base_commit` (== A's committed state) is the boundary.
-        let inherited = self.base.db_commit();
-        let db_commit = ancestors.last().map_or(inherited, |oldest| {
-            let oldest_base = oldest.bounds.base_commit;
+        // The DB boundary is inherited unless older ancestors were applied and freed, truncating
+        // the weak parent chain. The oldest live ancestor's base then names the boundary directly.
+        // For A -> B -> C with A applied and dropped, `ancestors()` yields [B]. B's items start at
+        // A's size, so B's `base` is the boundary.
+        let inherited = self.base.db();
+        let db_state = ancestors.last().map_or(inherited, |oldest| {
+            let oldest_base = oldest.bounds.base;
             if oldest_base.size > inherited.size {
                 oldest_base
             } else {
@@ -1382,8 +1380,8 @@ where
         let m = Merkleizer {
             journal_batch: self.journal_batch,
             ancestors,
-            base_commit: self.base.base_state(),
-            db_commit,
+            base_state: self.base.base_state(),
+            db_state,
             base_inactivity_floor_loc: self.base.inactivity_floor_loc(),
             base_active_keys: self.base.active_keys(),
         };
@@ -2049,7 +2047,7 @@ where
         // Write a user mutation at the next batch location, preserving the previous committed
         // location of the key it supersedes.
         let mut emit = |key: K, base_old_loc: Option<Location<F>>, mutation: Option<V::Value>| {
-            let new_loc = m.base_commit.size + ops.len() as u64;
+            let new_loc = m.base_state.size + ops.len() as u64;
             superseded_locs.extend(base_old_loc);
             match mutation {
                 Some(value) => {
@@ -2091,7 +2089,7 @@ where
         // key in the ancestor's traveling diff and supersedes its entry's location instead.
         let staged_base_old_loc = |sloc: StagedLoc<F>| match sloc {
             StagedLoc::Committed(loc) => Some(loc),
-            StagedLoc::Ancestor { loc, .. } if *loc < m.db_commit.size => Some(loc),
+            StagedLoc::Ancestor { loc, .. } if *loc < m.db_state.size => Some(loc),
             StagedLoc::Ancestor { base_old_loc, .. } => base_old_loc,
         };
         let mut cached = staged_updates.into_iter().peekable();
@@ -2151,7 +2149,7 @@ where
         db.strategy()
             .sort_by(&mut creates, |(a, _, _), (b, _, _)| a.cmp(b));
         for (key, value, base_old_loc) in creates {
-            let new_loc = m.base_commit.size + ops.len() as u64;
+            let new_loc = m.base_state.size + ops.len() as u64;
             superseded_locs.extend(base_old_loc);
             ops.push(Operation::Update(update::Unordered(
                 key.clone(),
@@ -2489,7 +2487,7 @@ where
         let mut ancestors = DiffCursors::new(m.ancestors.iter().map(|a| a.diff.as_slice()));
         let mut next_idx = 0;
         for (key, value, old_loc) in &updated {
-            let new_loc = m.base_commit.size + ops.len() as u64;
+            let new_loc = m.base_state.size + ops.len() as u64;
             let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
@@ -2515,7 +2513,7 @@ where
         // Process creates.
         let mut next_idx = 0;
         for (key, value, base_old_loc) in &created {
-            let new_loc = m.base_commit.size + ops.len() as u64;
+            let new_loc = m.base_state.size + ops.len() as u64;
             let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
@@ -2562,7 +2560,7 @@ where
                 let prev_value = prev_value
                     .as_ref()
                     .expect("staged-resolved keys are skipped as updated");
-                let prev_new_loc = m.base_commit.size + ops.len() as u64;
+                let prev_new_loc = m.base_state.size + ops.len() as u64;
                 let prev_next_key = find_next_key(prev_key, &next_candidates);
                 ops.push(Operation::Update(update::Ordered {
                     key: prev_key.clone(),
@@ -2614,7 +2612,7 @@ where
 {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
-        self.bounds.tip_commit.root
+        self.bounds.tip.root
     }
 
     /// Return the [`Bounds`] of the batch.
@@ -2630,7 +2628,7 @@ where
 
     /// The [`Commitment`] this batch commits to.
     pub(crate) const fn commitment(&self) -> Commitment<F, D> {
-        self.bounds.tip_commit
+        self.bounds.tip
     }
 }
 
@@ -2648,8 +2646,8 @@ where
         level = "debug",
         skip_all,
         fields(
-            base_size = *self.bounds.base_commit.size,
-            total_size = *self.bounds.tip_commit.size,
+            base_size = *self.bounds.base.size,
+            total_size = *self.bounds.tip.size,
             ancestor_batches = self.ancestor_diffs.len() as u64,
         ),
     )]
@@ -2807,8 +2805,8 @@ where
         level = "info",
         skip_all,
         fields(
-            batch_total_size = *batch.bounds.tip_commit.size,
-            batch_base_size = *batch.bounds.base_commit.size,
+            batch_total_size = *batch.bounds.tip.size,
+            batch_base_size = *batch.bounds.base.size,
             db_size = *self.last_commit_loc + 1,
             ancestor_batches = batch.ancestor_diffs.len() as u64,
         ),
@@ -2829,7 +2827,7 @@ where
         // Scoped so the bitmap guard drops before later `.await`s (guard is `!Send`).
         {
             let mut bitmap = self.bitmap.write();
-            bitmap.extend_to(*batch.bounds.tip_commit.size);
+            bitmap.extend_to(*batch.bounds.tip.size);
 
             if batch.ancestor_diffs.is_empty() {
                 // Fast path: no ancestors to merge, no fixups to look up.
@@ -2871,13 +2869,13 @@ where
             // set the new; earlier ancestor commits between them are already 0 from
             // `extend_to`.
             bitmap.set_bit(*self.last_commit_loc, false);
-            bitmap.set_bit(*batch.bounds.tip_commit.size - 1, true);
+            bitmap.set_bit(*batch.bounds.tip.size - 1, true);
         }
 
         // Update DB metadata.
         self.active_keys = batch.total_active_keys;
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
+        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.root = batch.root();
 
         // Return range of operations that were written to the log.
@@ -4419,7 +4417,7 @@ mod tests {
                 .write(key_current, Some(value_current));
             let (_mutations, merkleizer) = child.into_parts();
 
-            let current_loc = merkleizer.base_commit.size;
+            let current_loc = merkleizer.base_state.size;
             let batch_ops = vec![Operation::Update(update::Unordered(
                 key_current,
                 value_current,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -12,8 +12,8 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        Error, bitmap::Shared, delete_known_loc, metrics::Metrics, operation::Floored as _,
-        update_known_loc,
+        Error, batch_chain::CommitId, bitmap::Shared, delete_known_loc, metrics::Metrics,
+        operation::Floored as _, update_known_loc,
     },
 };
 use commonware_codec::{Codec, CodecShared};
@@ -181,13 +181,18 @@ where
         self.root
     }
 
+    /// The [`CommitId`] committed by the database's current state.
+    pub(crate) fn commit_id(&self) -> CommitId<F, H::Digest> {
+        CommitId::new(self.last_commit_loc + 1, self.root)
+    }
+
     /// Return the inactive_peaks count for the given leaf count and inactivity floor.
     pub(crate) fn inactive_peaks(
         &self,
         leaves: Location<F>,
         inactivity_floor: Location<F>,
     ) -> usize {
-        F::inactive_peaks(F::location_to_position(leaves), inactivity_floor)
+        F::inactive_peaks(leaves, inactivity_floor)
     }
 
     /// Return a reference to the merkleization strategy.
@@ -806,10 +811,7 @@ where
             ));
         }
 
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(log.merkle.leaves()),
-            inactivity_floor_loc,
-        );
+        let inactive_peaks = F::inactive_peaks(log.merkle.leaves(), inactivity_floor_loc);
         let root = log.root(inactive_peaks)?;
 
         let db = Self {

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     merkle::{Family, Location, Proof},
     qmdb::{
-        Error, batch_chain::CommitId, bitmap::Shared, delete_known_loc, metrics::Metrics,
+        Error, batch_chain::Commitment, bitmap::Shared, delete_known_loc, metrics::Metrics,
         operation::Floored as _, update_known_loc,
     },
 };
@@ -181,9 +181,9 @@ where
         self.root
     }
 
-    /// The [`CommitId`] committed by the database's current state.
-    pub(crate) fn commit_id(&self) -> CommitId<F, H::Digest> {
-        CommitId::new(self.last_commit_loc + 1, self.root)
+    /// The [`Commitment`] committed by the database's current state.
+    pub(crate) fn commitment(&self) -> Commitment<F, H::Digest> {
+        Commitment::new(self.last_commit_loc + 1, self.root)
     }
 
     /// Return the inactive_peaks count for the given leaf count and inactivity floor.

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -181,7 +181,7 @@ where
         self.root
     }
 
-    /// The [`Commitment`] committed by the database's current state.
+    /// The [`Commitment`] for the database's current state.
     pub(crate) fn commitment(&self) -> Commitment<F, H::Digest> {
         Commitment::new(self.last_commit_loc + 1, self.root)
     }

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2879,7 +2879,7 @@ mod bitmap_tests {
                     .merkleize(&db, None)
                     .await
                     .unwrap();
-                commit_locs.push(batch.bounds.tip_commit.size - 1);
+                commit_locs.push(batch.bounds.tip.size - 1);
                 (db, _) = db.apply_batch(batch).await.unwrap();
             }
             let db = db.commit().await.unwrap();
@@ -3000,7 +3000,7 @@ mod bitmap_tests {
                 .await
                 .unwrap();
             assert!(
-                parent.bounds.tip_commit.size > committed_bitmap_len,
+                parent.bounds.tip.size > committed_bitmap_len,
                 "parent must extend past committed bitmap to exercise the tail path",
             );
 
@@ -3015,7 +3015,7 @@ mod bitmap_tests {
             }
             let child = child_batch.merkleize(&db, None).await.unwrap();
             assert!(
-                child.bounds.tip_commit.size > committed_bitmap_len,
+                child.bounds.tip.size > committed_bitmap_len,
                 "child must include an uncommitted tail beyond committed bitmap",
             );
             let expected_root = child.root();

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2882,9 +2882,7 @@ mod bitmap_tests {
                     .merkleize(&db, None)
                     .await
                     .unwrap();
-                commit_locs.push(Location::<crate::merkle::mmr::Family>::new(
-                    batch.bounds.total_size - 1,
-                ));
+                commit_locs.push(batch.bounds.tip_commit.size - 1);
                 (db, _) = db.apply_batch(batch).await.unwrap();
             }
             let db = db.commit().await.unwrap();
@@ -3005,7 +3003,7 @@ mod bitmap_tests {
                 .await
                 .unwrap();
             assert!(
-                parent.bounds.total_size > committed_bitmap_len,
+                parent.bounds.tip_commit.size > committed_bitmap_len,
                 "parent must extend past committed bitmap to exercise the tail path",
             );
 
@@ -3020,7 +3018,7 @@ mod bitmap_tests {
             }
             let child = child_batch.merkleize(&db, None).await.unwrap();
             assert!(
-                child.bounds.total_size > committed_bitmap_len,
+                child.bounds.tip_commit.size > committed_bitmap_len,
                 "child must include an uncommitted tail beyond committed bitmap",
             );
             let expected_root = child.root();

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2428,7 +2428,7 @@ pub(crate) mod test {
             assert_eq!(db.root(), root_before);
             assert_eq!(db.size(), size_before);
 
-            let too_large_target = Location::new(*size_before + 1);
+            let too_large_target = size_before + 1;
             let Err(too_large_err) = db.rewind(too_large_target).await else {
                 panic!("expected rewind past size to fail");
             };
@@ -2478,7 +2478,7 @@ pub(crate) mod test {
 
             let rewind_target = db.size();
             let target_floor = db.inactivity_floor_loc();
-            let prune_loc = Location::new(*target_floor + (KEYS / 2));
+            let prune_loc = target_floor + (KEYS / 2);
             assert!(
                 rewind_target > *prune_loc,
                 "test setup expected target size > prune_loc; target={rewind_target:?}, floor={target_floor:?}"
@@ -2811,10 +2811,7 @@ mod bitmap_tests {
     //! Regression tests for activity-bitmap maintenance in `any::Db`. The mutation code in
     //! `apply_batch`, `prune_bitmap`, and `rewind` is independent of the snapshot index variant,
     //! so one variant (`unordered::variable`) suffices as the test bed.
-    use crate::{
-        merkle::Location,
-        qmdb::any::unordered::variable::test::{AnyTest, create_test_config},
-    };
+    use crate::qmdb::any::unordered::variable::test::{AnyTest, create_test_config};
     use commonware_cryptography::{Hasher as _, Sha256};
     use commonware_macros::{boxed, test_traced};
     use commonware_runtime::{
@@ -2930,7 +2927,7 @@ mod bitmap_tests {
                 .unwrap();
             let (db, _) = db.apply_batch(b1).await.unwrap();
             let db = db.commit().await.unwrap();
-            let size_after_first = Location::new(*db.last_commit_loc + 1);
+            let size_after_first = db.last_commit_loc + 1;
 
             let b2 = db
                 .new_batch()

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -684,7 +684,7 @@ pub(crate) mod test {
 
             // inactivity_floor should be at some location < op_count
             let inactivity_floor = db.inactivity_floor_loc();
-            let beyond_floor = Location::new(*inactivity_floor + 1);
+            let beyond_floor = inactivity_floor + 1;
 
             // Try to prune beyond the inactivity floor
             let Err(err) = db.prune(beyond_floor).await else {

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -770,7 +770,7 @@ pub(crate) mod test {
                 .unwrap();
 
             // B has more ops than A.
-            assert!(batch_b.bounds.tip_commit.size > batch_a.bounds.tip_commit.size);
+            assert!(batch_b.bounds.tip.size > batch_a.bounds.tip.size);
 
             // Apply A, then B must be stale.
             let (db, _) = db.apply_batch(batch_a).await.unwrap();
@@ -1517,8 +1517,8 @@ pub(crate) mod test {
 
             // With a's Weak reference gone, c's effective DB boundary moves forward from the
             // chain's original DB state to b's base: the authenticated state committed by a.
-            assert_eq!(c.bounds().db_commit.size, *db.bounds().end);
-            assert_eq!(c.bounds().db_commit.root, db.root());
+            assert_eq!(c.bounds().db.size, *db.bounds().end);
+            assert_eq!(c.bounds().db.root, db.root());
 
             // Commit b (skip_ancestors path since a is committed).
             let (db, _) = db.apply_batch(b).await.unwrap();

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -730,7 +730,7 @@ pub(crate) mod test {
             let Err(err) = db.apply_batch(batch_b).await else {
                 panic!("expected StaleBatch error");
             };
-            assert!(matches!(err, Error::StaleBatch { .. }));
+            assert!(matches!(err, Error::StaleBatch));
 
             // Reopen and confirm the stale batch left the committed state untouched.
             let db = open_db(context.child("reopen")).await;
@@ -770,14 +770,14 @@ pub(crate) mod test {
                 .unwrap();
 
             // B has more ops than A.
-            assert!(batch_b.bounds.total_size > batch_a.bounds.total_size);
+            assert!(batch_b.bounds.tip_commit.size > batch_a.bounds.tip_commit.size);
 
             // Apply A, then B must be stale.
             let (db, _) = db.apply_batch(batch_a).await.unwrap();
             let Err(err) = db.apply_batch(batch_b).await else {
                 panic!("expected StaleBatch for asymmetric sibling");
             };
-            assert!(matches!(err, Error::StaleBatch { .. }));
+            assert!(matches!(err, Error::StaleBatch));
         });
     }
 
@@ -835,46 +835,59 @@ pub(crate) mod test {
         executor.start(|context| async move {
             let db = open_db(context.child("storage")).await;
 
-            let key1 = Sha256::hash(&[&[1]]);
-            let key2 = Sha256::hash(&[&[2]]);
-            let key3 = Sha256::hash(&[&[3]]);
-
-            // Commit initial state.
-            let merkleized = db
+            // A conventional fork after a shared parent remains stale.
+            let common_parent = db
                 .new_batch()
-                .write(key1, Some(vec![10]))
+                .write(Sha256::hash(&[&[10]]), Some(vec![10]))
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let sibling_a = common_parent
+                .new_batch::<Sha256>()
+                .write(Sha256::hash(&[&[11]]), Some(vec![11]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let sibling_b = common_parent
+                .new_batch::<Sha256>()
+                .write(Sha256::hash(&[&[12]]), Some(vec![12]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(sibling_a).await.unwrap();
+            assert!(matches!(
+                db.validate_batch(&sibling_b),
+                Err(Error::StaleBatch)
+            ));
 
-            // Create a parent batch, then fork two children.
-            let parent = db
+            // Build equal-size sibling parents, then extend only one sibling.
+            let parent_a = db
                 .new_batch()
-                .write(key2, Some(vec![20]))
+                .write(Sha256::hash(&[&[1]]), Some(vec![10]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let parent_b = db
+                .new_batch()
+                .write(Sha256::hash(&[&[2]]), Some(vec![20]))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let child_b = parent_b
+                .new_batch::<Sha256>()
+                .write(Sha256::hash(&[&[3]]), Some(vec![30]))
                 .merkleize(&db, None)
                 .await
                 .unwrap();
 
-            let child_a = parent
-                .new_batch::<Sha256>()
-                .write(key3, Some(vec![30]))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-            let child_b = parent
-                .new_batch::<Sha256>()
-                .write(key3, Some(vec![40]))
-                .merkleize(&db, None)
-                .await
-                .unwrap();
-
-            // Apply child_a, then child_b should be stale.
-            let (db, _) = db.apply_batch(child_a).await.unwrap();
-            let Err(err) = db.apply_batch(child_b).await else {
-                panic!("expected StaleBatch error for sibling");
-            };
-            assert!(matches!(err, Error::StaleBatch { .. }));
+            // The DB now has parent_b's size but parent_a's root. A size-only lineage check
+            // would incorrectly accept child_b here.
+            let (db, _) = db.apply_batch(parent_a).await.unwrap();
+            assert!(matches!(
+                db.validate_batch(&child_b),
+                Err(Error::StaleBatch)
+            ));
+            db.destroy().await.unwrap();
         });
     }
 
@@ -943,7 +956,7 @@ pub(crate) mod test {
             let Err(err) = db.apply_batch(parent).await else {
                 panic!("expected StaleBatch for parent after child applied");
             };
-            assert!(matches!(err, Error::StaleBatch { .. }));
+            assert!(matches!(err, Error::StaleBatch));
         });
     }
 
@@ -1501,6 +1514,11 @@ pub(crate) mod test {
                 .merkleize(&db, None)
                 .await
                 .unwrap();
+
+            // With a's Weak reference gone, c's effective DB boundary moves forward from the
+            // chain's original DB state to b's base: the authenticated state committed by a.
+            assert_eq!(c.bounds().db_commit.size, *db.bounds().end);
+            assert_eq!(c.bounds().db_commit.root, db.root());
 
             // Commit b (skip_ancestors path since a is committed).
             let (db, _) = db.apply_batch(b).await.unwrap();

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -3,8 +3,8 @@
 //! A batch chain is a linked sequence of in-memory batches built on top of a DB state. Each batch
 //! records its state via [`Bounds`] (where its operations sit in the log, and the root at each
 //! applicable boundary) and the inactivity floor declared by its commit. Older batches in the chain
-//! are tracked as [`AncestorBounds`] in newest-first order; some may already be on disk and others
-//! may not.
+//! are tracked as [`AncestorBounds`] in newest-first order. Some may already be applied to the
+//! database while others may not.
 //!
 //! Before applying a batch to the DB, the internal validation checks two things shared across QMDB
 //! variants (any, immutable, keyless):
@@ -12,8 +12,9 @@
 //! - The batch is not stale: the current DB state must match either the batch's recorded DB state
 //!   or one of its ancestor states.
 //! - Commit floors are monotonically non-decreasing along the chain, and no floor exceeds
-//!   its own commit location. Ancestors already on disk are skipped (their floors were
-//!   validated when they were first applied); the rest of the chain and the tip are checked.
+//!   its own commit location. Ancestors already applied to the database are skipped because their
+//!   floors were validated when they were first applied. The rest of the chain and the tip are
+//!   checked.
 //!
 //! Internal helpers walk the chain via weak parent references and snapshot ancestor bounds into a
 //! `Vec` for storage on a merkleized batch.
@@ -29,7 +30,7 @@ use std::sync::{Arc, Weak};
 /// Identifies a QMDB state by its operation `size` and authenticated `root`.
 #[derive(Clone, Copy, Debug)]
 pub struct Commitment<F: Family, D: Digest> {
-    /// Number of operations committed by the state.
+    /// Number of operations in the state.
     pub size: Location<F>,
     /// Root committing to those operations.
     pub root: D,
@@ -66,12 +67,12 @@ pub struct AncestorBounds<F: Family, D: Digest> {
 pub struct Bounds<F: Family, D: Digest> {
     /// [`Commitment`] immediately before this batch's own operations.
     pub base_commit: Commitment<F, D>,
-    /// [`Commitment`] at the boundary between committed DB operations and operations kept in
+    /// [`Commitment`] at the boundary between applied database operations and operations kept in
     /// this batch chain.
     ///
-    /// Usually this is the committed DB state when the batch chain was created.
+    /// Usually this is the database state when the batch chain was created.
     pub db_commit: Commitment<F, D>,
-    /// [`Commitment`] committed by this batch (its tip): the state after all its operations.
+    /// This batch's tip [`Commitment`]: the state after all its operations.
     pub tip_commit: Commitment<F, D>,
     /// Ancestor bounds in newest-first order.
     pub ancestors: Vec<AncestorBounds<F, D>>,
@@ -80,7 +81,7 @@ pub struct Bounds<F: Family, D: Digest> {
 }
 
 impl<F: Family, D: Digest> Bounds<F, D> {
-    /// Create initial bounds for a batch built directly from a committed database state.
+    /// Create initial bounds for a batch built directly from the current database state.
     ///
     /// The base, DB boundary, and tip all coincide at `commit`, with no ancestors.
     pub(crate) const fn from_db(commit: Commitment<F, D>, inactivity_floor: Location<F>) -> Self {

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -28,15 +28,15 @@ use std::sync::{Arc, Weak};
 
 /// Identifies a QMDB state by its operation `size` and authenticated `root`.
 #[derive(Clone, Copy, Debug)]
-pub struct CommitId<F: Family, D: Digest> {
+pub struct Commitment<F: Family, D: Digest> {
     /// Number of operations committed by the state.
     pub size: Location<F>,
     /// Root committing to those operations.
     pub root: D,
 }
 
-impl<F: Family, D: Digest> CommitId<F, D> {
-    /// Create a [`CommitId`] from an operation `size` and its committing `root` digest.
+impl<F: Family, D: Digest> Commitment<F, D> {
+    /// Create a [`Commitment`] from an operation `size` and its committing `root` digest.
     pub(crate) const fn new(size: Location<F>, root: D) -> Self {
         Self { size, root }
     }
@@ -44,35 +44,35 @@ impl<F: Family, D: Digest> CommitId<F, D> {
 
 // `Family` is not `PartialEq`, so deriving would demand `F: PartialEq` at every call site.
 // Compare the fields directly, which needs only `Location<F>: PartialEq` and `D: Eq`.
-impl<F: Family, D: Digest> PartialEq for CommitId<F, D> {
+impl<F: Family, D: Digest> PartialEq for Commitment<F, D> {
     fn eq(&self, other: &Self) -> bool {
         self.size == other.size && self.root == other.root
     }
 }
 
-impl<F: Family, D: Digest> Eq for CommitId<F, D> {}
+impl<F: Family, D: Digest> Eq for Commitment<F, D> {}
 
 /// Bounds declared by an ancestor batch's commit.
 #[derive(Clone)]
 pub struct AncestorBounds<F: Family, D: Digest> {
     /// Inactivity floor declared by the ancestor commit.
     pub floor: Location<F>,
-    /// [`CommitId`] after the ancestor batch.
-    pub state: CommitId<F, D>,
+    /// [`Commitment`] after the ancestor batch.
+    pub state: Commitment<F, D>,
 }
 
 /// Position and inactivity-floor state for a merkleized QMDB batch.
 #[derive(Clone)]
 pub struct Bounds<F: Family, D: Digest> {
-    /// [`CommitId`] immediately before this batch's own operations.
-    pub base_commit: CommitId<F, D>,
-    /// [`CommitId`] at the boundary between committed DB operations and operations kept in
+    /// [`Commitment`] immediately before this batch's own operations.
+    pub base_commit: Commitment<F, D>,
+    /// [`Commitment`] at the boundary between committed DB operations and operations kept in
     /// this batch chain.
     ///
     /// Usually this is the committed DB state when the batch chain was created.
-    pub db_commit: CommitId<F, D>,
-    /// [`CommitId`] committed by this batch (its tip): the state after all its operations.
-    pub tip_commit: CommitId<F, D>,
+    pub db_commit: Commitment<F, D>,
+    /// [`Commitment`] committed by this batch (its tip): the state after all its operations.
+    pub tip_commit: Commitment<F, D>,
     /// Ancestor bounds in newest-first order.
     pub ancestors: Vec<AncestorBounds<F, D>>,
     /// Inactivity floor declared by this batch's commit.
@@ -83,7 +83,7 @@ impl<F: Family, D: Digest> Bounds<F, D> {
     /// Create initial bounds for a batch built directly from a committed database state.
     ///
     /// The base, DB boundary, and tip all coincide at `commit`, with no ancestors.
-    pub(crate) const fn from_db(commit: CommitId<F, D>, inactivity_floor: Location<F>) -> Self {
+    pub(crate) const fn from_db(commit: Commitment<F, D>, inactivity_floor: Location<F>) -> Self {
         Self {
             base_commit: commit,
             db_commit: commit,
@@ -96,7 +96,7 @@ impl<F: Family, D: Digest> Bounds<F, D> {
     /// Validate that this batch can be applied to the current database state.
     pub(crate) fn validate_apply_to(
         &self,
-        current: CommitId<F, D>,
+        current: Commitment<F, D>,
         current_floor: Location<F>,
     ) -> Result<(), Error<F>> {
         validate_batch_applicable(current, self.db_commit, &self.ancestors)?;
@@ -157,7 +157,7 @@ where
     D: Digest,
     I: IntoIterator<Item = Arc<T>>,
     L: Fn(&T) -> Location<F>,
-    C: Fn(&T) -> CommitId<F, D>,
+    C: Fn(&T) -> Commitment<F, D>,
 {
     ancestors
         .into_iter()
@@ -168,14 +168,14 @@ where
         .collect()
 }
 
-/// Validate that a batch can be applied to the database at the given [`CommitId`].
+/// Validate that a batch can be applied to the database at the given [`Commitment`].
 ///
 /// A batch is applicable if the database has not advanced since the batch was created, if all
 /// ancestors are already committed, or if the database has advanced to one of the batch's ancestor
-/// [`CommitId`]s.
+/// [`Commitment`]s.
 pub(crate) fn validate_batch_applicable<F: Family, D: Digest>(
-    current: CommitId<F, D>,
-    batch_db: CommitId<F, D>,
+    current: Commitment<F, D>,
+    batch_db: Commitment<F, D>,
     ancestors: &[AncestorBounds<F, D>],
 ) -> Result<(), Error<F>> {
     // A separate base check is unnecessary: a direct batch's base is `batch_db`, while a child
@@ -244,8 +244,8 @@ mod tests {
         Location::new(n)
     }
 
-    fn state(size: u64, marker: u8) -> CommitId<F, D> {
-        CommitId::new(Location::new(size), D::from([marker; 32]))
+    fn state(size: u64, marker: u8) -> Commitment<F, D> {
+        Commitment::new(Location::new(size), D::from([marker; 32]))
     }
 
     fn ancestor(floor: Location<F>, end: u64, marker: u8) -> AncestorBounds<F, D> {

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -171,7 +171,7 @@ where
 /// Validate that a batch can be applied to the database at the given [`Commitment`].
 ///
 /// A batch is applicable if the database has not advanced since the batch was created, if all
-/// ancestors are already committed, or if the database has advanced to one of the batch's ancestor
+/// ancestors are already applied, or if the database has advanced to one of the batch's ancestor
 /// [`Commitment`]s.
 pub(crate) fn validate_batch_applicable<F: Family, D: Digest>(
     current: Commitment<F, D>,
@@ -191,7 +191,7 @@ pub(crate) fn validate_batch_applicable<F: Family, D: Digest>(
 ///
 /// Ancestors are stored newest-first. Validation walks them in reverse so unapplied ancestors are
 /// checked oldest-to-newest, then checks the tip. Ancestors at or below `db_size` are already
-/// committed locally and are skipped.
+/// applied locally and are skipped.
 pub(crate) fn validate_commit_floors<F: Family, D: Digest>(
     starting_floor: Location<F>,
     db_size: Location<F>,

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -66,14 +66,14 @@ pub struct AncestorBounds<F: Family, D: Digest> {
 #[derive(Clone)]
 pub struct Bounds<F: Family, D: Digest> {
     /// [`Commitment`] immediately before this batch's own operations.
-    pub base_commit: Commitment<F, D>,
+    pub base: Commitment<F, D>,
     /// [`Commitment`] at the boundary between applied database operations and operations kept in
     /// this batch chain.
     ///
     /// Usually this is the database state when the batch chain was created.
-    pub db_commit: Commitment<F, D>,
+    pub db: Commitment<F, D>,
     /// This batch's tip [`Commitment`]: the state after all its operations.
-    pub tip_commit: Commitment<F, D>,
+    pub tip: Commitment<F, D>,
     /// Ancestor bounds in newest-first order.
     pub ancestors: Vec<AncestorBounds<F, D>>,
     /// Inactivity floor declared by this batch's commit.
@@ -83,12 +83,12 @@ pub struct Bounds<F: Family, D: Digest> {
 impl<F: Family, D: Digest> Bounds<F, D> {
     /// Create initial bounds for a batch built directly from the current database state.
     ///
-    /// The base, DB boundary, and tip all coincide at `commit`, with no ancestors.
-    pub(crate) const fn from_db(commit: Commitment<F, D>, inactivity_floor: Location<F>) -> Self {
+    /// The base, DB boundary, and tip all coincide at `state`, with no ancestors.
+    pub(crate) const fn from_db(state: Commitment<F, D>, inactivity_floor: Location<F>) -> Self {
         Self {
-            base_commit: commit,
-            db_commit: commit,
-            tip_commit: commit,
+            base: state,
+            db: state,
+            tip: state,
             ancestors: Vec::new(),
             inactivity_floor,
         }
@@ -100,13 +100,13 @@ impl<F: Family, D: Digest> Bounds<F, D> {
         current: Commitment<F, D>,
         current_floor: Location<F>,
     ) -> Result<(), Error<F>> {
-        validate_batch_applicable(current, self.db_commit, &self.ancestors)?;
+        validate_batch_applicable(current, self.db, &self.ancestors)?;
         validate_commit_floors(
             current_floor,
             current.size,
             &self.ancestors,
             self.inactivity_floor,
-            self.tip_commit
+            self.tip
                 .size
                 .checked_sub(1)
                 .expect("merkleized batch includes a commit"),
@@ -151,7 +151,7 @@ where
 pub(crate) fn collect_ancestor_bounds<T, F, D, I, L, C>(
     ancestors: I,
     floor: L,
-    commit: C,
+    state: C,
 ) -> Vec<AncestorBounds<F, D>>
 where
     F: Family,
@@ -164,7 +164,7 @@ where
         .into_iter()
         .map(|batch| AncestorBounds {
             floor: floor(&batch),
-            state: commit(&batch),
+            state: state(&batch),
         })
         .collect()
 }
@@ -284,9 +284,9 @@ mod tests {
         let grandparent = Arc::new(TestBatch {
             id: 1,
             bounds: Bounds {
-                base_commit: state(0, 0),
-                db_commit: state(0, 0),
-                tip_commit: state(5, 5),
+                base: state(0, 0),
+                db: state(0, 0),
+                tip: state(5, 5),
                 ancestors: Vec::new(),
                 inactivity_floor: loc(3),
             },
@@ -295,9 +295,9 @@ mod tests {
         let parent = Arc::new(TestBatch {
             id: 2,
             bounds: Bounds {
-                base_commit: state(5, 5),
-                db_commit: state(0, 0),
-                tip_commit: state(7, 7),
+                base: state(5, 5),
+                db: state(0, 0),
+                tip: state(7, 7),
                 ancestors: vec![ancestor(loc(3), 5, 5)],
                 inactivity_floor: loc(6),
             },
@@ -316,9 +316,9 @@ mod tests {
         let parent = Arc::new(TestBatch {
             id: 1,
             bounds: Bounds {
-                base_commit: state(0, 0),
-                db_commit: state(0, 0),
-                tip_commit: state(12, 12),
+                base: state(0, 0),
+                db: state(0, 0),
+                tip: state(12, 12),
                 ancestors: Vec::new(),
                 inactivity_floor: loc(10),
             },
@@ -327,9 +327,9 @@ mod tests {
         let grandparent = Arc::new(TestBatch {
             id: 2,
             bounds: Bounds {
-                base_commit: state(0, 0),
-                db_commit: state(0, 0),
-                tip_commit: state(8, 8),
+                base: state(0, 0),
+                db: state(0, 0),
+                tip: state(8, 8),
                 ancestors: Vec::new(),
                 inactivity_floor: loc(6),
             },
@@ -339,12 +339,7 @@ mod tests {
         let bounds = collect_ancestor_bounds(
             vec![Arc::clone(&parent), Arc::clone(&grandparent)],
             |batch| batch.bounds.inactivity_floor,
-            |batch| {
-                state(
-                    *batch.bounds.tip_commit.size,
-                    *batch.bounds.tip_commit.size as u8,
-                )
-            },
+            |batch| state(*batch.bounds.tip.size, *batch.bounds.tip.size as u8),
         );
 
         assert_eq!(bounds.len(), 2);
@@ -357,9 +352,9 @@ mod tests {
     #[test]
     fn bounds_validates_apply_to_current_state() {
         let bounds = Bounds::<F, D> {
-            base_commit: state(10, 1),
-            db_commit: state(10, 1),
-            tip_commit: state(14, 14),
+            base: state(10, 1),
+            db: state(10, 1),
+            tip: state(14, 14),
             ancestors: vec![ancestor(loc(10), 12, 12)],
             inactivity_floor: loc(11),
         };

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -1,29 +1,19 @@
 //! Shared validation for QMDB batch chains.
 //!
-//! A batch chain is a linked sequence of in-memory batches built on top of a DB state. Each
-//! batch records its position via [`Bounds`] (where its operations sit in the log) and the
-//! inactivity floor declared by its commit. Older batches in the chain are tracked as
-//! [`AncestorBounds`] in newest-first order; some may already be on disk and others may not.
+//! A batch chain is a linked sequence of in-memory batches built on top of a DB state. Each batch
+//! records its state via [`Bounds`] (where its operations sit in the log, and the root at each
+//! applicable boundary) and the inactivity floor declared by its commit. Older batches in the chain
+//! are tracked as [`AncestorBounds`] in newest-first order; some may already be on disk and others
+//! may not.
 //!
 //! Before applying a batch to the DB, the internal validation checks two things shared across QMDB
 //! variants (any, immutable, keyless):
 //!
-//! - The batch is not stale: the current DB size must match either the batch's recorded
-//!   `db_size`, its `base_size`, or one of its ancestor boundaries.
+//! - The batch is not stale: the current DB state must match either the batch's recorded DB state
+//!   or one of its ancestor states.
 //! - Commit floors are monotonically non-decreasing along the chain, and no floor exceeds
 //!   its own commit location. Ancestors already on disk are skipped (their floors were
 //!   validated when they were first applied); the rest of the chain and the tip are checked.
-//!
-//! # Best-effort staleness detection
-//!
-//! Boundaries are compared by operation count alone, so the staleness check cannot distinguish
-//! equal-size sibling branches (branches built from the same state with the same total operation
-//! count). After one sibling is applied, a batch from the other branch (or one of its
-//! descendants) whose sizes line up with an accepted boundary still passes the staleness check,
-//! and applying it silently corrupts the database: the committed log (and any snapshot) keeps
-//! the applied sibling's operations while the root commits to the orphaned branch. The check is
-//! a safety net for pipelining bugs, not an authoritative fork check: callers must only apply a
-//! batch when every batch applied since its chain was created is an ancestor of that batch.
 //!
 //! Internal helpers walk the chain via weak parent references and snapshot ancestor bounds into a
 //! `Vec` for storage on a merkleized batch.
@@ -32,54 +22,93 @@ use crate::{
     merkle::{Family, Location},
     qmdb::Error,
 };
+use commonware_cryptography::Digest;
 use core::iter;
 use std::sync::{Arc, Weak};
 
+/// Identifies a QMDB state by its operation `size` and authenticated `root`.
+#[derive(Clone, Copy, Debug)]
+pub struct CommitId<F: Family, D: Digest> {
+    /// Number of operations committed by the state.
+    pub size: Location<F>,
+    /// Root committing to those operations.
+    pub root: D,
+}
+
+impl<F: Family, D: Digest> CommitId<F, D> {
+    /// Create a [`CommitId`] from an operation `size` and its committing `root` digest.
+    pub(crate) const fn new(size: Location<F>, root: D) -> Self {
+        Self { size, root }
+    }
+}
+
+// `Family` is not `PartialEq`, so deriving would demand `F: PartialEq` at every call site.
+// Compare the fields directly, which needs only `Location<F>: PartialEq` and `D: Eq`.
+impl<F: Family, D: Digest> PartialEq for CommitId<F, D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.size == other.size && self.root == other.root
+    }
+}
+
+impl<F: Family, D: Digest> Eq for CommitId<F, D> {}
+
 /// Bounds declared by an ancestor batch's commit.
 #[derive(Clone)]
-pub struct AncestorBounds<F: Family> {
+pub struct AncestorBounds<F: Family, D: Digest> {
     /// Inactivity floor declared by the ancestor commit.
     pub floor: Location<F>,
-    /// Total operations after the ancestor batch.
-    pub end: u64,
+    /// [`CommitId`] after the ancestor batch.
+    pub state: CommitId<F, D>,
 }
 
 /// Position and inactivity-floor state for a merkleized QMDB batch.
 #[derive(Clone)]
-pub struct Bounds<F: Family> {
-    /// Total operations before this batch's own operations.
-    pub base_size: u64,
-    /// Boundary between committed DB operations and operations kept in this batch chain.
+pub struct Bounds<F: Family, D: Digest> {
+    /// [`CommitId`] immediately before this batch's own operations.
+    pub base_commit: CommitId<F, D>,
+    /// [`CommitId`] at the boundary between committed DB operations and operations kept in
+    /// this batch chain.
     ///
-    /// Usually this is the DB size when the batch was created. If older ancestors were
-    /// dropped, the boundary moves forward to the oldest ancestor still kept in memory.
-    pub db_size: u64,
-    /// Total operations after this batch.
-    pub total_size: u64,
+    /// Usually this is the committed DB state when the batch chain was created.
+    pub db_commit: CommitId<F, D>,
+    /// [`CommitId`] committed by this batch (its tip): the state after all its operations.
+    pub tip_commit: CommitId<F, D>,
     /// Ancestor bounds in newest-first order.
-    pub ancestors: Vec<AncestorBounds<F>>,
+    pub ancestors: Vec<AncestorBounds<F, D>>,
     /// Inactivity floor declared by this batch's commit.
     pub inactivity_floor: Location<F>,
 }
 
-impl<F: Family> Bounds<F> {
+impl<F: Family, D: Digest> Bounds<F, D> {
+    /// Create initial bounds for a batch built directly from a committed database state.
+    ///
+    /// The base, DB boundary, and tip all coincide at `commit`, with no ancestors.
+    pub(crate) const fn from_db(commit: CommitId<F, D>, inactivity_floor: Location<F>) -> Self {
+        Self {
+            base_commit: commit,
+            db_commit: commit,
+            tip_commit: commit,
+            ancestors: Vec::new(),
+            inactivity_floor,
+        }
+    }
+
     /// Validate that this batch can be applied to the current database state.
     pub(crate) fn validate_apply_to(
         &self,
-        current_size: u64,
+        current: CommitId<F, D>,
         current_floor: Location<F>,
     ) -> Result<(), Error<F>> {
-        validate_batch_applicable(current_size, self.db_size, self.base_size, &self.ancestors)?;
+        validate_batch_applicable(current, self.db_commit, &self.ancestors)?;
         validate_commit_floors(
             current_floor,
-            current_size,
+            current.size,
             &self.ancestors,
             self.inactivity_floor,
-            Location::new(
-                self.total_size
-                    .checked_sub(1)
-                    .expect("merkleized batch includes a commit"),
-            ),
+            self.tip_commit
+                .size
+                .checked_sub(1)
+                .expect("merkleized batch includes a commit"),
         )
     }
 }
@@ -118,53 +147,44 @@ where
 }
 
 /// Collect ancestor bounds in newest-first order.
-pub(crate) fn collect_ancestor_bounds<T, F, I, E, L>(
+pub(crate) fn collect_ancestor_bounds<T, F, D, I, L, C>(
     ancestors: I,
     floor: L,
-    end: E,
-) -> Vec<AncestorBounds<F>>
+    commit: C,
+) -> Vec<AncestorBounds<F, D>>
 where
     F: Family,
+    D: Digest,
     I: IntoIterator<Item = Arc<T>>,
-    E: Fn(&T) -> u64,
     L: Fn(&T) -> Location<F>,
+    C: Fn(&T) -> CommitId<F, D>,
 {
-    let mut bounds = Vec::new();
-
-    for batch in ancestors {
-        bounds.push(AncestorBounds {
+    ancestors
+        .into_iter()
+        .map(|batch| AncestorBounds {
             floor: floor(&batch),
-            end: end(&batch),
-        });
-    }
-
-    bounds
+            state: commit(&batch),
+        })
+        .collect()
 }
 
-/// Validate that a batch can be applied to a database with `db_size` committed operations.
+/// Validate that a batch can be applied to the database at the given [`CommitId`].
 ///
-/// A batch is applicable if the database has not advanced since the batch was created
-/// (`batch_db_size`), if all ancestors are already committed (`batch_base_size`), or if the
-/// database has advanced to one of the batch's ancestor boundaries. Boundaries are compared by
-/// operation count alone. See the module docs for the equal-size sibling limitation.
-pub(crate) fn validate_batch_applicable<F: Family>(
-    db_size: u64,
-    batch_db_size: u64,
-    batch_base_size: u64,
-    ancestors: &[AncestorBounds<F>],
+/// A batch is applicable if the database has not advanced since the batch was created, if all
+/// ancestors are already committed, or if the database has advanced to one of the batch's ancestor
+/// [`CommitId`]s.
+pub(crate) fn validate_batch_applicable<F: Family, D: Digest>(
+    current: CommitId<F, D>,
+    batch_db: CommitId<F, D>,
+    ancestors: &[AncestorBounds<F, D>],
 ) -> Result<(), Error<F>> {
-    if db_size == batch_db_size
-        || db_size == batch_base_size
-        || ancestors.iter().any(|ancestor| ancestor.end == db_size)
-    {
+    // A separate base check is unnecessary: a direct batch's base is `batch_db`, while a child
+    // batch's base is its first ancestor.
+    if current == batch_db || ancestors.iter().any(|ancestor| ancestor.state == current) {
         return Ok(());
     }
 
-    Err(Error::StaleBatch {
-        db_size,
-        batch_db_size,
-        batch_base_size,
-    })
+    Err(Error::StaleBatch)
 }
 
 /// Validate commit-floor monotonicity for a batch chain.
@@ -172,20 +192,20 @@ pub(crate) fn validate_batch_applicable<F: Family>(
 /// Ancestors are stored newest-first. Validation walks them in reverse so unapplied ancestors are
 /// checked oldest-to-newest, then checks the tip. Ancestors at or below `db_size` are already
 /// committed locally and are skipped.
-pub(crate) fn validate_commit_floors<F: Family>(
+pub(crate) fn validate_commit_floors<F: Family, D: Digest>(
     starting_floor: Location<F>,
-    db_size: u64,
-    ancestors: &[AncestorBounds<F>],
+    db_size: Location<F>,
+    ancestors: &[AncestorBounds<F, D>],
     tip_floor: Location<F>,
     tip_commit_loc: Location<F>,
 ) -> Result<(), Error<F>> {
     let mut prev_floor = starting_floor;
     for ancestor in ancestors.iter().rev() {
-        if ancestor.end <= db_size {
+        if ancestor.state.size <= db_size {
             continue;
         }
 
-        let ancestor_commit_loc = Location::new(ancestor.end - 1);
+        let ancestor_commit_loc = ancestor.state.size - 1;
         if ancestor.floor < prev_floor {
             return Err(Error::FloorRegressed(ancestor.floor, prev_floor));
         }
@@ -208,13 +228,15 @@ pub(crate) fn validate_commit_floors<F: Family>(
 mod tests {
     use super::*;
     use crate::merkle::mmr;
+    use commonware_cryptography::sha256;
     use std::sync::{Arc, Weak};
 
     type F = mmr::Family;
+    type D = sha256::Digest;
 
     struct TestBatch {
         id: u8,
-        bounds: Bounds<F>,
+        bounds: Bounds<F, D>,
         parent: Option<Weak<Self>>,
     }
 
@@ -222,30 +244,38 @@ mod tests {
         Location::new(n)
     }
 
-    const fn ancestor(floor: Location<F>, end: u64) -> AncestorBounds<F> {
-        AncestorBounds { floor, end }
+    fn state(size: u64, marker: u8) -> CommitId<F, D> {
+        CommitId::new(Location::new(size), D::from([marker; 32]))
+    }
+
+    fn ancestor(floor: Location<F>, end: u64, marker: u8) -> AncestorBounds<F, D> {
+        AncestorBounds {
+            floor,
+            state: state(end, marker),
+        }
     }
 
     #[test]
     fn validate_batch_applicable_accepts_valid_boundaries() {
-        let ancestors = vec![ancestor(loc(10), 12), ancestor(loc(14), 16)];
-        assert!(validate_batch_applicable::<F>(10, 10, 20, &ancestors).is_ok());
-        assert!(validate_batch_applicable::<F>(20, 10, 20, &ancestors).is_ok());
-        assert!(validate_batch_applicable::<F>(16, 10, 20, &ancestors).is_ok());
+        let ancestors = vec![ancestor(loc(10), 12, 12), ancestor(loc(14), 16, 16)];
+        // Current matches the recorded DB state.
+        assert!(validate_batch_applicable::<F, D>(state(10, 1), state(10, 1), &ancestors).is_ok());
+        // Current matches one of the ancestor states.
+        assert!(validate_batch_applicable::<F, D>(state(16, 16), state(10, 1), &ancestors).is_ok());
     }
 
     #[test]
     fn validate_batch_applicable_rejects_stale_batch() {
-        let ancestors = vec![ancestor(loc(10), 12), ancestor(loc(14), 16)];
-        let result = validate_batch_applicable::<F>(18, 10, 20, &ancestors);
-        assert!(matches!(
-            result,
-            Err(Error::StaleBatch {
-                db_size: 18,
-                batch_db_size: 10,
-                batch_base_size: 20,
-            })
-        ));
+        let ancestors = vec![ancestor(loc(10), 12, 12), ancestor(loc(14), 16, 16)];
+        let result = validate_batch_applicable::<F, D>(state(18, 18), state(10, 1), &ancestors);
+        assert!(matches!(result, Err(Error::StaleBatch)));
+    }
+
+    #[test]
+    fn validate_batch_applicable_rejects_equal_size_sibling() {
+        let ancestors = vec![ancestor(loc(14), 16, 16)];
+        let result = validate_batch_applicable::<F, D>(state(16, 99), state(10, 1), &ancestors);
+        assert!(matches!(result, Err(Error::StaleBatch)));
     }
 
     #[test]
@@ -253,9 +283,9 @@ mod tests {
         let grandparent = Arc::new(TestBatch {
             id: 1,
             bounds: Bounds {
-                base_size: 0,
-                db_size: 0,
-                total_size: 5,
+                base_commit: state(0, 0),
+                db_commit: state(0, 0),
+                tip_commit: state(5, 5),
                 ancestors: Vec::new(),
                 inactivity_floor: loc(3),
             },
@@ -264,10 +294,10 @@ mod tests {
         let parent = Arc::new(TestBatch {
             id: 2,
             bounds: Bounds {
-                base_size: 5,
-                db_size: 0,
-                total_size: 7,
-                ancestors: vec![ancestor(loc(3), 5)],
+                base_commit: state(5, 5),
+                db_commit: state(0, 0),
+                tip_commit: state(7, 7),
+                ancestors: vec![ancestor(loc(3), 5, 5)],
                 inactivity_floor: loc(6),
             },
             parent: Some(Arc::downgrade(&grandparent)),
@@ -285,9 +315,9 @@ mod tests {
         let parent = Arc::new(TestBatch {
             id: 1,
             bounds: Bounds {
-                base_size: 0,
-                db_size: 0,
-                total_size: 12,
+                base_commit: state(0, 0),
+                db_commit: state(0, 0),
+                tip_commit: state(12, 12),
                 ancestors: Vec::new(),
                 inactivity_floor: loc(10),
             },
@@ -296,9 +326,9 @@ mod tests {
         let grandparent = Arc::new(TestBatch {
             id: 2,
             bounds: Bounds {
-                base_size: 0,
-                db_size: 0,
-                total_size: 8,
+                base_commit: state(0, 0),
+                db_commit: state(0, 0),
+                tip_commit: state(8, 8),
                 ancestors: Vec::new(),
                 inactivity_floor: loc(6),
             },
@@ -308,52 +338,56 @@ mod tests {
         let bounds = collect_ancestor_bounds(
             vec![Arc::clone(&parent), Arc::clone(&grandparent)],
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.bounds.total_size,
+            |batch| {
+                state(
+                    *batch.bounds.tip_commit.size,
+                    *batch.bounds.tip_commit.size as u8,
+                )
+            },
         );
 
         assert_eq!(bounds.len(), 2);
-        assert_eq!((bounds[0].floor, bounds[0].end), (loc(10), 12));
-        assert_eq!((bounds[1].floor, bounds[1].end), (loc(6), 8));
+        assert_eq!(bounds[0].floor, loc(10));
+        assert_eq!(bounds[0].state, state(12, 12));
+        assert_eq!(bounds[1].floor, loc(6));
+        assert_eq!(bounds[1].state, state(8, 8));
     }
 
     #[test]
     fn bounds_validates_apply_to_current_state() {
-        let bounds = Bounds::<F> {
-            base_size: 10,
-            db_size: 10,
-            total_size: 14,
-            ancestors: vec![ancestor(loc(10), 12)],
+        let bounds = Bounds::<F, D> {
+            base_commit: state(10, 1),
+            db_commit: state(10, 1),
+            tip_commit: state(14, 14),
+            ancestors: vec![ancestor(loc(10), 12, 12)],
             inactivity_floor: loc(11),
         };
-        assert!(bounds.validate_apply_to(10, loc(9)).is_ok());
+        assert!(bounds.validate_apply_to(state(10, 1), loc(9)).is_ok());
 
-        let result = bounds.validate_apply_to(11, loc(9));
-        assert!(matches!(
-            result,
-            Err(Error::StaleBatch {
-                db_size: 11,
-                batch_db_size: 10,
-                batch_base_size: 10,
-            })
-        ));
+        let result = bounds.validate_apply_to(state(11, 11), loc(9));
+        assert!(matches!(result, Err(Error::StaleBatch)));
     }
 
     #[test]
     fn validate_commit_floors_accepts_monotonic_chain() {
-        let ancestors = vec![ancestor(loc(6), 7), ancestor(loc(4), 5)];
-        assert!(validate_commit_floors::<F>(loc(2), 1, &ancestors, loc(8), loc(9),).is_ok());
+        let ancestors = vec![ancestor(loc(6), 7, 7), ancestor(loc(4), 5, 5)];
+        assert!(
+            validate_commit_floors::<F, D>(loc(2), loc(1), &ancestors, loc(8), loc(9),).is_ok()
+        );
     }
 
     #[test]
     fn validate_commit_floors_skips_committed_ancestors() {
-        let ancestors = vec![ancestor(loc(1), 7), ancestor(loc(1), 5)];
-        assert!(validate_commit_floors::<F>(loc(6), 7, &ancestors, loc(8), loc(9),).is_ok());
+        let ancestors = vec![ancestor(loc(1), 7, 7), ancestor(loc(1), 5, 5)];
+        assert!(
+            validate_commit_floors::<F, D>(loc(6), loc(7), &ancestors, loc(8), loc(9),).is_ok()
+        );
     }
 
     #[test]
     fn validate_commit_floors_rejects_ancestor_regression() {
-        let ancestors = vec![ancestor(loc(6), 7), ancestor(loc(3), 5)];
-        let result = validate_commit_floors::<F>(loc(4), 1, &ancestors, loc(8), loc(9));
+        let ancestors = vec![ancestor(loc(6), 7, 7), ancestor(loc(3), 5, 5)];
+        let result = validate_commit_floors::<F, D>(loc(4), loc(1), &ancestors, loc(8), loc(9));
         assert!(matches!(
             result,
             Err(Error::FloorRegressed(floor, previous)) if floor == loc(3) && previous == loc(4)
@@ -362,8 +396,8 @@ mod tests {
 
     #[test]
     fn validate_commit_floors_rejects_ancestor_floor_beyond_commit() {
-        let ancestors = vec![ancestor(loc(8), 7), ancestor(loc(4), 5)];
-        let result = validate_commit_floors::<F>(loc(2), 1, &ancestors, loc(9), loc(9));
+        let ancestors = vec![ancestor(loc(8), 7, 7), ancestor(loc(4), 5, 5)];
+        let result = validate_commit_floors::<F, D>(loc(2), loc(1), &ancestors, loc(9), loc(9));
         assert!(matches!(
             result,
             Err(Error::FloorBeyondSize(floor, commit)) if floor == loc(8) && commit == loc(6)
@@ -372,8 +406,8 @@ mod tests {
 
     #[test]
     fn validate_commit_floors_rejects_tip_regression() {
-        let ancestors = vec![ancestor(loc(4), 5)];
-        let result = validate_commit_floors::<F>(loc(2), 1, &ancestors, loc(3), loc(9));
+        let ancestors = vec![ancestor(loc(4), 5, 5)];
+        let result = validate_commit_floors::<F, D>(loc(2), loc(1), &ancestors, loc(3), loc(9));
         assert!(matches!(
             result,
             Err(Error::FloorRegressed(floor, previous)) if floor == loc(3) && previous == loc(4)
@@ -382,8 +416,8 @@ mod tests {
 
     #[test]
     fn validate_commit_floors_rejects_tip_floor_beyond_commit() {
-        let ancestors = vec![ancestor(loc(4), 5)];
-        let result = validate_commit_floors::<F>(loc(2), 1, &ancestors, loc(10), loc(9));
+        let ancestors = vec![ancestor(loc(4), 5, 5)];
+        let result = validate_commit_floors::<F, D>(loc(2), loc(1), &ancestors, loc(10), loc(9));
         assert!(matches!(
             result,
             Err(Error::FloorBeyondSize(floor, commit)) if floor == loc(10) && commit == loc(9)

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -566,7 +566,7 @@ where
     merkle.with_mem(|mem| {
         let size = mem.leaves();
         let last_commit_loc = Location::new(*size - 1);
-        let inactive_peaks = F::inactive_peaks(F::location_to_position(size), inactivity_floor_loc);
+        let inactive_peaks = F::inactive_peaks(size, inactivity_floor_loc);
         let root = mem.root(&hasher, inactive_peaks)?;
         let pinned_nodes = F::nodes_to_pin(last_commit_loc)
             .map(|pos| *mem.get_node_unchecked(pos))

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -190,7 +190,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         // entry. Decode outside it so concurrent readers do not contend.
         let (entry, proof) = self.with(|w| -> Result<(Witness<F, D>, Proof<F, D>), Error<F>> {
             let current = w.size();
-            let last_commit_loc = Location::new(*current - 1);
+            let last_commit_loc = current - 1;
             if request.size() > current || request.size() == 0 {
                 return Err(merkle::Error::RangeOutOfBounds(request.size()).into());
             }
@@ -565,7 +565,7 @@ where
     let hasher = qmdb::hasher::<H>();
     merkle.with_mem(|mem| {
         let size = mem.leaves();
-        let last_commit_loc = Location::new(*size - 1);
+        let last_commit_loc = size - 1;
         let inactive_peaks = F::inactive_peaks(size, inactivity_floor_loc);
         let root = mem.root(&hasher, inactive_peaks)?;
         let pinned_nodes = F::nodes_to_pin(last_commit_loc)
@@ -644,7 +644,7 @@ where
 
     // Decode the commit op to get the inactivity floor, which determines the inactive peak
     // boundary used for root computation.
-    let last_commit_loc = Location::new(*size - 1);
+    let last_commit_loc = size - 1;
     let last_commit_op = Op::decode_cfg(witness.op_bytes.as_ref(), commit_codec_config)
         .map_err(|_| Error::DataCorrupted("invalid commit operation"))?;
     let inactivity_floor_loc = last_commit_op

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -760,7 +760,7 @@ where
     Operation<F, U>: Codec,
 {
     let batch_len = inner.journal_batch.items().len();
-    let batch_base = *inner.bounds.tip_commit.size - batch_len as u64;
+    let batch_base = *inner.bounds.tip.size - batch_len as u64;
 
     // Build chunk overlay: materialized bytes for every dirty chunk.
     let overlay = build_chunk_overlay::<F, U, _, N>(
@@ -777,7 +777,7 @@ where
 
     // Snapshot ops_leaves for the post-batch state (the canonical root we're about to compute
     // sees this many ops). Thread it through `graftable_chunks` derivation and root computation.
-    let overlay_ops_leaves = inner.bounds.tip_commit.size;
+    let overlay_ops_leaves = inner.bounds.tip.size;
 
     // Distinguish three counters:
     //   - new_complete_chunks: chunks with all bits filled in the post-batch bitmap
@@ -1045,7 +1045,7 @@ where
         // inactivity floor when pruning has not run.
         super::db::sync_boundary::<F, N>(
             *self.inner.bounds().inactivity_floor / bitmap::Prunable::<N>::CHUNK_SIZE_BITS,
-            *self.inner.bounds().tip_commit.size,
+            *self.inner.bounds().tip.size,
         )
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -294,12 +294,9 @@ where
 /// Once a non-ancestor batch is applied, this batch and all of its descendants become invalid
 /// objects. The library does not guard against continued use after that point.
 ///
-/// Applying an invalid batch is caught by the any-layer staleness check and returns
+/// Applying an invalid batch is caught by the any-layer authenticated lineage check and returns
 /// [`Error::StaleBatch`] without mutating committed state, so `apply_batch` itself cannot corrupt
-/// the DB. The one exception is equal-size sibling branches (where both branches have the same
-/// total operation count): the staleness check is size-based and cannot distinguish them, so
-/// applying a descendant of one sibling after the other was already applied can silently corrupt
-/// snapshot/log state. Callers must not apply batches from an orphaned branch.
+/// the DB.
 ///
 /// Rules of thumb:
 /// - Drop any `Arc<MerkleizedBatch>` you no longer intend to apply.
@@ -763,7 +760,7 @@ where
     Operation<F, U>: Codec,
 {
     let batch_len = inner.journal_batch.items().len();
-    let batch_base = inner.bounds.total_size - batch_len as u64;
+    let batch_base = *inner.bounds.tip_commit.size - batch_len as u64;
 
     // Build chunk overlay: materialized bytes for every dirty chunk.
     let overlay = build_chunk_overlay::<F, U, _, N>(
@@ -780,7 +777,7 @@ where
 
     // Snapshot ops_leaves for the post-batch state (the canonical root we're about to compute
     // sees this many ops). Thread it through `graftable_chunks` derivation and root computation.
-    let overlay_ops_leaves = Location::<F>::new(inner.bounds.total_size);
+    let overlay_ops_leaves = inner.bounds.tip_commit.size;
 
     // Distinguish three counters:
     //   - new_complete_chunks: chunks with all bits filled in the post-batch bitmap
@@ -1035,7 +1032,7 @@ where
     }
 
     /// Return the [`Bounds`] of the batch.
-    pub fn bounds(&self) -> &Bounds<F> {
+    pub fn bounds(&self) -> &Bounds<F, D> {
         self.inner.bounds()
     }
 
@@ -1048,7 +1045,7 @@ where
         // inactivity floor when pruning has not run.
         super::db::sync_boundary::<F, N>(
             *self.inner.bounds().inactivity_floor / bitmap::Prunable::<N>::CHUNK_SIZE_BITS,
-            self.inner.bounds().total_size,
+            *self.inner.bounds().tip_commit.size,
         )
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1577,7 +1577,7 @@ mod tests {
                 let mut scan = Location::new(floor);
                 while let Some(c) = next_candidate(chain, scan, tip) {
                     want.push(c);
-                    scan = Location::new(*c + 1);
+                    scan = c + 1;
                 }
                 for split in 0..=want.len() {
                     let mut got = Vec::new();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -2855,7 +2855,7 @@ pub mod tests {
             let expected_value = db.get(&key0).await.unwrap();
 
             // 32 * 8 = 256 bits per chunk for N=32.
-            let invalid_prune_loc = Location::new(*expected_boundary + 256);
+            let invalid_prune_loc = expected_boundary + 256;
             let Err(err) = db.prune(invalid_prune_loc).await else {
                 panic!("expected prune rejection above sync boundary");
             };

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1369,7 +1369,7 @@ pub mod tests {
             panic!("expected StaleBatch error");
         };
         assert!(
-            matches!(err, Error::StaleBatch { .. }),
+            matches!(err, Error::StaleBatch),
             "expected StaleBatch error, got {err:?}"
         );
 

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -2059,8 +2059,7 @@ mod tests {
         let leaves = mmb::Location::new(leaf_count);
         let inactivity_floor = mmb::Location::new(chunk_bits - 2);
 
-        let ops_inactive_peaks =
-            F::inactive_peaks(F::location_to_position(leaves), inactivity_floor);
+        let ops_inactive_peaks = F::inactive_peaks(leaves, inactivity_floor);
         let aligned_inactive =
             grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)
                 .unwrap();

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -8,7 +8,7 @@ use crate::{
     qmdb::{
         Error,
         any::{ValueEncoding, batch::lookup_sorted},
-        batch_chain::{self, Bounds, CommitId},
+        batch_chain::{self, Bounds, Commitment},
         immutable::operation::Operation,
         operation::Key,
     },
@@ -55,7 +55,7 @@ where
 
     /// The committed state immediately before this batch's operations (committed DB + prior
     /// batches). This batch's i-th operation lands at location `base.size + i`.
-    base: CommitId<F, H::Digest>,
+    base: Commitment<F, H::Digest>,
 }
 
 /// Merkleized authenticated-journal batch wrapping an [`Operation`] payload.
@@ -95,7 +95,7 @@ where
     /// Create a batch from a committed DB (no parent chain).
     pub(super) fn new<E, C, T>(
         immutable: &Immutable<F, E, K, V, C, H, T, S>,
-        commit: CommitId<F, H::Digest>,
+        commit: Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -114,7 +114,7 @@ where
     /// The database's committed state at the base of this batch chain.
     ///
     /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> CommitId<F, H::Digest> {
+    fn db_commit(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
             .map_or(self.base, |parent| parent.bounds.db_commit)
@@ -284,7 +284,7 @@ where
             ancestor_diffs.push(Arc::clone(&batch.diff));
             ancestors.push(batch_chain::AncestorBounds {
                 floor: batch.bounds.inactivity_floor,
-                state: batch.commit_id(),
+                state: batch.commitment(),
             });
         }
 
@@ -296,7 +296,7 @@ where
             bounds: batch_chain::Bounds {
                 base_commit: self.base,
                 db_commit,
-                tip_commit: CommitId::new(total_size, root),
+                tip_commit: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -323,8 +323,8 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
-    /// The [`CommitId`] this batch commits to.
-    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+    /// The [`Commitment`] this batch commits to.
+    pub(super) const fn commitment(&self) -> Commitment<F, D> {
         self.bounds.tip_commit
     }
 
@@ -425,7 +425,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             mutations: BTreeMap::new(),
             parent: Some(Arc::clone(self)),
-            base: self.commit_id(),
+            base: self.commitment(),
         }
     }
 }
@@ -449,7 +449,7 @@ where
             diff: Arc::new(Vec::new()),
             parent: None,
             ancestor_diffs: Vec::new(),
-            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
+            bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
         })
     }
 }

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -53,8 +53,8 @@ where
     /// Parent batch in the chain. `None` for batches created directly from the DB.
     parent: Option<Arc<MerkleizedBatch<F, H::Digest, K, V, S>>>,
 
-    /// The committed state immediately before this batch's operations (committed DB + prior
-    /// batches). This batch's i-th operation lands at location `base.size + i`.
+    /// The state immediately before this batch's operations.
+    /// This batch's i-th operation lands at location `base.size + i`.
     base: Commitment<F, H::Digest>,
 }
 

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -8,7 +8,7 @@ use crate::{
     qmdb::{
         Error,
         any::{ValueEncoding, batch::lookup_sorted},
-        batch_chain::{self, Bounds},
+        batch_chain::{self, Bounds, CommitId},
         immutable::operation::Operation,
         operation::Key,
     },
@@ -53,12 +53,9 @@ where
     /// Parent batch in the chain. `None` for batches created directly from the DB.
     parent: Option<Arc<MerkleizedBatch<F, H::Digest, K, V, S>>>,
 
-    /// Total operation count before this batch (committed DB + prior batches).
-    /// This batch's i-th operation lands at location `base_size + i`.
-    base_size: u64,
-
-    /// The database size when this batch was created, used to detect stale batches.
-    db_size: u64,
+    /// The committed state immediately before this batch's operations (committed DB + prior
+    /// batches). This batch's i-th operation lands at location `base.size + i`.
+    base: CommitId<F, H::Digest>,
 }
 
 /// Merkleized authenticated-journal batch wrapping an [`Operation`] payload.
@@ -70,9 +67,6 @@ type JournalBatch<F, D, K, V, S> = Arc<authenticated::MerkleizedBatch<F, D, Oper
 pub struct MerkleizedBatch<F: Family, D: Digest, K: Key, V: ValueEncoding, S: Strategy> {
     /// Authenticated journal batch (Merkle state + local items).
     pub(super) journal_batch: JournalBatch<F, D, K, V, S>,
-
-    /// Cached operations root after applying this batch.
-    pub(super) root: D,
 
     /// This batch's local key-level changes only (not accumulated from ancestors).
     /// Sorted by key with no duplicates; queried via `lookup_sorted` (binary search).
@@ -87,7 +81,7 @@ pub struct MerkleizedBatch<F: Family, D: Digest, K: Key, V: ValueEncoding, S: St
     pub(super) ancestor_diffs: Vec<Arc<DiffVec<K, F, V::Value>>>,
 
     /// Position and floor bounds for this batch chain.
-    pub(super) bounds: batch_chain::Bounds<F>,
+    pub(super) bounds: batch_chain::Bounds<F, D>,
 }
 
 impl<F, H, K, V, S: Strategy> UnmerkleizedBatch<F, H, K, V, S>
@@ -101,7 +95,7 @@ where
     /// Create a batch from a committed DB (no parent chain).
     pub(super) fn new<E, C, T>(
         immutable: &Immutable<F, E, K, V, C, H, T, S>,
-        journal_size: u64,
+        commit: CommitId<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -113,9 +107,17 @@ where
             journal_batch: immutable.journal.new_batch(),
             mutations: BTreeMap::new(),
             parent: None,
-            base_size: journal_size,
-            db_size: journal_size,
+            base: commit,
         }
+    }
+
+    /// The database's committed state at the base of this batch chain.
+    ///
+    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
+    fn db_commit(&self) -> CommitId<F, H::Digest> {
+        self.parent
+            .as_ref()
+            .map_or(self.base, |parent| parent.bounds.db_commit)
     }
 
     /// Set a key to a value.
@@ -243,7 +245,10 @@ where
         C::Item: EncodeShared,
         T: Translator,
     {
-        let base = self.base_size;
+        let base = self.base.size;
+
+        // Capture the DB boundary before `self` is consumed below.
+        let db_commit = self.db_commit();
 
         // Build operations: one Set per key, then Commit. `self.mutations` is a BTreeMap, so
         // iteration yields keys in sorted order, which `diff` relies on for binary search.
@@ -251,7 +256,7 @@ where
         let mut diff: DiffVec<K, F, V::Value> = Vec::with_capacity(self.mutations.len());
 
         for (key, value) in self.mutations {
-            let loc = Location::new(base + ops.len() as u64);
+            let loc = base + ops.len() as u64;
             ops.push(Operation::Set(key.clone(), value.clone()));
             diff.push((key, DiffEntry { value, loc }));
         }
@@ -260,10 +265,7 @@ where
         ops.push(Operation::Commit(metadata, inactivity_floor));
 
         let total_size = base + ops.len() as u64;
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(total_size)),
-            inactivity_floor,
-        );
+        let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
 
         // Leaf and node hashing dominate merkleization, so run them as one job on the
         // strategy instead of occupying the calling task (see `Journal::merkleize`).
@@ -282,20 +284,19 @@ where
             ancestor_diffs.push(Arc::clone(&batch.diff));
             ancestors.push(batch_chain::AncestorBounds {
                 floor: batch.bounds.inactivity_floor,
-                end: batch.bounds.total_size,
+                state: batch.commit_id(),
             });
         }
 
         Arc::new(MerkleizedBatch {
             journal_batch: journal,
-            root,
             diff: Arc::new(diff),
             parent: self.parent.as_ref().map(Arc::downgrade),
             ancestor_diffs,
             bounds: batch_chain::Bounds {
-                base_size: self.base_size,
-                db_size: self.db_size,
-                total_size,
+                base_commit: self.base,
+                db_commit,
+                tip_commit: CommitId::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -309,17 +310,22 @@ where
 {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
-        self.root
+        self.bounds.tip_commit.root
     }
 
     /// Return the [`Bounds`] of the batch.
-    pub const fn bounds(&self) -> &Bounds<F> {
+    pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
     }
 
     /// Iterate over ancestor batches (parent first, then grandparent, etc.).
     pub(super) fn ancestors(&self) -> impl Iterator<Item = Arc<Self>> + use<F, D, K, V, S> {
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
+    }
+
+    /// The [`CommitId`] this batch commits to.
+    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+        self.bounds.tip_commit
     }
 
     /// Read through: local diff -> ancestor diffs -> committed DB.
@@ -419,8 +425,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             mutations: BTreeMap::new(),
             parent: Some(Arc::clone(self)),
-            base_size: self.bounds.total_size,
-            db_size: self.bounds.db_size,
+            base: self.commit_id(),
         }
     }
 }
@@ -439,20 +444,12 @@ where
 {
     /// Create an initial [`MerkleizedBatch`] from the committed DB state.
     pub fn to_batch(&self) -> Arc<MerkleizedBatch<F, H::Digest, K, V, S>> {
-        let journal_size = *self.last_commit_loc + 1;
         Arc::new(MerkleizedBatch {
             journal_batch: self.journal.to_merkleized_batch(),
-            root: self.root,
             diff: Arc::new(Vec::new()),
             parent: None,
             ancestor_diffs: Vec::new(),
-            bounds: batch_chain::Bounds {
-                base_size: journal_size,
-                db_size: journal_size,
-                total_size: journal_size,
-                ancestors: Vec::new(),
-                inactivity_floor: self.inactivity_floor_loc,
-            },
+            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
         })
     }
 }

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -95,7 +95,7 @@ where
     /// Create a batch from a committed DB (no parent chain).
     pub(super) fn new<E, C, T>(
         immutable: &Immutable<F, E, K, V, C, H, T, S>,
-        commit: Commitment<F, H::Digest>,
+        base: Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -107,17 +107,17 @@ where
             journal_batch: immutable.journal.new_batch(),
             mutations: BTreeMap::new(),
             parent: None,
-            base: commit,
+            base,
         }
     }
 
-    /// The database's committed state at the base of this batch chain.
+    /// The database boundary for this batch chain.
     ///
-    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> Commitment<F, H::Digest> {
+    /// A batch created from the database uses its base. A child inherits its parent's `db`.
+    fn db(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
-            .map_or(self.base, |parent| parent.bounds.db_commit)
+            .map_or(self.base, |parent| parent.bounds.db)
     }
 
     /// Set a key to a value.
@@ -248,7 +248,7 @@ where
         let base = self.base.size;
 
         // Capture the DB boundary before `self` is consumed below.
-        let db_commit = self.db_commit();
+        let boundary = self.db();
 
         // Build operations: one Set per key, then Commit. `self.mutations` is a BTreeMap, so
         // iteration yields keys in sorted order, which `diff` relies on for binary search.
@@ -294,9 +294,9 @@ where
             parent: self.parent.as_ref().map(Arc::downgrade),
             ancestor_diffs,
             bounds: batch_chain::Bounds {
-                base_commit: self.base,
-                db_commit,
-                tip_commit: Commitment::new(total_size, root),
+                base: self.base,
+                db: boundary,
+                tip: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -310,7 +310,7 @@ where
 {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
-        self.bounds.tip_commit.root
+        self.bounds.tip.root
     }
 
     /// Return the [`Bounds`] of the batch.
@@ -325,7 +325,7 @@ where
 
     /// The [`Commitment`] this batch commits to.
     pub(super) const fn commitment(&self) -> Commitment<F, D> {
-        self.bounds.tip_commit
+        self.bounds.tip
     }
 
     /// Read through: local diff -> ancestor diffs -> committed DB.

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -32,7 +32,7 @@ use crate::{
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
-        batch_chain::{self, Bounds, CommitId},
+        batch_chain::{self, Bounds, Commitment},
         compact::{
             batch as compact_batch,
             witness::{self, VerifiedWitness},
@@ -107,7 +107,7 @@ where
     merkle_batch: compact_merkle::UnmerkleizedBatch<F, H::Digest, S>,
     mutations: BTreeMap<K, V::Value>,
     parent: Option<Arc<MerkleizedBatch<F, H::Digest, K, V, S>>>,
-    base: batch_chain::CommitId<F, H::Digest>,
+    base: batch_chain::Commitment<F, H::Digest>,
 }
 
 /// A speculative batch whose root digest has been computed.
@@ -131,8 +131,8 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
-    /// The [`CommitId`] this batch commits to.
-    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+    /// The [`Commitment`] this batch commits to.
+    pub(super) const fn commitment(&self) -> Commitment<F, D> {
         self.bounds.tip_commit
     }
 
@@ -155,7 +155,7 @@ where
             merkle_batch: compact_merkle::UnmerkleizedBatch::wrap(self.merkle_batch.new_batch()),
             mutations: BTreeMap::new(),
             parent: Some(Arc::clone(self)),
-            base: self.commit_id(),
+            base: self.commitment(),
         }
     }
 }
@@ -171,7 +171,7 @@ where
 {
     pub(super) fn new<E, C>(
         db: &Db<F, E, K, V, H, C, S>,
-        commit: batch_chain::CommitId<F, H::Digest>,
+        commit: batch_chain::Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -189,7 +189,7 @@ where
     /// The database's committed state at the base of this batch chain.
     ///
     /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> CommitId<F, H::Digest> {
+    fn db_commit(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
             .map_or(self.base, |parent| parent.bounds.db_commit)
@@ -249,7 +249,7 @@ where
         let ancestors = batch_chain::collect_ancestor_bounds(
             ancestors,
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.commit_id(),
+            |batch| batch.commitment(),
         );
 
         Arc::new(MerkleizedBatch {
@@ -259,7 +259,7 @@ where
             bounds: batch_chain::Bounds {
                 base_commit: self.base,
                 db_commit,
-                tip_commit: CommitId::new(total_size, root),
+                tip_commit: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -411,14 +411,14 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
-    /// The [`CommitId`] committed by the database's current state.
-    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
-        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root())
+    /// The [`Commitment`] committed by the database's current state.
+    pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
+        batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
     }
 
     /// Create a new speculative batch of operations with this database as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, H, K, V, S> {
-        UnmerkleizedBatch::new(self, self.commit_id())
+        UnmerkleizedBatch::new(self, self.commitment())
     }
 
     /// Create an owned merkleized batch representing the current applied state.
@@ -430,7 +430,7 @@ where
             merkle_batch: self.merkle.to_batch(),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
-            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
+            bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
             _key: PhantomData,
         })
     }
@@ -446,7 +446,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
+            .validate_apply_to(self.commitment(), self.inactivity_floor_loc)
     }
 
     /// Apply a merkleized batch to the database.

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -133,12 +133,12 @@ where
 
     /// The [`Commitment`] this batch commits to.
     pub(super) const fn commitment(&self) -> Commitment<F, D> {
-        self.bounds.tip_commit
+        self.bounds.tip
     }
 
     /// Return the root digest after this batch is applied.
     pub const fn root(&self) -> D {
-        self.bounds.tip_commit.root
+        self.bounds.tip.root
     }
 
     /// Return the [`Bounds`] of the batch.
@@ -171,7 +171,7 @@ where
 {
     pub(super) fn new<E, C>(
         db: &Db<F, E, K, V, H, C, S>,
-        commit: batch_chain::Commitment<F, H::Digest>,
+        base: batch_chain::Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -182,17 +182,17 @@ where
             merkle_batch: db.merkle.new_batch(),
             mutations: BTreeMap::new(),
             parent: None,
-            base: commit,
+            base,
         }
     }
 
-    /// The database's committed state at the base of this batch chain.
+    /// The database boundary for this batch chain.
     ///
-    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> Commitment<F, H::Digest> {
+    /// A batch created from the database uses its base. A child inherits its parent's `db`.
+    fn db(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
-            .map_or(self.base, |parent| parent.bounds.db_commit)
+            .map_or(self.base, |parent| parent.bounds.db)
     }
 
     pub fn set(mut self, key: K, value: V::Value) -> Self {
@@ -225,7 +225,7 @@ where
         Operation<F, K, V>: Read<Cfg = C>,
     {
         // Capture the DB boundary before `self` is consumed below.
-        let db_commit = self.db_commit();
+        let boundary = self.db();
 
         let mut ops: Vec<Operation<F, K, V>> = Vec::with_capacity(self.mutations.len() + 1);
         for (key, value) in self.mutations {
@@ -257,9 +257,9 @@ where
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
-                base_commit: self.base,
-                db_commit,
-                tip_commit: Commitment::new(total_size, root),
+                base: self.base,
+                db: boundary,
+                tip: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -477,10 +477,10 @@ where
         let start_loc = self.last_commit_loc + 1;
         self.merkle.apply_batch(&batch.merkle_batch)?;
         self.root = batch.root();
-        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
+        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        Ok((self, start_loc..batch.bounds.tip_commit.size))
+        Ok((self, start_loc..batch.bounds.tip.size))
     }
 
     /// Begin durably persisting the current db state to disk.

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -356,7 +356,7 @@ where
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
-        let last_commit_loc = Location::new(*witness.with(|w| w.size()) - 1);
+        let last_commit_loc = witness.with(|w| w.size()) - 1;
         let root = witness.with(|w| w.root);
 
         Ok(Self {
@@ -411,7 +411,7 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
-    /// The [`Commitment`] committed by the database's current state.
+    /// The [`Commitment`] for the committed state of this database.
     pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
         batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
     }
@@ -571,7 +571,7 @@ where
         };
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
-        self.last_commit_loc = Location::new(*target - 1);
+        self.last_commit_loc = target - 1;
         self.root = self.witness.with(|w| w.root);
         Ok(self)
     }
@@ -1519,7 +1519,7 @@ mod tests {
             // then drop the journal. The unsynced tail must not survive reopen.
             let journal = open_witness_journal(context.child("crash"), partition).await;
             let (op_bytes, mut size, pinned_nodes) = witness::tests::tip(&journal).await;
-            size = Location::new(*size + 2);
+            size += 2;
             witness::tests::append_unsynced(journal, op_bytes, size, pinned_nodes).await;
 
             // Reopen must drop the unsynced entry and recover state A.
@@ -1543,7 +1543,7 @@ mod tests {
             let db =
                 open_db::<mmr::Family>(context.child("reopen"), "immutable-rewind-beyond").await;
             // A target past the tip is not a commit either.
-            let beyond_tip = Location::new(*db.size() + 100);
+            let beyond_tip = db.size() + 100;
             assert!(matches!(
                 db.rewind(beyond_tip).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
@@ -1736,7 +1736,7 @@ mod tests {
             let target = db.target();
 
             // Prune with a boundary beyond the tip: the tip entry must survive.
-            let boundary = Location::new(*db.size() + 100);
+            let boundary = db.size() + 100;
             let db = db.prune(boundary).await.unwrap();
             assert_eq!(db.target(), target);
             drop(db);

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -32,7 +32,7 @@ use crate::{
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
-        batch_chain::{self, Bounds},
+        batch_chain::{self, Bounds, CommitId},
         compact::{
             batch as compact_batch,
             witness::{self, VerifiedWitness},
@@ -66,6 +66,7 @@ where
     C: Clone + Send + Sync + 'static,
 {
     merkle: compact_merkle::Merkle<F, H::Digest, S>,
+    root: H::Digest,
     last_commit_loc: Location<F>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
@@ -106,8 +107,7 @@ where
     merkle_batch: compact_merkle::UnmerkleizedBatch<F, H::Digest, S>,
     mutations: BTreeMap<K, V::Value>,
     parent: Option<Arc<MerkleizedBatch<F, H::Digest, K, V, S>>>,
-    base_size: u64,
-    db_size: u64,
+    base: batch_chain::CommitId<F, H::Digest>,
 }
 
 /// A speculative batch whose root digest has been computed.
@@ -117,10 +117,9 @@ where
     Operation<F, K, V>: EncodeShared,
 {
     pub(super) merkle_batch: Arc<batch::MerkleizedBatch<F, D, S>>,
-    pub(super) root: D,
     pub(super) commit_metadata: Option<V::Value>,
     pub(super) parent: Option<Weak<Self>>,
-    pub(super) bounds: batch_chain::Bounds<F>,
+    pub(super) bounds: batch_chain::Bounds<F, D>,
     pub(super) _key: PhantomData<K>,
 }
 
@@ -132,13 +131,18 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
+    /// The [`CommitId`] this batch commits to.
+    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+        self.bounds.tip_commit
+    }
+
     /// Return the root digest after this batch is applied.
     pub const fn root(&self) -> D {
-        self.root
+        self.bounds.tip_commit.root
     }
 
     /// Return the [`Bounds`] of the batch.
-    pub const fn bounds(&self) -> &Bounds<F> {
+    pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
     }
 
@@ -151,8 +155,7 @@ where
             merkle_batch: compact_merkle::UnmerkleizedBatch::wrap(self.merkle_batch.new_batch()),
             mutations: BTreeMap::new(),
             parent: Some(Arc::clone(self)),
-            base_size: self.bounds.total_size,
-            db_size: self.bounds.db_size,
+            base: self.commit_id(),
         }
     }
 }
@@ -166,7 +169,10 @@ where
     S: Strategy,
     Operation<F, K, V>: EncodeShared,
 {
-    pub(super) fn new<E, C>(db: &Db<F, E, K, V, H, C, S>, committed_size: u64) -> Self
+    pub(super) fn new<E, C>(
+        db: &Db<F, E, K, V, H, C, S>,
+        commit: batch_chain::CommitId<F, H::Digest>,
+    ) -> Self
     where
         E: Context,
         C: Clone + Send + Sync + 'static,
@@ -176,9 +182,17 @@ where
             merkle_batch: db.merkle.new_batch(),
             mutations: BTreeMap::new(),
             parent: None,
-            base_size: committed_size,
-            db_size: committed_size,
+            base: commit,
         }
+    }
+
+    /// The database's committed state at the base of this batch chain.
+    ///
+    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
+    fn db_commit(&self) -> CommitId<F, H::Digest> {
+        self.parent
+            .as_ref()
+            .map_or(self.base, |parent| parent.bounds.db_commit)
     }
 
     pub fn set(mut self, key: K, value: V::Value) -> Self {
@@ -210,17 +224,17 @@ where
         C: Clone + Send + Sync + 'static,
         Operation<F, K, V>: Read<Cfg = C>,
     {
+        // Capture the DB boundary before `self` is consumed below.
+        let db_commit = self.db_commit();
+
         let mut ops: Vec<Operation<F, K, V>> = Vec::with_capacity(self.mutations.len() + 1);
         for (key, value) in self.mutations {
             ops.push(Operation::Set(key, value));
         }
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
-        let total_size = self.base_size + ops.len() as u64;
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(total_size)),
-            inactivity_floor,
-        );
+        let total_size = self.base.size + ops.len() as u64;
+        let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
@@ -235,18 +249,17 @@ where
         let ancestors = batch_chain::collect_ancestor_bounds(
             ancestors,
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.bounds.total_size,
+            |batch| batch.commit_id(),
         );
 
         Arc::new(MerkleizedBatch {
             merkle_batch: merkle,
-            root,
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
-                base_size: self.base_size,
-                db_size: self.db_size,
-                total_size,
+                base_commit: self.base,
+                db_commit,
+                tip_commit: CommitId::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -300,8 +313,10 @@ where
         merkle.prune_to_frontier();
 
         let witness = witness::Store::from_import(journal, imported);
+        let root = witness.with(|w| w.root);
         Ok(Self {
             merkle,
+            root,
             last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
@@ -342,9 +357,11 @@ where
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
         let last_commit_loc = Location::new(*witness.with(|w| w.size()) - 1);
+        let root = witness.with(|w| w.root);
 
         Ok(Self {
             merkle,
+            root,
             last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
@@ -355,18 +372,8 @@ where
     }
 
     /// Return the root of the db.
-    pub fn root(&self) -> H::Digest
-    where
-        F: Family,
-    {
-        let hasher = qmdb::hasher::<H>();
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(*self.last_commit_loc + 1)),
-            self.inactivity_floor_loc,
-        );
-        self.merkle
-            .root(&hasher, inactive_peaks)
-            .expect("compact Merkle root should not fail")
+    pub const fn root(&self) -> H::Digest {
+        self.root
     }
 
     /// Return a reference to the merkleization strategy.
@@ -386,7 +393,7 @@ where
 
     /// Return the location of the next operation appended to this db.
     pub fn size(&self) -> Location<F> {
-        Location::new(*self.last_commit_loc + 1)
+        self.last_commit_loc + 1
     }
 
     /// Get the metadata associated with the last commit.
@@ -404,10 +411,14 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
+    /// The [`CommitId`] committed by the database's current state.
+    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
+        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root())
+    }
+
     /// Create a new speculative batch of operations with this database as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, H, K, V, S> {
-        let committed_size = *self.last_commit_loc + 1;
-        UnmerkleizedBatch::new(self, committed_size)
+        UnmerkleizedBatch::new(self, self.commit_id())
     }
 
     /// Create an owned merkleized batch representing the current applied state.
@@ -415,19 +426,11 @@ where
     where
         F: Family,
     {
-        let committed_size = *self.last_commit_loc + 1;
         Arc::new(MerkleizedBatch {
             merkle_batch: self.merkle.to_batch(),
-            root: self.root(),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
-            bounds: batch_chain::Bounds {
-                base_size: committed_size,
-                db_size: committed_size,
-                total_size: committed_size,
-                ancestors: Vec::new(),
-                inactivity_floor: self.inactivity_floor_loc,
-            },
+            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
             _key: PhantomData,
         })
     }
@@ -443,7 +446,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
     }
 
     /// Apply a merkleized batch to the database.
@@ -473,10 +476,11 @@ where
 
         let start_loc = self.last_commit_loc + 1;
         self.merkle.apply_batch(&batch.merkle_batch)?;
-        self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
+        self.root = batch.root();
+        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        Ok((self, start_loc..Location::new(batch.bounds.total_size)))
+        Ok((self, start_loc..batch.bounds.tip_commit.size))
     }
 
     /// Begin durably persisting the current db state to disk.
@@ -568,6 +572,7 @@ where
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
         self.last_commit_loc = Location::new(*target - 1);
+        self.root = self.witness.with(|w| w.root);
         Ok(self)
     }
 
@@ -882,10 +887,7 @@ mod tests {
             let expected_root = batch_a.root();
             let (db, _) = db.apply_batch(batch_a).unwrap();
             assert_eq!(db.root(), expected_root);
-            assert!(matches!(
-                db.apply_batch(batch_b),
-                Err(Error::StaleBatch { .. })
-            ));
+            assert!(matches!(db.apply_batch(batch_b), Err(Error::StaleBatch)));
         });
     }
 
@@ -936,27 +938,49 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let db = open_db::<mmr::Family>(context.child("db"), "immutable-chained-stale").await;
 
-            let parent = db
+            let common_parent = db
+                .new_batch()
+                .set(Sha256::hash(&[&[10]]), Sha256::fill(10u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let sibling_a = common_parent
+                .new_batch::<Sha256>()
+                .set(Sha256::hash(&[&[11]]), Sha256::fill(11u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let sibling_b = common_parent
+                .new_batch::<Sha256>()
+                .set(Sha256::hash(&[&[12]]), Sha256::fill(12u8))
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let (db, _) = db.apply_batch(sibling_a).unwrap();
+            assert!(matches!(
+                db.validate_batch(&sibling_b),
+                Err(Error::StaleBatch)
+            ));
+
+            let parent_a = db
                 .new_batch()
                 .set(Sha256::hash(&[&[1]]), Sha256::fill(1u8))
                 .merkleize(&db, None, Location::new(0))
                 .await;
-            let child_a = parent
-                .new_batch::<Sha256>()
+            let parent_b = db
+                .new_batch()
                 .set(Sha256::hash(&[&[2]]), Sha256::fill(2u8))
                 .merkleize(&db, None, Location::new(0))
                 .await;
-            let child_b = parent
+            let child_b = parent_b
                 .new_batch::<Sha256>()
                 .set(Sha256::hash(&[&[3]]), Sha256::fill(3u8))
                 .merkleize(&db, None, Location::new(0))
                 .await;
 
-            let (db, _) = db.apply_batch(child_a).unwrap();
+            let (db, _) = db.apply_batch(parent_a).unwrap();
             assert!(matches!(
-                db.apply_batch(child_b),
-                Err(Error::StaleBatch { .. })
+                db.validate_batch(&child_b),
+                Err(Error::StaleBatch)
             ));
+            db.destroy().await.unwrap();
         });
     }
 
@@ -978,10 +1002,7 @@ mod tests {
                 .await;
 
             let (db, _) = db.apply_batch(child).unwrap();
-            assert!(matches!(
-                db.apply_batch(parent),
-                Err(Error::StaleBatch { .. })
-            ));
+            assert!(matches!(db.apply_batch(parent), Err(Error::StaleBatch)));
         });
     }
 
@@ -1912,10 +1933,7 @@ mod tests {
 
             // After rewind, mem.size reflects post-commit-A, but the held batch starts after
             // post-commit-B. Apply must be rejected with StaleBatch.
-            assert!(matches!(
-                db.apply_batch(held),
-                Err(Error::StaleBatch { .. })
-            ));
+            assert!(matches!(db.apply_batch(held), Err(Error::StaleBatch)));
         });
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -411,7 +411,7 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
-    /// The [`Commitment`] for the committed state of this database.
+    /// The [`Commitment`] for the database's current state.
     pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
         batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
     }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -794,10 +794,10 @@ where
         }
 
         // Update state.
-        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
+        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         self.root = batch.root();
-        let range = db_size..batch.bounds.tip_commit.size;
+        let range = db_size..batch.bounds.tip.size;
         self.update_metrics();
         self.metrics
             .operations_applied

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -682,7 +682,7 @@ where
         Ok(self.journal.destroy().await?)
     }
 
-    /// The [`Commitment`](batch_chain::Commitment) committed by the database's current state.
+    /// The [`Commitment`](batch_chain::Commitment) for the database's current state.
     pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
         batch_chain::Commitment::new(self.last_commit_loc + 1, self.root)
     }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -80,8 +80,8 @@ use crate::{
     },
     merkle::{Family, Location, Proof, full::Config as MerkleConfig},
     qmdb::{
-        Error, any::ValueEncoding, build_snapshot_from_log, metrics::Metrics, operation::Key,
-        single_operation_root,
+        Error, any::ValueEncoding, batch_chain, build_snapshot_from_log, metrics::Metrics,
+        operation::Key, single_operation_root,
     },
     translator::Translator,
 };
@@ -269,10 +269,8 @@ where
 
             (last_commit_loc, inactivity_floor_loc)
         };
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(*last_commit_loc + 1)),
-            inactivity_floor_loc,
-        );
+        let inactive_peaks =
+            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);
@@ -615,7 +613,7 @@ where
 
         self.last_commit_loc = rewind_last_loc;
         self.inactivity_floor_loc = rewind_floor;
-        let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
+        let inactive_peaks = F::inactive_peaks(size, rewind_floor);
         self.root = self.journal.root(inactive_peaks)?;
         self.update_metrics();
 
@@ -685,11 +683,15 @@ where
         Ok(self.journal.destroy().await?)
     }
 
+    /// The [`CommitId`](batch_chain::CommitId) committed by the database's current state.
+    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
+        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root)
+    }
+
     /// Create a new speculative batch of operations with this database as its parent.
     #[allow(clippy::type_complexity)]
     pub fn new_batch(&self) -> batch::UnmerkleizedBatch<F, H, K, V, S> {
-        let journal_size = *self.last_commit_loc + 1;
-        batch::UnmerkleizedBatch::new(self, journal_size)
+        batch::UnmerkleizedBatch::new(self, self.commit_id())
     }
 
     /// Check that `batch` can be applied to the database in its current state, without
@@ -703,7 +705,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
     }
 
     /// Apply a [`batch::MerkleizedBatch`] to the database.
@@ -743,8 +745,7 @@ where
         let _timer = self.metrics.apply_batch_timer();
         self.metrics.apply_batch_calls.inc();
         self.validate_batch(&batch)?;
-        let db_size = *self.last_commit_loc + 1;
-        let start_loc = Location::new(db_size);
+        let db_size = self.last_commit_loc + 1;
 
         // Apply journal.
         self.journal = self.journal.apply_batch(&batch.journal_batch).await?;
@@ -755,7 +756,11 @@ where
         // `seen` is only consulted when at least one ancestor diff will be applied, so it is
         // skipped entirely otherwise.
         let bounds = self.journal.bounds();
-        let track_shadow = batch.bounds.ancestors.iter().any(|a| a.end > db_size);
+        let track_shadow = batch
+            .bounds
+            .ancestors
+            .iter()
+            .any(|a| a.state.size > db_size);
         let seen_cap = if track_shadow {
             batch.diff.len()
                 + batch
@@ -763,7 +768,7 @@ where
                     .ancestors
                     .iter()
                     .zip(&batch.ancestor_diffs)
-                    .filter(|(a, _)| a.end > db_size)
+                    .filter(|(a, _)| a.state.size > db_size)
                     .map(|(_, d)| d.len())
                     .sum::<usize>()
         } else {
@@ -778,7 +783,7 @@ where
                 .insert_and_retain(key, entry.loc, |v| *v >= bounds.start);
         }
         for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
-            if batch.bounds.ancestors[i].end <= db_size {
+            if batch.bounds.ancestors[i].state.size <= db_size {
                 continue;
             }
             for (key, entry) in ancestor_diff.iter() {
@@ -790,10 +795,10 @@ where
         }
 
         // Update state.
-        self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
+        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        self.root = batch.root;
-        let range = start_loc..Location::new(batch.bounds.total_size);
+        self.root = batch.root();
+        let range = db_size..batch.bounds.tip_commit.size;
         self.update_metrics();
         self.metrics
             .operations_applied
@@ -2404,7 +2409,7 @@ pub(super) mod test {
 
         // Apply the second -- should fail because the DB was modified.
         let result = db.apply_batch(batch_b).await;
-        assert!(matches!(result, Err(Error::StaleBatch { .. })));
+        assert!(matches!(result, Err(Error::StaleBatch)));
 
         // The rejection mutated nothing: reopening recovers the committed state.
         let db = open_db(context.child("reopen")).await;
@@ -2432,31 +2437,50 @@ pub(super) mod test {
         let key2 = Sha256::hash(&[&[2]]);
         let key3 = Sha256::hash(&[&[3]]);
 
-        // Parent batch.
-        let parent_m = db
+        let common_parent = db
+            .new_batch()
+            .set(Sha256::hash(&[&[10]]), Sha256::fill(10u8))
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let sibling_a = common_parent
+            .new_batch::<Sha256>()
+            .set(Sha256::hash(&[&[11]]), Sha256::fill(11u8))
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let sibling_b = common_parent
+            .new_batch::<Sha256>()
+            .set(Sha256::hash(&[&[12]]), Sha256::fill(12u8))
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(sibling_a).await.unwrap();
+        assert!(matches!(
+            db.validate_batch(&sibling_b),
+            Err(Error::StaleBatch)
+        ));
+
+        // Build equal-size sibling parents, then extend only one sibling.
+        let parent_a = db
             .new_batch()
             .set(key1, Sha256::fill(1u8))
             .merkleize(&db, None, Location::new(0))
             .await;
-
-        // Fork two children from the same parent.
-        let child_a = parent_m
-            .new_batch::<Sha256>()
+        let parent_b = db
+            .new_batch()
             .set(key2, Sha256::fill(2u8))
             .merkleize(&db, None, Location::new(0))
             .await;
-        let child_b = parent_m
+        let child_b = parent_b
             .new_batch::<Sha256>()
             .set(key3, Sha256::fill(3u8))
             .merkleize(&db, None, Location::new(0))
             .await;
 
-        // Apply child A.
-        let (db, _) = db.apply_batch(child_a).await.unwrap();
-
-        // Child B is stale.
-        let result = db.apply_batch(child_b).await;
-        assert!(matches!(result, Err(Error::StaleBatch { .. })));
+        let (db, _) = db.apply_batch(parent_a).await.unwrap();
+        assert!(matches!(
+            db.validate_batch(&child_b),
+            Err(Error::StaleBatch)
+        ));
+        db.destroy().await.unwrap();
     }
 
     #[boxed]
@@ -2632,7 +2656,7 @@ pub(super) mod test {
 
         // Parent is stale.
         let result = db.apply_batch(parent_m).await;
-        assert!(matches!(result, Err(Error::StaleBatch { .. })));
+        assert!(matches!(result, Err(Error::StaleBatch)));
     }
 
     /// to_batch() creates an owned snapshot whose root matches the committed DB.

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -683,15 +683,15 @@ where
         Ok(self.journal.destroy().await?)
     }
 
-    /// The [`CommitId`](batch_chain::CommitId) committed by the database's current state.
-    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
-        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root)
+    /// The [`Commitment`](batch_chain::Commitment) committed by the database's current state.
+    pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
+        batch_chain::Commitment::new(self.last_commit_loc + 1, self.root)
     }
 
     /// Create a new speculative batch of operations with this database as its parent.
     #[allow(clippy::type_complexity)]
     pub fn new_batch(&self) -> batch::UnmerkleizedBatch<F, H, K, V, S> {
-        batch::UnmerkleizedBatch::new(self, self.commit_id())
+        batch::UnmerkleizedBatch::new(self, self.commitment())
     }
 
     /// Check that `batch` can be applied to the database in its current state, without
@@ -705,7 +705,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
+            .validate_apply_to(self.commitment(), self.inactivity_floor_loc)
     }
 
     /// Apply a [`batch::MerkleizedBatch`] to the database.

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -269,8 +269,7 @@ where
 
             (last_commit_loc, inactivity_floor_loc)
         };
-        let inactive_peaks =
-            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
+        let inactive_peaks = F::inactive_peaks(last_commit_loc + 1, inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);
@@ -1086,7 +1085,7 @@ pub(super) mod test {
         let root_before = db.root();
         let bounds_before = db.bounds();
 
-        let prune_loc = Location::new(*bounds_before.end - 5);
+        let prune_loc = bounds_before.end - 5;
         let db = db.prune(prune_loc).await.unwrap();
 
         assert_eq!(db.root(), root_before);
@@ -1710,7 +1709,7 @@ pub(super) mod test {
 
             // Floor must be >= last_commit_loc for prune to succeed.
             // With 16 sets, commit is at current end + 16.
-            let floor = Location::new(*db.bounds().end + 16);
+            let floor = db.bounds().end + 16;
             (db, _) = commit_sets_with_floor(
                 db,
                 (0u64..16).map(|i| {
@@ -3408,7 +3407,7 @@ pub(super) mod test {
             bounds.start <= commit_loc,
             "prune must not advance bounds.start past the floor"
         );
-        assert_eq!(bounds.end, Location::new(*commit_loc + 1));
+        assert_eq!(bounds.end, commit_loc + 1);
 
         // State preserved across the prune; root unchanged; commit metadata still readable.
         assert_eq!(db.last_commit_loc, commit_loc);
@@ -3419,7 +3418,7 @@ pub(super) mod test {
         // Persist, then verify pruning one past the floor is rejected — the floor is
         // the hard ceiling.
         let db = db.sync().await.unwrap();
-        let Err(err) = db.prune(Location::new(*commit_loc + 1)).await else {
+        let Err(err) = db.prune(commit_loc + 1).await else {
             panic!("expected prune to fail");
         };
         assert!(matches!(err, Error::PruneBeyondMinRequired(p, f)

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -118,10 +118,8 @@ where
 
             (last_commit_loc, inactivity_floor_loc)
         };
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(*last_commit_loc + 1)),
-            inactivity_floor_loc,
-        );
+        let inactive_peaks =
+            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -118,8 +118,7 @@ where
 
             (last_commit_loc, inactivity_floor_loc)
         };
-        let inactive_peaks =
-            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
+        let inactive_peaks = F::inactive_peaks(last_commit_loc + 1, inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -1219,7 +1219,7 @@ where
         fetch_batch_size: NZU64!(1),
         target: sync::Target {
             root: target.root,
-            range: non_empty_range!(Location::new(*target.size - 1), target.size),
+            range: non_empty_range!(target.size - 1, target.size),
         },
         source,
         apply_batch_size: NZU64!(1024),
@@ -1575,7 +1575,7 @@ mod compact_variable_mmr {
             let sync::Response::Boundary { proof, .. } = &mut bad_state else {
                 unreachable!("boundary fetch returns a boundary response");
             };
-            proof.leaves = Location::new(*proof.leaves - 1);
+            proof.leaves -= 1;
 
             let client: ClientDb = sync::sync(compact_engine_config(
                 context.child("client"),
@@ -1919,7 +1919,7 @@ mod compact_variable_mmr {
                 client_cfg.strategy.clone(),
                 journal,
                 client_cfg.commit_codec_config,
-                Location::new(*target_b.size - 1),
+                target_b.size - 1,
                 pinned_nodes,
                 op,
             )
@@ -1950,7 +1950,7 @@ mod compact_variable_mmr {
                 client_cfg.strategy.clone(),
                 journal,
                 client_cfg.commit_codec_config,
-                Location::new(*target_b.size - 1),
+                target_b.size - 1,
                 pinned_nodes,
                 op,
             )
@@ -2317,7 +2317,7 @@ mod compact_variable_mmb {
             let sync::Response::Boundary { proof, .. } = &mut bad_state else {
                 unreachable!("boundary fetch returns a boundary response");
             };
-            proof.leaves = Location::new(*proof.leaves - 1);
+            proof.leaves -= 1;
 
             let client: ClientDb = sync::sync(compact_engine_config(
                 context.child("client"),

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -72,7 +72,7 @@ where
 
     /// The [`Commitment`] this batch commits to.
     pub(super) const fn commitment(&self) -> Commitment<F, D> {
-        self.bounds.tip_commit
+        self.bounds.tip
     }
 }
 
@@ -116,7 +116,7 @@ where
     /// Create a batch from a committed DB (no parent chain).
     pub(super) fn new<E, C>(
         keyless: &Keyless<F, E, V, C, H, S>,
-        commit: Commitment<F, H::Digest>,
+        base: Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -126,7 +126,7 @@ where
             journal_batch: keyless.journal.new_batch(),
             appends: Vec::new(),
             parent: None,
-            base: commit,
+            base,
         }
     }
 
@@ -135,13 +135,13 @@ where
         self.base.size + self.appends.len() as u64
     }
 
-    /// The database's committed state at the base of this batch chain.
+    /// The database boundary for this batch chain.
     ///
-    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> Commitment<F, H::Digest> {
+    /// A batch created from the database uses its base. A child inherits its parent's `db`.
+    fn db(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
-            .map_or(self.base, |parent| parent.bounds.db_commit)
+            .map_or(self.base, |parent| parent.bounds.db)
     }
 
     /// Append a value.
@@ -177,7 +177,7 @@ where
         // Check parent operation chain. If the ancestor was freed, read_chain_op returns None
         // and we fall through to the DB.
         if let Some(parent) = self.parent.as_ref()
-            && loc_val >= parent.bounds.db_commit.size
+            && loc_val >= parent.bounds.db.size
             && let Some(op) = read_chain_op(parent, loc_val)
         {
             return Ok(op.into_value());
@@ -227,7 +227,7 @@ where
 
             // Check parent operation chain.
             if let Some(parent) = self.parent.as_ref()
-                && loc_val >= parent.bounds.db_commit.size
+                && loc_val >= parent.bounds.db.size
                 && let Some(op) = read_chain_op(parent, loc_val)
             {
                 results.push(op.into_value());
@@ -268,7 +268,7 @@ where
         C: Mutable<Item = Operation<F, V>>,
     {
         // Capture the DB boundary before `self` is consumed below.
-        let db_commit = self.db_commit();
+        let boundary = self.db();
 
         // Build operations: one Append per value, then Commit.
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
@@ -301,9 +301,9 @@ where
             journal_batch: journal,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
-                base_commit: self.base,
-                db_commit,
-                tip_commit: Commitment::new(total_size, root),
+                base: self.base,
+                db: boundary,
+                tip: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -317,7 +317,7 @@ where
 {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
-        self.bounds.tip_commit.root
+        self.bounds.tip.root
     }
 
     /// Return the [`Bounds`] of the batch.
@@ -340,7 +340,7 @@ where
 
         // Check this batch's local items first, then walk parent chain. If an ancestor was
         // freed, fall through to the committed DB.
-        if loc_val >= self.bounds.db_commit.size
+        if loc_val >= self.bounds.db.size
             && let Some(op) = read_chain_op(self, loc_val)
         {
             return Ok(op.into_value());
@@ -378,7 +378,7 @@ where
         for (i, &loc) in locs.iter().enumerate() {
             let loc_val = *loc;
 
-            if loc_val >= self.bounds.db_commit.size
+            if loc_val >= self.bounds.db.size
                 && let Some(op) = read_chain_op(self, loc_val)
             {
                 results.push(op.into_value());

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -8,7 +8,7 @@ use crate::{
     qmdb::{
         Error,
         any::value::ValueEncoding,
-        batch_chain::{self, Bounds, CommitId},
+        batch_chain::{self, Bounds, Commitment},
     },
 };
 use commonware_codec::EncodeShared;
@@ -41,7 +41,7 @@ where
 
     /// The committed state immediately before this batch's operations (committed DB + prior
     /// batches). This batch's i-th operation lands at location `base.size + i`.
-    base: CommitId<F, H::Digest>,
+    base: Commitment<F, H::Digest>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -70,8 +70,8 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
-    /// The [`CommitId`] this batch commits to.
-    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+    /// The [`Commitment`] this batch commits to.
+    pub(super) const fn commitment(&self) -> Commitment<F, D> {
         self.bounds.tip_commit
     }
 }
@@ -116,7 +116,7 @@ where
     /// Create a batch from a committed DB (no parent chain).
     pub(super) fn new<E, C>(
         keyless: &Keyless<F, E, V, C, H, S>,
-        commit: CommitId<F, H::Digest>,
+        commit: Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -138,7 +138,7 @@ where
     /// The database's committed state at the base of this batch chain.
     ///
     /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> CommitId<F, H::Digest> {
+    fn db_commit(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
             .map_or(self.base, |parent| parent.bounds.db_commit)
@@ -294,7 +294,7 @@ where
         let ancestors = batch_chain::collect_ancestor_bounds(
             ancestors,
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.commit_id(),
+            |batch| batch.commitment(),
         );
 
         Arc::new(MerkleizedBatch {
@@ -303,7 +303,7 @@ where
             bounds: batch_chain::Bounds {
                 base_commit: self.base,
                 db_commit,
-                tip_commit: CommitId::new(total_size, root),
+                tip_commit: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -413,7 +413,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             appends: Vec::new(),
             parent: Some(Arc::clone(self)),
-            base: self.commit_id(),
+            base: self.commitment(),
         }
     }
 }

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -39,8 +39,8 @@ where
     /// Parent batch in the chain. `None` for batches created directly from the DB.
     parent: Option<MerkleizedParent<F, H, V, S>>,
 
-    /// The committed state immediately before this batch's operations (committed DB + prior
-    /// batches). This batch's i-th operation lands at location `base.size + i`.
+    /// The state immediately before this batch's operations.
+    /// This batch's i-th operation lands at location `base.size + i`.
     base: Commitment<F, H::Digest>,
 }
 

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -8,7 +8,7 @@ use crate::{
     qmdb::{
         Error,
         any::value::ValueEncoding,
-        batch_chain::{self, Bounds},
+        batch_chain::{self, Bounds, CommitId},
     },
 };
 use commonware_codec::EncodeShared;
@@ -39,12 +39,9 @@ where
     /// Parent batch in the chain. `None` for batches created directly from the DB.
     parent: Option<MerkleizedParent<F, H, V, S>>,
 
-    /// Total operation count before this batch (committed DB + prior batches).
-    /// This batch's i-th operation lands at location `base_size + i`.
-    base_size: u64,
-
-    /// The database size when this batch was created, used to detect stale batches.
-    db_size: u64,
+    /// The committed state immediately before this batch's operations (committed DB + prior
+    /// batches). This batch's i-th operation lands at location `base.size + i`.
+    base: CommitId<F, H::Digest>,
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -57,14 +54,11 @@ where
     /// Authenticated journal batch (Merkle state + local items).
     pub(super) journal_batch: Arc<authenticated::MerkleizedBatch<F, D, Operation<F, V>, S>>,
 
-    /// Cached operations root after applying this batch.
-    pub(super) root: D,
-
     /// The parent batch in the chain, if any.
     pub(super) parent: Option<Weak<Self>>,
 
     /// Position and floor bounds for this batch chain.
-    pub(super) bounds: batch_chain::Bounds<F>,
+    pub(super) bounds: batch_chain::Bounds<F, D>,
 }
 
 impl<F: Family, D: Digest, V: ValueEncoding, S: Strategy> MerkleizedBatch<F, D, V, S>
@@ -74,6 +68,11 @@ where
     /// Iterate over ancestor batches (parent first, then grandparent, etc.).
     pub(super) fn ancestors(&self) -> impl Iterator<Item = Arc<Self>> + use<F, D, V, S> {
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
+    }
+
+    /// The [`CommitId`] this batch commits to.
+    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+        self.bounds.tip_commit
     }
 }
 
@@ -115,7 +114,10 @@ where
     Operation<F, V>: EncodeShared,
 {
     /// Create a batch from a committed DB (no parent chain).
-    pub(super) fn new<E, C>(keyless: &Keyless<F, E, V, C, H, S>, journal_size: u64) -> Self
+    pub(super) fn new<E, C>(
+        keyless: &Keyless<F, E, V, C, H, S>,
+        commit: CommitId<F, H::Digest>,
+    ) -> Self
     where
         E: Context,
         C: Mutable<Item = Operation<F, V>>,
@@ -124,14 +126,22 @@ where
             journal_batch: keyless.journal.new_batch(),
             appends: Vec::new(),
             parent: None,
-            base_size: journal_size,
-            db_size: journal_size,
+            base: commit,
         }
     }
 
     /// The location that the next appended value will be placed at.
-    pub const fn size(&self) -> Location<F> {
-        Location::new(self.base_size + self.appends.len() as u64)
+    pub fn size(&self) -> Location<F> {
+        self.base.size + self.appends.len() as u64
+    }
+
+    /// The database's committed state at the base of this batch chain.
+    ///
+    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
+    fn db_commit(&self) -> CommitId<F, H::Digest> {
+        self.parent
+            .as_ref()
+            .map_or(self.base, |parent| parent.bounds.db_commit)
     }
 
     /// Append a value.
@@ -155,8 +165,8 @@ where
         let loc_val = *loc;
 
         // Check this batch's pending appends.
-        if loc_val >= self.base_size {
-            let idx = (loc_val - self.base_size) as usize;
+        if loc_val >= self.base.size {
+            let idx = (loc_val - *self.base.size) as usize;
             return if idx < self.appends.len() {
                 Ok(Some(self.appends[idx].clone()))
             } else {
@@ -167,7 +177,7 @@ where
         // Check parent operation chain. If the ancestor was freed, read_chain_op returns None
         // and we fall through to the DB.
         if let Some(parent) = self.parent.as_ref()
-            && loc_val >= self.db_size
+            && loc_val >= parent.bounds.db_commit.size
             && let Some(op) = read_chain_op(parent, loc_val)
         {
             return Ok(op.into_value());
@@ -205,8 +215,8 @@ where
             let loc_val = *loc;
 
             // Check this batch's pending appends.
-            if loc_val >= self.base_size {
-                let idx = (loc_val - self.base_size) as usize;
+            if loc_val >= self.base.size {
+                let idx = (loc_val - *self.base.size) as usize;
                 results.push(if idx < self.appends.len() {
                     Some(self.appends[idx].clone())
                 } else {
@@ -217,7 +227,7 @@ where
 
             // Check parent operation chain.
             if let Some(parent) = self.parent.as_ref()
-                && loc_val >= self.db_size
+                && loc_val >= parent.bounds.db_commit.size
                 && let Some(op) = read_chain_op(parent, loc_val)
             {
                 results.push(op.into_value());
@@ -257,6 +267,9 @@ where
         E: Context,
         C: Mutable<Item = Operation<F, V>>,
     {
+        // Capture the DB boundary before `self` is consumed below.
+        let db_commit = self.db_commit();
+
         // Build operations: one Append per value, then Commit.
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
@@ -264,11 +277,8 @@ where
         }
         ops.push(Operation::Commit(metadata, inactivity_floor));
 
-        let total_size = self.base_size + ops.len() as u64;
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(total_size)),
-            inactivity_floor,
-        );
+        let total_size = self.base.size + ops.len() as u64;
+        let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
 
         // Leaf and node hashing dominate merkleization, so run them as one job on the
         // strategy instead of occupying the calling task (see `Journal::merkleize`).
@@ -284,17 +294,16 @@ where
         let ancestors = batch_chain::collect_ancestor_bounds(
             ancestors,
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.bounds.total_size,
+            |batch| batch.commit_id(),
         );
 
         Arc::new(MerkleizedBatch {
             journal_batch: journal,
-            root,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
-                base_size: self.base_size,
-                db_size: self.db_size,
-                total_size,
+                base_commit: self.base,
+                db_commit,
+                tip_commit: CommitId::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -308,11 +317,11 @@ where
 {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
-        self.root
+        self.bounds.tip_commit.root
     }
 
     /// Return the [`Bounds`] of the batch.
-    pub const fn bounds(&self) -> &Bounds<F> {
+    pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
     }
 
@@ -331,7 +340,7 @@ where
 
         // Check this batch's local items first, then walk parent chain. If an ancestor was
         // freed, fall through to the committed DB.
-        if loc_val >= self.bounds.db_size
+        if loc_val >= self.bounds.db_commit.size
             && let Some(op) = read_chain_op(self, loc_val)
         {
             return Ok(op.into_value());
@@ -369,7 +378,7 @@ where
         for (i, &loc) in locs.iter().enumerate() {
             let loc_val = *loc;
 
-            if loc_val >= self.bounds.db_size
+            if loc_val >= self.bounds.db_commit.size
                 && let Some(op) = read_chain_op(self, loc_val)
             {
                 results.push(op.into_value());
@@ -404,8 +413,7 @@ where
             journal_batch: self.journal_batch.new_batch::<H>(),
             appends: Vec::new(),
             parent: Some(Arc::clone(self)),
-            base_size: self.bounds.total_size,
-            db_size: self.bounds.db_size,
+            base: self.commit_id(),
         }
     }
 }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -32,7 +32,7 @@ use crate::{
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
-        batch_chain::{self, Bounds, CommitId},
+        batch_chain::{self, Bounds, Commitment},
         compact::{
             batch as compact_batch,
             witness::{self, VerifiedWitness},
@@ -98,7 +98,7 @@ where
     merkle_batch: compact_merkle::UnmerkleizedBatch<F, H::Digest, S>,
     appends: Vec<V::Value>,
     parent: Option<Arc<MerkleizedBatch<F, H::Digest, V, S>>>,
-    base: batch_chain::CommitId<F, H::Digest>,
+    base: batch_chain::Commitment<F, H::Digest>,
 }
 
 /// A speculative batch whose root digest has been computed.
@@ -121,8 +121,8 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
-    /// The [`CommitId`] this batch commits to.
-    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+    /// The [`Commitment`] this batch commits to.
+    pub(super) const fn commitment(&self) -> Commitment<F, D> {
         self.bounds.tip_commit
     }
 
@@ -145,7 +145,7 @@ where
             merkle_batch: compact_merkle::UnmerkleizedBatch::wrap(self.merkle_batch.new_batch()),
             appends: Vec::new(),
             parent: Some(Arc::clone(self)),
-            base: self.commit_id(),
+            base: self.commitment(),
         }
     }
 }
@@ -160,7 +160,7 @@ where
 {
     pub(super) fn new<E, C>(
         db: &Db<F, E, V, H, C, S>,
-        commit: batch_chain::CommitId<F, H::Digest>,
+        commit: batch_chain::Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -178,7 +178,7 @@ where
     /// The database's committed state at the base of this batch chain.
     ///
     /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> CommitId<F, H::Digest> {
+    fn db_commit(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
             .map_or(self.base, |parent| parent.bounds.db_commit)
@@ -238,7 +238,7 @@ where
         let ancestors = batch_chain::collect_ancestor_bounds(
             ancestors,
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.commit_id(),
+            |batch| batch.commitment(),
         );
 
         Arc::new(MerkleizedBatch {
@@ -248,7 +248,7 @@ where
             bounds: batch_chain::Bounds {
                 base_commit: self.base,
                 db_commit,
-                tip_commit: CommitId::new(total_size, root),
+                tip_commit: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -396,14 +396,14 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
-    /// The [`CommitId`] committed by the database's current state.
-    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
-        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root())
+    /// The [`Commitment`] committed by the database's current state.
+    pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
+        batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
     }
 
     /// Create a new speculative batch of operations with this database as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, H, V, S> {
-        UnmerkleizedBatch::new(self, self.commit_id())
+        UnmerkleizedBatch::new(self, self.commitment())
     }
 
     /// Create an owned merkleized batch representing the current applied state.
@@ -415,7 +415,7 @@ where
             merkle_batch: self.merkle.to_batch(),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
-            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
+            bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
         })
     }
 
@@ -430,7 +430,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
+            .validate_apply_to(self.commitment(), self.inactivity_floor_loc)
     }
 
     /// Apply a merkleized batch to the database.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -396,7 +396,7 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
-    /// The [`Commitment`] for the committed state of this database.
+    /// The [`Commitment`] for the database's current state.
     pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
         batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
     }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -123,12 +123,12 @@ where
 
     /// The [`Commitment`] this batch commits to.
     pub(super) const fn commitment(&self) -> Commitment<F, D> {
-        self.bounds.tip_commit
+        self.bounds.tip
     }
 
     /// Return the root digest after this batch is applied.
     pub const fn root(&self) -> D {
-        self.bounds.tip_commit.root
+        self.bounds.tip.root
     }
 
     /// Return the [`Bounds`] of the batch.
@@ -160,7 +160,7 @@ where
 {
     pub(super) fn new<E, C>(
         db: &Db<F, E, V, H, C, S>,
-        commit: batch_chain::Commitment<F, H::Digest>,
+        base: batch_chain::Commitment<F, H::Digest>,
     ) -> Self
     where
         E: Context,
@@ -171,17 +171,17 @@ where
             merkle_batch: db.merkle.new_batch(),
             appends: Vec::new(),
             parent: None,
-            base: commit,
+            base,
         }
     }
 
-    /// The database's committed state at the base of this batch chain.
+    /// The database boundary for this batch chain.
     ///
-    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
-    fn db_commit(&self) -> Commitment<F, H::Digest> {
+    /// A batch created from the database uses its base. A child inherits its parent's `db`.
+    fn db(&self) -> Commitment<F, H::Digest> {
         self.parent
             .as_ref()
-            .map_or(self.base, |parent| parent.bounds.db_commit)
+            .map_or(self.base, |parent| parent.bounds.db)
     }
 
     pub fn append(mut self, value: V::Value) -> Self {
@@ -214,7 +214,7 @@ where
         Operation<F, V>: Read<Cfg = C>,
     {
         // Capture the DB boundary before `self` is consumed below.
-        let db_commit = self.db_commit();
+        let boundary = self.db();
 
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
@@ -246,9 +246,9 @@ where
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
-                base_commit: self.base,
-                db_commit,
-                tip_commit: Commitment::new(total_size, root),
+                base: self.base,
+                db: boundary,
+                tip: Commitment::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -457,10 +457,10 @@ where
         let start_loc = self.last_commit_loc + 1;
         self.merkle.apply_batch(&batch.merkle_batch)?;
         self.root = batch.root();
-        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
+        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        Ok((self, start_loc..batch.bounds.tip_commit.size))
+        Ok((self, start_loc..batch.bounds.tip.size))
     }
 
     /// Begin durably persisting the current db state to disk.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -342,7 +342,7 @@ where
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
-        let last_commit_loc = Location::new(*witness.with(|w| w.size()) - 1);
+        let last_commit_loc = witness.with(|w| w.size()) - 1;
         let root = witness.with(|w| w.root);
 
         Ok(Self {
@@ -396,7 +396,7 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
-    /// The [`Commitment`] committed by the database's current state.
+    /// The [`Commitment`] for the committed state of this database.
     pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
         batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
     }
@@ -547,7 +547,7 @@ where
         };
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
-        self.last_commit_loc = Location::new(*target - 1);
+        self.last_commit_loc = target - 1;
         self.root = self.witness.with(|w| w.root);
         Ok(self)
     }
@@ -682,9 +682,9 @@ mod tests {
                     max_ops: NZU64!(1),
                 };
 
-            let beyond = Location::new(*n + 1);
+            let beyond = n + 1;
             assert!(matches!(
-                db.serve(boundary(beyond, Location::new(*n))).await,
+                db.serve(boundary(beyond, n)).await,
                 Err(Error::Merkle(crate::merkle::Error::RangeOutOfBounds(_)))
             ));
             assert!(matches!(
@@ -693,8 +693,7 @@ mod tests {
                 Err(Error::Merkle(crate::merkle::Error::RangeOutOfBounds(_)))
             ));
             assert!(matches!(
-                db.serve(operations(Location::new(*n - 1), Location::new(*n - 2)))
-                    .await,
+                db.serve(operations(n - 1, n - 2)).await,
                 Err(Error::Journal(crate::journal::Error::ItemPruned(_)))
             ));
             assert!(matches!(
@@ -702,7 +701,7 @@ mod tests {
                 Err(Error::Merkle(crate::merkle::Error::RangeOutOfBounds(_)))
             ));
             assert!(matches!(
-                db.serve(boundary(n, Location::new(*n - 2))).await,
+                db.serve(boundary(n, n - 2)).await,
                 Err(Error::Journal(crate::journal::Error::ItemPruned(_)))
             ));
 
@@ -711,7 +710,7 @@ mod tests {
             let (response, feedback_tx) = db
                 .serve(Request::Operations {
                     size: n,
-                    start: Location::new(*n - 1),
+                    start: n - 1,
                     max_ops: NZU64!(5),
                 })
                 .await
@@ -721,7 +720,7 @@ mod tests {
                 panic!("operations request should get an operations response");
             };
             assert_eq!(operations.len(), 1);
-            let (response, _) = db.serve(boundary(n, Location::new(*n - 1))).await.unwrap();
+            let (response, _) = db.serve(boundary(n, n - 1)).await.unwrap();
             assert!(matches!(response, Response::Boundary { .. }));
         });
     }
@@ -1271,7 +1270,7 @@ mod tests {
                     Sequential,
                     journal,
                     (),
-                    Location::new(*size_b - 1),
+                    size_b - 1,
                     pinned_b,
                     Operation::Commit(Some(meta_b.clone()), Location::new(0)),
                 )
@@ -1733,7 +1732,7 @@ mod tests {
                 let (response, _) = source
                     .serve(Request::Boundary {
                         size: target.size,
-                        start: Location::new(*target.size - 1),
+                        start: target.size - 1,
                     })
                     .await
                     .unwrap();
@@ -1763,7 +1762,7 @@ mod tests {
                     Sequential,
                     journal,
                     (),
-                    Location::new(*target_b.size - 1),
+                    target_b.size - 1,
                     pinned_b,
                     Operation::Commit(Some(meta_b.clone()), Location::new(0)),
                 )
@@ -2026,7 +2025,7 @@ mod tests {
             let target = db.target();
 
             // Prune with a boundary beyond the tip: the tip entry must survive.
-            let boundary = Location::new(*db.size() + 100);
+            let boundary = db.size() + 100;
             let db = db.prune(boundary).await.unwrap();
             assert_eq!(db.target(), target);
             drop(db);
@@ -2050,7 +2049,7 @@ mod tests {
 
             let db = open_db::<mmr::Family>(context.child("reopen"), "keyless-rewind-beyond").await;
             // A target past the tip is not a commit either.
-            let beyond_tip = Location::new(*db.size() + 100);
+            let beyond_tip = db.size() + 100;
             assert!(matches!(
                 db.rewind(beyond_tip).await,
                 Err(Error::Merkle(crate::merkle::Error::RewindBeyondHistory))
@@ -2134,7 +2133,7 @@ mod tests {
             // then drop the journal. The unsynced tail must not survive reopen.
             let journal = open_witness_journal(context.child("crash"), partition).await;
             let (op_bytes, mut size, pinned_nodes) = witness::tests::tip(&journal).await;
-            size = Location::new(*size + 2);
+            size += 2;
             witness::tests::append_unsynced(journal, op_bytes, size, pinned_nodes).await;
 
             // Reopen must drop the unsynced entry and recover state A.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -32,7 +32,7 @@ use crate::{
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
-        batch_chain::{self, Bounds},
+        batch_chain::{self, Bounds, CommitId},
         compact::{
             batch as compact_batch,
             witness::{self, VerifiedWitness},
@@ -60,6 +60,7 @@ where
     C: Clone + Send + Sync + 'static,
 {
     merkle: compact_merkle::Merkle<F, H::Digest, S>,
+    root: H::Digest,
     last_commit_loc: Location<F>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
@@ -97,8 +98,7 @@ where
     merkle_batch: compact_merkle::UnmerkleizedBatch<F, H::Digest, S>,
     appends: Vec<V::Value>,
     parent: Option<Arc<MerkleizedBatch<F, H::Digest, V, S>>>,
-    base_size: u64,
-    db_size: u64,
+    base: batch_chain::CommitId<F, H::Digest>,
 }
 
 /// A speculative batch whose root digest has been computed.
@@ -108,10 +108,9 @@ where
     Operation<F, V>: EncodeShared,
 {
     pub(super) merkle_batch: Arc<batch::MerkleizedBatch<F, D, S>>,
-    pub(super) root: D,
     pub(super) commit_metadata: Option<V::Value>,
     pub(super) parent: Option<Weak<Self>>,
-    pub(super) bounds: batch_chain::Bounds<F>,
+    pub(super) bounds: batch_chain::Bounds<F, D>,
 }
 
 impl<F: Family, D: Digest, V: ValueEncoding, S: Strategy> MerkleizedBatch<F, D, V, S>
@@ -122,13 +121,18 @@ where
         batch_chain::ancestors(self.parent.clone(), |batch| batch.parent.as_ref())
     }
 
+    /// The [`CommitId`] this batch commits to.
+    pub(super) const fn commit_id(&self) -> CommitId<F, D> {
+        self.bounds.tip_commit
+    }
+
     /// Return the root digest after this batch is applied.
     pub const fn root(&self) -> D {
-        self.root
+        self.bounds.tip_commit.root
     }
 
     /// Return the [`Bounds`] of the batch.
-    pub const fn bounds(&self) -> &Bounds<F> {
+    pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
     }
 
@@ -141,8 +145,7 @@ where
             merkle_batch: compact_merkle::UnmerkleizedBatch::wrap(self.merkle_batch.new_batch()),
             appends: Vec::new(),
             parent: Some(Arc::clone(self)),
-            base_size: self.bounds.total_size,
-            db_size: self.bounds.db_size,
+            base: self.commit_id(),
         }
     }
 }
@@ -155,7 +158,10 @@ where
     S: Strategy,
     Operation<F, V>: EncodeShared,
 {
-    pub(super) fn new<E, C>(db: &Db<F, E, V, H, C, S>, committed_size: u64) -> Self
+    pub(super) fn new<E, C>(
+        db: &Db<F, E, V, H, C, S>,
+        commit: batch_chain::CommitId<F, H::Digest>,
+    ) -> Self
     where
         E: Context,
         C: Clone + Send + Sync + 'static,
@@ -165,9 +171,17 @@ where
             merkle_batch: db.merkle.new_batch(),
             appends: Vec::new(),
             parent: None,
-            base_size: committed_size,
-            db_size: committed_size,
+            base: commit,
         }
+    }
+
+    /// The database's committed state at the base of this batch chain.
+    ///
+    /// Derived: a DB-created batch's base is the DB commit; a child's is its parent's `db_commit`.
+    fn db_commit(&self) -> CommitId<F, H::Digest> {
+        self.parent
+            .as_ref()
+            .map_or(self.base, |parent| parent.bounds.db_commit)
     }
 
     pub fn append(mut self, value: V::Value) -> Self {
@@ -199,17 +213,17 @@ where
         C: Clone + Send + Sync + 'static,
         Operation<F, V>: Read<Cfg = C>,
     {
+        // Capture the DB boundary before `self` is consumed below.
+        let db_commit = self.db_commit();
+
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
             ops.push(Operation::Append(value));
         }
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
-        let total_size = self.base_size + ops.len() as u64;
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(total_size)),
-            inactivity_floor,
-        );
+        let total_size = self.base.size + ops.len() as u64;
+        let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
@@ -224,18 +238,17 @@ where
         let ancestors = batch_chain::collect_ancestor_bounds(
             ancestors,
             |batch| batch.bounds.inactivity_floor,
-            |batch| batch.bounds.total_size,
+            |batch| batch.commit_id(),
         );
 
         Arc::new(MerkleizedBatch {
             merkle_batch: merkle,
-            root,
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
-                base_size: self.base_size,
-                db_size: self.db_size,
-                total_size,
+                base_commit: self.base,
+                db_commit,
+                tip_commit: CommitId::new(total_size, root),
                 ancestors,
                 inactivity_floor,
             },
@@ -287,8 +300,10 @@ where
         merkle.prune_to_frontier();
 
         let witness = witness::Store::from_import(journal, imported);
+        let root = witness.with(|w| w.root);
         Ok(Self {
             merkle,
+            root,
             last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
@@ -328,9 +343,11 @@ where
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
         let last_commit_loc = Location::new(*witness.with(|w| w.size()) - 1);
+        let root = witness.with(|w| w.root);
 
         Ok(Self {
             merkle,
+            root,
             last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
@@ -340,18 +357,8 @@ where
     }
 
     /// Return the root of the db.
-    pub fn root(&self) -> H::Digest
-    where
-        F: Family,
-    {
-        let hasher = qmdb::hasher::<H>();
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(*self.last_commit_loc + 1)),
-            self.inactivity_floor_loc,
-        );
-        self.merkle
-            .root(&hasher, inactive_peaks)
-            .expect("compact Merkle root should not fail")
+    pub const fn root(&self) -> H::Digest {
+        self.root
     }
 
     /// Return a reference to the merkleization strategy.
@@ -371,7 +378,7 @@ where
 
     /// Return the location of the next operation appended to this db.
     pub fn size(&self) -> Location<F> {
-        Location::new(*self.last_commit_loc + 1)
+        self.last_commit_loc + 1
     }
 
     /// Get the metadata associated with the last commit.
@@ -389,10 +396,14 @@ where
         self.witness.with(VerifiedWitness::target)
     }
 
+    /// The [`CommitId`] committed by the database's current state.
+    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
+        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root())
+    }
+
     /// Create a new speculative batch of operations with this database as its parent.
     pub fn new_batch(&self) -> UnmerkleizedBatch<F, H, V, S> {
-        let committed_size = *self.last_commit_loc + 1;
-        UnmerkleizedBatch::new(self, committed_size)
+        UnmerkleizedBatch::new(self, self.commit_id())
     }
 
     /// Create an owned merkleized batch representing the current applied state.
@@ -400,19 +411,11 @@ where
     where
         F: Family,
     {
-        let committed_size = *self.last_commit_loc + 1;
         Arc::new(MerkleizedBatch {
             merkle_batch: self.merkle.to_batch(),
-            root: self.root(),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
-            bounds: batch_chain::Bounds {
-                base_size: committed_size,
-                db_size: committed_size,
-                total_size: committed_size,
-                ancestors: Vec::new(),
-                inactivity_floor: self.inactivity_floor_loc,
-            },
+            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
         })
     }
 
@@ -427,7 +430,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
     }
 
     /// Apply a merkleized batch to the database.
@@ -453,10 +456,11 @@ where
 
         let start_loc = self.last_commit_loc + 1;
         self.merkle.apply_batch(&batch.merkle_batch)?;
-        self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
+        self.root = batch.root();
+        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        Ok((self, start_loc..Location::new(batch.bounds.total_size)))
+        Ok((self, start_loc..batch.bounds.tip_commit.size))
     }
 
     /// Begin durably persisting the current db state to disk.
@@ -544,6 +548,7 @@ where
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
         self.last_commit_loc = Location::new(*target - 1);
+        self.root = self.witness.with(|w| w.root);
         Ok(self)
     }
 
@@ -1305,10 +1310,7 @@ mod tests {
             let expected_root = batch_a.root();
             let (db, _) = db.apply_batch(batch_a).unwrap();
             assert_eq!(db.root(), expected_root);
-            assert!(matches!(
-                db.apply_batch(batch_b),
-                Err(Error::StaleBatch { .. })
-            ));
+            assert!(matches!(db.apply_batch(batch_b), Err(Error::StaleBatch)));
         });
     }
 
@@ -1359,27 +1361,49 @@ mod tests {
             let db = open_db::<mmr::Family>(context.child("db"), "keyless-chained-stale").await;
             let floor = db.inactivity_floor_loc();
 
-            let parent = db
+            let common_parent = db
+                .new_batch()
+                .append(U64::new(10))
+                .merkleize(&db, Some(U64::new(110)), floor)
+                .await;
+            let sibling_a = common_parent
+                .new_batch::<Sha256>()
+                .append(U64::new(11))
+                .merkleize(&db, Some(U64::new(111)), floor)
+                .await;
+            let sibling_b = common_parent
+                .new_batch::<Sha256>()
+                .append(U64::new(12))
+                .merkleize(&db, Some(U64::new(112)), floor)
+                .await;
+            let (db, _) = db.apply_batch(sibling_a).unwrap();
+            assert!(matches!(
+                db.validate_batch(&sibling_b),
+                Err(Error::StaleBatch)
+            ));
+
+            let parent_a = db
                 .new_batch()
                 .append(U64::new(1))
                 .merkleize(&db, Some(U64::new(11)), floor)
                 .await;
-            let child_a = parent
-                .new_batch::<Sha256>()
+            let parent_b = db
+                .new_batch()
                 .append(U64::new(2))
                 .merkleize(&db, Some(U64::new(22)), floor)
                 .await;
-            let child_b = parent
+            let child_b = parent_b
                 .new_batch::<Sha256>()
                 .append(U64::new(3))
                 .merkleize(&db, Some(U64::new(33)), floor)
                 .await;
 
-            let (db, _) = db.apply_batch(child_a).unwrap();
+            let (db, _) = db.apply_batch(parent_a).unwrap();
             assert!(matches!(
-                db.apply_batch(child_b),
-                Err(Error::StaleBatch { .. })
+                db.validate_batch(&child_b),
+                Err(Error::StaleBatch)
             ));
+            db.destroy().await.unwrap();
         });
     }
 
@@ -1402,10 +1426,7 @@ mod tests {
                 .await;
 
             let (db, _) = db.apply_batch(child).unwrap();
-            assert!(matches!(
-                db.apply_batch(parent),
-                Err(Error::StaleBatch { .. })
-            ));
+            assert!(matches!(db.apply_batch(parent), Err(Error::StaleBatch)));
         });
     }
 
@@ -2389,10 +2410,7 @@ mod tests {
 
             // After rewind, mem.size reflects post-commit-A, but the held batch starts after
             // post-commit-B. Apply must be rejected with StaleBatch.
-            assert!(matches!(
-                db.apply_batch(held),
-                Err(Error::StaleBatch { .. })
-            ));
+            assert!(matches!(db.apply_batch(held), Err(Error::StaleBatch)));
         });
     }
 

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -505,7 +505,7 @@ where
         Ok(self.journal.destroy().await?)
     }
 
-    /// The [`Commitment`](batch_chain::Commitment) committed by the database's current state.
+    /// The [`Commitment`](batch_chain::Commitment) for the database's current state.
     pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
         batch_chain::Commitment::new(self.last_commit_loc + 1, self.root)
     }

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -181,10 +181,8 @@ where
                 .expect("last operation should be a commit with floor");
             (last_commit_loc, inactivity_floor_loc)
         };
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(*last_commit_loc + 1)),
-            inactivity_floor_loc,
-        );
+        let inactive_peaks =
+            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let db = Self {
@@ -458,7 +456,7 @@ where
         self.journal = self.journal.rewind(rewind_size).await?;
         self.last_commit_loc = rewind_last_loc;
         self.inactivity_floor_loc = rewind_floor;
-        let inactive_peaks = F::inactive_peaks(F::location_to_position(size), rewind_floor);
+        let inactive_peaks = F::inactive_peaks(size, rewind_floor);
         self.root = self.journal.root(inactive_peaks)?;
         self.update_metrics();
         Ok(self)
@@ -508,26 +506,22 @@ where
         Ok(self.journal.destroy().await?)
     }
 
+    /// The [`CommitId`](batch_chain::CommitId) committed by the database's current state.
+    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
+        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root)
+    }
+
     /// Create a new speculative batch of operations with this database as its parent.
     pub fn new_batch(&self) -> batch::UnmerkleizedBatch<F, H, V, S> {
-        let journal_size = *self.last_commit_loc + 1;
-        batch::UnmerkleizedBatch::new(self, journal_size)
+        batch::UnmerkleizedBatch::new(self, self.commit_id())
     }
 
     /// Create an initial [`batch::MerkleizedBatch`] from the committed DB state.
     pub fn to_batch(&self) -> Arc<batch::MerkleizedBatch<F, H::Digest, V, S>> {
-        let journal_size = *self.last_commit_loc + 1;
         Arc::new(batch::MerkleizedBatch {
             journal_batch: self.journal.to_merkleized_batch(),
-            root: self.root,
             parent: None,
-            bounds: batch_chain::Bounds {
-                base_size: journal_size,
-                db_size: journal_size,
-                total_size: journal_size,
-                ancestors: Vec::new(),
-                inactivity_floor: self.inactivity_floor_loc,
-            },
+            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
         })
     }
 
@@ -542,7 +536,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(*self.last_commit_loc + 1, self.inactivity_floor_loc)
+            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
     }
 
     /// Apply a [`batch::MerkleizedBatch`] to the database.
@@ -583,10 +577,10 @@ where
 
         self.journal = self.journal.apply_batch(&batch.journal_batch).await?;
 
-        self.last_commit_loc = Location::new(batch.bounds.total_size - 1);
+        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        self.root = batch.root;
-        let end_loc = Location::new(batch.bounds.total_size);
+        self.root = batch.root();
+        let end_loc = batch.bounds.tip_commit.size;
         debug!(size = ?end_loc, "applied batch");
         let range = start_loc..end_loc;
         self.update_metrics();
@@ -1309,7 +1303,7 @@ pub(crate) mod tests {
         let last_commit_loc = db.last_commit_loc();
 
         let result = db.apply_batch(batch_b).await;
-        assert!(matches!(result, Err(Error::StaleBatch { .. })));
+        assert!(matches!(result, Err(Error::StaleBatch)));
 
         // The rejection mutated nothing: reopening recovers the committed state.
         let db = reopen(context.child("reopen")).await;
@@ -1999,27 +1993,49 @@ pub(crate) mod tests {
         C: Mutable<Item = Operation<F, V>>,
         Operation<F, V>: EncodeShared,
     {
-        let parent = db
+        let common_parent = db
+            .new_batch()
+            .append(V::Value::make(10))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let sibling_a = common_parent
+            .new_batch::<Sha256>()
+            .append(V::Value::make(11))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let sibling_b = common_parent
+            .new_batch::<Sha256>()
+            .append(V::Value::make(12))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (db, _) = db.apply_batch(sibling_a).await.unwrap();
+        assert!(matches!(
+            db.validate_batch(&sibling_b),
+            Err(Error::StaleBatch)
+        ));
+
+        let parent_a = db
             .new_batch()
             .append(V::Value::make(1))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        let child_a = parent
-            .new_batch::<Sha256>()
+        let parent_b = db
+            .new_batch()
             .append(V::Value::make(2))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        let child_b = parent
+        let child_b = parent_b
             .new_batch::<Sha256>()
             .append(V::Value::make(3))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
 
-        let (db, _) = db.apply_batch(child_a).await.unwrap();
+        let (db, _) = db.apply_batch(parent_a).await.unwrap();
         assert!(matches!(
-            db.apply_batch(child_b).await,
-            Err(Error::StaleBatch { .. })
+            db.validate_batch(&child_b),
+            Err(Error::StaleBatch)
         ));
+        db.destroy().await.unwrap();
     }
 
     #[boxed]
@@ -2074,7 +2090,7 @@ pub(crate) mod tests {
         let (db, _) = db.apply_batch(child).await.unwrap();
         assert!(matches!(
             db.apply_batch(parent).await,
-            Err(Error::StaleBatch { .. })
+            Err(Error::StaleBatch)
         ));
     }
 

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -576,10 +576,10 @@ where
 
         self.journal = self.journal.apply_batch(&batch.journal_batch).await?;
 
-        self.last_commit_loc = batch.bounds.tip_commit.size - 1;
+        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         self.root = batch.root();
-        let end_loc = batch.bounds.tip_commit.size;
+        let end_loc = batch.bounds.tip.size;
         debug!(size = ?end_loc, "applied batch");
         let range = start_loc..end_loc;
         self.update_metrics();

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -181,8 +181,7 @@ where
                 .expect("last operation should be a commit with floor");
             (last_commit_loc, inactivity_floor_loc)
         };
-        let inactive_peaks =
-            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
+        let inactive_peaks = F::inactive_peaks(last_commit_loc + 1, inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let db = Self {
@@ -1001,7 +1000,7 @@ pub(crate) mod tests {
 
         // Pruning beyond the current floor fails.
         let new_floor = db.inactivity_floor_loc();
-        let beyond = Location::new(*new_floor + 1);
+        let beyond = new_floor + 1;
         let result = db.prune(beyond).await;
         assert!(
             matches!(result, Err(Error::PruneBeyondMinRequired(prune_loc, floor))
@@ -1400,7 +1399,7 @@ pub(crate) mod tests {
             for i in 0..ELEMENTS {
                 batch = batch.append(V::Value::make(i));
             }
-            let new_commit = Location::new(*db.last_commit_loc() + 1 + ELEMENTS);
+            let new_commit = db.last_commit_loc() + 1 + ELEMENTS;
             let merkleized = batch.merkleize(&db, None, new_commit).await;
             (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
@@ -1557,7 +1556,7 @@ pub(crate) mod tests {
             for i in 0u64..ELEMENTS {
                 batch = batch.append(V::Value::make(i));
             }
-            let new_commit = Location::new(*db.last_commit_loc() + 1 + ELEMENTS);
+            let new_commit = db.last_commit_loc() + 1 + ELEMENTS;
             let merkleized = batch.merkleize(&db, None, new_commit).await;
             (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
@@ -1567,7 +1566,7 @@ pub(crate) mod tests {
             for i in ELEMENTS..ELEMENTS * 2 {
                 batch = batch.append(V::Value::make(i));
             }
-            let new_commit = Location::new(*db.last_commit_loc() + 1 + ELEMENTS);
+            let new_commit = db.last_commit_loc() + 1 + ELEMENTS;
             let merkleized = batch.merkleize(&db, None, new_commit).await;
             (db, _) = db.apply_batch(merkleized).await.unwrap();
         }
@@ -1687,10 +1686,7 @@ pub(crate) mod tests {
         let new_loc = batch.size();
         let batch = batch.append(new_val.clone());
         assert_eq!(batch.get(new_loc, &db).await.unwrap(), Some(new_val));
-        assert_eq!(
-            batch.get(Location::new(*new_loc + 1), &db).await.unwrap(),
-            None
-        );
+        assert_eq!(batch.get(new_loc + 1, &db).await.unwrap(), None);
 
         db.destroy().await.unwrap();
     }
@@ -2498,7 +2494,7 @@ pub(crate) mod tests {
             .await;
         let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let db = db.commit().await.unwrap();
-        let rewind_target = Location::new(*db.last_commit_loc() + 1);
+        let rewind_target = db.last_commit_loc() + 1;
 
         // Second commit: floor advances to 6.
         let floor_b = Location::<F>::new(6);
@@ -2520,7 +2516,7 @@ pub(crate) mod tests {
         let db = db.prune(floor_a).await.unwrap();
 
         // Pruning past the floor fails.
-        let beyond = Location::new(*floor_a + 1);
+        let beyond = floor_a + 1;
         let Err(err) = db.prune(beyond).await else {
             panic!("expected prune to fail");
         };
@@ -2622,7 +2618,7 @@ pub(crate) mod tests {
             .await;
         let (db, _) = db.apply_batch(merkleized).await.unwrap();
         let db = db.commit().await.unwrap();
-        let rewind_target = Location::new(*db.last_commit_loc() + 1);
+        let rewind_target = db.last_commit_loc() + 1;
 
         // Second commit: 2 appends + commit, floor advances to 6.
         let floor_b = Location::<F>::new(6);
@@ -2793,7 +2789,7 @@ pub(crate) mod tests {
             bounds.start <= commit_loc,
             "prune must not advance bounds.start past the floor"
         );
-        assert_eq!(bounds.end, Location::new(*commit_loc + 1));
+        assert_eq!(bounds.end, commit_loc + 1);
 
         // The commit op remains readable; its metadata is intact.
         assert_eq!(db.get(commit_loc).await.unwrap(), Some(metadata.clone()));
@@ -2806,7 +2802,7 @@ pub(crate) mod tests {
         // Persist the prune, then verify pruning one past the floor is rejected — the
         // floor is the hard ceiling.
         let db = db.sync().await.unwrap();
-        let Err(err) = db.prune(Location::new(*commit_loc + 1)).await else {
+        let Err(err) = db.prune(commit_loc + 1).await else {
             panic!("expected prune to fail");
         };
         assert!(matches!(err, Error::PruneBeyondMinRequired(p, f)
@@ -2815,7 +2811,7 @@ pub(crate) mod tests {
         // Reopen: `init_from_journal` must recover the floor from the last commit op.
         let db = reopen(context.child("reopened")).await;
         let reopened_bounds = db.bounds();
-        assert_eq!(reopened_bounds.end, Location::new(*commit_loc + 1));
+        assert_eq!(reopened_bounds.end, commit_loc + 1);
         assert_eq!(db.last_commit_loc(), commit_loc);
         assert_eq!(db.inactivity_floor_loc(), commit_loc);
         assert_eq!(db.root(), root_after_commit);

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -506,14 +506,14 @@ where
         Ok(self.journal.destroy().await?)
     }
 
-    /// The [`CommitId`](batch_chain::CommitId) committed by the database's current state.
-    pub(crate) fn commit_id(&self) -> batch_chain::CommitId<F, H::Digest> {
-        batch_chain::CommitId::new(self.last_commit_loc + 1, self.root)
+    /// The [`Commitment`](batch_chain::Commitment) committed by the database's current state.
+    pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
+        batch_chain::Commitment::new(self.last_commit_loc + 1, self.root)
     }
 
     /// Create a new speculative batch of operations with this database as its parent.
     pub fn new_batch(&self) -> batch::UnmerkleizedBatch<F, H, V, S> {
-        batch::UnmerkleizedBatch::new(self, self.commit_id())
+        batch::UnmerkleizedBatch::new(self, self.commitment())
     }
 
     /// Create an initial [`batch::MerkleizedBatch`] from the committed DB state.
@@ -521,7 +521,7 @@ where
         Arc::new(batch::MerkleizedBatch {
             journal_batch: self.journal.to_merkleized_batch(),
             parent: None,
-            bounds: batch_chain::Bounds::from_db(self.commit_id(), self.inactivity_floor_loc),
+            bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
         })
     }
 
@@ -536,7 +536,7 @@ where
     ) -> Result<(), Error<F>> {
         batch
             .bounds
-            .validate_apply_to(self.commit_id(), self.inactivity_floor_loc)
+            .validate_apply_to(self.commitment(), self.inactivity_floor_loc)
     }
 
     /// Apply a [`batch::MerkleizedBatch`] to the database.

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -95,8 +95,7 @@ where
                 qmdb::find_inactivity_floor_at::<F, _>(&journal, Location::new(bounds.end)).await?;
             (Location::new(loc), floor)
         };
-        let inactive_peaks =
-            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
+        let inactive_peaks = F::inactive_peaks(last_commit_loc + 1, inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);

--- a/storage/src/qmdb/keyless/sync/mod.rs
+++ b/storage/src/qmdb/keyless/sync/mod.rs
@@ -95,10 +95,8 @@ where
                 qmdb::find_inactivity_floor_at::<F, _>(&journal, Location::new(bounds.end)).await?;
             (Location::new(loc), floor)
         };
-        let inactive_peaks = F::inactive_peaks(
-            F::location_to_position(Location::new(*last_commit_loc + 1)),
-            inactivity_floor_loc,
-        );
+        let inactive_peaks =
+            F::inactive_peaks(Location::new(*last_commit_loc + 1), inactivity_floor_loc);
         let root = journal.root(inactive_peaks)?;
 
         let metrics = Metrics::new(context);

--- a/storage/src/qmdb/keyless/sync/tests.rs
+++ b/storage/src/qmdb/keyless/sync/tests.rs
@@ -1255,7 +1255,7 @@ where
         fetch_batch_size: NZU64!(1),
         target: sync::Target {
             root: target.root,
-            range: non_empty_range!(Location::new(*target.size - 1), target.size),
+            range: non_empty_range!(target.size - 1, target.size),
         },
         source,
         apply_batch_size: NZU64!(1024),
@@ -1599,7 +1599,7 @@ mod compact_variable_mmr {
             let sync::Response::Boundary { proof, .. } = &mut bad_state else {
                 unreachable!("boundary fetch returns a boundary response");
             };
-            proof.leaves = Location::new(*proof.leaves - 1);
+            proof.leaves -= 1;
 
             let client: ClientDb = sync::sync(compact_engine_config(
                 context.child("client"),
@@ -1989,7 +1989,7 @@ mod compact_variable_mmr {
             let (source, _) = source.apply_batch(batch).await.unwrap();
             let source = source.commit().await.unwrap();
             let size = source.bounds().end;
-            let last_commit_loc = Location::new(*size - 1);
+            let last_commit_loc = size - 1;
             let canonical_target = sync::CompactTarget {
                 root: source.root(),
                 size,
@@ -2113,7 +2113,7 @@ mod compact_variable_mmr {
                 client_cfg.strategy.clone(),
                 journal,
                 client_cfg.commit_codec_config,
-                Location::new(*target_b.size - 1),
+                target_b.size - 1,
                 pinned_nodes,
                 op,
             )
@@ -2144,7 +2144,7 @@ mod compact_variable_mmr {
                 client_cfg.strategy.clone(),
                 journal,
                 client_cfg.commit_codec_config,
-                Location::new(*target_b.size - 1),
+                target_b.size - 1,
                 pinned_nodes,
                 op,
             )
@@ -2490,7 +2490,7 @@ mod compact_variable_mmb {
             let sync::Response::Boundary { proof, .. } = &mut bad_state else {
                 unreachable!("boundary fetch returns a boundary response");
             };
-            proof.leaves = Location::new(*proof.leaves - 1);
+            proof.leaves -= 1;
 
             let client: ClientDb = sync::sync(compact_engine_config(
                 context.child("client"),

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -262,7 +262,7 @@ mod test {
                             batch_idx * 10 + j,
                         ));
                 }
-                let new_commit_loc = Location::new(*db.last_commit_loc() + 1 + 3);
+                let new_commit_loc = db.last_commit_loc() + 1 + 3;
                 let merkleized = batch.merkleize(&db, None, new_commit_loc).await;
                 (db, _) = db.apply_batch(merkleized).await.unwrap();
             }

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -179,7 +179,7 @@ where
     }
 
     let floor = find_inactivity_floor_at::<F, _>(reader, op_count).await?;
-    Ok(F::inactive_peaks(F::location_to_position(op_count), floor))
+    Ok(F::inactive_peaks(op_count, floor))
 }
 
 /// Errors that can occur when interacting with an authenticated database.
@@ -223,14 +223,8 @@ pub enum Error<F: Family> {
     /// The batch was created from a different database state than the current one.
     ///
     /// See [`batch_chain`] for more details on staleness detection.
-    #[error(
-        "stale batch: db has {db_size} ops, batch requires {batch_db_size}, {batch_base_size}, or an ancestor boundary"
-    )]
-    StaleBatch {
-        db_size: u64,
-        batch_db_size: u64,
-        batch_base_size: u64,
-    },
+    #[error("stale batch: current database state does not match the batch")]
+    StaleBatch,
 
     /// The batch's inactivity floor is lower than the database's current floor.
     #[error("floor regressed: batch floor {0} < current floor {1}")]

--- a/storage/src/qmdb/sync/database.rs
+++ b/storage/src/qmdb/sync/database.rs
@@ -124,10 +124,7 @@ where
         return Ok(None);
     }
 
-    let inactive_peaks = F::inactive_peaks(
-        F::location_to_position(target.range.end()),
-        inactivity_floor,
-    );
+    let inactive_peaks = F::inactive_peaks(target.range.end(), inactivity_floor);
     if merkle.root(&hasher, inactive_peaks)? != target.root {
         return Ok(None);
     }

--- a/storage/src/qmdb/sync/source.rs
+++ b/storage/src/qmdb/sync/source.rs
@@ -652,7 +652,7 @@ pub(crate) mod tests {
         source
             .serve(Request::Boundary {
                 size: target.size,
-                start: Location::new(*target.size - 1),
+                start: target.size - 1,
             })
             .await
     }

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -355,7 +355,7 @@ mod tests {
         // A size outside the location domain is rejected.
         let beyond = CompactTarget::<MmrFamily, _> {
             root,
-            size: Location::new(*MmrFamily::MAX_LEAVES + 1),
+            size: MmrFamily::MAX_LEAVES + 1,
         };
         assert!(matches!(
             Target::try_from(&beyond),


### PR DESCRIPTION
## Motivation

QMDB batch applicability identifies lineage boundaries by operation count alone. That cannot distinguish equal-size sibling states: after applying sibling parent A, a descendant built on sibling parent B can be accepted because the database size matches the descendant's recorded base size, even though the roots differ — silently grafting the batch onto a state it was never built against.

## Changes

The fix is a representation change: make a QMDB state's identity a single authenticated value, then require exact identity — not merely a matching size — to apply a batch. The remaining changes are consequences of that, not independent scope.

**The fix**

- introduce `Commitment<F, D>` — identifies a QMDB state by its operation `size` (a typed `Location`, consistent with sync's `CompactTarget`) and authenticated `root`. Size and root become one inseparable value that cannot describe two different states.
- a batch's `Bounds` records its boundaries as commitments — `base_commit`, `db_commit`, and `tip_commit` (the tip replacing the former bare `total_size`; each merkleized batch's root now lives in `tip_commit.root` rather than a separate field)
- require the live database to match an exact recorded `Commitment` (size **and** root) before applying a batch — the equal-size sibling case that size-only applicability silently accepted is now rejected

**Follows from the new representation**

- applicability collapses to `current == db_commit || ancestors.any(...)`: with every boundary carried as a commitment, lineage checks are direct comparisons, so the prior size-indexed `state_at`/`db_size` lookups are dead and removed
- the compact variants now cache their committed root (read for free from the authenticated witness, matching what `any`/full already do) instead of re-folding peaks — needing a root at each batch boundary would otherwise add hashing to compact's batch-create/validate path
- state that can be derived is no longer stored: an unmerkleized batch derives its DB boundary from its parent instead of keeping a separate field that could drift from it
- related cleanup: `Family::inactive_peaks` takes a leaf `Location` instead of a node `Position`, moving the one `location_to_position` conversion into the merkle layer and dropping it at its ~16 call sites now that sizes are `Location`-typed (`Family::peaks` stays `Position`, its natural tree coordinate)

**Tests**

- add cross-variant regressions for descendants of equal-size sibling parents, retaining conventional sibling-fork coverage

This does not change wire formats, persisted storage, recovery, durability, or fsync behavior.

## Tradeoffs

- each snapshotted ancestor carries an additional digest (its root); ancestor snapshots already grow with pipeline depth, so this increases that constant
- ALPHA `Bounds`/`Commitment` API change (size-only fields → `(size, root)` commitments); because `qmdb::batch_chain` is public, it ripples into downstream consumers (`commonware-glue`, examples) as mechanical updates

## Validation

- `just test -p commonware-storage`
- `just clippy -p commonware-storage`
- `just check-stability`
- `just check-docs`
- `just check-fmt`
- `git diff --check`
