### PR TITLE
[storage/qmdb] Share the commit-operation codec across db families

### DIFF
--- a/storage/src/qmdb/any/operation/fixed.rs
+++ b/storage/src/qmdb/any/operation/fixed.rs
@@ -9,7 +9,7 @@ use crate::{
             },
             value::FixedEncoding,
         },
-        operation::{commit_fixed_size, read_commit_fixed, write_commit_fixed},
+        operation::{commit_fixed_operation_size, read_commit_fixed, write_commit_fixed},
     },
 };
 use commonware_codec::{
@@ -35,7 +35,7 @@ const fn delete_op_size<K: Array>() -> usize {
 const fn total_op_size<K: Array, V: FixedSize, S: FixedSize>() -> usize {
     const_max(
         update_op_size::<S>(),
-        const_max(commit_fixed_size::<V>(), delete_op_size::<K>()),
+        const_max(commit_fixed_operation_size::<V>(), delete_op_size::<K>()),
     )
 }
 
@@ -64,7 +64,7 @@ where
             Operation::CommitFloor(metadata, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
                 write_commit_fixed(metadata, *floor_loc, buf);
-                buf.put_bytes(0, total - commit_fixed_size::<V>());
+                buf.put_bytes(0, total - commit_fixed_operation_size::<V>());
             }
         }
     }
@@ -89,7 +89,7 @@ where
             }
             COMMIT_CONTEXT => {
                 let (metadata, floor_loc) = read_commit_fixed(buf)?;
-                ensure_zeros(buf, total - commit_fixed_size::<V>())?;
+                ensure_zeros(buf, total - commit_fixed_operation_size::<V>())?;
                 Ok(Operation::CommitFloor(metadata, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),

--- a/storage/src/qmdb/any/operation/fixed.rs
+++ b/storage/src/qmdb/any/operation/fixed.rs
@@ -1,12 +1,15 @@
 use crate::{
-    merkle::{Family, Location},
-    qmdb::any::{
-        FixedValue,
-        operation::{
-            COMMIT_CONTEXT, DELETE_CONTEXT, Operation, OperationCodec, UPDATE_CONTEXT, Update,
-            update,
+    merkle::Family,
+    qmdb::{
+        any::{
+            FixedValue,
+            operation::{
+                COMMIT_CONTEXT, DELETE_CONTEXT, Operation, OperationCodec, UPDATE_CONTEXT, Update,
+                update,
+            },
+            value::FixedEncoding,
         },
-        value::FixedEncoding,
+        operation::{commit_fixed_size, read_commit_fixed, write_commit_fixed},
     },
 };
 use commonware_codec::{
@@ -25,10 +28,6 @@ const fn update_op_size<S: FixedSize>() -> usize {
     1 + S::SIZE
 }
 
-const fn commit_op_size<V: FixedSize>() -> usize {
-    1 + 1 + V::SIZE + u64::SIZE
-}
-
 const fn delete_op_size<K: Array>() -> usize {
     1 + K::SIZE
 }
@@ -36,7 +35,7 @@ const fn delete_op_size<K: Array>() -> usize {
 const fn total_op_size<K: Array, V: FixedSize, S: FixedSize>() -> usize {
     const_max(
         update_op_size::<S>(),
-        const_max(commit_op_size::<V>(), delete_op_size::<K>()),
+        const_max(commit_fixed_size::<V>(), delete_op_size::<K>()),
     )
 }
 
@@ -64,14 +63,8 @@ where
             }
             Operation::CommitFloor(metadata, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
-                if let Some(metadata) = metadata {
-                    true.write(buf);
-                    metadata.write(buf);
-                } else {
-                    buf.put_bytes(0, V::SIZE + 1);
-                }
-                buf.put_slice(&floor_loc.to_be_bytes());
-                buf.put_bytes(0, total - commit_op_size::<V>());
+                write_commit_fixed(metadata, *floor_loc, buf);
+                buf.put_bytes(0, total - commit_fixed_size::<V>());
             }
         }
     }
@@ -95,21 +88,8 @@ where
                 Ok(Operation::Update(payload))
             }
             COMMIT_CONTEXT => {
-                let is_some = bool::read(buf)?;
-                let metadata = if is_some {
-                    Some(V::read_cfg(buf, cfg)?)
-                } else {
-                    ensure_zeros(buf, V::SIZE)?;
-                    None
-                };
-                let floor_loc = Location::new(u64::read(buf)?);
-                if !floor_loc.is_valid() {
-                    return Err(CodecError::Invalid(
-                        "storage::qmdb::any::operation::fixed::Operation",
-                        "commit floor location overflow",
-                    ));
-                }
-                ensure_zeros(buf, total - commit_op_size::<V>())?;
+                let (metadata, floor_loc) = read_commit_fixed(buf)?;
+                ensure_zeros(buf, total - commit_fixed_size::<V>())?;
                 Ok(Operation::CommitFloor(metadata, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),

--- a/storage/src/qmdb/any/operation/mod.rs
+++ b/storage/src/qmdb/any/operation/mod.rs
@@ -151,7 +151,7 @@ impl<F: Family, S: Update> fmt::Display for Operation<F, S> {
 mod tests {
     use super::*;
     use crate::qmdb::any::value::{FixedEncoding, VariableEncoding};
-    use commonware_codec::{Codec, RangeCfg, Read};
+    use commonware_codec::{Codec, Decode, FixedSize, RangeCfg, Read};
     use commonware_utils::sequence::FixedBytes;
 
     type F = crate::merkle::mmr::Family;
@@ -201,6 +201,21 @@ mod tests {
         roundtrip(&delete, &());
         roundtrip(&update, &());
         roundtrip(&commit, &());
+    }
+
+    #[test]
+    fn fixed_commit_nonzero_trailing_padding_rejected() {
+        type K = FixedBytes<8>;
+        type V = u64;
+        type Op = Ordered<F, K, FixedEncoding<V>>;
+
+        // With 8-byte keys the update variant is the largest, so commit records carry trailing
+        // padding beyond the commit payload.
+        let op = Op::CommitFloor(None, crate::mmr::Location::new(7));
+        let mut buf: Vec<u8> = op.encode().to_vec();
+        assert!(buf.len() > 1 + 1 + u64::SIZE + u64::SIZE);
+        *buf.last_mut().unwrap() = 0x01;
+        assert!(Op::decode_cfg(buf.as_ref(), &()).is_err());
     }
 
     #[test]

--- a/storage/src/qmdb/any/operation/variable.rs
+++ b/storage/src/qmdb/any/operation/variable.rs
@@ -9,7 +9,9 @@ use crate::{
             },
             value::VariableEncoding,
         },
-        operation::{Key, commit_variable_size, read_commit_variable, write_commit_variable},
+        operation::{
+            Key, commit_variable_payload_size, read_commit_variable, write_commit_variable,
+        },
     },
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
@@ -77,7 +79,7 @@ where
         1 + match self {
             Self::Delete(k) => k.encode_size(),
             Self::Update(p) => p.encode_size(),
-            Self::CommitFloor(v, floor) => commit_variable_size(v, *floor),
+            Self::CommitFloor(v, floor) => commit_variable_payload_size(v, *floor),
         }
     }
 }
@@ -94,7 +96,7 @@ where
         1 + match self {
             Self::Delete(k) => k.encode_size(),
             Self::Update(p) => p.encode_size(),
-            Self::CommitFloor(v, floor) => commit_variable_size(v, *floor),
+            Self::CommitFloor(v, floor) => commit_variable_payload_size(v, *floor),
         }
     }
 }

--- a/storage/src/qmdb/any/operation/variable.rs
+++ b/storage/src/qmdb/any/operation/variable.rs
@@ -1,5 +1,5 @@
 use crate::{
-    merkle::{Family, Location},
+    merkle::Family,
     qmdb::{
         any::{
             VariableValue,
@@ -9,10 +9,10 @@ use crate::{
             },
             value::VariableEncoding,
         },
-        operation::Key,
+        operation::{Key, commit_variable_size, read_commit_variable, write_commit_variable},
     },
 };
-use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write, varint::UInt};
+use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
 use commonware_runtime::{Buf, BufMut};
 
 impl<F, V, S> OperationCodec<F, S> for VariableEncoding<V>
@@ -38,8 +38,7 @@ where
             }
             Operation::CommitFloor(metadata, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
-                metadata.write(buf);
-                UInt(**floor_loc).write(buf);
+                write_commit_variable(metadata, *floor_loc, buf);
             }
         }
     }
@@ -58,8 +57,7 @@ where
                 Ok(Operation::Update(payload))
             }
             COMMIT_CONTEXT => {
-                let metadata = Option::<V>::read_cfg(buf, &cfg.1)?;
-                let floor_loc = Location::read(buf)?;
+                let (metadata, floor_loc) = read_commit_variable(buf, &cfg.1)?;
                 Ok(Operation::CommitFloor(metadata, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),
@@ -79,7 +77,7 @@ where
         1 + match self {
             Self::Delete(k) => k.encode_size(),
             Self::Update(p) => p.encode_size(),
-            Self::CommitFloor(v, floor) => v.encode_size() + UInt(**floor).encode_size(),
+            Self::CommitFloor(v, floor) => commit_variable_size(v, *floor),
         }
     }
 }
@@ -96,7 +94,7 @@ where
         1 + match self {
             Self::Delete(k) => k.encode_size(),
             Self::Update(p) => p.encode_size(),
-            Self::CommitFloor(v, floor) => v.encode_size() + UInt(**floor).encode_size(),
+            Self::CommitFloor(v, floor) => commit_variable_size(v, *floor),
         }
     }
 }

--- a/storage/src/qmdb/immutable/operation/fixed.rs
+++ b/storage/src/qmdb/immutable/operation/fixed.rs
@@ -3,7 +3,7 @@ use crate::{
     merkle::Family,
     qmdb::{
         any::{FixedValue, value::FixedEncoding},
-        operation::{commit_fixed_size, read_commit_fixed, write_commit_fixed},
+        operation::{commit_fixed_operation_size, read_commit_fixed, write_commit_fixed},
     },
 };
 use commonware_codec::{
@@ -23,7 +23,7 @@ const fn set_op_size<K: Array, V: FixedSize>() -> usize {
 }
 
 const fn total_op_size<K: Array, V: FixedSize>() -> usize {
-    const_max(set_op_size::<K, V>(), commit_fixed_size::<V>())
+    const_max(set_op_size::<K, V>(), commit_fixed_operation_size::<V>())
 }
 
 impl<F: Family, K: Array, V: FixedValue> FixedSize for Operation<F, K, FixedEncoding<V>> {
@@ -43,7 +43,7 @@ impl<F: Family, K: Array, V: FixedValue> Write for Operation<F, K, FixedEncoding
             Self::Commit(v, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
                 write_commit_fixed(v, *floor_loc, buf);
-                buf.put_bytes(0, total - commit_fixed_size::<V>());
+                buf.put_bytes(0, total - commit_fixed_operation_size::<V>());
             }
         }
     }
@@ -65,7 +65,7 @@ impl<F: Family, K: Array, V: FixedValue> Read for Operation<F, K, FixedEncoding<
             }
             COMMIT_CONTEXT => {
                 let (value, floor_loc) = read_commit_fixed(buf)?;
-                ensure_zeros(buf, total - commit_fixed_size::<V>())?;
+                ensure_zeros(buf, total - commit_fixed_operation_size::<V>())?;
                 Ok(Self::Commit(value, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),

--- a/storage/src/qmdb/immutable/operation/fixed.rs
+++ b/storage/src/qmdb/immutable/operation/fixed.rs
@@ -1,7 +1,10 @@
 use super::{COMMIT_CONTEXT, Operation, SET_CONTEXT};
 use crate::{
-    merkle::{Family, Location},
-    qmdb::any::{FixedValue, value::FixedEncoding},
+    merkle::Family,
+    qmdb::{
+        any::{FixedValue, value::FixedEncoding},
+        operation::{commit_fixed_size, read_commit_fixed, write_commit_fixed},
+    },
 };
 use commonware_codec::{
     Error as CodecError, FixedSize, Read, ReadExt as _, Write,
@@ -19,12 +22,8 @@ const fn set_op_size<K: Array, V: FixedSize>() -> usize {
     1 + K::SIZE + V::SIZE
 }
 
-const fn commit_op_size<V: FixedSize>() -> usize {
-    1 + 1 + V::SIZE + u64::SIZE
-}
-
 const fn total_op_size<K: Array, V: FixedSize>() -> usize {
-    const_max(set_op_size::<K, V>(), commit_op_size::<V>())
+    const_max(set_op_size::<K, V>(), commit_fixed_size::<V>())
 }
 
 impl<F: Family, K: Array, V: FixedValue> FixedSize for Operation<F, K, FixedEncoding<V>> {
@@ -43,14 +42,8 @@ impl<F: Family, K: Array, V: FixedValue> Write for Operation<F, K, FixedEncoding
             }
             Self::Commit(v, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
-                if let Some(v) = v {
-                    true.write(buf);
-                    v.write(buf);
-                } else {
-                    buf.put_bytes(0, 1 + V::SIZE);
-                }
-                buf.put_slice(&floor_loc.to_be_bytes());
-                buf.put_bytes(0, total - commit_op_size::<V>());
+                write_commit_fixed(v, *floor_loc, buf);
+                buf.put_bytes(0, total - commit_fixed_size::<V>());
             }
         }
     }
@@ -71,21 +64,8 @@ impl<F: Family, K: Array, V: FixedValue> Read for Operation<F, K, FixedEncoding<
                 Ok(Self::Set(key, value))
             }
             COMMIT_CONTEXT => {
-                let is_some = bool::read(buf)?;
-                let value = if is_some {
-                    Some(V::read(buf)?)
-                } else {
-                    ensure_zeros(buf, V::SIZE)?;
-                    None
-                };
-                let floor_loc = Location::new(u64::read(buf)?);
-                if !floor_loc.is_valid() {
-                    return Err(CodecError::Invalid(
-                        "storage::qmdb::immutable::operation::fixed::Operation",
-                        "commit floor location overflow",
-                    ));
-                }
-                ensure_zeros(buf, total - commit_op_size::<V>())?;
+                let (value, floor_loc) = read_commit_fixed(buf)?;
+                ensure_zeros(buf, total - commit_fixed_size::<V>())?;
                 Ok(Self::Commit(value, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),
@@ -96,7 +76,7 @@ impl<F: Family, K: Array, V: FixedValue> Read for Operation<F, K, FixedEncoding<
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr;
+    use crate::merkle::{Location, mmr};
     use commonware_codec::{DecodeExt, Encode};
     use commonware_utils::sequence::U64;
 

--- a/storage/src/qmdb/immutable/operation/variable.rs
+++ b/storage/src/qmdb/immutable/operation/variable.rs
@@ -3,7 +3,9 @@ use crate::{
     merkle::Family,
     qmdb::{
         any::{VariableValue, value::VariableEncoding},
-        operation::{Key, commit_variable_size, read_commit_variable, write_commit_variable},
+        operation::{
+            Key, commit_variable_payload_size, read_commit_variable, write_commit_variable,
+        },
     },
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
@@ -13,7 +15,7 @@ impl<F: Family, K: Key, V: VariableValue> EncodeSize for Operation<F, K, Variabl
     fn encode_size(&self) -> usize {
         1 + match self {
             Self::Set(k, v) => k.encode_size() + v.encode_size(),
-            Self::Commit(v, floor) => commit_variable_size(v, *floor),
+            Self::Commit(v, floor) => commit_variable_payload_size(v, *floor),
         }
     }
 }

--- a/storage/src/qmdb/immutable/operation/variable.rs
+++ b/storage/src/qmdb/immutable/operation/variable.rs
@@ -1,19 +1,19 @@
 use super::{COMMIT_CONTEXT, Operation, SET_CONTEXT};
 use crate::{
-    merkle::{Family, Location},
+    merkle::Family,
     qmdb::{
         any::{VariableValue, value::VariableEncoding},
-        operation::Key,
+        operation::{Key, commit_variable_size, read_commit_variable, write_commit_variable},
     },
 };
-use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write, varint::UInt};
+use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
 use commonware_runtime::{Buf, BufMut};
 
 impl<F: Family, K: Key, V: VariableValue> EncodeSize for Operation<F, K, VariableEncoding<V>> {
     fn encode_size(&self) -> usize {
         1 + match self {
             Self::Set(k, v) => k.encode_size() + v.encode_size(),
-            Self::Commit(v, floor) => v.encode_size() + UInt(**floor).encode_size(),
+            Self::Commit(v, floor) => commit_variable_size(v, *floor),
         }
     }
 }
@@ -28,8 +28,7 @@ impl<F: Family, K: Key, V: VariableValue> Write for Operation<F, K, VariableEnco
             }
             Self::Commit(v, floor_loc) => {
                 COMMIT_CONTEXT.write(buf);
-                v.write(buf);
-                UInt(**floor_loc).write(buf);
+                write_commit_variable(v, *floor_loc, buf);
             }
         }
     }
@@ -46,8 +45,7 @@ impl<F: Family, K: Key, V: VariableValue> Read for Operation<F, K, VariableEncod
                 Ok(Self::Set(key, value))
             }
             COMMIT_CONTEXT => {
-                let metadata = Option::<V>::read_cfg(buf, &cfg.1)?;
-                let floor_loc = Location::read(buf)?;
+                let (metadata, floor_loc) = read_commit_variable(buf, &cfg.1)?;
                 Ok(Self::Commit(metadata, floor_loc))
             }
             e => Err(CodecError::InvalidEnum(e)),
@@ -58,8 +56,8 @@ impl<F: Family, K: Key, V: VariableValue> Read for Operation<F, K, VariableEncod
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr;
-    use commonware_codec::{DecodeExt, Encode, EncodeSize, FixedSize as _};
+    use crate::merkle::{Location, mmr};
+    use commonware_codec::{DecodeExt, Encode, EncodeSize, FixedSize as _, varint::UInt};
     use commonware_utils::sequence::U64;
 
     type VarOp = Operation<mmr::Family, U64, VariableEncoding<U64>>;

--- a/storage/src/qmdb/keyless/operation/fixed.rs
+++ b/storage/src/qmdb/keyless/operation/fixed.rs
@@ -161,4 +161,17 @@ mod tests {
             CodecError::Invalid(_, _)
         ));
     }
+
+    #[test]
+    fn commit_nonzero_metadata_bytes_rejected() {
+        // Construct a Commit buffer by hand with option tag = false (None metadata) but a
+        // nonzero byte in the metadata region.
+        let mut buf = vec![0u8; Op::SIZE];
+        buf[0] = COMMIT_CONTEXT;
+        buf[2] = 0x01;
+        assert!(matches!(
+            Op::decode(buf.as_ref()).unwrap_err(),
+            CodecError::Invalid(_, _)
+        ));
+    }
 }

--- a/storage/src/qmdb/keyless/operation/fixed.rs
+++ b/storage/src/qmdb/keyless/operation/fixed.rs
@@ -1,8 +1,9 @@
 use crate::{
-    merkle::{Family, Location},
+    merkle::Family,
     qmdb::{
         any::{FixedValue, value::FixedEncoding},
         keyless::operation::{APPEND_CONTEXT, COMMIT_CONTEXT, Codec, Operation},
+        operation::{commit_fixed_size, read_commit_fixed, write_commit_fixed},
     },
 };
 use commonware_codec::{
@@ -11,14 +12,11 @@ use commonware_codec::{
 };
 use commonware_runtime::{Buf, BufMut};
 
-/// Fixed padded operation size: `Commit` is always the larger variant.
-///
-/// - Append: 1 (context) + V::SIZE + padding
-/// - Commit: 1 (context) + 1 (option tag) + V::SIZE + u64::SIZE (floor)
-///
-/// Total = 2 + V::SIZE + u64::SIZE. Append pads to match.
+/// Fixed padded operation size. `Commit` (1 context + 1 option tag + `V::SIZE` + `u64` floor) is
+/// always the larger variant, so the uniform size is the commit size; `Append` (1 context +
+/// `V::SIZE`) pads to match.
 const fn op_size<V: FixedSize>() -> usize {
-    2 + V::SIZE + u64::SIZE
+    commit_fixed_size::<V>()
 }
 
 impl<V: FixedValue> Codec for FixedEncoding<V> {
@@ -35,13 +33,7 @@ impl<V: FixedValue> Codec for FixedEncoding<V> {
             }
             Operation::Commit(metadata, floor) => {
                 COMMIT_CONTEXT.write(buf);
-                if let Some(metadata) = metadata {
-                    true.write(buf);
-                    metadata.write(buf);
-                } else {
-                    buf.put_bytes(0, 1 + V::SIZE);
-                }
-                buf.put_slice(&floor.as_u64().to_be_bytes());
+                write_commit_fixed(metadata, *floor, buf);
             }
         }
     }
@@ -60,20 +52,7 @@ impl<V: FixedValue> Codec for FixedEncoding<V> {
                 Ok(Operation::Append(value))
             }
             COMMIT_CONTEXT => {
-                let is_some = bool::read(buf)?;
-                let metadata = if is_some {
-                    Some(V::read(buf)?)
-                } else {
-                    ensure_zeros(buf, V::SIZE)?;
-                    None
-                };
-                let floor = Location::<F>::new(u64::read(buf)?);
-                if !floor.is_valid() {
-                    return Err(CodecError::Invalid(
-                        "storage::qmdb::keyless::operation::fixed::Operation",
-                        "commit floor location overflow",
-                    ));
-                }
+                let (metadata, floor) = read_commit_fixed(buf)?;
                 Ok(Operation::Commit(metadata, floor))
             }
             e => Err(CodecError::InvalidEnum(e)),
@@ -88,7 +67,7 @@ impl<F: Family, V: FixedValue> FixedSize for Operation<F, FixedEncoding<V>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr;
+    use crate::merkle::{Location, mmr};
     use commonware_codec::{DecodeExt, Encode, FixedSize};
     use commonware_utils::sequence::U64;
 

--- a/storage/src/qmdb/keyless/operation/fixed.rs
+++ b/storage/src/qmdb/keyless/operation/fixed.rs
@@ -3,7 +3,7 @@ use crate::{
     qmdb::{
         any::{FixedValue, value::FixedEncoding},
         keyless::operation::{APPEND_CONTEXT, COMMIT_CONTEXT, Codec, Operation},
-        operation::{commit_fixed_size, read_commit_fixed, write_commit_fixed},
+        operation::{commit_fixed_operation_size, read_commit_fixed, write_commit_fixed},
     },
 };
 use commonware_codec::{
@@ -12,11 +12,10 @@ use commonware_codec::{
 };
 use commonware_runtime::{Buf, BufMut};
 
-/// Fixed padded operation size. `Commit` (1 context + 1 option tag + `V::SIZE` + `u64` floor) is
-/// always the larger variant, so the uniform size is the commit size; `Append` (1 context +
-/// `V::SIZE`) pads to match.
+/// Fixed padded operation size: `Commit` is always the larger variant, so the uniform size is the
+/// commit size, which `Append` pads to match.
 const fn op_size<V: FixedSize>() -> usize {
-    commit_fixed_size::<V>()
+    commit_fixed_operation_size::<V>()
 }
 
 impl<V: FixedValue> Codec for FixedEncoding<V> {

--- a/storage/src/qmdb/keyless/operation/variable.rs
+++ b/storage/src/qmdb/keyless/operation/variable.rs
@@ -3,7 +3,7 @@ use crate::{
     qmdb::{
         any::{VariableValue, value::VariableEncoding},
         keyless::operation::{APPEND_CONTEXT, COMMIT_CONTEXT, Codec, Operation},
-        operation::{commit_variable_size, read_commit_variable, write_commit_variable},
+        operation::{commit_variable_payload_size, read_commit_variable, write_commit_variable},
     },
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
@@ -44,7 +44,7 @@ impl<F: Family, V: VariableValue> EncodeSize for Operation<F, VariableEncoding<V
     fn encode_size(&self) -> usize {
         1 + match self {
             Self::Append(v) => v.encode_size(),
-            Self::Commit(v, floor) => commit_variable_size(v, *floor),
+            Self::Commit(v, floor) => commit_variable_payload_size(v, *floor),
         }
     }
 }

--- a/storage/src/qmdb/keyless/operation/variable.rs
+++ b/storage/src/qmdb/keyless/operation/variable.rs
@@ -1,8 +1,9 @@
 use crate::{
-    merkle::{Family, Location},
+    merkle::Family,
     qmdb::{
         any::{VariableValue, value::VariableEncoding},
         keyless::operation::{APPEND_CONTEXT, COMMIT_CONTEXT, Codec, Operation},
+        operation::{commit_variable_size, read_commit_variable, write_commit_variable},
     },
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
@@ -19,8 +20,7 @@ impl<V: VariableValue> Codec for VariableEncoding<V> {
             }
             Operation::Commit(metadata, floor) => {
                 COMMIT_CONTEXT.write(buf);
-                metadata.write(buf);
-                floor.write(buf);
+                write_commit_variable(metadata, *floor, buf);
             }
         }
     }
@@ -32,8 +32,7 @@ impl<V: VariableValue> Codec for VariableEncoding<V> {
         match u8::read(buf)? {
             APPEND_CONTEXT => Ok(Operation::Append(V::read_cfg(buf, cfg)?)),
             COMMIT_CONTEXT => {
-                let metadata = Option::<V>::read_cfg(buf, cfg)?;
-                let floor = Location::<F>::read(buf)?;
+                let (metadata, floor) = read_commit_variable(buf, cfg)?;
                 Ok(Operation::Commit(metadata, floor))
             }
             e => Err(CodecError::InvalidEnum(e)),
@@ -45,7 +44,7 @@ impl<F: Family, V: VariableValue> EncodeSize for Operation<F, VariableEncoding<V
     fn encode_size(&self) -> usize {
         1 + match self {
             Self::Append(v) => v.encode_size(),
-            Self::Commit(v, floor) => v.encode_size() + floor.encode_size(),
+            Self::Commit(v, floor) => commit_variable_size(v, *floor),
         }
     }
 }
@@ -53,7 +52,7 @@ impl<F: Family, V: VariableValue> EncodeSize for Operation<F, VariableEncoding<V
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::merkle::mmr;
+    use crate::merkle::{Location, mmr};
     use commonware_codec::{DecodeExt, Encode, EncodeSize};
     use commonware_utils::sequence::U64;
 

--- a/storage/src/qmdb/operation.rs
+++ b/storage/src/qmdb/operation.rs
@@ -51,7 +51,7 @@ pub trait Committable {
     fn is_commit(&self) -> bool;
 }
 
-/// On-disk size of a fixed-encoded commit operation.
+/// Unpadded size of a fixed-encoded commit operation, context byte included.
 pub(crate) const fn commit_fixed_operation_size<V: FixedSize>() -> usize {
     1 + 1 + V::SIZE + u64::SIZE
 }

--- a/storage/src/qmdb/operation.rs
+++ b/storage/src/qmdb/operation.rs
@@ -1,3 +1,5 @@
+//! Shared traits and codecs for QMDB operations.
+
 use crate::merkle::{Family, Location};
 use commonware_codec::{
     CodecShared, EncodeSize, Error as CodecError, FixedSize, Read, ReadExt as _, Write,
@@ -48,9 +50,6 @@ pub trait Committable {
     /// If this operation is a commit operation.
     fn is_commit(&self) -> bool;
 }
-
-// Commit operations are shared across the `any`, `immutable`, and `keyless` families: every commit
-// carries optional metadata and an inactivity floor, encoded identically.
 
 /// On-disk size of a fixed-encoded commit operation.
 pub(crate) const fn commit_fixed_operation_size<V: FixedSize>() -> usize {

--- a/storage/src/qmdb/operation.rs
+++ b/storage/src/qmdb/operation.rs
@@ -1,5 +1,9 @@
 use crate::merkle::{Family, Location};
-use commonware_codec::CodecShared;
+use commonware_codec::{
+    CodecShared, EncodeSize, Error as CodecError, FixedSize, Read, ReadExt as _, Write,
+    util::ensure_zeros,
+};
+use commonware_runtime::{Buf, BufMut};
 use core::{fmt::Debug, hash::Hash, ops::Deref};
 
 /// Trait bound for key types used in QMDB operations. Satisfied by both fixed-size keys
@@ -43,4 +47,87 @@ pub trait Operation<F: Family>: Floored<F> {
 pub trait Committable {
     /// If this operation is a commit operation.
     fn is_commit(&self) -> bool;
+}
+
+// Commit operations are shared across the `any`, `immutable`, and `keyless` families: every commit
+// carries optional metadata and an inactivity floor, encoded identically. These helpers write and
+// read that shared payload, so each family's codec only supplies its own context byte (and, in the
+// fixed encoding, any trailing padding to a uniform operation size).
+
+/// On-disk size of a fixed-encoded commit operation: the context byte, the option tag, the value
+/// padded to `V::SIZE`, and the `u64` inactivity floor.
+pub(crate) const fn commit_fixed_size<V: FixedSize>() -> usize {
+    1 + 1 + V::SIZE + u64::SIZE
+}
+
+/// Writes the fixed-encoded commit payload that follows the context byte: an option tag, the value
+/// (or `V::SIZE` zero bytes when absent), and the inactivity floor as a big-endian `u64`.
+pub(crate) fn write_commit_fixed<F: Family, V: Write + FixedSize>(
+    metadata: &Option<V>,
+    floor: Location<F>,
+    buf: &mut impl BufMut,
+) {
+    if let Some(value) = metadata {
+        true.write(buf);
+        value.write(buf);
+    } else {
+        buf.put_bytes(0, 1 + V::SIZE);
+    }
+    buf.put_slice(&floor.as_u64().to_be_bytes());
+}
+
+/// Reads the fixed-encoded commit payload following the context byte written by
+/// [`write_commit_fixed`]: the option tag, the value (validating the zero padding of an absent
+/// value), and the inactivity floor.
+///
+/// Returns [`CodecError::Invalid`] if the floor overflows the location space.
+pub(crate) fn read_commit_fixed<F: Family, V: Read<Cfg = ()> + FixedSize>(
+    buf: &mut impl Buf,
+) -> Result<(Option<V>, Location<F>), CodecError> {
+    let metadata = if bool::read(buf)? {
+        Some(V::read(buf)?)
+    } else {
+        ensure_zeros(buf, V::SIZE)?;
+        None
+    };
+    let floor = Location::new(u64::read(buf)?);
+    if !floor.is_valid() {
+        return Err(CodecError::Invalid(
+            "storage::qmdb::operation::commit",
+            "commit floor location overflow",
+        ));
+    }
+    Ok((metadata, floor))
+}
+
+/// Encoded size of the variable-encoded commit payload following the context byte: the optional
+/// value and the inactivity floor varint.
+pub(crate) fn commit_variable_size<F: Family, V: EncodeSize>(
+    metadata: &Option<V>,
+    floor: Location<F>,
+) -> usize {
+    metadata.encode_size() + floor.encode_size()
+}
+
+/// Writes the variable-encoded commit payload following the context byte: the optional value, then
+/// the inactivity floor as a varint.
+pub(crate) fn write_commit_variable<F: Family, V: Write>(
+    metadata: &Option<V>,
+    floor: Location<F>,
+    buf: &mut impl BufMut,
+) {
+    metadata.write(buf);
+    floor.write(buf);
+}
+
+/// Reads the variable-encoded commit payload following the context byte written by
+/// [`write_commit_variable`]: the optional value, then the inactivity floor (validated by
+/// [`Location`]'s decoder).
+pub(crate) fn read_commit_variable<F: Family, V: Read>(
+    buf: &mut impl Buf,
+    value_cfg: &V::Cfg,
+) -> Result<(Option<V>, Location<F>), CodecError> {
+    let metadata = Option::<V>::read_cfg(buf, value_cfg)?;
+    let floor = Location::read(buf)?;
+    Ok((metadata, floor))
 }

--- a/storage/src/qmdb/operation.rs
+++ b/storage/src/qmdb/operation.rs
@@ -50,18 +50,14 @@ pub trait Committable {
 }
 
 // Commit operations are shared across the `any`, `immutable`, and `keyless` families: every commit
-// carries optional metadata and an inactivity floor, encoded identically. These helpers write and
-// read that shared payload, so each family's codec only supplies its own context byte (and, in the
-// fixed encoding, any trailing padding to a uniform operation size).
+// carries optional metadata and an inactivity floor, encoded identically.
 
-/// On-disk size of a fixed-encoded commit operation: the context byte, the option tag, the value
-/// padded to `V::SIZE`, and the `u64` inactivity floor.
-pub(crate) const fn commit_fixed_size<V: FixedSize>() -> usize {
+/// On-disk size of a fixed-encoded commit operation.
+pub(crate) const fn commit_fixed_operation_size<V: FixedSize>() -> usize {
     1 + 1 + V::SIZE + u64::SIZE
 }
 
-/// Writes the fixed-encoded commit payload that follows the context byte: an option tag, the value
-/// (or `V::SIZE` zero bytes when absent), and the inactivity floor as a big-endian `u64`.
+/// Writes a commit's optional metadata and inactivity floor in the fixed encoding.
 pub(crate) fn write_commit_fixed<F: Family, V: Write + FixedSize>(
     metadata: &Option<V>,
     floor: Location<F>,
@@ -76,11 +72,7 @@ pub(crate) fn write_commit_fixed<F: Family, V: Write + FixedSize>(
     buf.put_slice(&floor.as_u64().to_be_bytes());
 }
 
-/// Reads the fixed-encoded commit payload following the context byte written by
-/// [`write_commit_fixed`]: the option tag, the value (validating the zero padding of an absent
-/// value), and the inactivity floor.
-///
-/// Returns [`CodecError::Invalid`] if the floor overflows the location space.
+/// Reads a commit's optional metadata and inactivity floor from the fixed encoding.
 pub(crate) fn read_commit_fixed<F: Family, V: Read<Cfg = ()> + FixedSize>(
     buf: &mut impl Buf,
 ) -> Result<(Option<V>, Location<F>), CodecError> {
@@ -100,17 +92,15 @@ pub(crate) fn read_commit_fixed<F: Family, V: Read<Cfg = ()> + FixedSize>(
     Ok((metadata, floor))
 }
 
-/// Encoded size of the variable-encoded commit payload following the context byte: the optional
-/// value and the inactivity floor varint.
-pub(crate) fn commit_variable_size<F: Family, V: EncodeSize>(
+/// Encoded size of a variable-encoded commit payload.
+pub(crate) fn commit_variable_payload_size<F: Family, V: EncodeSize>(
     metadata: &Option<V>,
     floor: Location<F>,
 ) -> usize {
     metadata.encode_size() + floor.encode_size()
 }
 
-/// Writes the variable-encoded commit payload following the context byte: the optional value, then
-/// the inactivity floor as a varint.
+/// Writes a commit's optional metadata and inactivity floor in the variable encoding.
 pub(crate) fn write_commit_variable<F: Family, V: Write>(
     metadata: &Option<V>,
     floor: Location<F>,
@@ -120,9 +110,7 @@ pub(crate) fn write_commit_variable<F: Family, V: Write>(
     floor.write(buf);
 }
 
-/// Reads the variable-encoded commit payload following the context byte written by
-/// [`write_commit_variable`]: the optional value, then the inactivity floor (validated by
-/// [`Location`]'s decoder).
+/// Reads a commit's optional metadata and inactivity floor from the variable encoding.
 pub(crate) fn read_commit_variable<F: Family, V: Read>(
     buf: &mut impl Buf,
     value_cfg: &V::Cfg,


### PR DESCRIPTION
## Motivation

The `any`, `immutable`, and `keyless` QMDB families each define a commit operation with the **same shape** — `(Option<value>, Location)` (an optional metadata value and an inactivity floor) — encoded **identically** on the wire. Its encode/decode was copy-pasted **six times** (three families × fixed/variable): the option tag, the padded-or-absent value, the floor-overflow check (fixed), and the floor varint (variable). Six hand-maintained copies of a roundtrip-critical codec that must stay byte-compatible — a latent drift risk.

## Changes

Add a shared commit-payload codec in `qmdb::operation` and call it from every family:

- `commit_fixed_size` / `write_commit_fixed` / `read_commit_fixed` (fixed encoding)
- `commit_variable_size` / `write_commit_variable` / `read_commit_variable` (variable encoding)

Each family's codec keeps ownership of what actually differs — its **context byte** (`any`=`0xD3`, `immutable`=`1`, `keyless`=`0`) and, in the fixed encoding, any **trailing padding** to a uniform operation size (`keyless`'s commit is already the largest variant, so it pads nothing). Only the shared commit payload moves into the helpers. The duplicated `commit_op_size` const folds into the shared `commit_fixed_size`.

## Behavior-preserving

The wire format is **unchanged**. `Location` encodes as a varint (`UInt`), so `keyless`'s `floor.write()` and `any`/`immutable`'s `UInt(**floor)` already emitted identical bytes; the fixed floor is a big-endian `u64` in all three. The floor-overflow check and absent-value zero-padding validation are preserved.

## Validation

- **All 19 qmdb operation codec-conformance tests pass** against the stored fixtures (`any` ordered/unordered × fixed/variable × mmr/mmb, `immutable` fixed/var/var-key, `keyless` fixed/var) — proof the format did not drift; **no fixtures regenerated**.
- 73 operation unit tests pass (roundtrips, overflow rejection, padding).
- `cargo check -p commonware-storage` clean under default features **and `--no-default-features`** (`-D warnings`).

This is a dedup for a single source of truth over a correctness-critical codec (net LOC ≈ flat), not a line-count play. Builds on `main`.
