### PR TITLE
[simplex] Split repair demand into kind and until

### DIFF
--- a/consensus/src/simplex/actors/mod.rs
+++ b/consensus/src/simplex/actors/mod.rs
@@ -77,9 +77,8 @@ pub(crate) enum Until {
     Floor,
     /// The view is finalized.
     ///
-    /// Used for ancestry a proposal named. A proposal may name ancestry below the
-    /// local floor, which is the case where a peer holds a nullification
-    /// for a view this node has certified a notarization for, so only
-    /// finalization can retire it.
+    /// Used for ancestry a proposal named. A proposal may name ancestry below
+    /// the local floor, as when a peer holds a nullification for a view this
+    /// node certified a notarization for. Only finalization retires the demand.
     Finalization,
 }

--- a/consensus/src/simplex/actors/mod.rs
+++ b/consensus/src/simplex/actors/mod.rs
@@ -4,40 +4,82 @@ pub mod batcher;
 pub mod resolver;
 pub mod voter;
 
-/// Why a certificate is being fetched.
+/// What a resolver request wants, and what retires it.
 ///
-/// This is local resolver bookkeeping and is never encoded on the wire.
+/// This is local bookkeeping and is never encoded. The wire key names only a
+/// view, so a responder cannot tell which certificate was asked for and may
+/// answer with one that does not settle the request. Keeping the demand local
+/// is what lets the requester recognize that case (see
+/// [resolver::Actor::settled]).
+///
+/// Only three of the four combinations occur: background repair always wants a
+/// nullification, while proposal ancestry wants either kind.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub(crate) enum Purpose {
-    /// Background repair between the local floor and current view.
-    Backfill,
-    /// A nullification covering the requested view.
-    Nullification,
-    /// A certified notarization or finalization for the named parent.
-    Parent,
+pub(crate) struct Demand {
+    /// The certificate that settles the request.
+    pub kind: Kind,
+    /// The boundary that retires the request.
+    pub until: Until,
 }
 
-impl Purpose {
-    /// Returns whether the fetch came from proposal ancestry repair.
-    pub const fn is_targeted(self) -> bool {
-        !matches!(self, Self::Backfill)
-    }
-
-    /// Returns whether matching evidence retires this purpose.
-    pub const fn is_retired_by(self, resolved: Self) -> bool {
-        matches!(
-            (self, resolved),
-            (Self::Backfill | Self::Nullification, Self::Nullification)
-                | (Self::Parent, Self::Parent)
-        )
-    }
-
-    /// Returns the stable trace field value for this purpose.
-    pub const fn as_str(self) -> &'static str {
-        match self {
-            Self::Backfill => "backfill",
-            Self::Nullification => "nullification",
-            Self::Parent => "parent",
+impl Demand {
+    /// Returns a demand for background repair of a nullification gap.
+    pub const fn backfill() -> Self {
+        Self {
+            kind: Kind::Nullification,
+            until: Until::Floor,
         }
     }
+
+    /// Returns a demand for ancestry a proposal named.
+    pub const fn ancestry(kind: Kind) -> Self {
+        Self {
+            kind,
+            until: Until::Finalization,
+        }
+    }
+}
+
+/// The certificate that settles a request.
+///
+/// A notarization and a nullification covering the same view can both exist, and
+/// neither substitutes for the other, so this cannot be inferred from the view.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum Kind {
+    /// A nullification covering the view.
+    ///
+    /// Wanted to justify a proposal that skips the view, and to fill the
+    /// nullification gaps below the current view.
+    Nullification,
+    /// A notarization for the view.
+    ///
+    /// Wanted to certify the parent a proposal names.
+    Notarization,
+}
+
+impl Kind {
+    /// Returns the stable trace field value for this kind.
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Nullification => "nullification",
+            Self::Notarization => "notarization",
+        }
+    }
+}
+
+/// The boundary at which a demand retires.
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) enum Until {
+    /// The resolver floor passes the view.
+    ///
+    /// Used for background repair of the nullification gaps below the current
+    /// view, which resolver state stops tracking once its floor is above them.
+    Floor,
+    /// The view is finalized.
+    ///
+    /// Used for ancestry a proposal named. A proposal may name ancestry below the
+    /// local floor, which is exactly the case where a peer holds a nullification
+    /// for a view this node has certified a notarization for, so only
+    /// finalization can retire it.
+    Finalization,
 }

--- a/consensus/src/simplex/actors/mod.rs
+++ b/consensus/src/simplex/actors/mod.rs
@@ -6,11 +6,9 @@ pub mod voter;
 
 /// What a resolver request wants, and what retires it.
 ///
-/// This is local bookkeeping and is never encoded. The wire key names only a
-/// view, so a responder cannot tell which certificate was asked for and may
-/// answer with one that does not settle the request. Keeping the ask local
-/// is what lets the requester recognize that case (see
-/// [resolver::Actor::settled]).
+/// The wire key names only a view, so a responder cannot tell which certificate was
+/// asked for and may answer with one that does not settle the request. Keeping the
+/// ask local lets the requester recognize that case (see [resolver::Actor::settled]).
 ///
 /// Only three of the four combinations occur: background repair always wants a
 /// nullification, while proposal ancestry wants either kind.

--- a/consensus/src/simplex/actors/mod.rs
+++ b/consensus/src/simplex/actors/mod.rs
@@ -8,22 +8,22 @@ pub mod voter;
 ///
 /// This is local bookkeeping and is never encoded. The wire key names only a
 /// view, so a responder cannot tell which certificate was asked for and may
-/// answer with one that does not settle the request. Keeping the demand local
+/// answer with one that does not settle the request. Keeping the ask local
 /// is what lets the requester recognize that case (see
 /// [resolver::Actor::settled]).
 ///
 /// Only three of the four combinations occur: background repair always wants a
 /// nullification, while proposal ancestry wants either kind.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
-pub(crate) struct Demand {
+pub(crate) struct Ask {
     /// The certificate that settles the request.
     pub kind: Kind,
     /// The boundary that retires the request.
     pub until: Until,
 }
 
-impl Demand {
-    /// Returns a demand for background repair of a nullification gap.
+impl Ask {
+    /// Returns an ask for background repair of a nullification gap.
     pub const fn backfill() -> Self {
         Self {
             kind: Kind::Nullification,
@@ -31,7 +31,7 @@ impl Demand {
         }
     }
 
-    /// Returns a demand for ancestry a proposal named.
+    /// Returns an ask for ancestry a proposal named.
     pub const fn ancestry(kind: Kind) -> Self {
         Self {
             kind,
@@ -67,7 +67,7 @@ impl Kind {
     }
 }
 
-/// The boundary at which a demand retires.
+/// The boundary at which an ask retires.
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) enum Until {
     /// The resolver floor passes the view.
@@ -79,6 +79,6 @@ pub(crate) enum Until {
     ///
     /// Used for ancestry a proposal named. A proposal may name ancestry below
     /// the local floor, as when a peer holds a nullification for a view this
-    /// node certified a notarization for. Only finalization retires the demand.
+    /// node certified a notarization for. Only finalization retires the ask.
     Finalization,
 }

--- a/consensus/src/simplex/actors/mod.rs
+++ b/consensus/src/simplex/actors/mod.rs
@@ -78,7 +78,7 @@ pub(crate) enum Until {
     /// The view is finalized.
     ///
     /// Used for ancestry a proposal named. A proposal may name ancestry below the
-    /// local floor, which is exactly the case where a peer holds a nullification
+    /// local floor, which is the case where a peer holds a nullification
     /// for a view this node has certified a notarization for, so only
     /// finalization can retire it.
     Finalization,

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -81,13 +81,6 @@ pub struct Actor<
     /// arrive, so the tombstone is kept here against the finalization boundary.
     failed_certifications: BTreeSet<View>,
 
-    /// Certificates still wanted from peers, paired with what retires each.
-    ///
-    /// This mirrors the resolver's outstanding fetches. Owning them here keeps
-    /// retirement in one place: [Self::settled] decides it from local evidence,
-    /// and [Self::sync_demands] publishes the survivors to the resolver.
-    demands: BTreeSet<(View, Demand)>,
-
     mailbox_receiver: mailbox::Receiver<MailboxMessage<S, D>>,
 }
 
@@ -117,7 +110,6 @@ impl<
                 nullification_responses: BTreeMap::new(),
                 notarization_responses: BTreeMap::new(),
                 failed_certifications: BTreeSet::new(),
-                demands: BTreeSet::new(),
 
                 mailbox_receiver: receiver,
             },
@@ -225,14 +217,20 @@ impl<
             Certificate::Notarization(notarization) => (None, None, Some(notarization.view())),
         };
 
+        let term_length = self.state.term_length();
+
         // Cache response payloads for as long as a peer can still ask for them.
         // [State] prunes at the floor, which rises sooner than finalization and
         // would hide this evidence from a peer still repairing the view.
         if let Some(nullified) = nullified
-            && nullified.term_end(self.state.term_length()) > self.last_finalized
+            && nullified.term_end(term_length) > self.last_finalized
         {
             self.nullification_responses
                 .insert(nullified, certificate.encode());
+            let covered = nullified..=nullified.term_end(term_length);
+            Self::retire(resolver, move |view, demand| {
+                demand.kind == Kind::Nullification && covered.contains(&view)
+            });
         }
         if let Some(notarized) = notarized
             && notarized > self.last_finalized
@@ -240,21 +238,23 @@ impl<
         {
             self.notarization_responses
                 .insert(notarized, certificate.encode());
+            Self::retire(resolver, move |view, demand| {
+                demand.kind == Kind::Notarization && view == notarized
+            });
         }
 
         // Finalization is the global retirement boundary: a valid proposal can no
         // longer name ancestry at or below it, so nothing here can still be asked
-        // for. Demands below it are dropped by [Self::sync_demands], which treats
-        // a finalized view as settled.
+        // for.
         if let Some(finalized) = finalized {
             self.last_finalized = self.last_finalized.max(finalized);
-            let term_length = self.state.term_length();
+            let finalized = self.last_finalized;
             self.nullification_responses
-                .retain(|view, _| view.term_end(term_length) > self.last_finalized);
+                .retain(|view, _| view.term_end(term_length) > finalized);
             self.notarization_responses
-                .retain(|view, _| *view > self.last_finalized);
-            self.failed_certifications
-                .retain(|view| *view > self.last_finalized);
+                .retain(|view, _| *view > finalized);
+            self.failed_certifications.retain(|view| *view > finalized);
+            Self::retire(resolver, move |view, _| view <= finalized);
         }
 
         // Certificate state owns floor selection and background repair.
@@ -276,6 +276,9 @@ impl<
             if view > self.last_finalized {
                 self.failed_certifications.insert(view);
             }
+            Self::retire(resolver, move |demanded, demand| {
+                demand.kind == Kind::Notarization && demanded == view
+            });
         }
 
         let effects = self.state.handle_certified(view, success);
@@ -283,10 +286,6 @@ impl<
     }
 
     /// Applies the side effects requested by [super::state::State] to the resolver.
-    ///
-    /// Call this after recording new evidence: it ends by syncing the resolver to
-    /// the surviving demands, which is what publishes both the effects below and
-    /// the evidence recorded by the caller.
     fn apply_effects<R: Resolver<Key = U64, Subscriber = Demand>>(
         &mut self,
         resolver: &mut R,
@@ -301,51 +300,53 @@ impl<
                 } => self.fetch(resolver, view, cause, reason),
                 Effect::RetainAbove(floor) => {
                     // Resolver state does not repair below its floor, so a
-                    // background demand there has nothing left to do. This is
-                    // the only retirement that depends on the floor:
-                    // [Self::settled] cannot use it, because a proposal may name
+                    // background demand there has nothing left to do. Only
+                    // background demands retire here, because a proposal may name
                     // ancestry below the floor and only finalization rules that
                     // out.
-                    self.demands
-                        .retain(|(view, demand)| demand.until != Until::Floor || *view > floor);
+                    Self::retire(resolver, move |view, demand| {
+                        demand.until == Until::Floor && view <= floor
+                    });
                 }
             }
         }
-
-        self.sync_demands(resolver);
     }
 
-    /// Drops settled demands and mirrors the survivors into the resolver.
+    /// Retires the demands that new evidence settles.
     ///
-    /// [Resolver::retain] takes a `'static` predicate and so cannot consult
-    /// [Self::settled] directly, which is why the survivors are snapshotted into
-    /// it.
-    fn sync_demands<R: Resolver<Key = U64, Subscriber = Demand>>(&mut self, resolver: &mut R) {
-        let live: BTreeSet<_> = self
-            .demands
-            .iter()
-            .copied()
-            .filter(|(view, demand)| !self.settled(*view, demand.kind))
-            .collect();
-        self.demands = live.clone();
-        let _ = resolver
-            .retain(move |key, demand| live.contains(&(View::new(u64::from(key)), *demand)));
+    /// `settled` reports whether the evidence answers a demand. [Resolver::retain]
+    /// takes an owned predicate, so it cannot call [Self::settled]. Every
+    /// retirement here names a span of views and a kind, which the caller captures
+    /// by value instead.
+    ///
+    /// Settlement is monotonic: no later evidence unsettles a demand. A retirement
+    /// therefore stays true however the resolver orders it against fetches, which
+    /// it reorders under backpressure.
+    fn retire<R: Resolver<Key = U64, Subscriber = Demand>>(
+        resolver: &mut R,
+        settled: impl Fn(View, Demand) -> bool + Send + 'static,
+    ) {
+        let _ = resolver.retain(move |key, demand| !settled(View::new(u64::from(key)), *demand));
     }
 
     /// Issues a background fetch for the nullification covering `view`.
     ///
-    /// Both [FetchReason]s want the same certificate: [State] only ever reports
+    /// Both [FetchReason]s want the same certificate: [State] only reports
     /// a view whose covering nullification is missing, whether the gap was found
     /// by scanning below the current view or opened by a failed certification.
     fn fetch<R: Resolver<Key = U64, Subscriber = Demand>>(
-        &mut self,
+        &self,
         resolver: &mut R,
         view: View,
         cause: View,
         reason: FetchReason,
     ) {
         let demand = Demand::backfill();
-        self.demands.insert((view, demand));
+
+        // Every reported gap sits above the floor, and a cached nullification
+        // covering a view above the floor is also stored in [State], so a
+        // reported gap is never settled.
+        debug_assert!(!self.settled(view, demand.kind));
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
@@ -363,7 +364,7 @@ impl<
 
     /// Fetches ancestry from the leader whose proposal requires it.
     fn resolve<R>(
-        &mut self,
+        &self,
         resolver: &mut R,
         proposal_view: View,
         view: View,
@@ -376,7 +377,6 @@ impl<
             return;
         }
         let demand = Demand::ancestry(kind);
-        self.demands.insert((view, demand));
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
@@ -399,12 +399,12 @@ impl<
     ///
     /// Settled means there is nothing left to fetch: either the evidence is in
     /// hand, or no response could ever serve the demand. This decides whether to
-    /// open a fetch, whether a delivery completed one, and which demands survive
-    /// [Self::sync_demands].
+    /// open a fetch and whether a delivery completed one. [Self::retire] carries
+    /// the same rule to the resolver, one piece of evidence at a time.
     ///
     /// A valid response does not imply this. The wire key names only a view, so a
     /// peer may answer a notarization request with a covering nullification: valid
-    /// evidence, worth recording, but not what was asked for.
+    /// evidence the actor records, but not what was asked for.
     fn settled(&self, view: View, kind: Kind) -> bool {
         // Finalization rules out any further need for the view. This is also
         // what settles a demand answered by a finalization, since recording one
@@ -415,8 +415,8 @@ impl<
         match kind {
             Kind::Nullification => self.covering_nullification(view).is_some(),
             // Holding the notarization settles this, and so does a failed
-            // verdict: certification is an application judgement on the
-            // evidence itself, so no other copy of it could pass either.
+            // verdict: certification judges the evidence itself, so no other
+            // copy of it could pass either.
             Kind::Notarization => {
                 self.notarization_responses.contains_key(&view)
                     || self.failed_certifications.contains(&view)
@@ -472,7 +472,7 @@ impl<
     /// named. Any certificate an honest peer could serve for the view is accepted,
     /// including one that answers the other kind: rejecting it would fault a peer
     /// that answered the only question the wire key asked. Whether it
-    /// settles the demand is a separate judgement (see [Self::settled]).
+    /// settles the demand is a separate check (see [Self::settled]).
     fn validate(&mut self, view: View, data: Bytes) -> Option<Certificate<S, D>> {
         let incoming =
             Certificate::<S, D>::decode_cfg(data, &self.scheme.certificate_codec_config()).ok()?;
@@ -579,10 +579,9 @@ impl<
                 }
 
                 // The peer answered the view it was asked about, so it is never
-                // faulted here. Whether that answer was the certificate anyone
-                // wanted is a separate question: if a demand for this view is
-                // still open, the response was valid but ambiguous, and the
-                // resolver retries without penalizing the peer.
+                // faulted here. If a demand for this view is still open, the
+                // response was valid but ambiguous, and the resolver retries
+                // without penalizing the peer.
                 let outcome = if demands.iter().all(|demand| self.settled(view, demand.kind)) {
                     Outcome::Complete
                 } else {

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -68,10 +68,14 @@ pub struct Actor<
     /// finalization so an ask below the floor can still be served.
     nullification_responses: BTreeMap<View, Bytes>,
 
-    /// Notarizations cached in the encoded form expected by [p2p::Producer].
-    /// These response payloads remain available until finalization so exact
-    /// parents survive later floor raises. A view whose certification fails is
-    /// removed: no copy of that notarization can certify anywhere.
+    /// Notarizations awaiting certification, cached in the encoded form received
+    /// by the actor. Possession completes an exact-parent fetch, but these
+    /// payloads are not served until certification succeeds.
+    uncertified_notarizations: BTreeMap<View, Bytes>,
+
+    /// Successfully certified notarizations cached in the encoded form expected
+    /// by [p2p::Producer]. These response payloads remain available until
+    /// finalization so exact parents survive later floor raises.
     notarization_responses: BTreeMap<View, Bytes>,
 
     /// Views whose certification failed, retained until covering finalization.
@@ -108,6 +112,7 @@ impl<
                 state: State::new(cfg.fetch_concurrent, cfg.term_length),
                 last_finalized: View::zero(),
                 nullification_responses: BTreeMap::new(),
+                uncertified_notarizations: BTreeMap::new(),
                 notarization_responses: BTreeMap::new(),
                 failed_certifications: BTreeSet::new(),
 
@@ -236,8 +241,10 @@ impl<
             && notarized > self.last_finalized
             && !self.failed_certifications.contains(&notarized)
         {
-            self.notarization_responses
-                .insert(notarized, certificate.encode());
+            if !self.notarization_responses.contains_key(&notarized) {
+                self.uncertified_notarizations
+                    .insert(notarized, certificate.encode());
+            }
             Self::retire(resolver, move |view, ask| {
                 ask.kind == Kind::Notarization && view == notarized
             });
@@ -251,6 +258,8 @@ impl<
             let finalized = self.last_finalized;
             self.nullification_responses
                 .retain(|view, _| view.term_end(term_length) > finalized);
+            self.uncertified_notarizations
+                .retain(|view, _| *view > finalized);
             self.notarization_responses
                 .retain(|view, _| *view > finalized);
             self.failed_certifications.retain(|view| *view > finalized);
@@ -269,6 +278,15 @@ impl<
         view: View,
         success: bool,
     ) {
+        // Every verdict clears the uncertified payload. Only successful
+        // notarizations above finalization become servable.
+        if let Some(notarization) = self.uncertified_notarizations.remove(&view)
+            && success
+            && view > self.last_finalized
+        {
+            self.notarization_responses.insert(view, notarization);
+        }
+
         // No copy of an uncertifiable notarization can certify anywhere, so it
         // is not an answer to an exact-parent request.
         if !success {
@@ -418,7 +436,8 @@ impl<
             // verdict: certification judges the evidence itself, so no other
             // copy of it could pass either.
             Kind::Notarization => {
-                self.notarization_responses.contains_key(&view)
+                self.uncertified_notarizations.contains_key(&view)
+                    || self.notarization_responses.contains_key(&view)
                     || self.failed_certifications.contains(&view)
             }
         }
@@ -1359,6 +1378,7 @@ mod tests {
             );
             assert!(resolver.outstanding().is_empty());
             assert!(actor.nullification_responses.is_empty());
+            assert!(actor.uncertified_notarizations.is_empty());
             assert!(actor.notarization_responses.is_empty());
             assert!(actor.failed_certifications.is_empty());
             actor.resolve(
@@ -1429,6 +1449,41 @@ mod tests {
                 second_saw_parent,
                 "second requester stayed pinned to the nullification"
             );
+        });
+    }
+
+    #[test_async]
+    async fn notarization_is_served_only_after_certification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
+            let mut voter = voter::Mailbox::new(voter_tx);
+            let mut actor = build_actor(context.child("actor"), verifier.clone());
+            let mut resolver = RecordingResolver::default();
+            let view = View::new(3);
+            let notarization = build_notarization(&schemes, &verifier, EPOCH, view);
+            let encoded = Certificate::Notarization(notarization.clone()).encode();
+
+            let (response, receiver) = oneshot::channel();
+            actor.handle_resolver(
+                HandlerMessage::Deliver {
+                    span: tracing::Span::none(),
+                    view,
+                    data: encoded.clone(),
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
+                    response,
+                },
+                &mut voter,
+                &mut resolver,
+            );
+            assert_eq!(receiver.await.unwrap(), Outcome::Complete);
+            assert!(actor.produce_certificate(view).is_none());
+
+            actor.certified(&mut resolver, view, true);
+            assert_eq!(actor.produce_certificate(view), Some(encoded));
         });
     }
 
@@ -1613,7 +1668,8 @@ mod tests {
                 &mut resolver,
             );
             assert_eq!(receiver.await.unwrap(), Outcome::Complete);
-            assert!(actor.notarization_responses.contains_key(&view));
+            assert!(actor.uncertified_notarizations.contains_key(&view));
+            assert!(!actor.notarization_responses.contains_key(&view));
         });
     }
 
@@ -1640,6 +1696,7 @@ mod tests {
             // The payload is no longer an answer, and the tombstone keeps a
             // delayed request from recreating the ask. A floor raise above the
             // view must not resurrect it (state prunes its own failed views).
+            assert!(!actor.uncertified_notarizations.contains_key(&view));
             assert!(!actor.notarization_responses.contains_key(&view));
             let floor = View::new(9);
             actor.updated(
@@ -1697,6 +1754,7 @@ mod tests {
                 &mut resolver,
             );
             assert_eq!(receiver.await.unwrap(), Outcome::Complete);
+            assert!(!actor.uncertified_notarizations.contains_key(&view));
             assert!(!actor.notarization_responses.contains_key(&view));
             drop(voter);
             assert!(voter_rx.recv().await.is_none());
@@ -1959,6 +2017,7 @@ mod tests {
 
             let notarization = build_notarization(&schemes, &verifier, EPOCH, failed);
             assert!(actor.failed_certifications.contains(&failed));
+            assert!(!actor.uncertified_notarizations.contains_key(&failed));
             assert!(!actor.notarization_responses.contains_key(&failed));
             assert!(
                 actor

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::{Demand, Kind, Until},
+    super::{Ask, Kind, Until},
     Config,
     ingress::{Handler, HandlerMessage, Mailbox, MailboxMessage},
     state::{Effect, FetchReason},
@@ -65,7 +65,7 @@ pub struct Actor<
 
     /// Nullifications cached in the encoded form expected by [p2p::Producer].
     /// These response payloads remain available while they cover views above
-    /// finalization so a demand below the floor can still be served.
+    /// finalization so an ask below the floor can still be served.
     nullification_responses: BTreeMap<View, Bytes>,
 
     /// Notarizations cached in the encoded form expected by [p2p::Producer].
@@ -206,7 +206,7 @@ impl<
     }
 
     /// Records a certificate and applies its resolver lifecycle effects.
-    fn updated<R: Resolver<Key = U64, Subscriber = Demand>>(
+    fn updated<R: Resolver<Key = U64, Subscriber = Ask>>(
         &mut self,
         resolver: &mut R,
         certificate: Certificate<S, D>,
@@ -228,8 +228,8 @@ impl<
             self.nullification_responses
                 .insert(nullified, certificate.encode());
             let covered = nullified..=nullified.term_end(term_length);
-            Self::retire(resolver, move |view, demand| {
-                demand.kind == Kind::Nullification && covered.contains(&view)
+            Self::retire(resolver, move |view, ask| {
+                ask.kind == Kind::Nullification && covered.contains(&view)
             });
         }
         if let Some(notarized) = notarized
@@ -238,8 +238,8 @@ impl<
         {
             self.notarization_responses
                 .insert(notarized, certificate.encode());
-            Self::retire(resolver, move |view, demand| {
-                demand.kind == Kind::Notarization && view == notarized
+            Self::retire(resolver, move |view, ask| {
+                ask.kind == Kind::Notarization && view == notarized
             });
         }
 
@@ -263,7 +263,7 @@ impl<
     }
 
     /// Handles a certification outcome from the voter.
-    fn certified<R: Resolver<Key = U64, Subscriber = Demand>>(
+    fn certified<R: Resolver<Key = U64, Subscriber = Ask>>(
         &mut self,
         resolver: &mut R,
         view: View,
@@ -276,8 +276,8 @@ impl<
             if view > self.last_finalized {
                 self.failed_certifications.insert(view);
             }
-            Self::retire(resolver, move |demanded, demand| {
-                demand.kind == Kind::Notarization && demanded == view
+            Self::retire(resolver, move |asked, ask| {
+                ask.kind == Kind::Notarization && asked == view
             });
         }
 
@@ -286,7 +286,7 @@ impl<
     }
 
     /// Applies the side effects requested by [super::state::State] to the resolver.
-    fn apply_effects<R: Resolver<Key = U64, Subscriber = Demand>>(
+    fn apply_effects<R: Resolver<Key = U64, Subscriber = Ask>>(
         &mut self,
         resolver: &mut R,
         effects: Vec<Effect>,
@@ -300,33 +300,33 @@ impl<
                 } => self.fetch(resolver, view, cause, reason),
                 Effect::RetainAbove(floor) => {
                     // Resolver state does not repair below its floor, so a
-                    // background demand there has nothing left to do. Only
-                    // background demands retire here, because a proposal may name
+                    // background ask there has nothing left to do. Only
+                    // background asks retire here, because a proposal may name
                     // ancestry below the floor and only finalization rules that
                     // out.
-                    Self::retire(resolver, move |view, demand| {
-                        demand.until == Until::Floor && view <= floor
+                    Self::retire(resolver, move |view, ask| {
+                        ask.until == Until::Floor && view <= floor
                     });
                 }
             }
         }
     }
 
-    /// Retires the demands that new evidence settles.
+    /// Retires the asks that new evidence settles.
     ///
-    /// `settled` reports whether the evidence answers a demand. [Resolver::retain]
+    /// `settled` reports whether the evidence answers an ask. [Resolver::retain]
     /// takes an owned predicate, so it cannot call [Self::settled]. Every
     /// retirement here names a span of views and a kind, which the caller captures
     /// by value instead.
     ///
-    /// Settlement is monotonic: no later evidence unsettles a demand. A retirement
+    /// Settlement is monotonic: no later evidence unsettles an ask. A retirement
     /// therefore stays true however the resolver orders it against fetches, which
     /// it reorders under backpressure.
-    fn retire<R: Resolver<Key = U64, Subscriber = Demand>>(
+    fn retire<R: Resolver<Key = U64, Subscriber = Ask>>(
         resolver: &mut R,
-        settled: impl Fn(View, Demand) -> bool + Send + 'static,
+        settled: impl Fn(View, Ask) -> bool + Send + 'static,
     ) {
-        let _ = resolver.retain(move |key, demand| !settled(View::new(u64::from(key)), *demand));
+        let _ = resolver.retain(move |key, ask| !settled(View::new(u64::from(key)), *ask));
     }
 
     /// Issues a background fetch for the nullification covering `view`.
@@ -334,30 +334,30 @@ impl<
     /// Both [FetchReason]s want the same certificate: [State] only reports
     /// a view whose covering nullification is missing, whether the gap was found
     /// by scanning below the current view or opened by a failed certification.
-    fn fetch<R: Resolver<Key = U64, Subscriber = Demand>>(
+    fn fetch<R: Resolver<Key = U64, Subscriber = Ask>>(
         &self,
         resolver: &mut R,
         view: View,
         cause: View,
         reason: FetchReason,
     ) {
-        let demand = Demand::backfill();
+        let ask = Ask::backfill();
 
         // Every reported gap sits above the floor, and a cached nullification
         // covering a view above the floor is also stored in [State], so a
         // reported gap is never settled.
-        debug_assert!(!self.settled(view, demand.kind));
+        debug_assert!(!self.settled(view, ask.kind));
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
             cause = cause.traced(),
             view = view.traced(),
             reason = reason.as_str(),
-            kind = demand.kind.as_str()
+            kind = ask.kind.as_str()
         );
         let _ = resolver.fetch(Fetch {
             key: U64::from(view),
-            subscriber: demand,
+            subscriber: ask,
             span,
         });
     }
@@ -371,34 +371,34 @@ impl<
         kind: Kind,
         target: S::PublicKey,
     ) where
-        R: TargetedResolver<Key = U64, Subscriber = Demand, PublicKey = S::PublicKey>,
+        R: TargetedResolver<Key = U64, Subscriber = Ask, PublicKey = S::PublicKey>,
     {
         if view >= proposal_view || self.settled(view, kind) {
             return;
         }
-        let demand = Demand::ancestry(kind);
+        let ask = Ask::ancestry(kind);
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
             cause = proposal_view.traced(),
             view = view.traced(),
             reason = "proposal_ancestry",
-            kind = demand.kind.as_str()
+            kind = ask.kind.as_str()
         );
         let _ = resolver.fetch_targeted(
             Fetch {
                 key: U64::from(view),
-                subscriber: demand,
+                subscriber: ask,
                 span,
             },
             NonEmptyVec::new(target),
         );
     }
 
-    /// Returns whether local evidence has settled a demand for `kind` at `view`.
+    /// Returns whether local evidence has settled an ask for `kind` at `view`.
     ///
     /// Settled means there is nothing left to fetch: either the evidence is in
-    /// hand, or no response could ever serve the demand. This decides whether to
+    /// hand, or no response could ever serve the ask. This decides whether to
     /// open a fetch and whether a delivery completed one. [Self::retire] carries
     /// the same rule to the resolver, one piece of evidence at a time.
     ///
@@ -407,7 +407,7 @@ impl<
     /// evidence the actor records, but not what was asked for.
     fn settled(&self, view: View, kind: Kind) -> bool {
         // Finalization rules out any further need for the view. This is also
-        // what settles a demand answered by a finalization, since recording one
+        // what settles an ask answered by a finalization, since recording one
         // raises [Self::last_finalized].
         if view <= self.last_finalized {
             return true;
@@ -472,7 +472,7 @@ impl<
     /// named. Any certificate an honest peer could serve for the view is accepted,
     /// including one that answers the other kind: rejecting it would fault a peer
     /// that answered the only question the wire key asked. Whether it
-    /// settles the demand is a separate check (see [Self::settled]).
+    /// settles the ask is a separate check (see [Self::settled]).
     fn validate(&mut self, view: View, data: Bytes) -> Option<Certificate<S, D>> {
         let incoming =
             Certificate::<S, D>::decode_cfg(data, &self.scheme.certificate_codec_config()).ok()?;
@@ -523,7 +523,7 @@ impl<
     }
 
     /// Handles a message from the [p2p::Engine].
-    fn handle_resolver<R: Resolver<Key = U64, Subscriber = Demand>>(
+    fn handle_resolver<R: Resolver<Key = U64, Subscriber = Ask>>(
         &mut self,
         message: HandlerMessage,
         voter: &mut voter::Mailbox<S, D>,
@@ -534,7 +534,7 @@ impl<
                 span,
                 view,
                 data,
-                demands,
+                asks,
                 response,
             } => {
                 let span = info_span!(
@@ -557,7 +557,7 @@ impl<
                 };
 
                 // A failed notarization remains valid protocol evidence, but
-                // replaying it cannot satisfy any outstanding repair demand.
+                // replaying it cannot satisfy any outstanding repair ask.
                 let obsolete = matches!(
                     &parsed,
                     Certificate::Notarization(notarization)
@@ -573,16 +573,16 @@ impl<
                     );
                     resolved.in_scope(|| voter.resolved(parsed.clone()));
 
-                    // Record the certificate, which settles whichever demands it
+                    // Record the certificate, which settles whichever asks it
                     // answered and retires their fetches.
                     self.updated(resolver, parsed);
                 }
 
                 // The peer answered the view it was asked about, so it is never
-                // faulted here. If a demand for this view is still open, the
+                // faulted here. If an ask for this view is still open, the
                 // response was valid but ambiguous, and the resolver retries
                 // without penalizing the peer.
-                let outcome = if demands.iter().all(|demand| self.settled(view, demand.kind)) {
+                let outcome = if asks.iter().all(|ask| self.settled(view, ask.kind)) {
                     Outcome::Complete
                 } else {
                     Outcome::Ambiguous
@@ -652,8 +652,8 @@ mod tests {
     /// Tracks the set of pending requests the way the resolver engine would.
     #[derive(Clone, Default)]
     struct RecordingResolver {
-        outstanding: Arc<Mutex<BTreeSet<(U64, Demand)>>>,
-        targeted: Arc<Mutex<Vec<(U64, Demand, PublicKey)>>>,
+        outstanding: Arc<Mutex<BTreeSet<(U64, Ask)>>>,
+        targeted: Arc<Mutex<Vec<(U64, Ask, PublicKey)>>>,
     }
 
     impl RecordingResolver {
@@ -667,7 +667,7 @@ mod tests {
                 .collect()
         }
 
-        fn targeted(&self) -> Vec<(u64, Demand, PublicKey)> {
+        fn targeted(&self) -> Vec<(u64, Ask, PublicKey)> {
             self.targeted
                 .lock()
                 .iter()
@@ -675,7 +675,7 @@ mod tests {
                 .collect()
         }
 
-        fn subscriptions(&self, view: u64) -> Vec<Demand> {
+        fn subscriptions(&self, view: u64) -> Vec<Ask> {
             self.outstanding
                 .lock()
                 .iter()
@@ -686,11 +686,11 @@ mod tests {
 
     impl Resolver for RecordingResolver {
         type Key = U64;
-        type Subscriber = Demand;
+        type Subscriber = Ask;
 
         fn fetch<F>(&mut self, key: F) -> Feedback
         where
-            F: Into<Fetch<U64, Demand>> + Send,
+            F: Into<Fetch<U64, Ask>> + Send,
         {
             let fetch = key.into();
             self.outstanding
@@ -701,7 +701,7 @@ mod tests {
 
         fn fetch_all<F>(&mut self, keys: Vec<F>) -> Feedback
         where
-            F: Into<Fetch<U64, Demand>> + Send,
+            F: Into<Fetch<U64, Ask>> + Send,
         {
             for key in keys {
                 self.fetch(key);
@@ -709,10 +709,7 @@ mod tests {
             Feedback::Ok
         }
 
-        fn retain(
-            &mut self,
-            predicate: impl Fn(&U64, &Demand) -> bool + Send + 'static,
-        ) -> Feedback {
+        fn retain(&mut self, predicate: impl Fn(&U64, &Ask) -> bool + Send + 'static) -> Feedback {
             self.outstanding
                 .lock()
                 .retain(|(key, subscription)| predicate(key, subscription));
@@ -725,7 +722,7 @@ mod tests {
 
         fn fetch_targeted(
             &mut self,
-            fetch: impl Into<Fetch<U64, Demand>> + Send,
+            fetch: impl Into<Fetch<U64, Ask>> + Send,
             targets: NonEmptyVec<PublicKey>,
         ) -> Feedback {
             let fetch = fetch.into();
@@ -742,7 +739,7 @@ mod tests {
 
         fn fetch_all_targeted<F>(&mut self, fetches: Vec<(F, NonEmptyVec<PublicKey>)>) -> Feedback
         where
-            F: Into<Fetch<U64, Demand>> + Send,
+            F: Into<Fetch<U64, Ask>> + Send,
         {
             for (fetch, targets) in fetches {
                 self.fetch_targeted(fetch, targets);
@@ -883,7 +880,7 @@ mod tests {
             responder_mailbox.updated(Certificate::Nullification(available.clone()));
             context.sleep(Duration::from_millis(10)).await;
 
-            // Advancing to view 2 creates unrestricted background demand for
+            // Advancing to view 2 creates an unrestricted background ask for
             // view 1. The only connected peer is the silent target, so seeing
             // its request proves the background fetch is already in flight.
             requester_mailbox.updated(Certificate::Nullification(build_nullification(
@@ -900,7 +897,7 @@ mod tests {
             };
             assert_eq!(requester_key, participants[0]);
 
-            // Add targeted ancestry demand for the same key and silent peer.
+            // Add a targeted ancestry ask for the same key and silent peer.
             // It must attach a subscriber without narrowing the in-flight
             // unrestricted fetch.
             requester_mailbox.resolve(
@@ -912,7 +909,7 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
 
             // Remove the silent target and expose a different responder. If
-            // the targeted demand narrowed the fetch, recovery cannot finish.
+            // the targeted ask narrowed the fetch, recovery cannot finish.
             oracle
                 .remove_link(participants[0].clone(), participants[1].clone())
                 .await
@@ -1237,7 +1234,7 @@ mod tests {
             );
             resolver.fetch(Fetch {
                 key: U64::from(requested),
-                subscriber: Demand::backfill(),
+                subscriber: Ask::backfill(),
                 span: tracing::Span::none(),
             });
             assert_eq!(
@@ -1245,12 +1242,12 @@ mod tests {
                 vec![
                     (
                         3,
-                        Demand::ancestry(Kind::Nullification),
+                        Ask::ancestry(Kind::Nullification),
                         participants[0].clone()
                     ),
                     (
                         3,
-                        Demand::ancestry(Kind::Notarization),
+                        Ask::ancestry(Kind::Notarization),
                         participants[1].clone()
                     ),
                 ]
@@ -1258,9 +1255,9 @@ mod tests {
             assert_eq!(
                 resolver.subscriptions(3),
                 vec![
-                    Demand::backfill(),
-                    Demand::ancestry(Kind::Nullification),
-                    Demand::ancestry(Kind::Notarization),
+                    Ask::backfill(),
+                    Ask::ancestry(Kind::Nullification),
+                    Ask::ancestry(Kind::Notarization),
                 ]
             );
 
@@ -1276,7 +1273,7 @@ mod tests {
             );
             assert_eq!(
                 resolver.subscriptions(3),
-                vec![Demand::ancestry(Kind::Notarization)]
+                vec![Ask::ancestry(Kind::Notarization)]
             );
             actor.resolve(
                 &mut resolver,
@@ -1314,7 +1311,7 @@ mod tests {
             );
             resolver.fetch(Fetch {
                 key: U64::from(second_requested),
-                subscriber: Demand::backfill(),
+                subscriber: Ask::backfill(),
                 span: tracing::Span::none(),
             });
             actor.updated(
@@ -1329,11 +1326,11 @@ mod tests {
             actor.certified(&mut resolver, second_requested, true);
 
             // The certified notarization is now the floor, which satisfies
-            // background repair at that view. Targeted nullification demand
+            // background repair at that view. The targeted nullification ask
             // survives: a notarization is not a nullification covering it.
             assert_eq!(
                 resolver.subscriptions(6),
-                vec![Demand::ancestry(Kind::Nullification)]
+                vec![Ask::ancestry(Kind::Nullification)]
             );
             actor.resolve(
                 &mut resolver,
@@ -1477,12 +1474,12 @@ mod tests {
             );
             assert_eq!(
                 resolver.subscriptions(3),
-                vec![Demand::ancestry(Kind::Nullification)]
+                vec![Ask::ancestry(Kind::Nullification)]
             );
 
             // Certificate state still prefers the certified floor for
             // background bookkeeping, but locally observing the nullification
-            // must retire the exact targeted demand it satisfies.
+            // must retire the exact targeted ask it satisfies.
             actor.updated(
                 &mut resolver,
                 Certificate::Nullification(build_nullification(
@@ -1535,7 +1532,7 @@ mod tests {
                 resolver.targeted(),
                 vec![(
                     4,
-                    Demand::ancestry(Kind::Notarization),
+                    Ask::ancestry(Kind::Notarization),
                     participants[0].clone()
                 )]
             );
@@ -1572,7 +1569,7 @@ mod tests {
             // A false certification verdict is permanent. Parent repair is
             // retired, while ordinary repair asks for the nullification that
             // can now cover the failed view.
-            assert_eq!(resolver.subscriptions(5), vec![Demand::backfill()]);
+            assert_eq!(resolver.subscriptions(5), vec![Ask::backfill()]);
             actor.resolve(
                 &mut resolver,
                 View::new(11),
@@ -1609,7 +1606,7 @@ mod tests {
                         build_notarization(&schemes, &verifier, EPOCH, view),
                     )
                     .encode(),
-                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1641,7 +1638,7 @@ mod tests {
             actor.certified(&mut resolver, view, false);
 
             // The payload is no longer an answer, and the tombstone keeps a
-            // delayed request from recreating demand. A floor raise above the
+            // delayed request from recreating the ask. A floor raise above the
             // view must not resurrect it (state prunes its own failed views).
             assert!(!actor.notarization_responses.contains_key(&view));
             let floor = View::new(9);
@@ -1686,7 +1683,7 @@ mod tests {
                     view: View::new(4),
                     data: Certificate::<TestScheme, Sha256Digest>::Nullification(nullification)
                         .encode(),
-                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1723,7 +1720,7 @@ mod tests {
                     view: requested,
                     data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
                         .encode(),
-                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1774,7 +1771,7 @@ mod tests {
                     span: tracing::Span::none(),
                     view,
                     data: Certificate::<TestScheme, Sha256Digest>::Notarization(alternate).encode(),
-                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1806,10 +1803,10 @@ mod tests {
                         build_finalization(&schemes, &verifier, EPOCH, View::new(6)),
                     )
                     .encode(),
-                    demands: non_empty_vec![
-                        Demand::backfill(),
-                        Demand::ancestry(Kind::Nullification),
-                        Demand::ancestry(Kind::Notarization),
+                    asks: non_empty_vec![
+                        Ask::backfill(),
+                        Ask::ancestry(Kind::Nullification),
+                        Ask::ancestry(Kind::Notarization),
                     ],
                     response,
                 },

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -364,7 +364,7 @@ impl<
         // Every reported gap sits above the floor, and a cached nullification
         // covering a view above the floor is also stored in [State], so a
         // reported gap is never settled.
-        debug_assert!(!self.settled(view, ask.kind));
+        assert!(!self.settled(view, ask.kind));
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
@@ -457,10 +457,11 @@ impl<
     /// Selects a certificate to serve for `view`.
     ///
     /// The request does not say which certificate it wants, so when both a
-    /// notarization and a covering nullification are held either may be the one
-    /// the requester needs. The choice is random: a fixed preference
+    /// certified notarization and a covering nullification are held either may
+    /// be the one the requester needs. The choice is random: a fixed preference
     /// would answer every retry from a requester wanting the other
-    /// kind with the same useless certificate.
+    /// kind with the same useless certificate. A notarization awaiting its
+    /// verdict is never served.
     fn produce_certificate(&mut self, view: View) -> Option<Bytes> {
         // A finalization settles either kind, so weaker evidence would only
         // delay the requester.
@@ -1488,6 +1489,42 @@ mod tests {
     }
 
     #[test_async]
+    async fn late_verdict_after_finalization_promotes_nothing() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let mut actor = build_actor(context, verifier.clone());
+            let mut resolver = RecordingResolver::default();
+            let view = View::new(5);
+
+            actor.updated(
+                &mut resolver,
+                Certificate::Notarization(build_notarization(&schemes, &verifier, EPOCH, view)),
+            );
+            assert!(actor.uncertified_notarizations.contains_key(&view));
+
+            // A covering finalization prunes the payload awaiting its verdict.
+            actor.updated(
+                &mut resolver,
+                Certificate::Finalization(build_finalization(
+                    &schemes,
+                    &verifier,
+                    EPOCH,
+                    view.next(),
+                )),
+            );
+            assert!(actor.uncertified_notarizations.is_empty());
+
+            // The late verdict finds nothing to promote: a notarization at or
+            // below finalization never becomes servable.
+            actor.certified(&mut resolver, view, true);
+            assert!(actor.notarization_responses.is_empty());
+        });
+    }
+
+    #[test_async]
     async fn nullification_satisfies_target_at_certified_floor() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
@@ -1891,6 +1928,10 @@ mod tests {
                 &mut resolver,
             );
             assert_eq!(receiver.await.unwrap(), Outcome::Complete);
+
+            // The duplicate is not re-cached as uncertified: no second verdict
+            // would ever clear it.
+            assert!(actor.uncertified_notarizations.is_empty());
         });
     }
 

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -1205,7 +1205,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn targeted_fetches_drop_only_when_demand_is_satisfied() {
+    async fn targeted_fetches_drop_only_when_ask_is_satisfied() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
@@ -1618,7 +1618,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn failed_certification_retires_parent_demand_until_finalization() {
+    async fn failed_certification_retires_parent_ask_until_finalization() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
@@ -1782,7 +1782,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn finalization_completes_every_delivery_demand() {
+    async fn finalization_completes_every_delivery_ask() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -83,12 +83,9 @@ pub struct Actor<
 
     /// Certificates still wanted from peers, paired with what retires each.
     ///
-    /// This mirrors the resolver's outstanding fetches. Whether a demand still
-    /// needs fetching is decided by [Self::settled], which reads local evidence
-    /// and so needs `&self`, while [Resolver::retain] takes a `'static`
-    /// predicate. Owning the demands here keeps that decision in one place and
-    /// lets the survivors be snapshotted into the predicate (see
-    /// [Self::sync_demands]).
+    /// This mirrors the resolver's outstanding fetches. Owning them here keeps
+    /// retirement in one place: [Self::settled] decides it from local evidence,
+    /// and [Self::sync_demands] publishes the survivors to the resolver.
     demands: BTreeSet<(View, Demand)>,
 
     mailbox_receiver: mailbox::Receiver<MailboxMessage<S, D>>,
@@ -324,15 +321,13 @@ impl<
     /// [Self::settled] directly, which is why the survivors are snapshotted into
     /// it.
     fn sync_demands<R: Resolver<Key = U64, Subscriber = Demand>>(&mut self, resolver: &mut R) {
-        let settled: Vec<_> = self
+        let live: BTreeSet<_> = self
             .demands
             .iter()
             .copied()
-            .filter(|(view, demand)| self.settled(*view, demand.kind))
+            .filter(|(view, demand)| !self.settled(*view, demand.kind))
             .collect();
-        self.demands.retain(|entry| !settled.contains(entry));
-
-        let live = self.demands.clone();
+        self.demands = live.clone();
         let _ = resolver
             .retain(move |key, demand| live.contains(&(View::new(u64::from(key)), *demand)));
     }
@@ -444,8 +439,8 @@ impl<
     ///
     /// The request does not say which certificate it wants, so when both a
     /// notarization and a covering nullification are held either may be the one
-    /// the requester needs. The choice is random rather than fixed: a fixed
-    /// preference would answer every retry from a requester wanting the other
+    /// the requester needs. The choice is random: a fixed preference
+    /// would answer every retry from a requester wanting the other
     /// kind with the same useless certificate.
     fn produce_certificate(&mut self, view: View) -> Option<Bytes> {
         // A finalization settles either kind, so weaker evidence would only
@@ -476,7 +471,7 @@ impl<
     /// Validity is judged against `view` alone, because that is all the request
     /// named. Any certificate an honest peer could serve for the view is accepted,
     /// including one that answers the other kind: rejecting it would fault a peer
-    /// that answered the only question the wire key actually asked. Whether it
+    /// that answered the only question the wire key asked. Whether it
     /// settles the demand is a separate judgement (see [Self::settled]).
     fn validate(&mut self, view: View, data: Bytes) -> Option<Certificate<S, D>> {
         let incoming =

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -947,10 +947,10 @@ mod tests {
         });
     }
 
-    /// A valid notarization with pending certification does not prevent a
+    /// A valid notarization that does not settle the ask does not prevent a
     /// different peer from supplying the requested nullification.
     #[test_async]
-    async fn pending_certification_does_not_block_nullification_fetch() {
+    async fn ambiguous_notarization_does_not_block_nullification_fetch() {
         let runtime = deterministic::Runner::timed(Duration::from_secs(10));
         runtime.start(|mut context| async move {
             let Fixture {
@@ -1076,8 +1076,8 @@ mod tests {
             let notarized = requested.next();
             let notarization = build_notarization(&schemes, &verifier, EPOCH, notarized);
             first_responder_mailbox.updated(Certificate::Notarization(notarization.clone()));
-            // Model the Byzantine peer as willing to serve this notarization.
-            // Honest certification at the requester may still reject it.
+            // Certifying the notarization makes it the responder's floor, so
+            // the responder answers a lower-view request with it.
             first_responder_mailbox.certified(notarization.round(), true);
             let nullification = build_nullification(&schemes, &verifier, EPOCH, requested);
             nullification_holder_mailbox.updated(Certificate::Nullification(nullification.clone()));
@@ -1085,7 +1085,7 @@ mod tests {
 
             // A later nullification exposes a gap and starts an unrestricted
             // background fetch. The only connected peer answers with a valid
-            // notarization, whose resolver verdict waits for certification.
+            // notarization that does not settle the nullification ask.
             requester_mailbox.updated(Certificate::Nullification(build_nullification(
                 &schemes, &verifier, EPOCH, notarized,
             )));
@@ -1127,10 +1127,10 @@ mod tests {
                 .unwrap();
             context.sleep(Duration::from_millis(10)).await;
 
-            // A proposal objection for the same view attaches another
-            // subscriber. Certification remains pending, but the valid
-            // notarization must release the network slot so another peer can
-            // supply the nullification that this proposal actually needs.
+            // A targeted ancestry ask for the same view attaches another
+            // subscriber. The ambiguous notarization answer released the
+            // network slot, so another peer can supply the nullification
+            // this proposal actually needs.
             requester_mailbox.resolve(
                 View::new(3),
                 requested,
@@ -1142,7 +1142,7 @@ mod tests {
                     message.expect("voter mailbox closed")
                 },
                 _ = context.sleep(Duration::from_secs(2)) => {
-                    panic!("pending certification blocked ancestry repair");
+                    panic!("ambiguous notarization answer blocked ancestry repair");
                 },
             };
             assert!(matches!(
@@ -1657,6 +1657,61 @@ mod tests {
                 participants[0].clone(),
             );
             assert_eq!(resolver.targeted().len(), targeted);
+        });
+    }
+
+    #[test_async]
+    async fn tombstoned_notarization_delivery_completes_without_recording() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let (voter_tx, mut voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
+            let mut voter = voter::Mailbox::new(voter_tx);
+            let mut actor = build_actor(context, verifier.clone());
+            let mut resolver = RecordingResolver::default();
+            let view = View::new(6);
+
+            let notarization = build_notarization(&schemes, &verifier, EPOCH, view);
+            actor.updated(
+                &mut resolver,
+                Certificate::Notarization(notarization.clone()),
+            );
+            actor.certified(&mut resolver, view, false);
+
+            // Replaying the failed notarization is not new evidence: the voter
+            // is not re-notified and the payload is not re-cached. The failed
+            // verdict settles the ask, so the fetch still completes.
+            let (response, receiver) = oneshot::channel();
+            actor.handle_resolver(
+                HandlerMessage::Deliver {
+                    span: tracing::Span::none(),
+                    view,
+                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
+                        .encode(),
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
+                    response,
+                },
+                &mut voter,
+                &mut resolver,
+            );
+            assert_eq!(receiver.await.unwrap(), Outcome::Complete);
+            assert!(!actor.notarization_responses.contains_key(&view));
+            drop(voter);
+            assert!(voter_rx.recv().await.is_none());
+
+            // Finalization is the tombstone's retirement boundary.
+            actor.updated(
+                &mut resolver,
+                Certificate::Finalization(build_finalization(
+                    &schemes,
+                    &verifier,
+                    EPOCH,
+                    view.next(),
+                )),
+            );
+            assert!(actor.failed_certifications.is_empty());
         });
     }
 

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -26,101 +26,19 @@ use commonware_runtime::{
     telemetry::traces::TracedExt as _,
 };
 use commonware_utils::{
-    channel::{fallible::OneshotExt, oneshot},
-    futures::Pool,
+    channel::fallible::OneshotExt,
     ordered::Quorum,
     sequence::U64,
     vec::NonEmptyVec,
 };
 use rand::RngExt as _;
 use rand_core::CryptoRng;
-use std::{collections::BTreeMap, future::Future, num::NonZeroUsize, time::Duration};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroUsize,
+    time::Duration,
+};
 use tracing::{debug, info_span};
-
-/// A valid delivery waiting for local certification to determine whether it
-/// satisfies every attached purpose.
-struct PendingDelivery {
-    id: u64,
-    requested: View,
-    certification: View,
-    purposes: NonEmptyVec<Purpose>,
-    response: oneshot::Sender<Outcome>,
-}
-
-/// Owns deferred deliveries and their independent certification deadlines.
-///
-/// Timeout futures intentionally run to completion after a delivery resolves
-/// because some clocks retain registered alarms until their deadline. Removing
-/// the future would leave those alarms without a task to wake.
-#[derive(Default)]
-struct PendingDeliveries {
-    entries: Vec<PendingDelivery>,
-    timeouts: Pool<u64>,
-    next_id: u64,
-}
-
-impl PendingDeliveries {
-    /// Registers a delivery and its timeout under a never-reused ID.
-    ///
-    /// A timeout may complete after its delivery resolves. Never reusing IDs
-    /// prevents that stale completion from removing a newer delivery.
-    fn push(
-        &mut self,
-        requested: View,
-        certification: View,
-        purposes: NonEmptyVec<Purpose>,
-        response: oneshot::Sender<Outcome>,
-        timeout: impl Future<Output = ()> + Send + 'static,
-    ) {
-        let id = self.next_id;
-        self.next_id = self
-            .next_id
-            .checked_add(1)
-            .expect("pending delivery ID overflow");
-        self.timeouts.push(async move {
-            timeout.await;
-            id
-        });
-        self.entries.push(PendingDelivery {
-            id,
-            requested,
-            certification,
-            purposes,
-            response,
-        });
-    }
-
-    /// Removes the delivery associated with an expired timeout.
-    ///
-    /// Returns `None` when the delivery resolved before its timeout completed.
-    fn remove(&mut self, id: u64) -> Option<PendingDelivery> {
-        let index = self.entries.iter().position(|delivery| delivery.id == id)?;
-        Some(self.entries.swap_remove(index))
-    }
-
-    /// Drains active deliveries while reserving capacity to requeue unresolved ones.
-    fn take(&mut self) -> Vec<PendingDelivery> {
-        let entries = std::mem::take(&mut self.entries);
-        self.entries.reserve(entries.len());
-        entries
-    }
-
-    /// Requeues an unresolved delivery without replacing or extending its timeout.
-    fn requeue(&mut self, delivery: PendingDelivery) {
-        self.entries.push(delivery);
-    }
-
-    /// Waits for the next timeout and returns its associated delivery ID.
-    fn next_completed(&mut self) -> impl Future<Output = u64> + '_ {
-        self.timeouts.next_completed()
-    }
-
-    /// Returns all live timeout futures, including those for resolved deliveries.
-    #[cfg(test)]
-    fn timeout_count(&self) -> usize {
-        self.timeouts.len()
-    }
-}
 
 /// Requests are made concurrently to multiple peers.
 pub struct Actor<
@@ -138,7 +56,6 @@ pub struct Actor<
     epoch: Epoch,
     mailbox_size: NonZeroUsize,
     fetch_timeout: Duration,
-    certification_timeout: Duration,
 
     /// Certificates known between the floor and the current view. Serves
     /// [HandlerMessage::Produce] requests and emits the [Effect]s the actor
@@ -154,17 +71,18 @@ pub struct Actor<
     /// finalization so kindless retries survive later floor raises.
     nullification_responses: BTreeMap<View, Bytes>,
 
-    /// Successfully certified notarizations cached in the encoded form
-    /// expected by [p2p::Producer]. These response payloads are not certificate
-    /// identities and remain available until finalization so exact parents
-    /// survive later floor raises.
+    /// Notarizations cached in the encoded form expected by [p2p::Producer].
+    /// These response payloads remain available until finalization so exact
+    /// parents survive later floor raises. A view whose certification fails is
+    /// removed: no copy of that notarization can certify anywhere.
     notarization_responses: BTreeMap<View, Bytes>,
 
-    /// Terminal certification outcomes retained until covering finalization.
-    certification_outcomes: BTreeMap<View, bool>,
-
-    /// Deliveries independently waiting for bounded local certification.
-    pending: PendingDeliveries,
+    /// Views whose certification failed, retained until covering finalization.
+    ///
+    /// This is the sole record of a failed verdict. [State] prunes at the floor,
+    /// which rises above a failed view while a delayed request for it can still
+    /// arrive, so the tombstone is kept here against the finalization boundary.
+    failed_certifications: BTreeSet<View>,
 
     mailbox_receiver: mailbox::Receiver<MailboxMessage<S, D>>,
 }
@@ -189,14 +107,12 @@ impl<
                 epoch: cfg.epoch,
                 mailbox_size: cfg.mailbox_size,
                 fetch_timeout: cfg.fetch_timeout,
-                certification_timeout: cfg.certification_timeout,
 
                 state: State::new(cfg.fetch_concurrent, cfg.term_length),
                 last_finalized: View::zero(),
                 nullification_responses: BTreeMap::new(),
                 notarization_responses: BTreeMap::new(),
-                certification_outcomes: BTreeMap::new(),
-                pending: PendingDeliveries::default(),
+                failed_certifications: BTreeSet::new(),
 
                 mailbox_receiver: receiver,
             },
@@ -256,9 +172,6 @@ impl<
             _ = &mut resolver_task => {
                 break;
             },
-            delivery = self.pending.next_completed() => {
-                self.expire_pending_delivery(delivery);
-            },
             Some(message) = self.mailbox_receiver.recv() else break => {
                 let span = info_span!(
                     parent: message.span(),
@@ -272,18 +185,8 @@ impl<
                     MailboxMessage::Certificate { certificate, .. } => {
                         self.updated(&mut resolver, certificate);
                     }
-                    MailboxMessage::Certified {
-                        round,
-                        encoded_notarization,
-                        success,
-                        ..
-                    } => {
-                        self.certified_notarization(
-                            &mut resolver,
-                            round.view(),
-                            encoded_notarization,
-                            success,
-                        );
+                    MailboxMessage::Certified { round, success, .. } => {
+                        self.certified(&mut resolver, round.view(), success);
                     }
                     MailboxMessage::Resolve {
                         proposal_view,
@@ -305,110 +208,16 @@ impl<
         }
     }
 
-    /// Releases a delivery whose bounded certification wait has elapsed.
-    fn expire_pending_delivery(&mut self, id: u64) {
-        // A response may resolve before its sleeper. The sleeper is retained
-        // to keep the runtime alarm live, so a missing delivery is expected.
-        let Some(delivery) = self.pending.remove(id) else {
-            return;
-        };
-        if delivery.response.is_closed() {
-            return;
-        }
-
-        // Re-check all purposes at the deadline because certificates handled
-        // after deferral may have completed the delivery. Otherwise the valid
-        // response is ambiguous and must remain eligible for resolver retry.
-        let outcome = if delivery
-            .purposes
-            .iter()
-            .all(|purpose| self.purpose_satisfied(delivery.requested, *purpose))
-        {
-            Outcome::Complete
-        } else {
-            Outcome::Ambiguous
-        };
-        delivery.response.send_lossy(outcome);
-    }
-
-    /// Re-evaluates deliveries after resolver state changes. A terminal
-    /// certification result releases deliveries that were waiting on that
-    /// exact certification even when another purpose remains unresolved.
-    fn resolve_pending_deliveries(&mut self, certified: Option<View>) {
-        for delivery in self.pending.take() {
-            // Closed consumers need no verdict. Their sleepers still run to
-            // completion so registered runtime alarms remain well-formed.
-            if delivery.response.is_closed() {
-                continue;
-            }
-
-            let resolved = delivery
-                .purposes
-                .iter()
-                .all(|purpose| self.purpose_satisfied(delivery.requested, *purpose));
-
-            // Complete only when every subscriber purpose is satisfied. A
-            // terminal verdict for the exact certification makes any still-
-            // unresolved purpose ambiguous rather than worth waiting longer.
-            if resolved {
-                delivery.response.send_lossy(Outcome::Complete);
-            } else if certified == Some(delivery.certification) {
-                delivery.response.send_lossy(Outcome::Ambiguous);
-            } else {
-                self.pending.requeue(delivery);
-            }
-        }
-    }
-
-    /// Returns whether successful certification of `certification` could
-    /// satisfy every purpose that is not already resolved.
-    fn certification_could_complete(
-        &self,
-        requested: View,
-        certification: View,
-        purposes: &NonEmptyVec<Purpose>,
-    ) -> bool {
-        // Certification can satisfy any backfill subscriber, but a parent
-        // subscriber requires this exact view. A notarization can never
-        // satisfy a nullification subscriber.
-        !self.certification_outcomes.contains_key(&certification)
-            && purposes.iter().all(|purpose| {
-                self.purpose_satisfied(requested, *purpose)
-                    || match purpose {
-                        Purpose::Backfill => true,
-                        Purpose::Parent => requested == certification,
-                        Purpose::Nullification => false,
-                    }
-            })
-    }
-
-    /// Holds one delivery without blocking the actor while local
-    /// certification remains capable of satisfying it.
-    fn defer_delivery(
-        &mut self,
-        requested: View,
-        certification: View,
-        purposes: NonEmptyVec<Purpose>,
-        response: oneshot::Sender<Outcome>,
-    ) {
-        // Awaiting this sleep here would block unrelated resolver work. The
-        // persistent pool gives each delivery one fixed deadline while the
-        // actor continues processing certificates and certification verdicts.
-        let timeout = self.context.sleep(self.certification_timeout);
-        self.pending
-            .push(requested, certification, purposes, response, timeout);
-    }
-
     /// Records a certificate and applies its resolver lifecycle effects.
     fn updated<R: Resolver<Key = U64, Subscriber = Purpose>>(
         &mut self,
         resolver: &mut R,
         certificate: Certificate<S, D>,
     ) {
-        let (finalized, nullified) = match &certificate {
-            Certificate::Finalization(finalization) => (Some(finalization.view()), None),
-            Certificate::Nullification(nullification) => (None, Some(nullification.view())),
-            Certificate::Notarization(_) => (None, None),
+        let (finalized, nullified, notarized) = match &certificate {
+            Certificate::Finalization(finalization) => (Some(finalization.view()), None, None),
+            Certificate::Nullification(nullification) => (None, Some(nullification.view()), None),
+            Certificate::Notarization(notarization) => (None, None, Some(notarization.view())),
         };
 
         // A nullification retires background and targeted nullification demand across the rest of
@@ -421,6 +230,19 @@ impl<
                     .insert(nullified, certificate.encode());
             }
             self.retire(resolver, Purpose::Nullification, nullified, term_end);
+        }
+
+        // Holding a notarization is what an exact-parent request asks for, so
+        // retain it as a response payload independently of whether it later
+        // certifies locally. State pruning would otherwise drop it once a
+        // higher floor is set, hiding it from a peer still repairing that view.
+        if let Some(notarized) = notarized
+            && notarized > self.last_finalized
+            && !self.failed_certifications.contains(&notarized)
+        {
+            self.notarization_responses
+                .insert(notarized, certificate.encode());
+            self.retire(resolver, Purpose::Parent, notarized, notarized);
         }
 
         // Certificate state owns floor selection and background repair.
@@ -436,27 +258,11 @@ impl<
                 .retain(|view, _| view.term_end(term_length) > self.last_finalized);
             self.notarization_responses
                 .retain(|view, _| *view > self.last_finalized);
-            self.certification_outcomes
-                .retain(|view, _| *view > self.last_finalized);
+            self.failed_certifications
+                .retain(|view| *view > self.last_finalized);
             let floor = U64::from(self.last_finalized);
             let _ = resolver.retain(move |candidate, _| *candidate > floor);
         }
-        self.resolve_pending_deliveries(None);
-    }
-
-    /// Retains a successful exact parent before applying its certification outcome.
-    fn certified_notarization<R: Resolver<Key = U64, Subscriber = Purpose>>(
-        &mut self,
-        resolver: &mut R,
-        view: View,
-        encoded_notarization: Bytes,
-        success: bool,
-    ) {
-        if success && view > self.last_finalized {
-            self.notarization_responses
-                .insert(view, encoded_notarization);
-        }
-        self.certified(resolver, view, success);
     }
 
     /// Handles a certification outcome from the voter.
@@ -466,23 +272,23 @@ impl<
         view: View,
         success: bool,
     ) {
-        // A terminal outcome is a tombstone for delayed targeted work. Views
-        // covered by finalization need no tombstone because finalization is the
-        // global retirement boundary.
-        if view > self.last_finalized {
-            self.certification_outcomes.insert(view, success);
-            if !success {
-                self.notarization_responses.remove(&view);
+        // No copy of an uncertifiable notarization can certify anywhere, so it
+        // is not an answer to an exact-parent request.
+        if !success {
+            self.notarization_responses.remove(&view);
+            if view > self.last_finalized {
+                self.failed_certifications.insert(view);
             }
         }
 
-        // Exact parent demand is terminal regardless of the verdict. Apply
-        // state effects before releasing deliveries so success can advance the
-        // floor and failure can schedule nullification repair first.
+        // A verdict is terminal for exact-parent demand either way: success
+        // means the notarization is in hand, and failure means no copy of it
+        // can ever answer. Possession already retired this demand on arrival;
+        // repeating it here also covers a verdict for a view whose
+        // notarization state was pruned.
         self.retire(resolver, Purpose::Parent, view, view);
         let effects = self.state.handle_certified(view, success);
         self.apply_effects(resolver, effects);
-        self.resolve_pending_deliveries(Some(view));
     }
 
     /// Applies the side effects requested by [super::state::State] to the resolver.
@@ -589,10 +395,15 @@ impl<
     /// prevents an older queued request from resurrecting retired work.
     fn purpose_resolved(&self, view: View, purpose: Purpose) -> bool {
         self.purpose_satisfied(view, purpose)
-            || matches!(purpose, Purpose::Parent) && self.certification_outcomes.contains_key(&view)
+            || matches!(purpose, Purpose::Parent) && self.failed_certifications.contains(&view)
     }
 
     /// Returns whether local evidence satisfies a delivered subscriber.
+    ///
+    /// An exact-parent subscriber is satisfied by holding the notarization, not
+    /// by certifying it. Certification is an application verdict on evidence
+    /// already in hand, so waiting for it here would keep a fetch open with
+    /// nothing left to fetch.
     fn purpose_satisfied(&self, view: View, purpose: Purpose) -> bool {
         if view <= self.last_finalized {
             return true;
@@ -603,7 +414,7 @@ impl<
                 .range(view.covering_range(self.state.term_length()))
                 .next_back()
                 .is_some(),
-            Purpose::Parent => self.certification_outcomes.get(&view) == Some(&true),
+            Purpose::Parent => self.notarization_responses.contains_key(&view),
             Purpose::Backfill => self.state.get(view).is_some(),
         }
     }
@@ -614,9 +425,7 @@ impl<
     /// retry. Otherwise a newer floor can permanently hide the exact parent or
     /// covering nullification requested from a proposal leader.
     fn produce_certificate(&mut self, view: View) -> Option<Bytes> {
-        let exact_parent = (self.certification_outcomes.get(&view) == Some(&true))
-            .then(|| self.notarization_responses.get(&view))
-            .flatten();
+        let exact_parent = self.notarization_responses.get(&view);
         let covering_nullification = self
             .nullification_responses
             .range(view.covering_range(self.state.term_length()))
@@ -760,16 +569,8 @@ impl<
                 let obsolete = matches!(
                     &parsed,
                     Certificate::Notarization(notarization)
-                        if self.state.is_failed(notarization.view())
-                            || self.certification_outcomes.get(&notarization.view())
-                                == Some(&false)
+                        if self.failed_certifications.contains(&notarization.view())
                 );
-                let certification = match &parsed {
-                    Certificate::Notarization(notarization) if !obsolete => {
-                        Some(notarization.view())
-                    }
-                    _ => None,
-                };
                 if !obsolete {
                     // Notify voter as soon as possible.
                     let resolved = info_span!(
@@ -785,22 +586,19 @@ impl<
                     self.updated(resolver, parsed);
                 }
 
-                if purposes
+                // Every purpose is decided by evidence now in hand, so the
+                // outcome is immediate: either this response answered what was
+                // asked, or the kindless key admitted a different certificate
+                // and the resolver retries without faulting the peer.
+                let outcome = if purposes
                     .iter()
                     .all(|purpose| self.purpose_satisfied(view, *purpose))
                 {
-                    response.send_lossy(Outcome::Complete);
-                    return;
-                }
-
-                if let Some(certification) = certification
-                    && self.certification_could_complete(view, certification, &purposes)
-                {
-                    self.defer_delivery(view, certification, purposes, response);
-                    return;
-                }
-
-                response.send_lossy(Outcome::Ambiguous);
+                    Outcome::Complete
+                } else {
+                    Outcome::Ambiguous
+                };
+                response.send_lossy(outcome);
             }
             HandlerMessage::Produce { view, response } => {
                 let span = info_span!(
@@ -983,7 +781,6 @@ mod tests {
                 mailbox_size: NZUsize!(8),
                 fetch_concurrent: NZUsize!(4),
                 fetch_timeout: Duration::from_secs(1),
-                certification_timeout: Duration::from_secs(1),
                 term_length,
             },
         );
@@ -1062,7 +859,6 @@ mod tests {
                     mailbox_size: NZUsize!(8),
                     fetch_concurrent: NZUsize!(4),
                     fetch_timeout: Duration::from_millis(200),
-                    certification_timeout: Duration::from_millis(200),
                     term_length: TermLength::ONE,
                 },
             );
@@ -1084,7 +880,6 @@ mod tests {
                     mailbox_size: NZUsize!(8),
                     fetch_concurrent: NZUsize!(4),
                     fetch_timeout: Duration::from_millis(200),
-                    certification_timeout: Duration::from_millis(200),
                     term_length: TermLength::ONE,
                 },
             );
@@ -1240,7 +1035,6 @@ mod tests {
                     mailbox_size: NZUsize!(8),
                     fetch_concurrent: NZUsize!(4),
                     fetch_timeout: Duration::from_millis(200),
-                    certification_timeout: Duration::from_millis(200),
                     term_length: TermLength::ONE,
                 },
             );
@@ -1262,7 +1056,6 @@ mod tests {
                     mailbox_size: NZUsize!(8),
                     fetch_concurrent: NZUsize!(4),
                     fetch_timeout: Duration::from_millis(200),
-                    certification_timeout: Duration::from_millis(200),
                     term_length: TermLength::ONE,
                 },
             );
@@ -1284,7 +1077,6 @@ mod tests {
                     mailbox_size: NZUsize!(8),
                     fetch_concurrent: NZUsize!(4),
                     fetch_timeout: Duration::from_millis(200),
-                    certification_timeout: Duration::from_millis(200),
                     term_length: TermLength::ONE,
                 },
             );
@@ -1300,7 +1092,7 @@ mod tests {
             first_responder_mailbox.updated(Certificate::Notarization(notarization.clone()));
             // Model the Byzantine peer as willing to serve this notarization.
             // Honest certification at the requester may still reject it.
-            first_responder_mailbox.certified(&notarization, true);
+            first_responder_mailbox.certified(notarization.round(), true);
             let nullification = build_nullification(&schemes, &verifier, EPOCH, requested);
             nullification_holder_mailbox.updated(Certificate::Nullification(nullification.clone()));
             context.sleep(Duration::from_millis(10)).await;
@@ -1498,9 +1290,9 @@ mod tests {
             );
             assert_eq!(resolver.targeted().len(), 2);
 
-            // Exercise the mirror case at another key. Successful
-            // certification completes only the exact parent request. It does
-            // not provide the nullification needed to skip that view.
+            // Exercise the mirror case at another key. Holding the exact
+            // parent completes only the targeted parent request. It does not
+            // provide the nullification needed to skip that view.
             let second_requested = requested.next_term_start(actor.state.term_length());
             actor.resolve(
                 &mut resolver,
@@ -1521,11 +1313,21 @@ mod tests {
                 subscriber: Purpose::Backfill,
                 span: tracing::Span::none(),
             });
-            actor.certified(&mut resolver, second_requested, true);
-            assert_eq!(
-                resolver.subscriptions(6),
-                vec![Purpose::Backfill, Purpose::Nullification,]
+            actor.updated(
+                &mut resolver,
+                Certificate::Notarization(build_notarization(
+                    &schemes,
+                    &verifier,
+                    EPOCH,
+                    second_requested,
+                )),
             );
+            actor.certified(&mut resolver, second_requested, true);
+
+            // The certified notarization is now the floor, which satisfies
+            // background repair at that view. Targeted nullification demand
+            // survives: a notarization is not a nullification covering it.
+            assert_eq!(resolver.subscriptions(6), vec![Purpose::Nullification]);
             actor.resolve(
                 &mut resolver,
                 View::new(14),
@@ -1553,7 +1355,8 @@ mod tests {
             );
             assert!(resolver.outstanding().is_empty());
             assert!(actor.nullification_responses.is_empty());
-            assert!(actor.certification_outcomes.is_empty());
+            assert!(actor.notarization_responses.is_empty());
+            assert!(actor.failed_certifications.is_empty());
             actor.resolve(
                 &mut resolver,
                 finalized.next(),
@@ -1590,25 +1393,14 @@ mod tests {
             let parent = build_notarization(&schemes, &verifier, EPOCH, requested);
             let expected_parent = Certificate::Notarization(parent.clone()).encode();
             responder.updated(&mut responder_resolver, Certificate::Notarization(parent));
-            responder.certified_notarization(
-                &mut responder_resolver,
-                requested,
-                expected_parent.clone(),
-                true,
-            );
+            responder.certified(&mut responder_resolver, requested, true);
             let floor = View::new(4);
             let floor_notarization = build_notarization(&schemes, &verifier, EPOCH, floor);
-            let floor_certificate = Certificate::Notarization(floor_notarization.clone()).encode();
             responder.updated(
                 &mut responder_resolver,
                 Certificate::Notarization(floor_notarization),
             );
-            responder.certified_notarization(
-                &mut responder_resolver,
-                floor,
-                floor_certificate,
-                true,
-            );
+            responder.certified(&mut responder_resolver, floor, true);
 
             let mut first_saw_nullification = false;
             let mut second_saw_parent = false;
@@ -1782,69 +1574,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn pending_notarization_waits_without_blocking_other_deliveries() {
-        let runtime = deterministic::Runner::default();
-        runtime.start(|mut context| async move {
-            let Fixture {
-                schemes, verifier, ..
-            } = ed25519::fixture(&mut context, NAMESPACE, 4);
-            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
-            let mut voter = voter::Mailbox::new(voter_tx);
-            let mut actor = build_actor(context.child("actor"), verifier.clone());
-            let mut resolver = RecordingResolver::default();
-
-            let notarization = build_notarization(&schemes, &verifier, EPOCH, View::new(6));
-            let (response, receiver) = oneshot::channel();
-            actor.handle_resolver(
-                HandlerMessage::Deliver {
-                    span: tracing::Span::none(),
-                    view: View::new(6),
-                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
-                        .encode(),
-                    purposes: non_empty_vec![Purpose::Backfill],
-                    response,
-                },
-                &mut voter,
-                &mut resolver,
-            );
-            assert_eq!(actor.pending.timeout_count(), 1);
-            let mut receiver = receiver;
-            select! {
-                outcome = &mut receiver => {
-                    panic!("pending certification completed delivery early: {outcome:?}");
-                },
-                _ = context.sleep(Duration::from_millis(1)) => {},
-            }
-
-            let (other_response, other_receiver) = oneshot::channel();
-            actor.handle_resolver(
-                HandlerMessage::Deliver {
-                    span: tracing::Span::none(),
-                    view: View::new(11),
-                    data: Certificate::<TestScheme, Sha256Digest>::Nullification(
-                        build_nullification(&schemes, &verifier, EPOCH, View::new(11)),
-                    )
-                    .encode(),
-                    purposes: non_empty_vec![Purpose::Backfill],
-                    response: other_response,
-                },
-                &mut voter,
-                &mut resolver,
-            );
-            assert_eq!(other_receiver.await.unwrap(), Outcome::Complete);
-            assert_eq!(actor.pending.timeout_count(), 1);
-            assert!(matches!(
-                receiver.try_recv(),
-                Err(oneshot::error::TryRecvError::Empty)
-            ));
-
-            actor.certified(&mut resolver, View::new(6), true);
-            assert_eq!(receiver.await.unwrap(), Outcome::Complete);
-        });
-    }
-
-    #[test_async]
-    async fn failed_parent_certification_is_ambiguous() {
+    async fn parent_delivery_completes_on_possession_not_certification() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
@@ -1856,6 +1586,9 @@ mod tests {
             let mut resolver = RecordingResolver::default();
             let view = View::new(6);
 
+            // The exact parent was asked for and arrived. Certification is an
+            // application verdict on evidence already in hand, so the fetch has
+            // nothing left to retrieve and must not stay open waiting for it.
             let (response, receiver) = oneshot::channel();
             actor.handle_resolver(
                 HandlerMessage::Deliver {
@@ -1871,92 +1604,51 @@ mod tests {
                 &mut voter,
                 &mut resolver,
             );
-
-            actor.certified(&mut resolver, view, false);
-            assert_eq!(receiver.await.unwrap(), Outcome::Ambiguous);
+            assert_eq!(receiver.await.unwrap(), Outcome::Complete);
+            assert!(actor.notarization_responses.contains_key(&view));
         });
     }
 
     #[test_async]
-    async fn pending_notarization_times_out_as_ambiguous() {
+    async fn failed_certification_retires_parent_demand_until_finalization() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
-                schemes, verifier, ..
+                schemes,
+                verifier,
+                participants,
+                ..
             } = ed25519::fixture(&mut context, NAMESPACE, 4);
-            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
-            let mut voter = voter::Mailbox::new(voter_tx);
-            let mut actor = build_actor(context.child("actor"), verifier.clone());
-            let mut resolver = RecordingResolver::default();
-
-            let (response, receiver) = oneshot::channel();
-            actor.handle_resolver(
-                HandlerMessage::Deliver {
-                    span: tracing::Span::none(),
-                    view: View::new(6),
-                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(
-                        build_notarization(&schemes, &verifier, EPOCH, View::new(6)),
-                    )
-                    .encode(),
-                    purposes: non_empty_vec![Purpose::Backfill],
-                    response,
-                },
-                &mut voter,
-                &mut resolver,
-            );
-
-            let id = actor.pending.next_completed().await;
-            actor.expire_pending_delivery(id);
-            assert_eq!(receiver.await.unwrap(), Outcome::Ambiguous);
-        });
-    }
-
-    #[test_async]
-    async fn completed_delivery_timeout_keeps_runtime_live() {
-        let runtime = deterministic::Runner::default();
-        runtime.start(|mut context| async move {
-            let Fixture {
-                schemes, verifier, ..
-            } = ed25519::fixture(&mut context, NAMESPACE, 4);
-            let (voter_tx, _voter_rx) = mailbox::new(context.child("voter"), NZUsize!(8));
-            let mut voter = voter::Mailbox::new(voter_tx);
-            let mut actor = build_actor(context.child("actor"), verifier.clone());
+            let mut actor = build_actor(context, verifier.clone());
             let mut resolver = RecordingResolver::default();
             let view = View::new(6);
 
-            let (response, receiver) = oneshot::channel();
-            actor.handle_resolver(
-                HandlerMessage::Deliver {
-                    span: tracing::Span::none(),
-                    view,
-                    data: Certificate::<TestScheme, Sha256Digest>::Notarization(
-                        build_notarization(&schemes, &verifier, EPOCH, view),
-                    )
-                    .encode(),
-                    purposes: non_empty_vec![Purpose::Backfill],
-                    response,
-                },
-                &mut voter,
+            actor.updated(
                 &mut resolver,
+                Certificate::Notarization(build_notarization(&schemes, &verifier, EPOCH, view)),
             );
+            actor.certified(&mut resolver, view, false);
 
-            // Poll the timeout once so it is registered with the runtime.
-            let mut pending_timeout = actor.pending.next_completed();
-            select! {
-                result = &mut pending_timeout => {
-                    panic!("delivery timed out early: {result:?}");
-                },
-                _ = context.sleep(Duration::from_millis(1)) => {},
-            }
-            drop(pending_timeout);
+            // The payload is no longer an answer, and the tombstone keeps a
+            // delayed request from recreating demand. A floor raise above the
+            // view must not resurrect it (state prunes its own failed views).
+            assert!(!actor.notarization_responses.contains_key(&view));
+            let floor = View::new(9);
+            actor.updated(
+                &mut resolver,
+                Certificate::Notarization(build_notarization(&schemes, &verifier, EPOCH, floor)),
+            );
+            actor.certified(&mut resolver, floor, true);
 
-            actor.certified(&mut resolver, view, true);
-            assert_eq!(receiver.await.unwrap(), Outcome::Complete);
-
-            // Drive the timeout pool once more, then cross the original
-            // deadline. Cleanup must not strand the deterministic clock.
-            let _ = actor.pending.next_completed().await;
-            context.sleep(Duration::from_secs(2)).await;
+            let targeted = resolver.targeted().len();
+            actor.resolve(
+                &mut resolver,
+                View::new(11),
+                view,
+                Purpose::Parent,
+                participants[0].clone(),
+            );
+            assert_eq!(resolver.targeted().len(), targeted);
         });
     }
 
@@ -2203,7 +1895,8 @@ mod tests {
             actor.certified(&mut resolver, floor, true);
 
             let notarization = build_notarization(&schemes, &verifier, EPOCH, failed);
-            assert_eq!(actor.certification_outcomes.get(&failed), Some(&false));
+            assert!(actor.failed_certifications.contains(&failed));
+            assert!(!actor.notarization_responses.contains_key(&failed));
             assert!(
                 actor
                     .validate(failed, Certificate::Notarization(notarization).encode())

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::Purpose,
+    super::{Demand, Kind, Until},
     Config,
     ingress::{Handler, HandlerMessage, Mailbox, MailboxMessage},
     state::{Effect, FetchReason},
@@ -26,10 +26,7 @@ use commonware_runtime::{
     telemetry::traces::TracedExt as _,
 };
 use commonware_utils::{
-    channel::fallible::OneshotExt,
-    ordered::Quorum,
-    sequence::U64,
-    vec::NonEmptyVec,
+    channel::fallible::OneshotExt, ordered::Quorum, sequence::U64, vec::NonEmptyVec,
 };
 use rand::RngExt as _;
 use rand_core::CryptoRng;
@@ -68,7 +65,7 @@ pub struct Actor<
 
     /// Nullifications cached in the encoded form expected by [p2p::Producer].
     /// These response payloads remain available while they cover views above
-    /// finalization so kindless retries survive later floor raises.
+    /// finalization so a demand below the floor can still be served.
     nullification_responses: BTreeMap<View, Bytes>,
 
     /// Notarizations cached in the encoded form expected by [p2p::Producer].
@@ -83,6 +80,16 @@ pub struct Actor<
     /// which rises above a failed view while a delayed request for it can still
     /// arrive, so the tombstone is kept here against the finalization boundary.
     failed_certifications: BTreeSet<View>,
+
+    /// Certificates still wanted from peers, paired with what retires each.
+    ///
+    /// This mirrors the resolver's outstanding fetches. Whether a demand still
+    /// needs fetching is decided by [Self::settled], which reads local evidence
+    /// and so needs `&self`, while [Resolver::retain] takes a `'static`
+    /// predicate. Owning the demands here keeps that decision in one place and
+    /// lets the survivors be snapshotted into the predicate (see
+    /// [Self::sync_demands]).
+    demands: BTreeSet<(View, Demand)>,
 
     mailbox_receiver: mailbox::Receiver<MailboxMessage<S, D>>,
 }
@@ -113,6 +120,7 @@ impl<
                 nullification_responses: BTreeMap::new(),
                 notarization_responses: BTreeMap::new(),
                 failed_certifications: BTreeSet::new(),
+                demands: BTreeSet::new(),
 
                 mailbox_receiver: receiver,
             },
@@ -191,11 +199,11 @@ impl<
                     MailboxMessage::Resolve {
                         proposal_view,
                         view,
-                        purpose,
+                        kind,
                         target,
                         ..
                     } => {
-                        self.resolve(&mut resolver, proposal_view, view, purpose, target);
+                        self.resolve(&mut resolver, proposal_view, view, kind, target);
                     }
                 }
             },
@@ -209,7 +217,7 @@ impl<
     }
 
     /// Records a certificate and applies its resolver lifecycle effects.
-    fn updated<R: Resolver<Key = U64, Subscriber = Purpose>>(
+    fn updated<R: Resolver<Key = U64, Subscriber = Demand>>(
         &mut self,
         resolver: &mut R,
         certificate: Certificate<S, D>,
@@ -220,37 +228,27 @@ impl<
             Certificate::Notarization(notarization) => (None, None, Some(notarization.view())),
         };
 
-        // A nullification retires background and targeted nullification demand across the rest of
-        // its term. Retain the evidence above finalization so delayed requests cannot recreate the
-        // demand and kindless retries can still serve it after a certified-floor raise.
-        if let Some(nullified) = nullified {
-            let term_end = nullified.term_end(self.state.term_length());
-            if term_end > self.last_finalized {
-                self.nullification_responses
-                    .insert(nullified, certificate.encode());
-            }
-            self.retire(resolver, Purpose::Nullification, nullified, term_end);
+        // Cache response payloads for as long as a peer can still ask for them.
+        // [State] prunes at the floor, which rises sooner than finalization and
+        // would hide this evidence from a peer still repairing the view.
+        if let Some(nullified) = nullified
+            && nullified.term_end(self.state.term_length()) > self.last_finalized
+        {
+            self.nullification_responses
+                .insert(nullified, certificate.encode());
         }
-
-        // Holding a notarization is what an exact-parent request asks for, so
-        // retain it as a response payload independently of whether it later
-        // certifies locally. State pruning would otherwise drop it once a
-        // higher floor is set, hiding it from a peer still repairing that view.
         if let Some(notarized) = notarized
             && notarized > self.last_finalized
             && !self.failed_certifications.contains(&notarized)
         {
             self.notarization_responses
                 .insert(notarized, certificate.encode());
-            self.retire(resolver, Purpose::Parent, notarized, notarized);
         }
 
-        // Certificate state owns floor selection and background repair.
-        let effects = self.state.handle(certificate);
-        self.apply_effects(resolver, effects);
-
-        // Finalization is the global retirement boundary. Remove covered tombstones and resolver
-        // requests so delayed work cannot recreate demand below the finalized view.
+        // Finalization is the global retirement boundary: a valid proposal can no
+        // longer name ancestry at or below it, so nothing here can still be asked
+        // for. Demands below it are dropped by [Self::sync_demands], which treats
+        // a finalized view as settled.
         if let Some(finalized) = finalized {
             self.last_finalized = self.last_finalized.max(finalized);
             let term_length = self.state.term_length();
@@ -260,13 +258,15 @@ impl<
                 .retain(|view, _| *view > self.last_finalized);
             self.failed_certifications
                 .retain(|view| *view > self.last_finalized);
-            let floor = U64::from(self.last_finalized);
-            let _ = resolver.retain(move |candidate, _| *candidate > floor);
         }
+
+        // Certificate state owns floor selection and background repair.
+        let effects = self.state.handle(certificate);
+        self.apply_effects(resolver, effects);
     }
 
     /// Handles a certification outcome from the voter.
-    fn certified<R: Resolver<Key = U64, Subscriber = Purpose>>(
+    fn certified<R: Resolver<Key = U64, Subscriber = Demand>>(
         &mut self,
         resolver: &mut R,
         view: View,
@@ -281,18 +281,16 @@ impl<
             }
         }
 
-        // A verdict is terminal for exact-parent demand either way: success
-        // means the notarization is in hand, and failure means no copy of it
-        // can ever answer. Possession already retired this demand on arrival;
-        // repeating it here also covers a verdict for a view whose
-        // notarization state was pruned.
-        self.retire(resolver, Purpose::Parent, view, view);
         let effects = self.state.handle_certified(view, success);
         self.apply_effects(resolver, effects);
     }
 
     /// Applies the side effects requested by [super::state::State] to the resolver.
-    fn apply_effects<R: Resolver<Key = U64, Subscriber = Purpose>>(
+    ///
+    /// Call this after recording new evidence: it ends by syncing the resolver to
+    /// the surviving demands, which is what publishes both the effects below and
+    /// the evidence recorded by the caller.
+    fn apply_effects<R: Resolver<Key = U64, Subscriber = Demand>>(
         &mut self,
         resolver: &mut R,
         effects: Vec<Effect>,
@@ -305,233 +303,232 @@ impl<
                     reason,
                 } => self.fetch(resolver, view, cause, reason),
                 Effect::RetainAbove(floor) => {
-                    // Resolver retention cancels background-only delivery.
-                    // Targeted subscribers keep the key active until evidence
-                    // satisfies their specific purpose.
-                    let floor = U64::from(floor);
-                    let _ = resolver.retain(move |candidate, purpose| {
-                        purpose.is_targeted() || *candidate > floor
-                    });
+                    // Resolver state does not repair below its floor, so a
+                    // background demand there has nothing left to do. This is
+                    // the only retirement that depends on the floor:
+                    // [Self::settled] cannot use it, because a proposal may name
+                    // ancestry below the floor and only finalization rules that
+                    // out.
+                    self.demands
+                        .retain(|(view, demand)| demand.until != Until::Floor || *view > floor);
                 }
             }
         }
+
+        self.sync_demands(resolver);
     }
 
-    /// Removes demand made unnecessary by matching terminal evidence.
-    fn retire<R: Resolver<Key = U64, Subscriber = Purpose>>(
-        &self,
-        resolver: &mut R,
-        resolved: Purpose,
-        start: View,
-        end: View,
-    ) {
-        let start = U64::from(start);
-        let end = U64::from(end);
-        let _ = resolver.retain(move |candidate, purpose| {
-            *candidate < start || *candidate > end || !purpose.is_retired_by(resolved)
-        });
+    /// Drops settled demands and mirrors the survivors into the resolver.
+    ///
+    /// [Resolver::retain] takes a `'static` predicate and so cannot consult
+    /// [Self::settled] directly, which is why the survivors are snapshotted into
+    /// it.
+    fn sync_demands<R: Resolver<Key = U64, Subscriber = Demand>>(&mut self, resolver: &mut R) {
+        let settled: Vec<_> = self
+            .demands
+            .iter()
+            .copied()
+            .filter(|(view, demand)| self.settled(*view, demand.kind))
+            .collect();
+        self.demands.retain(|entry| !settled.contains(entry));
+
+        let live = self.demands.clone();
+        let _ = resolver
+            .retain(move |key, demand| live.contains(&(View::new(u64::from(key)), *demand)));
     }
 
-    /// Issues a resolver fetch for `view`, attaching a span that records why the
-    /// fetch was needed and which view's processing caused it.
-    fn fetch<R: Resolver<Key = U64, Subscriber = Purpose>>(
-        &self,
+    /// Issues a background fetch for the nullification covering `view`.
+    ///
+    /// Both [FetchReason]s want the same certificate: [State] only ever reports
+    /// a view whose covering nullification is missing, whether the gap was found
+    /// by scanning below the current view or opened by a failed certification.
+    fn fetch<R: Resolver<Key = U64, Subscriber = Demand>>(
+        &mut self,
         resolver: &mut R,
         view: View,
         cause: View,
         reason: FetchReason,
     ) {
+        let demand = Demand::backfill();
+        self.demands.insert((view, demand));
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
             cause = cause.traced(),
             view = view.traced(),
-            reason = reason.as_str()
+            reason = reason.as_str(),
+            kind = demand.kind.as_str()
         );
         let _ = resolver.fetch(Fetch {
             key: U64::from(view),
-            subscriber: Purpose::Backfill,
+            subscriber: demand,
             span,
         });
     }
 
     /// Fetches ancestry from the leader whose proposal requires it.
     fn resolve<R>(
-        &self,
+        &mut self,
         resolver: &mut R,
         proposal_view: View,
         view: View,
-        purpose: Purpose,
+        kind: Kind,
         target: S::PublicKey,
     ) where
-        R: TargetedResolver<Key = U64, Subscriber = Purpose, PublicKey = S::PublicKey>,
+        R: TargetedResolver<Key = U64, Subscriber = Demand, PublicKey = S::PublicKey>,
     {
-        if view >= proposal_view
-            || view <= self.last_finalized
-            || self.purpose_resolved(view, purpose)
-        {
+        if view >= proposal_view || self.settled(view, kind) {
             return;
         }
+        let demand = Demand::ancestry(kind);
+        self.demands.insert((view, demand));
         let span = info_span!(
             "simplex.resolver.fetch",
             epoch = self.epoch.traced(),
             cause = proposal_view.traced(),
             view = view.traced(),
             reason = "proposal_ancestry",
-            purpose = purpose.as_str()
+            kind = demand.kind.as_str()
         );
         let _ = resolver.fetch_targeted(
             Fetch {
                 key: U64::from(view),
-                subscriber: purpose,
+                subscriber: demand,
                 span,
             },
             NonEmptyVec::new(target),
         );
     }
 
-    /// Returns whether local evidence has already made this targeted demand
-    /// unnecessary. Keeping this knowledge separately from resolver storage
-    /// prevents an older queued request from resurrecting retired work.
-    fn purpose_resolved(&self, view: View, purpose: Purpose) -> bool {
-        self.purpose_satisfied(view, purpose)
-            || matches!(purpose, Purpose::Parent) && self.failed_certifications.contains(&view)
-    }
-
-    /// Returns whether local evidence satisfies a delivered subscriber.
+    /// Returns whether local evidence has settled a demand for `kind` at `view`.
     ///
-    /// An exact-parent subscriber is satisfied by holding the notarization, not
-    /// by certifying it. Certification is an application verdict on evidence
-    /// already in hand, so waiting for it here would keep a fetch open with
-    /// nothing left to fetch.
-    fn purpose_satisfied(&self, view: View, purpose: Purpose) -> bool {
+    /// Settled means there is nothing left to fetch: either the evidence is in
+    /// hand, or no response could ever serve the demand. This decides whether to
+    /// open a fetch, whether a delivery completed one, and which demands survive
+    /// [Self::sync_demands].
+    ///
+    /// A valid response does not imply this. The wire key names only a view, so a
+    /// peer may answer a notarization request with a covering nullification: valid
+    /// evidence, worth recording, but not what was asked for.
+    fn settled(&self, view: View, kind: Kind) -> bool {
+        // Finalization rules out any further need for the view. This is also
+        // what settles a demand answered by a finalization, since recording one
+        // raises [Self::last_finalized].
         if view <= self.last_finalized {
             return true;
         }
-        match purpose {
-            Purpose::Nullification => self
-                .nullification_responses
-                .range(view.covering_range(self.state.term_length()))
-                .next_back()
-                .is_some(),
-            Purpose::Parent => self.notarization_responses.contains_key(&view),
-            Purpose::Backfill => self.state.get(view).is_some(),
+        match kind {
+            Kind::Nullification => self.covering_nullification(view).is_some(),
+            // Holding the notarization settles this, and so does a failed
+            // verdict: certification is an application judgement on the
+            // evidence itself, so no other copy of it could pass either.
+            Kind::Notarization => {
+                self.notarization_responses.contains_key(&view)
+                    || self.failed_certifications.contains(&view)
+            }
         }
     }
 
-    /// Selects among the valid artifacts for a kindless wire key.
+    /// Returns the cached nullification covering `view`, if any.
     ///
-    /// Every retained evidence class must remain selectable on an ambiguous
-    /// retry. Otherwise a newer floor can permanently hide the exact parent or
-    /// covering nullification requested from a proposal leader.
-    fn produce_certificate(&mut self, view: View) -> Option<Bytes> {
-        let exact_parent = self.notarization_responses.get(&view);
-        let covering_nullification = self
-            .nullification_responses
+    /// A nullification covers the rest of its term, so it may be keyed at an
+    /// earlier view than the one being served.
+    fn covering_nullification(&self, view: View) -> Option<&Bytes> {
+        self.nullification_responses
             .range(view.covering_range(self.state.term_length()))
             .next_back()
-            .map(|(_, nullification)| nullification);
-        let fallback = self.state.get(view);
+            .map(|(_, nullification)| nullification)
+    }
 
-        // A finalization satisfies every purpose, so selecting weaker
-        // evidence would only delay completion.
-        if let Some(certificate @ Certificate::Finalization(_)) = fallback {
+    /// Selects a certificate to serve for `view`.
+    ///
+    /// The request does not say which certificate it wants, so when both a
+    /// notarization and a covering nullification are held either may be the one
+    /// the requester needs. The choice is random rather than fixed: a fixed
+    /// preference would answer every retry from a requester wanting the other
+    /// kind with the same useless certificate.
+    fn produce_certificate(&mut self, view: View) -> Option<Bytes> {
+        // A finalization settles either kind, so weaker evidence would only
+        // delay the requester.
+        if let Some(certificate @ Certificate::Finalization(_)) = self.state.get(view) {
             return Some(certificate.encode());
         }
 
-        // Either purpose-specific certificate also satisfies ordinary
-        // backfill, so a newer floor adds no useful response class here.
-        // Independent selection prevents concurrent requesters from being
-        // pinned to opposite sides of a shared rotation.
-        match (exact_parent, covering_nullification) {
-            (Some(parent), Some(nullification)) => {
-                let candidates = [parent, nullification];
-                Some(candidates[self.context.random_range(0..2)].clone())
+        let notarization = self.notarization_responses.get(&view).cloned();
+        let nullification = self.covering_nullification(view).cloned();
+        match (notarization, nullification) {
+            (Some(notarization), Some(nullification)) => {
+                Some(if self.context.random_range(0..2) == 0 {
+                    notarization
+                } else {
+                    nullification
+                })
             }
-            (Some(certificate), None) | (None, Some(certificate)) => Some(certificate.clone()),
-            (None, None) => fallback.map(|certificate| certificate.encode()),
+            (Some(certificate), None) | (None, Some(certificate)) => Some(certificate),
+            // Either cached response also serves ordinary backfill, so the floor
+            // adds no response the requester could not already have.
+            (None, None) => self.state.get(view).map(|certificate| certificate.encode()),
         }
     }
 
     /// Validates an incoming message, returning the parsed message if valid.
+    ///
+    /// Validity is judged against `view` alone, because that is all the request
+    /// named. Any certificate an honest peer could serve for the view is accepted,
+    /// including one that answers the other kind: rejecting it would fault a peer
+    /// that answered the only question the wire key actually asked. Whether it
+    /// settles the demand is a separate judgement (see [Self::settled]).
     fn validate(&mut self, view: View, data: Bytes) -> Option<Certificate<S, D>> {
-        // Decode message
         let incoming =
             Certificate::<S, D>::decode_cfg(data, &self.scheme.certificate_codec_config()).ok()?;
 
-        // Validate message
-        match incoming {
-            Certificate::Notarization(notarization) => {
-                let notarization_view = notarization.view();
-                if notarization.view() < view {
-                    debug!(%view, received = %notarization.view(), "notarization below view");
-                    return None;
-                }
-                if notarization.epoch() != self.epoch {
-                    debug!(
-                        epoch = %notarization.epoch(),
-                        expected = %self.epoch,
-                        "rejecting notarization from different epoch"
-                    );
-                    return None;
-                }
-                if !notarization.verify(self.context.as_mut(), &self.scheme, &self.strategy) {
-                    debug!(%view, "notarization failed verification");
-                    return None;
-                }
-                debug!(%view, received = %notarization_view, "received notarization for request");
-                Some(Certificate::Notarization(notarization))
+        // A nullification covers the rest of its term. A notarization or
+        // finalization is servable from a peer's floor, which may sit above the
+        // requested view.
+        let servable = match &incoming {
+            Certificate::Nullification(nullification) => {
+                nullification.view().covers(view, self.state.term_length())
             }
-            Certificate::Finalization(finalization) => {
-                if finalization.view() < view {
-                    debug!(%view, received = %finalization.view(), "finalization below view");
-                    return None;
-                }
-                if finalization.epoch() != self.epoch {
-                    debug!(
-                        epoch = %finalization.epoch(),
-                        expected = %self.epoch,
-                        "rejecting finalization from different epoch"
-                    );
-                    return None;
-                }
-                if !finalization.verify(self.context.as_mut(), &self.scheme, &self.strategy) {
-                    debug!(%view, "finalization failed verification");
-                    return None;
-                }
-                debug!(%view, received = %finalization.view(), "received finalization for request");
-                Some(Certificate::Finalization(finalization))
+            Certificate::Notarization(notarization) => notarization.view() >= view,
+            Certificate::Finalization(finalization) => finalization.view() >= view,
+        };
+        if !servable {
+            debug!(%view, received = %incoming.view(), "certificate below requested view");
+            return None;
+        }
+
+        if incoming.epoch() != self.epoch {
+            debug!(
+                %view,
+                epoch = %incoming.epoch(),
+                expected = %self.epoch,
+                "rejecting certificate from different epoch"
+            );
+            return None;
+        }
+
+        let verified = match &incoming {
+            Certificate::Notarization(notarization) => {
+                notarization.verify(self.context.as_mut(), &self.scheme, &self.strategy)
             }
             Certificate::Nullification(nullification) => {
-                let nullified_view = nullification.view();
-                if !nullified_view.covers(view, self.state.term_length()) {
-                    debug!(%view, received = %nullified_view, "nullification view mismatch");
-                    return None;
-                }
-                if nullification.epoch() != self.epoch {
-                    debug!(
-                        epoch = %nullification.epoch(),
-                        expected = %self.epoch,
-                        "rejecting nullification from different epoch"
-                    );
-                    return None;
-                }
-                if !nullification.verify::<_, D>(
-                    self.context.as_mut(),
-                    &self.scheme,
-                    &self.strategy,
-                ) {
-                    debug!(%view, "nullification failed verification");
-                    return None;
-                }
-                debug!(%view, received = %nullification.view(), "received nullification for request");
-                Some(Certificate::Nullification(nullification))
+                nullification.verify::<_, D>(self.context.as_mut(), &self.scheme, &self.strategy)
             }
+            Certificate::Finalization(finalization) => {
+                finalization.verify(self.context.as_mut(), &self.scheme, &self.strategy)
+            }
+        };
+        if !verified {
+            debug!(%view, "certificate failed verification");
+            return None;
         }
+
+        debug!(%view, received = %incoming.view(), "received certificate for request");
+        Some(incoming)
     }
 
     /// Handles a message from the [p2p::Engine].
-    fn handle_resolver<R: Resolver<Key = U64, Subscriber = Purpose>>(
+    fn handle_resolver<R: Resolver<Key = U64, Subscriber = Demand>>(
         &mut self,
         message: HandlerMessage,
         voter: &mut voter::Mailbox<S, D>,
@@ -542,7 +539,7 @@ impl<
                 span,
                 view,
                 data,
-                purposes,
+                demands,
                 response,
             } => {
                 let span = info_span!(
@@ -581,19 +578,17 @@ impl<
                     );
                     resolved.in_scope(|| voter.resolved(parsed.clone()));
 
-                    // Recording the certificate applies purpose-specific
-                    // retention before the resolver retries ambiguous data.
+                    // Record the certificate, which settles whichever demands it
+                    // answered and retires their fetches.
                     self.updated(resolver, parsed);
                 }
 
-                // Every purpose is decided by evidence now in hand, so the
-                // outcome is immediate: either this response answered what was
-                // asked, or the kindless key admitted a different certificate
-                // and the resolver retries without faulting the peer.
-                let outcome = if purposes
-                    .iter()
-                    .all(|purpose| self.purpose_satisfied(view, *purpose))
-                {
+                // The peer answered the view it was asked about, so it is never
+                // faulted here. Whether that answer was the certificate anyone
+                // wanted is a separate question: if a demand for this view is
+                // still open, the response was valid but ambiguous, and the
+                // resolver retries without penalizing the peer.
+                let outcome = if demands.iter().all(|demand| self.settled(view, demand.kind)) {
                     Outcome::Complete
                 } else {
                     Outcome::Ambiguous
@@ -663,8 +658,8 @@ mod tests {
     /// Tracks the set of pending requests the way the resolver engine would.
     #[derive(Clone, Default)]
     struct RecordingResolver {
-        outstanding: Arc<Mutex<BTreeSet<(U64, Purpose)>>>,
-        targeted: Arc<Mutex<Vec<(U64, Purpose, PublicKey)>>>,
+        outstanding: Arc<Mutex<BTreeSet<(U64, Demand)>>>,
+        targeted: Arc<Mutex<Vec<(U64, Demand, PublicKey)>>>,
     }
 
     impl RecordingResolver {
@@ -678,7 +673,7 @@ mod tests {
                 .collect()
         }
 
-        fn targeted(&self) -> Vec<(u64, Purpose, PublicKey)> {
+        fn targeted(&self) -> Vec<(u64, Demand, PublicKey)> {
             self.targeted
                 .lock()
                 .iter()
@@ -686,7 +681,7 @@ mod tests {
                 .collect()
         }
 
-        fn subscriptions(&self, view: u64) -> Vec<Purpose> {
+        fn subscriptions(&self, view: u64) -> Vec<Demand> {
             self.outstanding
                 .lock()
                 .iter()
@@ -697,11 +692,11 @@ mod tests {
 
     impl Resolver for RecordingResolver {
         type Key = U64;
-        type Subscriber = Purpose;
+        type Subscriber = Demand;
 
         fn fetch<F>(&mut self, key: F) -> Feedback
         where
-            F: Into<Fetch<U64, Purpose>> + Send,
+            F: Into<Fetch<U64, Demand>> + Send,
         {
             let fetch = key.into();
             self.outstanding
@@ -712,7 +707,7 @@ mod tests {
 
         fn fetch_all<F>(&mut self, keys: Vec<F>) -> Feedback
         where
-            F: Into<Fetch<U64, Purpose>> + Send,
+            F: Into<Fetch<U64, Demand>> + Send,
         {
             for key in keys {
                 self.fetch(key);
@@ -722,7 +717,7 @@ mod tests {
 
         fn retain(
             &mut self,
-            predicate: impl Fn(&U64, &Purpose) -> bool + Send + 'static,
+            predicate: impl Fn(&U64, &Demand) -> bool + Send + 'static,
         ) -> Feedback {
             self.outstanding
                 .lock()
@@ -736,7 +731,7 @@ mod tests {
 
         fn fetch_targeted(
             &mut self,
-            fetch: impl Into<Fetch<U64, Purpose>> + Send,
+            fetch: impl Into<Fetch<U64, Demand>> + Send,
             targets: NonEmptyVec<PublicKey>,
         ) -> Feedback {
             let fetch = fetch.into();
@@ -753,7 +748,7 @@ mod tests {
 
         fn fetch_all_targeted<F>(&mut self, fetches: Vec<(F, NonEmptyVec<PublicKey>)>) -> Feedback
         where
-            F: Into<Fetch<U64, Purpose>> + Send,
+            F: Into<Fetch<U64, Demand>> + Send,
         {
             for (fetch, targets) in fetches {
                 self.fetch_targeted(fetch, targets);
@@ -917,7 +912,7 @@ mod tests {
             requester_mailbox.resolve(
                 View::new(3),
                 requested,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[1].clone(),
             );
             context.sleep(Duration::from_millis(10)).await;
@@ -1148,7 +1143,7 @@ mod tests {
             requester_mailbox.resolve(
                 View::new(3),
                 requested,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[2].clone(),
             );
             let recovered = select! {
@@ -1219,7 +1214,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn targeted_fetches_drop_only_when_purpose_is_satisfied() {
+    async fn targeted_fetches_drop_only_when_demand_is_satisfied() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
@@ -1236,31 +1231,43 @@ mod tests {
                 &mut resolver,
                 View::new(10),
                 requested,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[0].clone(),
             );
             actor.resolve(
                 &mut resolver,
                 View::new(11),
                 requested,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[1].clone(),
             );
             resolver.fetch(Fetch {
                 key: U64::from(requested),
-                subscriber: Purpose::Backfill,
+                subscriber: Demand::backfill(),
                 span: tracing::Span::none(),
             });
             assert_eq!(
                 resolver.targeted(),
                 vec![
-                    (3, Purpose::Nullification, participants[0].clone()),
-                    (3, Purpose::Parent, participants[1].clone()),
+                    (
+                        3,
+                        Demand::ancestry(Kind::Nullification),
+                        participants[0].clone()
+                    ),
+                    (
+                        3,
+                        Demand::ancestry(Kind::Notarization),
+                        participants[1].clone()
+                    ),
                 ]
             );
             assert_eq!(
                 resolver.subscriptions(3),
-                vec![Purpose::Backfill, Purpose::Nullification, Purpose::Parent,]
+                vec![
+                    Demand::backfill(),
+                    Demand::ancestry(Kind::Nullification),
+                    Demand::ancestry(Kind::Notarization),
+                ]
             );
 
             // A covering nullification completes both background repair and
@@ -1273,19 +1280,22 @@ mod tests {
                     &schemes, &verifier, EPOCH, requested,
                 )),
             );
-            assert_eq!(resolver.subscriptions(3), vec![Purpose::Parent]);
+            assert_eq!(
+                resolver.subscriptions(3),
+                vec![Demand::ancestry(Kind::Notarization)]
+            );
             actor.resolve(
                 &mut resolver,
                 View::new(14),
                 requested,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[2].clone(),
             );
             actor.resolve(
                 &mut resolver,
                 View::new(14),
                 requested.next(),
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[2].clone(),
             );
             assert_eq!(resolver.targeted().len(), 2);
@@ -1298,19 +1308,19 @@ mod tests {
                 &mut resolver,
                 View::new(12),
                 second_requested,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[2].clone(),
             );
             actor.resolve(
                 &mut resolver,
                 View::new(13),
                 second_requested,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[3].clone(),
             );
             resolver.fetch(Fetch {
                 key: U64::from(second_requested),
-                subscriber: Purpose::Backfill,
+                subscriber: Demand::backfill(),
                 span: tracing::Span::none(),
             });
             actor.updated(
@@ -1327,12 +1337,15 @@ mod tests {
             // The certified notarization is now the floor, which satisfies
             // background repair at that view. Targeted nullification demand
             // survives: a notarization is not a nullification covering it.
-            assert_eq!(resolver.subscriptions(6), vec![Purpose::Nullification]);
+            assert_eq!(
+                resolver.subscriptions(6),
+                vec![Demand::ancestry(Kind::Nullification)]
+            );
             actor.resolve(
                 &mut resolver,
                 View::new(14),
                 second_requested,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[0].clone(),
             );
             assert_eq!(resolver.targeted().len(), 4);
@@ -1361,7 +1374,7 @@ mod tests {
                 &mut resolver,
                 finalized.next(),
                 requested,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[0].clone(),
             );
             assert!(resolver.outstanding().is_empty());
@@ -1465,12 +1478,12 @@ mod tests {
                 &mut resolver,
                 View::new(10),
                 view,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[0].clone(),
             );
             assert_eq!(
                 resolver.subscriptions(3),
-                vec![Purpose::Nullification]
+                vec![Demand::ancestry(Kind::Nullification)]
             );
 
             // Certificate state still prefers the certified floor for
@@ -1490,7 +1503,7 @@ mod tests {
                 &mut resolver,
                 View::new(11),
                 view,
-                Purpose::Nullification,
+                Kind::Nullification,
                 participants[1].clone(),
             );
             assert_eq!(resolver.targeted().len(), 1);
@@ -1521,12 +1534,16 @@ mod tests {
                 &mut resolver,
                 View::new(8),
                 View::new(4),
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[0].clone(),
             );
             assert_eq!(
                 resolver.targeted(),
-                vec![(4, Purpose::Parent, participants[0].clone())]
+                vec![(
+                    4,
+                    Demand::ancestry(Kind::Notarization),
+                    participants[0].clone()
+                )]
             );
         });
     }
@@ -1549,7 +1566,7 @@ mod tests {
                 &mut resolver,
                 View::new(10),
                 view,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[0].clone(),
             );
             actor.updated(
@@ -1561,12 +1578,12 @@ mod tests {
             // A false certification verdict is permanent. Parent repair is
             // retired, while ordinary repair asks for the nullification that
             // can now cover the failed view.
-            assert_eq!(resolver.subscriptions(5), vec![Purpose::Backfill]);
+            assert_eq!(resolver.subscriptions(5), vec![Demand::backfill()]);
             actor.resolve(
                 &mut resolver,
                 View::new(11),
                 view,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[1].clone(),
             );
             assert_eq!(resolver.targeted().len(), 1);
@@ -1598,7 +1615,7 @@ mod tests {
                         build_notarization(&schemes, &verifier, EPOCH, view),
                     )
                     .encode(),
-                    purposes: non_empty_vec![Purpose::Parent],
+                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1645,7 +1662,7 @@ mod tests {
                 &mut resolver,
                 View::new(11),
                 view,
-                Purpose::Parent,
+                Kind::Notarization,
                 participants[0].clone(),
             );
             assert_eq!(resolver.targeted().len(), targeted);
@@ -1675,7 +1692,7 @@ mod tests {
                     view: View::new(4),
                     data: Certificate::<TestScheme, Sha256Digest>::Nullification(nullification)
                         .encode(),
-                    purposes: non_empty_vec![Purpose::Parent],
+                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1712,7 +1729,7 @@ mod tests {
                     view: requested,
                     data: Certificate::<TestScheme, Sha256Digest>::Notarization(notarization)
                         .encode(),
-                    purposes: non_empty_vec![Purpose::Parent],
+                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1763,7 +1780,7 @@ mod tests {
                     span: tracing::Span::none(),
                     view,
                     data: Certificate::<TestScheme, Sha256Digest>::Notarization(alternate).encode(),
-                    purposes: non_empty_vec![Purpose::Parent],
+                    demands: non_empty_vec![Demand::ancestry(Kind::Notarization)],
                     response,
                 },
                 &mut voter,
@@ -1774,7 +1791,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn finalization_completes_every_delivery_purpose() {
+    async fn finalization_completes_every_delivery_demand() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
@@ -1795,10 +1812,10 @@ mod tests {
                         build_finalization(&schemes, &verifier, EPOCH, View::new(6)),
                     )
                     .encode(),
-                    purposes: non_empty_vec![
-                        Purpose::Backfill,
-                        Purpose::Nullification,
-                        Purpose::Parent,
+                    demands: non_empty_vec![
+                        Demand::backfill(),
+                        Demand::ancestry(Kind::Nullification),
+                        Demand::ancestry(Kind::Notarization),
                     ],
                     response,
                 },

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -1,7 +1,7 @@
 use crate::{
     Epochable, Viewable,
     simplex::{
-        actors::{Demand, Kind},
+        actors::{Ask, Kind},
         types::Certificate,
     },
     types::{Round as Rnd, View},
@@ -265,7 +265,7 @@ pub(crate) enum HandlerMessage {
         span: Span,
         view: View,
         data: Bytes,
-        demands: NonEmptyVec<Demand>,
+        asks: NonEmptyVec<Ask>,
         response: oneshot::Sender<Outcome>,
     },
     Produce {
@@ -335,7 +335,7 @@ impl Handler {
 impl Consumer for Handler {
     type Key = U64;
     type Value = Bytes;
-    type Subscriber = Demand;
+    type Subscriber = Ask;
     type Outcome = Outcome;
 
     fn deliver(
@@ -345,12 +345,12 @@ impl Consumer for Handler {
     ) -> oneshot::Receiver<Self::Outcome> {
         let (response, receiver) = oneshot::channel();
         let (_, span) = delivery.subscribers.first().clone();
-        let demands = delivery.subscribers.map_into(|(demand, _)| demand);
+        let asks = delivery.subscribers.map_into(|(ask, _)| ask);
         let _ = self.sender.enqueue(HandlerMessage::Deliver {
             span,
             view: View::new(delivery.key.into()),
             data: value,
-            demands,
+            asks,
             response,
         });
         receiver

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -2,13 +2,12 @@ use crate::{
     Epochable, Viewable,
     simplex::{
         actors::Purpose,
-        types::{Certificate, Notarization},
+        types::Certificate,
     },
     types::{Round as Rnd, View},
 };
 use bytes::Bytes;
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
-use commonware_codec::Encode;
 use commonware_cryptography::{Digest, certificate::Scheme};
 use commonware_resolver::{Consumer, Delivery, Outcome, p2p::Producer};
 use commonware_runtime::telemetry::traces::TracedExt as _;
@@ -31,8 +30,6 @@ pub enum MailboxMessage<S: Scheme, D: Digest> {
         span: Span,
         /// The certified round.
         round: Rnd,
-        /// Exact notarization encoded for serving if certification succeeds.
-        encoded_notarization: Bytes,
         /// Whether certification succeeded.
         success: bool,
     },
@@ -226,18 +223,15 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
     }
 
     /// Notify the resolver of a certification result.
-    pub fn certified(&mut self, notarization: &Notarization<S, D>, success: bool) {
-        let round = notarization.round();
-        let encoded_notarization = Certificate::Notarization(notarization.clone()).encode();
+    pub fn certified(&mut self, round: Rnd, success: bool) {
         let _ = self.sender.enqueue(MailboxMessage::Certified {
             span: info_span!(
                 "simplex.resolver.mailbox.certified",
-                epoch = notarization.epoch().traced(),
-                view = notarization.view().traced(),
+                epoch = round.epoch().traced(),
+                view = round.view().traced(),
                 success
             ),
             round,
-            encoded_notarization,
             success,
         });
     }
@@ -459,7 +453,6 @@ mod tests {
         MailboxMessage::Certified {
             span: Span::none(),
             round: Round::new(EPOCH, view),
-            encoded_notarization: Bytes::new(),
             success,
         }
     }

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -1,7 +1,7 @@
 use crate::{
     Epochable, Viewable,
     simplex::{
-        actors::Purpose,
+        actors::{Demand, Kind},
         types::Certificate,
     },
     types::{Round as Rnd, View},
@@ -41,8 +41,8 @@ pub enum MailboxMessage<S: Scheme, D: Digest> {
         proposal_view: View,
         /// View whose certificate is needed.
         view: View,
-        /// Why the certificate is needed.
-        purpose: Purpose,
+        /// The certificate that is needed.
+        kind: Kind,
         /// Proposal leader to query.
         target: S::PublicKey,
     },
@@ -241,7 +241,7 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
         &mut self,
         proposal_view: View,
         view: View,
-        purpose: Purpose,
+        kind: Kind,
         target: S::PublicKey,
     ) {
         let _ = self.sender.enqueue(MailboxMessage::Resolve {
@@ -249,11 +249,11 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
                 "simplex.resolver.mailbox.resolve",
                 proposal_view = proposal_view.traced(),
                 view = view.traced(),
-                purpose = purpose.as_str()
+                kind = kind.as_str()
             ),
             proposal_view,
             view,
-            purpose,
+            kind,
             target,
         });
     }
@@ -265,7 +265,7 @@ pub(crate) enum HandlerMessage {
         span: Span,
         view: View,
         data: Bytes,
-        purposes: NonEmptyVec<Purpose>,
+        demands: NonEmptyVec<Demand>,
         response: oneshot::Sender<Outcome>,
     },
     Produce {
@@ -335,7 +335,7 @@ impl Handler {
 impl Consumer for Handler {
     type Key = U64;
     type Value = Bytes;
-    type Subscriber = Purpose;
+    type Subscriber = Demand;
     type Outcome = Outcome;
 
     fn deliver(
@@ -345,12 +345,12 @@ impl Consumer for Handler {
     ) -> oneshot::Receiver<Self::Outcome> {
         let (response, receiver) = oneshot::channel();
         let (_, span) = delivery.subscribers.first().clone();
-        let purposes = delivery.subscribers.map_into(|(purpose, _)| purpose);
+        let demands = delivery.subscribers.map_into(|(demand, _)| demand);
         let _ = self.sender.enqueue(HandlerMessage::Deliver {
             span,
             view: View::new(delivery.key.into()),
             data: value,
-            purposes,
+            demands,
             response,
         });
         receiver
@@ -460,7 +460,7 @@ mod tests {
     fn resolve_msg(
         proposal_view: View,
         view: View,
-        purpose: Purpose,
+        kind: Kind,
     ) -> MailboxMessage<TestScheme, Sha256Digest> {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, b"resolver-policy-target", 5);
@@ -468,7 +468,7 @@ mod tests {
             span: Span::none(),
             proposal_view,
             view,
-            purpose,
+            kind,
             target: participants[0].clone(),
         }
     }
@@ -545,11 +545,11 @@ mod tests {
         let mut overflow = Pending::default();
         MailboxMessage::handle(
             &mut overflow,
-            resolve_msg(View::new(10), View::new(2), Purpose::Nullification),
+            resolve_msg(View::new(10), View::new(2), Kind::Nullification),
         );
         MailboxMessage::handle(
             &mut overflow,
-            resolve_msg(View::new(10), View::new(5), Purpose::Parent),
+            resolve_msg(View::new(10), View::new(5), Kind::Notarization),
         );
         MailboxMessage::handle(&mut overflow, certificate_msg(finalization(View::new(3))));
 
@@ -565,7 +565,7 @@ mod tests {
             Some(MailboxMessage::Resolve {
                 proposal_view,
                 view,
-                purpose: Purpose::Parent,
+                kind: Kind::Notarization,
                 ..
             }) if proposal_view == View::new(10) && view == View::new(5)
         ));
@@ -574,14 +574,10 @@ mod tests {
     #[test]
     fn resolve_deduplicates_by_proposal_and_requested_view() {
         let mut overflow = Pending::default();
-        for purpose in [
-            Purpose::Nullification,
-            Purpose::Nullification,
-            Purpose::Parent,
-        ] {
+        for kind in [Kind::Nullification, Kind::Nullification, Kind::Notarization] {
             MailboxMessage::handle(
                 &mut overflow,
-                resolve_msg(View::new(10), View::new(3), purpose),
+                resolve_msg(View::new(10), View::new(3), kind),
             );
         }
 
@@ -590,7 +586,7 @@ mod tests {
         assert!(matches!(
             &overflow[0],
             MailboxMessage::Resolve {
-                purpose: Purpose::Nullification,
+                kind: Kind::Nullification,
                 ..
             }
         ));
@@ -624,12 +620,12 @@ mod tests {
         MailboxMessage::handle(&mut overflow, certificate_msg(finalization(View::new(2))));
         MailboxMessage::handle(
             &mut overflow,
-            resolve_msg(View::new(10), View::new(2), Purpose::Nullification),
+            resolve_msg(View::new(10), View::new(2), Kind::Nullification),
         );
         MailboxMessage::handle(&mut overflow, certificate_msg(nullification(View::new(4))));
         MailboxMessage::handle(
             &mut overflow,
-            resolve_msg(View::new(10), View::new(4), Purpose::Parent),
+            resolve_msg(View::new(10), View::new(4), Kind::Notarization),
         );
 
         let mut overflow = drain(overflow);
@@ -648,7 +644,7 @@ mod tests {
             overflow.pop_front(),
             Some(MailboxMessage::Resolve {
                 view,
-                purpose: Purpose::Parent,
+                kind: Kind::Notarization,
                 ..
             }) if view == View::new(4)
         ));

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -28,13 +28,18 @@
 //!
 //! Background repair cannot detect a split where one participant certifies a notarization while
 //! another holds a covering nullification. Proposal verification exposes the missing ancestry and
-//! targets the first gap at the proposal's leader. Matching evidence or finalization retires that
-//! request, whereas a certified-floor raise retires only background work.
+//! targets the first gap at the proposal's leader. Matching evidence, finalization, or a failed
+//! certification verdict retires that request, whereas a certified-floor raise retires only
+//! background work.
 //!
-//! The wire key names only the view. A responder holding both a notarization and a covering
-//! nullification cannot tell which one the requester wants, so it serves one at random. The
-//! requester recognizes a response that does not settle its ask and retries without faulting the
-//! peer.
+//! The wire key names only the view. A responder holding both a certified notarization and a
+//! covering nullification cannot tell which one the requester wants, so it serves one at random.
+//! The requester recognizes a response that does not settle its ask and retries without faulting
+//! the peer.
+//!
+//! A notarization is served only after local certification succeeds. Possession still settles the
+//! holder's own ask, because certification judges evidence already in hand. A failed verdict also
+//! settles it, since no copy of that notarization can certify anywhere.
 //!
 //! # Mid-Term Floor Raises
 //!

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -31,10 +31,10 @@
 //! targets the first gap at the proposal's leader. Matching evidence or finalization retires that
 //! request, whereas a certified-floor raise retires only background work.
 //!
-//! The wire key names the certificate wanted alongside the view, so a responder holding both a
-//! notarization and a covering nullification does not have to guess, and any other certificate is
-//! invalid for the key. A valid notarization may wait up to the certification timeout for its local
-//! verdict while other deliveries continue independently.
+//! The wire key names only the view. A responder holding both a notarization and a covering
+//! nullification cannot tell which one the requester wants, so it serves one at random. The
+//! requester recognizes a response that does not settle its demand and retries without faulting the
+//! peer.
 //!
 //! # Mid-Term Floor Raises
 //!

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -97,7 +97,6 @@ pub struct Config<S: Scheme, B: Blocker, T: Strategy> {
     pub mailbox_size: NonZeroUsize,
     pub fetch_concurrent: NonZeroUsize,
     pub fetch_timeout: Duration,
-    pub certification_timeout: Duration,
     pub term_length: TermLength,
 }
 

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -33,7 +33,7 @@
 //!
 //! The wire key names only the view. A responder holding both a notarization and a covering
 //! nullification cannot tell which one the requester wants, so it serves one at random. The
-//! requester recognizes a response that does not settle its demand and retries without faulting the
+//! requester recognizes a response that does not settle its ask and retries without faulting the
 //! peer.
 //!
 //! # Mid-Term Floor Raises

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -31,10 +31,10 @@
 //! targets the first gap at the proposal's leader. Matching evidence or finalization retires that
 //! request, whereas a certified-floor raise retires only background work.
 //!
-//! The wire key remains the requested view. A cryptographically valid response that does not satisfy
-//! every attached purpose is ambiguous, so the resolver retries without faulting its peer. A valid
-//! notarization may wait up to the certification timeout for its local verdict while other deliveries
-//! continue independently.
+//! The wire key names the certificate wanted alongside the view, so a responder holding both a
+//! notarization and a covering nullification does not have to guess, and any other certificate is
+//! invalid for the key. A valid notarization may wait up to the certification timeout for its local
+//! verdict while other deliveries continue independently.
 //!
 //! # Mid-Term Floor Raises
 //!

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use commonware_cryptography::{Digest, certificate::Scheme};
 use core::num::NonZeroUsize;
-use std::collections::{BTreeMap, HashSet};
+use std::collections::BTreeMap;
 
 /// Why a resolver fetch was requested.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -61,14 +61,11 @@ pub struct State<S: Scheme, D: Digest> {
     fetch_floor: View,
     /// Number of views in each leader term.
     term_length: TermLength,
-    /// Views where certification has failed. Only nullifications
-    /// are accepted for these views.
-    failed_views: HashSet<View>,
 }
 
 impl<S: Scheme, D: Digest> State<S, D> {
     /// Create a new instance of [State].
-    pub fn new(fetch_concurrent: NonZeroUsize, term_length: TermLength) -> Self {
+    pub const fn new(fetch_concurrent: NonZeroUsize, term_length: TermLength) -> Self {
         Self {
             current_view: View::zero(),
             floor: None,
@@ -77,13 +74,7 @@ impl<S: Scheme, D: Digest> State<S, D> {
             fetch_concurrent: fetch_concurrent.get(),
             fetch_floor: View::zero(),
             term_length,
-            failed_views: HashSet::new(),
         }
-    }
-
-    /// Returns true if the given view has failed certification.
-    pub fn is_failed(&self, view: View) -> bool {
-        self.failed_views.contains(&view)
     }
 
     /// Returns the term length this state was built with.
@@ -145,7 +136,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
             effects.extend(self.fetch_missing(view));
         } else {
             self.notarizations.remove(&view);
-            self.failed_views.insert(view);
 
             // Request a nullification for this view (if not already covered).
             // Existing fetches remain active when the failed notarization did
@@ -241,7 +231,6 @@ impl<S: Scheme, D: Digest> State<S, D> {
         let term_length = self.term_length;
         self.nullifications
             .retain(|view, _| covers_above_floor(*view, term_length, floor));
-        self.failed_views.retain(|view| *view > floor);
 
         // A floor inside a partially-fetched term strands the term's tail
         // (see the module docs). Pull the cursor back to just above the
@@ -594,15 +583,13 @@ mod tests {
                 fetch(4, 5, FetchReason::MissingNullification),
             ]
         );
-        assert!(!state.is_failed(View::new(5)));
 
         // Certification fails for view 5
         let effects = state.handle_certified(View::new(5), false);
 
-        // View 5 is marked failed and only the failed view gets a new
-        // background request. Requests answered by the failed notarization
-        // are retried by the resolver engine.
-        assert!(state.is_failed(View::new(5)));
+        // Only the failed view gets a new background request. Requests
+        // answered by the failed notarization are retried by the resolver
+        // engine.
         assert_eq!(effects, vec![fetch(5, 5, FetchReason::CertificationFailed)]);
     }
 
@@ -627,12 +614,11 @@ mod tests {
         // Certification succeeds for view 5
         let effects = state.handle_certified(View::new(5), true);
 
-        // The certified notarization becomes the floor and view 5 is not marked failed
+        // The certified notarization becomes the floor
         assert!(
             matches!(state.floor.as_ref(), Some(Certificate::Notarization(n)) if n == &notarization_v5)
         );
         assert_eq!(effects, vec![Effect::RetainAbove(View::new(5))]);
-        assert!(!state.is_failed(View::new(5)));
     }
 
     #[test]
@@ -790,7 +776,6 @@ mod tests {
         state.handle(Certificate::Nullification(nullification_v1));
 
         let effects = state.handle_certified(View::new(5), false);
-        assert!(state.is_failed(View::new(5)));
         assert!(effects.is_empty());
     }
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -380,10 +380,10 @@ impl<
             Verify::Resolve {
                 proposal_view,
                 view,
-                purpose,
+                kind,
                 target,
             } => {
-                resolver.resolve(proposal_view, view, purpose, target);
+                resolver.resolve(proposal_view, view, kind, target);
                 return None;
             }
             Verify::Wait => return None,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -859,7 +859,7 @@ impl<
             // after a nullification for the same view because certification is
             // asynchronous; finalization is the boundary that cancels in-flight
             // certification and suppresses late reporting.
-            resolver.certified(&notarization, certified);
+            resolver.certified(notarization.round(), certified);
             if certified {
                 self.reporter.report(Activity::Certification(notarization));
             }
@@ -1008,7 +1008,7 @@ impl<
                         let Some(notarization) = notarization else {
                             continue;
                         };
-                        resolver.certified(&notarization, success);
+                        resolver.certified(round, success);
                         if success {
                             self.reporter.report(Activity::Certification(notarization));
                         }

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -3708,9 +3708,10 @@ mod tests {
                         && target == expected_leader
             ));
 
-            // The leader's preferred notarization is already known and does not
-            // provide the nullification this proposal needs. It must neither permit a
-            // vote nor create a request loop in the same round.
+            // The leader's preferred notarization is already known and does
+            // not provide the nullification this proposal needs. It must
+            // neither permit a vote nor create a request loop in the same
+            // round.
             let (added, _) = state.add_notarization(notarization);
             assert!(!added);
             assert!(matches!(state.try_verify(), Verify::Wait));
@@ -3754,9 +3755,9 @@ mod tests {
                         && view == parent_view
             ));
 
-            // The leader's preferred covering nullification does not certify the
-            // named parent, so it must neither permit a
-            // vote nor create a same-round request loop.
+            // The leader's preferred covering nullification does not certify
+            // the named parent, so it must neither permit a vote nor create a
+            // same-round request loop.
             assert!(!state.add_nullification(nullification_1));
             assert!(matches!(state.try_verify(), Verify::Wait));
         });

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1,4 +1,4 @@
-use super::{super::Purpose, round::Round};
+use super::{super::Kind, round::Round};
 use crate::{
     Viewable,
     simplex::{
@@ -88,7 +88,7 @@ pub enum Verify<S: Scheme<D>, D: Digest> {
     Resolve {
         proposal_view: View,
         view: View,
-        purpose: Purpose,
+        kind: Kind,
         target: S::PublicKey,
     },
     Wait,
@@ -759,12 +759,12 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                         "proposal exists but ancestry is not yet certified"
                     );
                 }
-                let (requested, purpose) = match err {
+                let (missing, kind) = match err {
                     ParentPayloadError::MissingNullification { missing_view, .. } => {
-                        (missing_view, Purpose::Nullification)
+                        (missing_view, Kind::Nullification)
                     }
                     ParentPayloadError::ParentNotCertified { parent_view, .. } => {
-                        (parent_view, Purpose::Parent)
+                        (parent_view, Kind::Notarization)
                     }
                     ParentPayloadError::ParentNotBeforeProposal { .. }
                     | ParentPayloadError::IntraTermProposalSkipsViews { .. }
@@ -774,14 +774,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                     .views
                     .get_mut(&view)
                     .expect("current round must exist")
-                    .request(requested)
+                    .request(missing)
                 {
                     return Verify::Wait;
                 }
                 return Verify::Resolve {
                     proposal_view: proposal.view(),
-                    view: requested,
-                    purpose,
+                    view: missing,
+                    kind,
                     target: leader.key,
                 };
             }
@@ -3700,18 +3700,16 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Nullification,
                     target,
                 }
                     if proposal_view == child_view
                         && view == skipped_view
-                        && purpose == Purpose::Nullification
                         && target == expected_leader
             ));
 
-            // A kindless response can validly contain the leader's preferred
-            // notarization, which is already known and does not provide the
-            // nullification this proposal needs. It must neither permit a
+            // The leader's preferred notarization is already known and does not
+            // provide the nullification this proposal needs. It must neither permit a
             // vote nor create a request loop in the same round.
             let (added, _) = state.add_notarization(notarization);
             assert!(!added);
@@ -3749,17 +3747,15 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Notarization,
                     ..
                 }
                     if proposal_view == child_view
                         && view == parent_view
-                        && purpose == Purpose::Parent
             ));
 
-            // A kindless response can instead contain the leader's preferred
-            // covering nullification. It is valid evidence for the key but
-            // does not certify the named parent, so it must neither permit a
+            // The leader's preferred covering nullification does not certify the
+            // named parent, so it must neither permit a
             // vote nor create a same-round request loop.
             assert!(!state.add_nullification(nullification_1));
             assert!(matches!(state.try_verify(), Verify::Wait));
@@ -3841,12 +3837,11 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Nullification,
                     ..
                 }
                     if proposal_view == child_view
                         && view == View::new(2)
-                        && purpose == Purpose::Nullification
             ));
         });
     }
@@ -3880,7 +3875,7 @@ mod tests {
                 state.try_verify(),
                 Verify::Resolve {
                     view,
-                    purpose: Purpose::Nullification,
+                    kind: Kind::Nullification,
                     ..
                 } if view == skipped_view
             ));
@@ -3909,12 +3904,11 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Nullification,
                     ..
                 }
                     if proposal_view == retry_view
                         && view == skipped_view
-                        && purpose == Purpose::Nullification
             ));
         });
     }
@@ -3953,12 +3947,11 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Nullification,
                     ..
                 }
                     if proposal_view == child_view
                         && view == skipped_view
-                        && purpose == Purpose::Nullification
             ));
 
             // Certification does not duplicate the still-active request.
@@ -3998,12 +3991,11 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Notarization,
                     ..
                 }
                     if proposal_view == child_view
                         && view == View::new(2)
-                        && purpose == Purpose::Parent
             ));
         });
     }
@@ -4043,12 +4035,11 @@ mod tests {
                 Verify::Resolve {
                     proposal_view,
                     view,
-                    purpose,
+                    kind: Kind::Nullification,
                     ..
                 }
                     if proposal_view == child_view
                         && view == View::new(2)
-                        && purpose == Purpose::Nullification
             ));
         });
     }

--- a/consensus/src/simplex/config.rs
+++ b/consensus/src/simplex/config.rs
@@ -188,10 +188,6 @@ where
     /// Amount of time to wait for certification progress in a view
     /// before attempting to skip the view.
     ///
-    /// This also bounds how long the resolver holds a valid notarization
-    /// delivery for local certification. Expiry releases only the delivery
-    /// while application certification continues.
-    ///
     /// This timeout must be greater than the leader timeout.
     pub certification_timeout: Duration,
 

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -123,7 +123,6 @@ impl<
                 epoch: cfg.epoch,
                 fetch_concurrent: cfg.fetch_concurrent,
                 fetch_timeout: cfg.fetch_timeout,
-                certification_timeout: cfg.certification_timeout,
                 term_length,
             },
         );

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -312,8 +312,9 @@
 //! parent from the proposal's elected leader, even below the certified floor. The voter rechecks the
 //! full ancestry after each delivery and votes only once it is valid.
 //!
-//! Resolver keys identify views rather than certificate types. A valid response that does not satisfy
-//! every local purpose is retried without faulting its peer. A notarization delivery may wait up to
+//! Resolver keys name the certificate wanted, not just the view, because a notarization and a
+//! covering nullification for one view answer opposite questions. Any other certificate is invalid
+//! for the key. A notarization delivery may wait up to
 //! [`Config::certification_timeout`](config::Config::certification_timeout) for local certification.
 //! Expiry releases the delivery but does not resolve or cancel certification. Matching evidence or
 //! finalization retires targeted work.

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -312,12 +312,11 @@
 //! parent from the proposal's elected leader, even below the certified floor. The voter rechecks the
 //! full ancestry after each delivery and votes only once it is valid.
 //!
-//! Resolver keys name the certificate wanted, not just the view, because a notarization and a
-//! covering nullification for one view answer opposite questions. Any other certificate is invalid
-//! for the key. A notarization delivery may wait up to
-//! [`Config::certification_timeout`](config::Config::certification_timeout) for local certification.
-//! Expiry releases the delivery but does not resolve or cancel certification. Matching evidence or
-//! finalization retires targeted work.
+//! A resolver key identifies a view, not a certificate. A notarization and a covering nullification
+//! for one view answer opposite questions, so a peer can return valid evidence that does not settle
+//! the request. The requester records that evidence and retries without faulting the peer. A
+//! delivered notarization completes its fetch on arrival, because certification judges evidence
+//! already in hand. Matching evidence or finalization retires targeted work.
 //!
 //! ## Pluggable Hashing and Cryptography
 //!


### PR DESCRIPTION
Targets `simplex-repair-cleanup` (#4386).

This reworks how the simplex resolver tracks what it still wants. Possession replaces certification on both sides of the wire: a fetch completes once the requested notarization arrives, and a responder serves a cached notarization without waiting for its own verdict. A notarization whose certification fails leaves the cache, since certification judges the evidence itself and no other copy could pass. Those are the behavior changes; the rest reshapes the demand bookkeeping.

## Split `Purpose` into two axes

`Purpose` on the base branch names three cases without naming the two dimensions they vary along, which makes its retirement rules hard to follow:

```rust
struct Demand {
    kind: Kind,    // Nullification | Notarization  -- what settles the request
    until: Until,  // Floor | Finalization          -- what retires the request
}
```

`Backfill` is `(Nullification, Floor)`, `Nullification` is `(Nullification, Finalization)`, and `Parent` is `(Notarization, Finalization)`. The fourth combination does not occur, because background repair only ever wants a nullification.

The two axes cannot be collapsed into one. Retiring an `Until::Finalization` demand at the floor breaks the certificate split that #4386 addresses: the floor may be an unfinalized certified notarization, and a proposal can still name ancestry below it. Holding an `Until::Floor` demand until finalization is a griefing vector, because views that are notarized and certified but never finalized would accumulate permanently unsatisfiable demands.

## One predicate for retirement

`settled(view, kind)` replaces `purpose_resolved`, `purpose_satisfied`, `is_retired_by`, and `retire`. It answers one question: is there anything left to fetch for this view and kind. Every site that needs retirement asks it.

The resolver stays the sole owner of the outstanding demands. Each piece of evidence publishes what it settles through `retire`, which takes an owned predicate naming a span of views and a kind. That is sound because settlement is monotonic: no later evidence unsettles a demand, so a retirement stays true however the resolver mailbox orders it against fetches, which it reorders under backpressure.

A valid response still does not imply a settled demand. The resolver key names only a view, so a peer may answer a notarization request with a covering nullification. That is valid evidence the requester records, but it is not what was asked for. The requester reports `Outcome::Ambiguous` and does not fault the peer, as in #4383.

`validate` also becomes a single match over the certificate, where the base branch uses per-kind arms with duplicated epoch and verification checks. It still accepts any certificate an honest peer could serve for the view, including a higher-view notarization served off a peer's floor.
