### PR TITLE
[cryptography] Handle Nightly cpufeatures Deprecation

### DIFF
--- a/cryptography/src/reed_solomon/engine.rs
+++ b/cryptography/src/reed_solomon/engine.rs
@@ -32,6 +32,29 @@
 //! [`Decoder`]: crate::reed_solomon::Decoder
 //! [`rate`]: crate::reed_solomon::rate
 
+// TODO(https://github.com/commonwarexyz/monorepo/issues/4414): Bump cpufeatures and remove this workaround.
+#[allow(
+    unfulfilled_lint_expectations,
+    reason = "stable Rust does not emit this nightly-only deprecation"
+)]
+#[expect(
+    deprecated,
+    reason = "tracked by https://github.com/commonwarexyz/monorepo/issues/4414"
+)]
+mod cpu_features {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    cpufeatures::new!(has_avx2, "avx2");
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    cpufeatures::new!(has_ssse3, "ssse3");
+    #[cfg(target_arch = "aarch64")]
+    cpufeatures::new!(has_neon, "neon");
+
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+    pub(super) use self::{has_avx2::get as avx2, has_ssse3::get as ssse3};
+    #[cfg(target_arch = "aarch64")]
+    pub(super) use has_neon::get as neon;
+}
+
 #[cfg(target_arch = "aarch64")]
 pub use self::engine_neon::Neon;
 pub(crate) use self::shards::Shards;

--- a/cryptography/src/reed_solomon/engine/engine_avx2.rs
+++ b/cryptography/src/reed_solomon/engine/engine_avx2.rs
@@ -33,8 +33,7 @@ impl Avx2 {
     ///
     /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
     pub fn new() -> Self {
-        cpufeatures::new!(has_avx2_for_engine, "avx2");
-        assert!(has_avx2_for_engine::get());
+        assert!(super::cpu_features::avx2());
 
         let mul128 = tables::get_mul128();
         let skew = tables::get_skew();

--- a/cryptography/src/reed_solomon/engine/engine_default.rs
+++ b/cryptography/src/reed_solomon/engine/engine_default.rs
@@ -28,21 +28,18 @@ impl DefaultEngine {
     pub fn new() -> Self {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            cpufeatures::new!(has_avx2, "avx2");
-            if has_avx2::get() {
+            if super::cpu_features::avx2() {
                 return Self(Box::new(Avx2::new()));
             }
 
-            cpufeatures::new!(has_ssse3, "ssse3");
-            if has_ssse3::get() {
+            if super::cpu_features::ssse3() {
                 return Self(Box::new(Ssse3::new()));
             }
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            cpufeatures::new!(has_neon, "neon");
-            if has_neon::get() {
+            if super::cpu_features::neon() {
                 return Self(Box::new(Neon::new()));
             }
         }
@@ -93,21 +90,18 @@ impl Engine for DefaultEngine {
     fn eval_poly(erasures: &mut [GfElement; GF_ORDER], truncated_size: usize) {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         {
-            cpufeatures::new!(has_avx2, "avx2");
-            if has_avx2::get() {
+            if super::cpu_features::avx2() {
                 return Avx2::eval_poly(erasures, truncated_size);
             }
 
-            cpufeatures::new!(has_ssse3, "ssse3");
-            if has_ssse3::get() {
+            if super::cpu_features::ssse3() {
                 return Ssse3::eval_poly(erasures, truncated_size);
             }
         }
 
         #[cfg(target_arch = "aarch64")]
         {
-            cpufeatures::new!(has_neon, "neon");
-            if has_neon::get() {
+            if super::cpu_features::neon() {
                 return Neon::eval_poly(erasures, truncated_size);
             }
         }

--- a/cryptography/src/reed_solomon/engine/engine_neon.rs
+++ b/cryptography/src/reed_solomon/engine/engine_neon.rs
@@ -29,8 +29,7 @@ impl Neon {
     ///
     /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
     pub fn new() -> Self {
-        cpufeatures::new!(has_neon_for_engine, "neon");
-        assert!(has_neon_for_engine::get());
+        assert!(super::cpu_features::neon());
 
         let mul128 = tables::get_mul128();
         let skew = tables::get_skew();

--- a/cryptography/src/reed_solomon/engine/engine_ssse3.rs
+++ b/cryptography/src/reed_solomon/engine/engine_ssse3.rs
@@ -33,8 +33,7 @@ impl Ssse3 {
     ///
     /// [`LogWalsh`]: crate::reed_solomon::engine::tables::LogWalsh
     pub fn new() -> Self {
-        cpufeatures::new!(has_ssse3_for_engine, "ssse3");
-        assert!(has_ssse3_for_engine::get());
+        assert!(super::cpu_features::ssse3());
 
         let mul128 = tables::get_mul128();
         let skew = tables::get_skew();


### PR DESCRIPTION
## Overview

- isolate `cpufeatures` runtime detection behind one private module
- expect the nightly-only `u8::max_value()` deprecation without weakening other warnings
- track removal of the workaround after an upstream release

related: https://github.com/commonwarexyz/monorepo/issues/4414