### PR TITLE
[resolver] Add Support for `Ambiguous` Outcomes

### DIFF
--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -138,6 +138,7 @@ impl<D: Digest> Consumer for Handler<D> {
     type Key = Key<D>;
     type Value = Bytes;
     type Subscriber = Annotation;
+    type Outcome = bool;
 
     fn deliver(
         &mut self,

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3866,6 +3866,7 @@ mod tests {
         type Key = handler::Key<D>;
         type Value = Bytes;
         type Subscriber = handler::Annotation;
+        type Outcome = bool;
 
         fn deliver(
             &mut self,

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -281,6 +281,7 @@ impl Consumer for Handler {
     type Key = U64;
     type Value = Bytes;
     type Subscriber = ();
+    type Outcome = bool;
 
     fn deliver(
         &mut self,

--- a/glue/src/stateful/db/p2p/handler.rs
+++ b/glue/src/stateful/db/p2p/handler.rs
@@ -101,6 +101,7 @@ impl<F: Family> resolver::Consumer for Handler<F> {
     type Key = Request<F>;
     type Value = Bytes;
     type Subscriber = ();
+    type Outcome = bool;
 
     fn deliver(
         &mut self,

--- a/resolver/src/delivery.rs
+++ b/resolver/src/delivery.rs
@@ -6,7 +6,7 @@
 //! while validation was in progress. This module owns that lifecycle without
 //! making assumptions about how data is fetched.
 
-use crate::{Consumer, Delivery};
+use crate::{Consumer, Delivery, Outcome};
 use commonware_utils::futures::{AbortablePool, Aborter};
 use futures::future::Aborted;
 use std::collections::{HashMap, hash_map::Entry as HashMapEntry};
@@ -20,8 +20,8 @@ pub struct Completion<K, S, Context = ()> {
     /// Key and subscribers that were passed to the consumer.
     pub delivery: Delivery<K, S>,
 
-    /// Whether the consumer accepted the response as valid for the key.
-    pub valid: bool,
+    /// Consumer disposition for the delivered response.
+    pub outcome: Outcome,
 }
 
 // Cached response that can be redelivered after the consumer accepts it.
@@ -212,8 +212,8 @@ where
 
     /// Drop the cached response without removing the tracked key.
     ///
-    /// Use this after a consumer rejects a response and the resolver wants to
-    /// retry the same key with different bytes or metadata.
+    /// Use this when a response is invalid or does not satisfy every delivered
+    /// subscriber and the resolver wants to retry the key.
     pub fn discard_response(&mut self, key: &Con::Key) {
         if let Some(entry) = self.entries.get_mut(key) {
             entry.response = None;
@@ -266,7 +266,7 @@ where
                 completion: Completion {
                     context,
                     delivery: completed,
-                    valid: receiver.await.unwrap_or(false),
+                    outcome: receiver.await.map(Into::into).unwrap_or(Outcome::Invalid),
                 },
             }
         });
@@ -334,6 +334,7 @@ mod tests {
         type Key = MockKey;
         type Value = Bytes;
         type Subscriber = ();
+        type Outcome = bool;
 
         fn deliver(
             &mut self,
@@ -381,7 +382,7 @@ mod tests {
                 .expect("delivery should complete");
             assert_eq!(completed.context, 9);
             assert_eq!(completed.delivery.key, key);
-            assert!(completed.valid);
+            assert_eq!(completed.outcome, Outcome::Complete);
 
             let (delivered_key, delivered_value) = events.recv().await.unwrap();
             assert_eq!(delivered_key, key);
@@ -434,7 +435,7 @@ mod tests {
                 .expect("new delivery should complete");
             assert_eq!(completed.context, 2);
             assert_eq!(completed.delivery.key, key);
-            assert!(completed.valid);
+            assert_eq!(completed.outcome, Outcome::Complete);
         });
     }
 
@@ -454,7 +455,7 @@ mod tests {
                 .next_completion()
                 .await
                 .expect("first delivery should complete");
-            assert!(completed.valid);
+            assert_eq!(completed.outcome, Outcome::Complete);
             tracker.accept_response(&key);
             assert!(tracker.response_accepted(&key));
 
@@ -465,7 +466,7 @@ mod tests {
                 .expect("redelivery should complete");
             assert_eq!(redelivered.context, 3);
             assert_eq!(redelivered.delivery.key, key);
-            assert!(redelivered.valid);
+            assert_eq!(redelivered.outcome, Outcome::Complete);
 
             let first = events.recv().await.unwrap();
             let second = events.recv().await.unwrap();
@@ -489,7 +490,7 @@ mod tests {
                 .next_completion()
                 .await
                 .expect("first delivery should complete");
-            assert!(completed.valid);
+            assert_eq!(completed.outcome, Outcome::Complete);
 
             tracker.redeliver(delivery(key));
         });
@@ -510,7 +511,7 @@ mod tests {
                 .next_completion()
                 .await
                 .expect("rejected delivery should complete");
-            assert!(!rejected.valid);
+            assert_eq!(rejected.outcome, Outcome::Invalid);
 
             tracker.discard_response(&key);
             assert!(!tracker.response_accepted(&key));
@@ -521,7 +522,7 @@ mod tests {
                 .await
                 .expect("accepted delivery should complete");
             assert_eq!(accepted.context, 2);
-            assert!(accepted.valid);
+            assert_eq!(accepted.outcome, Outcome::Complete);
         });
     }
 }

--- a/resolver/src/lib.rs
+++ b/resolver/src/lib.rs
@@ -111,6 +111,31 @@ commonware_macros::stability_scope!(BETA {
         }
     }
 
+    /// Consumer disposition for a delivered response.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum Outcome {
+        /// The response is invalid for the peer-visible key.
+        ///
+        /// Network resolvers may penalize the serving peer before retrying.
+        Invalid,
+
+        /// The response is valid and satisfies every delivered subscriber.
+        Complete,
+
+        /// The peer-visible key admits multiple valid responses, and this response does not
+        /// satisfy every delivered subscriber.
+        ///
+        /// The resolver retries the key without penalizing the serving peer so another response
+        /// can be tried.
+        Ambiguous,
+    }
+
+    impl From<bool> for Outcome {
+        fn from(valid: bool) -> Self {
+            if valid { Self::Complete } else { Self::Invalid }
+        }
+    }
+
     /// Notified when data is available, and must validate it.
     pub trait Consumer: Clone + Send + 'static {
         /// Type used to key data requested from peers.
@@ -122,9 +147,17 @@ commonware_macros::stability_scope!(BETA {
         /// Type used to track subscribers on fetch keys.
         type Subscriber: Clone + Eq + Send + 'static;
 
+        /// Delivery disposition returned after validation.
+        ///
+        /// Consumers that only distinguish valid and invalid data may use
+        /// `bool`, which maps to [`crate::Outcome::Complete`] and
+        /// [`crate::Outcome::Invalid`].
+        type Outcome: Into<crate::Outcome> + Send + 'static;
+
         /// Deliver data to the consumer.
         ///
-        /// Returns a receiver that resolves to `true` if the data is valid for the key.
+        /// Returns a receiver that reports whether the response completes the
+        /// delivery, is invalid, or is valid but leaves subscribers unresolved.
         ///
         /// The returned receiver may be dropped before completion if the application
         /// cancels the fetch via [`Resolver::retain`]. When this happens, the
@@ -140,7 +173,7 @@ commonware_macros::stability_scope!(BETA {
             &mut self,
             delivery: Delivery<Self::Key, Self::Subscriber>,
             value: Self::Value,
-        ) -> oneshot::Receiver<bool>;
+        ) -> oneshot::Receiver<Self::Outcome>;
     }
 
     /// Responsible for fetching data and notifying a `Consumer`.

--- a/resolver/src/opaque.rs
+++ b/resolver/src/opaque.rs
@@ -19,7 +19,10 @@ use crate::{
 use commonware_actor::{Feedback, mailbox};
 use commonware_cryptography::PublicKey;
 use commonware_macros::select_loop;
-use commonware_runtime::{Clock, ContextCell, Handle, Metrics, Spawner, spawn_cell};
+use commonware_runtime::{
+    Clock, ContextCell, Handle, Metrics, Spawner, spawn_cell,
+    telemetry::metrics::{MetricsExt as _, status, status::Status},
+};
 use commonware_utils::{
     Span,
     futures::{AbortablePool, Aborter},
@@ -190,7 +193,7 @@ where
 /// Actor that coalesces opaque fetches, retries failures, and delivers accepted values.
 struct Actor<E, F, Con>
 where
-    E: Clock + Spawner,
+    E: Clock + Spawner + Metrics,
     F: Fetcher,
     F::Value: Clone + Send + 'static,
     Con: Consumer<Key = F::Key, Value = F::Value>,
@@ -203,6 +206,7 @@ where
     deliveries: DeliveryTracker<Con, u64>,
     requests: BTreeMap<F::Key, Attempt>,
     subscribers: subscribers::Tracker<F::Key, Con::Subscriber>,
+    fetch: status::Counter,
     retry_schedule: BTreeSet<(SystemTime, F::Key)>,
     fetch_retry_timeout: Duration,
     next_id: u64,
@@ -227,7 +231,7 @@ struct FetchCompletion<K, V> {
 
 impl<E, F, Con> Actor<E, F, Con>
 where
-    E: Clock + Spawner,
+    E: Clock + Spawner + Metrics,
     F: Fetcher + Clone + Send + 'static,
     F::Value: Clone + Send + 'static,
     Con: Consumer<Key = F::Key, Value = F::Value>,
@@ -240,6 +244,7 @@ where
         consumer: Con,
         fetch_retry_timeout: Duration,
     ) -> Self {
+        let fetch = context.family("fetch", "Number of fetches by status");
         Self {
             context: ContextCell::new(context),
             fetcher,
@@ -248,6 +253,7 @@ where
             deliveries: DeliveryTracker::new(consumer),
             requests: BTreeMap::new(),
             subscribers: subscribers::Tracker::new(),
+            fetch,
             retry_schedule: BTreeSet::new(),
             fetch_retry_timeout,
             next_id: 0,
@@ -519,6 +525,10 @@ where
                 }
             }
             Outcome::Ambiguous => {
+                // The fetcher returned one of multiple valid responses, but this response did not
+                // satisfy every subscriber. Discard it and retain the fetch so another response
+                // can be tried.
+                self.fetch.inc(Status::Ambiguous);
                 self.deliveries.discard_response(&key);
                 self.schedule_retry(key);
             }
@@ -902,6 +912,11 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
             assert_eq!(consumer.len(), 0);
             assert_eq!(fetcher.calls(), 2);
+            assert!(
+                context
+                    .encode()
+                    .contains("resolver_actor_fetch_total{status=\"Ambiguous\"} 1")
+            );
         });
     }
 

--- a/resolver/src/opaque.rs
+++ b/resolver/src/opaque.rs
@@ -11,7 +11,7 @@
 //! fetchers do not have peer-specific routing.
 
 use crate::{
-    Consumer, Delivery, Fetch, TargetedResolver,
+    Consumer, Delivery, Fetch, Outcome, TargetedResolver,
     delivery::{Completion as DeliveryCompletion, Tracker as DeliveryTracker},
     ingress::{self, FetchKey, Message},
     subscribers,
@@ -389,7 +389,7 @@ where
         let DeliveryCompletion {
             context: id,
             delivery,
-            valid,
+            outcome,
         } = completion;
         let Delivery {
             key,
@@ -399,7 +399,7 @@ where
         if !self.current_delivery(&key, id) {
             return;
         }
-        self.handle_delivered(key, delivered, valid);
+        self.handle_delivered(key, delivered, outcome);
     }
 
     /// Return whether a fetch completion matches the current attempt id.
@@ -494,48 +494,54 @@ where
         &mut self,
         key: F::Key,
         delivered: NonEmptyVec<(Con::Subscriber, tracing::Span)>,
-        valid: bool,
+        outcome: Outcome,
     ) {
         let accepted = self.deliveries.response_accepted(&key);
 
-        if valid {
-            let remaining = self
-                .subscribers
-                .remove_delivered(&key, delivered.map_into(|(subscriber, _)| subscriber));
+        match outcome {
+            Outcome::Complete => {
+                let remaining = self
+                    .subscribers
+                    .remove_delivered(&key, delivered.map_into(|(subscriber, _)| subscriber));
 
-            // The first accepted response is reused for subscribers that joined
-            // while validation was pending, avoiding a duplicate source fetch
-            // for the same key.
-            if let Some(subscribers) = remaining {
-                if !accepted {
-                    self.deliveries.accept_response(&key);
+                // The first accepted response is reused for subscribers that joined
+                // while validation was pending, avoiding a duplicate source fetch
+                // for the same key.
+                if let Some(subscribers) = remaining {
+                    if !accepted {
+                        self.deliveries.accept_response(&key);
+                    }
+                    self.redeliver(key, subscribers);
+                } else {
+                    self.requests.remove(&key);
+                    self.subscribers.remove(&key);
+                    self.deliveries.remove(&key);
                 }
-                self.redeliver(key, subscribers);
-            } else {
-                self.requests.remove(&key);
-                self.subscribers.remove(&key);
-                self.deliveries.remove(&key);
             }
-            return;
-        }
+            Outcome::Ambiguous => {
+                self.deliveries.discard_response(&key);
+                self.schedule_retry(key);
+            }
+            Outcome::Invalid => {
+                // A cached response already satisfied at least one subscriber. Treat a
+                // later rejection during redelivery as stale application feedback rather
+                // than re-fetching data that was accepted once.
+                if accepted {
+                    warn!(
+                        ?key,
+                        "previously accepted resolver response rejected during opaque redelivery"
+                    );
+                    self.requests.remove(&key);
+                    self.subscribers.remove(&key);
+                    self.deliveries.remove(&key);
+                    return;
+                }
 
-        // A cached response already satisfied at least one subscriber. Treat a
-        // later rejection during redelivery as stale application feedback rather
-        // than re-fetching data that was accepted once.
-        if accepted {
-            warn!(
-                ?key,
-                "previously accepted resolver response rejected during opaque redelivery"
-            );
-            self.requests.remove(&key);
-            self.subscribers.remove(&key);
-            self.deliveries.remove(&key);
-            return;
+                warn!(?key, "consumer rejected opaque resolver delivery");
+                self.deliveries.discard_response(&key);
+                self.schedule_retry(key);
+            }
         }
-
-        warn!(?key, "consumer rejected opaque resolver delivery");
-        self.deliveries.discard_response(&key);
-        self.schedule_retry(key);
     }
 
     /// Schedule the next fetch attempt for `key`.
@@ -678,7 +684,7 @@ mod tests {
     struct CapturedDelivery {
         delivery: Delivery<u8, u16>,
         value: Bytes,
-        response: oneshot::Sender<bool>,
+        response: oneshot::Sender<Outcome>,
     }
 
     #[derive(Clone, Default)]
@@ -700,12 +706,13 @@ mod tests {
         type Key = u8;
         type Value = Bytes;
         type Subscriber = u16;
+        type Outcome = Outcome;
 
         fn deliver(
             &mut self,
             delivery: Delivery<Self::Key, Self::Subscriber>,
             value: Self::Value,
-        ) -> oneshot::Receiver<bool> {
+        ) -> oneshot::Receiver<Self::Outcome> {
             let (response, receiver) = oneshot::channel();
             self.deliveries.lock().push_back(CapturedDelivery {
                 delivery,
@@ -777,7 +784,10 @@ mod tests {
                     .accepted()
             );
             context.sleep(Duration::from_millis(10)).await;
-            first.response.send(true).expect("response dropped");
+            first
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
 
             let second = wait_for_delivery(&context, &consumer).await;
             assert_eq!(second.value, Bytes::from_static(b"value"));
@@ -790,7 +800,10 @@ mod tests {
                     .collect::<Vec<_>>(),
                 vec![11]
             );
-            second.response.send(true).expect("response dropped");
+            second
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
 
             context.sleep(Duration::from_millis(10)).await;
             assert_eq!(fetcher.calls(), 1);
@@ -822,7 +835,72 @@ mod tests {
 
             let delivery = wait_for_delivery(&context, &consumer).await;
             assert_eq!(delivery.value, Bytes::from_static(b"value"));
-            delivery.response.send(true).expect("response dropped");
+            delivery
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
+            assert_eq!(fetcher.calls(), 2);
+        });
+    }
+
+    #[test]
+    fn ambiguous_delivery_retries_without_retiring_subscriber() {
+        Runner::default().start(|context| async move {
+            let fetcher = MockFetcher::default();
+            fetcher.push(1, Some(Bytes::from_static(b"ambiguous")));
+            fetcher.push(1, Some(Bytes::from_static(b"complete")));
+            let consumer = MockConsumer::default();
+            let mut resolver =
+                start_resolver(context.child("resolver"), fetcher.clone(), consumer.clone());
+
+            assert!(
+                resolver
+                    .fetch(Fetch {
+                        key: 1,
+                        subscriber: 10,
+                        span: tracing::Span::none(),
+                    })
+                    .accepted()
+            );
+
+            let first = wait_for_delivery(&context, &consumer).await;
+            assert_eq!(first.value, Bytes::from_static(b"ambiguous"));
+            assert_eq!(
+                first
+                    .delivery
+                    .subscribers
+                    .iter()
+                    .map(|(subscriber, _)| *subscriber)
+                    .collect::<Vec<_>>(),
+                vec![10]
+            );
+            first
+                .response
+                .send(Outcome::Ambiguous)
+                .expect("response dropped");
+
+            context
+                .sleep(RETRY_TIMEOUT + Duration::from_millis(10))
+                .await;
+            let second = wait_for_delivery(&context, &consumer).await;
+            assert_eq!(second.value, Bytes::from_static(b"complete"));
+            assert_eq!(
+                second
+                    .delivery
+                    .subscribers
+                    .iter()
+                    .map(|(subscriber, _)| *subscriber)
+                    .collect::<Vec<_>>(),
+                vec![10]
+            );
+            assert_eq!(fetcher.calls(), 2);
+
+            second
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
+            context.sleep(Duration::from_millis(10)).await;
+            assert_eq!(consumer.len(), 0);
             assert_eq!(fetcher.calls(), 2);
         });
     }
@@ -857,10 +935,16 @@ mod tests {
                     .accepted()
             );
             context.sleep(Duration::from_millis(10)).await;
-            first.response.send(true).expect("response dropped");
+            first
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
 
             let second = wait_for_delivery(&context, &consumer).await;
-            second.response.send(false).expect("response dropped");
+            second
+                .response
+                .send(Outcome::Invalid)
+                .expect("response dropped");
 
             context
                 .sleep(RETRY_TIMEOUT + Duration::from_millis(10))
@@ -916,7 +1000,10 @@ mod tests {
                     .collect::<Vec<_>>(),
                 vec![11]
             );
-            delivery.response.send(true).expect("response dropped");
+            delivery
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
         });
     }
 
@@ -974,7 +1061,7 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(
-                delivery.response.send(false).is_err(),
+                delivery.response.send(Outcome::Invalid).is_err(),
                 "delivery future should be aborted after its last subscriber is pruned"
             );
             context
@@ -1009,7 +1096,10 @@ mod tests {
             );
             let delivery = wait_for_delivery(&context, &consumer).await;
             assert_eq!(delivery.value, Bytes::from_static(b"value"));
-            delivery.response.send(true).expect("response dropped");
+            delivery
+                .response
+                .send(Outcome::Complete)
+                .expect("response dropped");
             assert_eq!(fetcher.calls(), 1);
         });
     }

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -6,7 +6,7 @@ use super::{
     ingress::{FetchKey, Mailbox, Message},
     metrics, wire,
 };
-use crate::{Consumer, Delivery, subscribers};
+use crate::{Consumer, Delivery, Outcome, subscribers};
 use bytes::Bytes;
 use commonware_actor::mailbox;
 use commonware_cryptography::PublicKey;
@@ -417,60 +417,74 @@ where
     }
 
     /// Handle completed delivery to the consumer.
-    fn handle_delivery(&mut self, peer: P, delivery: Delivery<Key, Con::Subscriber>, valid: bool) {
+    fn handle_delivery(
+        &mut self,
+        peer: P,
+        delivery: Delivery<Key, Con::Subscriber>,
+        outcome: Outcome,
+    ) {
         let Delivery {
             key,
             subscribers: delivered,
             ..
         } = delivery;
 
-        if valid {
-            let already_accepted = self.inflight.response_accepted(&key);
+        match outcome {
+            Outcome::Complete => {
+                let already_accepted = self.inflight.response_accepted(&key);
 
-            // Remove only the subscribers that accepted this response. If other
-            // subscribers still need the key, deliver the same accepted response
-            // locally with the remaining annotations.
-            let remaining = self
-                .subscribers
-                .remove_delivered(&key, delivered.map_into(|(subscriber, _)| subscriber));
+                // Remove only the subscribers that accepted this response. If other
+                // subscribers still need the key, deliver the same accepted response
+                // locally with the remaining annotations.
+                let remaining = self
+                    .subscribers
+                    .remove_delivered(&key, delivered.map_into(|(subscriber, _)| subscriber));
 
-            if let Some(subscribers) = remaining {
-                if !already_accepted {
-                    self.metrics.fetch.inc(Status::Success);
-                    self.inflight.accept_response(&key, self.context.as_ref());
+                if let Some(subscribers) = remaining {
+                    if !already_accepted {
+                        self.metrics.fetch.inc(Status::Success);
+                        self.inflight.accept_response(&key, self.context.as_ref());
+                    }
+                    self.inflight.redeliver(Delivery { key, subscribers });
+                } else {
+                    // All subscribers observed a valid response; clear any targeting
+                    // state retained for this key.
+                    if !already_accepted {
+                        self.metrics.fetch.inc(Status::Success);
+                    }
+                    self.inflight.complete(self.context.as_ref(), &key);
+                    self.fetcher.clear_targets(&key);
                 }
-                self.inflight.redeliver(Delivery { key, subscribers });
-            } else {
-                // All subscribers observed a valid response; clear any targeting
-                // state retained for this key.
-                if !already_accepted {
-                    self.metrics.fetch.inc(Status::Success);
-                }
-                self.inflight.complete(self.context.as_ref(), &key);
-                self.fetcher.clear_targets(&key);
             }
-            return;
-        }
+            Outcome::Ambiguous => {
+                // The peer served valid data for the wire key, but local
+                // subscribers still need different evidence. Do not cache the
+                // response or penalize the peer; retry the same key.
+                self.inflight.discard_response(&key);
+                self.fetcher.add_retry(key);
+            }
+            Outcome::Invalid => {
+                if self.inflight.response_accepted(&key) {
+                    warn!(
+                        ?key,
+                        "previously accepted response was rejected during local redelivery"
+                    );
+                    self.metrics.fetch.inc(Status::Failure);
+                    self.inflight.complete(self.context.as_ref(), &key);
+                    self.subscribers.remove(&key);
+                    self.fetcher.clear_targets(&key);
+                    return;
+                }
 
-        if self.inflight.response_accepted(&key) {
-            warn!(
-                ?key,
-                "previously accepted response was rejected during local redelivery"
-            );
-            self.metrics.fetch.inc(Status::Failure);
-            self.inflight.complete(self.context.as_ref(), &key);
-            self.subscribers.remove(&key);
-            self.fetcher.clear_targets(&key);
-            return;
+                // If the data is invalid, block the peer and try again. Blocking the
+                // peer also removes any targets associated with it.
+                commonware_p2p::block!(self.blocker, peer.clone(), "invalid data received");
+                self.fetcher.block(peer);
+                self.metrics.fetch.inc(Status::Failure);
+                self.inflight.discard_response(&key);
+                self.fetcher.add_retry(key);
+            }
         }
-
-        // If the data is invalid, block the peer and try again. Blocking the
-        // peer also removes any targets associated with it.
-        commonware_p2p::block!(self.blocker, peer.clone(), "invalid data received");
-        self.fetcher.block(peer);
-        self.metrics.fetch.inc(Status::Failure);
-        self.inflight.discard_response(&key);
-        self.fetcher.add_retry(key);
     }
 
     /// Handle a network response from a peer that did not have the data.

--- a/resolver/src/p2p/engine.rs
+++ b/resolver/src/p2p/engine.rs
@@ -460,10 +460,15 @@ where
                 // The peer served valid data for the wire key, but local
                 // subscribers still need different evidence. Do not cache the
                 // response or penalize the peer; retry the same key.
+                self.metrics.fetch.inc(Status::Ambiguous);
                 self.inflight.discard_response(&key);
                 self.fetcher.add_retry(key);
             }
             Outcome::Invalid => {
+                // A previously accepted response is only redelivered locally to subscribers that
+                // joined while validation was pending. A later invalid outcome therefore reflects
+                // conflicting consumer verdicts, not invalid peer data. Retire the fetch without
+                // blocking the peer or retrying the accepted response.
                 if self.inflight.response_accepted(&key) {
                     warn!(
                         ?key,

--- a/resolver/src/p2p/inflight.rs
+++ b/resolver/src/p2p/inflight.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Consumer, Delivery,
+    Consumer, Delivery, Outcome,
     delivery::{Completion, Tracker},
 };
 use commonware_cryptography::PublicKey;
@@ -106,18 +106,17 @@ where
         self.deliveries.discard_response(key);
     }
 
-    /// Returns the next completed delivery as `(peer, delivery, valid)`, or [Aborted] if the
-    /// delivery was canceled. Clears the entry's delivery aborter so the slot is available
-    /// for a retry.
+    /// Returns the next completed delivery, or [Aborted] if it was canceled.
+    /// Clears the entry's delivery aborter so the slot is available for a retry.
     pub(super) async fn next_delivery(
         &mut self,
-    ) -> Result<(P, Delivery<Con::Key, Con::Subscriber>, bool), Aborted> {
+    ) -> Result<(P, Delivery<Con::Key, Con::Subscriber>, Outcome), Aborted> {
         let Completion {
             context,
             delivery,
-            valid,
+            outcome,
         } = self.deliveries.next_completion().await?;
-        Ok((context, delivery, valid))
+        Ok((context, delivery, outcome))
     }
 }
 
@@ -273,11 +272,11 @@ mod tests {
             inflight.insert(key.clone(), timed.timer(&context));
             inflight.deliver(delivery(key.clone()), peer.clone(), value.clone());
 
-            let (delivered_peer, delivered, valid) =
+            let (delivered_peer, delivered, outcome) =
                 inflight.next_delivery().await.expect("delivery aborted");
             assert_eq!(delivered.key, key);
             assert_eq!(delivered_peer, peer);
-            assert!(valid);
+            assert_eq!(outcome, Outcome::Complete);
 
             // The consumer was actually invoked.
             let (k, v) = events.recv().await.unwrap();
@@ -320,9 +319,10 @@ mod tests {
             inflight.insert(key.clone(), timed.timer(&context));
             inflight.deliver(delivery(key.clone()), peer, Bytes::from("v"));
 
-            let (_, delivered, valid) = inflight.next_delivery().await.expect("delivery completed");
+            let (_, delivered, outcome) =
+                inflight.next_delivery().await.expect("delivery completed");
             assert_eq!(delivered.key, key);
-            assert!(valid);
+            assert_eq!(outcome, Outcome::Complete);
             inflight.complete(&context, &key);
 
             // Late cancel finds no entry; must not panic.

--- a/resolver/src/p2p/mocks/consumer.rs
+++ b/resolver/src/p2p/mocks/consumer.rs
@@ -64,6 +64,7 @@ where
     type Key = R;
     type Value = V;
     type Subscriber = S;
+    type Outcome = bool;
 
     /// Deliver data to the consumer.
     ///

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -1016,6 +1016,12 @@ mod tests {
             second_gate_sender.send(()).unwrap();
             assert_eq!(cons_out1.recv().await.unwrap(), (key, data));
             assert!(oracle.blocked().await.unwrap().is_empty());
+
+            let metrics = context.encode();
+            assert_eq!(
+                status_metric_total(&metrics, "actor_fetch_total", "Ambiguous"),
+                1
+            );
         });
     }
 

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -12,9 +12,10 @@
 //! fulfilled, delivering data to the `Consumer` for verification.
 //!
 //! The `Consumer` checks data integrity and authenticity (critical in an adversarial environment)
-//! and returns `true` if valid, completing the fetch, or `false` to retry. Pruning a fetch with
-//! in-progress response validation aborts that validation. If the aborted validation would have
-//! returned `false`, the peer is not blocked for that response.
+//! and returns a [`crate::Outcome`]. A complete response retires its delivered subscribers,
+//! an ambiguous response retries without penalizing the peer, and an invalid response retries
+//! after blocking the peer. Pruning a fetch with in-progress response validation aborts that
+//! validation; an invalid outcome produced after cancellation does not block the peer.
 //!
 //! The peer also serves data to other peers, forwarding network requests to the `Producer`. The
 //! `Producer` provides data asynchronously (e.g., from storage). If it fails, the peer sends an
@@ -47,6 +48,13 @@
 //! key and currently retained subscribers are supplied to
 //! [`Consumer::deliver`](crate::Consumer::deliver). Subscribers added while response validation
 //! is in progress are delivered the same accepted response locally.
+//!
+//! While a response is being validated, its key remains in flight, so no further request is sent.
+//! New fetches for the key only attach subscribers or targets. A complete outcome retires the
+//! delivered subscribers, an ambiguous outcome retries the key, and an invalid outcome retries the
+//! key after blocking the serving peer. When a peer-visible key admits multiple valid responses, a
+//! consumer should return an ambiguous outcome if the delivered response does not satisfy every
+//! subscriber, allowing the resolver to try another response.
 //!
 //! # Peer Selection
 //!
@@ -95,7 +103,7 @@ mod tests {
         Config, Engine, Mailbox,
         mocks::{Consumer, Key, Producer},
     };
-    use crate::{Delivery, Fetch, Resolver, TargetedResolver};
+    use crate::{Delivery, Fetch, Outcome, Resolver, TargetedResolver};
     use bytes::Bytes;
     use commonware_cryptography::{
         Signer,
@@ -327,7 +335,7 @@ mod tests {
         mailbox
     }
 
-    type DeliveryGate = (oneshot::Receiver<()>, bool);
+    type DeliveryGate = (oneshot::Receiver<()>, Outcome);
     type DeliveryGates = Arc<Mutex<VecDeque<DeliveryGate>>>;
 
     #[derive(Clone)]
@@ -366,19 +374,22 @@ mod tests {
         type Key = Key;
         type Value = Bytes;
         type Subscriber = ();
+        type Outcome = Outcome;
 
         fn deliver(
             &mut self,
             delivery: Delivery<Self::Key, Self::Subscriber>,
             value: Self::Value,
-        ) -> oneshot::Receiver<bool> {
+        ) -> oneshot::Receiver<Self::Outcome> {
             let key = delivery.key;
             self.started.send_lossy(key.clone());
-            let (gate, valid) = self
+            let (gate, outcome) = self
                 .gates
                 .lock()
                 .pop_front()
-                .map_or((None, true), |(gate, valid)| (Some(gate), valid));
+                .map_or((None, Outcome::Complete), |(gate, outcome)| {
+                    (Some(gate), outcome)
+                });
             let (mut response, receiver) = oneshot::channel();
             let sender = self.sender.clone();
             self.context.child("delivery").spawn(move |_| async move {
@@ -387,16 +398,16 @@ mod tests {
                         _ = response.closed() => return,
                         result = gate => {
                             if result.is_err() {
-                                let _ = response.send(false);
+                                let _ = response.send(Outcome::Invalid);
                                 return;
                             }
                         },
                     }
                 }
-                if valid {
+                if outcome == Outcome::Complete {
                     sender.send_lossy((key, value));
                 }
-                let _ = response.send(valid);
+                let _ = response.send(outcome);
             });
             receiver
         }
@@ -443,18 +454,21 @@ mod tests {
         type Key = Key;
         type Value = Bytes;
         type Subscriber = SubscriberTag;
+        type Outcome = Outcome;
 
         fn deliver(
             &mut self,
             delivery: Delivery<Self::Key, Self::Subscriber>,
             value: Self::Value,
-        ) -> oneshot::Receiver<bool> {
+        ) -> oneshot::Receiver<Self::Outcome> {
             self.started.send_lossy(delivery.clone());
-            let (gate, valid) = self
+            let (gate, outcome) = self
                 .gates
                 .lock()
                 .pop_front()
-                .map_or((None, true), |(gate, valid)| (Some(gate), valid));
+                .map_or((None, Outcome::Complete), |(gate, outcome)| {
+                    (Some(gate), outcome)
+                });
             let (mut response, receiver) = oneshot::channel();
             let sender = self.sender.clone();
             self.context.child("delivery").spawn(move |_| async move {
@@ -463,16 +477,16 @@ mod tests {
                         _ = response.closed() => return,
                         result = gate => {
                             if result.is_err() {
-                                let _ = response.send(false);
+                                let _ = response.send(Outcome::Invalid);
                                 return;
                             }
                         },
                     }
                 }
-                if valid {
+                if outcome == Outcome::Complete {
                     sender.send_lossy((delivery, value));
                 }
-                let _ = response.send(valid);
+                let _ = response.send(outcome);
             });
             receiver
         }
@@ -494,6 +508,7 @@ mod tests {
         type Key = Key;
         type Value = Bytes;
         type Subscriber = SubscriberTag;
+        type Outcome = bool;
 
         fn deliver(
             &mut self,
@@ -599,6 +614,7 @@ mod tests {
         type Key = Key;
         type Value = Bytes;
         type Subscriber = ();
+        type Outcome = bool;
 
         fn deliver(
             &mut self,
@@ -698,7 +714,10 @@ mod tests {
             let (gate_sender2, gate_receiver2) = oneshot::channel();
             let (cons1, mut cons_out1, mut started) = BlockingConsumer::new(
                 context.child("consumer"),
-                vec![(gate_receiver1, true), (gate_receiver2, true)],
+                vec![
+                    (gate_receiver1, Outcome::Complete),
+                    (gate_receiver2, Outcome::Complete),
+                ],
             );
 
             let scheme = schemes.remove(0);
@@ -778,7 +797,10 @@ mod tests {
             let (second_gate_sender, second_gate_receiver) = oneshot::channel();
             let (cons1, mut cons_out1, mut started) = BlockingConsumer::new(
                 context.child("consumer"),
-                vec![(first_gate_receiver, true), (second_gate_receiver, true)],
+                vec![
+                    (first_gate_receiver, Outcome::Complete),
+                    (second_gate_receiver, Outcome::Complete),
+                ],
             );
 
             let scheme = schemes.remove(0);
@@ -849,7 +871,10 @@ mod tests {
             let (second_gate_sender, second_gate_receiver) = oneshot::channel();
             let (cons1, mut cons_out1, mut started) = BlockingConsumer::new(
                 context.child("consumer"),
-                vec![(first_gate_receiver, false), (second_gate_receiver, true)],
+                vec![
+                    (first_gate_receiver, Outcome::Invalid),
+                    (second_gate_receiver, Outcome::Complete),
+                ],
             );
 
             let scheme = schemes.remove(0);
@@ -911,6 +936,89 @@ mod tests {
         });
     }
 
+    #[test_traced]
+    fn test_ambiguous_delivery_retries_without_blocking_peer() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|context| async move {
+            let (mut oracle, mut schemes, peers, mut connections) =
+                setup_network_and_peers(&context, &[1, 2, 3]).await;
+
+            add_link(&mut oracle, LINK.clone(), &peers, 0, 1).await;
+
+            let key = Key(1);
+            let data = Bytes::from("data for key 1");
+            let mut prod2 = Producer::default();
+            prod2.insert(key.clone(), data.clone());
+            let mut prod3 = Producer::default();
+            prod3.insert(key.clone(), data.clone());
+
+            let (first_gate_sender, first_gate_receiver) = oneshot::channel();
+            let (second_gate_sender, second_gate_receiver) = oneshot::channel();
+            let (cons1, mut cons_out1, mut started) = BlockingConsumer::new(
+                context.child("consumer"),
+                vec![
+                    (first_gate_receiver, Outcome::Ambiguous),
+                    (second_gate_receiver, Outcome::Complete),
+                ],
+            );
+
+            let scheme = schemes.remove(0);
+            let mut mailbox1 = setup_and_spawn_actor(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                cons1,
+                Producer::default(),
+            );
+
+            let scheme = schemes.remove(0);
+            let _mailbox2 = setup_and_spawn_actor(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                dummy_consumer(),
+                prod2,
+            );
+
+            let scheme = schemes.remove(0);
+            let _mailbox3 = setup_and_spawn_actor(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                dummy_consumer(),
+                prod3,
+            );
+
+            mailbox1.fetch_targeted(
+                key.clone(),
+                non_empty_vec![peers[1].clone(), peers[2].clone()],
+            );
+            assert_eq!(started.recv().await.unwrap(), key);
+            first_gate_sender.send(()).unwrap();
+
+            add_link(&mut oracle, LINK.clone(), &peers, 0, 2).await;
+            oracle
+                .remove_link(peers[0].clone(), peers[1].clone())
+                .await
+                .unwrap();
+            oracle
+                .remove_link(peers[1].clone(), peers[0].clone())
+                .await
+                .unwrap();
+
+            assert_eq!(started.recv().await.unwrap(), key);
+            second_gate_sender.send(()).unwrap();
+            assert_eq!(cons_out1.recv().await.unwrap(), (key, data));
+            assert!(oracle.blocked().await.unwrap().is_empty());
+        });
+    }
+
     async fn run_pending_invalid_delivery_race(
         context: &deterministic::Context,
         validation_first: bool,
@@ -925,8 +1033,10 @@ mod tests {
         prod2.insert(key.clone(), Bytes::from("data for key 1"));
 
         let (mut gate_sender, gate_receiver) = oneshot::channel();
-        let (cons1, mut cons_out1, mut started) =
-            BlockingConsumer::new(context.child("consumer"), vec![(gate_receiver, false)]);
+        let (cons1, mut cons_out1, mut started) = BlockingConsumer::new(
+            context.child("consumer"),
+            vec![(gate_receiver, Outcome::Invalid)],
+        );
 
         let scheme = schemes.remove(0);
         let mut mailbox1 = setup_and_spawn_actor(
@@ -2318,7 +2428,10 @@ mod tests {
             let (second_gate_sender, second_gate_receiver) = oneshot::channel();
             let (cons1, mut deliveries, mut started) = BlockingSubscriberRecordingConsumer::new(
                 context.child("consumer"),
-                vec![(first_gate_receiver, true), (second_gate_receiver, true)],
+                vec![
+                    (first_gate_receiver, Outcome::Complete),
+                    (second_gate_receiver, Outcome::Complete),
+                ],
             );
 
             let scheme = schemes.remove(0);
@@ -2411,6 +2524,164 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_late_targeted_subscriber_joins_retry_after_ambiguous_delivery() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|context| async move {
+            let (mut oracle, mut schemes, peers, mut connections) =
+                setup_network_and_peers(&context, &[1, 2, 3]).await;
+
+            add_link(&mut oracle, LINK.clone(), &peers, 0, 1).await;
+
+            let key = Key(5);
+            let ambiguous_response = Bytes::from("ambiguous data for key 5");
+            let unexpected_refetch = Bytes::from("unexpected refetch for key 5");
+            let mut prod2 = SequencedProducer::default();
+            prod2.insert(
+                key.clone(),
+                [ambiguous_response, unexpected_refetch.clone()],
+            );
+            let prod2_observer = prod2.clone();
+
+            let valid_response = Bytes::from("valid data for key 5");
+            let mut prod3 = SequencedProducer::default();
+            prod3.insert(key.clone(), [valid_response.clone()]);
+            let prod3_observer = prod3.clone();
+
+            let (first_gate_sender, first_gate_receiver) = oneshot::channel();
+            let (second_gate_sender, second_gate_receiver) = oneshot::channel();
+            let (cons1, mut deliveries, mut started) = BlockingSubscriberRecordingConsumer::new(
+                context.child("consumer"),
+                vec![
+                    (first_gate_receiver, Outcome::Ambiguous),
+                    (second_gate_receiver, Outcome::Complete),
+                ],
+            );
+
+            let scheme = schemes.remove(0);
+            let mut mailbox1 = setup_and_spawn_actor(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                cons1,
+                Producer::default(),
+            );
+
+            let scheme = schemes.remove(0);
+            let _mailbox2 = setup_and_spawn_actor_with_producer(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                dummy_consumer(),
+                prod2,
+            );
+
+            let scheme = schemes.remove(0);
+            let _mailbox3 = setup_and_spawn_actor_with_producer(
+                &context,
+                oracle.manager(),
+                oracle.control(scheme.public_key()),
+                scheme,
+                connections.remove(0),
+                dummy_consumer(),
+                prod3,
+            );
+
+            let first_subscriber = SubscriberTag(49);
+            let second_subscriber = SubscriberTag(50);
+
+            // Start unrestricted repair and park its first response in validation.
+            mailbox1.fetch(Fetch {
+                key: key.clone(),
+                subscriber: first_subscriber.clone(),
+                span: tracing::Span::none(),
+            });
+
+            let delivery = started.recv().await.expect("delivery did not start");
+            assert_eq!(
+                delivery,
+                Delivery {
+                    key: key.clone(),
+                    subscribers: non_empty_vec![(first_subscriber.clone(), tracing::Span::none())],
+                }
+            );
+
+            // A targeted objection for the same key attaches to the parked fetch
+            // without issuing another network request.
+            add_link(&mut oracle, LINK.clone(), &peers, 0, 2).await;
+            mailbox1.fetch_targeted(
+                Fetch {
+                    key: key.clone(),
+                    subscriber: second_subscriber.clone(),
+                    span: tracing::Span::none(),
+                },
+                non_empty_vec![peers[2].clone()],
+            );
+
+            context.sleep(Duration::from_millis(100)).await;
+            assert_eq!(
+                prod2_observer.remaining(&key),
+                vec![unexpected_refetch.clone()]
+            );
+            assert_eq!(prod3_observer.remaining(&key), vec![valid_response.clone()]);
+
+            oracle
+                .remove_link(peers[0].clone(), peers[1].clone())
+                .await
+                .unwrap();
+            oracle
+                .remove_link(peers[1].clone(), peers[0].clone())
+                .await
+                .unwrap();
+
+            // An ambiguous response retries unrestricted repair with both
+            // subscribers and does not penalize the serving peer.
+            first_gate_sender.send(()).unwrap();
+            oracle.manager().track(
+                1,
+                Set::try_from([peers[0].clone(), peers[2].clone()]).unwrap(),
+            );
+
+            let delivery = select! {
+                delivery = started.recv() => delivery.expect("retry delivery did not start"),
+                _ = context.sleep(Duration::from_secs(2)) => {
+                    panic!("ambiguous response was not retried with the late subscriber");
+                },
+            };
+            assert_eq!(
+                delivery,
+                Delivery {
+                    key: key.clone(),
+                    subscribers: non_empty_vec![
+                        (first_subscriber.clone(), tracing::Span::none()),
+                        (second_subscriber.clone(), tracing::Span::none())
+                    ],
+                }
+            );
+
+            second_gate_sender.send(()).unwrap();
+            let (delivery, value) = deliveries.recv().await.expect("consumer channel closed");
+            assert_eq!(
+                delivery,
+                Delivery {
+                    key: key.clone(),
+                    subscribers: non_empty_vec![
+                        (first_subscriber, tracing::Span::none()),
+                        (second_subscriber, tracing::Span::none())
+                    ],
+                }
+            );
+            assert_eq!(value, valid_response);
+            assert_eq!(prod2_observer.remaining(&key), vec![unexpected_refetch]);
+            assert!(prod3_observer.remaining(&key).is_empty());
+            assert!(oracle.blocked().await.unwrap().is_empty());
+        });
+    }
+
+    #[test_traced]
     fn test_late_subscriber_delivery_ignores_unrelated_waiter() {
         let executor = deterministic::Runner::timed(Duration::from_secs(10));
         executor.start(|context| async move {
@@ -2435,7 +2706,10 @@ mod tests {
             let (second_gate_sender, second_gate_receiver) = oneshot::channel();
             let (cons1, mut deliveries, mut started) = BlockingSubscriberRecordingConsumer::new(
                 context.child("consumer"),
-                vec![(first_gate_receiver, false), (second_gate_receiver, true)],
+                vec![
+                    (first_gate_receiver, Outcome::Invalid),
+                    (second_gate_receiver, Outcome::Complete),
+                ],
             );
 
             let scheme = schemes.remove(0);
@@ -3395,8 +3669,10 @@ mod tests {
             prod2.insert(key.clone(), data);
 
             let (mut gate_sender, gate_receiver) = oneshot::channel();
-            let (cons1, mut cons_out1, mut started) =
-                BlockingConsumer::new(context.child("consumer"), vec![(gate_receiver, true)]);
+            let (cons1, mut cons_out1, mut started) = BlockingConsumer::new(
+                context.child("consumer"),
+                vec![(gate_receiver, Outcome::Complete)],
+            );
 
             let actor_context = context.child("actor");
 

--- a/runtime/src/telemetry/metrics/status.rs
+++ b/runtime/src/telemetry/metrics/status.rs
@@ -14,6 +14,8 @@ pub struct Label {
 pub enum Status {
     /// Processed successfully.
     Success,
+    /// Processing produced one of multiple valid results but did not satisfy the request.
+    Ambiguous,
     /// Processing failed.
     Failure,
     /// Input was malformed or invalid in some way. Indicates a client error.


### PR DESCRIPTION
Related: #4332

## Summary

Adds an explicit resolver outcome for valid-but-ambiguous responses, separating them from invalid data.

- Introduces `Outcome::{Invalid, Complete, Ambiguous}` and `Consumer::Outcome`. Existing boolean consumers retain their behavior through `From<bool>`.
- Threads the outcome through shared delivery tracking and both opaque and P2P resolvers.
- Treats `Ambiguous` as a retryable response when a peer-visible key permits multiple valid replies: discard the current response, retain subscribers and targets, and retry without penalizing the serving peer.
- Keeps `Invalid` behavior intact: block the serving peer and retry the key. `Complete` retires the delivered subscribers.
- Adds deterministic coverage for opaque retries, P2P peer treatment, and subscribers or targets added while validation is in progress.

This is the generic resolver prerequisite split out of #4332. It intentionally contains no Simplex-specific certification or resolver behavior, and all existing consumers outside `resolver` remain boolean adapters.
