### PR TITLE
[storage/qmdb] Make current partial_chunk total for empty bitmaps

### DIFF
--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -890,17 +890,17 @@ where
     }
 }
 
-/// Returns `Some((last_chunk, next_bit))` if the bitmap has an incomplete trailing chunk, or
-/// `None` if all bits fall on complete chunk boundaries.
+/// The bitmap's incomplete trailing chunk and the number of bits in it, or `None` if the bitmap
+/// is empty or its bits end exactly on a chunk boundary.
 pub(super) fn partial_chunk<B: bitmap::Readable<N>, const N: usize>(
     bitmap: &B,
 ) -> Option<([u8; N], u64)> {
-    let (last_chunk, next_bit) = bitmap.last_chunk();
-    if next_bit == bitmap::Prunable::<N>::CHUNK_SIZE_BITS {
-        None
-    } else {
-        Some((last_chunk, next_bit))
+    let next_bit = bitmap.len() % bitmap::Prunable::<N>::CHUNK_SIZE_BITS;
+    if next_bit == 0 {
+        return None;
     }
+    let (last_chunk, _) = bitmap.last_chunk();
+    Some((last_chunk, next_bit))
 }
 
 /// Return complete and graftable chunk counts, enforcing the pending and pruning invariants.
@@ -1353,6 +1353,21 @@ mod tests {
         assert!(result.is_some());
         let (_chunk, next_bit) = result.unwrap();
         assert_eq!(next_bit, 5);
+    }
+
+    #[test]
+    fn partial_chunk_empty() {
+        // An empty bitmap has no partial chunk, and must not panic on `last_chunk`.
+        let bm = PrunableBitMap::<N>::new();
+        assert!(partial_chunk::<PrunableBitMap<N>, N>(&bm).is_none());
+    }
+
+    #[test]
+    fn partial_chunk_fully_pruned() {
+        // A fully-pruned bitmap is chunk-aligned but its backing store is empty; still no partial
+        // chunk, and must not panic on `last_chunk`.
+        let bm = PrunableBitMap::<N>::new_with_pruned_chunks(1).unwrap();
+        assert!(partial_chunk::<PrunableBitMap<N>, N>(&bm).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`db::partial_chunk` — the canonical helper for a bitmap's incomplete trailing chunk, used by the `current`-variant root-witness (`db.rs:315`), grafted-tree rebuild (`db.rs:1064`), and proof generation (`proof/mod.rs:211`) — calls `last_chunk()` unconditionally. The base `BitMap::last_chunk` does `self.chunks.back().unwrap()`, which **panics on an empty or fully-pruned bitmap**. The `BitmapBatch` backend instead returns `Some((EMPTY_CHUNK, 0))` for an empty bitmap, so the empty-bitmap contract was also **inconsistent** across backends.

Every real caller passes a QMDB bitmap that always carries a committed bit (`len ≥ 1`), so this panic is unreachable today — this is a defensive totality fix, not a live bug.

## Changes

- Compute `next_bit = len() % CHUNK_SIZE_BITS` first; return `None` when it is 0 (empty or chunk-aligned) *without* consulting `last_chunk()`; call `last_chunk()` only when a partial chunk actually exists.
- `partial_chunk` is now **total** — an empty or fully-pruned bitmap returns `None` uniformly across all backends, no panic.
- Behavior is unchanged for every reachable state (`len ≥ 1`): non-aligned → same `Some((last_chunk, next_bit))`; chunk-aligned → `None`.
- Add a `partial_chunk_empty` test (panics on the pre-change code).

No wire, storage, recovery, durability, or fsync change.

## Validation

- `just test -p commonware-storage qmdb::current` — 407 tests pass, incl. the new `partial_chunk_empty`
- `just clippy -p commonware-storage`
- `just check-fmt`
