### PR TITLE
[consensus/marshal] Decouple Resolver Fetches from Block Subscriptions

### DIFF
--- a/consensus/src/marshal/ancestry.rs
+++ b/consensus/src/marshal/ancestry.rs
@@ -169,8 +169,8 @@ pub trait BlockProvider: Send + 'static {
     /// will be notified when the parent is available. If the parent is not finalized, it's possible
     /// that it may never become available.
     ///
-    /// Returns `None` when the subscription is canceled or the provider can no longer deliver
-    /// the parent.
+    /// Returns `None` only when the provider can no longer obtain the parent from any source.
+    /// Dropping the returned future cancels the subscription.
     ///
     /// The child block can carry variant-specific context needed to retrieve its parent.
     fn subscribe_parent(

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -187,7 +187,7 @@ pub(crate) const fn resolve(verdict: Option<bool>, durable: bool) -> Option<bool
 
 /// Forwards `input` while `output` still has a receiver.
 ///
-/// Dropping the output receiver cancels this task and, by ownership, the input operation.
+/// If the output receiver closes first, the input operation is canceled.
 pub(crate) async fn forward<T, U>(
     mut output: oneshot::Sender<T>,
     input: oneshot::Receiver<U>,

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -185,6 +185,25 @@ pub(crate) const fn resolve(verdict: Option<bool>, durable: bool) -> Option<bool
     }
 }
 
+/// Forwards `input` while `output` still has a receiver.
+///
+/// Dropping the output receiver cancels this task and, by ownership, the input operation.
+pub(crate) async fn forward<T, U>(
+    mut output: oneshot::Sender<T>,
+    input: oneshot::Receiver<U>,
+    map: impl FnOnce(U) -> Option<T>,
+) {
+    let result = select! {
+        _ = output.closed() => return,
+        result = input => result,
+    };
+    if let Ok(value) = result
+        && let Some(value) = map(value)
+    {
+        output.send_lossy(value);
+    }
+}
+
 /// Drives a certification gate `task` to a certify verdict, recovering through `fallback` when the
 /// gate cannot speak for the notarized proposal.
 ///
@@ -368,6 +387,20 @@ mod tests {
         // A true verdict publishes only once the store is durable.
         assert_eq!(resolve(Some(true), true), Some(true));
         assert_eq!(resolve(Some(true), false), None);
+    }
+
+    #[test]
+    fn test_forward_cancels_input_when_output_closes() {
+        let runner = deterministic::Runner::default();
+        runner.start(|_| async move {
+            let (input_tx, input_rx) = oneshot::channel::<bool>();
+            let (output_tx, output_rx) = oneshot::channel::<bool>();
+            drop(output_rx);
+
+            forward(output_tx, input_rx, Some).await;
+
+            assert!(input_tx.is_closed());
+        });
     }
 
     #[test]

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -264,7 +264,7 @@ mod tests {
     use super::*;
     use crate::types::{Epoch, View};
     use commonware_cryptography::{Hasher, Sha256, sha256::Digest as Sha256Digest};
-    use commonware_runtime::{Runner, Spawner, deterministic};
+    use commonware_runtime::{Runner, Spawner, Supervisor, deterministic};
     use std::future::ready;
 
     type D = Sha256Digest;
@@ -399,6 +399,26 @@ mod tests {
 
             forward(output_tx, input_rx, Some).await;
 
+            assert!(input_tx.is_closed());
+        });
+    }
+
+    #[test]
+    fn test_forward_cancels_in_flight_input_when_output_closes() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            let (input_tx, input_rx) = oneshot::channel::<bool>();
+            let (output_tx, output_rx) = oneshot::channel::<bool>();
+            let (started_tx, started_rx) = oneshot::channel();
+            let forwarder = context.child("forwarder").spawn(|_| async move {
+                started_tx.send_lossy(());
+                forward(output_tx, input_rx, Some).await;
+            });
+
+            started_rx.await.expect("forwarder should start");
+            assert!(!input_tx.is_closed());
+            drop(output_rx);
+            forwarder.await.expect("forwarder should stop");
             assert!(input_tx.is_closed());
         });
     }

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -59,8 +59,9 @@
 //!
 //! In rare crash cases, it is possible for a notarization certificate to exist without a block being
 //! available to the honest parties (e.g., if the whole network crashed before receiving `f+1` shards
-//! and the proposer went permanently offline). In this case, `certify` will be unable to fetch the
-//! block before timeout and result in a nullification.
+//! and the proposer went permanently offline). In this case, `certify` may remain pending while it
+//! waits for the unavailable block. Simplex may time out and nullify the view, but that timeout does
+//! not resolve the certification request.
 //!
 //! For this reason, it should not be expected that every notarized payload will be certifiable due
 //! to the lack of an available block. However, if even one honest and online party has the block,
@@ -75,7 +76,7 @@
 //! │          B1         │◀──│          B2         │◀──│          B3         │XXX│          B4         │
 //! └─────────────────────┘   └─────────────────────┘   └──────────┬──────────┘   └─────────────────────┘
 //!                                                                │
-//!                                                          Failed Certify
+//!                                                         Pending Certify
 //! ```
 
 use crate::{
@@ -585,9 +586,11 @@ where
                 let verify_rx = marshaled
                     .deferred_verify(embedded_context, payload, Some(block), Stage::Certified)
                     .await;
-                if let Ok(GateOutcome::Ready(result)) = verify_rx.await {
-                    tx.send_lossy(result);
-                }
+                gates::forward(tx, verify_rx, |result| match result {
+                    GateOutcome::Ready(result) => Some(result),
+                    GateOutcome::Recover => None,
+                })
+                .await;
             }
             .instrument(info_span!(
                 "marshal.coding.certify.embedded",
@@ -1066,9 +1069,7 @@ where
                     .with_attribute("round", round);
                 context.spawn(move |_| {
                     async move {
-                        if validity_rx.await.is_ok() {
-                            tx.send_lossy(true);
-                        }
+                        gates::forward(tx, validity_rx, |()| Some(true)).await;
                     }
                     .instrument(info_span!(
                         "marshal.coding.verify.shard_validity",

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1795,24 +1795,22 @@ mod tests {
             };
 
             // Verify must not synthesize `false` when the block cannot be fetched.
-            let verify_rx = marshaled.verify(reproposal_context, missing_payload).await;
+            let mut verify_rx = marshaled.verify(reproposal_context, missing_payload).await;
 
-            // Ensure the certification gate task has registered its subscription, then
-            // force cancellation by pruning the missing commitment.
+            // Register the certification gate before pruning reconstruction state.
             context.sleep(Duration::from_millis(100)).await;
             shards.prune(missing_payload);
 
-            select! {
-                result = verify_rx => {
-                    assert!(
-                        result.is_err(),
-                        "verify should resolve without explicit false when re-proposal block is unavailable"
-                    );
-                },
-                _ = context.sleep(Duration::from_secs(5)) => {
-                    panic!("verify should resolve promptly when re-proposal block is unavailable");
-                },
-            }
+            // Pruning removes reconstruction state but preserves the live local wait.
+            assert!(shards.get(missing_payload).await.is_none());
+            assert!(
+                matches!(
+                    verify_rx.try_recv(),
+                    Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
+                ),
+                "pruning must not cancel a live local-only block wait"
+            );
+            drop(verify_rx);
 
             // Certify should not surface the closed certification gate task as the final result.
             // With no block available, it remains pending on the recovery path until the
@@ -1831,7 +1829,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_core_subscription_closes_when_coding_buffer_prunes_missing_commitment() {
+    fn test_coding_floor_preserves_registered_subscriptions() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -1846,6 +1844,8 @@ mod tests {
             )
             .await;
 
+            // No links are added. Network fetches cannot complete. Waiters
+            // resolve only through the buffer or closure.
             let setup = CodingHarness::setup_validator(
                 context.child("validator").with_attribute("index", 0),
                 &mut oracle,
@@ -1853,45 +1853,115 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
             )
             .await;
-            let marshal = setup.mailbox;
+            let mailbox = setup.mailbox;
             let shards = setup.extra;
 
-            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
-            let missing_commitment = Commitment::from((
-                Sha256::hash(&[b"missing_block"]),
-                Sha256::hash(&[b"missing_root"]),
-                Sha256::hash(&[b"missing_context"]),
-                coding_config,
-            ));
-            let round = Round::new(Epoch::zero(), View::new(1));
+            // Give the missing commitment reconstruction state below the coming
+            // floor. Coding finalization prunes this state even though the block
+            // has not yet been reconstructed.
+            let missing_round = Round::new(Epoch::zero(), View::new(1));
+            let missing = CodingHarness::make_test_block(
+                Sha256::hash(&[b""]),
+                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16),
+                Height::new(1),
+                1_000,
+                NUM_VALIDATORS as u16,
+            );
+            let missing_commitment = CodingHarness::commitment(&missing);
+            shards.discovered(missing_commitment, participants[0].clone(), missing_round);
+            assert!(shards.get(missing_commitment).await.is_none());
 
-            // Subscribe through the core actor. This internally subscribes to the
-            // coding shard buffer and registers local waiters.
-            let block_rx = marshal.subscribe_by_commitment(
+            // Coalesce two fetch-backed subscriptions and a local wait onto the
+            // same core and shard-buffer subscription.
+            let mut by_round = mailbox.subscribe_by_commitment(
                 missing_commitment,
-                core::CommitmentFallback::FetchByRound { round },
+                core::CommitmentFallback::FetchByRound {
+                    round: missing_round,
+                },
+            );
+            let mut by_height = mailbox.subscribe_by_commitment(
+                missing_commitment,
+                core::CommitmentFallback::FetchByCommitment {
+                    height: Height::new(1),
+                },
+            );
+            let mut wait =
+                mailbox.subscribe_by_commitment(missing_commitment, core::CommitmentFallback::Wait);
+            let _ = mailbox.get_processed_height().await;
+
+            // Build a valid floor anchor above the missing reconstruction state.
+            const ANCHOR_HEIGHT: u64 = 5;
+            let mut parent = Sha256::hash(&[b""]);
+            let mut parent_commitment =
+                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16);
+            let mut anchor = None;
+            for height in 1..=ANCHOR_HEIGHT {
+                let block = CodingHarness::make_test_block(
+                    parent,
+                    parent_commitment,
+                    Height::new(height),
+                    height,
+                    NUM_VALIDATORS as u16,
+                );
+                parent = CodingHarness::digest(&block);
+                parent_commitment = CodingHarness::commitment(&block);
+                anchor = Some(block);
+            }
+            let anchor = anchor.unwrap();
+            let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
+            let anchor_commitment = CodingHarness::commitment(&anchor);
+            let anchor_wait = mailbox.subscribe_by_commitment(
+                anchor_commitment,
+                core::CommitmentFallback::FetchByRound {
+                    round: anchor_round,
+                },
             );
 
-            // Allow core actor to register the underlying buffer subscription.
-            context.sleep(Duration::from_millis(100)).await;
-
-            // Prune the missing commitment in the shard engine, which should cancel
-            // the underlying buffer subscription.
-            shards.prune(missing_commitment);
-
-            // The core actor must surface cancellation by closing the subscription,
-            // not by panicking or leaving the waiter parked indefinitely.
-            select! {
-                result = block_rx => {
-                    assert!(
-                        result.is_err(),
-                        "core subscription should close when coding buffer drops subscription"
-                    );
+            let finalization = CodingHarness::make_finalization(
+                Proposal {
+                    round: anchor_round,
+                    parent: View::new(ANCHOR_HEIGHT - 1),
+                    payload: anchor_commitment,
                 },
-                _ = context.sleep(Duration::from_secs(5)) => {
-                    panic!("core subscription should resolve promptly after coding prune");
-                },
+                &schemes,
+                QUORUM,
+            );
+            mailbox.set_floor(finalization);
+            shards.proposed(anchor_round, anchor);
+            assert_eq!(anchor_wait.await.unwrap().commitment(), anchor_commitment);
+
+            // Wait for the application acknowledgement that advances the floors
+            // and asks Coding to prune reconstruction state through the anchor.
+            while mailbox.get_processed_height().await != Some(Height::new(ANCHOR_HEIGHT)) {
+                context.sleep(Duration::from_millis(10)).await;
             }
+            assert!(
+                shards.get(anchor_commitment).await.is_none(),
+                "coding buffer did not process the finalization prune"
+            );
+            let _ = mailbox.get_processed_height().await;
+
+            assert!(matches!(
+                by_round.try_recv(),
+                Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
+            ));
+            assert!(matches!(
+                by_height.try_recv(),
+                Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
+            ));
+            assert!(
+                matches!(
+                    wait.try_recv(),
+                    Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
+                ),
+                "local wait closed during coding finalization"
+            );
+
+            // Reconstruction after pruning satisfies every registered caller.
+            shards.proposed(missing_round, missing);
+            assert_eq!(by_round.await.unwrap().commitment(), missing_commitment);
+            assert_eq!(by_height.await.unwrap().commitment(), missing_commitment);
+            assert_eq!(wait.await.unwrap().commitment(), missing_commitment);
         })
     }
 

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1795,22 +1795,24 @@ mod tests {
             };
 
             // Verify must not synthesize `false` when the block cannot be fetched.
-            let mut verify_rx = marshaled.verify(reproposal_context, missing_payload).await;
+            let verify_rx = marshaled.verify(reproposal_context, missing_payload).await;
 
-            // Register the certification gate before pruning reconstruction state.
+            // Ensure the certification gate task has registered its subscription, then
+            // force cancellation by pruning the missing commitment.
             context.sleep(Duration::from_millis(100)).await;
             shards.prune(missing_payload);
 
-            // Pruning removes reconstruction state but preserves the live local wait.
-            assert!(shards.get(missing_payload).await.is_none());
-            assert!(
-                matches!(
-                    verify_rx.try_recv(),
-                    Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
-                ),
-                "pruning must not cancel a live local-only block wait"
-            );
-            drop(verify_rx);
+            select! {
+                result = verify_rx => {
+                    assert!(
+                        result.is_err(),
+                        "verify should resolve without explicit false when re-proposal block is unavailable"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("verify should resolve promptly when re-proposal block is unavailable");
+                },
+            }
 
             // Certify should not surface the closed certification gate task as the final result.
             // With no block available, it remains pending on the recovery path until the
@@ -1829,7 +1831,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_coding_floor_preserves_registered_subscriptions() {
+    fn test_core_subscription_closes_when_coding_buffer_prunes_missing_commitment() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -1844,8 +1846,6 @@ mod tests {
             )
             .await;
 
-            // No links are added. Network fetches cannot complete. Waiters
-            // resolve only through the buffer or closure.
             let setup = CodingHarness::setup_validator(
                 context.child("validator").with_attribute("index", 0),
                 &mut oracle,
@@ -1853,115 +1853,45 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
             )
             .await;
-            let mailbox = setup.mailbox;
+            let marshal = setup.mailbox;
             let shards = setup.extra;
 
-            // Give the missing commitment reconstruction state below the coming
-            // floor. Coding finalization prunes this state even though the block
-            // has not yet been reconstructed.
-            let missing_round = Round::new(Epoch::zero(), View::new(1));
-            let missing = CodingHarness::make_test_block(
-                Sha256::hash(&[b""]),
-                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16),
-                Height::new(1),
-                1_000,
-                NUM_VALIDATORS as u16,
-            );
-            let missing_commitment = CodingHarness::commitment(&missing);
-            shards.discovered(missing_commitment, participants[0].clone(), missing_round);
-            assert!(shards.get(missing_commitment).await.is_none());
-
-            // Coalesce two fetch-backed subscriptions and a local wait onto the
-            // same core and shard-buffer subscription.
-            let mut by_round = mailbox.subscribe_by_commitment(
-                missing_commitment,
-                core::CommitmentFallback::FetchByRound {
-                    round: missing_round,
-                },
-            );
-            let mut by_height = mailbox.subscribe_by_commitment(
-                missing_commitment,
-                core::CommitmentFallback::FetchByCommitment {
-                    height: Height::new(1),
-                },
-            );
-            let mut wait =
-                mailbox.subscribe_by_commitment(missing_commitment, core::CommitmentFallback::Wait);
-            let _ = mailbox.get_processed_height().await;
-
-            // Build a valid floor anchor above the missing reconstruction state.
-            const ANCHOR_HEIGHT: u64 = 5;
-            let mut parent = Sha256::hash(&[b""]);
-            let mut parent_commitment =
-                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16);
-            let mut anchor = None;
-            for height in 1..=ANCHOR_HEIGHT {
-                let block = CodingHarness::make_test_block(
-                    parent,
-                    parent_commitment,
-                    Height::new(height),
-                    height,
-                    NUM_VALIDATORS as u16,
-                );
-                parent = CodingHarness::digest(&block);
-                parent_commitment = CodingHarness::commitment(&block);
-                anchor = Some(block);
-            }
-            let anchor = anchor.unwrap();
-            let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
-            let anchor_commitment = CodingHarness::commitment(&anchor);
-            let anchor_wait = mailbox.subscribe_by_commitment(
-                anchor_commitment,
-                core::CommitmentFallback::FetchByRound {
-                    round: anchor_round,
-                },
-            );
-
-            let finalization = CodingHarness::make_finalization(
-                Proposal {
-                    round: anchor_round,
-                    parent: View::new(ANCHOR_HEIGHT - 1),
-                    payload: anchor_commitment,
-                },
-                &schemes,
-                QUORUM,
-            );
-            mailbox.set_floor(finalization);
-            shards.proposed(anchor_round, anchor);
-            assert_eq!(anchor_wait.await.unwrap().commitment(), anchor_commitment);
-
-            // Wait for the application acknowledgement that advances the floors
-            // and asks Coding to prune reconstruction state through the anchor.
-            while mailbox.get_processed_height().await != Some(Height::new(ANCHOR_HEIGHT)) {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-            assert!(
-                shards.get(anchor_commitment).await.is_none(),
-                "coding buffer did not process the finalization prune"
-            );
-            let _ = mailbox.get_processed_height().await;
-
-            assert!(matches!(
-                by_round.try_recv(),
-                Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+            let missing_commitment = Commitment::from((
+                Sha256::hash(&[b"missing_block"]),
+                Sha256::hash(&[b"missing_root"]),
+                Sha256::hash(&[b"missing_context"]),
+                coding_config,
             ));
-            assert!(matches!(
-                by_height.try_recv(),
-                Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
-            ));
-            assert!(
-                matches!(
-                    wait.try_recv(),
-                    Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
-                ),
-                "local wait closed during coding finalization"
+            let round = Round::new(Epoch::zero(), View::new(1));
+
+            // Subscribe through the core actor. This internally subscribes to the
+            // coding shard buffer and registers local waiters.
+            let block_rx = marshal.subscribe_by_commitment(
+                missing_commitment,
+                core::CommitmentFallback::FetchByRound { round },
             );
 
-            // Reconstruction after pruning satisfies every registered caller.
-            shards.proposed(missing_round, missing);
-            assert_eq!(by_round.await.unwrap().commitment(), missing_commitment);
-            assert_eq!(by_height.await.unwrap().commitment(), missing_commitment);
-            assert_eq!(wait.await.unwrap().commitment(), missing_commitment);
+            // Allow core actor to register the underlying buffer subscription.
+            context.sleep(Duration::from_millis(100)).await;
+
+            // Prune the missing commitment in the shard engine, which should cancel
+            // the underlying buffer subscription.
+            shards.prune(missing_commitment);
+
+            // The core actor must surface cancellation by closing the subscription,
+            // not by panicking or leaving the waiter parked indefinitely.
+            select! {
+                result = block_rx => {
+                    assert!(
+                        result.is_err(),
+                        "core subscription should close when coding buffer drops subscription"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("core subscription should resolve promptly after coding prune");
+                },
+            }
         })
     }
 

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1031,7 +1031,7 @@ where
             Err(err) => {
                 warn!(%commitment, ?err, "failed to reconstruct block from checked shards");
                 self.state.remove(&commitment);
-                self.drop_subscriptions(commitment);
+                self.drop_commitment_subscriptions(commitment);
                 self.metrics.reconstruction_failures_total.inc();
             }
         }
@@ -1140,24 +1140,21 @@ where
         }
     }
 
-    /// Drops all subscriptions associated with a commitment.
+    /// Drops subscriptions for an exact commitment that cannot reconstruct a valid block.
     ///
-    /// Removing these entries drops all senders, causing receivers to resolve
-    /// with cancellation (`RecvError`) instead of hanging indefinitely.
-    fn drop_subscriptions(&mut self, commitment: Commitment) {
+    /// A different commitment can still reconstruct the same block digest.
+    /// Digest subscriptions remain open for that later availability.
+    fn drop_commitment_subscriptions(&mut self, commitment: Commitment) {
         self.assigned_shard_verified_subscriptions
             .remove(&commitment);
         self.block_subscriptions
             .remove(&BlockSubscriptionKey::Commitment(commitment));
-        self.block_subscriptions
-            .remove(&BlockSubscriptionKey::Digest(
-                commitment.block::<B::Digest>(),
-            ));
     }
 
     /// Prunes all blocks in the reconstructed block cache that are older than the block
-    /// with the given commitment. Also cleans up stale reconstruction state
-    /// and subscriptions.
+    /// with the given commitment. Also cleans up stale reconstruction state and
+    /// assigned-shard subscriptions. Pruning is eviction rather than a tombstone,
+    /// so caller-owned block subscriptions survive.
     ///
     /// This is the only place reconstruction state is pruned by round. We
     /// intentionally avoid pruning on reconstruction success because a
@@ -1174,10 +1171,11 @@ where
                 .retain(|_, entry| entry.block.height() > height);
         }
 
-        // Always clear direct state/subscriptions for the pruned commitment.
-        // This avoids dangling waiters when prune is called for a commitment
-        // that was never reconstructed locally.
-        self.drop_subscriptions(through);
+        // Assigned-shard readiness cannot outlive the reconstruction state
+        // being pruned. Block-availability subscriptions are caller-owned.
+        // They survive cache and state pruning. Event-loop cleanup removes
+        // subscriptions whose receivers have closed.
+        self.assigned_shard_verified_subscriptions.remove(&through);
         let state_round = self.state.remove(&through).map(|state| state.round());
         let cached_round = cached.map(|(round, _)| round);
         let Some(round) = state_round.or(cached_round) else {
@@ -1193,7 +1191,7 @@ where
             keep
         });
         for pruned in pruned_commitments {
-            self.drop_subscriptions(pruned);
+            self.assigned_shard_verified_subscriptions.remove(&pruned);
         }
     }
 }
@@ -3048,7 +3046,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_local_proposal_prune_clears_older_reconstruction_state() {
+    fn test_local_proposal_prune_preserves_older_block_subscription() {
         let fixture: Fixture<C> = Fixture {
             num_peers: 10,
             ..Default::default()
@@ -3076,7 +3074,7 @@ mod tests {
                 let round_b = Round::new(Epoch::zero(), View::new(2));
 
                 peers[2].mailbox.discovered(commitment_a, leader, round_a);
-                let block_sub = peers[2].mailbox.subscribe(commitment_a);
+                let mut block_sub = peers[2].mailbox.subscribe(commitment_a);
 
                 let peer1_index = peers[1].index.get() as u16;
                 let shard_a = block_a.shard(peer1_index).expect("missing shard");
@@ -3102,18 +3100,17 @@ mod tests {
                     "local proposal should be cached before pruning"
                 );
                 peers[2].mailbox.prune(commitment_b);
-
-                select! {
-                    result = block_sub => {
-                        assert!(
-                            result.is_err(),
-                            "older block subscription should close after local-proposal prune"
-                        );
-                    },
-                    _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("older block subscription remained open after local-proposal prune");
-                    },
-                }
+                assert!(
+                    peers[2].mailbox.get(commitment_b).await.is_none(),
+                    "pruned local proposal should leave the cache"
+                );
+                assert!(
+                    matches!(
+                        block_sub.try_recv(),
+                        Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
+                    ),
+                    "older block subscription should survive state pruning"
+                );
 
                 peers[1]
                     .sender
@@ -3128,6 +3125,15 @@ mod tests {
                     !blocked_peer1,
                     "peer1 should not be blocked after older state was pruned"
                 );
+
+                peers[2].mailbox.proposed(round_a, block_a);
+                let reconstructed = select! {
+                    result = block_sub => result.expect("block subscription closed after prune"),
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("preserved block subscription was not satisfied");
+                    },
+                };
+                assert_eq!(reconstructed.commitment(), commitment_a);
             },
         );
     }
@@ -4221,8 +4227,9 @@ mod tests {
         // decoded blob has a different digest than what the commitment claims. This triggers
         // Error::DigestMismatch in try_reconstruct. Verify that:
         //   1. The failed commitment's state is cleaned up
-        //   2. Subscriptions for the failed commitment never resolve
-        //   3. A subsequent valid commitment reconstructs successfully
+        //   2. The exact commitment subscription closes
+        //   3. The digest subscription survives for another commitment
+        //   4. A subsequent valid commitment reconstructs successfully
         let fixture: Fixture<C> = Fixture {
             num_peers: 10,
             ..Default::default()
@@ -4303,16 +4310,16 @@ mod tests {
                     "block should not be available after DigestMismatch"
                 );
 
-                // Block subscription should be closed after failed reconstruction cleanup.
+                // Commitment validity governs the exact-commitment subscription.
+                // The digest subscription accepts another valid commitment.
                 assert!(
                     matches!(block_sub.try_recv(), Err(TryRecvError::Closed)),
                     "subscription should close for failed reconstruction"
                 );
                 assert!(
-                    matches!(digest_sub.try_recv(), Err(TryRecvError::Closed)),
-                    "digest subscription should close after failed reconstruction"
+                    matches!(digest_sub.try_recv(), Err(TryRecvError::Empty)),
+                    "digest subscription should survive failed reconstruction"
                 );
-
                 // Now verify the engine is not stuck: send valid shards for block1's real
                 // commitment and confirm reconstruction succeeds.
                 let real_commitment1 = coded_block1.commitment();
@@ -4348,6 +4355,10 @@ mod tests {
                     .await
                     .expect("valid block should reconstruct after prior failure");
                 assert_eq!(reconstructed.commitment(), real_commitment1);
+                let by_digest = digest_sub
+                    .await
+                    .expect("valid commitment should satisfy digest subscription");
+                assert_eq!(by_digest.commitment(), real_commitment1);
             },
         );
     }

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1140,10 +1140,10 @@ where
         }
     }
 
-    /// Drops subscriptions whose result is bound to an exact commitment.
+    /// Drops subscriptions bound to an exact commitment.
     ///
-    /// A different commitment can still reconstruct the same block digest.
-    /// Digest subscriptions remain open for that later availability.
+    /// Before marshal accepts a block, a candidate can claim a digest it cannot reconstruct.
+    /// Retiring it therefore does not prove the digest unavailable.
     fn drop_commitment_subscriptions(&mut self, commitment: Commitment) {
         self.assigned_shard_verified_subscriptions
             .remove(&commitment);
@@ -4212,8 +4212,8 @@ mod tests {
         // Error::DigestMismatch in try_reconstruct. Verify that:
         //   1. The failed commitment's state is cleaned up
         //   2. The exact commitment subscription closes
-        //   3. The digest subscription survives for another commitment
-        //   4. A subsequent valid commitment reconstructs successfully
+        //   3. The digest subscription survives the invalid candidate
+        //   4. The valid commitment later reconstructs the claimed digest
         let fixture: Fixture<C> = Fixture {
             num_peers: 10,
             ..Default::default()
@@ -4230,7 +4230,8 @@ mod tests {
                 let coded_block2 = CodedBlock::<B, C, H>::new(inner2, coding_config, &STRATEGY);
                 let real_commitment2 = coded_block2.commitment();
 
-                // Build a fake commitment: block1's digest + block2's coding root/context/config.
+                // This is an invalid claim, not a second accepted commitment for block1.
+                // Build it from block1's digest and block2's coding root/context/config.
                 // Shards from block2 will verify against block2's root (present in the fake
                 // commitment), but try_reconstruct will decode block2 and find its digest != D1.
                 let fake_commitment = Commitment::from((

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1151,23 +1151,10 @@ where
             .remove(&BlockSubscriptionKey::Commitment(commitment));
     }
 
-    /// Evicts cached blocks and reconstruction state relative to `through`.
+    /// Evicts cached blocks and reconstruction state through `through`.
     ///
-    /// The production caller has already archived and applied `through`; this cache is not the
-    /// durable source for later use of that block.
-    ///
-    /// Pruning closes assigned-shard and exact-commitment subscriptions for `through` and every
-    /// reconstruction state it retires. Digest subscriptions remain open because another
-    /// commitment may reconstruct the same block digest.
-    ///
-    /// This is not an ingress floor. Queued consensus messages and later-round notifications can
-    /// recreate evicted state.
-    ///
-    /// This is the only place reconstruction state is pruned by round. We
-    /// intentionally avoid pruning on reconstruction success because a
-    /// Byzantine leader can equivocate, producing multiple valid commitments
-    /// in the same round. Both must remain recoverable until finalization
-    /// determines which one is canonical.
+    /// Pruning waits for finalization because a Byzantine leader may produce multiple valid
+    /// commitments in one round.
     fn prune(&mut self, through: Commitment) {
         let cached = self
             .reconstructed_blocks

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1140,7 +1140,7 @@ where
         }
     }
 
-    /// Drops subscriptions for an exact commitment that cannot reconstruct a valid block.
+    /// Drops subscriptions whose result is bound to an exact commitment.
     ///
     /// A different commitment can still reconstruct the same block digest.
     /// Digest subscriptions remain open for that later availability.
@@ -1151,10 +1151,17 @@ where
             .remove(&BlockSubscriptionKey::Commitment(commitment));
     }
 
-    /// Prunes all blocks in the reconstructed block cache that are older than the block
-    /// with the given commitment. Also cleans up stale reconstruction state and
-    /// assigned-shard subscriptions. Pruning is eviction rather than a tombstone,
-    /// so caller-owned block subscriptions survive.
+    /// Evicts cached blocks and reconstruction state relative to `through`.
+    ///
+    /// The production caller has already archived and applied `through`; this cache is not the
+    /// durable source for later use of that block.
+    ///
+    /// Pruning closes assigned-shard and exact-commitment subscriptions for `through` and every
+    /// reconstruction state it retires. Digest subscriptions remain open because another
+    /// commitment may reconstruct the same block digest.
+    ///
+    /// This is not an ingress floor. Queued consensus messages and later-round notifications can
+    /// recreate evicted state.
     ///
     /// This is the only place reconstruction state is pruned by round. We
     /// intentionally avoid pruning on reconstruction success because a
@@ -1171,11 +1178,9 @@ where
                 .retain(|_, entry| entry.block.height() > height);
         }
 
-        // Assigned-shard readiness cannot outlive the reconstruction state
-        // being pruned. Block-availability subscriptions are caller-owned.
-        // They survive cache and state pruning. Event-loop cleanup removes
-        // subscriptions whose receivers have closed.
-        self.assigned_shard_verified_subscriptions.remove(&through);
+        // Finalization makes existing exact-commitment and assigned-shard waits for these states
+        // obsolete. Digest waits are not commitment-specific.
+        self.drop_commitment_subscriptions(through);
         let state_round = self.state.remove(&through).map(|state| state.round());
         let cached_round = cached.map(|(round, _)| round);
         let Some(round) = state_round.or(cached_round) else {
@@ -1191,7 +1196,7 @@ where
             keep
         });
         for pruned in pruned_commitments {
-            self.assigned_shard_verified_subscriptions.remove(&pruned);
+            self.drop_commitment_subscriptions(pruned);
         }
     }
 }
@@ -3046,7 +3051,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_local_proposal_prune_preserves_older_block_subscription() {
+    fn test_local_proposal_prune_clears_older_reconstruction_state() {
         let fixture: Fixture<C> = Fixture {
             num_peers: 10,
             ..Default::default()
@@ -3074,7 +3079,7 @@ mod tests {
                 let round_b = Round::new(Epoch::zero(), View::new(2));
 
                 peers[2].mailbox.discovered(commitment_a, leader, round_a);
-                let mut block_sub = peers[2].mailbox.subscribe(commitment_a);
+                let block_sub = peers[2].mailbox.subscribe(commitment_a);
 
                 let peer1_index = peers[1].index.get() as u16;
                 let shard_a = block_a.shard(peer1_index).expect("missing shard");
@@ -3100,17 +3105,18 @@ mod tests {
                     "local proposal should be cached before pruning"
                 );
                 peers[2].mailbox.prune(commitment_b);
-                assert!(
-                    peers[2].mailbox.get(commitment_b).await.is_none(),
-                    "pruned local proposal should leave the cache"
-                );
-                assert!(
-                    matches!(
-                        block_sub.try_recv(),
-                        Err(commonware_utils::channel::oneshot::error::TryRecvError::Empty)
-                    ),
-                    "older block subscription should survive state pruning"
-                );
+
+                select! {
+                    result = block_sub => {
+                        assert!(
+                            result.is_err(),
+                            "older block subscription should close after local-proposal prune"
+                        );
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("older block subscription remained open after local-proposal prune");
+                    },
+                }
 
                 peers[1]
                     .sender
@@ -3125,15 +3131,6 @@ mod tests {
                     !blocked_peer1,
                     "peer1 should not be blocked after older state was pruned"
                 );
-
-                peers[2].mailbox.proposed(round_a, block_a);
-                let reconstructed = select! {
-                    result = block_sub => result.expect("block subscription closed after prune"),
-                    _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("preserved block subscription was not satisfied");
-                    },
-                };
-                assert_eq!(reconstructed.commitment(), commitment_a);
             },
         );
     }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -324,22 +324,10 @@ where
         receiver
     }
 
-    /// Request to evict cached blocks and reconstruction state relative to `through`.
+    /// Evict cached blocks and reconstruction state through `through`.
     ///
-    /// Marshal invokes this after the finalized block is durable and acknowledged by the
-    /// application. Later use of that block can recover it from marshal's archive without relying
-    /// on this reconstruction cache.
-    ///
-    /// Cached blocks are evicted through `through`'s cached height, when present. Reconstruction
-    /// state is evicted through the round recorded for `through` in either the cache or state.
-    ///
-    /// Pruning does not install an ingress floor. Proposal, discovery, and notarization messages may
-    /// already be queued, and peer shards do not carry a round. A later-round notification can
-    /// therefore recreate reconstruction state for an evicted commitment.
-    ///
-    /// Pruning closes assigned-shard and exact-commitment subscriptions for `through` and every
-    /// reconstruction state it retires. Digest subscriptions remain open because another
-    /// commitment may reconstruct the same block digest.
+    /// Assigned-shard and exact-commitment subscriptions for retired state are closed. Digest
+    /// subscriptions remain open, and later consensus notifications may recreate state.
     pub fn prune(&self, through: Commitment) {
         let _ = self.sender.enqueue(Message::Prune { through });
     }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -324,7 +324,13 @@ where
         receiver
     }
 
-    /// Request to prune all caches at and below the given commitment.
+    /// Request to prune reconstruction caches and state at and below the given commitment.
+    ///
+    /// Pruning only evicts reconstruction state. It does not declare the commitment permanently
+    /// unavailable. A later proposal or discovery can recreate the state. Block-availability
+    /// subscriptions remain registered and can resolve if the block is reconstructed again. Drop
+    /// the receiver to cancel a subscription. Assigned-shard verification subscriptions are tied
+    /// to reconstruction state and close when it is pruned.
     pub fn prune(&self, through: Commitment) {
         let _ = self.sender.enqueue(Message::Prune { through });
     }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -94,7 +94,7 @@ where
         /// The response channel.
         response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
     },
-    /// A request to prune all caches at and below the given commitment.
+    /// A request to evict cached blocks and reconstruction state relative to a commitment.
     Prune {
         /// Inclusive prune target [`Commitment`].
         through: Commitment,
@@ -324,13 +324,22 @@ where
         receiver
     }
 
-    /// Request to prune reconstruction caches and state at and below the given commitment.
+    /// Request to evict cached blocks and reconstruction state relative to `through`.
     ///
-    /// Pruning only evicts reconstruction state. It does not declare the commitment permanently
-    /// unavailable. A later proposal or discovery can recreate the state. Block-availability
-    /// subscriptions remain registered and can resolve if the block is reconstructed again. Drop
-    /// the receiver to cancel a subscription. Assigned-shard verification subscriptions are tied
-    /// to reconstruction state and close when it is pruned.
+    /// Marshal invokes this after the finalized block is durable and acknowledged by the
+    /// application. Later use of that block can recover it from marshal's archive without relying
+    /// on this reconstruction cache.
+    ///
+    /// Cached blocks are evicted through `through`'s cached height, when present. Reconstruction
+    /// state is evicted through the round recorded for `through` in either the cache or state.
+    ///
+    /// Pruning does not install an ingress floor. Proposal, discovery, and notarization messages may
+    /// already be queued, and peer shards do not carry a round. A later-round notification can
+    /// therefore recreate reconstruction state for an evicted commitment.
+    ///
+    /// Pruning closes assigned-shard and exact-commitment subscriptions for `through` and every
+    /// reconstruction state it retires. Digest subscriptions remain open because another
+    /// commitment may reconstruct the same block digest.
     pub fn prune(&self, through: Commitment) {
         let _ = self.sender.enqueue(Message::Prune { through });
     }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -450,6 +450,7 @@ where
                         .await;
                 }
                 Err(key) => {
+                    // A closed buffer subscription marks the key as permanently unavailable.
                     match key {
                         SubscriptionKey::Digest(digest) => {
                             debug!(
@@ -903,10 +904,6 @@ where
                 }
 
                 self = self.prune_finalized_archives(height).await;
-
-                // Intentionally keep existing block subscriptions alive. Canceling
-                // waiters can have catastrophic consequences because actors do not
-                // retry subscriptions on failed channels.
             }
         }
         self
@@ -1079,12 +1076,12 @@ where
             return;
         }
 
-        // We don't have the block locally. Local-only waits reach this point
-        // without a round or height, so they only register a subscriber below.
+        // Resolver admission controls remote acquisition. Every caller remains
+        // registered for later local availability.
         //
         // Round-based fetching is for notarized proposal lookups whose height is
         // not known before the request. Height-based fetching is only for callers
-        // that already have a validated pruning height.
+        // that have a validated block height for resolver retention.
         match fallback {
             CommitmentFallback::FetchByRound { round } => {
                 // Fetch the notarized proposal for this round. The response
@@ -1092,14 +1089,10 @@ where
                 // certified round context. The decoded block is heightable, but
                 // that height is not known soon enough to key, coalesce, or prune
                 // the in-flight resolver request.
-                if self
-                    .floor
+                self.floor
                     .fetch_if_permitted(resolver, Request::notarized(round))
-                    .denied()
-                {
-                    return;
-                }
-                debug!(?round, ?digest, "requested block missing");
+                    .ignore();
+                debug!(?round, ?digest, "notarized block unavailable");
             }
             CommitmentFallback::FetchByCommitment { height } => {
                 let commitment = match key {
@@ -1111,30 +1104,21 @@ where
 
                 // This path is only for accepted ancestry or finalized repair,
                 // never for a candidate block's immediate parent.
-                if self
-                    .floor
+                self.floor
                     .fetch_if_permitted(resolver, Request::certified_block(commitment, height))
-                    .denied()
-                {
-                    return;
-                }
-                debug!(%height, ?commitment, ?digest, "requested certified ancestry block missing");
+                    .ignore();
+                debug!(%height, ?commitment, ?digest, "certified ancestry block unavailable");
             }
             CommitmentFallback::Wait => {}
         }
 
-        let round = match fallback {
-            CommitmentFallback::FetchByRound { round } => Some(round),
-            CommitmentFallback::Wait | CommitmentFallback::FetchByCommitment { .. } => None,
-        };
-
         // Register subscriber.
         match key {
             SubscriptionKey::Digest(digest) => {
-                debug!(?round, ?digest, "registering subscriber");
+                debug!(?fallback, ?digest, "registering subscriber");
             }
             SubscriptionKey::Commitment(commitment) => {
-                debug!(?round, ?commitment, ?digest, "registering subscriber");
+                debug!(?fallback, ?commitment, ?digest, "registering subscriber");
             }
         }
         self.block_subscriptions
@@ -1361,9 +1345,9 @@ where
         // The floor is durable, so cache/finalized data below it can be pruned.
         self = self.prune_after_floor(height).await;
 
-        // Intentionally keep existing block subscriptions alive. Canceling
-        // waiters can have catastrophic consequences (nodes can get stuck in
-        // different views) as actors do not retry subscriptions on failed channels.
+        // Keep caller-owned block subscriptions alive across the floor update. Resolver pruning
+        // stops obsolete network work, but later local ingress can still satisfy these waiters,
+        // and callers do not retry a closed subscription.
         let repaired;
         (self, repaired) = self.try_repair_gaps(buffer, resolver, application).await;
         if repaired {
@@ -2326,7 +2310,7 @@ where
             .processed_height
             .try_set(self.floor.processed_height().get());
 
-        // Prune any existing requests below the new floor.
+        // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_height_floor::<V::Commitment>(height));
     }
 
@@ -2388,7 +2372,7 @@ where
         );
         self.cache = self.cache.prune_by_view(prune_round).await;
 
-        // Prune round-bound requests at or below the processed round.
+        // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_round_floor::<V::Commitment>(
             self.floor.processed_round(),
         ));

--- a/consensus/src/marshal/core/floor.rs
+++ b/consensus/src/marshal/core/floor.rs
@@ -34,11 +34,6 @@ pub(super) enum FetchAdmission {
 }
 
 impl FetchAdmission {
-    #[cfg(test)]
-    pub(super) const fn denied(self) -> bool {
-        matches!(self, Self::Denied)
-    }
-
     pub(super) const fn ignore(self) {}
 }
 
@@ -273,36 +268,31 @@ mod tests {
         let floor = floor();
         let mut resolver = TestResolver::default();
 
-        assert!(
-            floor
-                .fetch_if_permitted(&mut resolver, Request::finalized(Height::new(5)))
-                .denied()
-        );
-        assert!(
-            floor
-                .fetch_if_permitted(
-                    &mut resolver,
-                    Request::finalized_block_by_height(digest(1), Height::new(4)),
-                )
-                .denied()
-        );
-        assert!(
-            floor
-                .fetch_if_permitted(&mut resolver, Request::notarized(round(5)))
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_if_permitted(&mut resolver, Request::finalized(Height::new(5))),
+            FetchAdmission::Denied
+        ));
+        assert!(matches!(
+            floor.fetch_if_permitted(
+                &mut resolver,
+                Request::finalized_block_by_height(digest(1), Height::new(4)),
+            ),
+            FetchAdmission::Denied
+        ));
+        assert!(matches!(
+            floor.fetch_if_permitted(&mut resolver, Request::notarized(round(5))),
+            FetchAdmission::Denied
+        ));
         assert!(resolver.fetches().is_empty());
 
-        assert!(
-            !floor
-                .fetch_if_permitted(&mut resolver, Request::finalized(Height::new(6)))
-                .denied()
-        );
-        assert!(
-            !floor
-                .fetch_if_permitted(&mut resolver, Request::notarized(round(6)))
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_if_permitted(&mut resolver, Request::finalized(Height::new(6))),
+            FetchAdmission::Issued
+        ));
+        assert!(matches!(
+            floor.fetch_if_permitted(&mut resolver, Request::notarized(round(6))),
+            FetchAdmission::Issued
+        ));
 
         let fetches = resolver.fetches();
         assert_eq!(fetches.len(), 2);
@@ -339,26 +329,24 @@ mod tests {
         let mut rng = commonware_utils::test_rng();
         let target = crypto_ed25519::PrivateKey::random(&mut rng).public_key();
 
-        assert!(
-            floor
-                .fetch_targeted_if_permitted(
-                    &mut resolver,
-                    Request::finalized(Height::new(5)),
-                    NonEmptyVec::new(target.clone()),
-                )
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_targeted_if_permitted(
+                &mut resolver,
+                Request::finalized(Height::new(5)),
+                NonEmptyVec::new(target.clone()),
+            ),
+            FetchAdmission::Denied
+        ));
         assert!(resolver.targeted().is_empty());
 
-        assert!(
-            !floor
-                .fetch_targeted_if_permitted(
-                    &mut resolver,
-                    Request::finalized(Height::new(6)),
-                    NonEmptyVec::new(target),
-                )
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_targeted_if_permitted(
+                &mut resolver,
+                Request::finalized(Height::new(6)),
+                NonEmptyVec::new(target),
+            ),
+            FetchAdmission::Issued
+        ));
         assert_eq!(
             resolver.targeted(),
             vec![Key::Finalized {
@@ -372,19 +360,18 @@ mod tests {
         let floor = floor();
         let mut resolver = TestResolver::default();
 
-        assert!(
-            !floor
-                .fetch_all_if_permitted(
-                    &mut resolver,
-                    vec![
-                        Request::finalized(Height::new(5)),
-                        Request::finalized(Height::new(6)),
-                        Request::notarized(round(5)),
-                        Request::notarized(round(6)),
-                    ],
-                )
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_all_if_permitted(
+                &mut resolver,
+                vec![
+                    Request::finalized(Height::new(5)),
+                    Request::finalized(Height::new(6)),
+                    Request::notarized(round(5)),
+                    Request::notarized(round(6)),
+                ],
+            ),
+            FetchAdmission::Issued
+        ));
 
         let fetches = resolver.fetches();
         assert_eq!(fetches.len(), 2);
@@ -394,17 +381,16 @@ mod tests {
         );
 
         let mut resolver = TestResolver::default();
-        assert!(
-            floor
-                .fetch_all_if_permitted(
-                    &mut resolver,
-                    vec![
-                        Request::finalized(Height::new(5)),
-                        Request::notarized(round(5)),
-                    ],
-                )
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_all_if_permitted(
+                &mut resolver,
+                vec![
+                    Request::finalized(Height::new(5)),
+                    Request::notarized(round(5)),
+                ],
+            ),
+            FetchAdmission::Denied
+        ));
         assert!(resolver.fetches().is_empty());
     }
 
@@ -413,11 +399,10 @@ mod tests {
         let floor = Floor::<TestScheme, TestDigest>::resolved(None, round(5));
         let mut resolver = TestResolver::default();
 
-        assert!(
-            !floor
-                .fetch_if_permitted(&mut resolver, Request::finalized(Height::zero()))
-                .denied()
-        );
+        assert!(matches!(
+            floor.fetch_if_permitted(&mut resolver, Request::finalized(Height::zero())),
+            FetchAdmission::Issued
+        ));
 
         let fetches = resolver.fetches();
         assert_eq!(fetches.len(), 1);

--- a/consensus/src/marshal/core/floor.rs
+++ b/consensus/src/marshal/core/floor.rs
@@ -34,6 +34,7 @@ pub(super) enum FetchAdmission {
 }
 
 impl FetchAdmission {
+    #[cfg(test)]
     pub(super) const fn denied(self) -> bool {
         matches!(self, Self::Denied)
     }

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -259,20 +259,19 @@ pub enum CommitmentFallback {
     /// child may lie about its height.
     ///
     /// The returned block is heightable once decoded, but that is too late for
-    /// the in-flight resolver key or pruning bound.
+    /// the in-flight resolver key or retention bound.
     FetchByRound { round: Round },
     /// Request the exact commitment from peers and prune the request at
     /// `height`.
     ///
-    /// Use this only when no certified parent round is available and the caller
-    /// has a locally validated pruning bound, such as repairing a finalized gap
-    /// or walking an accepted ancestry stream. Do not use it for a candidate's
-    /// immediate parent when the consensus context supplies the parent round.
+    /// Use this only when no certified parent round is available. The caller must have a locally
+    /// validated resolver retention bound. Examples include repairing a finalized gap or walking
+    /// an accepted ancestry stream. Do not use it for a candidate's immediate parent when the
+    /// consensus context supplies the parent round.
     ///
-    /// The height is not sent to peers. It is a local pruning hint for request
-    /// retention, not part of response validity: a fetched block is delivered
-    /// if its commitment matches, and certified storage uses the decoded block
-    /// height.
+    /// The height is not sent to peers. It is a local hint for request retention.
+    /// It is not part of response validity. A fetched block is delivered if its
+    /// commitment matches. Certified storage uses the decoded block height.
     FetchByCommitment { height: Height },
 }
 
@@ -733,6 +732,10 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// will be notified when the block is available. If the block is not finalized, it's possible
     /// that it may never become available.
     ///
+    /// Resolver fetches and subscriptions have independent lifetimes. The processed floor may deny
+    /// or retire a fetch. The subscription remains open while the block may still arrive through
+    /// local ingress. It closes without delivery only when marshal can no longer obtain the block.
+    ///
     /// The `fallback` parameter controls whether marshal also asks peers for the missing block.
     /// Digest-keyed subscriptions only support waiting locally or fetching by round.
     ///
@@ -763,6 +766,10 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// If the block is not available locally, the subscription will be registered and the caller
     /// will be notified when the block is available. If the block is not finalized, it's possible
     /// that it may never become available.
+    ///
+    /// Resolver fetches and subscriptions have independent lifetimes. The processed floor may deny
+    /// or retire a fetch. The subscription remains open while the block may still arrive through
+    /// local ingress. It closes without delivery only when marshal can no longer obtain the block.
     ///
     /// The `fallback` parameter controls whether marshal also asks peers for the missing block.
     ///

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -12,6 +12,10 @@ use tracing::{Span, info_span};
 
 /// A set of local subscribers waiting for one block.
 ///
+/// The retrieval strategy is not part of subscription ownership. Each caller
+/// remains registered until delivery, caller cancellation, or a backing-buffer
+/// closure that proves the buffer can no longer deliver.
+///
 /// Dropping the subscription aborts the backing buffer waiter, if one exists.
 struct BlockSubscription<V: Variant> {
     subscribers: Vec<Subscriber<V>>,

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -141,6 +141,9 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     /// If the block is already cached, the receiver may resolve immediately.
     /// Returns `None` when the buffer cannot provide availability notifications.
     ///
+    /// Keep the subscription open while the block may still arrive. Close it only when the buffer
+    /// shuts down or can no longer obtain the block from any source.
+    ///
     /// The returned receiver can be dropped to cancel the subscription.
     fn subscribe_by_digest(
         &self,
@@ -155,6 +158,9 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     ///
     /// Having the full commitment may enable additional retrieval mechanisms
     /// depending on the variant implementation.
+    ///
+    /// Keep the subscription open while the block may still arrive. Close it only when the buffer
+    /// shuts down or can no longer obtain the block from any source.
     ///
     /// The returned receiver can be dropped to cancel the subscription.
     fn subscribe_by_commitment(

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -5081,7 +5081,10 @@ where
             )
             .await
             .unwrap();
-        let blocks = ancestry.collect::<Vec<_>>().await;
+
+        // Consume the known finalized range. The stream may keep waiting for
+        // an older parent while that parent can still become available.
+        let blocks = ancestry.take(5).collect::<Vec<_>>().await;
 
         // Ensure correct delivery order: 5,4,3,2,1
         assert_eq!(blocks.len(), 5);

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -44,8 +44,8 @@
 //! # Notarization and Data Availability
 //!
 //! In rare crash cases, it is possible for a notarization certificate to exist without a block being
-//! available to the honest parties if [`CertifiableAutomaton::certify`] fails after a notarization is
-//! formed.
+//! available to the honest parties. [`CertifiableAutomaton::certify`] may then remain pending while
+//! it waits for the block. Simplex may time out and nullify the view without resolving that request.
 //!
 //! For this reason, it should not be expected that every notarized payload will be certifiable due
 //! to the lack of an available block. However, if even one honest and online party has the block,
@@ -58,7 +58,7 @@
 //! │          B1         │◀──│          B2         │◀──│          B3         │XXX│          B4         │
 //! └─────────────────────┘   └─────────────────────┘   └──────────┬──────────┘   └─────────────────────┘
 //!                                                                │
-//!                                                          Failed Certify
+//!                                                         Pending Certify
 //! ```
 //!
 //! # Future Work
@@ -415,9 +415,11 @@ where
                 let verify_rx = marshaled
                     .deferred_verify(embedded_context, block, parent_request, Stage::Certified)
                     .await;
-                if let Ok(GateOutcome::Ready(result)) = verify_rx.await {
-                    tx.send_lossy(result);
-                }
+                gates::forward(tx, verify_rx, |result| match result {
+                    GateOutcome::Ready(result) => Some(result),
+                    GateOutcome::Recover => None,
+                })
+                .await;
             }
             .instrument(info_span!(
                 "marshal.deferred.certify.embedded",
@@ -816,19 +818,14 @@ where
                 // `task_tx` so `certify` observes the same result via the
                 // synchronously-registered `task_rx`.
                 //
-                // The awaits below are deliberately not guarded on `tx.closed()`.
-                // Once the optimistic verdict is delivered, the gate is the only
-                // remaining consumer, and certification can still want it after
-                // the view exits (nullification does not cancel certification
-                // work), so deferred verification must run to completion into
-                // the gate.
+                // Once the optimistic verdict is delivered, the certification
+                // gate owns the deferred work. Nullification keeps that gate
+                // alive, while finalization drops it.
                 let deferred_rx = marshaled
                     .deferred_verify(context, block, parent_request, Stage::Verified)
                     .await;
                 tx.send_lossy(true);
-                if let Ok(result) = deferred_rx.await {
-                    task_tx.send_lossy(result);
-                }
+                gates::forward(task_tx, deferred_rx, Some).await;
             }
             .instrument(info_span!(
                 "marshal.deferred.verify.optimistic",

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -1486,6 +1486,136 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_standard_floor_preserves_registered_subscriptions() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            // No links are added. Network fetches cannot complete. Waiters
+            // resolve only through the buffer or closure.
+            let setup = StandardHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                participants[0].clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let mailbox = setup.mailbox;
+            let buffer = setup.extra;
+
+            // Build a chain whose tip is the floor anchor.
+            const ANCHOR_HEIGHT: u64 = 5;
+            let mut parent = Sha256::hash(&[b""]);
+            let mut anchor = None;
+            for i in 1..=ANCHOR_HEIGHT {
+                let block = make_raw_block(parent, Height::new(i), i);
+                parent = block.digest();
+                anchor = Some(block);
+            }
+            let anchor = anchor.unwrap();
+            let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
+
+            // Register every acquisition mode for the same unavailable parent.
+            // The parent subscription models verification that remains active
+            // while unrelated application progress advances the floor.
+            let missing = make_raw_block(Sha256::hash(&[b"missing-parent"]), Height::new(2), 999);
+            let missing_digest = missing.digest();
+            let child = make_raw_block(missing_digest, Height::new(3), 1_000);
+            let mut by_round = mailbox.subscribe_by_digest(
+                missing_digest,
+                DigestFallback::FetchByRound {
+                    round: Round::new(Epoch::zero(), View::new(2)),
+                },
+            );
+            let mut by_height = mailbox.subscribe_by_commitment(
+                missing_digest,
+                CommitmentFallback::FetchByCommitment {
+                    height: Height::new(2),
+                },
+            );
+            let mut wait = mailbox.subscribe_by_digest(missing_digest, DigestFallback::Wait);
+            let mut parent = Box::pin(mailbox.subscribe_parent(&child));
+
+            // The anchor subscription resolves when the block arrives.
+            let anchor_wait = mailbox.subscribe_by_digest(
+                anchor.digest(),
+                DigestFallback::FetchByRound {
+                    round: anchor_round,
+                },
+            );
+
+            // Install the floor and deliver the anchor through the buffer.
+            let finalization = StandardHarness::make_finalization(
+                Proposal {
+                    round: anchor_round,
+                    parent: View::new(ANCHOR_HEIGHT - 1),
+                    payload: anchor.digest(),
+                },
+                &schemes,
+                QUORUM,
+            );
+            mailbox.set_floor(finalization);
+            let _ = buffer.broadcast(Recipients::All, anchor.clone());
+            let received = anchor_wait.await.unwrap();
+            assert_eq!(received.digest(), anchor.digest());
+
+            // Wait for the application to process the anchor so the processed
+            // floors advance past the subscriptions' fetch coordinates.
+            while mailbox.get_processed_height().await != Some(Height::new(ANCHOR_HEIGHT)) {
+                context.sleep(Duration::from_millis(50)).await;
+            }
+
+            // Parent availability determines subscription lifetime.
+            assert!(matches!(by_round.try_recv(), Err(TryRecvError::Empty)));
+            assert!(matches!(by_height.try_recv(), Err(TryRecvError::Empty)));
+            assert!(matches!(wait.try_recv(), Err(TryRecvError::Empty)));
+            select! {
+                result = &mut parent => {
+                    panic!("parent subscription resolved at processed floor: {result:?}");
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {},
+            };
+
+            // A below-floor request skips remote acquisition and keeps a
+            // subscription for local ingress.
+            let mut late_by_round = mailbox.subscribe_by_digest(
+                missing_digest,
+                DigestFallback::FetchByRound {
+                    round: Round::new(Epoch::zero(), View::new(3)),
+                },
+            );
+            let mut late_parent = Box::pin(mailbox.subscribe_parent(&child));
+            let _ = mailbox.get_processed_height().await;
+            assert!(matches!(late_by_round.try_recv(), Err(TryRecvError::Empty)));
+            select! {
+                result = &mut late_parent => {
+                    panic!("late parent subscription resolved before availability: {result:?}");
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {},
+            };
+
+            // Later local availability satisfies every registered caller.
+            let _ = buffer.broadcast(Recipients::All, missing.clone());
+            assert_eq!(by_round.await.unwrap().digest(), missing_digest);
+            assert_eq!(by_height.await.unwrap().digest(), missing_digest);
+            assert_eq!(wait.await.unwrap().digest(), missing_digest);
+            assert_eq!(parent.await.unwrap().digest(), missing_digest);
+            assert_eq!(late_by_round.await.unwrap().digest(), missing_digest);
+            assert_eq!(late_parent.await.unwrap().digest(), missing_digest);
+        })
+    }
+
+    #[test_traced("WARN")]
     fn test_standard_resolver_floor_anchor_install_wakes_subscriber() {
         let runner = deterministic::Runner::timed(Duration::from_secs(60));
         runner.start(|mut context| async move {
@@ -5991,7 +6121,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_standard_round_fetches_reject_processed_round() {
+    fn test_standard_processed_round_skips_fetch_and_preserves_subscription() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
@@ -6002,7 +6132,7 @@ mod tests {
             let proposal = Proposal::new(round, View::zero(), StandardHarness::commitment(&block));
             let finalization = StandardHarness::make_finalization(proposal, &schemes, QUORUM);
             let application = Application::<B>::manual_ack();
-            let (mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
+            let (mailbox, buffer, resolver, _actor_handle) = start_standard_actor(
                 context.child("validator"),
                 "fetch-notarized-processed-round",
                 ConstantProvider::new(schemes[0].clone()),
@@ -6011,6 +6141,7 @@ mod tests {
                 Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
             )
             .await;
+            let buffer = buffer.expect("buffer was provided");
             let mut mailbox = mailbox;
             assert_eq!(application.acknowledged().await, Height::zero());
 
@@ -6036,8 +6167,10 @@ mod tests {
 
             let fetches_before = resolver.fetches().len();
             mailbox.hint_notarized(round, Sha256::hash(&[b"missing-at-processed-round"]));
-            let subscription = mailbox.subscribe_by_commitment(
-                Sha256::hash(&[b"missing-subscription-at-processed-round"]),
+            let missing = make_raw_block(Sha256::hash(&[b""]), Height::new(1), 101);
+            let missing_digest = missing.digest();
+            let mut subscription = mailbox.subscribe_by_commitment(
+                missing_digest,
                 CommitmentFallback::FetchByRound { round },
             );
 
@@ -6054,17 +6187,15 @@ mod tests {
                 fetches_before,
                 "hint_notarized must not enqueue the already-pruned processed round"
             );
-            select! {
-                result = subscription => {
-                    assert!(
-                        result.is_err(),
-                        "processed-round subscription should be canceled without a fetch"
-                    );
-                },
-                _ = context.sleep(Duration::from_secs(5)) => {
-                    panic!("processed-round subscription remained open");
-                },
-            }
+            assert!(matches!(subscription.try_recv(), Err(TryRecvError::Empty)));
+
+            buffer
+                .commitment_subscriptions
+                .lock()
+                .pop()
+                .expect("commitment subscription should be registered")
+                .send_lossy(Arc::new(missing));
+            assert_eq!(subscription.await.unwrap().digest(), missing_digest);
         });
     }
 
@@ -6235,7 +6366,7 @@ mod tests {
             drop(mailbox);
             context.sleep(Duration::from_millis(1)).await;
 
-            let (mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
+            let (mailbox, buffer, resolver, _actor_handle) = start_standard_actor(
                 context
                     .child("validator_restart")
                     .with_attribute("index", 0),
@@ -6246,11 +6377,14 @@ mod tests {
                 Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
             )
             .await;
+            let buffer = buffer.expect("buffer was provided");
 
             let fetches_before = resolver.fetches().len();
             mailbox.hint_notarized(round, Sha256::hash(&[b"missing-after-restart"]));
-            let subscription = mailbox.subscribe_by_commitment(
-                Sha256::hash(&[b"missing-subscription-after-restart"]),
+            let missing = make_raw_block(Sha256::hash(&[b""]), Height::new(1), 101);
+            let missing_digest = missing.digest();
+            let mut subscription = mailbox.subscribe_by_commitment(
+                missing_digest,
                 CommitmentFallback::FetchByRound { round },
             );
 
@@ -6266,17 +6400,17 @@ mod tests {
                 fetches_before,
                 "restart must restore the processed round floor"
             );
-            select! {
-                result = subscription => {
-                    assert!(
-                        result.is_err(),
-                        "processed-round subscription should be canceled after restart"
-                    );
-                },
-                _ = context.sleep(Duration::from_secs(5)) => {
-                    panic!("processed-round subscription remained open after restart");
-                },
-            }
+            assert!(matches!(subscription.try_recv(), Err(TryRecvError::Empty)));
+
+            // Restored progress controls network acquisition. Local ingress
+            // remains a valid source for the block.
+            buffer
+                .commitment_subscriptions
+                .lock()
+                .pop()
+                .expect("commitment subscription should be registered")
+                .send_lossy(Arc::new(missing));
+            assert_eq!(subscription.await.unwrap().digest(), missing_digest);
         });
     }
 


### PR DESCRIPTION
Related: #4332

## Summary

Separates marshal block-subscription ownership from resolver fetch lifetime while keeping Coding reconstruction cleanup terminal for exact state-bound waits.

- Processed and finalized floors may deny or retire obsolete network acquisition without automatically canceling a caller that can still be satisfied by local ingress.
- Standard and Coding subscriptions coalesce callers until delivery, caller cancellation, or a terminal backing-buffer closure.
- Coding prune evicts reconstruction cache and state, closing assigned-shard and exact-commitment waiters for the state it retires. Digest waiters remain available because another commitment may reconstruct the same block digest.
- Downstream cancellation propagates through Standard Deferred and Coding verification, so caller abandonment or covering finalization releases owned inner work. Nullification leaves the certification gate alive for later certification.

## Motivation

Resolver progress and reconstruction cleanup establish different terminal conditions. A processed floor can make a remote fetch obsolete while the block may still arrive locally, so it must not implicitly discard the caller. Coding prune occurs after the finalized block is durable and application-acknowledged, and may retire exact reconstruction attempts that should no longer keep callers parked.

Keeping these lifetimes explicit prevents ordinary resolver cleanup from becoming a liveness failure without preserving obsolete exact-commitment work after Coding state is pruned.

## Scope

This is the marshal subscription and cancellation lifecycle split out of #4332. It intentionally excludes the Simplex targeted ancestry repair, the generic resolver outcome API already landed in #4383, and Stateful scheduling/replay optimizations.

There are no new dependencies, public API signatures, encoded types, wire-format changes, or storage-format changes.

## Testing

Deterministic coverage exercises:

- subscriptions across processed and finalized resolver-floor advancement;
- restored processed floors after restart;
- Coding prune closing exact-commitment and assigned-state work;
- exact-commitment reconstruction failure with digest recovery under another commitment;
- later-view certification surviving unrelated earlier-view retention pruning;
- forwarding cancellation and covering-finalization gate cleanup; and
- ancestry streams under the separated ownership model.

Validation completed with:

- `just check-fmt`
- `just test -p commonware-consensus`
- `just check-docs -p commonware-consensus`
- `just clippy -p commonware-consensus`
- `just check-stability`