### PR TITLE
The mock InlineApp::propose now returns None when the proposal height

### DIFF
--- a/consensus/fuzz/src/marshal/runner.rs
+++ b/consensus/fuzz/src/marshal/runner.rs
@@ -320,6 +320,12 @@ impl ConsensusApplication<deterministic::Context> for InlineApp {
         }
         let expected_parent = consensus_context.parent.1;
         let expected_height = Height::new(consensus_context.round.view().get());
+        if !FixedEpocher::new(BLOCKS_PER_EPOCH)
+            .containing(expected_height)
+            .is_some_and(|info| info.epoch() == consensus_context.round.epoch())
+        {
+            return None;
+        }
         match self.propose_result.clone() {
             None => None,
             Some(block)
@@ -748,5 +754,31 @@ mod tests {
                 },
             ],
         });
+    }
+
+    #[test]
+    fn out_of_epoch_propose_does_not_arm_certification() {
+        let input = MarshalActorStandardInput {
+            raw_bytes: vec![0],
+            app_propose_idx: Some(21),
+            app_verify_result: true,
+            events: vec![
+                InlineEvent::Seed {
+                    block_idx: 20,
+                    seed: InlineSeed::Verified,
+                },
+                InlineEvent::Propose {
+                    parent_idx: 20,
+                    await_result: true,
+                },
+                InlineEvent::Certify {
+                    block_idx: 21,
+                    await_result: true,
+                },
+            ],
+        };
+        for kind in [WrapperKind::Inline, WrapperKind::Deferred] {
+            fuzz_marshal_actor_standard(input.clone(), kind);
+        }
     }
 }

--- a/consensus/fuzz/src/marshal/runner.rs
+++ b/consensus/fuzz/src/marshal/runner.rs
@@ -771,6 +771,15 @@ mod tests {
                     parent_idx: 20,
                     await_result: true,
                 },
+                InlineEvent::Seed {
+                    block_idx: 21,
+                    seed: InlineSeed::Variant,
+                },
+                InlineEvent::Verify {
+                    block_idx: 21,
+                    context: InlineContext::Stored,
+                    await_result: true,
+                },
                 InlineEvent::Certify {
                     block_idx: 21,
                     await_result: true,


### PR DESCRIPTION
Changes:

- The mock InlineApp::propose now returns None when the proposal height implied by the view does not belong to the proposal context’s epoch
- Added one focused regression in the same file for the malformed out-of-epoch proposal path
