### PR TITLE
[storage] Reuse shared helpers across qmdb, merkle, and bitmap

### DIFF
--- a/storage/src/bitmap/authenticated.rs
+++ b/storage/src/bitmap/authenticated.rs
@@ -172,13 +172,7 @@ impl<E: Context, D: Digest, const N: usize, M: State<D>, S: Strategy> BitMap<E, 
     /// The returned index is absolute and includes pruned chunks.
     #[inline]
     fn complete_chunks(&self) -> usize {
-        let chunks_len = self.bitmap.chunks_len();
-        if self.bitmap.is_chunk_aligned() {
-            chunks_len
-        } else {
-            // Last chunk is partial
-            chunks_len.checked_sub(1).unwrap()
-        }
+        self.bitmap.complete_chunks()
     }
 
     /// Return the last chunk of the bitmap and its size in bits. The size can be 0 (meaning the

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -215,11 +215,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             else {
                 return false;
             };
-            node_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
-            node_positions.extend(&bp.fetch_nodes);
-            if let Some(suffix_peaks) = bp.suffix_peaks() {
-                node_positions.extend(suffix_peaks);
-            }
+            node_positions.extend(bp.required_positions());
             blueprints.insert(*loc, bp);
         }
 
@@ -255,9 +251,8 @@ impl<F: Family, D: Digest> Proof<F, D> {
                 });
                 digests.push(acc);
             }
-            let prefix_active_count = bp.prefix_active_count();
-            let after_count = bp.after_peaks_count();
-            for &pos in &bp.fetch_nodes[..prefix_active_count + after_count] {
+            let sibling_start = bp.sibling_start();
+            for &pos in &bp.fetch_nodes[..sibling_start] {
                 let d = node_digests.get(&pos).expect("must exist by construction");
                 digests.push(*d);
             }
@@ -274,7 +269,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
                 }
                 digests.push(acc);
             }
-            for &pos in &bp.fetch_nodes[prefix_active_count + after_count..] {
+            for &pos in &bp.fetch_nodes[sibling_start..] {
                 let d = node_digests.get(&pos).expect("must exist by construction");
                 digests.push(*d);
             }
@@ -925,19 +920,25 @@ impl<F: Family> Blueprint<F> {
         out
     }
 
-    /// Return the number of active prefix peak digests stored before after-peak digests.
-    pub(crate) const fn prefix_active_count(&self) -> usize {
-        self.prefix_active_peaks.len()
-    }
-
-    /// Return the number of non-collapsed after-peak digests in the proof layout.
-    pub(crate) const fn after_peaks_count(&self) -> usize {
-        self.after_peaks.len()
+    /// The index within `fetch_nodes` where the DFS sibling nodes begin, following the
+    /// prefix-active peaks and the after-peaks.
+    pub(crate) const fn sibling_start(&self) -> usize {
+        self.prefix_active_peaks.len() + self.after_peaks.len()
     }
 
     /// Return active after-peaks that are collapsed into a backward-folded suffix accumulator.
     pub(crate) fn suffix_peaks(&self) -> Option<&[Position<F>]> {
         (!self.suffix_peaks.is_empty()).then_some(&self.suffix_peaks)
+    }
+
+    /// All node positions this blueprint needs from the tree: fold-prefix peaks, fetch nodes,
+    /// and suffix peaks. Order is unspecified; callers collect into a set.
+    pub(crate) fn required_positions(&self) -> impl Iterator<Item = Position<F>> + '_ {
+        self.fold_prefix
+            .iter()
+            .map(|s| s.pos)
+            .chain(self.fetch_nodes.iter().copied())
+            .chain(self.suffix_peaks.iter().copied())
     }
 
     /// Split a proof's digest vector according to this blueprint's range-proof layout.
@@ -957,14 +958,13 @@ impl<F: Family> Blueprint<F> {
 
         let prefix_start = fold_count;
         let after_start = prefix_start + self.prefix_active_peaks.len();
-        let siblings_start = after_start + self.after_peaks.len();
-        let suffix_start = siblings_start;
+        let suffix_start = after_start + self.after_peaks.len();
         let suffix_end = suffix_start + suffix_count;
 
         Ok(ProofDigestLayout {
             fold_prefix: (!self.fold_prefix.is_empty()).then(|| &digests[0]),
             prefix_active_peaks: &digests[prefix_start..after_start],
-            after_peaks: &digests[after_start..siblings_start],
+            after_peaks: &digests[after_start..suffix_start],
             suffix_acc: (!self.suffix_peaks.is_empty()).then(|| &digests[suffix_start]),
             siblings: &digests[suffix_end..],
         })
@@ -1032,7 +1032,7 @@ impl<F: Family> Blueprint<F> {
             digests.push(acc);
         }
 
-        let sibling_start = self.prefix_active_peaks.len() + self.after_peaks.len();
+        let sibling_start = self.sibling_start();
         for &pos in &self.fetch_nodes[sibling_start..] {
             digests.push(get_node(pos).ok_or_else(|| element_pruned(pos))?);
         }
@@ -1094,11 +1094,7 @@ pub(crate) fn nodes_required_for_multi_proof<F: Family>(
             return Err(super::Error::LocationOverflow(*loc));
         }
         let bp = Blueprint::new(leaves, inactive_peaks, bagging, *loc..*loc + 1)?;
-        if let Some(suffix_peaks) = bp.suffix_peaks() {
-            acc.extend(suffix_peaks);
-        }
-        acc.extend(bp.fold_prefix.into_iter().map(|s| s.pos));
-        acc.extend(bp.fetch_nodes);
+        acc.extend(bp.required_positions());
         Ok(acc)
     })
 }

--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -136,9 +136,8 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
             digests.push(acc.expect("fold_prefix is non-empty so acc must be set"));
         }
 
-        let prefix_active_count = bp.prefix_active_count();
-        let after_count = bp.after_peaks_count();
-        for &pos in &bp.fetch_nodes[..prefix_active_count + after_count] {
+        let sibling_start = bp.sibling_start();
+        for &pos in &bp.fetch_nodes[..sibling_start] {
             match self.digests.get(&pos) {
                 Some(d) => digests.push(*d),
                 None => return Err(Error::ElementPruned(pos)),
@@ -147,7 +146,7 @@ impl<F: Family, D: Digest> ProofStore<F, D> {
         if let Some(suffix_peaks) = bp.suffix_peaks() {
             digests.push(self.suffix_acc(hasher, suffix_peaks)?);
         }
-        for &pos in &bp.fetch_nodes[prefix_active_count + after_count..] {
+        for &pos in &bp.fetch_nodes[sibling_start..] {
             match self.digests.get(&pos) {
                 Some(d) => digests.push(*d),
                 None => return Err(Error::ElementPruned(pos)),
@@ -322,12 +321,7 @@ pub async fn historical_range_proof<
 ) -> Result<Proof<F, D>, Error<F>> {
     let bp = Blueprint::new(leaves, inactive_peaks, hasher.root_bagging(), range)?;
 
-    let mut all_positions = BTreeSet::new();
-    all_positions.extend(bp.fold_prefix.iter().map(|s| s.pos));
-    all_positions.extend(bp.fetch_nodes.iter().copied());
-    if let Some(suffix_peaks) = bp.suffix_peaks() {
-        all_positions.extend(suffix_peaks.iter().copied());
-    }
+    let all_positions: BTreeSet<_> = bp.required_positions().collect();
 
     let node_futures: Vec<_> = all_positions
         .into_iter()

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -21,7 +21,7 @@ use crate::{
         batch_chain::Bounds,
         bitmap::{Shared, fill_from},
         current::{
-            db::{compute_db_root, read_graft_inputs},
+            db::{compute_db_root, partial_chunk, read_graft_inputs},
             grafting,
         },
         operation::Key,
@@ -880,16 +880,7 @@ where
     // from `graftable_overlay` (the grafted-tree boundary). At gh >= 3, partial and pending can
     // coexist; this branch only handles partial. The pending chunk (when present) is read
     // from the bitmap inside `compute_db_root` via `pending_chunk()`.
-    let partial = {
-        let rem = bitmap_batch.len() % BitmapBatch::<N>::CHUNK_SIZE_BITS;
-        if rem == 0 {
-            None
-        } else {
-            let idx = new_complete_chunks;
-            let chunk = bitmap_batch.get_chunk(idx);
-            Some((chunk, rem))
-        }
-    };
+    let partial = partial_chunk::<_, N>(&bitmap_batch);
     let canonical_root = compute_db_root::<F, H, _, _, N>(
         &bitmap_batch,
         &grafted_storage,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -54,6 +54,9 @@ const NODE_PREFIX: u8 = 0;
 /// Prefix used for the metadata key for the number of pruned bitmap chunks.
 const PRUNED_CHUNKS_PREFIX: u8 = 1;
 
+/// `(position, digest)` pairs for a grafted tree's pinned nodes, in `Family::nodes_to_pin` order.
+type GraftedPinnedNodes<F, D> = Vec<(Position<F>, D)>;
+
 /// Metrics for the Current layer.
 pub(crate) struct Metrics<E: Context> {
     /// Pruned bitmap chunks.
@@ -496,6 +499,25 @@ where
         pair_absorption_threshold::<F, N>(self.any.bitmap.pruned_chunks() as u64)
     }
 
+    /// Read the grafted tree's pinned-node digests for pruning boundary `loc`, in
+    /// `Family::nodes_to_pin` order, as `(position, digest)` pairs.
+    ///
+    /// Errors with [`Error::DataCorrupted`] if any pinned node is absent from the grafted tree.
+    fn grafted_pinned_nodes(
+        &self,
+        loc: Location<F>,
+    ) -> Result<GraftedPinnedNodes<F, H::Digest>, Error<F>> {
+        F::nodes_to_pin(loc)
+            .map(|pos| {
+                let digest = self
+                    .grafted_tree
+                    .get_node(pos)
+                    .ok_or(Error::<F>::DataCorrupted("missing grafted pinned node"))?;
+                Ok((pos, digest))
+            })
+            .collect()
+    }
+
     /// Prune the grafted tree to match the committed bitmap's pruned chunks.
     fn prune_grafted_tree_to_bitmap(&mut self) -> Result<(), Error<F>> {
         let pruned_chunks = self.any.bitmap.pruned_chunks() as u64;
@@ -512,14 +534,7 @@ where
             .map_err(|_| Error::<F>::DataCorrupted("prune location overflow"))?;
         let size = self.grafted_tree.size();
 
-        let mut pinned = BTreeMap::new();
-        for pos in F::nodes_to_pin(prune_loc) {
-            let digest = self
-                .grafted_tree
-                .get_node(pos)
-                .ok_or(Error::<F>::DataCorrupted("missing grafted pinned node"))?;
-            pinned.insert(pos, digest);
-        }
+        let pinned: BTreeMap<_, _> = self.grafted_pinned_nodes(prune_loc)?.into_iter().collect();
 
         let mut retained = Vec::with_capacity((*size - *prune_pos) as usize);
         for p in *prune_pos..*size {
@@ -657,17 +672,12 @@ where
         }
 
         // Extract pinned nodes for the existing pruning boundary from the in-memory grafted tree.
-        let pinned_nodes = if pruned_chunks > 0 {
+        let pinned_nodes: Vec<H::Digest> = if pruned_chunks > 0 {
             let grafted_leaves = Location::<F>::new(pruned_chunks as u64);
-            let mut pinned_nodes = Vec::new();
-            for pos in F::nodes_to_pin(grafted_leaves) {
-                let digest = self
-                    .grafted_tree
-                    .get_node(pos)
-                    .ok_or(Error::<F>::DataCorrupted("missing grafted pinned node"))?;
-                pinned_nodes.push(digest);
-            }
-            pinned_nodes
+            self.grafted_pinned_nodes(grafted_leaves)?
+                .into_iter()
+                .map(|(_, digest)| digest)
+                .collect()
         } else {
             Vec::new()
         };
@@ -709,11 +719,11 @@ where
 
         // Write the pinned nodes of the grafted tree.
         let pruned_chunks = Location::<F>::new(pruned_chunks_u64);
-        for (i, grafted_pos) in F::nodes_to_pin(pruned_chunks).enumerate() {
-            let digest = self
-                .grafted_tree
-                .get_node(grafted_pos)
-                .ok_or(Error::<F>::DataCorrupted("missing grafted pinned node"))?;
+        for (i, (_, digest)) in self
+            .grafted_pinned_nodes(pruned_chunks)?
+            .into_iter()
+            .enumerate()
+        {
             let key = U64::new(NODE_PREFIX, i as u64);
             self.metadata.put(key, digest.to_vec());
         }

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -20,7 +20,7 @@ use crate::{
     },
     translator::Translator,
 };
-use commonware_codec::{Codec, Read};
+use commonware_codec::Read;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use commonware_runtime::Spawner;
@@ -48,7 +48,7 @@ impl<
     S: Strategy,
 > Db<F, E, K, V, H, T, N, S>
 where
-    Operation<F, K, V>: Codec,
+    Operation<F, K, V>: Read,
 {
     /// Initializes a [Db] from the given `config`.
     /// The configured [`Strategy`] is used to parallelize merkleization.
@@ -97,7 +97,7 @@ pub mod partitioned {
         S: Strategy,
     > Db<F, E, K, V, H, T, P, N, S>
     where
-        Operation<F, K, V>: Codec,
+        Operation<F, K, V>: Read,
     {
         /// Initializes a [Db] from the given `config`.
         pub async fn init(

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -571,9 +571,7 @@ impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
             range_proof,
         })
     }
-}
 
-impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
     /// Verify that the proof proves that `operation` is active in the database with the given
     /// `root`.
     pub fn verify<H: Hasher<Digest = D>, O: Codec>(&self, operation: O, root: &D) -> bool {

--- a/storage/src/qmdb/sync/source.rs
+++ b/storage/src/qmdb/sync/source.rs
@@ -61,9 +61,7 @@ impl<F: Family> Request<F> {
             Self::Boundary { .. } => NonZeroU64::MIN,
         }
     }
-}
 
-impl<F: Family> Request<F> {
     /// Total-order key for map lookups. The final component separates the variants.
     fn order_key(&self) -> (u64, u64, u64, bool) {
         (


### PR DESCRIPTION
## Motivation

A batch of small simplifications across the storage crate, found while scrutinizing the qmdb `current` (grafted) variant. The common thread: several sites reimplemented logic an existing helper/method already provides, or duplicated a short loop/expression across multiple call sites. Each change replaces the inline logic with a call to the existing helper, deduplicates the repeat, and removes the dead code it subsumes.

## Changes

- **`qmdb::current::db`** — extract `grafted_pinned_nodes`, unifying the triplicated `nodes_to_pin` + `get_node` read (in `prune`, `rewind`, `sync_metadata`) and single-sourcing the `DataCorrupted("missing grafted pinned node")` invariant.
- **`qmdb::current::batch`** — `compute_current_layer` reuses the shared `db::partial_chunk` instead of re-deriving the partial-chunk logic inline. This also makes the commit-time root agree with the canonical witness/recovery recompute path on an *empty* bitmap, where the inline version previously returned `None` — a state unreachable in practice, since every batch carries a CommitFloor bit.
- **`bitmap::authenticated`** — `complete_chunks` delegates to the wrapped `PrunableBitMap::complete_chunks` instead of re-deriving it (verified algebraically identical).
- **`qmdb::current::ordered::variable`** — tighten the `init` bound from `Operation: Codec` to `Operation: Read` (matching `unordered::variable`; only `Read::Cfg` is used), dropping the now-unused `Codec` import.
- **`merkle`** — add `Blueprint::required_positions` (deduplicates the "nodes this blueprint needs" set built identically at 3 sites) and `Blueprint::sibling_start` (replaces two single-use count methods, deduplicated at 4 sites across proof construction/verification); also rename the misleading `siblings_start` local in `split_proof_digests` to `suffix_start`.
- **`qmdb`** — merge two pairs of artificially-split `impl` blocks (`current::proof` `OperationProof`, `sync::source` `Request`).

No wire, storage, recovery, durability, or fsync change; every change is behavior-preserving on all reachable states.

## Validation

- `just test -p commonware-storage` — 2893 tests pass
- `just clippy -p commonware-storage`
- `just check-fmt`
