### PR TITLE
[storage/qmdb] Track Exact Sync Request Ranges

### DIFF
--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -352,8 +352,7 @@ where
             let Some(gap_range) = crate::qmdb::sync::gaps::find_next(
                 Location::new(log_size)..self.target.range.end(),
                 &operation_counts,
-                self.outstanding_requests.locations(),
-                self.fetch_batch_size,
+                self.outstanding_requests.ranges(),
             ) else {
                 break; // No more gaps to fill
             };
@@ -997,6 +996,22 @@ mod tests {
                 .unwrap();
 
             assert_eq!(pinned_node_probes.load(Ordering::SeqCst), 0);
+        });
+    }
+
+    #[test]
+    fn new_schedules_operations_after_boundary_request() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut config = test_engine_config(context, 5, Arc::new(AtomicUsize::new(0)));
+            config.max_outstanding_requests = 2;
+            config.fetch_batch_size = NZU64!(5);
+
+            let engine = Engine::new(config).await.unwrap();
+            let requests = &engine.outstanding_requests;
+
+            assert_eq!(requests.len(), 2);
+            assert!(requests.contains(&Location::new(5)));
+            assert!(requests.contains(&Location::new(6)));
         });
     }
 

--- a/storage/src/qmdb/sync/gaps.rs
+++ b/storage/src/qmdb/sync/gaps.rs
@@ -1,33 +1,30 @@
 //! Gap detection algorithm for sync operations.
 
 use crate::merkle::{Family, Location};
-use core::{num::NonZeroU64, ops::Range};
+use core::ops::Range;
 use std::collections::BTreeMap;
 
 /// Find the next gap in operations that needs to be fetched.
 /// Returns a Range of operations to fetch, or None if no gaps.
 ///
-/// We assume that all outstanding requests will return `fetch_batch_size` operations,
-/// but the source may return fewer. In that case, we'll fetch the remaining operations
-/// in a subsequent request.
+/// Outstanding request ranges describe their maximum responses, but the source may return fewer
+/// operations. In that case, we'll fetch the remaining operations in a subsequent request.
 ///
 /// # Arguments
 ///
 /// * `range` - The sync range
 /// * `fetched_operations` - Map of start_loc -> operation count for fetched batches
-/// * `outstanding_requests` - Start locations of outstanding requests, in ascending order
-/// * `fetch_batch_size` - Expected size of each fetch batch
+/// * `outstanding_ranges` - Maximum ranges of outstanding requests, in ascending order
 ///
 /// # Invariants
 ///
 /// - All start locations in `fetched_operations` are in `range`
-/// - All start locations in `outstanding_requests` are in `range`
+/// - All outstanding request starts are in `range`
 /// - All operation counts in `fetched_operations` are > 0
-pub fn find_next<'a, F: Family>(
+pub fn find_next<F: Family>(
     range: Range<Location<F>>,
     fetched_operations: &BTreeMap<Location<F>, u64>, // start_loc -> operation_count
-    outstanding_requests: impl IntoIterator<Item = &'a Location<F>>,
-    fetch_batch_size: NonZeroU64,
+    outstanding_ranges: impl IntoIterator<Item = Range<Location<F>>>,
 ) -> Option<Range<Location<F>>> {
     if range.is_empty() {
         return None;
@@ -45,26 +42,20 @@ pub fn find_next<'a, F: Family>(
         })
         .peekable();
 
-    let mut outstanding_reqs_iter = outstanding_requests
-        .into_iter()
-        .map(|&start_loc| {
-            let end_loc = start_loc.checked_add(fetch_batch_size.get()).unwrap();
-            start_loc..end_loc
-        })
-        .peekable();
+    let mut outstanding_ranges_iter = outstanding_ranges.into_iter().peekable();
 
     // Merge process both iterators in sorted order
     loop {
-        let covered_range = match (fetched_ops_iter.peek(), outstanding_reqs_iter.peek()) {
+        let covered_range = match (fetched_ops_iter.peek(), outstanding_ranges_iter.peek()) {
             (Some(f_range), Some(o_range)) => {
                 if f_range.start <= o_range.start {
                     fetched_ops_iter.next().unwrap()
                 } else {
-                    outstanding_reqs_iter.next().unwrap()
+                    outstanding_ranges_iter.next().unwrap()
                 }
             }
             (Some(_), None) => fetched_ops_iter.next().unwrap(),
-            (None, Some(_)) => outstanding_reqs_iter.next().unwrap(),
+            (None, Some(_)) => outstanding_ranges_iter.next().unwrap(),
             (None, None) => break,
         };
 
@@ -260,16 +251,16 @@ mod tests {
             .into_iter()
             .map(|(k, v)| (Location::new(k), v))
             .collect();
-        let outstanding_requests: Vec<Location<MmrFamily>> = test_case
+        let request_size = test_case.fetch_batch_size;
+        let outstanding_ranges: Vec<Range<Location<MmrFamily>>> = test_case
             .requested_ops
             .into_iter()
-            .map(Location::new)
+            .map(|start| Location::new(start)..Location::new(start + request_size))
             .collect();
         let result = find_next(
             Location::new(test_case.lower_bound)..Location::new(test_case.upper_bound),
             &fetched_ops,
-            &outstanding_requests,
-            NonZeroU64::new(test_case.fetch_batch_size).unwrap(),
+            outstanding_ranges,
         );
         assert_eq!(
             result,

--- a/storage/src/qmdb/sync/requests.rs
+++ b/storage/src/qmdb/sync/requests.rs
@@ -13,6 +13,7 @@ use futures::future::Aborted;
 use std::{
     collections::{BTreeMap, HashMap},
     future::Future,
+    ops::Range,
 };
 
 /// Unique identifier for a fetch request.
@@ -101,9 +102,18 @@ impl<F: Family, Op: Send, D: Digest, E: Send> Requests<F, Op, D, E> {
         self.by_location = keep;
     }
 
-    /// Iterate over outstanding request locations in ascending order.
-    pub fn locations(&self) -> impl Iterator<Item = &Location<F>> {
-        self.by_location.keys()
+    /// Iterate over the maximum operation ranges covered by outstanding requests, in ascending
+    /// order.
+    pub fn ranges(&self) -> impl Iterator<Item = Range<Location<F>>> + '_ {
+        self.by_location.values().map(|id| {
+            let request = &self
+                .tracked
+                .get(id)
+                .expect("location index must reference a tracked request")
+                .request;
+            let start = request.start();
+            start..start.checked_add(request.max_ops().get()).unwrap()
+        })
     }
 
     /// Check if a location has an outstanding request.

--- a/storage/src/qmdb/sync/target.rs
+++ b/storage/src/qmdb/sync/target.rs
@@ -26,6 +26,10 @@ impl<F: Family, D: Digest> Target<F, D> {
     }
 
     /// Whether this target advances relative to `from`.
+    ///
+    /// Both targets are assumed to describe valid states of the same append-only QMDB. Because
+    /// the root commits to the database size, valid targets at different sizes have distinct
+    /// roots.
     pub fn advances(&self, from: &Self) -> bool {
         self.range.end().is_valid()
             && self.range.end() > from.range.end()
@@ -264,22 +268,23 @@ mod tests {
 
     #[test]
     fn test_advances() {
-        let root = sha256::Digest::from([0; 32]);
-        let current = target(root, 10, 100);
+        let current_root = sha256::Digest::from([0; 32]);
+        let advanced_root = sha256::Digest::from([1; 32]);
+        let current = target(current_root, 10, 100);
 
         // End strictly increases, start does not decrease.
-        assert!(target(root, 10, 101).advances(&current));
-        assert!(target(root, 50, 200).advances(&current));
+        assert!(target(advanced_root, 10, 101).advances(&current));
+        assert!(target(advanced_root, 50, 200).advances(&current));
 
         // Same or smaller end does not advance.
-        assert!(!target(root, 10, 100).advances(&current));
-        assert!(!target(root, 10, 50).advances(&current));
+        assert!(!target(current_root, 10, 100).advances(&current));
+        assert!(!target(current_root, 10, 50).advances(&current));
 
         // A start moving backward does not advance, even with a larger end.
-        assert!(!target(root, 5, 200).advances(&current));
+        assert!(!target(advanced_root, 5, 200).advances(&current));
 
         // An end outside the location domain does not advance.
-        let beyond = target(root, 10, *MmrFamily::MAX_LEAVES + 1);
+        let beyond = target(advanced_root, 10, *MmrFamily::MAX_LEAVES + 1);
         assert!(!beyond.advances(&current));
     }
 


### PR DESCRIPTION
Related: #4360

Track the exact maximum operation range covered by each outstanding sync request instead of assuming every request spans `fetch_batch_size`. Boundary requests cover one operation, so gap detection can schedule the rest of the first batch concurrently while pinned nodes are in flight.

Document the valid-target assumption behind `Target::advances`: targets come from the same append-only QMDB, and roots at different sizes are distinct.

Add a deterministic regression that requires both the boundary request and the adjacent operations request to be scheduled during engine initialization.