### PR TITLE
[storage] Preserve retained ancestor replay positions

### DIFF
--- a/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_unordered_batch_root.rs
@@ -9,7 +9,11 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{Family as MerkleFamily, full::Config as MerkleConfig, mmb, mmr},
-    qmdb::any::{FixedConfig as Config, unordered::fixed::Db as AnyDb},
+    qmdb::any::{
+        FixedConfig as Config,
+        batch::UnmerkleizedBatch,
+        unordered::fixed::{Db as AnyDb, Update},
+    },
     translator::OneCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
@@ -19,6 +23,7 @@ use std::num::NonZeroU16;
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
 type Db<F> = AnyDb<F, deterministic::Context, Key, Value, Sha256, OneCap, Sequential>;
+type Batch<F> = UnmerkleizedBatch<F, Sha256, Update<Key, Value>, Sequential>;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(131);
 const COLLISION_GROUPS: u8 = 4;
@@ -26,6 +31,13 @@ const KEY_SPACE: u64 = 32;
 const MAX_INITIAL_WRITES: usize = 16;
 const MAX_PARENT_MUTATIONS: usize = 16;
 const MAX_CHILD_MUTATIONS: usize = 16;
+const MAX_GRANDCHILD_MUTATIONS: usize = 16;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum Schedule {
+    PendingParent,
+    DroppedCommittedPrefix,
+}
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
 struct KeySeed {
@@ -47,16 +59,20 @@ enum Mutation {
 
 #[derive(Debug)]
 struct FuzzInput {
+    schedule: Schedule,
     initial: Vec<SeededWrite>,
     parent: Vec<Mutation>,
     child: Vec<Mutation>,
+    grandchild: Vec<Mutation>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schedule = Schedule::arbitrary(u)?;
         let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
         let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
+        let grandchild_len = u.int_in_range(1..=MAX_GRANDCHILD_MUTATIONS)?;
 
         let initial = (0..initial_len)
             .map(|_| SeededWrite::arbitrary(u))
@@ -67,11 +83,16 @@ impl<'a> Arbitrary<'a> for FuzzInput {
         let child = (0..child_len)
             .map(|_| Mutation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
+        let grandchild = (0..grandchild_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
+            schedule,
             initial,
             parent,
             child,
+            grandchild,
         })
     }
 }
@@ -112,6 +133,18 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
+fn apply_mutations<F: MerkleFamily>(mut batch: Batch<F>, mutations: &[Mutation]) -> Batch<F> {
+    for mutation in mutations {
+        batch = match mutation {
+            Mutation::Write { key, value } => {
+                batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+            }
+            Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+        };
+    }
+    batch
+}
+
 fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
     let runner = deterministic::Runner::default();
 
@@ -134,65 +167,88 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
         let (db, _) = db.apply_batch(initial).await.unwrap();
         let db = db.commit().await.unwrap();
 
-        // Build a parent batch, then build the child while the parent is still
-        // pending so the child must resolve through base_diff plus the stale
-        // committed snapshot.
-        let mut batch = db.new_batch();
-        for mutation in &input.parent {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let parent = batch.merkleize(&db, None).await.unwrap();
-        let mut batch = parent.new_batch::<Sha256>();
-        for mutation in &input.child {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let pending_child = batch.merkleize(&db, None).await.unwrap();
+        let db = match input.schedule {
+            Schedule::PendingParent => {
+                // Build a parent batch, then build the child while the parent is still
+                // pending so the child must resolve through base_diff plus the stale
+                // committed snapshot.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let pending_child = batch.merkleize(&db, None).await.unwrap();
 
-        // Commit the parent, then rebuild the same logical child from the
-        // committed DB state. Both speculative roots must match.
-        let (db, _) = db.apply_batch(parent).await.unwrap();
-        let db = db.commit().await.unwrap();
+                // Commit the parent, then rebuild the same logical child from the
+                // committed DB state. Both speculative roots must match.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
 
-        let mut batch = db.new_batch();
-        for mutation in &input.child {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let committed_child = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let committed_child = batch.merkleize(&db, None).await.unwrap();
 
-        assert_eq!(
-            pending_child.root(),
-            committed_child.root(),
-            "child root depended on pending-vs-committed parent path"
-        );
+                assert_eq!(
+                    pending_child.root(),
+                    committed_child.root(),
+                    "child root depended on pending-vs-committed parent path"
+                );
 
-        // Apply the pending child and verify the DB state matches.
-        let (db, _) = db.apply_batch(pending_child).await.unwrap();
-        assert_eq!(
-            db.root(),
-            committed_child.root(),
-            "pending child root diverged"
-        );
+                // Apply the pending child and verify the DB state matches.
+                let (db, _) = db.apply_batch(pending_child).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_child.root(),
+                    "pending child root diverged"
+                );
+                db
+            }
+            Schedule::DroppedCommittedPrefix => {
+                // Build A -> B, then commit and drop A before merkleizing C. C must retain
+                // only B and position that suffix relative to the now-committed A.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let a = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
+                let b = batch.merkleize(&db, None).await.unwrap();
+
+                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                let (db, _) = db.apply_batch(a).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(b.new_batch::<Sha256>(), &input.grandchild);
+                let retained_child = batch.merkleize(&db, None).await.unwrap();
+
+                // Rebuild B -> C from the committed A state as a reference.
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let rebuilt_b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_b.new_batch::<Sha256>(), &input.grandchild);
+                let rebuilt_child = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    retained_child.root(),
+                    rebuilt_child.root(),
+                    "child root depended on a committed-and-dropped prefix"
+                );
+
+                let (db, _) = db.apply_batch(retained_child).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    rebuilt_child.root(),
+                    "retained-suffix child root diverged"
+                );
+                db
+            }
+        };
 
         db.destroy().await.unwrap();
     });
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-unordered-batch-root");
-    fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-batch-root");
+    match input.schedule {
+        Schedule::PendingParent => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-unordered-batch-root");
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-batch-root");
+        }
+        Schedule::DroppedCommittedPrefix => {
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-dropped-prefix");
+        }
+    }
 });

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -83,23 +83,26 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
     /// Collect ancestor items from the parent chain before downgrading.
     fn collect_ancestor_items(
         parent: &Option<MerkleizedParent<F, H, Item, S>>,
-    ) -> Vec<Arc<Vec<Item>>> {
+        base_leaves: u64,
+    ) -> (u64, Vec<Arc<Vec<Item>>>) {
         let Some(parent) = parent else {
-            return Vec::new();
+            return (base_leaves, Vec::new());
         };
         let mut items = Vec::new();
+        let mut base_leaves = parent.as_ref().size() - parent.items.len() as u64;
         if !parent.items.is_empty() {
             items.push(Arc::clone(&parent.items));
         }
         let mut current = parent.parent.as_ref().and_then(Weak::upgrade);
         while let Some(batch) = current {
+            base_leaves = batch.as_ref().size() - batch.items.len() as u64;
             if !batch.items.is_empty() {
                 items.push(Arc::clone(&batch.items));
             }
             current = batch.parent.as_ref().and_then(Weak::upgrade);
         }
         items.reverse();
-        items
+        (base_leaves, items)
     }
 
     /// Merkleize the batch.
@@ -112,14 +115,17 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             parent,
         } = self;
 
+        let base_leaves = *inner.leaves() - items.len() as u64;
+        let (ancestor_base_leaves, ancestor_items) =
+            Self::collect_ancestor_items(&parent, base_leaves);
         let items = Arc::new(items);
         let merkle = inner.merkleize(base, &hasher);
-        let ancestor_items = Self::collect_ancestor_items(&parent);
         Arc::new(MerkleizedBatch {
             inner: merkle,
             bagging: hasher.root_bagging(),
             items,
             parent: parent.as_ref().map(Arc::downgrade),
+            ancestor_base_leaves,
             ancestor_items,
         })
     }
@@ -152,6 +158,8 @@ pub struct MerkleizedBatch<F: Family, D: Digest, Item: Send + Sync, S: Strategy>
     items: Arc<Vec<Item>>,
     /// This batch's parent, or None if the parent is the journal itself.
     parent: Option<Weak<Self>>,
+    /// Number of leaves before the oldest retained ancestor batch.
+    pub(crate) ancestor_base_leaves: u64,
     /// Ancestor item batches collected at merkleize time (root-to-tip order).
     pub(crate) ancestor_items: Vec<Arc<Vec<Item>>>,
 }
@@ -362,6 +370,7 @@ where
             bagging: self.hasher.root_bagging(),
             items: Arc::new(Vec::new()),
             parent: None,
+            ancestor_base_leaves: *self.size(),
             ancestor_items: Vec::new(),
         })
     }
@@ -546,8 +555,15 @@ where
         // Batches are collected into a single append_many call to acquire the
         // journal's write lock once instead of per-batch.
         let committed_leaves = self.journal.bounds().end;
-        let base_leaves = *Location::<F>::try_from(base_size)?;
-        let mut batch_leaf_end = base_leaves;
+        if committed_leaves < batch.ancestor_base_leaves {
+            return Err(merkle::Error::AncestorDropped {
+                expected: Position::<F>::try_from(Location::new(batch.ancestor_base_leaves))?,
+                actual: merkle_size,
+            }
+            .into());
+        }
+
+        let mut batch_leaf_end = batch.ancestor_base_leaves;
         let mut batches: Vec<&[C::Item]> = Vec::with_capacity(batch.ancestor_items.len() + 1);
         for ancestor in &batch.ancestor_items {
             batch_leaf_end += ancestor.len() as u64;
@@ -3435,5 +3451,56 @@ mod tests {
     fn test_apply_batch_skips_only_committed_ancestor_items_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_apply_batch_skips_only_committed_ancestor_items_inner::<mmb::Family>);
+    }
+
+    /// A dropped committed prefix must not shift the remaining uncommitted
+    /// ancestor items back to the original fork point.
+    async fn test_apply_batch_after_committed_ancestor_dropped_inner<F: Family + PartialEq>(
+        context: Context,
+    ) {
+        let mut journal =
+            create_empty_journal::<F>(context.child("storage"), "dropped-committed").await;
+
+        let mut a_batch = journal.new_batch();
+        for i in 0..8u8 {
+            a_batch = a_batch.add(create_operation::<F>(i));
+        }
+        let a = journal.merkle.with_mem(|mem| a_batch.merkleize(mem));
+        let b_batch = a.new_batch::<Sha256>().add(create_operation::<F>(8));
+        let b = journal.merkle.with_mem(|mem| b_batch.merkleize(mem));
+
+        journal = journal.apply_batch(&a).await.unwrap();
+        drop(a);
+
+        let c_batch = b.new_batch::<Sha256>().add(create_operation::<F>(9));
+        let c = journal.merkle.with_mem(|mem| c_batch.merkleize(mem));
+
+        // Only B remains in the retained ancestor suffix.
+        assert_eq!(c.ancestor_items.len(), 1);
+        assert_eq!(c.ancestor_base_leaves, *journal.size());
+        assert_eq!(c.inner.ancestor_base_size, journal.merkle.size());
+
+        drop(b);
+        journal = journal.apply_batch(&c).await.unwrap();
+        assert_eq!(*journal.size(), 10);
+
+        let mut reference =
+            create_empty_journal::<F>(context.child("reference"), "dropped-committed-ref").await;
+        for i in 0..10u8 {
+            (reference, _) = reference.append(&create_operation::<F>(i)).await.unwrap();
+        }
+        assert_eq!(journal_root(&journal), journal_root(&reference));
+    }
+
+    #[test_traced("INFO")]
+    fn test_apply_batch_after_committed_ancestor_dropped_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_apply_batch_after_committed_ancestor_dropped_inner::<mmr::Family>);
+    }
+
+    #[test_traced("INFO")]
+    fn test_apply_batch_after_committed_ancestor_dropped_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_apply_batch_after_committed_ancestor_dropped_inner::<mmb::Family>);
     }
 }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -3482,12 +3482,6 @@ mod tests {
     }
 
     #[test_traced("INFO")]
-    fn test_apply_batch_detects_dropped_uncommitted_ancestor_mmr() {
-        let executor = deterministic::Runner::default();
-        executor.start(test_apply_batch_detects_dropped_uncommitted_ancestor_inner::<mmr::Family>);
-    }
-
-    #[test_traced("INFO")]
     fn test_apply_batch_detects_dropped_uncommitted_ancestor_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_apply_batch_detects_dropped_uncommitted_ancestor_inner::<mmb::Family>);
@@ -3530,12 +3524,6 @@ mod tests {
             (reference, _) = reference.append(&create_operation::<F>(i)).await.unwrap();
         }
         assert_eq!(journal_root(&journal), journal_root(&reference));
-    }
-
-    #[test_traced("INFO")]
-    fn test_apply_batch_after_committed_ancestor_dropped_mmr() {
-        let executor = deterministic::Runner::default();
-        executor.start(test_apply_batch_after_committed_ancestor_dropped_inner::<mmr::Family>);
     }
 
     #[test_traced("INFO")]

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -80,14 +80,10 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
         self
     }
 
-    /// Collect ancestor items from the parent chain before downgrading.
+    /// Collect ancestor items and the leaf count before the oldest retained ancestor.
     fn collect_ancestor_items(
-        parent: &Option<MerkleizedParent<F, H, Item, S>>,
-        base_leaves: u64,
+        parent: &MerkleizedParent<F, H, Item, S>,
     ) -> (u64, Vec<Arc<Vec<Item>>>) {
-        let Some(parent) = parent else {
-            return (base_leaves, Vec::new());
-        };
         let mut items = Vec::new();
         let mut base_leaves = parent.as_ref().size() - parent.items.len() as u64;
         if !parent.items.is_empty() {
@@ -115,9 +111,10 @@ impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
             parent,
         } = self;
 
-        let base_leaves = *inner.leaves() - items.len() as u64;
-        let (ancestor_base_leaves, ancestor_items) =
-            Self::collect_ancestor_items(&parent, base_leaves);
+        let (ancestor_base_leaves, ancestor_items) = parent.as_ref().map_or_else(
+            || (*inner.leaves() - items.len() as u64, Vec::new()),
+            Self::collect_ancestor_items,
+        );
         let items = Arc::new(items);
         let merkle = inner.merkleize(base, &hasher);
         Arc::new(MerkleizedBatch {
@@ -558,7 +555,7 @@ where
         if committed_leaves < batch.ancestor_base_leaves {
             return Err(merkle::Error::AncestorDropped {
                 expected: Position::<F>::try_from(Location::new(batch.ancestor_base_leaves))?,
-                actual: merkle_size,
+                actual: Position::<F>::try_from(Location::new(committed_leaves))?,
             }
             .into());
         }
@@ -3451,6 +3448,49 @@ mod tests {
     fn test_apply_batch_skips_only_committed_ancestor_items_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_apply_batch_skips_only_committed_ancestor_items_inner::<mmb::Family>);
+    }
+
+    /// A descendant whose uncommitted ancestor was dropped must fail before
+    /// appending any of its retained journal items.
+    async fn test_apply_batch_detects_dropped_uncommitted_ancestor_inner<F: Family + PartialEq>(
+        context: Context,
+    ) {
+        let journal =
+            create_empty_journal::<F>(context.child("storage"), "dropped-uncommitted").await;
+
+        let a_batch = journal.new_batch().add(create_operation::<F>(1));
+        let a = journal.merkle.with_mem(|mem| a_batch.merkleize(mem));
+        let b_batch = a.new_batch::<Sha256>().add(create_operation::<F>(2));
+        let b = journal.merkle.with_mem(|mem| b_batch.merkleize(mem));
+
+        drop(a);
+        let c_batch = b.new_batch::<Sha256>().add(create_operation::<F>(3));
+        let c = journal.merkle.with_mem(|mem| c_batch.merkleize(mem));
+        drop(b);
+
+        assert_eq!(c.ancestor_base_leaves, 1);
+        assert_eq!(c.ancestor_items.len(), 1);
+
+        let result = journal.apply_batch(&c).await;
+        assert!(
+            matches!(
+                result,
+                Err(super::Error::Merkle(merkle::Error::AncestorDropped { .. }))
+            ),
+            "expected AncestorDropped, got {result:?}"
+        );
+    }
+
+    #[test_traced("INFO")]
+    fn test_apply_batch_detects_dropped_uncommitted_ancestor_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_apply_batch_detects_dropped_uncommitted_ancestor_inner::<mmr::Family>);
+    }
+
+    #[test_traced("INFO")]
+    fn test_apply_batch_detects_dropped_uncommitted_ancestor_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_apply_batch_detects_dropped_uncommitted_ancestor_inner::<mmb::Family>);
     }
 
     /// A dropped committed prefix must not shift the remaining uncommitted

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -554,8 +554,8 @@ where
         let committed_leaves = self.journal.bounds().end;
         if committed_leaves < batch.ancestor_base_leaves {
             return Err(merkle::Error::AncestorDropped {
-                expected: Position::<F>::try_from(Location::new(batch.ancestor_base_leaves))?,
-                actual: Position::<F>::try_from(Location::new(committed_leaves))?,
+                expected: batch.inner.size(),
+                actual: merkle_size,
             }
             .into());
         }
@@ -3475,7 +3475,8 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(super::Error::Merkle(merkle::Error::AncestorDropped { .. }))
+                Err(super::Error::Merkle(merkle::Error::AncestorDropped { expected, .. }))
+                    if expected == c.inner.size()
             ),
             "expected AncestorDropped, got {result:?}"
         );

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -33,15 +33,16 @@
 //! # Parent chain and memory
 //!
 //! Each [`MerkleizedBatch`] stores its own local data (appended nodes and overwrites)
-//! plus `Arc` refs to each ancestor's data, collected during
+//! plus `Arc` refs to each retained ancestor's data, collected during
 //! [`UnmerkleizedBatch::merkleize`]. These ancestor batches' data are used by
 //! [`Mem::apply_batch`] to replay uncommitted ancestors without requiring the
 //! ancestor batches to still be alive.
 //!
 //! A `Weak` pointer to the parent is kept for [`MerkleizedBatch::get_node`] lookups
 //! (used during a child's merkleize) and for walking the chain to collect ancestor
-//! batch data. Committed-and-dropped ancestors truncate the `Weak` walk, but their
-//! data is already captured in `ancestor_appended` / `ancestor_overwrites`.
+//! batch data. Committed-and-dropped ancestors truncate the `Weak` walk, leaving their
+//! data in the committed [`Mem`]. `ancestor_base_size` records the position before the
+//! oldest retained ancestor so the remaining suffix is replayed at the correct offset.
 //!
 //! During [`UnmerkleizedBatch::merkleize`], the parent is held as a strong `Arc`
 //! (keeping it alive for the walk), and the `Weak` chain is walked to collect

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -372,7 +372,8 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         }
 
         // Collect ancestor data by walking the parent chain (strong Arc + Weak walk).
-        let (ancestor_appended, ancestor_overwrites) = collect_ancestor_batches(&self.parent);
+        let (ancestor_base_size, ancestor_appended, ancestor_overwrites) =
+            collect_ancestor_batches(&self.parent);
 
         let parent_size = self.parent.size();
         Arc::new(MerkleizedBatch {
@@ -381,6 +382,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             overwrites: Arc::new(self.overwrites),
             parent_size,
             base_size: self.parent.base_size,
+            ancestor_base_size,
             pruning_boundary: self.parent.pruning_boundary(),
             ancestor_appended,
             ancestor_overwrites,
@@ -459,14 +461,15 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 }
 
 /// Collect ancestor batch data by walking the parent + its Weak chain.
-/// Returns (appended, overwrites) in root-to-tip order. Skips empty batches
-/// (e.g. root batches from `from_mem`).
+/// Returns the size before the oldest retained ancestor followed by its appended nodes and
+/// overwrites in root-to-tip order. Skips empty batches (e.g. root batches from `from_mem`).
 #[allow(clippy::type_complexity)]
 fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
     parent: &Arc<MerkleizedBatch<F, D, S>>,
-) -> (Vec<Arc<Vec<D>>>, Vec<Arc<Overwrites<F, D>>>) {
+) -> (Position<F>, Vec<Arc<Vec<D>>>, Vec<Arc<Overwrites<F, D>>>) {
     let mut appended = Vec::new();
     let mut overwrites = Vec::new();
+    let mut base_size = parent.parent_size;
 
     // Parent is alive (strong Arc held by UnmerkleizedBatch).
     if !parent.appended.is_empty() || !parent.overwrites.is_empty() {
@@ -477,6 +480,7 @@ fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
     // Walk Weak chain for grandparents+.
     let mut current = parent.parent.as_ref().and_then(Weak::upgrade);
     while let Some(batch) = current {
+        base_size = batch.parent_size;
         if !batch.appended.is_empty() || !batch.overwrites.is_empty() {
             appended.push(Arc::clone(&batch.appended));
             overwrites.push(Arc::clone(&batch.overwrites));
@@ -486,7 +490,7 @@ fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
 
     appended.reverse();
     overwrites.reverse();
-    (appended, overwrites)
+    (base_size, appended, overwrites)
 }
 
 // ---------------------------------------------------------------------------
@@ -512,6 +516,9 @@ pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     /// Number of committed nodes when the batch chain was forked. Inherited unchanged
     /// by all descendants. Used by `apply_batch` to detect already-committed ancestors.
     pub(crate) base_size: Position<F>,
+
+    /// Number of nodes before the oldest retained ancestor batch.
+    pub(crate) ancestor_base_size: Position<F>,
 
     /// Pruning boundary of the [`Mem`] when the batch chain was forked. Inherited
     /// unchanged by all descendants, like `base_size`.
@@ -546,6 +553,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
             overwrites: Arc::new(Overwrites::default()),
             parent_size: mem.size(),
             base_size: mem.size(),
+            ancestor_base_size: mem.size(),
             pruning_boundary: Readable::pruning_boundary(mem),
             ancestor_appended: Vec::new(),
             ancestor_overwrites: Vec::new(),

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -399,10 +399,17 @@ impl<F: Family, D: Digest> Mem<F, D> {
             });
         };
 
+        if self.size() < batch.ancestor_base_size {
+            return Err(Error::AncestorDropped {
+                expected: batch.ancestor_base_size,
+                actual: self.size(),
+            });
+        }
+
         // Apply ancestor batches in root-to-tip order. Already-committed
         // batches (whose appended nodes are already in the Mem) are skipped
-        // by tracking a running position through the ancestor chain.
-        let mut batch_pos = *batch.base_size;
+        // by tracking a running position through the retained ancestor suffix.
+        let mut batch_pos = *batch.ancestor_base_size;
         for (appended, overwrites) in batch
             .ancestor_appended
             .iter()
@@ -1132,6 +1139,44 @@ mod tests {
         );
     }
 
+    /// Dropping a committed ancestor before merkleizing a descendant must not
+    /// shift the retained uncommitted suffix back to the original fork point.
+    fn apply_batch_after_committed_ancestor_dropped<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        let mut mem = Mem::<F, D>::new();
+
+        let a = {
+            let mut batch = mem.new_batch();
+            for i in 0u64..8 {
+                batch = batch.add(&hasher, &i.to_be_bytes());
+            }
+            batch.merkleize(&mem, &hasher)
+        };
+        let b = a
+            .new_batch()
+            .add(&hasher, &8u64.to_be_bytes())
+            .merkleize(&mem, &hasher);
+
+        mem.apply_batch(&a).unwrap();
+        drop(a);
+
+        let c = b
+            .new_batch()
+            .add(&hasher, &9u64.to_be_bytes())
+            .merkleize(&mem, &hasher);
+
+        // Only the live, uncommitted suffix is retained, and its position starts
+        // immediately after the committed ancestor.
+        assert_eq!(c.ancestor_appended.len(), 1);
+        assert_eq!(c.ancestor_base_size, mem.size());
+
+        drop(b);
+        mem.apply_batch(&c).unwrap();
+
+        let reference = build_raw::<F>(&hasher, 10);
+        assert_eq!(plain_root(&mem, &hasher), plain_root(&reference, &hasher));
+    }
+
     /// Overwrite-only ancestor B must not be skipped when applying C after A.
     fn apply_batch_overwrite_only_ancestor<F: Family>() {
         let hasher: H = Standard::new(ForwardFold);
@@ -1287,6 +1332,10 @@ mod tests {
         apply_batch_detects_dropped_ancestor::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_apply_batch_after_committed_ancestor_dropped() {
+        apply_batch_after_committed_ancestor_dropped::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_apply_batch_overwrite_only_ancestor() {
         apply_batch_overwrite_only_ancestor::<crate::mmr::Family>();
     }
@@ -1384,6 +1433,10 @@ mod tests {
     #[test]
     fn mmb_apply_batch_detects_dropped_ancestor() {
         apply_batch_detects_dropped_ancestor::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_apply_batch_after_committed_ancestor_dropped() {
+        apply_batch_after_committed_ancestor_dropped::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_apply_batch_overwrite_only_ancestor() {

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -1387,14 +1387,6 @@ mod tests {
         apply_batch_detects_dropped_ancestor::<crate::mmr::Family>();
     }
     #[test]
-    fn mmr_apply_batch_after_committed_ancestor_dropped() {
-        apply_batch_after_committed_ancestor_dropped::<crate::mmr::Family>();
-    }
-    #[test]
-    fn mmr_apply_batch_after_committed_ancestor_dropped_with_overwrite() {
-        apply_batch_after_committed_ancestor_dropped_with_overwrite::<crate::mmr::Family>();
-    }
-    #[test]
     fn mmr_apply_batch_overwrite_only_ancestor() {
         apply_batch_overwrite_only_ancestor::<crate::mmr::Family>();
     }

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -1177,6 +1177,61 @@ mod tests {
         assert_eq!(plain_root(&mem, &hasher), plain_root(&reference, &hasher));
     }
 
+    /// A retained overwrite-only ancestor must not be skipped after an earlier
+    /// committed ancestor is dropped, even though it does not change the size.
+    fn apply_batch_after_committed_ancestor_dropped_with_overwrite<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        let mut mem = build_raw::<F>(&hasher, 10);
+
+        let a = {
+            let mut batch = mem.new_batch();
+            for i in 100u64..105 {
+                batch = batch.add(&hasher, &i.to_be_bytes());
+            }
+            batch.merkleize(&mem, &hasher)
+        };
+        let b = a
+            .new_batch()
+            .update_leaf(&hasher, Location::new(0), b"updated-0")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+
+        mem.apply_batch(&a).unwrap();
+        drop(a);
+
+        // Update a different peak so C's own overwrites do not carry B's
+        // updated peak into the Mem if B is incorrectly skipped.
+        let c = b
+            .new_batch()
+            .update_leaf(&hasher, Location::new(9), b"updated-9")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+
+        assert_eq!(c.ancestor_appended.len(), 1);
+        assert!(c.ancestor_appended[0].is_empty());
+        assert_eq!(c.ancestor_base_size, mem.size());
+
+        drop(b);
+        mem.apply_batch(&c).unwrap();
+
+        let mut reference = build_raw::<F>(&hasher, 10);
+        let expected = {
+            let mut batch = reference.new_batch();
+            for i in 100u64..105 {
+                batch = batch.add(&hasher, &i.to_be_bytes());
+            }
+            batch
+                .update_leaf(&hasher, Location::new(0), b"updated-0")
+                .unwrap()
+                .update_leaf(&hasher, Location::new(9), b"updated-9")
+                .unwrap()
+                .merkleize(&reference, &hasher)
+        };
+        reference.apply_batch(&expected).unwrap();
+
+        assert_eq!(plain_root(&mem, &hasher), plain_root(&reference, &hasher));
+    }
+
     /// Overwrite-only ancestor B must not be skipped when applying C after A.
     fn apply_batch_overwrite_only_ancestor<F: Family>() {
         let hasher: H = Standard::new(ForwardFold);
@@ -1336,6 +1391,10 @@ mod tests {
         apply_batch_after_committed_ancestor_dropped::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_apply_batch_after_committed_ancestor_dropped_with_overwrite() {
+        apply_batch_after_committed_ancestor_dropped_with_overwrite::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_apply_batch_overwrite_only_ancestor() {
         apply_batch_overwrite_only_ancestor::<crate::mmr::Family>();
     }
@@ -1437,6 +1496,10 @@ mod tests {
     #[test]
     fn mmb_apply_batch_after_committed_ancestor_dropped() {
         apply_batch_after_committed_ancestor_dropped::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_apply_batch_after_committed_ancestor_dropped_with_overwrite() {
+        apply_batch_after_committed_ancestor_dropped_with_overwrite::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_apply_batch_overwrite_only_ancestor() {

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -401,7 +401,7 @@ impl<F: Family, D: Digest> Mem<F, D> {
 
         if self.size() < batch.ancestor_base_size {
             return Err(Error::AncestorDropped {
-                expected: batch.ancestor_base_size,
+                expected: batch.size(),
                 actual: self.size(),
             });
         }
@@ -1134,7 +1134,10 @@ mod tests {
 
         let result = mem.apply_batch(&c);
         assert!(
-            matches!(result, Err(Error::AncestorDropped { .. })),
+            matches!(
+                result,
+                Err(Error::AncestorDropped { expected, .. }) if expected == c.size()
+            ),
             "expected AncestorDropped, got {result:?}"
         );
     }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -38,6 +38,9 @@ use tracing::debug;
 type DiffVec<K, F, V> = Vec<(K, DiffEntry<F, V>)>;
 type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 
+/// Sorted locations at the retained batch chain's committed boundary.
+type AncestorBaseLocs<K, F> = Vec<(K, Option<Location<F>>)>;
+
 /// One contiguous chunk of floor-raise candidates paired with their resolved operations.
 type CandidateChunk<'a, F, U> = (&'a [Location<F>], &'a [Operation<F, U>]);
 
@@ -419,6 +422,11 @@ where
     /// alive. Used by `apply_batch` to apply uncommitted ancestor snapshot diffs.
     /// 1:1 with `bounds.ancestors` (same length, same ordering).
     pub(crate) ancestor_diffs: Vec<Arc<DiffVec<U::Key, F, U::Value>>>,
+
+    /// Locations at `bounds.db` for keys whose retained ancestor diffs cross a dropped prefix.
+    /// Only overlapping keys are retained, bounding this by the live speculative suffix rather
+    /// than the committed history.
+    ancestor_base_locs: AncestorBaseLocs<U::Key, F>,
 
     /// Position and floor bounds for this batch chain.
     pub(crate) bounds: batch_chain::Bounds<F, D>,
@@ -1314,6 +1322,24 @@ where
             diff = job.await;
         }
 
+        // A retained ancestor's `base_old_loc` traces back to the DB boundary at which its chain
+        // was originally created. If an older committed prefix has since dropped out of the Weak
+        // chain, resolve keys touched on both sides of that boundary to their location after the
+        // dropped prefix. Keeping only the intersection avoids retaining the prefix's value diffs.
+        let ancestor_base_locs = self.ancestors.last().map_or_else(Vec::new, |oldest| {
+            if oldest.ancestor_diffs.iter().all(|diff| diff.is_empty()) {
+                return Vec::new();
+            }
+            let mut dropped =
+                DiffCursors::new(oldest.ancestor_diffs.iter().map(|diff| diff.as_slice()));
+            DiffMerge::new(
+                self.ancestors
+                    .iter()
+                    .map(|ancestor| ancestor.diff.as_slice()),
+            )
+            .filter_map(|(key, _)| dropped.resolve(key).map(|entry| (key.clone(), entry.loc())))
+            .collect()
+        });
         let ancestor_diffs: Vec<_> = self.ancestors.iter().map(|a| Arc::clone(&a.diff)).collect();
         let ancestors: Vec<_> = self
             .ancestors
@@ -1331,6 +1357,7 @@ where
             parent: self.ancestors.first().map(Arc::downgrade),
             total_active_keys: total_active_keys as usize,
             ancestor_diffs,
+            ancestor_base_locs,
             bounds: batch_chain::Bounds {
                 base: self.base_state,
                 db: self.db_state,
@@ -2853,15 +2880,44 @@ where
                     }
                 }
                 let mut resolver = DiffCursors::new(applied);
-                let merge = DiffMerge::new(
-                    iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
-                );
-                for (key, entry) in merge {
-                    let old = resolver
-                        .resolve(key)
-                        .map(DiffEntry::loc)
-                        .unwrap_or_else(|| entry.base_old_loc());
-                    apply_diff(&mut self.snapshot, &mut bitmap, key, entry, old);
+                if batch.ancestor_base_locs.is_empty() {
+                    let merge = DiffMerge::new(
+                        iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
+                    );
+                    for (key, entry) in merge {
+                        let old = resolver
+                            .resolve(key)
+                            .map(DiffEntry::loc)
+                            .unwrap_or_else(|| entry.base_old_loc());
+                        apply_diff(&mut self.snapshot, &mut bitmap, key, entry, old);
+                    }
+                } else {
+                    let mut ancestor_base_locs = batch.ancestor_base_locs.iter().peekable();
+                    let merge = DiffMerge::new(
+                        iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
+                    );
+                    for (key, entry) in merge {
+                        let old = resolver.resolve(key).map_or_else(
+                            || {
+                                while ancestor_base_locs
+                                    .peek()
+                                    .is_some_and(|(candidate, _)| candidate < key)
+                                {
+                                    ancestor_base_locs.next();
+                                }
+                                if ancestor_base_locs
+                                    .peek()
+                                    .is_some_and(|(candidate, _)| candidate == key)
+                                {
+                                    ancestor_base_locs.next().expect("peeked entry exists").1
+                                } else {
+                                    entry.base_old_loc()
+                                }
+                            },
+                            DiffEntry::loc,
+                        );
+                        apply_diff(&mut self.snapshot, &mut bitmap, key, entry, old);
+                    }
                 }
             }
 
@@ -2919,6 +2975,7 @@ where
             parent: None,
             total_active_keys: self.active_keys,
             ancestor_diffs: Vec::new(),
+            ancestor_base_locs: Vec::new(),
             bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
         })
     }

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -1431,6 +1431,60 @@ pub(crate) mod test {
         db.destroy().await.unwrap();
     }
 
+    async fn batch_apply_after_committed_prefix_dropped_inner<F: Family>(
+        context: deterministic::Context,
+    ) {
+        let db = open_db_generic::<F>(context.child("db")).await;
+        let updated = key(0);
+        let recreated = key(1);
+        let deleted = key(2);
+        let (db, _) = commit_writes_generic(
+            db,
+            [(updated, Some(val(0))), (recreated, Some(val(10)))],
+            None,
+        )
+        .await;
+
+        // Build A -> B with update/update, delete/recreate, and create/delete overlaps.
+        let a = db
+            .new_batch()
+            .write(updated, Some(val(1)))
+            .write(recreated, None)
+            .write(deleted, Some(val(20)))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        let b = a
+            .new_batch()
+            .write(updated, Some(val(2)))
+            .write(recreated, Some(val(11)))
+            .write(deleted, None)
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+
+        // Commit and drop A, then build C from the retained B suffix.
+        let (db, _) = db.apply_batch(a).await.unwrap();
+        let db = db.commit().await.unwrap();
+        let c = b
+            .new_batch()
+            .write(updated, Some(val(3)))
+            .merkleize(&db, None)
+            .await
+            .unwrap();
+        let expected_root = c.root();
+
+        // Applying C directly also applies B. The snapshot location must be rebased from
+        // the original DB location to A's now-committed update.
+        let (db, _) = db.apply_batch(c).await.unwrap();
+        assert_eq!(db.root(), expected_root);
+        assert_eq!(db.get(&updated).await.unwrap(), Some(val(3)));
+        assert_eq!(db.get(&recreated).await.unwrap(), Some(val(11)));
+        assert_eq!(db.get(&deleted).await.unwrap(), None);
+
+        db.destroy().await.unwrap();
+    }
+
     async fn log_replay_inner<F: Family>(context: deterministic::Context) {
         let db_context = context.child("db");
         let db = open_db_generic::<F>(db_context.child("db")).await;
@@ -1562,6 +1616,13 @@ pub(crate) mod test {
     fn test_unordered_fixed_batch_speculative_root_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(batch_speculative_root_inner::<crate::merkle::mmb::Family>);
+    }
+
+    #[test_traced("INFO")]
+    fn test_unordered_fixed_batch_apply_after_committed_prefix_dropped_mmb() {
+        let executor = deterministic::Runner::default();
+        executor
+            .start(batch_apply_after_committed_prefix_dropped_inner::<crate::merkle::mmb::Family>);
     }
 
     #[test_traced("WARN")]


### PR DESCRIPTION
## Motivation

A batch chain can outlive its original committed base. When a committed ancestor is dropped before a later descendant is merkleized, the weak parent walk retains only the live uncommitted suffix. Previously, `apply_batch` still positioned that suffix relative to the original fork point, which could classify its first batch as already committed and omit it from replay.

The resulting failure depends on the omitted mutations. For append-bearing ancestors, the missing nodes leave the structure smaller than the batch and `apply_batch` fails loudly with `AncestorDropped`, falsely rejecting a valid batch. For overwrite-only ancestors, the size is unchanged, so the omission can escape the size check and produce an incorrect root.

QMDB also carried key diffs whose `base_old_loc` referred to the original committed snapshot. If the dropped prefix had since moved the same key, applying the retained suffix tried to replace the stale location and panicked in `update_known_loc`.

## Changes

- Record the Merkle position and journal leaf count immediately before the oldest retained ancestor.
- Replay retained Merkle nodes and journal items from that effective base while preserving the original fork point for stale-batch validation.
- Reject genuinely missing uncommitted prefixes before mutating the authenticated journal.
- Rebase retained QMDB key diffs at the effective committed boundary. The batch stores only sorted `(key, location-or-deleted)` overrides for keys touched by both the dropped prefix and live suffix; it does not retain historical values or complete committed diffs.
- Preserve the existing fast apply path when no QMDB rebasing is needed.
- Keep weak parent links so committed prefixes are released in rolling pipelines. The QMDB rebase data is bounded by the overlapping keys in the live speculative suffix, not committed history.
- Add MMB regressions for append-bearing and overwrite-only Merkle replay, authenticated-journal gap detection, and QMDB update/update, delete/recreate, and create/delete overlaps.
- Extend `qmdb_unordered_batch_root` with an MMB-only schedule that drops a committed prefix, continues from the retained suffix, and compares both speculative and applied roots with a rebuilt reference chain.

## Testing

- `just test -p commonware-storage`: 2,911 passed
- `just check-fmt`: passed via the commit hook
- `cargo clippy -p commonware-storage --lib --no-deps -- -D warnings -A clippy::chunks_exact_to_as_chunks`: passed (the allowed lint is pre-existing outside this change)
- Focused unordered batch tests: 17 passed
- Reported artifact `crash-a899c3ea49a4bc72a0848daf7a473538f1dec733`: reproduced the pre-fix `update_known_loc` panic and passes after the fix
- `qmdb_unordered_batch_root`: 10,000 randomized executions passed
- With both retained replay origins temporarily restored to the original fork point, the fuzzer immediately crashes with `AncestorDropped`; the minimized reproducer passes with the fix restored
