### PR TITLE
[marshal] Improve Pruning Logic

### DIFF
--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -957,8 +957,10 @@ where
                 .marshal
                 .subscribe_by_commitment(payload, core::CommitmentFallback::Wait);
             let marshal = self.marshal.clone();
+            let shards = self.shards.clone();
             let epocher = self.epocher.clone();
             let round = consensus_context.round;
+            let leader = consensus_context.leader;
             let gates = self.gates.clone();
 
             // Register a certification gate task synchronously before spawning work so
@@ -1013,6 +1015,10 @@ where
                         tx.send_lossy(false);
                         return;
                     }
+
+                    // Register the re-proposal's leader only after confirming
+                    // the block belongs to this epoch boundary.
+                    shards.discovered(payload, leader, round);
 
                     // Valid re-proposal: notify the marshal and complete the
                     // certification gate task for `certify`.

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -22,10 +22,10 @@
 //! the shard assigned to this participant by the proposer. If that shard is valid, the assigned shard is
 //! relayed to all other participants to aid in block reconstruction.
 //!
-//! A participant may still reconstruct the full block from gossiped shards before its designated
-//! leader-delivered shard arrives. That is sufficient for later certification and repair flows, but it
-//! is not treated as notarization readiness: a participant only helps form a notarization once it has
-//! validated the shard it is supposed to echo.
+//! A participant may still reconstruct the full block from gossiped shards before its assigned shard
+//! arrives. That is sufficient for later certification and repair flows, but it is not treated as
+//! notarization readiness: a participant only helps form a notarization once it has validated the
+//! shard it is supposed to echo.
 //!
 //! During certification (the phase between notarization and finalization), the wrapper subscribes to
 //! block reconstruction and validates epoch boundaries, parent commitment, height contiguity, and
@@ -951,11 +951,18 @@ where
         // 2. The parent-child height check would fail (parent IS the block)
         // 3. Waiting for shards could stall if the leader doesn't rebroadcast
         if is_reproposal {
-            // Fetch the block to verify it's at the epoch boundary.
-            // This should be fast since the parent block is typically already cached.
-            let block_rx = self
-                .marshal
-                .subscribe_by_commitment(payload, core::CommitmentFallback::Wait);
+            // Fetch the block to verify it's at the epoch boundary. This should be fast
+            // since the parent block is typically already cached. A re-proposal names its
+            // own parent, so the parent round is a certified round for this commitment and
+            // lets a participant that never received the original proposal acquire it
+            // instead of waiting for shards it cannot yet classify.
+            let (parent_view, _) = consensus_context.parent;
+            let block_rx = self.marshal.subscribe_by_commitment(
+                payload,
+                core::CommitmentFallback::FetchByRound {
+                    round: Round::new(consensus_context.epoch(), parent_view),
+                },
+            );
             let marshal = self.marshal.clone();
             let shards = self.shards.clone();
             let epocher = self.epocher.clone();
@@ -1016,8 +1023,11 @@ where
                         return;
                     }
 
-                    // Register the re-proposal's leader only after confirming
-                    // the block belongs to this epoch boundary.
+                    // Announce the re-proposal only after the boundary check. A
+                    // re-proposal's consensus round is not bound to the commitment, and
+                    // the shard engine reads the participant set from the round's epoch,
+                    // so announcing an unvalidated round would classify this block's
+                    // shards against the wrong epoch.
                     shards.discovered(payload, leader, round);
 
                     // Valid re-proposal: notify the marshal and complete the
@@ -1038,7 +1048,8 @@ where
             return rx;
         }
 
-        // Inform the shard engine of an externally proposed commitment.
+        // Inform the shard engine of an externally proposed commitment. The context
+        // digest validated above binds this round and leader to the commitment.
         self.shards.discovered(
             payload,
             consensus_context.leader.clone(),
@@ -1061,10 +1072,9 @@ where
         match scheme.me() {
             Some(_) => {
                 // Subscribe to assigned shard verification. For participants, this
-                // only completes once the leader-delivered shard for our
-                // assigned index has been verified. Reconstructing the block
-                // from peer gossip is useful for certification later, but is
-                // not enough to emit a notarize vote.
+                // only completes once the shard for our assigned index has been
+                // verified. Reconstructing the block from peer gossip is useful for
+                // certification later, but is not enough to emit a notarize vote.
                 let validity_rx = self.shards.subscribe_assigned_shard_verified(payload);
                 let (tx, rx) = oneshot::channel();
                 let context = self

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -175,7 +175,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _round: Round, _commitment: Commitment) {}
+        fn finalized(&self, _round: Round, _commitments: Vec<Commitment>) {}
 
         fn send(&self, round: Round, block: Arc<TestCodedBlock>, recipients: Recipients<K>) {
             self.sends.lock().push((round, block, recipients));
@@ -484,6 +484,84 @@ mod tests {
         let coded_candidate: TestCodedBlock =
             CodedBlock::new(candidate, coding_config, &Sequential);
         (candidate_ctx, coded_candidate)
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_batched_acks_retire_each_exact_commitment() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+            let mut setup = CodingHarness::setup_validator_with(
+                context.child("validator"),
+                &mut oracle,
+                participants[0].clone(),
+                ConstantProvider::new(schemes[0].clone()),
+                NZUsize!(2),
+                Application::manual_ack(),
+            )
+            .await;
+            assert_eq!(setup.application.acknowledged().await, Height::zero());
+
+            let mut parent = Sha256::hash(&[b""]);
+            let mut parent_commitment =
+                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16);
+            let mut commitments = Vec::new();
+            for height in 1..=2 {
+                let round = Round::new(Epoch::zero(), View::new(height));
+                let block = CodingHarness::make_test_block(
+                    parent,
+                    parent_commitment,
+                    Height::new(height),
+                    height,
+                    NUM_VALIDATORS as u16,
+                );
+                let commitment = block.commitment();
+                parent = block.digest();
+                parent_commitment = commitment;
+                commitments.push(commitment);
+
+                setup.extra.proposed(
+                    Round::new(Epoch::zero(), View::new(height + 10)),
+                    block.clone(),
+                );
+                assert!(setup.extra.get(commitment).await.is_some());
+                assert!(setup.mailbox.verified(round, block).await);
+                CodingHarness::report_finalization(
+                    &mut setup.mailbox,
+                    CodingHarness::make_finalization(
+                        Proposal {
+                            round,
+                            parent: View::new(height - 1),
+                            payload: commitment,
+                        },
+                        &schemes,
+                        QUORUM,
+                    ),
+                )
+                .await;
+            }
+
+            while setup.application.pending_ack_heights() != vec![Height::new(1), Height::new(2)] {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(setup.application.acknowledge_next(), Some(Height::new(1)));
+            assert_eq!(setup.application.acknowledge_next(), Some(Height::new(2)));
+
+            while setup.extra.get(commitments[1]).await.is_some() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert!(setup.extra.get(commitments[0]).await.is_none());
+        });
     }
 
     #[test_traced("WARN")]
@@ -1800,7 +1878,7 @@ mod tests {
             // Ensure the certification gate task has registered its subscription, then
             // force cancellation by pruning the missing commitment.
             context.sleep(Duration::from_millis(100)).await;
-            shards.prune(round, missing_payload);
+            shards.prune(round, vec![missing_payload]);
 
             select! {
                 result = verify_rx => {
@@ -1877,7 +1955,7 @@ mod tests {
 
             // Prune the missing commitment in the shard engine, which should cancel
             // the underlying buffer subscription.
-            shards.prune(round, missing_commitment);
+            shards.prune(round, vec![missing_commitment]);
 
             // The core actor must surface cancellation by closing the subscription,
             // not by panicking or leaving the waiter parked indefinitely.

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1414,6 +1414,10 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
             )
             .await;
+            setup_network_links(&mut oracle, &participants[..2], LINK).await;
+            let reproposer_control = oracle.control(participants[1].clone());
+            let (mut reproposer_sender, _reproposer_receiver) =
+                reproposer_control.register(2, TEST_QUOTA).await.unwrap();
             let marshal = setup.mailbox;
             let shards = setup.extra;
 
@@ -1484,7 +1488,12 @@ mod tests {
             let coded_boundary =
                 CodedBlock::new(boundary_block.clone(), coding_config, &Sequential);
             let boundary_commitment = coded_boundary.commitment();
-            shards.proposed(boundary_round, coded_boundary);
+            shards.discovered(
+                boundary_commitment,
+                boundary_context.leader.clone(),
+                boundary_round,
+            );
+            shards.proposed(boundary_round, coded_boundary.clone());
 
             context.sleep(Duration::from_millis(10)).await;
 
@@ -1498,7 +1507,7 @@ mod tests {
             let reproposal_round = Round::new(Epoch::new(0), View::new(20));
             let reproposal_context = CodingCtx {
                 round: reproposal_round,
-                leader: me.clone(),
+                leader: participants[1].clone(),
                 parent: (View::new(boundary_height.get()), boundary_commitment), // Parent IS the boundary block
             };
 
@@ -1513,6 +1522,19 @@ mod tests {
                 shard_validity.unwrap(),
                 "Re-proposal verify should return true for shard validity"
             );
+
+            let assigned = shards.subscribe_assigned_shard_verified(boundary_commitment);
+            let assigned_shard = coded_boundary
+                .shard(0)
+                .expect("missing assigned shard")
+                .encode();
+            reproposer_sender.send(Recipients::One(me.clone()), assigned_shard, true);
+            select! {
+                result = assigned => result.expect("assigned shard sender dropped"),
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("reproposal leader was not authorized by verification");
+                },
+            }
 
             // Use certify to get the actual deferred_verify result
             let certify_result = marshaled

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1532,7 +1532,7 @@ mod tests {
             select! {
                 result = assigned => result.expect("assigned shard sender dropped"),
                 _ = context.sleep(Duration::from_secs(5)) => {
-                    panic!("reproposal leader was not authorized by verification");
+                    panic!("assigned shard from reproposer was not accepted");
                 },
             }
 
@@ -1644,6 +1644,104 @@ mod tests {
             // because they require multiple validators to reconstruct blocks from shards. In a
             // single-validator test setup, block reconstruction fails due to insufficient shards.
             // These paths are tested in integration tests with multiple validators.
+        })
+    }
+
+    /// An invalid re-proposal must not open shard reconstruction for its payload.
+    ///
+    /// A re-proposal's consensus round is not bound to its payload because the context
+    /// digest check is skipped: the block carries the context of its original proposal.
+    /// The shard engine resolves the participant set from the announced round's epoch, so
+    /// announcing before the boundary check lets a leader bind a commitment to a round it
+    /// was never proposed in and misclassify shards from honest peers.
+    #[test_traced("INFO")]
+    fn test_invalid_reproposal_does_not_open_reconstruction() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            setup_network_links(&mut oracle, &participants[..2], LINK).await;
+            let reproposer_control = oracle.control(participants[1].clone());
+            let (mut reproposer_sender, _reproposer_receiver) =
+                reproposer_control.register(2, TEST_QUOTA).await.unwrap();
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let mock_app: MockVerifyingApp<CodingB, S> = MockVerifyingApp::new();
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            // Store a mid-epoch block in core marshal without opening shard reconstruction.
+            let original_round = Round::new(Epoch::new(0), View::new(5));
+            let original_context = CodingCtx {
+                round: original_round,
+                leader: participants[1].clone(),
+                parent: (View::new(4), genesis_commitment()),
+            };
+            let block = make_coding_block(
+                original_context,
+                Sha256::hash(&[b"parent"]),
+                Height::new(5),
+                500,
+            );
+            let coded_block: TestCodedBlock = CodedBlock::new(block, coding_config, &Sequential);
+            let commitment = coded_block.commitment();
+            assert!(marshal.verified(original_round, coded_block.clone()).await);
+            assert!(shards.get(commitment).await.is_none());
+
+            // Re-proposing the old block as epoch 1's genesis parent is invalid.
+            // The payload is the parent, so `verify` takes the re-proposal path.
+            let reproposal_round = Round::new(Epoch::new(1), View::new(1));
+            let reproposal_context = CodingCtx {
+                round: reproposal_round,
+                leader: participants[1].clone(),
+                parent: (View::zero(), commitment),
+            };
+            let assigned = shards.subscribe_assigned_shard_verified(commitment);
+            let verdict = marshaled.verify(reproposal_context, commitment).await.await;
+            assert!(!verdict.expect("re-proposal verdict missing"));
+
+            // The re-proposer delivers this node's assigned shard. Without reconstruction
+            // state it stays buffered, so assigned shard verification cannot complete.
+            let assigned_shard = coded_block
+                .shard(0)
+                .expect("missing assigned shard")
+                .encode();
+            reproposer_sender.send(Recipients::One(me.clone()), assigned_shard, true);
+
+            select! {
+                _ = assigned => {
+                    panic!("invalid re-proposal opened reconstruction for its payload");
+                },
+                _ = context.sleep(Duration::from_secs(1)) => {},
+            }
         })
     }
 

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -175,7 +175,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn retire(&self, _update: core::RetentionUpdate<Commitment>) {}
+        fn retire(&self, _update: core::Retirement<Commitment>) {}
 
         fn send(&self, round: Round, block: Arc<TestCodedBlock>, recipients: Recipients<K>) {
             self.sends.lock().push((round, block, recipients));
@@ -1838,7 +1838,7 @@ mod tests {
     /// through core marshal's verified cache, while a post-retirement `discovered`
     /// announcement must recreate shard state needed before notarization.
     #[test_traced("WARN")]
-    fn test_coding_reproposal_survives_exact_retirement_orderings() {
+    fn test_coding_reproposal_recreates_shard_state_after_retirement() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -1911,7 +1911,7 @@ mod tests {
 
             // Exact retirement with a round floor below the commitment's observed
             // round: only the exact commitment list can retire it.
-            shards.retire(core::RetentionUpdate {
+            shards.retire(core::Retirement {
                 round_floor: Round::new(Epoch::zero(), View::new(1)),
                 exact_retirements: vec![boundary_commitment],
             });
@@ -1953,7 +1953,7 @@ mod tests {
             // Retiring again after verification removes the newly recreated shard
             // state, but not the block persisted in core marshal. Certification and
             // caller-owned core subscriptions must remain live through that cache.
-            shards.retire(core::RetentionUpdate {
+            shards.retire(core::Retirement {
                 round_floor: Round::new(Epoch::zero(), View::new(1)),
                 exact_retirements: vec![boundary_commitment],
             });
@@ -2335,7 +2335,7 @@ mod tests {
             // Ensure the certification gate task has registered its subscription, then
             // force cancellation by pruning the missing commitment.
             context.sleep(Duration::from_millis(100)).await;
-            shards.retire(core::RetentionUpdate {
+            shards.retire(core::Retirement {
                 round_floor: round,
                 exact_retirements: vec![missing_payload],
             });
@@ -2415,7 +2415,7 @@ mod tests {
 
             // Prune the missing commitment in the shard engine, which should cancel
             // the underlying buffer subscription.
-            shards.retire(core::RetentionUpdate {
+            shards.retire(core::Retirement {
                 round_floor: round,
                 exact_retirements: vec![missing_commitment],
             });

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -565,6 +565,92 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_coding_floor_retires_superseded_ack_commitments() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+            let mut setup = CodingHarness::setup_validator_with(
+                context.child("validator"),
+                &mut oracle,
+                participants[0].clone(),
+                ConstantProvider::new(schemes[0].clone()),
+                NZUsize!(1),
+                Application::manual_ack(),
+            )
+            .await;
+            assert_eq!(setup.application.acknowledged().await, Height::zero());
+
+            let block_round = Round::new(Epoch::zero(), View::new(1));
+            let block = CodingHarness::make_test_block(
+                Sha256::hash(&[b""]),
+                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16),
+                Height::new(1),
+                100,
+                NUM_VALIDATORS as u16,
+            );
+            let commitment = block.commitment();
+
+            // The cache observation is newer than the delayed floor, so only
+            // exact-commitment retirement can remove it.
+            setup
+                .extra
+                .proposed(Round::new(Epoch::zero(), View::new(10)), block.clone());
+            assert!(setup.mailbox.verified(block_round, block.clone()).await);
+            CodingHarness::report_finalization(
+                &mut setup.mailbox,
+                CodingHarness::make_finalization(
+                    Proposal {
+                        round: block_round,
+                        parent: View::zero(),
+                        payload: commitment,
+                    },
+                    &schemes,
+                    QUORUM,
+                ),
+            )
+            .await;
+            while setup.application.pending_ack_heights() != vec![Height::new(1)] {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            let floor_round = Round::new(Epoch::zero(), View::new(2));
+            let floor_block = CodingHarness::make_test_block(
+                block.digest(),
+                commitment,
+                Height::new(2),
+                200,
+                NUM_VALIDATORS as u16,
+            );
+            let floor_commitment = floor_block.commitment();
+            setup.extra.proposed(floor_round, floor_block);
+            setup.mailbox.set_floor(CodingHarness::make_finalization(
+                Proposal {
+                    round: floor_round,
+                    parent: View::new(1),
+                    payload: floor_commitment,
+                },
+                &schemes,
+                QUORUM,
+            ));
+
+            while setup.application.pending_ack_heights() != vec![Height::new(1), Height::new(2)] {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert!(setup.extra.get(commitment).await.is_none());
+        });
+    }
+
+    #[test_traced("WARN")]
     fn test_coding_notarized_delivery_rejects_dishonest_payload_config() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1833,6 +1833,131 @@ mod tests {
         })
     }
 
+    /// Exact commitment retirement (durable application progress) can race an
+    /// in-flight re-proposal of the same commitment. The re-proposal must still
+    /// verify: the block remains available through core marshal's verified cache,
+    /// and the post-verification `discovered` announcement must recreate shard
+    /// reconstruction state so the re-proposer can deliver assigned shards.
+    #[test_traced("WARN")]
+    fn test_coding_reproposal_survives_exact_commitment_retirement() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            setup_network_links(&mut oracle, &participants[..2], LINK).await;
+            let reproposer_control = oracle.control(participants[1].clone());
+            let (mut reproposer_sender, _reproposer_receiver) =
+                reproposer_control.register(2, TEST_QUOTA).await.unwrap();
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let mock_app: MockVerifyingApp<CodingB, S> = MockVerifyingApp::new();
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            // Build the epoch boundary block, store it in core marshal (the durable
+            // backstop), and cache it in the shard engine.
+            let boundary_height = Height::new(BLOCKS_PER_EPOCH.get() - 1);
+            let boundary_round = Round::new(Epoch::new(0), View::new(boundary_height.get()));
+            let boundary_context = CodingCtx {
+                round: boundary_round,
+                leader: me.clone(),
+                parent: (View::new(boundary_height.get() - 1), genesis_commitment()),
+            };
+            let boundary_block = make_coding_block(
+                boundary_context.clone(),
+                Sha256::hash(&[b"parent"]),
+                boundary_height,
+                1900,
+            );
+            let coded_boundary: TestCodedBlock =
+                CodedBlock::new(boundary_block, coding_config, &Sequential);
+            let boundary_commitment = coded_boundary.commitment();
+            assert!(marshal.verified(boundary_round, coded_boundary.clone()).await);
+            shards.discovered(boundary_commitment, me.clone(), boundary_round);
+            shards.proposed(boundary_round, coded_boundary.clone());
+            context.sleep(Duration::from_millis(10)).await;
+            assert!(shards.get(boundary_commitment).await.is_some());
+
+            // Exact retirement with a round floor below the commitment's observed
+            // round: only the exact commitment list can retire it.
+            shards.prune(
+                Round::new(Epoch::zero(), View::new(1)),
+                vec![boundary_commitment],
+            );
+            context.sleep(Duration::from_millis(10)).await;
+            assert!(shards.get(boundary_commitment).await.is_none());
+
+            // Re-propose the boundary block in the same epoch. Verification must
+            // fetch the block from the core backstop and re-announce discovery.
+            let reproposal_round = Round::new(Epoch::new(0), View::new(20));
+            let reproposal_context = CodingCtx {
+                round: reproposal_round,
+                leader: participants[1].clone(),
+                parent: (View::new(boundary_height.get()), boundary_commitment),
+            };
+            let verdict = marshaled
+                .verify(reproposal_context, boundary_commitment)
+                .await
+                .await;
+            assert!(
+                verdict.expect("re-proposal verdict missing"),
+                "re-proposal should verify from the core backstop after exact retirement"
+            );
+
+            // The recreated reconstruction state must accept this node's assigned
+            // shard from the re-proposer (not the original leader).
+            let assigned = shards.subscribe_assigned_shard_verified(boundary_commitment);
+            let assigned_shard = coded_boundary
+                .shard(0)
+                .expect("missing assigned shard")
+                .encode();
+            reproposer_sender.send(Recipients::One(me.clone()), assigned_shard, true);
+            select! {
+                result = assigned => result.expect("assigned shard sender dropped"),
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("assigned shard was not accepted after state recreation");
+                },
+            }
+
+            let certify = marshaled
+                .certify(reproposal_round, boundary_commitment)
+                .await
+                .await;
+            assert!(
+                certify.expect("certify result missing"),
+                "re-proposal should certify after exact retirement"
+            );
+        })
+    }
+
     #[test_traced("WARN")]
     fn test_marshaled_rejects_mismatched_context_digest() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -2180,6 +2180,85 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_coding_floor_preserves_registered_commitment_subscription() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                participants[0].clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let missing_round = Round::new(Epoch::zero(), View::new(1));
+            let missing = CodingHarness::make_test_block(
+                Sha256::hash(&[b""]),
+                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16),
+                Height::new(1),
+                100,
+                NUM_VALIDATORS as u16,
+            );
+            let missing_commitment = missing.commitment();
+            shards.discovered(missing_commitment, participants[1].clone(), missing_round);
+
+            let subscription =
+                marshal.subscribe_by_commitment(missing_commitment, core::CommitmentFallback::Wait);
+            context.sleep(Duration::from_millis(100)).await;
+
+            let floor_round = Round::new(Epoch::zero(), View::new(2));
+            let floor = CodingHarness::make_test_block(
+                missing.digest(),
+                missing_commitment,
+                Height::new(2),
+                200,
+                NUM_VALIDATORS as u16,
+            );
+            let floor_commitment = floor.commitment();
+            shards.proposed(floor_round, floor);
+            assert!(shards.get(floor_commitment).await.is_some());
+            marshal.set_floor(CodingHarness::make_finalization(
+                Proposal {
+                    round: floor_round,
+                    parent: View::new(1),
+                    payload: floor_commitment,
+                },
+                &schemes,
+                QUORUM,
+            ));
+
+            while marshal.get_processed_height().await != Some(Height::new(2)) {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            shards.proposed(Round::new(Epoch::zero(), View::new(3)), missing);
+            select! {
+                result = subscription => {
+                    let block = result.expect("floor update closed commitment subscription");
+                    assert_eq!(block.commitment(), missing_commitment);
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("commitment subscription did not resolve after local ingress");
+                },
+            }
+        })
+    }
+
+    #[test_traced("WARN")]
     fn test_marshaled_rejects_unsupported_epoch() {
         #[derive(Clone)]
         struct LimitedEpocher {

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -175,7 +175,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _commitment: Commitment) {}
+        fn finalized(&self, _round: Round, _commitment: Commitment) {}
 
         fn send(&self, round: Round, block: Arc<TestCodedBlock>, recipients: Recipients<K>) {
             self.sends.lock().push((round, block, recipients));
@@ -1800,7 +1800,7 @@ mod tests {
             // Ensure the certification gate task has registered its subscription, then
             // force cancellation by pruning the missing commitment.
             context.sleep(Duration::from_millis(100)).await;
-            shards.prune(missing_payload);
+            shards.prune(round, missing_payload);
 
             select! {
                 result = verify_rx => {
@@ -1877,7 +1877,7 @@ mod tests {
 
             // Prune the missing commitment in the shard engine, which should cancel
             // the underlying buffer subscription.
-            shards.prune(missing_commitment);
+            shards.prune(round, missing_commitment);
 
             // The core actor must surface cancellation by closing the subscription,
             // not by panicking or leaving the waiter parked indefinitely.

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -565,7 +565,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_coding_floor_retires_superseded_ack_commitments() {
+    fn test_coding_floor_retires_only_superseded_ack_commitments() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -584,69 +584,71 @@ mod tests {
                 &mut oracle,
                 participants[0].clone(),
                 ConstantProvider::new(schemes[0].clone()),
-                NZUsize!(1),
+                NZUsize!(3),
                 Application::manual_ack(),
             )
             .await;
             assert_eq!(setup.application.acknowledged().await, Height::zero());
 
-            let block_round = Round::new(Epoch::zero(), View::new(1));
-            let block = CodingHarness::make_test_block(
-                Sha256::hash(&[b""]),
-                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16),
-                Height::new(1),
-                100,
-                NUM_VALIDATORS as u16,
-            );
-            let commitment = block.commitment();
+            let mut parent = Sha256::hash(&[b""]);
+            let mut parent_commitment =
+                CodingHarness::genesis_parent_commitment(NUM_VALIDATORS as u16);
+            let mut commitments = Vec::new();
+            let mut floor = None;
+            for height in 1..=3 {
+                let round = Round::new(Epoch::zero(), View::new(height));
+                let block = CodingHarness::make_test_block(
+                    parent,
+                    parent_commitment,
+                    Height::new(height),
+                    height * 100,
+                    NUM_VALIDATORS as u16,
+                );
+                let commitment = block.commitment();
+                parent = block.digest();
+                parent_commitment = commitment;
+                commitments.push(commitment);
 
-            // The cache observation is newer than the delayed floor, so only
-            // exact-commitment retirement can remove it.
-            setup
-                .extra
-                .proposed(Round::new(Epoch::zero(), View::new(10)), block.clone());
-            assert!(setup.mailbox.verified(block_round, block.clone()).await);
-            CodingHarness::report_finalization(
-                &mut setup.mailbox,
-                CodingHarness::make_finalization(
+                // Every cache observation is newer than the floor, so only an exact
+                // commitment retirement can remove it.
+                setup.extra.proposed(
+                    Round::new(Epoch::zero(), View::new(height + 10)),
+                    block.clone(),
+                );
+                assert!(setup.mailbox.verified(round, block).await);
+                let finalization = CodingHarness::make_finalization(
                     Proposal {
-                        round: block_round,
-                        parent: View::zero(),
+                        round,
+                        parent: View::new(height - 1),
                         payload: commitment,
                     },
                     &schemes,
                     QUORUM,
-                ),
-            )
-            .await;
-            while setup.application.pending_ack_heights() != vec![Height::new(1)] {
+                );
+                if height == 2 {
+                    floor = Some(finalization.clone());
+                }
+                CodingHarness::report_finalization(&mut setup.mailbox, finalization).await;
+            }
+
+            while setup.application.pending_ack_heights()
+                != vec![Height::new(1), Height::new(2), Height::new(3)]
+            {
                 context.sleep(Duration::from_millis(10)).await;
             }
 
-            let floor_round = Round::new(Epoch::zero(), View::new(2));
-            let floor_block = CodingHarness::make_test_block(
-                block.digest(),
-                commitment,
-                Height::new(2),
-                200,
-                NUM_VALIDATORS as u16,
-            );
-            let floor_commitment = floor_block.commitment();
-            setup.extra.proposed(floor_round, floor_block);
-            setup.mailbox.set_floor(CodingHarness::make_finalization(
-                Proposal {
-                    round: floor_round,
-                    parent: View::new(1),
-                    payload: floor_commitment,
-                },
-                &schemes,
-                QUORUM,
-            ));
+            setup
+                .mailbox
+                .set_floor(floor.expect("height 2 floor missing"));
 
-            while setup.application.pending_ack_heights() != vec![Height::new(1), Height::new(2)] {
+            // The height-2 floor makes height 1 durable application progress. Heights 2 and 3
+            // are re-dispatched, so their coding-buffer commitments remain live.
+            while setup.mailbox.get_processed_height().await != Some(Height::new(1)) {
                 context.sleep(Duration::from_millis(10)).await;
             }
-            assert!(setup.extra.get(commitment).await.is_none());
+            assert!(setup.extra.get(commitments[0]).await.is_none());
+            assert!(setup.extra.get(commitments[1]).await.is_some());
+            assert!(setup.extra.get(commitments[2]).await.is_some());
         });
     }
 

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -175,7 +175,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _round: Round, _commitments: Vec<Commitment>) {}
+        fn retire(&self, _update: core::RetentionUpdate<Commitment>) {}
 
         fn send(&self, round: Round, block: Arc<TestCodedBlock>, recipients: Recipients<K>) {
             self.sends.lock().push((round, block, recipients));
@@ -1833,13 +1833,12 @@ mod tests {
         })
     }
 
-    /// Exact commitment retirement (durable application progress) can race an
-    /// in-flight re-proposal of the same commitment. The re-proposal must still
-    /// verify: the block remains available through core marshal's verified cache,
-    /// and the post-verification `discovered` announcement must recreate shard
-    /// reconstruction state so the re-proposer can deliver assigned shards.
+    /// Exact commitment retirement (durable application progress) can occur on
+    /// either side of re-proposal verification. The re-proposal must remain live
+    /// through core marshal's verified cache, while a post-retirement `discovered`
+    /// announcement must recreate shard state needed before notarization.
     #[test_traced("WARN")]
-    fn test_coding_reproposal_survives_exact_commitment_retirement() {
+    fn test_coding_reproposal_survives_exact_retirement_orderings() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -1912,10 +1911,10 @@ mod tests {
 
             // Exact retirement with a round floor below the commitment's observed
             // round: only the exact commitment list can retire it.
-            shards.prune(
-                Round::new(Epoch::zero(), View::new(1)),
-                vec![boundary_commitment],
-            );
+            shards.retire(core::RetentionUpdate {
+                round_floor: Round::new(Epoch::zero(), View::new(1)),
+                exact_retirements: vec![boundary_commitment],
+            });
             context.sleep(Duration::from_millis(10)).await;
             assert!(shards.get(boundary_commitment).await.is_none());
 
@@ -1950,6 +1949,23 @@ mod tests {
                     panic!("assigned shard was not accepted after state recreation");
                 },
             }
+
+            // Retiring again after verification removes the newly recreated shard
+            // state, but not the block persisted in core marshal. Certification and
+            // caller-owned core subscriptions must remain live through that cache.
+            shards.retire(core::RetentionUpdate {
+                round_floor: Round::new(Epoch::zero(), View::new(1)),
+                exact_retirements: vec![boundary_commitment],
+            });
+            while shards.get(boundary_commitment).await.is_some() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            let block = marshal
+                .subscribe_by_commitment(boundary_commitment, core::CommitmentFallback::Wait)
+                .await
+                .expect("core block subscription closed after shard retirement");
+            assert_eq!(block.commitment(), boundary_commitment);
 
             let certify = marshaled
                 .certify(reproposal_round, boundary_commitment)
@@ -2215,7 +2231,10 @@ mod tests {
             // Ensure the certification gate task has registered its subscription, then
             // force cancellation by pruning the missing commitment.
             context.sleep(Duration::from_millis(100)).await;
-            shards.prune(round, vec![missing_payload]);
+            shards.retire(core::RetentionUpdate {
+                round_floor: round,
+                exact_retirements: vec![missing_payload],
+            });
 
             select! {
                 result = verify_rx => {
@@ -2292,7 +2311,10 @@ mod tests {
 
             // Prune the missing commitment in the shard engine, which should cancel
             // the underlying buffer subscription.
-            shards.prune(round, vec![missing_commitment]);
+            shards.retire(core::RetentionUpdate {
+                round_floor: round,
+                exact_retirements: vec![missing_commitment],
+            });
 
             // The core actor must surface cancellation by closing the subscription,
             // not by panicking or leaving the waiter parked indefinitely.

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1978,6 +1978,110 @@ mod tests {
         })
     }
 
+    /// A participant that never held the payload cannot wait for shards it
+    /// cannot yet classify. Re-proposal verification must acquire the block by
+    /// fetching at the parent's certified round and return the boundary verdict.
+    #[test_traced("WARN")]
+    fn test_coding_reproposal_verify_fetches_block_by_parent_round() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants[..2].iter().cloned(),
+            )
+            .await;
+
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let v0_setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                participants[0].clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let v1_setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 1),
+                &mut oracle,
+                participants[1].clone(),
+                ConstantProvider::new(schemes[1].clone()),
+            )
+            .await;
+            setup_network_links(&mut oracle, &participants[..2], LINK).await;
+
+            let mut v0_mailbox = v0_setup.mailbox;
+            let v1_marshal = v1_setup.mailbox;
+            let v1_shards = v1_setup.extra;
+
+            // The boundary block of epoch 0, originally proposed at view 5.
+            let original_round = Round::new(Epoch::new(0), View::new(5));
+            let original_context = CodingCtx {
+                round: original_round,
+                leader: participants[0].clone(),
+                parent: (View::new(4), genesis_commitment()),
+            };
+            let block = make_coding_block(
+                original_context,
+                Sha256::hash(&[b"parent"]),
+                Height::new(BLOCKS_PER_EPOCH.get() - 1),
+                1900,
+            );
+            let coded_block: TestCodedBlock = CodedBlock::new(block, coding_config, &Sequential);
+            let commitment = coded_block.commitment();
+
+            // Serving a fetch by round requires the block and the round's
+            // notarization certificate.
+            assert!(
+                v0_mailbox
+                    .verified(original_round, coded_block.clone())
+                    .await
+            );
+            CodingHarness::report_notarization(
+                &mut v0_mailbox,
+                CodingHarness::make_notarization(
+                    Proposal {
+                        round: original_round,
+                        parent: View::new(4),
+                        payload: commitment,
+                    },
+                    &schemes,
+                    QUORUM,
+                ),
+            )
+            .await;
+
+            // The re-proposal names its own parent, so verification targets the
+            // parent round. Validator 1 never held the payload.
+            assert!(v1_shards.get(commitment).await.is_none());
+            let mock_app: MockVerifyingApp<CodingB, S> = MockVerifyingApp::new();
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: v1_marshal.clone(),
+                shards: v1_shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[1].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+            let reproposal_context = CodingCtx {
+                round: Round::new(Epoch::new(0), View::new(7)),
+                leader: participants[1].clone(),
+                parent: (View::new(5), commitment),
+            };
+            let verdict = marshaled.verify(reproposal_context, commitment).await.await;
+            assert!(
+                verdict.expect("re-proposal verdict missing"),
+                "re-proposal should verify after fetching the block by parent round"
+            );
+        })
+    }
+
     #[test_traced("WARN")]
     fn test_marshaled_rejects_mismatched_context_digest() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1900,7 +1900,11 @@ mod tests {
             let coded_boundary: TestCodedBlock =
                 CodedBlock::new(boundary_block, coding_config, &Sequential);
             let boundary_commitment = coded_boundary.commitment();
-            assert!(marshal.verified(boundary_round, coded_boundary.clone()).await);
+            assert!(
+                marshal
+                    .verified(boundary_round, coded_boundary.clone())
+                    .await
+            );
             shards.discovered(boundary_commitment, me.clone(), boundary_round);
             shards.proposed(boundary_round, coded_boundary.clone());
             context.sleep(Duration::from_millis(10)).await;

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1494,6 +1494,14 @@ where
     /// Re-proposals reuse commitments, and application acknowledgments can lag consensus.
     /// Retaining the latest observed round prevents an older acknowledgment from retiring
     /// reconstruction still needed by a later proposal.
+    ///
+    /// The refreshed round also governs shard classification, which resolves the
+    /// participant set from `round`'s epoch. That is unambiguous only because every
+    /// observation path binds the commitment to a single epoch: proposals bind it in
+    /// the context digest, re-proposals are validated as the last block of the
+    /// announced round's own epoch, and notarizations imply such a proposal. An
+    /// epocher that allowed a block to close more than one epoch would break this
+    /// invariant.
     fn observe(&mut self, round: Round) {
         let common = self.common_mut();
         common.round = common.round.max(round);

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -710,12 +710,10 @@ where
         // redundant, unless notarized recovery created leaderless state first.
         // In that case, the leader announcement must still populate the
         // leader-dependent path.
-        let block_cached = if let Some(entry) = self.reconstructed_blocks.get_mut(&commitment) {
-            entry.round = entry.round.max(round);
-            true
-        } else {
-            false
-        };
+        let block_cached = self.reconstructed_blocks.contains_key(&commitment);
+        if block_cached {
+            self.observe_existing_commitment(commitment, round);
+        }
         if block_cached
             && self
                 .state
@@ -733,8 +731,10 @@ where
             warn!(?leader, %commitment, "leader update for non-participant, ignoring");
             return;
         }
+        if !block_cached {
+            self.observe_existing_commitment(commitment, round);
+        }
         if let Some(state) = self.state.get_mut(&commitment) {
-            state.observe(round);
             if let Some(existing) = state.leader() {
                 if existing != &leader {
                     warn!(
@@ -774,12 +774,10 @@ where
         commitment: Commitment,
         round: Round,
     ) {
-        if let Some(entry) = self.reconstructed_blocks.get_mut(&commitment) {
-            entry.round = entry.round.max(round);
+        if self.observe_existing_commitment(commitment, round) {
             return;
         }
-        if let Some(state) = self.state.get_mut(&commitment) {
-            state.observe(round);
+        if self.state.contains_key(&commitment) {
             let buffered_progress = self.ingest_buffered_shards(commitment);
             if buffered_progress {
                 self.try_advance(sender, commitment);
@@ -887,6 +885,25 @@ where
         progressed
     }
 
+    /// Records a consensus observation on every existing owner of a commitment.
+    ///
+    /// A cached block may retain reconstruction state while assigned-shard verification is
+    /// pending. Updating both owners together keeps their pruning decisions consistent.
+    ///
+    /// Returns whether the block is already cached.
+    fn observe_existing_commitment(&mut self, commitment: Commitment, round: Round) -> bool {
+        let block_cached = if let Some(entry) = self.reconstructed_blocks.get_mut(&commitment) {
+            entry.round = entry.round.max(round);
+            true
+        } else {
+            false
+        };
+        if let Some(state) = self.state.get_mut(&commitment) {
+            state.observe(round);
+        }
+        block_cached
+    }
+
     /// Cache a block and notify all subscribers waiting on it.
     fn cache_block(
         &mut self,
@@ -894,9 +911,9 @@ where
         block: Arc<CodedBlock<B, C, H>>,
     ) -> Arc<CodedBlock<B, C, H>> {
         let commitment = block.commitment();
+        self.observe_existing_commitment(commitment, round);
         self.reconstructed_blocks
             .entry(commitment)
-            .and_modify(|entry| entry.round = entry.round.max(round))
             .or_insert_with(|| ReconstructedBlock {
                 round,
                 block: Arc::clone(&block),
@@ -3145,6 +3162,135 @@ mod tests {
                     },
                     _ = context.sleep(config.link.latency * 10) => {
                         panic!("later-round reconstruction did not complete");
+                    },
+                }
+            },
+        );
+    }
+
+    #[test_traced]
+    fn test_cached_observations_refresh_reconstruction_state_round() {
+        let fixture: Fixture<C> = Fixture {
+            num_peers: 10,
+            ..Default::default()
+        };
+
+        fixture.start(
+            |config, context, _, mut peers, _, coding_config| async move {
+                let live = CodedBlock::<B, C, H>::new(
+                    B::new::<H>((), Sha256Digest::EMPTY, Height::new(2), 200),
+                    coding_config,
+                    &STRATEGY,
+                );
+                let finalized = CodedBlock::<B, C, H>::new(
+                    B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100),
+                    coding_config,
+                    &STRATEGY,
+                );
+                let live_commitment = live.commitment();
+                let finalized_commitment = finalized.commitment();
+                let leader = peers[0].public_key.clone();
+                let receivers = [3usize, 6usize];
+                let receiver_keys = [
+                    peers[receivers[0]].public_key.clone(),
+                    peers[receivers[1]].public_key.clone(),
+                ];
+                let original_round = Round::new(Epoch::zero(), View::new(1));
+
+                for &receiver_idx in &receivers {
+                    peers[receiver_idx].mailbox.discovered(
+                        live_commitment,
+                        leader.clone(),
+                        original_round,
+                    );
+                }
+
+                // Reconstruct from gossip while leaving assigned-shard verification pending.
+                for sender_idx in [1usize, 2usize, 4usize, 5usize] {
+                    let shard = live
+                        .shard(peers[sender_idx].index.get() as u16)
+                        .expect("missing gossip shard")
+                        .encode();
+                    for receiver in &receiver_keys {
+                        peers[sender_idx].sender.send(
+                            Recipients::One(receiver.clone()),
+                            shard.clone(),
+                            true,
+                        );
+                    }
+                }
+                context.sleep(config.link.latency * 4).await;
+
+                for &receiver_idx in &receivers {
+                    assert!(
+                        peers[receiver_idx]
+                            .mailbox
+                            .get(live_commitment)
+                            .await
+                            .is_some(),
+                        "block should be cached before its round is refreshed"
+                    );
+                }
+
+                let mut notarized_sub = peers[receivers[0]]
+                    .mailbox
+                    .subscribe_assigned_shard_verified(live_commitment);
+                let mut discovered_sub = peers[receivers[1]]
+                    .mailbox
+                    .subscribe_assigned_shard_verified(live_commitment);
+                let later_round = Round::new(Epoch::zero(), View::new(4));
+                peers[receivers[0]]
+                    .mailbox
+                    .notarized(live_commitment, later_round);
+                peers[receivers[1]].mailbox.discovered(
+                    live_commitment,
+                    leader,
+                    later_round,
+                );
+                context.sleep(Duration::from_millis(10)).await;
+
+                let prune_round = Round::new(Epoch::zero(), View::new(3));
+                for &receiver_idx in &receivers {
+                    peers[receiver_idx]
+                        .mailbox
+                        .prune(prune_round, finalized_commitment);
+                }
+                context.sleep(Duration::from_millis(10)).await;
+
+                assert!(
+                    matches!(notarized_sub.try_recv(), Err(TryRecvError::Empty)),
+                    "cached notarization should keep reconstruction state live"
+                );
+                assert!(
+                    matches!(discovered_sub.try_recv(), Err(TryRecvError::Empty)),
+                    "cached discovery should keep reconstruction state live"
+                );
+
+                for (&receiver_idx, receiver) in receivers.iter().zip(&receiver_keys) {
+                    let leader_shard = live
+                        .shard(peers[receiver_idx].index.get() as u16)
+                        .expect("missing leader shard");
+                    peers[0].sender.send(
+                        Recipients::One(receiver.clone()),
+                        leader_shard.encode(),
+                        true,
+                    );
+                }
+
+                select! {
+                    result = notarized_sub => {
+                        result.expect("notarized reconstruction state should accept the leader shard");
+                    },
+                    _ = context.sleep(config.link.latency * 10) => {
+                        panic!("notarized reconstruction state did not accept the leader shard");
+                    },
+                }
+                select! {
+                    result = discovered_sub => {
+                        result.expect("discovered reconstruction state should accept the leader shard");
+                    },
+                    _ = context.sleep(config.link.latency * 10) => {
+                        panic!("discovered reconstruction state did not accept the leader shard");
                     },
                 }
             },

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -302,16 +302,23 @@ where
     phase: CommitmentPhase<B, C, H, P>,
 }
 
+/// Whether a commitment already has an owned lifecycle record.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum CommitmentPresence {
+    /// No record exists for the commitment.
     Absent,
+    /// The commitment is accumulating or validating shards.
     Reconstructing,
+    /// The commitment has an available block.
     Cached,
 }
 
+/// Why a commitment is eligible for retirement.
 #[derive(Clone, Copy)]
 enum RetirementReason {
+    /// Durable progress explicitly retired the commitment.
     Exact,
+    /// The commitment's last observation is covered by the durable round floor.
     Floor,
 }
 
@@ -322,6 +329,7 @@ where
     H: Hasher,
     P: PublicKey,
 {
+    /// Creates a record that is reconstructing a commitment observed at `round`.
     const fn reconstructing(round: Round, reconstruction: ReconstructionState<P, C, H>) -> Self {
         Self {
             round,
@@ -329,6 +337,7 @@ where
         }
     }
 
+    /// Creates a record for a block already available at `round`.
     const fn cached(round: Round, block: Arc<CodedBlock<B, C, H>>) -> Self {
         Self {
             round,
@@ -339,10 +348,12 @@ where
         }
     }
 
+    /// Returns the latest valid observation round.
     const fn round(&self) -> Round {
         self.round
     }
 
+    /// Ensures that `round` uses the epoch that owns this commitment record.
     fn validate_epoch(&self, round: Round) -> Result<(), Epoch> {
         let existing_epoch = self.round.epoch();
         if existing_epoch != round.epoch() {
@@ -351,12 +362,14 @@ where
         Ok(())
     }
 
+    /// Records a same-epoch observation without moving the retention round backward.
     fn observe(&mut self, round: Round) -> Result<(), Epoch> {
         self.validate_epoch(round)?;
         self.round = self.round.max(round);
         Ok(())
     }
 
+    /// Returns the cached block, if available.
     const fn block(&self) -> Option<&Arc<CodedBlock<B, C, H>>> {
         match &self.phase {
             CommitmentPhase::Reconstructing(_) => None,
@@ -364,6 +377,7 @@ where
         }
     }
 
+    /// Returns shard reconstruction state retained for the commitment, if any.
     const fn reconstruction(&self) -> Option<&ReconstructionState<P, C, H>> {
         match &self.phase {
             CommitmentPhase::Reconstructing(reconstruction) => Some(reconstruction),
@@ -371,6 +385,7 @@ where
         }
     }
 
+    /// Returns mutable shard reconstruction state retained for the commitment, if any.
     const fn reconstruction_mut(&mut self) -> Option<&mut ReconstructionState<P, C, H>> {
         match &mut self.phase {
             CommitmentPhase::Reconstructing(reconstruction) => Some(reconstruction),
@@ -378,6 +393,9 @@ where
         }
     }
 
+    /// Caches `block` while preserving reconstruction state needed for shard readiness.
+    ///
+    /// If a block is already cached, retains and returns the existing instance.
     fn install_block(&mut self, block: Arc<CodedBlock<B, C, H>>) -> Arc<CodedBlock<B, C, H>> {
         let previous = std::mem::replace(
             &mut self.phase,

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -115,11 +115,10 @@
 //! The engine enforces strict validation to prevent Byzantine attacks:
 //!
 //! - All shards MUST be sent by participants in the current epoch.
-//! - If the sender is the leader: the shard index MUST match the recipient's
-//!   participant index (for participants) or the leader's index (for
-//!   non-participants).
-//! - If the sender is not the leader: the shard index MUST match the sender's
-//!   participant index (each participant can only gossip their own shard).
+//! - A discovered leader may send the recipient's assigned shard.
+//! - Any participant, including a discovered leader, may gossip its own shard.
+//! - A recipient-indexed shard from an undiscovered participant is retained in
+//!   the bounded peer buffer until consensus identifies the sender's role.
 //! - All shards MUST pass cryptographic verification against the commitment.
 //! - Each shard index may only contribute ONE shard per commitment.
 //! - Sending a second shard for the same index with different data
@@ -131,8 +130,8 @@
 //! tracked in reconstruction state. Once a block is already reconstructed and
 //! cached, additional shards for that commitment are ignored.
 //!
-//! _If the leader is not yet known, shards are buffered in fixed-size per-peer
-//! queues until consensus signals either the leader via [`Mailbox::discovered`]
+//! _If a sender's role is not yet known, shards are buffered in fixed-size per-peer
+//! queues until consensus signals a leader via [`Mailbox::discovered`]
 //! or a notarization via [`Mailbox::notarized`]. A notarization activates
 //! reconstruction interest without a leader, so only sender-indexed gossip
 //! shards can be ingested. Assigned shard verification still requires leader
@@ -174,7 +173,7 @@ use commonware_utils::{
 };
 use rand_core::Rng;
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, BTreeSet, VecDeque},
     num::NonZeroUsize,
     sync::Arc,
 };
@@ -569,20 +568,20 @@ where
                 return;
             };
 
-            // Notarized recovery can create state before leader discovery. Until
-            // the leader is known, only sender-indexed gossip shards are safe to
-            // ingest: a participant may only gossip its own shard.
-            if existing.leader().is_none()
-                && let Some(sender_index) = scheme.participants().index(&peer)
-            {
-                let expected_index: u16 = sender_index
+            // Sender-indexed gossip is immediately actionable. A recipient-indexed
+            // shard from an undiscovered reproposer remains buffered until consensus
+            // confirms the sender's role.
+            if let Some(sender_index) = scheme.participants().index(&peer) {
+                let sender_index: u16 = sender_index
                     .get()
                     .try_into()
                     .expect("participant index impossibly out of bounds");
-                if shard.index() != expected_index {
-                    // A mismatched shard is invalid for a non-leader, but it may be
-                    // the assigned shard if this peer later turns out to be the leader.
-                    // Keep it buffered until the sender's role is known.
+                let could_be_assigned = scheme
+                    .me()
+                    .is_some_and(|index| index.get() == u32::from(shard.index()));
+                if shard.index() != sender_index
+                    && (!existing.has_leader() || could_be_assigned && !existing.is_leader(&peer))
+                {
                     self.buffer_peer_shard(peer, shard);
                     return;
                 }
@@ -706,10 +705,8 @@ where
         leader: P,
         round: Round,
     ) {
-        // A reconstructed block normally makes duplicate leader announcements
-        // redundant, unless notarized recovery created leaderless state first.
-        // In that case, the leader announcement must still populate the
-        // leader-dependent path.
+        // A reconstructed block normally makes leader announcements redundant,
+        // unless its assigned shard is still pending.
         let block_cached = self.reconstructed_blocks.contains_key(&commitment);
         if block_cached {
             self.observe_existing_commitment(commitment, round);
@@ -718,7 +715,7 @@ where
             && self
                 .state
                 .get(&commitment)
-                .is_none_or(|state| state.leader().is_some())
+                .is_none_or(ReconstructionState::is_assigned_shard_verified)
         {
             return;
         }
@@ -735,20 +732,7 @@ where
             self.observe_existing_commitment(commitment, round);
         }
         if let Some(state) = self.state.get_mut(&commitment) {
-            if let Some(existing) = state.leader() {
-                if existing != &leader {
-                    warn!(
-                        existing = ?existing,
-                        ?leader,
-                        %commitment,
-                        "conflicting leader update, ignoring"
-                    );
-                }
-                return;
-            }
-            state
-                .set_leader(leader)
-                .expect("leader was checked as absent");
+            state.add_leader(leader);
         } else {
             let participants_len = u64::try_from(participants.len())
                 .expect("participant count impossibly out of bounds");
@@ -800,7 +784,7 @@ where
         }
     }
 
-    /// Buffer a shard from a peer until a leader is known.
+    /// Buffer a shard from a peer until its sender role is known.
     fn buffer_peer_shard(&mut self, peer: P, shard: Shard<C, H>) {
         if self.latest_primary_peers.position(&peer).is_none() {
             debug!(
@@ -822,22 +806,16 @@ where
         self.latest_primary_peers = peers;
     }
 
-    /// Ingest buffered pre-leader shards for a commitment into active state.
+    /// Ingest actionable buffered shards for a commitment into active state.
     ///
-    /// The buffers are per sender and may contain shards from many peers. Before
-    /// the leader is known, the only actionable shard from each sender is the
-    /// one at that sender's participant index, because that is the shard a
-    /// non-leader is allowed to gossip. This still lets a notarized commitment
-    /// reconstruct from many peer-gossiped shards. The local assigned shard is
-    /// different: it is only valid when it came from the leader, and the leader's
-    /// identity is needed before it can be accepted as assigned-shard evidence.
+    /// Sender-indexed gossip is always actionable. Recipient-indexed shards are
+    /// retained until consensus identifies their sender as a leader.
     fn ingest_buffered_shards(&mut self, commitment: Commitment) -> bool {
         let state = self
             .state
             .get(&commitment)
             .expect("buffered shards can only be ingested with reconstruction state");
         let round = state.round();
-        let leader_known = state.leader().is_some();
         let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
             warn!(%commitment, "no scheme for epoch, dropping buffered shards");
             return false;
@@ -851,19 +829,23 @@ where
                     i += 1;
                     continue;
                 }
-                if !leader_known {
-                    let Some(sender_index) = scheme.participants().index(peer) else {
-                        i += 1;
-                        continue;
-                    };
-                    let expected_index: u16 = sender_index
-                        .get()
-                        .try_into()
-                        .expect("participant index impossibly out of bounds");
-                    if queue[i].index() != expected_index {
-                        i += 1;
-                        continue;
-                    }
+                let Some(sender_index) = scheme.participants().index(peer) else {
+                    i += 1;
+                    continue;
+                };
+                let sender_index: u16 = sender_index
+                    .get()
+                    .try_into()
+                    .expect("participant index impossibly out of bounds");
+                let could_be_assigned = scheme
+                    .me()
+                    .is_some_and(|index| index.get() == u32::from(queue[i].index()));
+                let actionable = queue[i].index() == sender_index
+                    || state.is_leader(peer)
+                    || state.has_leader() && !could_be_assigned;
+                if !actionable {
+                    i += 1;
+                    continue;
                 }
                 let shard = queue.swap_remove_back(i).expect("index is valid");
                 buffered.push((peer.clone(), shard));
@@ -1256,9 +1238,8 @@ where
     C: CodingScheme,
     H: Hasher,
 {
-    /// The leader associated with this reconstruction state, if consensus has
-    /// provided it.
-    leader: Option<P>,
+    /// Leaders observed for this commitment.
+    leaders: BTreeSet<P>,
     /// Our validated shard and the action to take with it.
     pending_action: Option<AssignedShardVerifiedAction<C, H>>,
     /// Shards that have been verified and are ready to contribute to reconstruction.
@@ -1313,7 +1294,7 @@ where
     /// Create a new empty common state for the provided leader and round.
     fn new(leader: Option<P>, round: Round, participants_len: u64) -> Self {
         Self {
-            leader,
+            leaders: leader.into_iter().collect(),
             pending_action: None,
             checked_shards: Vec::new(),
             contributed: BitMap::zeroes(participants_len),
@@ -1421,10 +1402,9 @@ where
 
         // Transition to Ready.
         let round = self.common.round;
-        let leader = self.common.leader.clone();
         let common = std::mem::replace(
             &mut self.common,
-            CommonState::new(leader, round, participants_len),
+            CommonState::new(None, round, participants_len),
         );
         Some(ReadyState { common })
     }
@@ -1491,18 +1471,19 @@ where
         }
     }
 
-    /// Return the leader associated with this state.
-    const fn leader(&self) -> Option<&P> {
-        self.common().leader.as_ref()
+    /// Returns whether consensus has identified any leader for this commitment.
+    fn has_leader(&self) -> bool {
+        !self.common().leaders.is_empty()
     }
 
-    /// Set the leader for this state if it has not already been set.
-    fn set_leader(&mut self, leader: P) -> Result<(), P> {
-        if self.common().leader.is_some() {
-            return Err(leader);
-        }
-        self.common_mut().leader = Some(leader);
-        Ok(())
+    /// Returns whether consensus has identified `leader` for this commitment.
+    fn is_leader(&self, leader: &P) -> bool {
+        self.common().leaders.contains(leader)
+    }
+
+    /// Associates a consensus-observed leader with this commitment.
+    fn add_leader(&mut self, leader: P) {
+        self.common_mut().leaders.insert(leader);
     }
 
     /// Refreshes the round used to decide whether this state can be pruned.
@@ -1549,21 +1530,18 @@ where
     ///
     /// - MUST be sent by a participant in the current epoch. Non-participant
     ///   senders are blocked.
-    /// - If the sender is the leader: the shard index MUST match the
-    ///   recipient's own participant index (when the recipient is a
-    ///   participant) or the leader's participant index (when the recipient
-    ///   is a non-participant).
-    /// - If the sender is not the leader: the shard index MUST match the
-    ///   sender's participant index. Each non-leader participant may only
-    ///   gossip their own shard.
-    /// - Once the leader is known, a mismatched shard index results in
-    ///   blocking the sender.
+    /// - If the sender is a leader: the shard index MUST match either the
+    ///   recipient's participant index or the sender's participant index.
+    /// - If the sender is not a leader: the shard index MUST match the
+    ///   sender's participant index.
+    /// - Once a leader is known, any other shard index results in blocking.
     /// - Each shard index may only contribute ONE shard per commitment.
     ///   Sending a second shard for the same index with different data
     ///   (equivocation) results in blocking the sender.
-    /// - The leader's shard is verified eagerly via [`CodingScheme::check`].
-    ///   If verification fails, the leader is blocked.
-    /// - Non-leader shards are buffered in `pending_shards` and
+    /// - A leader's shard for the assigned index is verified eagerly via
+    ///   [`CodingScheme::check`].
+    ///   If verification fails, the sender is blocked.
+    /// - Own-index shards are buffered in `pending_shards` and
     ///   batch-validated when quorum is reached. Invalid shards discovered
     ///   during batch validation result in blocking their respective
     ///   senders.
@@ -1576,9 +1554,9 @@ where
     /// - Exact duplicate of a previously received shard for the same index.
     /// - The index has already been marked as contributed (via the bitmap,
     ///   e.g. after batch validation).
-    /// - Non-leader shards that arrive after the state has transitioned to
+    /// - Own-index shards that arrive after the state has transitioned to
     ///   [`ReconstructionState::Ready`] (i.e., batch validation has already
-    ///   passed). The leader's shard for our index is still accepted in
+    ///   passed). An assigned shard for our index is still accepted in
     ///   `Ready` state to ensure we verify and re-broadcast it.
     /// - Before a reconstruction state exists, shards are buffered at the
     ///   engine level in bounded per-peer queues until [`Mailbox::discovered`]
@@ -1605,23 +1583,26 @@ where
             data: shard.into_inner(),
         };
 
-        // Determine expected index based on sender role. Before the leader is
-        // known, only sender-indexed gossip shards are actionable; mismatched
-        // shards cannot be classified without the leader and do not satisfy
-        // assigned shard verification.
-        let leader = self.common().leader.as_ref();
-        let is_from_leader = leader.is_some_and(|leader| leader == &sender);
-        let expected_participant = if is_from_leader {
-            ctx.scheme.me().unwrap_or(sender_index)
-        } else {
-            sender_index
-        };
-        let expected_index: u16 = expected_participant
+        let sender_index: u16 = sender_index
             .get()
             .try_into()
             .expect("participant index impossibly out of bounds");
-        if indexed.index != expected_index {
-            if leader.is_some() {
+        let assigned_index = ctx.scheme.me().map_or(sender_index, |assigned_index| {
+            assigned_index
+                .get()
+                .try_into()
+                .expect("participant index impossibly out of bounds")
+        });
+        let is_from_leader = self.is_leader(&sender);
+        let is_assigned_shard = is_from_leader && indexed.index == assigned_index;
+        let is_gossip_shard = indexed.index == sender_index;
+        if !is_assigned_shard && !is_gossip_shard {
+            if self.has_leader() {
+                let expected_index = if is_from_leader {
+                    assigned_index
+                } else {
+                    sender_index
+                };
                 commonware_p2p::block!(
                     blocker,
                     sender,
@@ -1649,7 +1630,7 @@ where
         // Leader's shard for our index is always verified eagerly,
         // even after transitioning to Ready. This ensures we broadcast
         // our own shard to help slower peers reach quorum.
-        if is_from_leader && !self.common().assigned_shard_verified {
+        if is_assigned_shard && !self.common().assigned_shard_verified {
             let progressed = self.common_mut().verify_assigned_shard(
                 sender,
                 commitment,
@@ -1668,7 +1649,7 @@ where
             return progressed;
         }
 
-        // Non-leader shards are only accepted while awaiting quorum.
+        // Gossip shards are only accepted while awaiting quorum.
         let Self::AwaitingQuorum(state) = self else {
             return false;
         };
@@ -2644,10 +2625,10 @@ mod tests {
                 let coded_block = CodedBlock::<B, C, H>::new(inner, coding_config, &STRATEGY);
                 let commitment = coded_block.commitment();
 
-                // Get peer 2's own-index shard.
-                let peer2_index = peers[2].index.get() as u16;
-                let peer2_shard = coded_block.shard(peer2_index).expect("missing shard");
-                let shard_bytes = peer2_shard.encode();
+                // Get a shard that belongs to neither the sender nor receiver.
+                let unrelated_index = peers[3].index.get() as u16;
+                let unrelated_shard = coded_block.shard(unrelated_index).expect("missing shard");
+                let shard_bytes = unrelated_shard.encode();
 
                 let peer2_pk = peers[2].public_key.clone();
                 let leader = peers[0].public_key.clone();
@@ -2659,8 +2640,8 @@ mod tests {
                     Round::new(Epoch::zero(), View::new(1)),
                 );
 
-                // Peer 1 (not the leader) sends peer 2 a shard with peer 2's index
-                // (wrong: non-leaders must use their own index).
+                // Peer 1 (not the leader) sends peer 2 a shard for peer 3. It
+                // cannot be either sender-indexed gossip or an assigned shard.
                 peers[1]
                     .sender
                     .send(Recipients::One(peer2_pk), shard_bytes, true);
@@ -2683,15 +2664,14 @@ mod tests {
                 let coded_block = CodedBlock::<B, C, H>::new(inner, coding_config, &STRATEGY);
                 let commitment = coded_block.commitment();
 
-                // Get peer 2's own-index shard.
-                let peer2_index = peers[2].index.get() as u16;
-                let peer2_shard = coded_block.shard(peer2_index).expect("missing shard");
-                let shard_bytes = peer2_shard.encode();
+                // Get a shard that belongs to neither the sender nor receiver.
+                let unrelated_index = peers[3].index.get() as u16;
+                let unrelated_shard = coded_block.shard(unrelated_index).expect("missing shard");
+                let shard_bytes = unrelated_shard.encode();
 
                 let peer2_pk = peers[2].public_key.clone();
 
-                // Peer 1 sends a shard with peer 2's index before the leader is known (buffered).
-                // This is wrong: non-leaders must send at their own index.
+                // Peer 1 sends peer 3's shard before the leader is known.
                 peers[1]
                     .sender
                     .send(Recipients::One(peer2_pk), shard_bytes, true);
@@ -2705,8 +2685,8 @@ mod tests {
                 );
 
                 // Now inform peer 2 that peer 0 is the leader.
-                // This drains the buffer: peer 1's shard has peer 2's index but
-                // peer 1 is not the leader, so expected index is peer 1's own index.
+                // This drains the impossible candidate: it belongs to neither
+                // peer 1 nor peer 2.
                 let leader = peers[0].public_key.clone();
                 peers[2].mailbox.discovered(
                     commitment,
@@ -2721,7 +2701,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_conflicting_external_proposed_ignored() {
+    fn test_later_external_proposer_accepted() {
         let fixture = Fixture::<C>::default();
         fixture.start(
             |config, context, oracle, mut peers, _, coding_config| async move {
@@ -2729,7 +2709,7 @@ mod tests {
                 let coded_block = CodedBlock::<B, C, H>::new(inner, coding_config, &STRATEGY);
                 let commitment = coded_block.commitment();
 
-                // Get the shard the leader would send to peer 2 (at peer 2's index).
+                // Get peer 2's assigned shard.
                 let peer2_index = peers[2].index.get() as u16;
                 let peer2_shard = coded_block.shard(peer2_index).expect("missing shard");
                 let shard_bytes = peer2_shard.encode();
@@ -2739,55 +2719,41 @@ mod tests {
                 let leader_b = peers[1].public_key.clone();
 
                 // Subscribe before shards arrive so we can verify acceptance.
-                let shard_sub = peers[2]
+                let mut shard_sub = peers[2]
                     .mailbox
                     .subscribe_assigned_shard_verified(commitment);
 
-                // First leader update should stick.
+                // The commitment is first proposed by leader A.
                 peers[2].mailbox.discovered(
                     commitment,
-                    leader_a.clone(),
+                    leader_a,
                     Round::new(Epoch::zero(), View::new(1)),
                 );
 
-                // Conflicting update should be ignored.
-                peers[2].mailbox.discovered(
-                    commitment,
-                    leader_b,
-                    Round::new(Epoch::zero(), View::new(1)),
-                );
-
-                // Original leader sends shard; this should still be accepted.
-                peers[0]
-                    .sender
-                    .send(Recipients::One(peer2_pk.clone()), shard_bytes.clone(), true);
-                context.sleep(config.link.latency * 2).await;
-
-                // Subscription should resolve from accepted leader shard.
-                select! {
-                    _ = shard_sub => {},
-                    _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("subscription did not complete after shard from original leader");
-                    },
-                };
-
-                // The conflicting leader should still be treated as non-leader and blocked.
+                // The later leader's shard may arrive before its proposal.
                 peers[1]
                     .sender
                     .send(Recipients::One(peer2_pk), shard_bytes, true);
                 context.sleep(config.link.latency * 2).await;
+                assert!(oracle.blocked().await.unwrap().is_empty());
+                assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
 
-                assert_blocked(&oracle, &peers[2].public_key, &peers[1].public_key).await;
-
-                // Original leader should not be blocked.
-                let blocked_peers = oracle.blocked().await.unwrap();
-                let leader_a_blocked = blocked_peers
-                    .iter()
-                    .any(|(a, b)| a == &peers[2].public_key && b == &leader_a);
-                assert!(
-                    !leader_a_blocked,
-                    "original leader should not be blocked after conflicting leader update"
+                // Discovering the later leader makes its buffered shard actionable.
+                peers[2].mailbox.discovered(
+                    commitment,
+                    leader_b,
+                    Round::new(Epoch::zero(), View::new(2)),
                 );
+
+                // Subscription should resolve from the later leader's shard.
+                select! {
+                    _ = shard_sub => {},
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("subscription did not complete after shard from later leader");
+                    },
+                };
+
+                assert!(oracle.blocked().await.unwrap().is_empty());
             },
         );
     }

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -148,7 +148,7 @@ use crate::{
             types::{CodedBlock, Shard},
             validation::{ReconstructionError as InvariantError, validate_reconstruction},
         },
-        core::RetentionUpdate,
+        core::Retirement,
     },
     types::{Epoch, Round, coding::Commitment},
 };
@@ -304,9 +304,9 @@ where
     phase: CommitmentPhase<B, C, H, P>,
 }
 
-/// Whether a commitment already has an owned lifecycle record.
+/// The current lifecycle status of a commitment.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum CommitmentPresence {
+enum CommitmentStatus {
     /// No record exists for the commitment.
     Absent,
     /// The commitment is accumulating or validating shards.
@@ -850,10 +850,10 @@ where
         // redundant, unless notarized recovery created leaderless state first.
         // In that case, the leader announcement must still populate the
         // leader-dependent path.
-        let Some(presence) = self.observe_existing_commitment(commitment, round) else {
+        let Some(status) = self.observe_existing_commitment(commitment, round) else {
             return;
         };
-        if presence == CommitmentPresence::Cached
+        if status == CommitmentStatus::Cached
             && self
                 .records
                 .get(&commitment)
@@ -910,13 +910,13 @@ where
         commitment: Commitment,
         round: Round,
     ) {
-        let Some(presence) = self.observe_existing_commitment(commitment, round) else {
+        let Some(status) = self.observe_existing_commitment(commitment, round) else {
             return;
         };
-        if presence == CommitmentPresence::Cached {
+        if status == CommitmentStatus::Cached {
             return;
         }
-        if presence == CommitmentPresence::Reconstructing {
+        if status == CommitmentStatus::Reconstructing {
             let buffered_progress = self.ingest_buffered_shards(commitment);
             if buffered_progress {
                 self.try_advance(sender, commitment);
@@ -1027,16 +1027,16 @@ where
 
     /// Records a consensus observation on an existing commitment owner.
     ///
-    /// Returns the record's phase, [`CommitmentPresence::Absent`] if it has no
+    /// Returns the record's phase, [`CommitmentStatus::Absent`] if it has no
     /// owner yet, or `None` when its owner is bound to a different epoch.
     fn observe_existing_commitment(
         &mut self,
         commitment: Commitment,
         round: Round,
-    ) -> Option<CommitmentPresence> {
+    ) -> Option<CommitmentStatus> {
         let observed_epoch = round.epoch();
         let Some(record) = self.records.get_mut(&commitment) else {
-            return Some(CommitmentPresence::Absent);
+            return Some(CommitmentStatus::Absent);
         };
         if let Err(existing_epoch) = record.observe(round) {
             warn!(
@@ -1048,9 +1048,9 @@ where
             return None;
         }
         Some(if record.block().is_some() {
-            CommitmentPresence::Cached
+            CommitmentStatus::Cached
         } else {
-            CommitmentPresence::Reconstructing
+            CommitmentStatus::Reconstructing
         })
     }
 
@@ -1062,7 +1062,7 @@ where
         reconstruction: ReconstructionState<P, C, H>,
     ) {
         let Entry::Vacant(entry) = self.records.entry(commitment) else {
-            unreachable!("commitment presence was checked as absent");
+            unreachable!("commitment status was checked as absent");
         };
         entry.insert(CommitmentRecord::reconstructing(round, reconstruction));
         self.metrics.reconstruction_states_count.inc();
@@ -1390,8 +1390,8 @@ where
     ///
     /// Retirement waits for durable progress because a Byzantine leader may produce multiple
     /// valid commitments in one round.
-    fn retire(&mut self, update: RetentionUpdate<Commitment>) {
-        let RetentionUpdate {
+    fn retire(&mut self, update: Retirement<Commitment>) {
+        let Retirement {
             round_floor,
             exact_retirements,
         } = update;
@@ -2584,7 +2584,7 @@ mod tests {
 
             // The authoritative retirement floor removes every earlier candidate and the exact
             // processed commitment, even when that commitment was observed above the floor.
-            peer.mailbox.retire(RetentionUpdate {
+            peer.mailbox.retire(Retirement {
                 round_floor: Round::new(Epoch::zero(), View::new(3)),
                 exact_retirements: vec![processed_commitment],
             });
@@ -2650,7 +2650,7 @@ mod tests {
             let mut state_later_sub = peer.mailbox.subscribe(state_later);
             context.sleep(Duration::from_millis(10)).await;
 
-            peer.mailbox.retire(RetentionUpdate {
+            peer.mailbox.retire(Retirement {
                 round_floor: floor,
                 exact_retirements: vec![unseen],
             });
@@ -2713,7 +2713,7 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
             assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
 
-            peer.mailbox.retire(RetentionUpdate {
+            peer.mailbox.retire(Retirement {
                 round_floor: floor,
                 exact_retirements: vec![unseen],
             });
@@ -3056,7 +3056,7 @@ mod tests {
                 non_participant,
                 Round::new(Epoch::zero(), View::new(10)),
             );
-            receiver.mailbox.retire(RetentionUpdate {
+            receiver.mailbox.retire(Retirement {
                 round_floor: Round::new(Epoch::zero(), View::new(5)),
                 exact_retirements: vec![unrelated],
             });
@@ -3111,7 +3111,7 @@ mod tests {
             receiver
                 .mailbox
                 .notarized(incomplete_commitment, conflicting_round);
-            receiver.mailbox.retire(RetentionUpdate {
+            receiver.mailbox.retire(Retirement {
                 round_floor: Round::new(Epoch::zero(), View::new(5)),
                 exact_retirements: vec![unrelated],
             });
@@ -3519,7 +3519,7 @@ mod tests {
                     .mailbox
                     .notarized(live_commitment, Round::new(Epoch::zero(), View::new(4)));
                 context.sleep(Duration::from_millis(10)).await;
-                peers[receiver_idx].mailbox.retire(RetentionUpdate {
+                peers[receiver_idx].mailbox.retire(Retirement {
                     round_floor: Round::new(Epoch::zero(), View::new(3)),
                     exact_retirements: vec![finalized_commitment],
                 });
@@ -3646,7 +3646,7 @@ mod tests {
 
                 let prune_round = Round::new(Epoch::zero(), View::new(3));
                 for &receiver_idx in &receivers {
-                    peers[receiver_idx].mailbox.retire(RetentionUpdate {
+                    peers[receiver_idx].mailbox.retire(Retirement {
                         round_floor: prune_round,
                         exact_retirements: vec![finalized_commitment],
                     });
@@ -3756,7 +3756,7 @@ mod tests {
                     peers[2].mailbox.get(commitment_b).await.is_some(),
                     "local proposal should be cached before pruning"
                 );
-                peers[2].mailbox.retire(RetentionUpdate {
+                peers[2].mailbox.retire(Retirement {
                     round_floor: round_b,
                     exact_retirements: vec![commitment_b],
                 });

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1177,16 +1177,16 @@ where
             .remove(&BlockSubscriptionKey::Commitment(commitment));
     }
 
-    /// Prunes cached blocks and reconstruction state after finalization.
+    /// Prunes cached blocks and reconstruction state after durable application progress.
     ///
-    /// Pruning waits for finalization because a Byzantine leader may produce multiple valid
+    /// Pruning waits for durable progress because a Byzantine leader may produce multiple valid
     /// commitments in one round.
     fn prune(&mut self, round: Round, finalized: Commitment) {
-        // Finalization makes existing exact-commitment and assigned-shard waits for these states
-        // obsolete. Digest waits are not commitment-specific.
+        // Durable processing makes existing exact-commitment and assigned-shard waits for these
+        // states obsolete. Digest waits are not commitment-specific.
         self.drop_commitment_subscriptions(finalized);
 
-        // Evict the finalized block and blocks last observed no later than its finalization round.
+        // Evict the processed block and blocks last observed no later than the retirement floor.
         // Blocks observed in later rounds may still be needed for certification.
         self.reconstructed_blocks
             .retain(|commitment, entry| *commitment != finalized && entry.round > round);
@@ -1202,7 +1202,6 @@ where
             keep
         });
 
-        // Close exact subscriptions after `retain` releases the mutable borrow.
         for pruned in pruned_commitments {
             self.drop_commitment_subscriptions(pruned);
         }
@@ -2318,12 +2317,12 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_durable_prune_uses_consensus_round() {
+    fn test_prune_uses_inclusive_retirement_floor() {
         let fixture = Fixture::<C>::default();
         fixture.start(|_, context, _, mut peers, _, coding_config| async move {
-            // The commitment was cached in its original proposal round and later
-            // finalized by a re-proposal. A malicious candidate arrived in between.
-            let finalized = CodedBlock::<B, C, H>::new(
+            // The processed commitment was re-proposed above the retirement floor. A malicious
+            // candidate was observed below it.
+            let processed = CodedBlock::<B, C, H>::new(
                 B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100),
                 coding_config,
                 &STRATEGY,
@@ -2333,72 +2332,184 @@ mod tests {
                 coding_config,
                 &STRATEGY,
             );
+            let equal = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(3), 100),
+                coding_config,
+                &STRATEGY,
+            );
             let later = CodedBlock::<B, C, H>::new(
                 B::new::<H>((), Sha256Digest::EMPTY, Height::new(2), 100),
                 coding_config,
                 &STRATEGY,
             );
-            let finalized_commitment = finalized.commitment();
+            let processed_commitment = processed.commitment();
             let malicious_commitment = malicious.commitment();
+            let equal_commitment = equal.commitment();
             let later_commitment = later.commitment();
 
             // Cache all blocks via `proposed`.
             let peer = &mut peers[0];
-            peer.mailbox.proposed(
-                Round::new(Epoch::zero(), View::new(1)),
-                finalized,
-            );
-            peer.mailbox.proposed(
-                Round::new(Epoch::zero(), View::new(2)),
-                malicious,
-            );
-            peer.mailbox.proposed(
-                Round::new(Epoch::zero(), View::new(1)),
-                later,
-            );
-            // A later notarization makes the same canonical block live in a
-            // newer round while the application still processes older blocks.
-            peer.mailbox.notarized(
-                later_commitment,
-                Round::new(Epoch::zero(), View::new(4)),
-            );
+            peer.mailbox
+                .proposed(Round::new(Epoch::zero(), View::new(1)), processed.clone());
+            peer.mailbox
+                .proposed(Round::new(Epoch::zero(), View::new(2)), malicious);
+            peer.mailbox
+                .proposed(Round::new(Epoch::zero(), View::new(3)), equal);
+            peer.mailbox
+                .proposed(Round::new(Epoch::zero(), View::new(1)), later.clone());
+            // Re-proposals refresh ownership independently of the commitment's
+            // original context round.
+            peer.mailbox
+                .proposed(Round::new(Epoch::zero(), View::new(5)), processed);
+            peer.mailbox
+                .proposed(Round::new(Epoch::zero(), View::new(4)), later);
             context.sleep(Duration::from_millis(10)).await;
 
             // Verify all blocks are in the cache.
             assert!(
-                peer.mailbox.get(finalized_commitment).await.is_some(),
-                "finalized block should be cached"
+                peer.mailbox.get(processed_commitment).await.is_some(),
+                "processed block should be cached"
             );
             assert!(
                 peer.mailbox.get(malicious_commitment).await.is_some(),
                 "malicious block should be cached"
             );
             assert!(
+                peer.mailbox.get(equal_commitment).await.is_some(),
+                "equal-round block should be cached"
+            );
+            assert!(
                 peer.mailbox.get(later_commitment).await.is_some(),
                 "later block should be cached"
             );
 
-            // The authoritative finalization round retires every earlier candidate,
-            // regardless of its height or the target's original cache round.
+            // The authoritative retirement floor removes every earlier candidate and the exact
+            // processed commitment, even when that commitment was observed above the floor.
             peer.mailbox.prune(
                 Round::new(Epoch::zero(), View::new(3)),
-                finalized_commitment,
+                processed_commitment,
             );
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(
-                peer.mailbox.get(finalized_commitment).await.is_none(),
-                "finalized block should be pruned"
+                peer.mailbox.get(processed_commitment).await.is_none(),
+                "exact processed block should be pruned above the floor"
             );
             assert!(
                 peer.mailbox.get(malicious_commitment).await.is_none(),
                 "earlier malicious block should be pruned"
             );
-
+            assert!(
+                peer.mailbox.get(equal_commitment).await.is_none(),
+                "block observed at the retirement floor should be pruned"
+            );
             assert!(
                 peer.mailbox.get(later_commitment).await.is_some(),
-                "later-round block should still be cached"
+                "non-target block observed above the floor should remain cached"
             );
+        });
+    }
+
+    #[test_traced]
+    fn test_prune_unseen_commitment_applies_floor() {
+        let fixture = Fixture::<C>::default();
+        fixture.start(|_, context, _, mut peers, _, coding_config| async move {
+            let make_block = |id| {
+                CodedBlock::<B, C, H>::new(
+                    B::new::<H>((), Sha256Digest::EMPTY, Height::new(id), id),
+                    coding_config,
+                    &STRATEGY,
+                )
+            };
+            let cached_old = make_block(1);
+            let cached_equal = make_block(2);
+            let cached_later = make_block(3);
+            let state_old = make_block(4).commitment();
+            let state_equal = make_block(5).commitment();
+            let state_later = make_block(6).commitment();
+            let unseen = make_block(7).commitment();
+            let cached_old_commitment = cached_old.commitment();
+            let cached_equal_commitment = cached_equal.commitment();
+            let cached_later_commitment = cached_later.commitment();
+            let old_round = Round::new(Epoch::zero(), View::new(2));
+            let floor = Round::new(Epoch::zero(), View::new(3));
+            let later_round = Round::new(Epoch::zero(), View::new(4));
+            let leader = peers[1].public_key.clone();
+            let peer = &mut peers[0];
+
+            peer.mailbox.proposed(old_round, cached_old);
+            peer.mailbox.proposed(floor, cached_equal);
+            peer.mailbox.proposed(later_round, cached_later);
+            peer.mailbox
+                .discovered(state_old, leader.clone(), old_round);
+            peer.mailbox.discovered(state_equal, leader.clone(), floor);
+            peer.mailbox
+                .discovered(state_later, leader.clone(), old_round);
+            peer.mailbox.discovered(state_later, leader, later_round);
+            let mut state_old_sub = peer.mailbox.subscribe(state_old);
+            let mut state_equal_sub = peer.mailbox.subscribe(state_equal);
+            let mut state_later_sub = peer.mailbox.subscribe(state_later);
+            context.sleep(Duration::from_millis(10)).await;
+
+            peer.mailbox.prune(floor, unseen);
+            context.sleep(Duration::from_millis(10)).await;
+
+            assert!(peer.mailbox.get(cached_old_commitment).await.is_none());
+            assert!(peer.mailbox.get(cached_equal_commitment).await.is_none());
+            assert!(peer.mailbox.get(cached_later_commitment).await.is_some());
+            assert!(matches!(
+                state_old_sub.try_recv(),
+                Err(TryRecvError::Closed)
+            ));
+            assert!(matches!(
+                state_equal_sub.try_recv(),
+                Err(TryRecvError::Closed)
+            ));
+            assert!(matches!(
+                state_later_sub.try_recv(),
+                Err(TryRecvError::Empty)
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_local_reproposal_refreshes_existing_reconstruction_state() {
+        let fixture = Fixture::<C>::default();
+        fixture.start(|_, context, _, mut peers, _, coding_config| async move {
+            let live = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100),
+                coding_config,
+                &STRATEGY,
+            );
+            let unseen = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(2), 200),
+                coding_config,
+                &STRATEGY,
+            )
+            .commitment();
+            let live_commitment = live.commitment();
+            let leader = peers[0].public_key.clone();
+            let original_round = Round::new(Epoch::zero(), View::new(1));
+            let floor = Round::new(Epoch::zero(), View::new(3));
+            let reproposal_round = Round::new(Epoch::zero(), View::new(4));
+            let peer = &mut peers[0];
+
+            peer.mailbox
+                .discovered(live_commitment, leader, original_round);
+            peer.mailbox.proposed(reproposal_round, live);
+            assert!(peer.mailbox.get(live_commitment).await.is_some());
+
+            let mut shard_sub = peer
+                .mailbox
+                .subscribe_assigned_shard_verified(live_commitment);
+            context.sleep(Duration::from_millis(10)).await;
+            assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
+
+            peer.mailbox.prune(floor, unseen);
+            context.sleep(Duration::from_millis(10)).await;
+
+            assert!(peer.mailbox.get(live_commitment).await.is_some());
+            assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
         });
     }
 
@@ -3119,10 +3230,9 @@ mod tests {
 
                 // The same commitment becomes live in a later round while the application
                 // still has an older finalization to acknowledge.
-                peers[receiver_idx].mailbox.notarized(
-                    live_commitment,
-                    Round::new(Epoch::zero(), View::new(4)),
-                );
+                peers[receiver_idx]
+                    .mailbox
+                    .notarized(live_commitment, Round::new(Epoch::zero(), View::new(4)));
                 context.sleep(Duration::from_millis(10)).await;
                 peers[receiver_idx].mailbox.prune(
                     Round::new(Epoch::zero(), View::new(3)),
@@ -3265,6 +3375,16 @@ mod tests {
                     matches!(discovered_sub.try_recv(), Err(TryRecvError::Empty)),
                     "cached discovery should keep reconstruction state live"
                 );
+                for &receiver_idx in &receivers {
+                    assert!(
+                        peers[receiver_idx]
+                            .mailbox
+                            .get(live_commitment)
+                            .await
+                            .is_some(),
+                        "cached observation should keep the reconstructed block live"
+                    );
+                }
 
                 for (&receiver_idx, receiver) in receivers.iter().zip(&receiver_keys) {
                     let leader_shard = live

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -141,9 +141,12 @@ use super::{
 };
 use crate::{
     Block, CertifiableBlock, Heightable,
-    marshal::coding::{
-        types::{CodedBlock, Shard},
-        validation::{ReconstructionError as InvariantError, validate_reconstruction},
+    marshal::{
+        coding::{
+            types::{CodedBlock, Shard},
+            validation::{ReconstructionError as InvariantError, validate_reconstruction},
+        },
+        core::RetentionUpdate,
     },
     types::{Epoch, Round, coding::Commitment},
 };
@@ -162,7 +165,7 @@ use commonware_p2p::{
 use commonware_parallel::Strategy;
 use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, spawn_cell,
-    telemetry::metrics::{GaugeExt, HistogramExt},
+    telemetry::metrics::HistogramExt,
 };
 use commonware_utils::{
     bitmap::BitMap,
@@ -171,7 +174,7 @@ use commonware_utils::{
 };
 use rand_core::Rng;
 use std::{
-    collections::{BTreeMap, VecDeque},
+    collections::{BTreeMap, VecDeque, btree_map::Entry},
     num::NonZeroUsize,
     sync::Arc,
 };
@@ -265,15 +268,135 @@ where
     pub peer_provider: D,
 }
 
-/// A cached reconstructed block and its latest consensus round.
-struct ReconstructedBlock<B, C, H>
+/// The data currently owned for a consensus commitment.
+enum CommitmentPhase<B, C, H, P>
 where
     B: Block,
     C: CodingScheme,
     H: Hasher,
+    P: PublicKey,
+{
+    /// Shards are still being accumulated or validated.
+    Reconstructing(ReconstructionState<P, C, H>),
+    /// The block is cached. Reconstruction state remains only while shard-specific
+    /// evidence may still arrive.
+    Cached {
+        block: Arc<CodedBlock<B, C, H>>,
+        reconstruction: Option<ReconstructionState<P, C, H>>,
+    },
+}
+
+/// The single lifecycle owner for a consensus commitment.
+///
+/// The observation round determines both retention and the epoch whose participant
+/// scheme classifies shards. Keeping it outside the phase prevents cached and
+/// reconstructing views of the same commitment from diverging.
+struct CommitmentRecord<B, C, H, P>
+where
+    B: Block,
+    C: CodingScheme,
+    H: Hasher,
+    P: PublicKey,
 {
     round: Round,
-    block: Arc<CodedBlock<B, C, H>>,
+    phase: CommitmentPhase<B, C, H, P>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommitmentPresence {
+    Absent,
+    Reconstructing,
+    Cached,
+}
+
+#[derive(Clone, Copy)]
+enum RetirementReason {
+    Exact,
+    Floor,
+}
+
+impl<B, C, H, P> CommitmentRecord<B, C, H, P>
+where
+    B: Block,
+    C: CodingScheme,
+    H: Hasher,
+    P: PublicKey,
+{
+    const fn reconstructing(round: Round, reconstruction: ReconstructionState<P, C, H>) -> Self {
+        Self {
+            round,
+            phase: CommitmentPhase::Reconstructing(reconstruction),
+        }
+    }
+
+    const fn cached(round: Round, block: Arc<CodedBlock<B, C, H>>) -> Self {
+        Self {
+            round,
+            phase: CommitmentPhase::Cached {
+                block,
+                reconstruction: None,
+            },
+        }
+    }
+
+    const fn round(&self) -> Round {
+        self.round
+    }
+
+    fn validate_epoch(&self, round: Round) -> Result<(), Epoch> {
+        let existing_epoch = self.round.epoch();
+        if existing_epoch != round.epoch() {
+            return Err(existing_epoch);
+        }
+        Ok(())
+    }
+
+    fn observe(&mut self, round: Round) -> Result<(), Epoch> {
+        self.validate_epoch(round)?;
+        self.round = self.round.max(round);
+        Ok(())
+    }
+
+    const fn block(&self) -> Option<&Arc<CodedBlock<B, C, H>>> {
+        match &self.phase {
+            CommitmentPhase::Reconstructing(_) => None,
+            CommitmentPhase::Cached { block, .. } => Some(block),
+        }
+    }
+
+    const fn reconstruction(&self) -> Option<&ReconstructionState<P, C, H>> {
+        match &self.phase {
+            CommitmentPhase::Reconstructing(reconstruction) => Some(reconstruction),
+            CommitmentPhase::Cached { reconstruction, .. } => reconstruction.as_ref(),
+        }
+    }
+
+    const fn reconstruction_mut(&mut self) -> Option<&mut ReconstructionState<P, C, H>> {
+        match &mut self.phase {
+            CommitmentPhase::Reconstructing(reconstruction) => Some(reconstruction),
+            CommitmentPhase::Cached { reconstruction, .. } => reconstruction.as_mut(),
+        }
+    }
+
+    fn install_block(&mut self, block: Arc<CodedBlock<B, C, H>>) -> Arc<CodedBlock<B, C, H>> {
+        let previous = std::mem::replace(
+            &mut self.phase,
+            CommitmentPhase::Cached {
+                block: Arc::clone(&block),
+                reconstruction: None,
+            },
+        );
+        self.phase = match previous {
+            CommitmentPhase::Reconstructing(reconstruction) => CommitmentPhase::Cached {
+                block: Arc::clone(&block),
+                reconstruction: Some(reconstruction),
+            },
+            cached @ CommitmentPhase::Cached { .. } => cached,
+        };
+        self.block()
+            .cloned()
+            .expect("installing a block must leave a cached phase")
+    }
 }
 
 /// A network layer for broadcasting and receiving [`CodedBlock`]s as [`Shard`]s.
@@ -314,8 +437,8 @@ where
     /// The strategy used for parallel shard verification.
     strategy: T,
 
-    /// A map of [`Commitment`]s to [`ReconstructionState`]s.
-    state: BTreeMap<Commitment, ReconstructionState<P, C, H>>,
+    /// The cache and reconstruction lifecycle for each observed [`Commitment`].
+    records: BTreeMap<Commitment, CommitmentRecord<B, C, H, P>>,
 
     /// Per-peer ring buffers for shards received before leader announcement.
     ///
@@ -338,11 +461,6 @@ where
 
     /// Capacity of the background receiver channel.
     background_channel_capacity: NonZeroUsize,
-
-    /// An ephemeral cache of reconstructed blocks, keyed by commitment.
-    ///
-    /// These blocks are evicted after a durability signal from the marshal.
-    reconstructed_blocks: BTreeMap<Commitment, ReconstructedBlock<B, C, H>>,
 
     /// Open subscriptions for assigned shard verification for the keyed
     /// [`Commitment`].
@@ -391,14 +509,13 @@ where
                 shard_codec_cfg: config.shard_codec_cfg,
                 block_codec_cfg: config.block_codec_cfg,
                 strategy: config.strategy,
-                state: BTreeMap::new(),
+                records: BTreeMap::new(),
                 peer_buffers: BTreeMap::new(),
                 peer_buffer_size: config.peer_buffer_size,
                 peer_provider: config.peer_provider,
                 aggregate_peers: Set::default(),
                 latest_primary_peers: Set::default(),
                 background_channel_capacity: config.background_channel_capacity,
-                reconstructed_blocks: BTreeMap::new(),
                 assigned_shard_verified_subscriptions: BTreeMap::new(),
                 block_subscriptions: BTreeMap::new(),
                 metrics,
@@ -440,15 +557,6 @@ where
         select_loop! {
             self.context,
             on_start => {
-                let _ = self
-                    .metrics
-                    .reconstruction_states_count
-                    .try_set(self.state.len());
-                let _ = self
-                    .metrics
-                    .reconstructed_blocks_cache_count
-                    .try_set(self.reconstructed_blocks.len());
-
                 // Clean up closed subscriptions.
                 self.block_subscriptions.retain(|_, subscribers| {
                     subscribers.retain(|tx| !tx.is_closed());
@@ -498,14 +606,16 @@ where
                         response,
                     } => {
                         let block = self
-                            .reconstructed_blocks
+                            .records
                             .get(&commitment)
-                            .map(|entry| entry.block.clone());
+                            .and_then(CommitmentRecord::block)
+                            .cloned();
                         response.send_lossy(block);
                     }
                     Message::GetByDigest { digest, response } => {
-                        let block = self.reconstructed_blocks.values().find_map(|entry| {
-                            (entry.block.digest() == digest).then_some(entry.block.clone())
+                        let block = self.records.values().find_map(|record| {
+                            let block = record.block()?;
+                            (block.digest() == digest).then(|| Arc::clone(block))
                         });
                         response.send_lossy(block);
                     }
@@ -530,8 +640,8 @@ where
                             response,
                         );
                     }
-                    Message::Prune { round, commitments } => {
-                        self.prune(round, commitments);
+                    Message::Retire { update } => {
+                        self.retire(update);
                     }
                 }
             },
@@ -558,8 +668,10 @@ where
             return;
         }
 
-        if let Some(existing) = self.state.get(&commitment) {
-            let round = existing.round();
+        if let Some(record) = self.records.get(&commitment)
+            && let Some(existing) = record.reconstruction()
+        {
+            let round = record.round();
             let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
                 warn!(%commitment, "no scheme for epoch, ignoring shard");
                 return;
@@ -584,9 +696,10 @@ where
             }
 
             let state = self
-                .state
+                .records
                 .get_mut(&commitment)
-                .expect("state checked as present");
+                .and_then(CommitmentRecord::reconstruction_mut)
+                .expect("reconstruction checked as present");
             let progressed = state.on_network_shard(
                 peer,
                 shard,
@@ -607,12 +720,13 @@ where
     /// exception is a late shard for the assigned index, which we still accept
     /// so we can notify readiness and gossip it to slower peers.
     fn should_handle_network_shard(&self, commitment: Commitment) -> bool {
-        if self.reconstructed_blocks.contains_key(&commitment) {
+        if let Some(record) = self.records.get(&commitment)
+            && record.block().is_some()
+        {
             // State can be populated before our assigned shard is verified. Keep
             // handling shards until that state is complete.
-            return self
-                .state
-                .get(&commitment)
+            return record
+                .reconstruction()
                 .is_some_and(|s| !s.is_assigned_shard_verified());
         }
         true
@@ -630,13 +744,16 @@ where
         &mut self,
         commitment: Commitment,
     ) -> Result<Option<Arc<CodedBlock<B, C, H>>>, Error<C>> {
-        if let Some(entry) = self.reconstructed_blocks.get(&commitment) {
-            return Ok(Some(entry.block.clone()));
-        }
-        let Some(state) = self.state.get_mut(&commitment) else {
+        let Some(record) = self.records.get_mut(&commitment) else {
             return Ok(None);
         };
-        let round = state.round();
+        if let Some(block) = record.block() {
+            return Ok(Some(Arc::clone(block)));
+        }
+        let round = record.round();
+        let state = record
+            .reconstruction_mut()
+            .expect("an uncached commitment record must be reconstructing");
         if state.checked_shards().len() < usize::from(commitment.config().minimum_shards.get()) {
             debug!(%commitment, "not enough checked shards to reconstruct block");
             return Ok(None);
@@ -685,7 +802,9 @@ where
 
         // Construct a coding block with a _trusted_ commitment. `S::decode` verified the blob's
         // integrity against the commitment, so shards can be lazily re-constructed if need be.
-        let block = self.cache_block(round, Arc::new(CodedBlock::new_trusted(inner, commitment)));
+        let block = self
+            .cache_block(round, Arc::new(CodedBlock::new_trusted(inner, commitment)))
+            .expect("reconstruction uses its commitment record's epoch");
         self.metrics.blocks_reconstructed_total.inc();
         Ok(Some(block))
     }
@@ -711,15 +830,23 @@ where
         // redundant, unless notarized recovery created leaderless state first.
         // In that case, the leader announcement must still populate the
         // leader-dependent path.
-        if self.observe_existing_commitment(commitment, round)
+        let Some(presence) = self.observe_existing_commitment(commitment, round) else {
+            return;
+        };
+        if presence == CommitmentPresence::Cached
             && self
-                .state
+                .records
                 .get(&commitment)
+                .and_then(CommitmentRecord::reconstruction)
                 .is_none_or(|state| state.leader().is_some())
         {
             return;
         }
-        if let Some(state) = self.state.get_mut(&commitment) {
+        if let Some(state) = self
+            .records
+            .get_mut(&commitment)
+            .and_then(CommitmentRecord::reconstruction_mut)
+        {
             if let Some(existing) = state.leader() {
                 if existing != &leader {
                     // A later leader is expected when this commitment is
@@ -740,9 +867,10 @@ where
         } else {
             let participants_len = u64::try_from(participants.len())
                 .expect("participant count impossibly out of bounds");
-            self.state.insert(
+            self.insert_reconstruction_record(
                 commitment,
-                ReconstructionState::new(Some(leader), round, participants_len),
+                round,
+                ReconstructionState::new(Some(leader), participants_len),
             );
         }
         let buffered_progress = self.ingest_buffered_shards(commitment);
@@ -762,10 +890,13 @@ where
         commitment: Commitment,
         round: Round,
     ) {
-        if self.observe_existing_commitment(commitment, round) {
+        let Some(presence) = self.observe_existing_commitment(commitment, round) else {
+            return;
+        };
+        if presence == CommitmentPresence::Cached {
             return;
         }
-        if self.state.contains_key(&commitment) {
+        if presence == CommitmentPresence::Reconstructing {
             let buffered_progress = self.ingest_buffered_shards(commitment);
             if buffered_progress {
                 self.try_advance(sender, commitment);
@@ -778,9 +909,10 @@ where
         };
         let participants_len = u64::try_from(scheme.participants().len())
             .expect("participant count impossibly out of bounds");
-        self.state.insert(
+        self.insert_reconstruction_record(
             commitment,
-            ReconstructionState::new(None, round, participants_len),
+            round,
+            ReconstructionState::new(None, participants_len),
         );
         let buffered_progress = self.ingest_buffered_shards(commitment);
         if buffered_progress {
@@ -816,11 +948,14 @@ where
     /// actionable. Once context exists, the local assigned index is valid from
     /// any participant because its proof is bound to the commitment.
     fn ingest_buffered_shards(&mut self, commitment: Commitment) -> bool {
-        let state = self
-            .state
+        let record = self
+            .records
             .get(&commitment)
+            .expect("buffered shards can only be ingested with a commitment record");
+        let round = record.round();
+        let state = record
+            .reconstruction()
             .expect("buffered shards can only be ingested with reconstruction state");
-        let round = state.round();
         let leader_known = state.leader().is_some();
         let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
             warn!(%commitment, "no scheme for epoch, dropping buffered shards");
@@ -855,8 +990,9 @@ where
         }
 
         let state = self
-            .state
+            .records
             .get_mut(&commitment)
+            .and_then(CommitmentRecord::reconstruction_mut)
             .expect("reconstruction state checked before buffered shard drain");
 
         // Ingest buffered shards into the active reconstruction state. Batch verification
@@ -869,23 +1005,47 @@ where
         progressed
     }
 
-    /// Records a consensus observation on every existing owner of a commitment.
+    /// Records a consensus observation on an existing commitment owner.
     ///
-    /// A cached block may retain reconstruction state while assigned-shard verification is
-    /// pending. Updating both owners together keeps their pruning decisions consistent.
-    ///
-    /// Returns whether the block is already cached.
-    fn observe_existing_commitment(&mut self, commitment: Commitment, round: Round) -> bool {
-        let block_cached = if let Some(entry) = self.reconstructed_blocks.get_mut(&commitment) {
-            entry.round = entry.round.max(round);
-            true
-        } else {
-            false
+    /// Returns the record's phase, [`CommitmentPresence::Absent`] if it has no
+    /// owner yet, or `None` when its owner is bound to a different epoch.
+    fn observe_existing_commitment(
+        &mut self,
+        commitment: Commitment,
+        round: Round,
+    ) -> Option<CommitmentPresence> {
+        let observed_epoch = round.epoch();
+        let Some(record) = self.records.get_mut(&commitment) else {
+            return Some(CommitmentPresence::Absent);
         };
-        if let Some(state) = self.state.get_mut(&commitment) {
-            state.observe(round);
+        if let Err(existing_epoch) = record.observe(round) {
+            warn!(
+                %commitment,
+                %existing_epoch,
+                %observed_epoch,
+                "commitment observation has conflicting epoch, ignoring"
+            );
+            return None;
         }
-        block_cached
+        Some(if record.block().is_some() {
+            CommitmentPresence::Cached
+        } else {
+            CommitmentPresence::Reconstructing
+        })
+    }
+
+    /// Creates the first lifecycle record for a reconstructing commitment.
+    fn insert_reconstruction_record(
+        &mut self,
+        commitment: Commitment,
+        round: Round,
+        reconstruction: ReconstructionState<P, C, H>,
+    ) {
+        let Entry::Vacant(entry) = self.records.entry(commitment) else {
+            unreachable!("commitment presence was checked as absent");
+        };
+        entry.insert(CommitmentRecord::reconstructing(round, reconstruction));
+        self.metrics.reconstruction_states_count.inc();
     }
 
     /// Cache a block and notify all subscribers waiting on it.
@@ -893,21 +1053,26 @@ where
         &mut self,
         round: Round,
         block: Arc<CodedBlock<B, C, H>>,
-    ) -> Arc<CodedBlock<B, C, H>> {
+    ) -> Result<Arc<CodedBlock<B, C, H>>, Epoch> {
         let commitment = block.commitment();
-        let round = self.state.get_mut(&commitment).map_or(round, |state| {
-            state.observe(round);
-            state.round()
-        });
-        self.reconstructed_blocks
-            .entry(commitment)
-            .and_modify(|entry| entry.round = entry.round.max(round))
-            .or_insert_with(|| ReconstructedBlock {
-                round,
-                block: Arc::clone(&block),
-            });
-        self.notify_block_subscribers(Arc::clone(&block));
-        block
+        let cached = match self.records.entry(commitment) {
+            Entry::Occupied(mut entry) => {
+                entry.get_mut().observe(round)?;
+                let newly_cached = entry.get().block().is_none();
+                let cached = entry.get_mut().install_block(block);
+                if newly_cached {
+                    self.metrics.reconstructed_blocks_cache_count.inc();
+                }
+                cached
+            }
+            Entry::Vacant(entry) => {
+                entry.insert(CommitmentRecord::cached(round, Arc::clone(&block)));
+                self.metrics.reconstructed_blocks_cache_count.inc();
+                block
+            }
+        };
+        self.notify_block_subscribers(Arc::clone(&cached));
+        Ok(cached)
     }
 
     /// Broadcasts the shards of a [`CodedBlock`] and caches the block.
@@ -921,6 +1086,18 @@ where
         block: Arc<CodedBlock<B, C, H>>,
     ) {
         let commitment = block.commitment();
+
+        if let Some(record) = self.records.get(&commitment)
+            && let Err(existing_epoch) = record.validate_epoch(round)
+        {
+            warn!(
+                %commitment,
+                %existing_epoch,
+                observed_epoch = %round.epoch(),
+                "local proposal has conflicting epoch, ignoring"
+            );
+            return;
+        }
 
         let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
             warn!(%commitment, "no scheme available, cannot broadcast shards");
@@ -980,7 +1157,8 @@ where
         }
 
         // Cache the block so we don't have to reconstruct it again.
-        self.cache_block(round, block);
+        self.cache_block(round, block)
+            .expect("local proposal epoch was validated before broadcast");
 
         // Local proposals bypass reconstruction, so shard subscribers waiting
         // for "our valid shard arrived" still need a notification.
@@ -1004,15 +1182,21 @@ where
         );
     }
 
-    /// Broadcasts any pending validated shard for the given commitment and attempts
-    /// reconstruction. If reconstruction succeeds or fails, the state is cleaned
-    /// up and subscribers are notified.
+    /// Broadcasts any pending validated shard and attempts reconstruction.
+    ///
+    /// Successful reconstruction caches the block while retaining any shard state
+    /// still needed for assigned-shard readiness. Failed reconstruction retires the
+    /// commitment and its commitment-specific subscriptions.
     fn try_advance<Sr: Sender<PublicKey = P>>(
         &mut self,
         sender: &mut WrappedSender<Sr, Shard<C, H>>,
         commitment: Commitment,
     ) {
-        if let Some(state) = self.state.get_mut(&commitment) {
+        if let Some(state) = self
+            .records
+            .get_mut(&commitment)
+            .and_then(CommitmentRecord::reconstruction_mut)
+        {
             match state.take_pending_action() {
                 Some(AssignedShardVerifiedAction::Broadcast(shard)) => {
                     self.broadcast_shard(sender, shard);
@@ -1030,8 +1214,8 @@ where
                 // Do not prune other reconstruction state here. A Byzantine
                 // leader can equivocate by proposing multiple commitments in
                 // the same round, so more than one block may be reconstructed
-                // for a given round. Pruning is deferred to `prune()`, which
-                // is called once a commitment is finalized.
+                // for a given round. Retirement is deferred until durable
+                // application progress supplies both eligibility signals.
                 debug!(
                     %commitment,
                     parent = %block.parent(),
@@ -1044,8 +1228,7 @@ where
             }
             Err(err) => {
                 warn!(%commitment, ?err, "failed to reconstruct block from checked shards");
-                self.state.remove(&commitment);
-                self.drop_commitment_subscriptions(commitment);
+                self.retire_commitment(commitment, RetirementReason::Exact);
                 self.metrics.reconstruction_failures_total.inc();
             }
         }
@@ -1062,8 +1245,9 @@ where
     ) {
         // Answer immediately if our own shard has been verified.
         let has_shard = self
-            .state
+            .records
             .get(&commitment)
+            .and_then(CommitmentRecord::reconstruction)
             .is_some_and(|state| state.is_assigned_shard_verified());
         if has_shard {
             response.send_lossy(());
@@ -1073,8 +1257,10 @@ where
         // When there is no reconstruction state but the block is already in
         // the cache, the local node was the proposer. Proposers trivially
         // have all shards, so resolve immediately.
-        if !self.state.contains_key(&commitment)
-            && self.reconstructed_blocks.contains_key(&commitment)
+        if self
+            .records
+            .get(&commitment)
+            .is_some_and(|record| record.reconstruction().is_none() && record.block().is_some())
         {
             response.send_lossy(());
             return;
@@ -1094,13 +1280,14 @@ where
     ) {
         let block = match key {
             BlockSubscriptionKey::Commitment(commitment) => self
-                .reconstructed_blocks
+                .records
                 .get(&commitment)
-                .map(|entry| &entry.block),
+                .and_then(CommitmentRecord::block),
             BlockSubscriptionKey::Digest(digest) => self
-                .reconstructed_blocks
+                .records
                 .values()
-                .find_map(|entry| (entry.block.digest() == digest).then_some(&entry.block)),
+                .filter_map(CommitmentRecord::block)
+                .find(|block| block.digest() == digest),
         };
 
         // Answer immediately if we have the block cached.
@@ -1154,48 +1341,57 @@ where
         }
     }
 
-    /// Drops subscriptions bound to an exact commitment.
-    ///
-    /// Before marshal accepts a block, a candidate can claim a digest it cannot reconstruct.
-    /// Retiring it therefore does not prove the digest unavailable.
-    fn drop_commitment_subscriptions(&mut self, commitment: Commitment) {
-        self.assigned_shard_verified_subscriptions
-            .remove(&commitment);
-        self.block_subscriptions
-            .remove(&BlockSubscriptionKey::Commitment(commitment));
+    /// Retires one commitment and applies the subscription policy for the cause.
+    fn retire_commitment(&mut self, commitment: Commitment, reason: RetirementReason) {
+        let had_reconstruction = self.records.remove(&commitment).is_some_and(|record| {
+            let had_reconstruction = record.reconstruction().is_some();
+            if had_reconstruction {
+                self.metrics.reconstruction_states_count.dec();
+            }
+            if record.block().is_some() {
+                self.metrics.reconstructed_blocks_cache_count.dec();
+            }
+            had_reconstruction
+        });
+
+        if matches!(reason, RetirementReason::Exact) || had_reconstruction {
+            self.assigned_shard_verified_subscriptions
+                .remove(&commitment);
+        }
+        if matches!(reason, RetirementReason::Exact) {
+            // Before marshal accepts a block, a candidate can claim a digest it cannot
+            // reconstruct. Retiring it therefore does not prove the digest unavailable.
+            self.block_subscriptions
+                .remove(&BlockSubscriptionKey::Commitment(commitment));
+        }
     }
 
-    /// Prunes cached blocks and reconstruction state after durable application progress.
+    /// Retires cached blocks and reconstruction state after durable application progress.
     ///
-    /// Pruning waits for durable progress because a Byzantine leader may produce multiple valid
-    /// commitments in one round.
-    fn prune(&mut self, round: Round, commitments: Vec<Commitment>) {
+    /// Retirement waits for durable progress because a Byzantine leader may produce multiple
+    /// valid commitments in one round.
+    fn retire(&mut self, update: RetentionUpdate<Commitment>) {
+        let RetentionUpdate {
+            round_floor,
+            exact_retirements,
+        } = update;
         // Durable processing makes existing exact-commitment and assigned-shard waits for these
         // states obsolete. Digest waits are not commitment-specific.
-        for commitment in commitments {
-            self.drop_commitment_subscriptions(commitment);
-            self.reconstructed_blocks.remove(&commitment);
-            self.state.remove(&commitment);
+        for commitment in exact_retirements {
+            self.retire_commitment(commitment, RetirementReason::Exact);
         }
 
-        // Evict blocks last observed no later than the retirement floor. Blocks observed in later
-        // rounds may still be needed for certification.
-        self.reconstructed_blocks
-            .retain(|_, entry| entry.round > round);
-
-        // Evict incomplete reconstructions by the same round rule. Later observations refresh
-        // their round so a delayed application acknowledgment cannot retire a live re-proposal.
-        // Block subscriptions remain open because the block may still arrive through local ingress.
-        let mut pruned_commitments = Vec::new();
-        self.state.retain(|c, s| {
-            let keep = s.round() > round;
-            if !keep {
-                pruned_commitments.push(*c);
-            }
-            keep
-        });
-        for pruned in pruned_commitments {
-            self.assigned_shard_verified_subscriptions.remove(&pruned);
+        // Entries observed in later rounds may still be needed for certification. Block
+        // subscriptions remain open because local ingress can still satisfy them after a floor.
+        let retired = self
+            .records
+            .iter()
+            .filter_map(|(commitment, record)| {
+                (record.round() <= round_floor).then_some(*commitment)
+            })
+            .collect::<Vec<_>>();
+        for commitment in retired {
+            self.retire_commitment(commitment, RetirementReason::Floor);
         }
     }
 }
@@ -1249,8 +1445,6 @@ where
     checked_shards: Vec<C::CheckedShard>,
     /// Bitmap tracking which participant indices have contributed a shard.
     contributed: BitMap,
-    /// The latest consensus round in which this commitment was observed.
-    round: Round,
     /// Raw shard data received per index, retained for equivocation detection.
     /// Keyed by shard index.
     received_shards: BTreeMap<u16, C::Shard>,
@@ -1294,14 +1488,13 @@ where
     C: CodingScheme,
     H: Hasher,
 {
-    /// Create a new empty common state for the provided leader and round.
-    fn new(leader: Option<P>, round: Round, participants_len: u64) -> Self {
+    /// Create a new empty common state for the provided leader.
+    fn new(leader: Option<P>, participants_len: u64) -> Self {
         Self {
             leader,
             pending_action: None,
             checked_shards: Vec::new(),
             contributed: BitMap::zeroes(participants_len),
-            round,
             received_shards: BTreeMap::new(),
             assigned_shard_verified: false,
         }
@@ -1404,12 +1597,9 @@ where
         }
 
         // Transition to Ready.
-        let round = self.common.round;
         let leader = self.common.leader.clone();
-        let common = std::mem::replace(
-            &mut self.common,
-            CommonState::new(leader, round, participants_len),
-        );
+        let common =
+            std::mem::replace(&mut self.common, CommonState::new(leader, participants_len));
         Some(ReadyState { common })
     }
 }
@@ -1452,9 +1642,9 @@ where
     H: Hasher,
 {
     /// Create an initial reconstruction state for a commitment.
-    fn new(leader: Option<P>, round: Round, participants_len: u64) -> Self {
+    fn new(leader: Option<P>, participants_len: u64) -> Self {
         Self::AwaitingQuorum(AwaitingQuorumState {
-            common: CommonState::new(leader, round, participants_len),
+            common: CommonState::new(leader, participants_len),
             pending_shards: BTreeMap::new(),
         })
     }
@@ -1489,32 +1679,9 @@ where
         Ok(())
     }
 
-    /// Refreshes the round used to decide whether this state can be pruned.
-    ///
-    /// Re-proposals reuse commitments, and application acknowledgments can lag consensus.
-    /// Retaining the latest observed round prevents an older acknowledgment from retiring
-    /// reconstruction still needed by a later proposal.
-    ///
-    /// The refreshed round also governs shard classification, which resolves the
-    /// participant set from `round`'s epoch. That is unambiguous only because every
-    /// observation path binds the commitment to a single epoch: proposals bind it in
-    /// the context digest, re-proposals are validated as the last block of the
-    /// announced round's own epoch, and notarizations imply such a proposal. An
-    /// epocher that allowed a block to close more than one epoch would break this
-    /// invariant.
-    fn observe(&mut self, round: Round) {
-        let common = self.common_mut();
-        common.round = common.round.max(round);
-    }
-
     /// Returns whether the shard for our assigned index has been verified.
     const fn is_assigned_shard_verified(&self) -> bool {
         self.common().assigned_shard_verified
-    }
-
-    /// Return the latest consensus round associated with this state.
-    const fn round(&self) -> Round {
-        self.common().round
     }
 
     /// Returns all verified shards accumulated for reconstruction.
@@ -1870,6 +2037,8 @@ mod tests {
         num_peers: usize,
         /// Number of non-participant peers in the test network.
         num_non_participants: usize,
+        /// Additional epochs that use the fixture's participant set.
+        additional_scheme_epochs: Vec<Epoch>,
         /// Network link configuration.
         link: Link,
         /// Marker for the coding scheme type parameter.
@@ -1881,6 +2050,7 @@ mod tests {
             Self {
                 num_peers: 4,
                 num_non_participants: 0,
+                additional_scheme_epochs: Vec::new(),
                 link: DEFAULT_LINK,
                 _marker: PhantomData,
             }
@@ -1970,7 +2140,16 @@ mod tests {
                         private_keys[idx].clone(),
                     )
                     .expect("signer scheme should be created");
-                    let scheme_provider: Prov = MultiEpochProvider::single(scheme);
+                    let mut scheme_provider = MultiEpochProvider::single(scheme);
+                    for epoch in self.additional_scheme_epochs.iter().copied() {
+                        let scheme = Scheme::signer(
+                            SCHEME_NAMESPACE,
+                            participants.clone(),
+                            private_keys[idx].clone(),
+                        )
+                        .expect("signer scheme should be created");
+                        scheme_provider = scheme_provider.with_epoch(epoch, scheme);
+                    }
 
                     let config = Config {
                         scheme_provider,
@@ -2009,7 +2188,13 @@ mod tests {
                         .with_attribute("index", idx);
 
                     let scheme = Scheme::verifier(SCHEME_NAMESPACE, participants.clone());
-                    let scheme_provider: Prov = MultiEpochProvider::single(scheme);
+                    let mut scheme_provider = MultiEpochProvider::single(scheme);
+                    for epoch in self.additional_scheme_epochs.iter().copied() {
+                        scheme_provider = scheme_provider.with_epoch(
+                            epoch,
+                            Scheme::verifier(SCHEME_NAMESPACE, participants.clone()),
+                        );
+                    }
 
                     let config = Config {
                         scheme_provider,
@@ -2379,10 +2564,10 @@ mod tests {
 
             // The authoritative retirement floor removes every earlier candidate and the exact
             // processed commitment, even when that commitment was observed above the floor.
-            peer.mailbox.prune(
-                Round::new(Epoch::zero(), View::new(3)),
-                vec![processed_commitment],
-            );
+            peer.mailbox.retire(RetentionUpdate {
+                round_floor: Round::new(Epoch::zero(), View::new(3)),
+                exact_retirements: vec![processed_commitment],
+            });
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(
@@ -2445,7 +2630,10 @@ mod tests {
             let mut state_later_sub = peer.mailbox.subscribe(state_later);
             context.sleep(Duration::from_millis(10)).await;
 
-            peer.mailbox.prune(floor, vec![unseen]);
+            peer.mailbox.retire(RetentionUpdate {
+                round_floor: floor,
+                exact_retirements: vec![unseen],
+            });
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(peer.mailbox.get(cached_old_commitment).await.is_none());
@@ -2505,7 +2693,10 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
             assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
 
-            peer.mailbox.prune(floor, vec![unseen]);
+            peer.mailbox.retire(RetentionUpdate {
+                round_floor: floor,
+                exact_retirements: vec![unseen],
+            });
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(peer.mailbox.get(live_commitment).await.is_some());
@@ -2845,11 +3036,68 @@ mod tests {
                 non_participant,
                 Round::new(Epoch::zero(), View::new(10)),
             );
-            receiver
-                .mailbox
-                .prune(Round::new(Epoch::zero(), View::new(5)), vec![unrelated]);
+            receiver.mailbox.retire(RetentionUpdate {
+                round_floor: Round::new(Epoch::zero(), View::new(5)),
+                exact_retirements: vec![unrelated],
+            });
             context.sleep(Duration::from_millis(10)).await;
 
+            assert!(matches!(subscription.try_recv(), Err(TryRecvError::Closed)));
+        });
+    }
+
+    #[test_traced]
+    fn test_cross_epoch_observations_do_not_refresh_retirement_round() {
+        let fixture = Fixture::<C> {
+            additional_scheme_epochs: vec![Epoch::new(1)],
+            ..Default::default()
+        };
+        fixture.start(|_, context, _, mut peers, _, coding_config| async move {
+            let cached = CodedBlock::<B, C, H>::new(
+                B::new(Sha256Digest::EMPTY, Height::new(1), 100),
+                coding_config,
+                &STRATEGY,
+            );
+            let incomplete = CodedBlock::<B, C, H>::new(
+                B::new(Sha256Digest::EMPTY, Height::new(2), 200),
+                coding_config,
+                &STRATEGY,
+            );
+            let incomplete_commitment = incomplete.commitment();
+            let unrelated = CodedBlock::<B, C, H>::new(
+                B::new(Sha256Digest::EMPTY, Height::new(3), 300),
+                coding_config,
+                &STRATEGY,
+            )
+            .commitment();
+            let cached_commitment = cached.commitment();
+            let leader = peers[0].public_key.clone();
+            let receiver = &mut peers[2];
+            let original_round = Round::new(Epoch::zero(), View::new(1));
+
+            receiver.mailbox.proposed(original_round, cached);
+            receiver
+                .mailbox
+                .discovered(incomplete_commitment, leader, original_round);
+            let mut subscription = receiver
+                .mailbox
+                .subscribe_assigned_shard_verified(incomplete_commitment);
+
+            let conflicting_round = Round::new(Epoch::new(1), View::new(10));
+            receiver.mailbox.proposed(conflicting_round, incomplete);
+            receiver
+                .mailbox
+                .notarized(cached_commitment, conflicting_round);
+            receiver
+                .mailbox
+                .notarized(incomplete_commitment, conflicting_round);
+            receiver.mailbox.retire(RetentionUpdate {
+                round_floor: Round::new(Epoch::zero(), View::new(5)),
+                exact_retirements: vec![unrelated],
+            });
+            context.sleep(Duration::from_millis(10)).await;
+
+            assert!(receiver.mailbox.get(cached_commitment).await.is_none());
             assert!(matches!(subscription.try_recv(), Err(TryRecvError::Closed)));
         });
     }
@@ -3251,10 +3499,10 @@ mod tests {
                     .mailbox
                     .notarized(live_commitment, Round::new(Epoch::zero(), View::new(4)));
                 context.sleep(Duration::from_millis(10)).await;
-                peers[receiver_idx].mailbox.prune(
-                    Round::new(Epoch::zero(), View::new(3)),
-                    vec![finalized_commitment],
-                );
+                peers[receiver_idx].mailbox.retire(RetentionUpdate {
+                    round_floor: Round::new(Epoch::zero(), View::new(3)),
+                    exact_retirements: vec![finalized_commitment],
+                });
                 context.sleep(Duration::from_millis(10)).await;
 
                 assert!(
@@ -3378,9 +3626,10 @@ mod tests {
 
                 let prune_round = Round::new(Epoch::zero(), View::new(3));
                 for &receiver_idx in &receivers {
-                    peers[receiver_idx]
-                        .mailbox
-                        .prune(prune_round, vec![finalized_commitment]);
+                    peers[receiver_idx].mailbox.retire(RetentionUpdate {
+                        round_floor: prune_round,
+                        exact_retirements: vec![finalized_commitment],
+                    });
                 }
                 context.sleep(Duration::from_millis(10)).await;
 
@@ -3487,7 +3736,10 @@ mod tests {
                     peers[2].mailbox.get(commitment_b).await.is_some(),
                     "local proposal should be cached before pruning"
                 );
-                peers[2].mailbox.prune(round_b, vec![commitment_b]);
+                peers[2].mailbox.retire(RetentionUpdate {
+                    round_floor: round_b,
+                    exact_retirements: vec![commitment_b],
+                });
 
                 peers[1]
                     .sender

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -86,8 +86,10 @@
 //!    +----------------------+
 //!    | Ready                |
 //!    | - checked shards     |
-//!    | (frozen; no new      |
-//!    |  shards accepted)    |
+//!    | - no new gossip      |
+//!    |   shards accepted    |
+//!    | - assigned shard may |
+//!    |   still arrive late  |
 //!    +----------------------+
 //!               |
 //!               | checked_shards.len() >= minimum_shards
@@ -2514,7 +2516,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_prune_uses_inclusive_retirement_floor() {
+    fn test_retire_uses_inclusive_retirement_floor() {
         let fixture = Fixture::<C>::default();
         fixture.start(|_, context, _, mut peers, _, coding_config| async move {
             // The processed commitment was re-proposed above the retirement floor. A malicious
@@ -2608,7 +2610,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_prune_unseen_commitment_applies_floor() {
+    fn test_retire_unseen_commitment_applies_floor() {
         let fixture = Fixture::<C>::default();
         fixture.start(|_, context, _, mut peers, _, coding_config| async move {
             let make_block = |id| {

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -698,6 +698,15 @@ where
         leader: P,
         round: Round,
     ) {
+        let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
+            warn!(%commitment, "no scheme for epoch, ignoring external proposal");
+            return;
+        };
+        let participants = scheme.participants();
+        if participants.index(&leader).is_none() {
+            warn!(?leader, %commitment, "leader update for non-participant, ignoring");
+            return;
+        }
         // A reconstructed block normally makes duplicate leader announcements
         // redundant, unless notarized recovery created leaderless state first.
         // In that case, the leader announcement must still populate the
@@ -708,15 +717,6 @@ where
                 .get(&commitment)
                 .is_none_or(|state| state.leader().is_some())
         {
-            return;
-        }
-        let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
-            warn!(%commitment, "no scheme for epoch, ignoring external proposal");
-            return;
-        };
-        let participants = scheme.participants();
-        if participants.index(&leader).is_none() {
-            warn!(?leader, %commitment, "leader update for non-participant, ignoring");
             return;
         }
         if let Some(state) = self.state.get_mut(&commitment) {
@@ -1185,6 +1185,7 @@ where
 
         // Evict incomplete reconstructions by the same round rule. Later observations refresh
         // their round so a delayed application acknowledgment cannot retire a live re-proposal.
+        // Block subscriptions remain open because the block may still arrive through local ingress.
         let mut pruned_commitments = Vec::new();
         self.state.retain(|c, s| {
             let keep = s.round() > round;
@@ -1194,7 +1195,7 @@ where
             keep
         });
         for pruned in pruned_commitments {
-            self.drop_commitment_subscriptions(pruned);
+            self.assigned_shard_verified_subscriptions.remove(&pruned);
         }
     }
 }
@@ -2444,13 +2445,10 @@ mod tests {
             assert!(peer.mailbox.get(cached_old_commitment).await.is_none());
             assert!(peer.mailbox.get(cached_equal_commitment).await.is_none());
             assert!(peer.mailbox.get(cached_later_commitment).await.is_some());
-            assert!(matches!(
-                state_old_sub.try_recv(),
-                Err(TryRecvError::Closed)
-            ));
+            assert!(matches!(state_old_sub.try_recv(), Err(TryRecvError::Empty)));
             assert!(matches!(
                 state_equal_sub.try_recv(),
-                Err(TryRecvError::Closed)
+                Err(TryRecvError::Empty)
             ));
             assert!(matches!(
                 state_later_sub.try_recv(),
@@ -2806,6 +2804,48 @@ mod tests {
                 };
             },
         );
+    }
+
+    #[test_traced]
+    fn test_rejected_leader_does_not_refresh_retirement_round() {
+        let fixture = Fixture::<C>::default();
+        fixture.start(|_, context, _, mut peers, _, coding_config| async move {
+            let block = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100),
+                coding_config,
+                &STRATEGY,
+            );
+            let commitment = block.commitment();
+            let unrelated = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(2), 200),
+                coding_config,
+                &STRATEGY,
+            )
+            .commitment();
+            let leader = peers[0].public_key.clone();
+            let non_participant = PrivateKey::from_seed(10_000).public_key();
+            let receiver = &mut peers[2];
+
+            let mut subscription = receiver
+                .mailbox
+                .subscribe_assigned_shard_verified(commitment);
+            receiver.mailbox.discovered(
+                commitment,
+                leader,
+                Round::new(Epoch::zero(), View::new(1)),
+            );
+            receiver.mailbox.discovered(
+                commitment,
+                non_participant,
+                Round::new(Epoch::zero(), View::new(10)),
+            );
+            receiver
+                .mailbox
+                .prune(Round::new(Epoch::zero(), View::new(5)), vec![unrelated]);
+            context.sleep(Duration::from_millis(10)).await;
+
+            assert!(matches!(subscription.try_recv(), Err(TryRecvError::Closed)));
+        });
     }
 
     #[test_traced]
@@ -3417,7 +3457,6 @@ mod tests {
                 let round_b = Round::new(Epoch::zero(), View::new(2));
 
                 peers[2].mailbox.discovered(commitment_a, leader, round_a);
-                let block_sub = peers[2].mailbox.subscribe(commitment_a);
 
                 let peer1_index = peers[1].index.get() as u16;
                 let shard_a = block_a.shard(peer1_index).expect("missing shard");
@@ -3443,18 +3482,6 @@ mod tests {
                     "local proposal should be cached before pruning"
                 );
                 peers[2].mailbox.prune(round_b, vec![commitment_b]);
-
-                select! {
-                    result = block_sub => {
-                        assert!(
-                            result.is_err(),
-                            "older block subscription should close after local-proposal prune"
-                        );
-                    },
-                    _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("older block subscription remained open after local-proposal prune");
-                    },
-                }
 
                 peers[1]
                     .sender

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -268,7 +268,7 @@ where
     pub peer_provider: D,
 }
 
-/// A cached reconstructed block and the consensus round that produced it.
+/// A cached reconstructed block and its latest consensus round.
 struct ReconstructedBlock<B, C, H>
 where
     B: Block,
@@ -534,8 +534,8 @@ where
                             response,
                         );
                     }
-                    Message::Prune { through } => {
-                        self.prune(through);
+                    Message::Prune { round, commitment } => {
+                        self.prune(round, commitment);
                     }
                 }
             },
@@ -710,7 +710,13 @@ where
         // redundant, unless notarized recovery created leaderless state first.
         // In that case, the leader announcement must still populate the
         // leader-dependent path.
-        if self.reconstructed_blocks.contains_key(&commitment)
+        let block_cached = if let Some(entry) = self.reconstructed_blocks.get_mut(&commitment) {
+            entry.round = entry.round.max(round);
+            true
+        } else {
+            false
+        };
+        if block_cached
             && self
                 .state
                 .get(&commitment)
@@ -728,6 +734,7 @@ where
             return;
         }
         if let Some(state) = self.state.get_mut(&commitment) {
+            state.observe(round);
             if let Some(existing) = state.leader() {
                 if existing != &leader {
                     warn!(
@@ -767,10 +774,12 @@ where
         commitment: Commitment,
         round: Round,
     ) {
-        if self.reconstructed_blocks.contains_key(&commitment) {
+        if let Some(entry) = self.reconstructed_blocks.get_mut(&commitment) {
+            entry.round = entry.round.max(round);
             return;
         }
-        if self.state.contains_key(&commitment) {
+        if let Some(state) = self.state.get_mut(&commitment) {
+            state.observe(round);
             let buffered_progress = self.ingest_buffered_shards(commitment);
             if buffered_progress {
                 self.try_advance(sender, commitment);
@@ -885,13 +894,13 @@ where
         block: Arc<CodedBlock<B, C, H>>,
     ) -> Arc<CodedBlock<B, C, H>> {
         let commitment = block.commitment();
-        self.reconstructed_blocks.insert(
-            commitment,
-            ReconstructedBlock {
+        self.reconstructed_blocks
+            .entry(commitment)
+            .and_modify(|entry| entry.round = entry.round.max(round))
+            .or_insert_with(|| ReconstructedBlock {
                 round,
                 block: Arc::clone(&block),
-            },
-        );
+            });
         self.notify_block_subscribers(Arc::clone(&block));
         block
     }
@@ -1151,37 +1160,32 @@ where
             .remove(&BlockSubscriptionKey::Commitment(commitment));
     }
 
-    /// Evicts cached blocks and reconstruction state through `through`.
+    /// Prunes cached blocks and reconstruction state after finalization.
     ///
     /// Pruning waits for finalization because a Byzantine leader may produce multiple valid
     /// commitments in one round.
-    fn prune(&mut self, through: Commitment) {
-        let cached = self
-            .reconstructed_blocks
-            .get(&through)
-            .map(|entry| (entry.round, entry.block.height()));
-        if let Some((_, height)) = cached {
-            self.reconstructed_blocks
-                .retain(|_, entry| entry.block.height() > height);
-        }
-
+    fn prune(&mut self, round: Round, finalized: Commitment) {
         // Finalization makes existing exact-commitment and assigned-shard waits for these states
         // obsolete. Digest waits are not commitment-specific.
-        self.drop_commitment_subscriptions(through);
-        let state_round = self.state.remove(&through).map(|state| state.round());
-        let cached_round = cached.map(|(round, _)| round);
-        let Some(round) = state_round.or(cached_round) else {
-            return;
-        };
+        self.drop_commitment_subscriptions(finalized);
 
+        // Evict the finalized block and blocks last observed no later than its finalization round.
+        // Blocks observed in later rounds may still be needed for certification.
+        self.reconstructed_blocks
+            .retain(|commitment, entry| *commitment != finalized && entry.round > round);
+
+        // Evict incomplete reconstructions by the same round rule. Later observations refresh
+        // their round so a delayed application acknowledgment cannot retire a live re-proposal.
         let mut pruned_commitments = Vec::new();
         self.state.retain(|c, s| {
-            let keep = s.round() > round;
+            let keep = *c != finalized && s.round() > round;
             if !keep {
                 pruned_commitments.push(*c);
             }
             keep
         });
+
+        // Close exact subscriptions after `retain` releases the mutable borrow.
         for pruned in pruned_commitments {
             self.drop_commitment_subscriptions(pruned);
         }
@@ -1237,7 +1241,7 @@ where
     checked_shards: Vec<C::CheckedShard>,
     /// Bitmap tracking which participant indices have contributed a shard.
     contributed: BitMap,
-    /// The round for which this commitment was externally proposed.
+    /// The latest consensus round in which this commitment was observed.
     round: Round,
     /// Raw shard data received per index, retained for equivocation detection.
     /// Keyed by shard index.
@@ -1477,12 +1481,22 @@ where
         Ok(())
     }
 
+    /// Refreshes the round used to decide whether this state can be pruned.
+    ///
+    /// Re-proposals reuse commitments, and application acknowledgments can lag consensus.
+    /// Retaining the latest observed round prevents an older acknowledgment from retiring
+    /// reconstruction still needed by a later proposal.
+    fn observe(&mut self, round: Round) {
+        let common = self.common_mut();
+        common.round = common.round.max(round);
+    }
+
     /// Returns whether the leader's shard for our index has been verified.
     const fn is_assigned_shard_verified(&self) -> bool {
         self.common().assigned_shard_verified
     }
 
-    /// Return the proposal round associated with this state.
+    /// Return the latest consensus round associated with this state.
     const fn round(&self) -> Round {
         self.common().round
     }
@@ -2287,69 +2301,86 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_durable_prunes_reconstructed_blocks() {
+    fn test_durable_prune_uses_consensus_round() {
         let fixture = Fixture::<C>::default();
         fixture.start(|_, context, _, mut peers, _, coding_config| async move {
-            // Create 3 blocks at heights 1, 2, 3.
-            let block1 = CodedBlock::<B, C, H>::new(
+            // The commitment was cached in its original proposal round and later
+            // finalized by a re-proposal. A malicious candidate arrived in between.
+            let finalized = CodedBlock::<B, C, H>::new(
                 B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100),
                 coding_config,
                 &STRATEGY,
             );
-            let block2 = CodedBlock::<B, C, H>::new(
+            let malicious = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(u64::MAX), 100),
+                coding_config,
+                &STRATEGY,
+            );
+            let later = CodedBlock::<B, C, H>::new(
                 B::new::<H>((), Sha256Digest::EMPTY, Height::new(2), 100),
                 coding_config,
                 &STRATEGY,
             );
-            let block3 = CodedBlock::<B, C, H>::new(
-                B::new::<H>((), Sha256Digest::EMPTY, Height::new(3), 100),
-                coding_config,
-                &STRATEGY,
-            );
-            let commitment1 = block1.commitment();
-            let commitment2 = block2.commitment();
-            let commitment3 = block3.commitment();
+            let finalized_commitment = finalized.commitment();
+            let malicious_commitment = malicious.commitment();
+            let later_commitment = later.commitment();
 
             // Cache all blocks via `proposed`.
             let peer = &mut peers[0];
-            let round = Round::new(Epoch::zero(), View::new(1));
-            peer.mailbox.proposed(round, block1);
-            peer.mailbox.proposed(round, block2);
-            peer.mailbox.proposed(round, block3);
+            peer.mailbox.proposed(
+                Round::new(Epoch::zero(), View::new(1)),
+                finalized,
+            );
+            peer.mailbox.proposed(
+                Round::new(Epoch::zero(), View::new(2)),
+                malicious,
+            );
+            peer.mailbox.proposed(
+                Round::new(Epoch::zero(), View::new(1)),
+                later,
+            );
+            // A later notarization makes the same canonical block live in a
+            // newer round while the application still processes older blocks.
+            peer.mailbox.notarized(
+                later_commitment,
+                Round::new(Epoch::zero(), View::new(4)),
+            );
             context.sleep(Duration::from_millis(10)).await;
 
             // Verify all blocks are in the cache.
             assert!(
-                peer.mailbox.get(commitment1).await.is_some(),
-                "block1 should be cached"
+                peer.mailbox.get(finalized_commitment).await.is_some(),
+                "finalized block should be cached"
             );
             assert!(
-                peer.mailbox.get(commitment2).await.is_some(),
-                "block2 should be cached"
+                peer.mailbox.get(malicious_commitment).await.is_some(),
+                "malicious block should be cached"
             );
             assert!(
-                peer.mailbox.get(commitment3).await.is_some(),
-                "block3 should be cached"
+                peer.mailbox.get(later_commitment).await.is_some(),
+                "later block should be cached"
             );
 
-            // Prune at height 2 (blocks with height <= 2 should be removed).
-            peer.mailbox.prune(commitment2);
+            // The authoritative finalization round retires every earlier candidate,
+            // regardless of its height or the target's original cache round.
+            peer.mailbox.prune(
+                Round::new(Epoch::zero(), View::new(3)),
+                finalized_commitment,
+            );
             context.sleep(Duration::from_millis(10)).await;
 
-            // Blocks at heights 1 and 2 should be pruned.
             assert!(
-                peer.mailbox.get(commitment1).await.is_none(),
-                "block1 should be pruned"
+                peer.mailbox.get(finalized_commitment).await.is_none(),
+                "finalized block should be pruned"
             );
             assert!(
-                peer.mailbox.get(commitment2).await.is_none(),
-                "block2 should be pruned"
+                peer.mailbox.get(malicious_commitment).await.is_none(),
+                "earlier malicious block should be pruned"
             );
 
-            // Block at height 3 should still be cached.
             assert!(
-                peer.mailbox.get(commitment3).await.is_some(),
-                "block3 should still be cached"
+                peer.mailbox.get(later_commitment).await.is_some(),
+                "later-round block should still be cached"
             );
         });
     }
@@ -3038,6 +3069,89 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_later_notarization_refreshes_reconstruction_state_round() {
+        let fixture: Fixture<C> = Fixture {
+            num_peers: 10,
+            ..Default::default()
+        };
+
+        fixture.start(
+            |config, context, _, mut peers, _, coding_config| async move {
+                let live = CodedBlock::<B, C, H>::new(
+                    B::new::<H>((), Sha256Digest::EMPTY, Height::new(2), 200),
+                    coding_config,
+                    &STRATEGY,
+                );
+                let finalized = CodedBlock::<B, C, H>::new(
+                    B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100),
+                    coding_config,
+                    &STRATEGY,
+                );
+                let live_commitment = live.commitment();
+                let finalized_commitment = finalized.commitment();
+                let receiver_idx = 3usize;
+                let receiver_pk = peers[receiver_idx].public_key.clone();
+                let leader = peers[0].public_key.clone();
+
+                peers[receiver_idx].mailbox.discovered(
+                    live_commitment,
+                    leader,
+                    Round::new(Epoch::zero(), View::new(1)),
+                );
+                let mut live_sub = peers[receiver_idx].mailbox.subscribe(live_commitment);
+
+                // The same commitment becomes live in a later round while the application
+                // still has an older finalization to acknowledge.
+                peers[receiver_idx].mailbox.notarized(
+                    live_commitment,
+                    Round::new(Epoch::zero(), View::new(4)),
+                );
+                context.sleep(Duration::from_millis(10)).await;
+                peers[receiver_idx].mailbox.prune(
+                    Round::new(Epoch::zero(), View::new(3)),
+                    finalized_commitment,
+                );
+                context.sleep(Duration::from_millis(10)).await;
+
+                assert!(
+                    matches!(live_sub.try_recv(), Err(TryRecvError::Empty)),
+                    "later-round reconstruction subscription should remain open"
+                );
+
+                let leader_shard = live
+                    .shard(peers[receiver_idx].index.get() as u16)
+                    .expect("missing leader shard");
+                peers[0].sender.send(
+                    Recipients::One(receiver_pk.clone()),
+                    leader_shard.encode(),
+                    true,
+                );
+                for i in [1usize, 2usize, 4usize] {
+                    let shard = live
+                        .shard(peers[i].index.get() as u16)
+                        .expect("missing gossip shard");
+                    peers[i].sender.send(
+                        Recipients::One(receiver_pk.clone()),
+                        shard.encode(),
+                        true,
+                    );
+                }
+
+                select! {
+                    result = live_sub => {
+                        let reconstructed =
+                            result.expect("later-round reconstruction should remain live");
+                        assert_eq!(reconstructed.commitment(), live_commitment);
+                    },
+                    _ = context.sleep(config.link.latency * 10) => {
+                        panic!("later-round reconstruction did not complete");
+                    },
+                }
+            },
+        );
+    }
+
+    #[test_traced]
     fn test_local_proposal_prune_clears_older_reconstruction_state() {
         let fixture: Fixture<C> = Fixture {
             num_peers: 10,
@@ -3091,7 +3205,7 @@ mod tests {
                     peers[2].mailbox.get(commitment_b).await.is_some(),
                     "local proposal should be cached before pruning"
                 );
-                peers[2].mailbox.prune(commitment_b);
+                peers[2].mailbox.prune(round_b, commitment_b);
 
                 select! {
                     result = block_sub => {

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1424,10 +1424,10 @@ where
     H: Hasher,
 {
     /// Stage 1: accumulate shards. The shard for our assigned index is verified
-    /// immediately; all other shards are buffered until enough
-    /// are available for batch verification.
+    /// immediately. All other shards are buffered until enough are available
+    /// for batch verification.
     AwaitingQuorum(AwaitingQuorumState<P, C, H>),
-    /// Stage 2: batch validation passed; checked shards are available for
+    /// Stage 2: batch validation passed. Checked shards are available for
     /// reconstruction.
     Ready(ReadyState<P, C, H>),
 }
@@ -4282,6 +4282,81 @@ mod tests {
 
                 // Peer 0 (leader) should be blocked for invalid crypto.
                 assert_blocked(&oracle, &peers[2].public_key, &peers[0].public_key).await;
+            },
+        );
+    }
+
+    #[test_traced]
+    fn test_invalid_assigned_shard_from_non_leader_blocks_only_sender() {
+        // A Byzantine participant can race the leader with garbage at the
+        // victim's assigned index, since the assigned index is accepted from
+        // any participant. The sender must be blocked without poisoning the
+        // slot: the leader's genuine shard must still verify afterward.
+        let fixture: Fixture<C> = Fixture {
+            ..Default::default()
+        };
+
+        fixture.start(
+            |config, context, oracle, mut peers, _, coding_config| async move {
+                // Create two different blocks — shard from block2 won't verify
+                // against commitment from block1.
+                let inner1 = B::new(Sha256Digest::EMPTY, Height::new(1), 100);
+                let coded_block1 = CodedBlock::<B, C, H>::new(inner1, coding_config, &STRATEGY);
+                let commitment1 = coded_block1.commitment();
+
+                let inner2 = B::new(Sha256Digest::EMPTY, Height::new(2), 200);
+                let coded_block2 = CodedBlock::<B, C, H>::new(inner2, coding_config, &STRATEGY);
+
+                // Get peer 2's shard from block2, but re-wrap it with
+                // block1's commitment so it fails verification.
+                let peer2_index = peers[2].index.get() as u16;
+                let mut wrong_shard = coded_block2.shard(peer2_index).expect("missing shard");
+                wrong_shard.commitment = commitment1;
+                let wrong_bytes = wrong_shard.encode();
+
+                let peer2_pk = peers[2].public_key.clone();
+                let leader = peers[0].public_key.clone();
+
+                let mut shard_sub = peers[2]
+                    .mailbox
+                    .subscribe_assigned_shard_verified(commitment1);
+
+                // Inform peer 2 that peer 0 is the leader.
+                peers[2].mailbox.discovered(
+                    commitment1,
+                    leader,
+                    Round::new(Epoch::zero(), View::new(1)),
+                );
+
+                // Non-leader peer 1 sends the invalid shard at peer 2's
+                // assigned index.
+                peers[1]
+                    .sender
+                    .send(Recipients::One(peer2_pk.clone()), wrong_bytes, true);
+                context.sleep(config.link.latency * 2).await;
+
+                // Peer 1 should be blocked for invalid crypto, and the assigned
+                // slot must not be treated as satisfied.
+                assert_blocked(&oracle, &peers[2].public_key, &peers[1].public_key).await;
+                assert!(
+                    matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)),
+                    "subscription should not resolve from invalid shard"
+                );
+
+                // The leader's genuine shard for the same index must still verify.
+                let real_bytes = coded_block1
+                    .shard(peer2_index)
+                    .expect("missing shard")
+                    .encode();
+                peers[0]
+                    .sender
+                    .send(Recipients::One(peer2_pk), real_bytes, true);
+                select! {
+                    _ = shard_sub => {},
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("genuine assigned shard did not verify after invalid one");
+                    },
+                };
             },
         );
     }

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -302,6 +302,7 @@ where
 {
     round: Round,
     phase: CommitmentPhase<B, C, H, P>,
+    proposed: bool,
 }
 
 /// The current lifecycle status of a commitment.
@@ -336,6 +337,7 @@ where
         Self {
             round,
             phase: CommitmentPhase::Reconstructing(reconstruction),
+            proposed: false,
         }
     }
 
@@ -347,6 +349,7 @@ where
                 block,
                 reconstruction: None,
             },
+            proposed: false,
         }
     }
 
@@ -393,6 +396,19 @@ where
             CommitmentPhase::Reconstructing(reconstruction) => Some(reconstruction),
             CommitmentPhase::Cached { reconstruction, .. } => reconstruction.as_mut(),
         }
+    }
+
+    /// Returns whether the local validator can satisfy its assigned-shard obligation.
+    fn is_assigned_shard_ready(&self) -> bool {
+        self.proposed
+            || self
+                .reconstruction()
+                .is_some_and(ReconstructionState::is_assigned_shard_verified)
+    }
+
+    /// Records that the local validator built and cached this commitment.
+    const fn mark_proposed(&mut self) {
+        self.proposed = true;
     }
 
     /// Caches `block` while preserving reconstruction state needed for shard readiness.
@@ -1179,6 +1195,10 @@ where
         // Cache the block so we don't have to reconstruct it again.
         self.cache_block(round, block)
             .expect("local proposal epoch was validated before broadcast");
+        self.records
+            .get_mut(&commitment)
+            .expect("caching a local proposal must create a commitment record")
+            .mark_proposed();
 
         // Local proposals bypass reconstruction, so shard subscribers waiting
         // for "our valid shard arrived" still need a notification.
@@ -1263,24 +1283,11 @@ where
         commitment: Commitment,
         response: oneshot::Sender<()>,
     ) {
-        // Answer immediately if our own shard has been verified.
-        let has_shard = self
-            .records
-            .get(&commitment)
-            .and_then(CommitmentRecord::reconstruction)
-            .is_some_and(|state| state.is_assigned_shard_verified());
-        if has_shard {
-            response.send_lossy(());
-            return;
-        }
-
-        // When there is no reconstruction state but the block is already in
-        // the cache, the local node was the proposer. Proposers trivially
-        // have all shards, so resolve immediately.
+        // Answer immediately if our own shard has been verified or we built the block.
         if self
             .records
             .get(&commitment)
-            .is_some_and(|record| record.reconstruction().is_none() && record.block().is_some())
+            .is_some_and(CommitmentRecord::is_assigned_shard_ready)
         {
             response.send_lossy(());
             return;
@@ -2711,7 +2718,10 @@ mod tests {
                 .mailbox
                 .subscribe_assigned_shard_verified(live_commitment);
             context.sleep(Duration::from_millis(10)).await;
-            assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
+            assert!(
+                matches!(shard_sub.try_recv(), Ok(())),
+                "late subscription should resolve after a local reproposal"
+            );
 
             peer.mailbox.retire(Retirement {
                 round_floor: floor,
@@ -2721,7 +2731,14 @@ mod tests {
 
             assert!(peer.mailbox.get(live_commitment).await.is_some());
             assert!(peer.mailbox.get(state_first_commitment).await.is_some());
-            assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
+            let mut retained_shard_sub = peer
+                .mailbox
+                .subscribe_assigned_shard_verified(live_commitment);
+            context.sleep(Duration::from_millis(10)).await;
+            assert!(
+                matches!(retained_shard_sub.try_recv(), Ok(())),
+                "retained local proposal should resolve a late subscription"
+            );
         });
     }
 
@@ -5496,11 +5513,20 @@ mod tests {
                 let reconstructed = block_sub.await.expect("block subscription should resolve");
                 assert_eq!(reconstructed.commitment(), commitment);
 
-                // Shard subscription must NOT resolve because the leader
-                // never sent the victim its own shard.
+                let mut late_shard_sub = peers[1]
+                    .mailbox
+                    .subscribe_assigned_shard_verified(commitment);
+                context.sleep(Duration::from_millis(10)).await;
+
+                // Neither an existing nor a late shard subscription may resolve because
+                // the leader never sent the victim its own shard.
                 assert!(
                     matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)),
                     "shard subscription must not resolve without own shard verification"
+                );
+                assert!(
+                    matches!(late_shard_sub.try_recv(), Err(TryRecvError::Empty)),
+                    "late shard subscription must not resolve from reconstruction alone"
                 );
             },
         );

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -534,8 +534,8 @@ where
                             response,
                         );
                     }
-                    Message::Prune { round, commitment } => {
-                        self.prune(round, commitment);
+                    Message::Prune { round, commitments } => {
+                        self.prune(round, commitments);
                     }
                 }
             },
@@ -911,9 +911,13 @@ where
         block: Arc<CodedBlock<B, C, H>>,
     ) -> Arc<CodedBlock<B, C, H>> {
         let commitment = block.commitment();
-        self.observe_existing_commitment(commitment, round);
+        let round = self.state.get_mut(&commitment).map_or(round, |state| {
+            state.observe(round);
+            state.round()
+        });
         self.reconstructed_blocks
             .entry(commitment)
+            .and_modify(|entry| entry.round = entry.round.max(round))
             .or_insert_with(|| ReconstructedBlock {
                 round,
                 block: Arc::clone(&block),
@@ -1181,21 +1185,25 @@ where
     ///
     /// Pruning waits for durable progress because a Byzantine leader may produce multiple valid
     /// commitments in one round.
-    fn prune(&mut self, round: Round, finalized: Commitment) {
+    fn prune(&mut self, round: Round, commitments: Vec<Commitment>) {
         // Durable processing makes existing exact-commitment and assigned-shard waits for these
         // states obsolete. Digest waits are not commitment-specific.
-        self.drop_commitment_subscriptions(finalized);
+        for commitment in commitments {
+            self.drop_commitment_subscriptions(commitment);
+            self.reconstructed_blocks.remove(&commitment);
+            self.state.remove(&commitment);
+        }
 
-        // Evict the processed block and blocks last observed no later than the retirement floor.
-        // Blocks observed in later rounds may still be needed for certification.
+        // Evict blocks last observed no later than the retirement floor. Blocks observed in later
+        // rounds may still be needed for certification.
         self.reconstructed_blocks
-            .retain(|commitment, entry| *commitment != finalized && entry.round > round);
+            .retain(|_, entry| entry.round > round);
 
         // Evict incomplete reconstructions by the same round rule. Later observations refresh
         // their round so a delayed application acknowledgment cannot retire a live re-proposal.
         let mut pruned_commitments = Vec::new();
         self.state.retain(|c, s| {
-            let keep = *c != finalized && s.round() > round;
+            let keep = s.round() > round;
             if !keep {
                 pruned_commitments.push(*c);
             }
@@ -2387,7 +2395,7 @@ mod tests {
             // processed commitment, even when that commitment was observed above the floor.
             peer.mailbox.prune(
                 Round::new(Epoch::zero(), View::new(3)),
-                processed_commitment,
+                vec![processed_commitment],
             );
             context.sleep(Duration::from_millis(10)).await;
 
@@ -2451,7 +2459,7 @@ mod tests {
             let mut state_later_sub = peer.mailbox.subscribe(state_later);
             context.sleep(Duration::from_millis(10)).await;
 
-            peer.mailbox.prune(floor, unseen);
+            peer.mailbox.prune(floor, vec![unseen]);
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(peer.mailbox.get(cached_old_commitment).await.is_none());
@@ -2487,7 +2495,13 @@ mod tests {
                 &STRATEGY,
             )
             .commitment();
+            let state_first = CodedBlock::<B, C, H>::new(
+                B::new::<H>((), Sha256Digest::EMPTY, Height::new(3), 300),
+                coding_config,
+                &STRATEGY,
+            );
             let live_commitment = live.commitment();
+            let state_first_commitment = state_first.commitment();
             let leader = peers[0].public_key.clone();
             let original_round = Round::new(Epoch::zero(), View::new(1));
             let floor = Round::new(Epoch::zero(), View::new(3));
@@ -2497,6 +2511,9 @@ mod tests {
             peer.mailbox
                 .discovered(live_commitment, leader, original_round);
             peer.mailbox.proposed(reproposal_round, live);
+            peer.mailbox
+                .notarized(state_first_commitment, reproposal_round);
+            peer.mailbox.proposed(floor, state_first);
             assert!(peer.mailbox.get(live_commitment).await.is_some());
 
             let mut shard_sub = peer
@@ -2505,10 +2522,11 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
             assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
 
-            peer.mailbox.prune(floor, unseen);
+            peer.mailbox.prune(floor, vec![unseen]);
             context.sleep(Duration::from_millis(10)).await;
 
             assert!(peer.mailbox.get(live_commitment).await.is_some());
+            assert!(peer.mailbox.get(state_first_commitment).await.is_some());
             assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
         });
     }
@@ -3236,7 +3254,7 @@ mod tests {
                 context.sleep(Duration::from_millis(10)).await;
                 peers[receiver_idx].mailbox.prune(
                     Round::new(Epoch::zero(), View::new(3)),
-                    finalized_commitment,
+                    vec![finalized_commitment],
                 );
                 context.sleep(Duration::from_millis(10)).await;
 
@@ -3363,7 +3381,7 @@ mod tests {
                 for &receiver_idx in &receivers {
                     peers[receiver_idx]
                         .mailbox
-                        .prune(prune_round, finalized_commitment);
+                        .prune(prune_round, vec![finalized_commitment]);
                 }
                 context.sleep(Duration::from_millis(10)).await;
 
@@ -3471,7 +3489,7 @@ mod tests {
                     peers[2].mailbox.get(commitment_b).await.is_some(),
                     "local proposal should be cached before pruning"
                 );
-                peers[2].mailbox.prune(round_b, commitment_b);
+                peers[2].mailbox.prune(round_b, vec![commitment_b]);
 
                 select! {
                     result = block_sub => {

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -75,7 +75,7 @@
 //!    +----------------------+
 //!    | AwaitingQuorum       |
 //!    | - leader known       |
-//!    | - leader's shard     |  <--- verified immediately on receipt
+//!    | - assigned shard     |  <--- verified immediately on receipt
 //!    |   verified eagerly   |
 //!    | - other shards       |  <--- buffered in pending_shards
 //!    |   buffered           |
@@ -115,10 +115,8 @@
 //! The engine enforces strict validation to prevent Byzantine attacks:
 //!
 //! - All shards MUST be sent by participants in the current epoch.
-//! - A discovered leader may send the recipient's assigned shard.
-//! - Any participant, including a discovered leader, may gossip its own shard.
-//! - A recipient-indexed shard from an undiscovered participant is retained in
-//!   the bounded peer buffer until consensus identifies the sender's role.
+//! - Any participant may deliver the recipient's assigned shard.
+//! - Any participant may gossip its own shard.
 //! - All shards MUST pass cryptographic verification against the commitment.
 //! - Each shard index may only contribute ONE shard per commitment.
 //! - Sending a second shard for the same index with different data
@@ -130,11 +128,11 @@
 //! tracked in reconstruction state. Once a block is already reconstructed and
 //! cached, additional shards for that commitment are ignored.
 //!
-//! _If a sender's role is not yet known, shards are buffered in fixed-size per-peer
-//! queues until consensus signals a leader via [`Mailbox::discovered`]
+//! _Before proposal context is known, shards are buffered in fixed-size per-peer
+//! queues until consensus signals the proposal via [`Mailbox::discovered`]
 //! or a notarization via [`Mailbox::notarized`]. A notarization activates
 //! reconstruction interest without a leader, so only sender-indexed gossip
-//! shards can be ingested. Assigned shard verification still requires leader
+//! shards can be ingested. Other shards remain buffered until proposal
 //! discovery._
 
 use super::{
@@ -173,7 +171,7 @@ use commonware_utils::{
 };
 use rand_core::Rng;
 use std::{
-    collections::{BTreeMap, BTreeSet, VecDeque},
+    collections::{BTreeMap, VecDeque},
     num::NonZeroUsize,
     sync::Arc,
 };
@@ -349,10 +347,9 @@ where
     /// Open subscriptions for assigned shard verification for the keyed
     /// [`Commitment`].
     ///
-    /// For participants, readiness is satisfied once the leader-delivered
-    /// shard for the local participant index has been verified. Block
-    /// reconstruction from peer gossip is tracked separately and does not
-    /// satisfy this readiness condition.
+    /// For participants, readiness is satisfied once the shard for the local
+    /// participant index has been verified. Reconstruction from peer gossip is
+    /// tracked separately and does not satisfy this readiness condition.
     ///
     /// Proposers are a special case: they satisfy readiness once their local
     /// proposal is cached because they already hold all shards.
@@ -568,20 +565,19 @@ where
                 return;
             };
 
-            // Sender-indexed gossip is immediately actionable. A recipient-indexed
-            // shard from an undiscovered reproposer remains buffered until consensus
-            // confirms the sender's role.
-            if let Some(sender_index) = scheme.participants().index(&peer) {
-                let sender_index: u16 = sender_index
+            // Notarized recovery can create state before leader discovery. Until
+            // the leader is known, only sender-indexed gossip shards are safe to
+            // ingest: a participant may only gossip its own shard.
+            if existing.leader().is_none()
+                && let Some(sender_index) = scheme.participants().index(&peer)
+            {
+                let expected_index: u16 = sender_index
                     .get()
                     .try_into()
                     .expect("participant index impossibly out of bounds");
-                let could_be_assigned = scheme
-                    .me()
-                    .is_some_and(|index| index.get() == u32::from(shard.index()));
-                if shard.index() != sender_index
-                    && (!existing.has_leader() || could_be_assigned && !existing.is_leader(&peer))
-                {
+                if shard.index() != expected_index {
+                    // A mismatched shard may be assigned to us, but it cannot be
+                    // classified until consensus supplies the proposal context.
                     self.buffer_peer_shard(peer, shard);
                     return;
                 }
@@ -608,15 +604,12 @@ where
     /// Returns whether an incoming network shard should still be processed.
     ///
     /// Shards for reconstructed commitments are normally ignored. The only
-    /// exception is the late leader-delivered shard for the assigned index,
-    /// which we still accept so we can notify readiness and gossip it to
-    /// slower peers.
+    /// exception is a late shard for the assigned index, which we still accept
+    /// so we can notify readiness and gossip it to slower peers.
     fn should_handle_network_shard(&self, commitment: Commitment) -> bool {
         if self.reconstructed_blocks.contains_key(&commitment) {
-            // State can be populated without a leader when a notarization arrives
-            // before the leader announcement, or when our assigned shard was not
-            // verified. Keep handling shards until the leader-dependent state is
-            // complete.
+            // State can be populated before our assigned shard is verified. Keep
+            // handling shards until that state is complete.
             return self
                 .state
                 .get(&commitment)
@@ -705,17 +698,15 @@ where
         leader: P,
         round: Round,
     ) {
-        // A reconstructed block normally makes leader announcements redundant,
-        // unless its assigned shard is still pending.
-        let block_cached = self.reconstructed_blocks.contains_key(&commitment);
-        if block_cached {
-            self.observe_existing_commitment(commitment, round);
-        }
-        if block_cached
+        // A reconstructed block normally makes duplicate leader announcements
+        // redundant, unless notarized recovery created leaderless state first.
+        // In that case, the leader announcement must still populate the
+        // leader-dependent path.
+        if self.observe_existing_commitment(commitment, round)
             && self
                 .state
                 .get(&commitment)
-                .is_none_or(ReconstructionState::is_assigned_shard_verified)
+                .is_none_or(|state| state.leader().is_some())
         {
             return;
         }
@@ -728,11 +719,24 @@ where
             warn!(?leader, %commitment, "leader update for non-participant, ignoring");
             return;
         }
-        if !block_cached {
-            self.observe_existing_commitment(commitment, round);
-        }
         if let Some(state) = self.state.get_mut(&commitment) {
-            state.add_leader(leader);
+            if let Some(existing) = state.leader() {
+                if existing != &leader {
+                    // A later leader is expected when this commitment is
+                    // re-proposed. Retaining the first does not impede participant
+                    // readiness because assigned shards are source-independent.
+                    debug!(
+                        existing = ?existing,
+                        ?leader,
+                        %commitment,
+                        "commitment already has a leader, ignoring update"
+                    );
+                }
+                return;
+            }
+            state
+                .set_leader(leader)
+                .expect("leader was checked as absent");
         } else {
             let participants_len = u64::try_from(participants.len())
                 .expect("participant count impossibly out of bounds");
@@ -784,7 +788,7 @@ where
         }
     }
 
-    /// Buffer a shard from a peer until its sender role is known.
+    /// Buffer a shard from a peer until a leader is known.
     fn buffer_peer_shard(&mut self, peer: P, shard: Shard<C, H>) {
         if self.latest_primary_peers.position(&peer).is_none() {
             debug!(
@@ -806,16 +810,18 @@ where
         self.latest_primary_peers = peers;
     }
 
-    /// Ingest actionable buffered shards for a commitment into active state.
+    /// Ingest buffered pre-leader shards for a commitment into active state.
     ///
-    /// Sender-indexed gossip is always actionable. Recipient-indexed shards are
-    /// retained until consensus identifies their sender as a leader.
+    /// Before proposal context is known, only sender-indexed gossip is
+    /// actionable. Once context exists, the local assigned index is valid from
+    /// any participant because its proof is bound to the commitment.
     fn ingest_buffered_shards(&mut self, commitment: Commitment) -> bool {
         let state = self
             .state
             .get(&commitment)
             .expect("buffered shards can only be ingested with reconstruction state");
         let round = state.round();
+        let leader_known = state.leader().is_some();
         let Some(scheme) = self.scheme_provider.scheme(round.epoch()) else {
             warn!(%commitment, "no scheme for epoch, dropping buffered shards");
             return false;
@@ -829,23 +835,19 @@ where
                     i += 1;
                     continue;
                 }
-                let Some(sender_index) = scheme.participants().index(peer) else {
-                    i += 1;
-                    continue;
-                };
-                let sender_index: u16 = sender_index
-                    .get()
-                    .try_into()
-                    .expect("participant index impossibly out of bounds");
-                let could_be_assigned = scheme
-                    .me()
-                    .is_some_and(|index| index.get() == u32::from(queue[i].index()));
-                let actionable = queue[i].index() == sender_index
-                    || state.is_leader(peer)
-                    || state.has_leader() && !could_be_assigned;
-                if !actionable {
-                    i += 1;
-                    continue;
+                if !leader_known {
+                    let Some(sender_index) = scheme.participants().index(peer) else {
+                        i += 1;
+                        continue;
+                    };
+                    let expected_index: u16 = sender_index
+                        .get()
+                        .try_into()
+                        .expect("participant index impossibly out of bounds");
+                    if queue[i].index() != expected_index {
+                        i += 1;
+                        continue;
+                    }
                 }
                 let shard = queue.swap_remove_back(i).expect("index is valid");
                 buffered.push((peer.clone(), shard));
@@ -1051,8 +1053,8 @@ where
 
     /// Handles the registry of an assigned shard verification subscription.
     ///
-    /// For participants this is tied to verification of the leader-delivered
-    /// shard for the local index, not to generic block reconstruction.
+    /// For participants this is tied to verification of the shard for the local
+    /// index, not to generic block reconstruction.
     fn handle_assigned_shard_verified_subscription(
         &mut self,
         commitment: Commitment,
@@ -1191,7 +1193,6 @@ where
             }
             keep
         });
-
         for pruned in pruned_commitments {
             self.drop_commitment_subscriptions(pruned);
         }
@@ -1205,8 +1206,8 @@ where
     C: CodingScheme,
     H: Hasher,
 {
-    /// Stage 1: accumulate shards. The leader's shard for our index is
-    /// verified immediately; all other shards are buffered until enough
+    /// Stage 1: accumulate shards. The shard for our assigned index is verified
+    /// immediately; all other shards are buffered until enough
     /// are available for batch verification.
     AwaitingQuorum(AwaitingQuorumState<P, C, H>),
     /// Stage 2: batch validation passed; checked shards are available for
@@ -1238,8 +1239,9 @@ where
     C: CodingScheme,
     H: Hasher,
 {
-    /// Leaders observed for this commitment.
-    leaders: BTreeSet<P>,
+    /// The leader associated with this reconstruction state, if consensus has
+    /// provided it.
+    leader: Option<P>,
     /// Our validated shard and the action to take with it.
     pending_action: Option<AssignedShardVerifiedAction<C, H>>,
     /// Shards that have been verified and are ready to contribute to reconstruction.
@@ -1251,16 +1253,16 @@ where
     /// Raw shard data received per index, retained for equivocation detection.
     /// Keyed by shard index.
     received_shards: BTreeMap<u16, C::Shard>,
-    /// Whether the leader's shard for our assigned index has been verified.
+    /// Whether the shard for our assigned index has been verified.
     assigned_shard_verified: bool,
 }
 
 /// Phase data for `ReconstructionState::AwaitingQuorum`.
 ///
 /// In this phase, the leader may be unknown. Sender-indexed shards can still be
-/// buffered until enough are available to attempt batch validation. Once the
-/// leader is known, the leader's shard for our index is verified eagerly via
-/// `C::check`.
+/// buffered until enough are available to attempt batch validation. Once proposal
+/// context is known, the shard for our assigned index is verified eagerly via
+/// `C::check`, regardless of which participant delivered it.
 struct AwaitingQuorumState<P, C, H>
 where
     P: PublicKey,
@@ -1294,7 +1296,7 @@ where
     /// Create a new empty common state for the provided leader and round.
     fn new(leader: Option<P>, round: Round, participants_len: u64) -> Self {
         Self {
-            leaders: leader.into_iter().collect(),
+            leader,
             pending_action: None,
             checked_shards: Vec::new(),
             contributed: BitMap::zeroes(participants_len),
@@ -1311,7 +1313,7 @@ where
     C: CodingScheme,
     H: Hasher,
 {
-    /// Verify the leader's shard for our index and store it.
+    /// Verify the assigned shard and store it.
     ///
     /// When `is_participant` is true, the validated shard is stored for
     /// broadcasting to peers. When false (non-participant), only subscriber
@@ -1335,7 +1337,7 @@ where
         let Ok(checked) = C::check(&commitment.config(), &commitment.root(), shard.index, data)
         else {
             self.received_shards.remove(&shard.index);
-            commonware_p2p::block!(blocker, sender, "invalid shard received from leader");
+            commonware_p2p::block!(blocker, sender, "invalid assigned shard received");
             return false;
         };
 
@@ -1402,9 +1404,10 @@ where
 
         // Transition to Ready.
         let round = self.common.round;
+        let leader = self.common.leader.clone();
         let common = std::mem::replace(
             &mut self.common,
-            CommonState::new(None, round, participants_len),
+            CommonState::new(leader, round, participants_len),
         );
         Some(ReadyState { common })
     }
@@ -1471,19 +1474,18 @@ where
         }
     }
 
-    /// Returns whether consensus has identified any leader for this commitment.
-    fn has_leader(&self) -> bool {
-        !self.common().leaders.is_empty()
+    /// Return the leader associated with this state.
+    const fn leader(&self) -> Option<&P> {
+        self.common().leader.as_ref()
     }
 
-    /// Returns whether consensus has identified `leader` for this commitment.
-    fn is_leader(&self, leader: &P) -> bool {
-        self.common().leaders.contains(leader)
-    }
-
-    /// Associates a consensus-observed leader with this commitment.
-    fn add_leader(&mut self, leader: P) {
-        self.common_mut().leaders.insert(leader);
+    /// Set the leader for this state if it has not already been set.
+    fn set_leader(&mut self, leader: P) -> Result<(), P> {
+        if self.common().leader.is_some() {
+            return Err(leader);
+        }
+        self.common_mut().leader = Some(leader);
+        Ok(())
     }
 
     /// Refreshes the round used to decide whether this state can be pruned.
@@ -1496,7 +1498,7 @@ where
         common.round = common.round.max(round);
     }
 
-    /// Returns whether the leader's shard for our index has been verified.
+    /// Returns whether the shard for our assigned index has been verified.
     const fn is_assigned_shard_verified(&self) -> bool {
         self.common().assigned_shard_verified
     }
@@ -1513,7 +1515,7 @@ where
 
     /// Takes the pending action for this commitment's validated shard.
     ///
-    /// Returns [`None`] if the leader's shard hasn't been validated yet.
+    /// Returns [`None`] if the assigned shard hasn't been validated yet.
     const fn take_pending_action(&mut self) -> Option<AssignedShardVerifiedAction<C, H>> {
         self.common_mut().pending_action.take()
     }
@@ -1530,16 +1532,14 @@ where
     ///
     /// - MUST be sent by a participant in the current epoch. Non-participant
     ///   senders are blocked.
-    /// - If the sender is a leader: the shard index MUST match either the
-    ///   recipient's participant index or the sender's participant index.
-    /// - If the sender is not a leader: the shard index MUST match the
-    ///   sender's participant index.
-    /// - Once a leader is known, any other shard index results in blocking.
+    /// - A participant's assigned index may be delivered by any participant.
+    /// - Other shards MUST match the sender's participant index.
+    /// - Once proposal context is known, any other shard index results in
+    ///   blocking.
     /// - Each shard index may only contribute ONE shard per commitment.
     ///   Sending a second shard for the same index with different data
     ///   (equivocation) results in blocking the sender.
-    /// - A leader's shard for the assigned index is verified eagerly via
-    ///   [`CodingScheme::check`].
+    /// - The assigned shard is verified eagerly via [`CodingScheme::check`].
     ///   If verification fails, the sender is blocked.
     /// - Own-index shards are buffered in `pending_shards` and
     ///   batch-validated when quorum is reached. Invalid shards discovered
@@ -1583,32 +1583,31 @@ where
             data: shard.into_inner(),
         };
 
+        // A participant's assigned shard is source-independent because it is
+        // verified eagerly. Every other shard must be sender-owned so each sender
+        // contributes at most one shard before batch verification.
         let sender_index: u16 = sender_index
             .get()
             .try_into()
             .expect("participant index impossibly out of bounds");
-        let assigned_index = ctx.scheme.me().map_or(sender_index, |assigned_index| {
+        let assigned_index: Option<u16> = ctx.scheme.me().map(|assigned_index| {
             assigned_index
                 .get()
                 .try_into()
                 .expect("participant index impossibly out of bounds")
         });
-        let is_from_leader = self.is_leader(&sender);
-        let is_assigned_shard = is_from_leader && indexed.index == assigned_index;
+        let is_from_leader = self.leader().is_some_and(|leader| leader == &sender);
+        let is_assigned_shard = assigned_index
+            .is_some_and(|assigned_index| indexed.index == assigned_index)
+            || assigned_index.is_none() && is_from_leader && indexed.index == sender_index;
         let is_gossip_shard = indexed.index == sender_index;
         if !is_assigned_shard && !is_gossip_shard {
-            if self.has_leader() {
-                let expected_index = if is_from_leader {
-                    assigned_index
-                } else {
-                    sender_index
-                };
+            if self.leader().is_some() {
                 commonware_p2p::block!(
                     blocker,
                     sender,
                     shard_index = indexed.index,
-                    expected_index,
-                    "shard index does not match expected index"
+                    "shard index is neither assigned nor sender-owned"
                 );
             }
             return false;
@@ -1627,9 +1626,8 @@ where
             return false;
         }
 
-        // Leader's shard for our index is always verified eagerly,
-        // even after transitioning to Ready. This ensures we broadcast
-        // our own shard to help slower peers reach quorum.
+        // The assigned shard is always verified eagerly, even after transitioning
+        // to Ready. This ensures we broadcast it to help slower peers reach quorum.
         if is_assigned_shard && !self.common().assigned_shard_verified {
             let progressed = self.common_mut().verify_assigned_shard(
                 sender,
@@ -2701,10 +2699,10 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_later_external_proposer_accepted() {
+    fn test_assigned_shard_from_non_leader_accepted() {
         let fixture = Fixture::<C>::default();
         fixture.start(
-            |config, context, oracle, mut peers, _, coding_config| async move {
+            |_config, context, oracle, mut peers, _, coding_config| async move {
                 let inner = B::new::<H>((), Sha256Digest::EMPTY, Height::new(1), 100);
                 let coded_block = CodedBlock::<B, C, H>::new(inner, coding_config, &STRATEGY);
                 let commitment = coded_block.commitment();
@@ -2715,41 +2713,30 @@ mod tests {
                 let shard_bytes = peer2_shard.encode();
 
                 let peer2_pk = peers[2].public_key.clone();
-                let leader_a = peers[0].public_key.clone();
-                let leader_b = peers[1].public_key.clone();
+                let leader = peers[0].public_key.clone();
 
                 // Subscribe before shards arrive so we can verify acceptance.
-                let mut shard_sub = peers[2]
+                let shard_sub = peers[2]
                     .mailbox
                     .subscribe_assigned_shard_verified(commitment);
 
-                // The commitment is first proposed by leader A.
+                // Discover the proposal under peer 0.
                 peers[2].mailbox.discovered(
                     commitment,
-                    leader_a,
+                    leader,
                     Round::new(Epoch::zero(), View::new(1)),
                 );
 
-                // The later leader's shard may arrive before its proposal.
+                // The assigned shard is commitment-bound, so another participant
+                // may deliver it without being treated as a conflicting proposer.
                 peers[1]
                     .sender
                     .send(Recipients::One(peer2_pk), shard_bytes, true);
-                context.sleep(config.link.latency * 2).await;
-                assert!(oracle.blocked().await.unwrap().is_empty());
-                assert!(matches!(shard_sub.try_recv(), Err(TryRecvError::Empty)));
 
-                // Discovering the later leader makes its buffered shard actionable.
-                peers[2].mailbox.discovered(
-                    commitment,
-                    leader_b,
-                    Round::new(Epoch::zero(), View::new(2)),
-                );
-
-                // Subscription should resolve from the later leader's shard.
                 select! {
                     _ = shard_sub => {},
                     _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("subscription did not complete after shard from later leader");
+                        panic!("subscription did not complete after assigned shard");
                     },
                 };
 

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -337,8 +337,10 @@ where
     /// Entries last observed at or before `round` are eligible for retirement.
     /// Entries matching `commitments` are eligible regardless of observation round.
     ///
-    /// Assigned-shard and exact-commitment subscriptions for retired state are closed. Digest
-    /// subscriptions remain open, and later consensus notifications may recreate state.
+    /// Assigned-shard subscriptions for retired state are closed. Exact-commitment subscriptions
+    /// close only for entries named in `commitments`; other block subscriptions remain open for
+    /// local ingress. Digest subscriptions remain open, and later consensus notifications may
+    /// recreate state.
     pub fn prune(&self, round: Round, commitments: Vec<Commitment>) {
         let _ = self.sender.enqueue(Message::Prune { round, commitments });
     }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -94,11 +94,12 @@ where
         /// The response channel.
         response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
     },
-    /// A request to prune cached blocks and reconstruction state after finalization.
+    /// A request to retire cached blocks and reconstruction state after durable application
+    /// progress.
     Prune {
-        /// The finalized consensus round.
+        /// The inclusive consensus-round retirement floor.
         round: Round,
-        /// The finalized [`Commitment`].
+        /// The commitment through which application processing advanced.
         commitment: Commitment,
     },
 }
@@ -326,10 +327,11 @@ where
         receiver
     }
 
-    /// Prune cached blocks and reconstruction state after finalization.
+    /// Retire cached blocks and reconstruction state after durable application progress.
     ///
-    /// The finalized commitment and entries last associated with `round` or earlier are retired.
-    /// The round is supplied separately because a re-proposal retains its original commitment.
+    /// `commitment` is retired exactly. `round` is an inclusive retirement floor for every other
+    /// entry and is supplied separately because sparse finalization certificates and re-proposals
+    /// may associate it with a different block context.
     ///
     /// Assigned-shard and exact-commitment subscriptions for retired state are closed. Digest
     /// subscriptions remain open, and later consensus notifications may recreate state.

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -99,8 +99,8 @@ where
     Prune {
         /// The inclusive consensus-round retirement floor.
         round: Round,
-        /// The commitment through which application processing advanced.
-        commitment: Commitment,
+        /// The commitments through which application processing advanced.
+        commitments: Vec<Commitment>,
     },
 }
 
@@ -329,13 +329,13 @@ where
 
     /// Retire cached blocks and reconstruction state after durable application progress.
     ///
-    /// `commitment` is retired exactly. `round` is an inclusive retirement floor for every other
-    /// entry and is supplied separately because sparse finalization certificates and re-proposals
-    /// may associate it with a different block context.
+    /// `commitments` are retired exactly. `round` is an inclusive retirement floor for every
+    /// other entry and is supplied separately because sparse finalization certificates and
+    /// re-proposals may associate it with a different block context.
     ///
     /// Assigned-shard and exact-commitment subscriptions for retired state are closed. Digest
     /// subscriptions remain open, and later consensus notifications may recreate state.
-    pub fn prune(&self, round: Round, commitment: Commitment) {
-        let _ = self.sender.enqueue(Message::Prune { round, commitment });
+    pub fn prune(&self, round: Round, commitments: Vec<Commitment>) {
+        let _ = self.sender.enqueue(Message::Prune { round, commitments });
     }
 }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     CertifiableBlock,
-    marshal::{coding::types::CodedBlock, core::RetentionUpdate},
+    marshal::{coding::types::CodedBlock, core::Retirement},
     types::{Round, coding::Commitment},
 };
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
@@ -97,8 +97,8 @@ where
     /// A request to retire cached blocks and reconstruction state after durable application
     /// progress.
     Retire {
-        /// The atomic retention update.
-        update: RetentionUpdate<Commitment>,
+        /// The retirement to apply.
+        update: Retirement<Commitment>,
     },
 }
 
@@ -335,14 +335,14 @@ where
 
     /// Retire cached blocks and reconstruction state after durable application progress.
     ///
-    /// Entries last observed at or before [`RetentionUpdate::round_floor`] are eligible for
-    /// retirement. Entries in [`RetentionUpdate::exact_retirements`] are eligible regardless of
+    /// Entries last observed at or before [`Retirement::round_floor`] are eligible for
+    /// retirement. Entries in [`Retirement::exact_retirements`] are eligible regardless of
     /// observation round.
     ///
     /// Assigned-shard subscriptions for retired state are closed. Exact-commitment subscriptions
     /// close only for exact retirements. Other block subscriptions remain open for local ingress.
     /// Digest subscriptions remain open, and later consensus notifications may recreate state.
-    pub fn retire(&self, update: RetentionUpdate<Commitment>) {
+    pub fn retire(&self, update: Retirement<Commitment>) {
         let _ = self.sender.enqueue(Message::Retire { update });
     }
 }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -340,7 +340,7 @@ where
     /// observation round.
     ///
     /// Assigned-shard subscriptions for retired state are closed. Exact-commitment subscriptions
-    /// close only for exact retirements; other block subscriptions remain open for local ingress.
+    /// close only for exact retirements. Other block subscriptions remain open for local ingress.
     /// Digest subscriptions remain open, and later consensus notifications may recreate state.
     pub fn retire(&self, update: RetentionUpdate<Commitment>) {
         let _ = self.sender.enqueue(Message::Retire { update });

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -94,10 +94,12 @@ where
         /// The response channel.
         response: oneshot::Sender<Arc<CodedBlock<B, C, H>>>,
     },
-    /// A request to evict cached blocks and reconstruction state relative to a commitment.
+    /// A request to prune cached blocks and reconstruction state after finalization.
     Prune {
-        /// Inclusive prune target [`Commitment`].
-        through: Commitment,
+        /// The finalized consensus round.
+        round: Round,
+        /// The finalized [`Commitment`].
+        commitment: Commitment,
     },
 }
 
@@ -324,11 +326,14 @@ where
         receiver
     }
 
-    /// Evict cached blocks and reconstruction state through `through`.
+    /// Prune cached blocks and reconstruction state after finalization.
+    ///
+    /// The finalized commitment and entries last associated with `round` or earlier are retired.
+    /// The round is supplied separately because a re-proposal retains its original commitment.
     ///
     /// Assigned-shard and exact-commitment subscriptions for retired state are closed. Digest
     /// subscriptions remain open, and later consensus notifications may recreate state.
-    pub fn prune(&self, through: Commitment) {
-        let _ = self.sender.enqueue(Message::Prune { through });
+    pub fn prune(&self, round: Round, commitment: Commitment) {
+        let _ = self.sender.enqueue(Message::Prune { round, commitment });
     }
 }

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -64,9 +64,9 @@ where
     },
     /// A request to open a subscription for assigned shard verification.
     ///
-    /// For participants, this resolves once the leader-delivered shard for
-    /// the local participant index has been verified. Reconstructing the full
-    /// block from gossiped shards does not resolve this subscription: that
+    /// For participants, this resolves once the shard for the local participant
+    /// index has been verified. Reconstructing the full block from gossiped
+    /// shards does not resolve this subscription: that
     /// block may still be used for later certification, but it is not enough
     /// to claim the participant received the shard it is expected to echo.
     ///
@@ -97,9 +97,9 @@ where
     /// A request to retire cached blocks and reconstruction state after durable application
     /// progress.
     Prune {
-        /// The inclusive consensus-round retirement floor.
+        /// The inclusive observation-round retirement floor.
         round: Round,
-        /// The commitments through which application processing advanced.
+        /// Commitments to retire regardless of observation round.
         commitments: Vec<Commitment>,
     },
 }
@@ -241,6 +241,11 @@ where
     }
 
     /// Inform the engine of an externally proposed [`Commitment`].
+    ///
+    /// `round` MUST come from a trusted consensus observation, and its epoch
+    /// MUST be validated for `commitment`. The engine classifies the commitment's
+    /// shards against that epoch's participant set, so an unvalidated epoch can
+    /// misclassify shards from honest peers.
     pub fn discovered(&self, commitment: Commitment, leader: P, round: Round) {
         let _ = self.sender.enqueue(Message::Discovered {
             commitment,
@@ -282,9 +287,9 @@ where
 
     /// Subscribe to assigned shard verification for a commitment.
     ///
-    /// For participants, this resolves once the leader-delivered shard for
-    /// the local participant index has been verified. Reconstructing the full
-    /// block from gossiped shards does not resolve this subscription: that
+    /// For participants, this resolves once the shard for the local participant
+    /// index has been verified. Reconstructing the full block from gossiped
+    /// shards does not resolve this subscription: that
     /// block may still be used for later certification, but it is not enough
     /// to claim the participant received the shard it is expected to echo.
     ///
@@ -329,9 +334,8 @@ where
 
     /// Retire cached blocks and reconstruction state after durable application progress.
     ///
-    /// `commitments` are retired exactly. `round` is an inclusive retirement floor for every
-    /// other entry and is supplied separately because sparse finalization certificates and
-    /// re-proposals may associate it with a different block context.
+    /// Entries last observed at or before `round` are eligible for retirement.
+    /// Entries matching `commitments` are eligible regardless of observation round.
     ///
     /// Assigned-shard and exact-commitment subscriptions for retired state are closed. Digest
     /// subscriptions remain open, and later consensus notifications may recreate state.

--- a/consensus/src/marshal/coding/shards/mailbox.rs
+++ b/consensus/src/marshal/coding/shards/mailbox.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     CertifiableBlock,
-    marshal::coding::types::CodedBlock,
+    marshal::{coding::types::CodedBlock, core::RetentionUpdate},
     types::{Round, coding::Commitment},
 };
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
@@ -96,11 +96,9 @@ where
     },
     /// A request to retire cached blocks and reconstruction state after durable application
     /// progress.
-    Prune {
-        /// The inclusive observation-round retirement floor.
-        round: Round,
-        /// Commitments to retire regardless of observation round.
-        commitments: Vec<Commitment>,
+    Retire {
+        /// The atomic retention update.
+        update: RetentionUpdate<Commitment>,
     },
 }
 
@@ -122,7 +120,7 @@ where
             Self::Proposed { .. }
             | Self::Discovered { .. }
             | Self::Notarized { .. }
-            | Self::Prune { .. } => false,
+            | Self::Retire { .. } => false,
         }
     }
 }
@@ -256,6 +254,9 @@ where
 
     /// Inform the engine that a [`Commitment`] was notarized.
     ///
+    /// `round` MUST come from a trusted consensus observation, and its epoch
+    /// MUST be validated for `commitment`.
+    ///
     /// This is the leaderless reconstruction signal used by certification. It
     /// lets the engine drain sender-indexed gossip shards from its peer buffers
     /// for the commitment. Leader-specific validation and assigned shard
@@ -334,14 +335,14 @@ where
 
     /// Retire cached blocks and reconstruction state after durable application progress.
     ///
-    /// Entries last observed at or before `round` are eligible for retirement.
-    /// Entries matching `commitments` are eligible regardless of observation round.
+    /// Entries last observed at or before [`RetentionUpdate::round_floor`] are eligible for
+    /// retirement. Entries in [`RetentionUpdate::exact_retirements`] are eligible regardless of
+    /// observation round.
     ///
     /// Assigned-shard subscriptions for retired state are closed. Exact-commitment subscriptions
-    /// close only for entries named in `commitments`; other block subscriptions remain open for
-    /// local ingress. Digest subscriptions remain open, and later consensus notifications may
-    /// recreate state.
-    pub fn prune(&self, round: Round, commitments: Vec<Commitment>) {
-        let _ = self.sender.enqueue(Message::Prune { round, commitments });
+    /// close only for exact retirements; other block subscriptions remain open for local ingress.
+    /// Digest subscriptions remain open, and later consensus notifications may recreate state.
+    pub fn retire(&self, update: RetentionUpdate<Commitment>) {
+        let _ = self.sender.enqueue(Message::Retire { update });
     }
 }

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -155,8 +155,8 @@ where
         Some(self.subscribe(commitment))
     }
 
-    fn finalized(&self, commitment: Commitment) {
-        self.prune(commitment);
+    fn finalized(&self, round: Round, commitment: Commitment) {
+        self.prune(round, commitment);
     }
 
     fn send(&self, round: Round, block: Arc<CodedBlock<B, C, H>>, _recipients: Recipients<P>) {

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -6,7 +6,7 @@ use crate::{
             shards,
             types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_participants},
         },
-        core::{Buffer, CommitmentFallback, Mailbox, RetentionUpdate, Variant},
+        core::{Buffer, CommitmentFallback, Mailbox, Retirement, Variant},
     },
     simplex::{scheme::Scheme as SimplexScheme, types::Context},
     types::{Round, coding::Commitment},
@@ -155,7 +155,7 @@ where
         Some(self.subscribe(commitment))
     }
 
-    fn retire(&self, update: RetentionUpdate<Commitment>) {
+    fn retire(&self, update: Retirement<Commitment>) {
         Self::retire(self, update);
     }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -6,7 +6,7 @@ use crate::{
             shards,
             types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_participants},
         },
-        core::{Buffer, CommitmentFallback, Mailbox, Variant},
+        core::{Buffer, CommitmentFallback, Mailbox, RetentionUpdate, Variant},
     },
     simplex::{scheme::Scheme as SimplexScheme, types::Context},
     types::{Round, coding::Commitment},
@@ -155,8 +155,8 @@ where
         Some(self.subscribe(commitment))
     }
 
-    fn finalized(&self, round: Round, commitments: Vec<Commitment>) {
-        self.prune(round, commitments);
+    fn retire(&self, update: RetentionUpdate<Commitment>) {
+        Self::retire(self, update);
     }
 
     fn send(&self, round: Round, block: Arc<CodedBlock<B, C, H>>, _recipients: Recipients<P>) {

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -155,8 +155,8 @@ where
         Some(self.subscribe(commitment))
     }
 
-    fn finalized(&self, round: Round, commitment: Commitment) {
-        self.prune(round, commitment);
+    fn finalized(&self, round: Round, commitments: Vec<Commitment>) {
+        self.prune(round, commitments);
     }
 
     fn send(&self, round: Round, block: Arc<CodedBlock<B, C, H>>, _recipients: Recipients<P>) {

--- a/consensus/src/marshal/core/acks.rs
+++ b/consensus/src/marshal/core/acks.rs
@@ -44,10 +44,15 @@ impl<V: Variant, A: Acknowledgement> PendingAcks<V, A> {
         }
     }
 
-    /// Drops the current ack and all queued acks.
-    pub(super) fn clear(&mut self) {
-        self.current = None.into();
-        self.queue.clear();
+    /// Drops the current ack and all queued acks, returning their commitments.
+    pub(super) fn clear(&mut self) -> Vec<V::Commitment> {
+        let mut commitments =
+            Vec::with_capacity(self.queue.len() + usize::from(self.current.is_some()));
+        if let Some(ack) = self.current.take() {
+            commitments.push(ack.commitment);
+        }
+        commitments.extend(self.queue.drain(..).map(|ack| ack.commitment));
+        commitments
     }
 
     /// Returns the currently armed ack future (if any) for `select_loop!`.
@@ -178,7 +183,8 @@ mod tests {
         pending.enqueue(second);
         assert!(!pending.has_capacity());
 
-        pending.clear();
+        let commitments = pending.clear();
+        assert_eq!(commitments, vec![digest(1), digest(2)]);
         first_ack.acknowledge();
         second_ack.acknowledge();
 

--- a/consensus/src/marshal/core/acks.rs
+++ b/consensus/src/marshal/core/acks.rs
@@ -44,15 +44,14 @@ impl<V: Variant, A: Acknowledgement> PendingAcks<V, A> {
         }
     }
 
-    /// Drops the current ack and all queued acks, returning their commitments.
-    pub(super) fn clear(&mut self) -> Vec<V::Commitment> {
-        let mut commitments =
-            Vec::with_capacity(self.queue.len() + usize::from(self.current.is_some()));
+    /// Drops the current ack and all queued acks, returning their heights and commitments.
+    pub(super) fn clear(&mut self) -> Vec<(Height, V::Commitment)> {
+        let mut acks = Vec::with_capacity(self.queue.len() + usize::from(self.current.is_some()));
         if let Some(ack) = self.current.take() {
-            commitments.push(ack.commitment);
+            acks.push((ack.height, ack.commitment));
         }
-        commitments.extend(self.queue.drain(..).map(|ack| ack.commitment));
-        commitments
+        acks.extend(self.queue.drain(..).map(|ack| (ack.height, ack.commitment)));
+        acks
     }
 
     /// Returns the currently armed ack future (if any) for `select_loop!`.
@@ -183,8 +182,11 @@ mod tests {
         pending.enqueue(second);
         assert!(!pending.has_capacity());
 
-        let commitments = pending.clear();
-        assert_eq!(commitments, vec![digest(1), digest(2)]);
+        let acks = pending.clear();
+        assert_eq!(
+            acks,
+            vec![(Height::new(3), digest(1)), (Height::new(4), digest(2))]
+        );
         first_ack.acknowledge();
         second_ack.acknowledge();
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -574,8 +574,8 @@ where
             .await
             .expect("failed to sync application progress");
 
-        // The round is an inclusive floor; retire every exact commitment even if sparse
-        // certificates leave it above that floor.
+        // The round is an inclusive floor. Retire every exact commitment even if
+        // sparse certificates leave it above that floor.
         buffer.retire(RetentionUpdate {
             round_floor: processed_round,
             exact_retirements: processed_commitments,

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -134,8 +134,8 @@ where
     stream: Stream<E>,
     // Pending application acknowledgements
     pending_acks: PendingAcks<V, A>,
-    // Commitments whose acknowledgements were superseded by a pending floor
-    superseded_ack_commitments: Vec<V::Commitment>,
+    // Acknowledgements cleared while a floor transition owns application progress
+    cleared_acks: Vec<(Height, V::Commitment)>,
     // Highest known finalized height
     tip: Height,
     // Outstanding subscriptions for blocks
@@ -260,7 +260,7 @@ where
                 floor: floor_state,
                 stream,
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
-                superseded_ack_commitments: Vec::new(),
+                cleared_acks: Vec::new(),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
                 dispatch_gate: DispatchGate::default(),
@@ -1194,9 +1194,8 @@ where
 
         // The pending floor owns the next application sync point. Drop any
         // in-flight acks before they can advance the processed height past it,
-        // but retain their commitments until the anchor makes the floor active.
-        self.superseded_ack_commitments
-            .extend(self.pending_acks.clear());
+        // but retain their heights and commitments until the anchor makes the floor active.
+        self.cleared_acks.extend(self.pending_acks.clear());
 
         debug!(?round, ?commitment, "starting fetch for floor block");
         self.floor.await_anchor(finalization);
@@ -1309,7 +1308,7 @@ where
             self = self
                 .update_processed_round_floor(height, finalization.round(), resolver)
                 .await;
-            let commitments = std::mem::take(&mut self.superseded_ack_commitments);
+            let commitments = self.take_superseded_ack_commitments();
             buffer.finalized(self.floor.round(), commitments);
             let repaired;
             (self, repaired) = self.try_repair_gaps(buffer, resolver, application).await;
@@ -1359,12 +1358,11 @@ where
 
         // Drop all pending acknowledgement waiters so any in-flight application
         // acks for blocks below the new floor cannot rewrite the processed floor.
-        self.superseded_ack_commitments
-            .extend(self.pending_acks.clear());
+        self.cleared_acks.extend(self.pending_acks.clear());
 
         // The active floor retires round-bound entries and every commitment whose
         // acknowledgement it superseded.
-        let commitments = std::mem::take(&mut self.superseded_ack_commitments);
+        let commitments = self.take_superseded_ack_commitments();
         buffer.finalized(self.floor.round(), commitments);
 
         // The floor is durable, so cache/finalized data below it can be pruned.
@@ -1379,6 +1377,17 @@ where
             self = self.sync_finalized().await;
         }
         self.try_dispatch_blocks(application).await
+    }
+
+    /// Takes cleared acknowledgement commitments covered by the active processed-height floor.
+    ///
+    /// Cleared acknowledgements above the floor are re-dispatched and remain live.
+    fn take_superseded_ack_commitments(&mut self) -> Vec<V::Commitment> {
+        let processed_height = self.floor.processed_height();
+        std::mem::take(&mut self.cleared_acks)
+            .into_iter()
+            .filter_map(|(height, commitment)| (height <= processed_height).then_some(commitment))
+            .collect()
     }
 
     /// Handle a deliver message from the resolver. Block delivers are handled

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -530,7 +530,8 @@ where
     {
         // Start with the ack that woke this `select_loop!` arm.
         let mut pending = Some(self.pending_acks.complete_current(result));
-        let (processed_round, last_acked_commitment) = loop {
+        let mut processed_commitments = Vec::new();
+        let processed_round = loop {
             let (height, commitment, result) = pending.take().expect("pending ack must exist");
             match result {
                 Ok(()) => {
@@ -544,12 +545,13 @@ where
                     panic!("application did not acknowledge block at height {height}: {e:?}");
                 }
             }
+            processed_commitments.push(commitment);
 
             // Opportunistically drain any additional already-ready acks so we
             // can persist one metadata sync for the whole batch below.
             match self.pending_acks.pop_ready() {
                 Some(next) => pending = Some(next),
-                None => break (self.floor.processed_round(), commitment),
+                None => break self.floor.processed_round(),
             }
         };
 
@@ -560,9 +562,9 @@ where
             .await
             .expect("failed to sync application progress");
 
-        // Anything through the last acknowledged finalization round is safe
-        // for the buffer to prune.
-        buffer.finalized(processed_round, last_acked_commitment);
+        // The round is an inclusive floor; retire every exact commitment even if sparse
+        // certificates leave it above that floor.
+        buffer.finalized(processed_round, processed_commitments);
 
         // Refill the application dispatch pipeline.
         self.try_dispatch_blocks(application).await

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1,5 +1,5 @@
 use super::{
-    Buffer, RetentionUpdate, Variant,
+    Buffer, Retirement, Variant,
     acks::{PendingAck, PendingAcks},
     cache,
     delivery::PendingVerification,
@@ -576,7 +576,7 @@ where
 
         // The round is an inclusive floor. Retire every exact commitment even if
         // sparse certificates leave it above that floor.
-        buffer.retire(RetentionUpdate {
+        buffer.retire(Retirement {
             round_floor: processed_round,
             exact_retirements: processed_commitments,
         });
@@ -1312,7 +1312,7 @@ where
                 .update_processed_round_floor(height, finalization.round(), resolver)
                 .await;
             let commitments = self.take_superseded_ack_commitments();
-            buffer.retire(RetentionUpdate {
+            buffer.retire(Retirement {
                 round_floor: self.floor.round(),
                 exact_retirements: commitments,
             });
@@ -1369,7 +1369,7 @@ where
         // The active floor retires round-bound entries and every commitment whose
         // acknowledgement it superseded.
         let commitments = self.take_superseded_ack_commitments();
-        buffer.retire(RetentionUpdate {
+        buffer.retire(Retirement {
             round_floor: self.floor.round(),
             exact_retirements: commitments,
         });

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -134,6 +134,8 @@ where
     stream: Stream<E>,
     // Pending application acknowledgements
     pending_acks: PendingAcks<V, A>,
+    // Commitments whose acknowledgements were superseded by a pending floor
+    superseded_ack_commitments: Vec<V::Commitment>,
     // Highest known finalized height
     tip: Height,
     // Outstanding subscriptions for blocks
@@ -249,6 +251,7 @@ where
                 floor,
                 stream,
                 pending_acks: PendingAcks::new(config.max_pending_acks.get()),
+                superseded_ack_commitments: Vec::new(),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
                 dispatch_gate: DispatchGate::default(),
@@ -1180,8 +1183,10 @@ where
         }
 
         // The pending floor owns the next application sync point. Drop any
-        // in-flight acks before they can advance the processed height past it.
-        self.pending_acks.clear();
+        // in-flight acks before they can advance the processed height past it,
+        // but retain their commitments until the anchor makes the floor active.
+        self.superseded_ack_commitments
+            .extend(self.pending_acks.clear());
 
         debug!(?round, ?commitment, "starting fetch for floor block");
         self.floor.await_anchor(finalization);
@@ -1294,6 +1299,8 @@ where
             self = self
                 .update_processed_round_floor(height, finalization.round(), resolver)
                 .await;
+            let commitments = std::mem::take(&mut self.superseded_ack_commitments);
+            buffer.finalized(self.floor.processed_round(), commitments);
             let repaired;
             (self, repaired) = self.try_repair_gaps(buffer, resolver, application).await;
             if repaired {
@@ -1342,7 +1349,13 @@ where
 
         // Drop all pending acknowledgement waiters so any in-flight application
         // acks for blocks below the new floor cannot rewrite the processed floor.
-        self.pending_acks.clear();
+        self.superseded_ack_commitments
+            .extend(self.pending_acks.clear());
+
+        // The active floor retires round-bound entries and every commitment whose
+        // acknowledgement it superseded.
+        let commitments = std::mem::take(&mut self.superseded_ack_commitments);
+        buffer.finalized(self.floor.processed_round(), commitments);
 
         // The floor is durable, so cache/finalized data below it can be pruned.
         self = self.prune_after_floor(height).await;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1,5 +1,5 @@
 use super::{
-    Buffer, Variant,
+    Buffer, RetentionUpdate, Variant,
     acks::{PendingAck, PendingAcks},
     cache,
     delivery::PendingVerification,
@@ -576,7 +576,10 @@ where
 
         // The round is an inclusive floor; retire every exact commitment even if sparse
         // certificates leave it above that floor.
-        buffer.finalized(processed_round, processed_commitments);
+        buffer.retire(RetentionUpdate {
+            round_floor: processed_round,
+            exact_retirements: processed_commitments,
+        });
 
         // Refill the application dispatch pipeline.
         self.try_dispatch_blocks(application).await
@@ -1309,7 +1312,10 @@ where
                 .update_processed_round_floor(height, finalization.round(), resolver)
                 .await;
             let commitments = self.take_superseded_ack_commitments();
-            buffer.finalized(self.floor.round(), commitments);
+            buffer.retire(RetentionUpdate {
+                round_floor: self.floor.round(),
+                exact_retirements: commitments,
+            });
             let repaired;
             (self, repaired) = self.try_repair_gaps(buffer, resolver, application).await;
             if repaired {
@@ -1363,7 +1369,10 @@ where
         // The active floor retires round-bound entries and every commitment whose
         // acknowledgement it superseded.
         let commitments = self.take_superseded_ack_commitments();
-        buffer.finalized(self.floor.round(), commitments);
+        buffer.retire(RetentionUpdate {
+            round_floor: self.floor.round(),
+            exact_retirements: commitments,
+        });
 
         // The floor is durable, so cache/finalized data below it can be pruned.
         self = self.prune_after_floor(height).await;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -530,7 +530,7 @@ where
     {
         // Start with the ack that woke this `select_loop!` arm.
         let mut pending = Some(self.pending_acks.complete_current(result));
-        let last_acked_commitment = loop {
+        let (processed_round, last_acked_commitment) = loop {
             let (height, commitment, result) = pending.take().expect("pending ack must exist");
             match result {
                 Ok(()) => {
@@ -549,7 +549,7 @@ where
             // can persist one metadata sync for the whole batch below.
             match self.pending_acks.pop_ready() {
                 Some(next) => pending = Some(next),
-                None => break commitment,
+                None => break (self.floor.processed_round(), commitment),
             }
         };
 
@@ -560,9 +560,9 @@ where
             .await
             .expect("failed to sync application progress");
 
-        // Anything below the last acknowledged commitment is safe for the
-        // buffer to prune.
-        buffer.finalized(last_acked_commitment);
+        // Anything through the last acknowledged finalization round is safe
+        // for the buffer to prune.
+        buffer.finalized(processed_round, last_acked_commitment);
 
         // Refill the application dispatch pipeline.
         self.try_dispatch_blocks(application).await

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -58,4 +58,4 @@ pub use mailbox::{CommitmentFallback, DigestFallback, Mailbox};
 
 mod subscriptions;
 mod variant;
-pub use variant::{Buffer, RetentionUpdate, Variant};
+pub use variant::{Buffer, Retirement, Variant};

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -58,4 +58,4 @@ pub use mailbox::{CommitmentFallback, DigestFallback, Mailbox};
 
 mod subscriptions;
 mod variant;
-pub use variant::{Buffer, Variant};
+pub use variant::{Buffer, RetentionUpdate, Variant};

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -193,7 +193,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _commitment: Digest) {}
+        fn finalized(&self, _round: Round, _commitment: Digest) {}
 
         fn send(&self, _round: Round, _block: Arc<TestBlock>, _recipients: Recipients<PublicKey>) {}
     }

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -193,7 +193,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn retire(&self, _update: crate::marshal::core::RetentionUpdate<Digest>) {}
+        fn retire(&self, _update: crate::marshal::core::Retirement<Digest>) {}
 
         fn send(&self, _round: Round, _block: Arc<TestBlock>, _recipients: Recipients<PublicKey>) {}
     }

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -193,7 +193,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _round: Round, _commitments: Vec<Digest>) {}
+        fn retire(&self, _update: crate::marshal::core::RetentionUpdate<Digest>) {}
 
         fn send(&self, _round: Round, _block: Arc<TestBlock>, _recipients: Recipients<PublicKey>) {}
     }

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -193,7 +193,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _round: Round, _commitment: Digest) {}
+        fn finalized(&self, _round: Round, _commitments: Vec<Digest>) {}
 
         fn send(&self, _round: Round, _block: Arc<TestBlock>, _recipients: Recipients<PublicKey>) {}
     }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -168,10 +168,12 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         commitment: V::Commitment,
     ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
-    /// Notify the buffer that a block has been finalized in `round`.
+    /// Notify the buffer that application processing has durably advanced through `commitment`.
     ///
-    /// A re-proposal retains the block's original commitment, so `round` may differ from the
-    /// consensus context bound by `commitment`.
+    /// `round` is an inclusive retirement floor: the buffer may retire entries last observed in
+    /// that round or earlier. Sparse finalization certificates mean the floor may come from an
+    /// earlier height than `commitment`. A re-proposal may also retain a commitment bound to an
+    /// earlier consensus context.
     ///
     /// This allows the buffer to perform variant-specific cleanup operations.
     fn finalized(&self, round: Round, commitment: V::Commitment);

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -168,13 +168,10 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         commitment: V::Commitment,
     ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
-    /// Notify the buffer that application processing has durably advanced through `commitments`.
+    /// Notify the buffer of durable application progress.
     ///
-    /// `round` is an inclusive retirement floor: the buffer may retire entries last observed in
-    /// that round or earlier. Each listed commitment may be retired exactly, even if sparse
-    /// certificates or re-proposals leave its observation above the floor.
-    ///
-    /// This allows the buffer to perform variant-specific cleanup operations.
+    /// Entries last observed at or before `round` are eligible for retirement.
+    /// Entries matching `commitments` are eligible regardless of observation round.
     fn finalized(&self, round: Round, commitments: Vec<V::Commitment>);
 
     /// Send a block to peers.

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -168,15 +168,14 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         commitment: V::Commitment,
     ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
-    /// Notify the buffer that application processing has durably advanced through `commitment`.
+    /// Notify the buffer that application processing has durably advanced through `commitments`.
     ///
     /// `round` is an inclusive retirement floor: the buffer may retire entries last observed in
-    /// that round or earlier. Sparse finalization certificates mean the floor may come from an
-    /// earlier height than `commitment`. A re-proposal may also retain a commitment bound to an
-    /// earlier consensus context.
+    /// that round or earlier. Each listed commitment may be retired exactly, even if sparse
+    /// certificates or re-proposals leave its observation above the floor.
     ///
     /// This allows the buffer to perform variant-specific cleanup operations.
-    fn finalized(&self, round: Round, commitment: V::Commitment);
+    fn finalized(&self, round: Round, commitments: Vec<V::Commitment>);
 
     /// Send a block to peers.
     fn send(&self, round: Round, block: Arc<V::Block>, recipients: Recipients<Self::PublicKey>);
@@ -232,7 +231,7 @@ where
         None
     }
 
-    fn finalized(&self, _: Round, _: V::Commitment) {}
+    fn finalized(&self, _: Round, _: Vec<V::Commitment>) {}
 
     fn send(&self, _: Round, _: Arc<V::Block>, _: Recipients<Self::PublicKey>) {}
 }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -19,12 +19,12 @@ use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
 use std::{future::Future, marker::PhantomData, sync::Arc};
 
-/// An atomic update to a buffer's retained state.
+/// An atomic retirement from a buffer's retained state.
 ///
 /// The round floor and exact retirements are independent eligibility signals
 /// carried together so implementations apply one coherent update.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct RetentionUpdate<C> {
+pub struct Retirement<C> {
     /// The inclusive floor for entries owned by their last observation round.
     pub round_floor: Round,
     /// Commitments to retire regardless of their last observation round.
@@ -182,11 +182,11 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
 
     /// Retire entries made eligible by durable application progress.
     ///
-    /// [`RetentionUpdate::round_floor`] is nondecreasing and inclusive.
-    /// [`RetentionUpdate::exact_retirements`] may be empty, sparse, or batched.
+    /// [`Retirement::round_floor`] is increasing and inclusive.
+    /// [`Retirement::exact_retirements`] may be empty, sparse, or batched.
     /// Implementations must apply both fields as one update and must not infer
     /// that they describe the same finalization.
-    fn retire(&self, update: RetentionUpdate<V::Commitment>);
+    fn retire(&self, update: Retirement<V::Commitment>);
 
     /// Send a block to peers.
     fn send(&self, round: Round, block: Arc<V::Block>, recipients: Recipients<Self::PublicKey>);
@@ -242,7 +242,7 @@ where
         None
     }
 
-    fn retire(&self, _: RetentionUpdate<V::Commitment>) {}
+    fn retire(&self, _: Retirement<V::Commitment>) {}
 
     fn send(&self, _: Round, _: Arc<V::Block>, _: Recipients<Self::PublicKey>) {}
 }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -168,10 +168,13 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         commitment: V::Commitment,
     ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
-    /// Notify the buffer that a block has been finalized.
+    /// Notify the buffer that a block has been finalized in `round`.
+    ///
+    /// A re-proposal retains the block's original commitment, so `round` may differ from the
+    /// consensus context bound by `commitment`.
     ///
     /// This allows the buffer to perform variant-specific cleanup operations.
-    fn finalized(&self, commitment: V::Commitment);
+    fn finalized(&self, round: Round, commitment: V::Commitment);
 
     /// Send a block to peers.
     fn send(&self, round: Round, block: Arc<V::Block>, recipients: Recipients<Self::PublicKey>);
@@ -227,7 +230,7 @@ where
         None
     }
 
-    fn finalized(&self, _: V::Commitment) {}
+    fn finalized(&self, _: Round, _: V::Commitment) {}
 
     fn send(&self, _: Round, _: Arc<V::Block>, _: Recipients<Self::PublicKey>) {}
 }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -19,6 +19,18 @@ use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
 use std::{future::Future, marker::PhantomData, sync::Arc};
 
+/// An atomic update to a buffer's retained state.
+///
+/// The round floor and exact retirements are independent eligibility signals
+/// carried together so implementations apply one coherent update.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RetentionUpdate<C> {
+    /// The inclusive floor for entries owned by their last observation round.
+    pub round_floor: Round,
+    /// Commitments to retire regardless of their last observation round.
+    pub exact_retirements: Vec<C>,
+}
+
 /// A marker trait describing the types used by a variant of Marshal.
 pub trait Variant: Clone + Send + Sync + 'static {
     /// The working block type of marshal, supporting the consensus commitment.
@@ -168,11 +180,13 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
         commitment: V::Commitment,
     ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
 
-    /// Notify the buffer of durable application progress.
+    /// Retire entries made eligible by durable application progress.
     ///
-    /// Entries last observed at or before `round` are eligible for retirement.
-    /// Entries matching `commitments` are eligible regardless of observation round.
-    fn finalized(&self, round: Round, commitments: Vec<V::Commitment>);
+    /// [`RetentionUpdate::round_floor`] is nondecreasing and inclusive.
+    /// [`RetentionUpdate::exact_retirements`] may be empty, sparse, or batched.
+    /// Implementations must apply both fields as one update and must not infer
+    /// that they describe the same finalization.
+    fn retire(&self, update: RetentionUpdate<V::Commitment>);
 
     /// Send a block to peers.
     fn send(&self, round: Round, block: Arc<V::Block>, recipients: Recipients<Self::PublicKey>);
@@ -228,7 +242,7 @@ where
         None
     }
 
-    fn finalized(&self, _: Round, _: Vec<V::Commitment>) {}
+    fn retire(&self, _: RetentionUpdate<V::Commitment>) {}
 
     fn send(&self, _: Round, _: Arc<V::Block>, _: Recipients<Self::PublicKey>) {}
 }

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3818,7 +3818,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _round: Round, _commitments: Vec<D>) {}
+        fn retire(&self, _update: crate::marshal::core::RetentionUpdate<D>) {}
 
         fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
             self.sends.lock().push((round, block, recipients));

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3818,7 +3818,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn retire(&self, _update: crate::marshal::core::RetentionUpdate<D>) {}
+        fn retire(&self, _update: crate::marshal::core::Retirement<D>) {}
 
         fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
             self.sends.lock().push((round, block, recipients));

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3818,7 +3818,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _round: Round, _commitment: D) {}
+        fn finalized(&self, _round: Round, _commitments: Vec<D>) {}
 
         fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
             self.sends.lock().push((round, block, recipients));

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3818,7 +3818,7 @@ mod tests {
             Some(receiver)
         }
 
-        fn finalized(&self, _commitment: D) {}
+        fn finalized(&self, _round: Round, _commitment: D) {}
 
         fn send(&self, round: Round, block: Arc<B>, recipients: Recipients<PublicKey>) {
             self.sends.lock().push((round, block, recipients));

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -110,8 +110,8 @@ where
         self.subscribe_by_digest(commitment)
     }
 
-    fn finalized(&self, _commitment: B::Digest) {
-        // No cleanup needed in standard mode - the buffer handles its own pruning
+    fn finalized(&self, _round: Round, _commitment: B::Digest) {
+        // Standard's cache is already bounded and evicted per authenticated sender.
     }
 
     fn send(&self, _round: Round, block: Arc<B>, recipients: Recipients<K>) {

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -7,7 +7,7 @@ use crate::{
     Block,
     marshal::{
         ancestry::BlockProvider,
-        core::{Buffer, CommitmentFallback, Mailbox, RetentionUpdate, Variant},
+        core::{Buffer, CommitmentFallback, Mailbox, Retirement, Variant},
     },
     simplex::scheme::Scheme as SimplexScheme,
     types::Round,
@@ -110,9 +110,7 @@ where
         self.subscribe_by_digest(commitment)
     }
 
-    fn retire(&self, _update: RetentionUpdate<B::Digest>) {
-        // Standard's cache is already bounded and evicted per authenticated sender.
-    }
+    fn retire(&self, _update: Retirement<B::Digest>) {}
 
     fn send(&self, _round: Round, block: Arc<B>, recipients: Recipients<K>) {
         self.broadcast_shared(recipients, block);

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -7,7 +7,7 @@ use crate::{
     Block,
     marshal::{
         ancestry::BlockProvider,
-        core::{Buffer, CommitmentFallback, Mailbox, Variant},
+        core::{Buffer, CommitmentFallback, Mailbox, RetentionUpdate, Variant},
     },
     simplex::scheme::Scheme as SimplexScheme,
     types::Round,
@@ -110,7 +110,7 @@ where
         self.subscribe_by_digest(commitment)
     }
 
-    fn finalized(&self, _round: Round, _commitments: Vec<B::Digest>) {
+    fn retire(&self, _update: RetentionUpdate<B::Digest>) {
         // Standard's cache is already bounded and evicted per authenticated sender.
     }
 

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -110,7 +110,7 @@ where
         self.subscribe_by_digest(commitment)
     }
 
-    fn finalized(&self, _round: Round, _commitment: B::Digest) {
+    fn finalized(&self, _round: Round, _commitments: Vec<B::Digest>) {
         // Standard's cache is already bounded and evicted per authenticated sender.
     }
 


### PR DESCRIPTION
## Motivation

Marshal's coding buffer treated a finalized commitment as both an exact retirement and an implicit global pruning cursor. Those are independent signals: application acknowledgements may be batched or superseded by a floor, the same commitment may be observed in a later view, and the exact commitment may be absent from the local shard cache. Deriving retention from the target's cached metadata could therefore either retain stale state or retire state still needed by consensus.

## Bugs fixed

- **Batched acknowledgements lost exact retirements.** Core durably advanced every ready acknowledgement but reported only the final commitment, so earlier acknowledged commitments could remain cached when their observation rounds were above the floor.
- **Floor transitions lost retirement ownership.** Installing a floor discarded in-flight acknowledgement identities and did not advance variant-buffer retention. Superseded commitments could leak, while retiring every cleared acknowledgement would remove above-floor blocks that must be re-dispatched.
- **The implicit pruning cutoff was unsafe and incomplete.** Coding pruning compared cached blocks by application-supplied height, inferred the state cutoff from the exact target's observation round, and became a no-op when that target was unseen. Adversarial heights and re-proposals could cause under- or over-pruning, including retaining entries observed exactly at the floor.
- **Floor pruning canceled recoverable waits.** It closed commitment subscriptions for round-retired reconstruction state even though later local ingress could still satisfy them, causing callers that do not retry to miss an available block.
- **Later observations did not keep live commitments alive.** Discovery, notarization, and local re-proposal did not consistently refresh one shared retention round across cache and reconstruction state, so a later floor could retire state still needed for shard readiness or certification.
- **Commitments could be rebound across epochs.** Cache and reconstruction state could associate the same commitment with different epochs, pinning old state and classifying shards against the wrong participant set.
- **Re-proposal recovery could stall.** A node that missed the original block only waited for local ingress, and a valid re-proposal did not recreate shard state after exact retirement.
- **Assigned-shard readiness was tied to the original leader.** A valid assigned-index shard relayed by another participant could be rejected and the honest sender blocked, preventing progress despite successful commitment-bound verification.

## Changes

- Replace `Buffer::finalized(commitment)` with an atomic `Retirement` carrying an inclusive trusted round floor and independent exact commitment retirements.
- Preserve cleared acknowledgement metadata through floor activation, retire only acknowledgements covered by the durable processed-height floor, and leave higher blocks live for re-dispatch.
- Give each coding commitment one lifecycle owner for its cached block, optional reconstruction state, and latest valid same-epoch observation.
- Apply round retirement even when an exact target is unseen, and distinguish floor retirement from exact retirement when closing subscriptions.
- Fetch re-proposed epoch-boundary blocks by their certified parent round and recreate shard state only after validating the re-proposal.
- Accept the local assigned-index shard from any epoch participant after eager cryptographic verification; other gossiped shards remain sender-owned.

## Testing

- `just test -p commonware-consensus`
- `just clippy -p commonware-consensus`
- `just check-stability`
- `just check-fmt`