### PR TITLE
[runtime] Skip Canceled Timers When Advancing Time

### DIFF
--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -416,6 +416,13 @@ impl Executor {
         now
     }
 
+    /// Ensure the runtime has not reached its configured deadline.
+    fn assert_deadline(&self, current: SystemTime) {
+        if self.deadline.is_some_and(|deadline| current >= deadline) {
+            panic!("runtime timeout");
+        }
+    }
+
     /// When idle, jump directly to the next actionable time.
     ///
     /// When built with the `external` feature, never skip ahead (to ensure we poll all pending tasks
@@ -457,36 +464,25 @@ impl Executor {
         }
     }
 
-    /// Wake sleepers until a task is ready or no alarms remain.
+    /// Wake sleepers until the runtime can make progress.
     ///
     /// Canceling a polled sleep leaves its alarm registered until its deadline. If that alarm
     /// wakes no task, continue to later deadlines before deciding the runtime has stalled.
-    fn wake_until_ready_or_empty(&self, mut current: SystemTime) {
+    ///
+    /// When built with the `external` feature, the passage of time is sufficient to continue.
+    fn wake_until_progress(&self, mut current: SystemTime) {
         loop {
             current = self.skip_idle_time(current);
-            if self.deadline.is_some_and(|deadline| current >= deadline) {
-                panic!("runtime timeout");
-            }
+            self.assert_deadline(current);
             self.wake_ready_sleepers(current);
 
-            if cfg!(feature = "external")
-                || self.tasks.ready() != 0
-                || self.sleeping.lock().is_empty()
-            {
+            if cfg!(feature = "external") || self.tasks.ready() != 0 {
                 return;
             }
+            if self.sleeping.lock().is_empty() {
+                panic!("runtime stalled");
+            }
         }
-    }
-
-    /// Ensure the runtime is making progress.
-    ///
-    /// When built with the `external` feature, always poll pending tasks after the passage of time.
-    fn assert_liveness(&self) {
-        if cfg!(feature = "external") || self.tasks.ready() != 0 {
-            return;
-        }
-
-        panic!("runtime stalled");
     }
 }
 
@@ -591,15 +587,8 @@ impl Runner {
         let result = catch_unwind(AssertUnwindSafe(|| {
             loop {
                 // Ensure we have not exceeded our deadline
-                {
-                    let current = executor.time.lock();
-                    if let Some(deadline) = executor.deadline
-                        && *current >= deadline
-                    {
-                        drop(current);
-                        panic!("runtime timeout");
-                    }
-                }
+                let current = *executor.time.lock();
+                executor.assert_deadline(current);
 
                 // Drain all ready tasks
                 let mut queue = executor.tasks.drain();
@@ -685,10 +674,9 @@ impl Runner {
                     break output;
                 }
 
-                // Advance time and wake sleepers until a task is ready or no alarms remain
+                // Advance time and wake sleepers until the runtime can make progress
                 let current = executor.advance_time();
-                executor.wake_until_ready_or_empty(current);
-                executor.assert_liveness();
+                executor.wake_until_progress(current);
 
                 // Record that we completed another iteration of the event loop.
                 executor.metrics.iterations.inc();

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -457,6 +457,27 @@ impl Executor {
         }
     }
 
+    /// Wake sleepers until a task is ready or no alarms remain.
+    ///
+    /// Canceling a polled sleep leaves its alarm registered until its deadline. If that alarm
+    /// wakes no task, continue to later deadlines before deciding the runtime has stalled.
+    fn wake_until_ready_or_empty(&self, mut current: SystemTime) {
+        loop {
+            current = self.skip_idle_time(current);
+            if self.deadline.is_some_and(|deadline| current >= deadline) {
+                panic!("runtime timeout");
+            }
+            self.wake_ready_sleepers(current);
+
+            if cfg!(feature = "external")
+                || self.tasks.ready() != 0
+                || self.sleeping.lock().is_empty()
+            {
+                return;
+            }
+        }
+    }
+
     /// Ensure the runtime is making progress.
     ///
     /// When built with the `external` feature, always poll pending tasks after the passage of time.
@@ -664,12 +685,9 @@ impl Runner {
                     break output;
                 }
 
-                // Advance time (skipping ahead if no tasks are ready yet)
-                let mut current = executor.advance_time();
-                current = executor.skip_idle_time(current);
-
-                // Wake sleepers and ensure we continue to make progress
-                executor.wake_ready_sleepers(current);
+                // Advance time and wake sleepers until a task is ready or no alarms remain
+                let current = executor.advance_time();
+                executor.wake_until_ready_or_empty(current);
                 executor.assert_liveness();
 
                 // Record that we completed another iteration of the event loop.
@@ -1723,6 +1741,47 @@ mod tests {
                 now + Duration::new(15, 0),
             ]
         );
+    }
+
+    #[test]
+    fn test_dropped_sleeper_before_live_deadline() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (started_sender, started_receiver) = oneshot::channel();
+            let sleeper = context.child("sleeper").spawn(|context| async move {
+                let mut sleepers = FuturesUnordered::new();
+                sleepers.push(context.sleep(Duration::from_secs(1)));
+                started_sender.send(()).unwrap();
+                sleepers.next().await;
+            });
+
+            // Waiting for the signal ensures the child registered its alarm before being aborted.
+            started_receiver.await.unwrap();
+            sleeper.abort();
+
+            // The stale child alarm must not prevent a later live alarm from firing.
+            context.sleep(Duration::from_secs(2)).await;
+        });
+    }
+
+    #[cfg(not(feature = "external"))]
+    #[test]
+    #[should_panic(expected = "runtime timeout")]
+    fn test_dropped_sleeper_beyond_timeout() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|context| async move {
+            let (started_sender, started_receiver) = oneshot::channel();
+            let sleeper = context.child("sleeper").spawn(|context| async move {
+                let mut sleep = Box::pin(context.sleep(Duration::from_secs(20)));
+                assert!(sleep.as_mut().now_or_never().is_none());
+                started_sender.send(()).unwrap();
+                sleep.await;
+            });
+
+            started_receiver.await.unwrap();
+            sleeper.abort();
+            pending::<()>().await;
+        });
     }
 
     #[test]

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -472,10 +472,14 @@ impl Executor {
     /// When built with the `external` feature, the passage of time is sufficient to continue.
     fn wake_until_progress(&self, mut current: SystemTime) {
         loop {
+            // Move to the next actionable time. Check the runtime deadline before waking sleepers
+            // so timeout takes precedence over work scheduled at the deadline.
             current = self.skip_idle_time(current);
             self.assert_deadline(current);
             self.wake_ready_sleepers(current);
 
+            // Continue once external work or a woken task can make progress. Without either,
+            // another alarm is the runtime's only remaining source of progress.
             if cfg!(feature = "external") || self.tasks.ready() != 0 {
                 return;
             }


### PR DESCRIPTION
## Motivation

Polling a sleep registers an alarm with the deterministic executor. Dropping that sleep does not remove the alarm immediately. When a stale alarm was the next deadline and no task was ready, the runner woke it once and then failed its liveness check, even if a later live alarm could make progress.

## Changes

- Continue advancing through alarms that wake no task until runnable work appears or the alarm heap is empty.
- Enforce the configured runtime deadline at every skipped deadline.
- Cover a stale alarm before a live timer and a stale alarm beyond the runtime timeout.