### PR TITLE
[storage/qmdb] Single-source the current grafted-root rebuild

### DIFF
--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -677,30 +677,15 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any = self.any.rewind(size).await?;
 
-        let ops_size = self.any.log.merkle.size();
-        let ops_leaves = Location::<F>::try_from(ops_size)?;
-        let grafted_tree = build_grafted_tree::<F, H, S, N>(
+        let ops_leaves = Location::<F>::try_from(self.any.log.merkle.size())?;
+        let (grafted_tree, root) = rebuild_grafted_root::<F, H, S, N>(
             self.any.bitmap.as_ref(),
             &pinned_nodes,
             &self.any.log.merkle,
             ops_leaves,
-            &self.strategy,
-        )
-        .await?;
-        let storage = grafting::Storage::<F, H, _, _>::new(
-            &grafted_tree,
-            grafting::height::<N>(),
-            &self.any.log.merkle,
-        );
-        let partial_chunk = partial_chunk(self.any.bitmap.as_ref());
-        let ops_root = self.any.root();
-        let root = compute_db_root::<F, H, _, _, N>(
-            self.any.bitmap.as_ref(),
-            &storage,
-            ops_leaves,
-            partial_chunk,
             self.any.inactivity_floor_loc,
-            &ops_root,
+            self.any.root(),
+            &self.strategy,
         )
         .await?;
 
@@ -1054,6 +1039,44 @@ pub(super) async fn compute_db_root<
         pending.as_ref(),
         partial.as_ref().map(|(nb, d)| (*nb, d)),
     ))
+}
+
+/// Rebuild the grafted overlay tree and compute the canonical db root from the ops tree and
+/// bitmap.
+///
+/// Database open and `rewind` must reconstruct identical overlay state for the same committed ops
+/// log, so both go through this single path. `ops_leaves` must be a consistent snapshot of the ops
+/// tree size taken with the bitmap state. Returns the rebuilt grafted tree and the db root.
+pub(super) async fn rebuild_grafted_root<F, H, S, const N: usize>(
+    bitmap: &impl bitmap::Readable<N>,
+    pinned_nodes: &[H::Digest],
+    ops_tree: &impl MerkleStorage<F, Digest = H::Digest>,
+    ops_leaves: Location<F>,
+    inactivity_floor: Location<F>,
+    ops_root: H::Digest,
+    strategy: &S,
+) -> Result<(Mem<F, H::Digest>, H::Digest), Error<F>>
+where
+    F: merkle::Graftable,
+    H: Hasher,
+    S: Strategy,
+{
+    let grafted_tree =
+        build_grafted_tree::<F, H, S, N>(bitmap, pinned_nodes, ops_tree, ops_leaves, strategy)
+            .await?;
+    let storage =
+        grafting::Storage::<F, H, _, _>::new(&grafted_tree, grafting::height::<N>(), ops_tree);
+    let partial_chunk = partial_chunk(bitmap);
+    let root = compute_db_root::<F, H, _, _, N>(
+        bitmap,
+        &storage,
+        ops_leaves,
+        partial_chunk,
+        inactivity_floor,
+        &ops_root,
+    )
+    .await?;
+    Ok((grafted_tree, root))
 }
 
 /// Compute the root of the grafted structure represented by `storage`.

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -677,7 +677,7 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any = self.any.rewind(size).await?;
 
-        let (grafted_tree, root) = rebuild_grafted_root::<F, H, S, N>(
+        let (grafted_tree, root) = rebuild_grafted_tree::<F, H, S, N>(
             self.any.bitmap.as_ref(),
             &pinned_nodes,
             &self.any.log.merkle,
@@ -1040,12 +1040,8 @@ pub(super) async fn compute_db_root<
 }
 
 /// Rebuild the grafted overlay tree and compute the canonical db root from the ops tree and
-/// bitmap.
-///
-/// Database open, `rewind`, and sync-init must reconstruct identical overlay state for the same
-/// committed ops log, so all go through this single path. `ops_leaves` is taken from `ops_tree` so
-/// it always matches the tree being grafted. Returns the rebuilt grafted tree and the db root.
-pub(super) async fn rebuild_grafted_root<F, H, S, const N: usize>(
+/// bitmap. Returns the rebuilt grafted tree and the db root.
+pub(super) async fn rebuild_grafted_tree<F, H, S, const N: usize>(
     bitmap: &impl bitmap::Readable<N>,
     pinned_nodes: &[H::Digest],
     ops_tree: &impl MerkleStorage<F, Digest = H::Digest>,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -677,6 +677,7 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any = self.any.rewind(size).await?;
 
+        // Rebuild the grafted tree and canonical root from the rewound `any` state.
         let (grafted_tree, root) = rebuild_grafted_tree::<F, H, S, N>(
             self.any.bitmap.as_ref(),
             &pinned_nodes,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -677,12 +677,10 @@ where
         // the caller; reads through them now return inconsistent data.
         self.any = self.any.rewind(size).await?;
 
-        let ops_leaves = Location::<F>::try_from(self.any.log.merkle.size())?;
         let (grafted_tree, root) = rebuild_grafted_root::<F, H, S, N>(
             self.any.bitmap.as_ref(),
             &pinned_nodes,
             &self.any.log.merkle,
-            ops_leaves,
             self.any.inactivity_floor_loc,
             self.any.root(),
             &self.strategy,
@@ -1044,14 +1042,13 @@ pub(super) async fn compute_db_root<
 /// Rebuild the grafted overlay tree and compute the canonical db root from the ops tree and
 /// bitmap.
 ///
-/// Database open and `rewind` must reconstruct identical overlay state for the same committed ops
-/// log, so both go through this single path. `ops_leaves` must be a consistent snapshot of the ops
-/// tree size taken with the bitmap state. Returns the rebuilt grafted tree and the db root.
+/// Database open, `rewind`, and sync-init must reconstruct identical overlay state for the same
+/// committed ops log, so all go through this single path. `ops_leaves` is taken from `ops_tree` so
+/// it always matches the tree being grafted. Returns the rebuilt grafted tree and the db root.
 pub(super) async fn rebuild_grafted_root<F, H, S, const N: usize>(
     bitmap: &impl bitmap::Readable<N>,
     pinned_nodes: &[H::Digest],
     ops_tree: &impl MerkleStorage<F, Digest = H::Digest>,
-    ops_leaves: Location<F>,
     inactivity_floor: Location<F>,
     ops_root: H::Digest,
     strategy: &S,
@@ -1061,6 +1058,7 @@ where
     H: Hasher,
     S: Strategy,
 {
+    let ops_leaves = Location::<F>::try_from(ops_tree.size())?;
     let grafted_tree =
         build_grafted_tree::<F, H, S, N>(bitmap, pinned_nodes, ops_tree, ops_leaves, strategy)
             .await?;

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -448,15 +448,16 @@ where
     let (metadata, pruned_chunks, pinned_nodes) =
         db::init_metadata(context.child("metadata"), &metadata_partition).await?;
 
-    // Pre-build the activity-status bitmap with the known pruned-chunk count from grafted
-    // metadata, then hand it to `any` which becomes the sole owner. `any::init_with_bitmap`
-    // populates it during snapshot rebuild.
+    // Pre-build the activity-status bitmap with the known pruned-chunk count from grafted metadata.
     let bitmap = BitMap::<N>::new_with_pruned_chunks(pruned_chunks)
         .map_err(|_| crate::qmdb::Error::<F>::DataCorrupted("pruned chunks overflow"))?;
     let bitmap = Arc::new(Shared::<N>::new(bitmap));
 
+    // Initialize the underlying `any` database. It takes sole ownership of the bitmap and
+    // populates it during snapshot rebuild.
     let any = any::init_with_bitmap(context.child("any"), config.into(), Some(bitmap)).await?;
 
+    // Rebuild the grafted tree and canonical root from the initialized `any` state.
     let (grafted_tree, root) = db::rebuild_grafted_tree::<F, H, S, N>(
         any.bitmap.as_ref(),
         &pinned_nodes,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -457,13 +457,11 @@ where
 
     let any = any::init_with_bitmap(context.child("any"), config.into(), Some(bitmap)).await?;
 
-    // Rebuild the grafted overlay tree and compute the db root (shared with rewind).
-    let ops_leaves = crate::merkle::Location::<F>::try_from(any.log.merkle.size())?;
+    // Rebuild the grafted overlay tree and compute the db root (shared with rewind and sync-init).
     let (grafted_tree, root) = db::rebuild_grafted_root::<F, H, S, N>(
         any.bitmap.as_ref(),
         &pinned_nodes,
         &any.log.merkle,
-        ops_leaves,
         any.inactivity_floor_loc,
         any.root(),
         &strategy,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -457,8 +457,7 @@ where
 
     let any = any::init_with_bitmap(context.child("any"), config.into(), Some(bitmap)).await?;
 
-    // Rebuild the grafted overlay tree and compute the db root (shared with rewind and sync-init).
-    let (grafted_tree, root) = db::rebuild_grafted_root::<F, H, S, N>(
+    let (grafted_tree, root) = db::rebuild_grafted_tree::<F, H, S, N>(
         any.bitmap.as_ref(),
         &pinned_nodes,
         &any.log.merkle,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -457,33 +457,16 @@ where
 
     let any = any::init_with_bitmap(context.child("any"), config.into(), Some(bitmap)).await?;
 
-    // Build the grafted tree from the bitmap and ops tree.
-    let ops_size = any.log.merkle.size();
-    let ops_leaves = crate::merkle::Location::<F>::try_from(ops_size)?;
-    let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
+    // Rebuild the grafted overlay tree and compute the db root (shared with rewind).
+    let ops_leaves = crate::merkle::Location::<F>::try_from(any.log.merkle.size())?;
+    let (grafted_tree, root) = db::rebuild_grafted_root::<F, H, S, N>(
         any.bitmap.as_ref(),
         &pinned_nodes,
         &any.log.merkle,
         ops_leaves,
-        &strategy,
-    )
-    .await?;
-
-    // Compute and cache the root.
-    let storage = grafting::Storage::<F, H, _, _>::new(
-        &grafted_tree,
-        grafting::height::<N>(),
-        &any.log.merkle,
-    );
-    let partial_chunk = db::partial_chunk(any.bitmap.as_ref());
-    let ops_root = any.root();
-    let root = db::compute_db_root::<F, H, _, _, N>(
-        any.bitmap.as_ref(),
-        &storage,
-        ops_leaves,
-        partial_chunk,
         any.inactivity_floor_loc,
-        &ops_root,
+        any.root(),
+        &strategy,
     )
     .await?;
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -191,10 +191,8 @@ where
         pins
     };
 
-    // Rebuild the grafted overlay tree and compute the canonical root (shared with open and
-    // rewind). The root is deterministic from the ops (authenticated by the engine) and the
-    // bitmap (deterministic from the ops).
-    let (grafted_tree, root) = db::rebuild_grafted_root::<F, H, S, N>(
+    // Get the grafted tree and its root.
+    let (grafted_tree, root) = db::rebuild_grafted_tree::<F, H, S, N>(
         any.bitmap.as_ref(),
         &grafted_pinned_nodes,
         &any.log.merkle,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -191,7 +191,9 @@ where
         pins
     };
 
-    // Get the grafted tree and its root.
+    // Rebuild the grafted tree and canonical root from the synced `any` state.
+    // The canonical root is deterministic because the engine authenticates the ops and the
+    // bitmap is derived from them.
     let (grafted_tree, root) = db::rebuild_grafted_tree::<F, H, S, N>(
         any.bitmap.as_ref(),
         &grafted_pinned_nodes,

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -191,35 +191,18 @@ where
         pins
     };
 
-    // Build grafted tree.
-    let ops_size = any.log.merkle.size();
-    let ops_leaves = Location::<F>::try_from(ops_size)?;
-    let grafted_tree = db::build_grafted_tree::<F, H, S, N>(
+    // Rebuild the grafted overlay tree and compute the canonical root (shared with open and
+    // rewind). The root is deterministic from the ops (authenticated by the engine) and the
+    // bitmap (deterministic from the ops).
+    let ops_leaves = Location::<F>::try_from(any.log.merkle.size())?;
+    let (grafted_tree, root) = db::rebuild_grafted_root::<F, H, S, N>(
         any.bitmap.as_ref(),
         &grafted_pinned_nodes,
         &any.log.merkle,
         ops_leaves,
-        &strategy,
-    )
-    .await?;
-
-    // Compute the canonical root. The grafted root is deterministic from the ops
-    // (which are authenticated by the engine) and the bitmap (which is deterministic
-    // from the ops).
-    let storage = grafting::Storage::<F, H, _, _>::new(
-        &grafted_tree,
-        grafting::height::<N>(),
-        &any.log.merkle,
-    );
-    let partial = db::partial_chunk(any.bitmap.as_ref());
-    let ops_root = any.root();
-    let root = db::compute_db_root::<F, H, _, _, N>(
-        any.bitmap.as_ref(),
-        &storage,
-        ops_leaves,
-        partial,
         any.inactivity_floor_loc,
-        &ops_root,
+        any.root(),
+        &strategy,
     )
     .await?;
 

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -194,12 +194,10 @@ where
     // Rebuild the grafted overlay tree and compute the canonical root (shared with open and
     // rewind). The root is deterministic from the ops (authenticated by the engine) and the
     // bitmap (deterministic from the ops).
-    let ops_leaves = Location::<F>::try_from(any.log.merkle.size())?;
     let (grafted_tree, root) = db::rebuild_grafted_root::<F, H, S, N>(
         any.bitmap.as_ref(),
         &grafted_pinned_nodes,
         &any.log.merkle,
-        ops_leaves,
         any.inactivity_floor_loc,
         any.root(),
         &strategy,


### PR DESCRIPTION
`init`, `Db::rewind`, and sync-init (`current/sync/mod.rs`) each independently reconstructed the grafted overlay tree and recomputed the database root via the same `build_grafted_tree → grafting::Storage → partial_chunk → compute_db_root` sequence. Because a fresh open, a post-rewind state, and a synced state must all produce the identical root for the same committed ops log, those copies had to stay in lockstep — a change to one could silently make them disagree.

This extracts a single `rebuild_grafted_root` helper that all three paths call, so the overlay/root reconstruction lives in one place and cannot drift. The helper derives `ops_leaves` from the ops tree itself (`ops_tree.size()`), so no caller can pass a value out of sync with the tree being grafted.

No behavior change — a verbatim consolidation of the shared sequence.

Verification: `cargo check -p commonware-storage` and all 406 `qmdb::current` tests pass; `cargo +nightly fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
