### PR TITLE
[glue] Preserve Descendant Batches Across Finalization

### DIFF
--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -136,8 +136,12 @@ where
                     }
                 }
 
+                // Publish completed verdicts before admitting another message.
+                // A later finalization cannot retroactively invalidate them.
                 verifications.complete_ready();
 
+                // A message deferred by an active proposal is the FIFO barrier
+                // for subsequent mailbox work, so handle it before later arrivals.
                 let message = match deferred_message.take() {
                     Some(message) => Ok(message),
                     None => self.mailbox.try_recv(),

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -26,7 +26,7 @@ use futures::{
     future::{Either, ready},
 };
 use rand_core::Rng;
-use std::{collections::BTreeSet, future::Future, sync::mpsc::TryRecvError};
+use std::{collections::BTreeSet, sync::mpsc::TryRecvError};
 use tracing::{Instrument as _, debug, info_span};
 
 /// A single unit of work for the processing loop: either a mailbox message to
@@ -70,48 +70,6 @@ fn requeue_verifications<E, A>(
             ancestry,
             verification,
         });
-    }
-}
-
-async fn drive_finalization<E, A, S, V, T>(
-    mailbox: &mut actor_mailbox::Receiver<Message<E, A>>,
-    verifications: &mut Verifications<E, A, S, V>,
-    deferred_message: &mut Option<Message<E, A>>,
-    operation: impl Future<Output = T>,
-) -> (T, Vec<VerificationRequest<E, A>>)
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-    S: Scheme,
-    V: Variant<ApplicationBlock = A::Block>,
-    MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
-{
-    futures::pin_mut!(operation);
-    loop {
-        select! {
-            output = &mut operation => return (output, Vec::new()),
-            message = mailbox.recv() => match message {
-                Some(message) => {
-                    let finalization_fenced = matches!(message, Message::Finalized { .. });
-                    assert!(
-                        deferred_message.replace(message).is_none(),
-                        "finalization must have at most one deferred message",
-                    );
-                    if finalization_fenced {
-                        // The next finalization can invalidate retained work. Stop it before
-                        // allowing a verdict to publish, then finish the current mutation so
-                        // the requests can be retried against the new finalized state.
-                        let retry = verifications.quiesce().await;
-                        return (operation.await, retry);
-                    }
-                    // Preserve mailbox order. Only finalization fences active
-                    // verification, so other work waits while it keeps progressing.
-                    return (verifications.drive(operation).await, Vec::new());
-                }
-                None => return (verifications.drive(operation).await, Vec::new()),
-            },
-            _ = verifications.next_completed() => {},
-        }
     }
 }
 
@@ -178,18 +136,12 @@ where
                     }
                 }
 
+                verifications.complete_ready();
+
                 let message = match deferred_message.take() {
                     Some(message) => Ok(message),
                     None => self.mailbox.try_recv(),
                 };
-
-                // Verification results must not overtake finalization work
-                // that may invalidate them.
-                let finalization_deferred =
-                    matches!(message.as_ref(), Ok(Message::Finalized { .. }));
-                if !finalization_deferred {
-                    verifications.complete_ready();
-                }
 
                 // Pruning is non-critical work. We only run it when the mailbox is idle, and
                 // it is never raced against the mailbox due to its internal lock acquisition.
@@ -268,7 +220,6 @@ where
                         .instrument(process);
                     futures::pin_mut!(proposal);
                     let mut receive_messages = true;
-                    let mut verification_fenced = false;
                     loop {
                         if receive_messages {
                             select! {
@@ -290,12 +241,8 @@ where
                                     ),
                                     Some(message) => {
                                         // Only verification may overtake an active proposal. The
-                                        // first other message becomes a FIFO barrier, with
-                                        // finalization also fencing active verification results.
-                                        verification_fenced = matches!(
-                                            message,
-                                            Message::Finalized { .. },
-                                        );
+                                        // first other message becomes a FIFO barrier for later
+                                        // mailbox work.
                                         deferred_message = Some(message);
                                         receive_messages = false;
                                     }
@@ -303,9 +250,6 @@ where
                                 },
                                 _ = verifications.next_completed() => {},
                             }
-                        } else if verification_fenced {
-                            (&mut proposal).await;
-                            break;
                         } else {
                             select! {
                                 _ = &mut proposal => break,
@@ -338,43 +282,33 @@ where
                 }) => {
                     let process = info_span!(parent: &span, "stateful.actor.finalized");
                     if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
-                        let retry = async {
-                            let (_, retry) = drive_finalization(
-                                &mut self.mailbox,
-                                &mut verifications,
-                                &mut deferred_message,
-                                self.processor.notify_finalized(
+                        async {
+                            verifications
+                                .drive(self.processor.notify_finalized(
                                     self.context.as_present(),
                                     block.as_ref(),
-                                ),
-                            )
-                            .await;
+                                ))
+                                .await;
                             acknowledgement.acknowledge();
-                            retry
                         }
                         .instrument(process)
                         .await;
-                        requeue_verifications(retry_mailbox.as_ref(), retry);
                     } else {
                         let boundary = self.processor.finalization_boundary(block.as_ref());
                         let (retry, reject) = verifications
                             .quiesce_where(|progress| boundary.disposition(progress))
                             .await;
                         drop(boundary);
-                        let fenced_retry = async {
-                            let (applied, fenced_retry) = drive_finalization(
-                                &mut self.mailbox,
-                                &mut verifications,
-                                &mut deferred_message,
-                                self.processor.finalize(&self.context, block.as_ref()),
-                            )
-                            .await;
+                        async {
+                            let applied = verifications
+                                .drive(self.processor.finalize(&self.context, block.as_ref()))
+                                .await;
                             let Some(Applied { barrier, prune }) = applied else {
                                 // Duplicate report: marshal redelivers a processed
                                 // height only after a restart, where startup aligned
                                 // the databases to durable state.
                                 acknowledgement.acknowledge();
-                                return fenced_retry;
+                                return;
                             };
                             debug!(
                                 height = block.height().get(),
@@ -403,14 +337,12 @@ where
                             if let Some(prune) = prune {
                                 pending_prune = Some((prune, retry_mailbox.clone()));
                             }
-                            fenced_retry
                         }
                         .instrument(process)
                         .await;
                         for verification in reject {
                             verification.respond(false);
                         }
-                        requeue_verifications(retry_mailbox.as_ref(), fenced_retry);
                         requeue_verifications(retry_mailbox.as_ref(), retry);
                     }
                 }
@@ -419,7 +351,8 @@ where
                 }
                 Step::Prune((prune, retry_mailbox)) => {
                     // The prune target must be durable, but later blocks remain available in
-                    // marshal for replay and do not delay maintenance.
+                    // marshal for replay and do not delay maintenance. Verification may complete
+                    // during this wait; later mailbox work remains ordered behind the prune.
                     while pending_syncs
                         .first()
                         .is_some_and(|height| *height <= prune.barrier_height)
@@ -1179,7 +1112,7 @@ mod tests {
     }
 
     #[test]
-    fn deferred_finalization_fences_proposal_time_verification() {
+    fn deferred_finalization_does_not_block_completed_verification() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let (parent_gate, parent_started, parent_release) = application_gate();
             let (child_gate, child_started, child_release) = application_gate();
@@ -1242,11 +1175,14 @@ mod tests {
             child_release
                 .send(())
                 .expect("losing child verification should remain active");
-            context.sleep(Duration::from_millis(10)).await;
-            assert!(
-                poll!(&mut verify_child).is_pending(),
-                "verification must not publish after observing finalization",
-            );
+            select! {
+                valid = &mut verify_child => {
+                    assert!(valid, "completed branch-relative verification must remain valid");
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {
+                    panic!("deferred finalization blocked completed verification");
+                },
+            }
 
             proposal_release
                 .send(())
@@ -1255,7 +1191,6 @@ mod tests {
             waiter
                 .await
                 .expect("conflicting finalized block should be acknowledged");
-            assert!(!verify_child.await);
             actor.abort();
         });
     }
@@ -1827,15 +1762,18 @@ mod tests {
             );
 
             let (acknowledgement, waiter) = Exact::handle();
+            let mut waiter = Box::pin(waiter);
             let _ = mailbox.report(Update::Block(Arc::new(finalized), acknowledgement));
-            waiter
-                .await
-                .expect("cached winner should finalize without the replay");
-            assert!(poll!(&mut verify_child).is_pending());
-
+            assert!(
+                poll!(&mut waiter).is_pending(),
+                "finalization must wait for the existing winner computation",
+            );
             replay_release
                 .send(())
                 .expect("winner replay should remain active");
+            waiter
+                .await
+                .expect("cached winner should finalize after replay completes");
             let valid = verify_child.await;
             actor.abort();
             drop(marshal.guards);
@@ -1846,7 +1784,7 @@ mod tests {
     }
 
     #[test]
-    fn next_finalization_retries_replay_of_previous_anchor() {
+    fn consecutive_finalizations_preserve_descendant_replay() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let first = TestBlock::child(&genesis, 1);
@@ -1866,11 +1804,12 @@ mod tests {
             )
             .await;
             let (replay_gate, replay_started, replay_release) = application_gate();
+            let verify_gate = Arc::new(Mutex::new(None));
             let apply_calls = Arc::new(AtomicUsize::new(0));
             let verify_calls = Arc::new(AtomicUsize::new(0));
             let app = ReplayGatedApp {
                 gates: Arc::new(Mutex::new(VecDeque::from([replay_gate]))),
-                verify_gate: Arc::new(Mutex::new(None)),
+                verify_gate: verify_gate.clone(),
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: first.height(),
                 apply_calls: apply_calls.clone(),
@@ -1916,12 +1855,20 @@ mod tests {
                     .await,
                 "independent verification should cache the first finalized block",
             );
+            let (gate, verify_started, verify_release) = application_gate();
+            assert!(verify_gate.lock().replace(gate).is_none());
 
             let (acknowledgement, first_waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(first), acknowledgement));
+            replay_release
+                .send(())
+                .expect("first-block replay should remain active");
             first_waiter
                 .await
                 .expect("first finalized block should be acknowledged");
+            verify_started
+                .await
+                .expect("descendant verification should start");
             assert!(poll!(&mut verify_child).is_pending());
 
             let (acknowledgement, second_waiter) = Exact::handle();
@@ -1929,13 +1876,15 @@ mod tests {
             second_waiter
                 .await
                 .expect("second finalized block should be acknowledged");
+            verify_release
+                .send(())
+                .expect("descendant verification should remain active");
             let valid = verify_child.await;
             actor.abort();
             drop(marshal.guards);
-            drop(replay_release);
             assert!(
                 valid,
-                "replay of the previous anchor must retry across the next finalization",
+                "descendant replay must remain valid across consecutive finalizations",
             );
             assert_eq!(apply_calls.load(Ordering::SeqCst), 2);
             assert_eq!(verify_calls.load(Ordering::SeqCst), 2);
@@ -1943,7 +1892,7 @@ mod tests {
     }
 
     #[test]
-    fn active_verifications_wait_for_queued_finalization() {
+    fn retained_verification_can_finish_before_queued_finalization() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let first = TestBlock::child(&genesis, 1);
@@ -2025,23 +1974,25 @@ mod tests {
                 .await
                 .expect("first finalization hook should start");
 
-            select! {
+            let valid = select! {
                 valid = &mut first_attempt => {
-                    panic!("retained verification bypassed queued finalization: {valid}");
+                    valid
                 },
-                _ = context.sleep(Duration::from_millis(100)) => {},
-            }
+                _ = context.sleep(Duration::from_millis(100)) => {
+                    panic!("queued finalization blocked retained verification");
+                },
+            };
+            assert!(
+                valid,
+                "retained branch-relative verification must remain valid"
+            );
             finalized_release
                 .send(())
                 .expect("first finalization hook should remain active");
 
             assert!(
-                !first_attempt.await,
-                "retained verification must observe the queued finalization",
-            );
-            assert!(
-                !retried.await,
-                "finalization retry must observe the queued finalization",
+                retried.await,
+                "completed branch-relative verdict must remain valid"
             );
             first_waiter
                 .await

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -15,10 +15,7 @@ use commonware_runtime::{Clock, Metrics, Spawner};
 use commonware_utils::{channel::oneshot, futures::Pool};
 use futures::FutureExt as _;
 use rand_core::Rng;
-use std::{
-    collections::{BTreeMap, VecDeque},
-    future::Future,
-};
+use std::{collections::BTreeMap, future::Future};
 use tracing::{Instrument as _, Span, info_span};
 
 /// A verification request that can be deferred or retried.
@@ -76,7 +73,6 @@ where
 {
     marshal: MarshalMailbox<S, V>,
     jobs: Pool<JobResult<E, A>>,
-    completed: VecDeque<JobResult<E, A>>,
     controls: BTreeMap<u64, JobControl<PendingDigest<A, E>>>,
     next_id: u64,
 }
@@ -93,7 +89,6 @@ where
         Self {
             marshal,
             jobs: Pool::default(),
-            completed: VecDeque::new(),
             controls: BTreeMap::new(),
             next_id: 0,
         }
@@ -141,16 +136,13 @@ where
     }
 
     pub(super) fn complete_ready(&mut self) {
-        while let Some(result) = self.completed.pop_front() {
-            self.handle(result);
-        }
         while let Some(result) = self.jobs.next_completed().now_or_never() {
             self.handle(result);
         }
     }
 
     pub(super) async fn next_completed(&mut self) {
-        let result = self.next_result().await;
+        let result = self.jobs.next_completed().await;
         self.handle(result);
     }
 
@@ -164,12 +156,10 @@ where
         }
     }
 
-    /// Cancels active attempts and waits for all verification work to stop.
+    /// Cancels every active attempt and waits for verification work to stop.
     ///
-    /// Finalization and pruning must call this before mutating the databases so
-    /// verification-owned replays cannot race those mutations. Requests whose
-    /// callers still need a verdict are returned for rescheduling after the
-    /// mutation completes.
+    /// Pruning uses this full barrier because it can remove history needed by
+    /// every branch. Live requests are returned for rescheduling afterward.
     pub(super) async fn quiesce(&mut self) -> Vec<Request<E, A>> {
         let (retry, reject) = self.quiesce_where(|_| Disposition::Retry).await;
         assert!(reject.is_empty());
@@ -192,13 +182,11 @@ where
 
         let mut retry = Vec::with_capacity(pending.len());
         let mut reject = Vec::with_capacity(pending.len());
-        // Retained completions remain unpublished until every selected job stops.
-        let mut retained = VecDeque::new();
         while !pending.is_empty() {
-            let result = self.next_result().await;
+            let result = self.jobs.next_completed().await;
             let id = result.id();
             let Some(disposition) = pending.remove(&id) else {
-                retained.push_back(result);
+                self.handle(result);
                 continue;
             };
             let control = self
@@ -223,15 +211,7 @@ where
                 Disposition::Reject => reject.push(request.verification),
             }
         }
-        self.completed.extend(retained);
         (retry, reject)
-    }
-
-    async fn next_result(&mut self) -> JobResult<E, A> {
-        match self.completed.pop_front() {
-            Some(result) => result,
-            None => self.jobs.next_completed().await,
-        }
     }
 
     fn handle(&mut self, result: JobResult<E, A>) {

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -337,6 +337,8 @@ impl<D: Copy + Ord> ReplayFlights<D> {
         }
     }
 
+    /// Registers an owner through the caller-held registry guard, keeping the
+    /// existing-flight check and insertion in one critical section.
     fn register_owner(&self, digest: D, entries: &mut BTreeMap<D, ReplayFlight>) -> ReplayOwner<D> {
         let generation = Arc::new(ReplayGeneration);
         assert!(

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -83,17 +83,8 @@ struct ReplayFlight {
 #[derive(Clone, Copy)]
 enum VerificationPhase<D> {
     Acquiring,
-    Replaying {
-        digest: D,
-        parent: D,
-        round: Round,
-        owner: bool,
-    },
-    Verifying {
-        digest: D,
-        parent: D,
-        round: Round,
-    },
+    Replaying { digest: D, parent: D, round: Round },
+    Verifying { digest: D, parent: D, round: Round },
 }
 
 /// How tracked verification work crosses an incoming finalization.
@@ -101,7 +92,7 @@ enum VerificationPhase<D> {
 pub(super) enum Disposition {
     /// Continue polling work proven to descend from the finalized block.
     Retain,
-    /// Re-evaluate work whose branch is not yet known or is the finalized block itself.
+    /// Re-evaluate work whose branch is unknown or whose active phase cannot cross finalization.
     Retry,
     /// Return false for work already proven to use an incompatible parent.
     Reject,
@@ -119,12 +110,11 @@ impl<D: Copy> Default for VerificationProgress<D> {
 }
 
 impl<D: Copy> VerificationProgress<D> {
-    fn replaying(&self, digest: D, parent: D, round: Round, owner: bool) {
+    fn replaying(&self, digest: D, parent: D, round: Round) {
         *self.0.lock() = VerificationPhase::Replaying {
             digest,
             parent,
             round,
-            owner,
         };
     }
 
@@ -165,14 +155,12 @@ impl<D: Copy + Eq + Hash> FinalizationBoundary<D> {
                 digest,
                 parent,
                 round,
-                owner,
             } => {
                 if digest == self.processed_digest && round == self.processed_round {
                     return Disposition::Retry;
                 }
                 match digest == self.digest {
-                    true if owner => Disposition::Retain,
-                    true => Disposition::Retry,
+                    true => Disposition::Retain,
                     false if round > self.round && self.compatible.contains(&parent) => {
                         Disposition::Retain
                     }
@@ -211,20 +199,9 @@ where
 
 /// Speculative state shared by independently-polled verification jobs.
 ///
-/// Live verification may continue while finalization changes the applied
-/// database base. The finalization fields fence which results may publish
-/// across that transition and form one state machine:
-/// - Idle: `finalizing` is `None`, the batch is not secured, and the compatible
-///   set is empty.
-/// - Acquiring: `finalizing` is set and the batch is not secured. The exact
-///   winner replay and compatible descendants may still publish.
-/// - Secured: `finalizing` is set and the batch is secured. The winner is not
-///   reinserted. Compatible descendants may publish from pending state, while
-///   work that needs the applied winner waits for every database to reflect it.
-/// - Applied: the database set reflects the winner, so waiting descendants may
-///   fork from applied state while the application hook runs.
-///
-/// Finishing finalization advances `last_processed` and returns to Idle.
+/// During finalization, the winning batch remains available as a branch parent
+/// while a clone is applied. `finalizing_compatible` admits late state only
+/// when its recorded parent already belongs to that branch.
 struct ExecutionState<A, E>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -236,13 +213,9 @@ where
     last_processed: Anchor<PendingDigest<A, E>>,
     /// Winner currently being applied, if finalization is active.
     finalizing: Option<Anchor<PendingDigest<A, E>>>,
-    /// Whether finalization has taken or reconstructed the winner's batch.
-    finalizing_batch_secured: bool,
-    /// Whether every database reflects the finalizing winner.
-    finalizing_databases_applied: bool,
-    /// Work waiting to fork from the applied finalizing winner.
-    finalizing_apply_waiters: Vec<oneshot::Sender<()>>,
-    /// Winner and descendants allowed to publish during finalization.
+    /// Winner batch retained while a clone is applied to the databases.
+    finalizing_batch: Option<PendingBatches<A, E>>,
+    /// Winner and descendants allowed in pending state during finalization.
     finalizing_compatible: HashSet<PendingDigest<A, E>>,
 }
 
@@ -363,6 +336,28 @@ impl<D: Copy + Ord> ReplayFlights<D> {
             completion,
         }
     }
+
+    fn register_owner(&self, digest: D, entries: &mut BTreeMap<D, ReplayFlight>) -> ReplayOwner<D> {
+        let generation = Arc::new(ReplayGeneration);
+        assert!(
+            entries
+                .insert(
+                    digest,
+                    ReplayFlight {
+                        generation: Arc::clone(&generation),
+                        waiters: Vec::new(),
+                        vacant_slots: Vec::new(),
+                    },
+                )
+                .is_none(),
+        );
+        ReplayOwner {
+            flights: self.clone(),
+            digest,
+            generation,
+            result: None,
+        }
+    }
 }
 
 /// Outcome of requesting shared replay work for one block digest.
@@ -375,16 +370,11 @@ enum ReplayClaim<D: Copy + Ord> {
     Wait(ReplayWaiter<D>),
 }
 
-/// Outcome of finding a finalizing block's cached batches or joining an active
-/// replay that may produce them.
-enum FinalizationBatch<E, A>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-{
-    Ready,
-    Wait(ReplayWaiter<PendingDigest<A, E>>),
-    Missing,
+/// Claim on the finalizing winner's batch construction.
+enum FinalizationClaim<D: Copy + Ord> {
+    Cached,
+    Wait(ReplayWaiter<D>),
+    Reconstruct(ReplayOwner<D>),
 }
 
 /// Registration that removes its own waiter slot when dropped.
@@ -646,9 +636,7 @@ where
                     pending: BTreeMap::new(),
                     last_processed,
                     finalizing: None,
-                    finalizing_batch_secured: false,
-                    finalizing_databases_applied: false,
-                    finalizing_apply_waiters: Vec::new(),
+                    finalizing_batch: None,
                     finalizing_compatible: HashSet::new(),
                 })),
                 metrics,
@@ -890,19 +878,19 @@ where
         let sync_targets = A::sync_targets(block);
         self.execution.begin_finalization(finalized);
 
-        // Marshal finalization is ordered. A pending miss means we can replay
-        // this block on top of finalized state.
+        // Marshal finalization is ordered. If the winner is not cached,
+        // reconstruct its batch from the current finalized database state.
         //
-        // Safety contract: replayed `Application::apply` output must match the
-        // block commitments previously enforced by `Application::verify`.
-        let pending = loop {
+        // Safety contract: reconstructed `Application::apply` output must
+        // match the block commitments previously enforced by `Application::verify`.
+        let reconstruction = loop {
             match self
                 .execution
-                .find_finalization_batch(&self.replays, digest)
+                .claim_finalization_batch(&self.replays, digest)
             {
-                FinalizationBatch::Ready => break true,
-                FinalizationBatch::Missing => break false,
-                FinalizationBatch::Wait(mut waiter) => match (&mut waiter.completion).await {
+                FinalizationClaim::Cached => break None,
+                FinalizationClaim::Reconstruct(owner) => break Some(owner),
+                FinalizationClaim::Wait(mut waiter) => match (&mut waiter.completion).await {
                     Ok(Ok(())) | Err(_) => continue,
                     Ok(Err(error)) => {
                         warn!(
@@ -910,35 +898,37 @@ where
                             ?error,
                             "finalization could not reuse active verification replay"
                         );
-                        break false;
+                        continue;
                     }
                 },
             }
         };
-        let replayed = if pending {
+        let reconstructed = if reconstruction.is_none() {
             None
         } else {
             let batches = self.execution.databases.new_batches().await;
             let batch = self
                 .app
                 .apply(
-                    (context.child("finalize_replay"), block_context),
+                    (context.child("finalize_reconstruct"), block_context),
                     block,
                     batches,
                 )
                 .await;
             assert!(
                 A::Databases::matches_sync_targets(&batch, &sync_targets),
-                "finalize replay state root must match block commitments",
+                "finalize reconstruction must match block commitments",
             );
             Some(batch)
         };
 
-        // Once the winner leaves pending state, work that needs it waits until
-        // every database has applied it before rebuilding from committed state.
-        let batch = self.execution.secure_finalization_batch(digest, replayed);
+        let batch = self
+            .execution
+            .secure_finalization_batch(digest, reconstructed);
+        if let Some(owner) = reconstruction {
+            owner.finish(Ok(()));
+        }
         let barrier = self.execution.databases.finalize(batch).await;
-        self.execution.finish_database_apply();
         self.notify_finalized(context, block).await;
         let prune = self
             .pruning
@@ -984,7 +974,7 @@ where
         self.state.lock().last_processed
     }
 
-    /// Starts the publication fence for a serialized finalization.
+    /// Records the compatible pending state for a serialized finalization.
     fn begin_finalization(&self, anchor: Anchor<PendingDigest<A, E>>) {
         let mut state = self.state.lock();
         let compatible = compatible_pending(&state, anchor.digest, anchor.round);
@@ -992,23 +982,16 @@ where
             state.finalizing.replace(anchor).is_none(),
             "finalization must be serialized",
         );
-        assert!(!state.finalizing_batch_secured);
-        assert!(!state.finalizing_databases_applied);
-        assert!(state.finalizing_apply_waiters.is_empty());
+        assert!(state.finalizing_batch.is_none());
         assert!(state.finalizing_compatible.is_empty());
         state.finalizing_compatible = compatible;
     }
 
-    /// Secure the winner for database application and release batches that
-    /// cannot descend from it.
-    ///
-    /// The winner's batch has already been secured, so exact-block replay no longer needs its
-    /// pending ancestry. The compatibility set remains live until finalization completes so
-    /// retained descendants can continue publishing.
+    /// Retain the winner as a branch parent and discard incompatible state.
     fn secure_finalization_batch(
         &self,
         digest: PendingDigest<A, E>,
-        replayed: Option<PendingBatches<A, E>>,
+        reconstructed: Option<PendingBatches<A, E>>,
     ) -> PendingBatches<A, E> {
         let mut state = self.state.lock();
         assert_eq!(
@@ -1016,19 +999,19 @@ where
             Some(digest),
             "secured batch must match active finalization",
         );
-        assert!(!state.finalizing_batch_secured);
-        assert!(!state.finalizing_databases_applied);
-        state.finalizing_batch_secured = true;
+        assert!(state.finalizing_batch.is_none());
         let ExecutionState {
             pending,
+            finalizing_batch,
             finalizing_compatible,
             ..
         } = &mut *state;
         let batch = pending
             .remove(&digest)
             .map(|entry| entry.merkleized)
-            .or(replayed)
-            .expect("finalization must have a cached or replayed batch");
+            .or(reconstructed)
+            .expect("finalization must have a cached or reconstructed batch");
+        *finalizing_batch = Some(batch.clone());
         let before = pending.len();
         pending.retain(|candidate_digest, _| finalizing_compatible.contains(candidate_digest));
         let pruned = before - pending.len();
@@ -1039,29 +1022,11 @@ where
         batch
     }
 
-    /// Publish that every database now reflects the secured winner.
-    fn finish_database_apply(&self) {
-        let mut state = self.state.lock();
-        assert!(state.finalizing.is_some(), "finalization must be active");
-        assert!(state.finalizing_batch_secured);
-        assert!(!state.finalizing_databases_applied);
-        state.finalizing_databases_applied = true;
-        let waiters = std::mem::take(&mut state.finalizing_apply_waiters);
-        drop(state);
-        for waiter in waiters {
-            waiter.send_lossy(());
-        }
-    }
-
     /// Publish the finalized anchor after its application hook completes.
     fn finish_finalization(&self, finalized: Anchor<PendingDigest<A, E>>) {
         let mut state = self.state.lock();
         assert_eq!(state.finalizing.take(), Some(finalized));
-        assert!(state.finalizing_batch_secured);
-        assert!(state.finalizing_databases_applied);
-        assert!(state.finalizing_apply_waiters.is_empty());
-        state.finalizing_batch_secured = false;
-        state.finalizing_databases_applied = false;
+        assert!(state.finalizing_batch.take().is_some());
         state.finalizing_compatible.clear();
         state.last_processed = finalized;
     }
@@ -1098,20 +1063,20 @@ where
         }
 
         // A replay can finish after another copy supplied the batch consumed by finalization.
-        // Publishing that replay still succeeds, but the finalized batch must not be reinserted.
-        let batch_already_secured = state.finalizing.is_some_and(|finalizing| {
-            state.finalizing_batch_secured
+        // Treat it as cached without reinserting the finalized batch.
+        let winner_already_retained = state.finalizing.is_some_and(|finalizing| {
+            state.finalizing_batch.is_some()
                 && finalizing.digest == digest
                 && finalizing.round == round
         });
-        if batch_already_secured
+        if winner_already_retained
             || (state.last_processed.digest == digest && state.last_processed.round == round)
         {
             return true;
         }
 
         // The processed anchor is not advanced until the application hook returns. Retained
-        // descendants may publish during that interval, but new work on the old anchor may not.
+        // descendants may cache state during that interval, but new work on the old anchor may not.
         let compatible = state.finalizing.map_or_else(
             || {
                 round > state.last_processed.round
@@ -1143,39 +1108,45 @@ where
         true
     }
 
-    /// Finds a cached winner batch or waits for an active replay producing it.
+    /// Finds, joins, or reserves construction of the finalizing winner batch.
     ///
     /// Replay completion only tells the caller to check the cache again: the
-    /// owner publishes before notifying its waiters. Execution state is always
-    /// locked before the replay registry when both are inspected.
-    fn find_finalization_batch(
+    /// owner caches the batch before notifying its waiters. Execution state is
+    /// always locked before the replay registry when both are inspected.
+    fn claim_finalization_batch(
         &self,
         replays: &ReplayFlights<PendingDigest<A, E>>,
         digest: PendingDigest<A, E>,
-    ) -> FinalizationBatch<E, A> {
+    ) -> FinalizationClaim<PendingDigest<A, E>> {
         let state = self.state.lock();
-        if state.pending.contains_key(&digest) {
-            return FinalizationBatch::Ready;
-        }
-
         let mut entries = replays.entries.lock();
-        let Some(flight) = entries.get_mut(&digest) else {
-            return FinalizationBatch::Missing;
-        };
-        FinalizationBatch::Wait(replays.waiter(digest, flight))
+        if let Some(flight) = entries.get_mut(&digest) {
+            return FinalizationClaim::Wait(replays.waiter(digest, flight));
+        }
+        if state.pending.contains_key(&digest) {
+            FinalizationClaim::Cached
+        } else {
+            FinalizationClaim::Reconstruct(replays.register_owner(digest, &mut entries))
+        }
     }
 
     /// Reuses known state, joins an active replay, or claims replay ownership.
     ///
     /// The state-before-registry lock order prevents a replay registration from
-    /// racing publication of the same digest.
+    /// racing insertion of the same digest.
     fn claim_replay(
         &self,
         replays: &ReplayFlights<PendingDigest<A, E>>,
         digest: PendingDigest<A, E>,
     ) -> ReplayClaim<PendingDigest<A, E>> {
         let state = self.state.lock();
-        if state.last_processed.digest == digest || state.pending.contains_key(&digest) {
+        if state.last_processed.digest == digest
+            || state.pending.contains_key(&digest)
+            || (state.finalizing_batch.is_some()
+                && state
+                    .finalizing
+                    .is_some_and(|finalizing| finalizing.digest == digest))
+        {
             return ReplayClaim::Ready;
         }
 
@@ -1184,25 +1155,7 @@ where
             return ReplayClaim::Wait(replays.waiter(digest, flight));
         }
 
-        let generation = Arc::new(ReplayGeneration);
-        assert!(
-            entries
-                .insert(
-                    digest,
-                    ReplayFlight {
-                        generation: Arc::clone(&generation),
-                        waiters: Vec::new(),
-                        vacant_slots: Vec::new(),
-                    },
-                )
-                .is_none(),
-        );
-        ReplayClaim::Owner(ReplayOwner {
-            flights: replays.clone(),
-            digest,
-            generation,
-            result: None,
-        })
+        ReplayClaim::Owner(replays.register_owner(digest, &mut entries))
     }
 
     /// Forks batches from a known parent.
@@ -1210,47 +1163,33 @@ where
         &self,
         parent: &PendingDigest<A, E>,
     ) -> Result<<A::Databases as DatabaseSet<E>>::Unmerkleized, PrepareBatchesError> {
-        loop {
-            let waiter = {
-                let mut state = self.state.lock();
-                if let Some(entry) = state.pending.get(parent) {
-                    return Ok(A::Databases::fork_batches(&entry.merkleized));
-                }
-                if state.last_processed.digest == *parent {
-                    None
-                } else if state.finalizing_batch_secured
-                    && state
-                        .finalizing
-                        .is_some_and(|finalizing| finalizing.digest == *parent)
-                {
-                    // The winner's per-database batches are unavailable while
-                    // independent finalizers apply them. Rebuild only after
-                    // every database exposes the winner as committed state.
-                    if state.finalizing_databases_applied {
-                        None
-                    } else {
-                        let (sender, receiver) = oneshot::channel();
-                        state.finalizing_apply_waiters.push(sender);
-                        Some(receiver)
-                    }
-                } else {
-                    return Err(PrepareBatchesError::Invalid);
-                }
-            };
-
-            let Some(waiter) = waiter else {
-                return Ok(self.databases.new_batches().await);
-            };
-            if waiter.await.is_err() {
-                return Err(PrepareBatchesError::Cancelled);
+        {
+            let state = self.state.lock();
+            if let Some(entry) = state.pending.get(parent) {
+                return Ok(A::Databases::fork_batches(&entry.merkleized));
+            }
+            if state
+                .finalizing
+                .is_some_and(|finalizing| finalizing.digest == *parent)
+            {
+                let batch = state
+                    .finalizing_batch
+                    .as_ref()
+                    .ok_or(PrepareBatchesError::Invalid)?;
+                return Ok(A::Databases::fork_batches(batch));
+            }
+            if state.last_processed.digest != *parent {
+                return Err(PrepareBatchesError::Invalid);
             }
         }
+
+        Ok(self.databases.new_batches().await)
     }
 
     /// Replays one certified block and caches its commitment-matching state.
     ///
-    /// Cancellation publishes nothing. A commitment mismatch or a publication
-    /// rejected by the finalization fence makes the ancestry invalid.
+    /// Cancellation caches nothing. A commitment mismatch or state that cannot
+    /// be cached across active finalization makes the ancestry invalid.
     async fn replay_block<C>(
         &self,
         app: &mut A,
@@ -1321,7 +1260,7 @@ where
             match self.claim_replay(replay.flights, digest) {
                 ReplayClaim::Ready => return Ok(()),
                 ReplayClaim::Owner(owner) => {
-                    replay.progress.replaying(digest, parent, round, true);
+                    replay.progress.replaying(digest, parent, round);
                     let result = self
                         .replay_block(
                             app,
@@ -1337,7 +1276,7 @@ where
                     return result;
                 }
                 ReplayClaim::Wait(mut waiter) => {
-                    replay.progress.replaying(digest, parent, round, false);
+                    replay.progress.replaying(digest, parent, round);
                     let Some(completion) =
                         await_or_cancel(cancellation, &mut waiter.completion).await
                     else {
@@ -1629,16 +1568,14 @@ mod tests {
         let progress = VerificationProgress::default();
         assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
 
-        progress.replaying(9, 8, Round::new(Epoch::zero(), View::new(9)), true);
+        progress.replaying(9, 8, Round::new(Epoch::zero(), View::new(9)));
         assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
 
-        progress.replaying(10, 1, Round::new(Epoch::zero(), View::new(10)), true);
+        progress.replaying(10, 1, Round::new(Epoch::zero(), View::new(10)));
         assert_eq!(boundary.disposition(&progress), Disposition::Retain,);
-        progress.replaying(10, 1, Round::new(Epoch::zero(), View::new(10)), false);
-        assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
-        progress.replaying(12, 11, Round::new(Epoch::zero(), View::new(11)), false);
+        progress.replaying(12, 11, Round::new(Epoch::zero(), View::new(11)));
         assert_eq!(boundary.disposition(&progress), Disposition::Retain,);
-        progress.replaying(20, 19, Round::new(Epoch::zero(), View::new(11)), true);
+        progress.replaying(20, 19, Round::new(Epoch::zero(), View::new(11)));
         assert_eq!(boundary.disposition(&progress), Disposition::Reject,);
 
         progress.verifying(9, 8, Round::new(Epoch::zero(), View::new(9)));
@@ -2496,7 +2433,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_fallback_waits_until_finalizing_winner_is_applied() {
+    fn execution_forks_from_finalizing_winner_before_database_apply() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();
@@ -2514,20 +2451,19 @@ mod tests {
 
             let winner_digest = winner.digest();
             let mut fork = Box::pin(execution.fork_batches(&winner_digest));
-            assert!(
-                futures::poll!(&mut fork).is_pending(),
-                "committed fallback must wait until every database reflects the winner",
-            );
+            let forked = match futures::poll!(&mut fork) {
+                std::task::Poll::Ready(forked) => forked,
+                std::task::Poll::Pending => {
+                    panic!("finalizing winner should remain available for child batches")
+                }
+            };
+            assert!(forked.is_ok(), "finalizing winner should remain forkable");
 
             drop(read);
             let Applied { barrier, .. } = finalize
                 .await
                 .expect("finalized block should be newly applied");
             assert!(barrier.durable().await, "finalize flush must complete");
-            assert!(
-                fork.await.is_ok(),
-                "fallback should resume after database apply"
-            );
         });
     }
 
@@ -2828,7 +2764,7 @@ mod tests {
             assert_eq!(
                 probe.calls(),
                 2,
-                "finalization must replay the winner itself after the owner cancels",
+                "finalization must reconstruct the winner after the owner cancels",
             );
             assert_eq!(harness.processor.last_processed().digest, winner.digest());
             assert!(harness.processor.replays_idle());
@@ -2868,6 +2804,177 @@ mod tests {
             assert!(barrier.durable().await, "finalize flush must complete");
             assert_eq!(harness.processor.last_processed().digest, winner.digest());
             assert!(harness.processor.replays_idle());
+        });
+    }
+
+    #[test]
+    fn execution_finalization_waits_for_active_cached_winner_replay() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let mut harness = Harness::new(context).await;
+            let genesis = Block::genesis();
+            let (winner, merkleized) = harness.build_child(&genesis, View::new(1)).await;
+
+            let owner = match harness
+                .processor
+                .execution
+                .claim_replay(&harness.processor.replays, winner.digest())
+            {
+                ReplayClaim::Owner(owner) => owner,
+                _ => panic!("winner replay should own the flight"),
+            };
+            assert!(harness.processor.cache_pending(
+                winner.digest(),
+                genesis.digest(),
+                winner.context().round,
+                merkleized,
+            ));
+
+            let (gate, mut started, release) = apply_gate();
+            harness.processor.app.finalized_probe =
+                Some(ApplicationProbe::new(winner.digest(), [gate]));
+            let mut finalize = Box::pin(
+                harness
+                    .processor
+                    .finalize(harness.context_cell.as_present(), &winner),
+            );
+
+            select! {
+                _ = &mut finalize => {
+                    panic!("finalization bypassed active winner replay");
+                },
+                result = &mut started => {
+                    result.expect("finalized hook should remain reachable");
+                    panic!("finalization reached the application hook before replay completed");
+                },
+                _ = harness.context_cell.as_present().sleep(Duration::from_millis(10)) => {},
+            }
+
+            owner.finish(Ok(()));
+            select! {
+                result = &mut started => {
+                    result.expect("finalized hook should start after replay completes");
+                },
+                _ = &mut finalize => {
+                    panic!("finalization completed before its application hook");
+                },
+            }
+            release
+                .send(())
+                .expect("finalized hook should remain active");
+            let Applied { barrier, .. } = finalize
+                .await
+                .expect("finalized block should be newly applied");
+            assert!(barrier.durable().await, "finalize flush must complete");
+        });
+    }
+
+    #[test]
+    fn execution_replay_waiter_reuses_retained_finalizing_winner() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let mut harness = Harness::new(context).await;
+            let genesis = Block::genesis();
+            let (winner, _) = harness.build_child(&genesis, View::new(1)).await;
+
+            let (replay_gate, replay_started, replay_release) = apply_gate();
+            let probe = ApplicationProbe::new(winner.digest(), [replay_gate]);
+            harness.processor.app.apply_probe = Some(probe.clone());
+            let (finalized_gate, finalized_started, finalized_release) = apply_gate();
+            harness.processor.app.finalized_probe =
+                Some(ApplicationProbe::new(winner.digest(), [finalized_gate]));
+
+            let execution = harness.processor.execution.clone();
+            let replays = harness.processor.replays.clone();
+            let mut owner_app = harness.processor.app.clone();
+            let mut waiter_app = harness.processor.app.clone();
+            let replay_context = harness.context_cell.as_present();
+            let owner_progress = VerificationProgress::default();
+            let waiter_progress = VerificationProgress::default();
+            let (mut owner_cancellation, _owner_alive) = oneshot::channel::<()>();
+            let (mut waiter_cancellation, _waiter_alive) = oneshot::channel::<()>();
+
+            let mut owner = Box::pin(execution.replay_block_shared(
+                &mut owner_app,
+                replay_context,
+                winner.digest(),
+                Arc::new(winner.clone()),
+                &mut owner_cancellation,
+                ReplayTracking {
+                    flights: &replays,
+                    progress: &owner_progress,
+                },
+            ));
+            assert!(futures::poll!(&mut owner).is_pending());
+            replay_started.await.expect("winner replay should start");
+
+            let mut waiter = Box::pin(execution.replay_block_shared(
+                &mut waiter_app,
+                replay_context,
+                winner.digest(),
+                Arc::new(winner.clone()),
+                &mut waiter_cancellation,
+                ReplayTracking {
+                    flights: &replays,
+                    progress: &waiter_progress,
+                },
+            ));
+            assert!(futures::poll!(&mut waiter).is_pending());
+
+            let mut finalize = Box::pin(
+                harness
+                    .processor
+                    .finalize(harness.context_cell.as_present(), &winner),
+            );
+            assert!(futures::poll!(&mut finalize).is_pending());
+
+            replay_release
+                .send(())
+                .expect("winner replay should remain active");
+            assert_eq!(owner.await, Ok(()));
+            select! {
+                result = finalized_started => {
+                    result.expect("finalized hook should start");
+                },
+                _ = &mut finalize => {
+                    panic!("finalization completed before its application hook");
+                },
+            }
+
+            assert_eq!(
+                waiter.await,
+                Ok(()),
+                "waiter should reuse the retained winner batch",
+            );
+            assert_eq!(probe.calls(), 1, "winner should be reconstructed once");
+
+            finalized_release
+                .send(())
+                .expect("finalized hook should remain active");
+            let Applied { barrier, .. } = finalize
+                .await
+                .expect("finalized block should be newly applied");
+            assert!(barrier.durable().await, "finalize flush must complete");
+        });
+    }
+
+    #[test]
+    fn execution_finalization_reserves_missing_winner_reconstruction() {
+        deterministic::Runner::default().start(|context| async move {
+            let harness = Harness::new(context).await;
+            let genesis = Block::genesis();
+            let (winner, _) = harness.build_child(&genesis, View::new(1)).await;
+            let execution = harness.processor.execution.clone();
+            let replays = harness.processor.replays.clone();
+
+            execution.begin_finalization(Anchor::from(&winner));
+            let finalization = execution.claim_finalization_batch(&replays, winner.digest());
+            assert!(
+                matches!(
+                    execution.claim_replay(&replays, winner.digest()),
+                    ReplayClaim::Wait(_),
+                ),
+                "missing winner reconstruction must remain single-flight",
+            );
+            drop(finalization);
         });
     }
 
@@ -3548,8 +3655,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "finalize replay state root must match block commitments")]
-    fn execution_finalize_replay_rejects_state_root_mismatch() {
+    #[should_panic(expected = "finalize reconstruction must match block commitments")]
+    fn execution_finalize_reconstruction_rejects_state_root_mismatch() {
         deterministic::Runner::default().start(|context| async move {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();

--- a/glue/src/stateful/actor/processor/verifier.rs
+++ b/glue/src/stateful/actor/processor/verifier.rs
@@ -305,7 +305,7 @@ where
         })
     }
 
-    /// Executes application verification and publishes commitment-matching state.
+    /// Executes application verification and caches commitment-matching state.
     async fn verify(
         &mut self,
         context: &E,
@@ -376,7 +376,7 @@ where
             warn!(
                 parent_digest = ?parent.digest,
                 ?block_digest,
-                "verification result became incompatible before publication"
+                "verification result became incompatible before caching"
             );
             return Some(false);
         }

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -171,6 +171,25 @@ where
     db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
 }
 
+impl<F, E, C, I, H, U, S> Clone for AnyMerkleized<F, E, C, I, H, U, S>
+where
+    F: Family,
+    E: Context,
+    U: Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, C, I, H, U, S> Deref for AnyUnmerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
@@ -808,6 +827,35 @@ mod tests {
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }
+    }
+
+    #[test]
+    fn unmerkleized_batch_falls_through_to_applied_state() {
+        deterministic::Runner::default().start(|context| async move {
+            let config = fixed_config("unordered-fixed-live-fallback", &context);
+            let db = <UnorderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
+                .await
+                .unwrap();
+            let db = Shared::new("test", db);
+
+            let key = Sha256::hash(&[b"key"]);
+            let value = Sha256::hash(&[b"winner"]);
+            let pre_finalization = db.new_batch_for_test::<_>().await;
+            let winner = db.new_batch_for_test::<_>().await.write(key, Some(value));
+            let winner = crate::stateful::db::Unmerkleized::merkleize(winner)
+                .await
+                .unwrap();
+
+            let (slot, database) = db.write().await;
+            let (database, sync) = <UnorderedFixedDb as ManagedDb<_>>::finalize(database, winner)
+                .await
+                .unwrap();
+            slot.put(database);
+            sync.await.expect("finalize flush failed");
+
+            // The batch commitment does not provide a historical database view.
+            assert_eq!(pre_finalization.get(&key).await.unwrap(), Some(value));
+        });
     }
 
     /// The glue staged wrapper (`AnyUnmerkleized::stage` -> `AnyStaged::expand` ->

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -171,6 +171,25 @@ where
     db: Shared<Db<F, E, C, I, H, U, N, S>>,
 }
 
+impl<F, E, C, I, H, U, const N: usize, S> Clone for CurrentMerkleized<F, E, C, I, H, U, N, S>
+where
+    F: Graftable,
+    E: Context,
+    U: Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, C, I, H, U, const N: usize, S> Deref for CurrentUnmerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -115,6 +115,26 @@ where
     db: Shared<CompactDb<F, E, K, V, H, C, S>>,
 }
 
+impl<F, E, K, V, H, S, C> Clone for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
+where
+    F: Family,
+    E: Context,
+    K: Key,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, K, V>: EncodeShared,
+    Operation<F, K, V>: CodecRead<Cfg = C>,
+    C: Clone + Send + Sync + 'static,
+    S: Strategy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
 where
     F: Family,

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -143,6 +143,26 @@ where
     db: ImmutableDbHandle<F, E, K, V, C, H, T, S>,
 }
 
+impl<F, E, K, V, C, H, T, S> Clone for ImmutableMerkleized<F, E, K, V, C, H, T, S>
+where
+    F: Family,
+    E: Context,
+    K: Key,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<F, K, V>>,
+    H: Hasher,
+    T: Translator,
+    S: Strategy,
+    Operation<F, K, V>: EncodeShared,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, K, V, C, H, T, S> Deref for ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -110,6 +110,25 @@ where
     db: Shared<CompactDb<F, E, V, H, C, S>>,
 }
 
+impl<F, E, V, H, S, C> Clone for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
+where
+    F: Family,
+    E: Context,
+    V: ValueEncoding,
+    H: Hasher,
+    Operation<F, V>: EncodeShared,
+    Operation<F, V>: CodecRead<Cfg = C>,
+    C: Clone + Send + Sync + 'static,
+    S: Strategy,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, V, H, S, C> Deref for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
 where
     F: Family,

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -135,6 +135,24 @@ where
     db: Shared<Keyless<F, E, V, C, H, S>>,
 }
 
+impl<F, E, V, C, H, S> Clone for KeylessMerkleized<F, E, V, C, H, S>
+where
+    F: Family,
+    E: Context,
+    V: ValueEncoding,
+    C: Mutable<Item = Operation<F, V>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, V>: EncodeShared,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
 impl<F, E, V, C, H, S> Deref for KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -347,7 +347,8 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     ///
     /// Constrained so that [`Merkleized::new_batch`] produces the same
     /// [`Unmerkleized`] type as [`ManagedDb::new_batch`](Self::new_batch).
-    type Merkleized: Merkleized<Unmerkleized = Self::Unmerkleized>;
+    /// Cloning must preserve the same sealed branch state and should be cheap.
+    type Merkleized: Clone + Merkleized<Unmerkleized = Self::Unmerkleized>;
 
     /// The error type returned by fallible operations.
     type Error: Debug + Send;
@@ -509,7 +510,8 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     type Unmerkleized: Send;
 
     /// Tuple of [`ManagedDb::Merkleized`] for every database in the set.
-    type Merkleized: Send + Sync;
+    /// Cloning must preserve the same sealed branch state and should be cheap.
+    type Merkleized: Clone + Send + Sync;
 
     /// Read-only handles for observing the applied database state.
     ///

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -239,6 +239,9 @@ where
     /// still change as additional information becomes available, continue
     /// waiting instead of returning [`None`].
     ///
+    /// Validity is relative to those inputs: finalizing a competing branch
+    /// later does not retroactively change a completed verdict.
+    ///
     /// In other words, to abstain from voting, do not resolve this future yet.
     /// Keep it pending until the implementation can either prove the block
     /// valid, prove it invalid, or the consensus engine cancels the request.

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -977,19 +977,18 @@ impl Application<deterministic::Context> for GatedMultiApp {
         ancestry: impl Ancestry<Self::Block>,
         batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
     ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
-        let result = <MultiApp as Application<deterministic::Context>>::verify(
-            &mut self.inner,
-            context,
-            ancestry,
-            batches,
-        )
-        .await;
         let gate = self.verify_gates.lock().pop_front();
         if let Some(mut gate) = gate {
             let _ = gate.started.send(());
             let _ = (&mut gate.release).await;
         }
-        result
+        <MultiApp as Application<deterministic::Context>>::verify(
+            &mut self.inner,
+            context,
+            ancestry,
+            batches,
+        )
+        .await
     }
 
     async fn apply(
@@ -1426,8 +1425,7 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             "the first finalization should retain descendant verifications",
         );
 
-        // The next finalization must quiesce compatible verification before
-        // the active finalization callback is allowed to return.
+        // A queued finalization is not active until the current one completes.
         for block in &blocks[1..3] {
             let (acknowledgement, waiter) = Exact::handle();
             let _ = reporter.report(marshal::Update::Block(
@@ -1436,16 +1434,11 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             ));
             finalizations.push(waiter);
         }
-
-        select! {
-            _ = futures::future::join_all(
-                verify_releases.iter_mut().map(|release| release.closed()),
-            ) => {},
-            _ = context.sleep(Duration::from_secs(1)) => {
-                panic!("queued finalization did not quiesce retained multi-QMDB verifications");
-            },
-        }
-        drop(verify_releases);
+        context.sleep(Duration::from_millis(10)).await;
+        assert!(
+            verify_releases.iter().all(|release| !release.is_closed()),
+            "queued finalization quiesced work before the current finalization completed",
+        );
         finalize_release
             .send(())
             .expect("first multi-QMDB finalization should remain active");
@@ -1460,6 +1453,11 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
                 panic!("multi-QMDB finalizations did not become durable");
             },
         }
+        for release in verify_releases {
+            release
+                .send(())
+                .expect("compatible verification should remain active across finalization");
+        }
         for (index, certification) in certifications {
             select! {
                 result = certification => {
@@ -1471,12 +1469,32 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             }
         }
 
+        let mut descendant_finalizations = Vec::new();
+        for block in &blocks[3..] {
+            let (acknowledgement, waiter) = Exact::handle();
+            let _ = reporter.report(marshal::Update::Block(
+                Arc::new(block.clone()),
+                acknowledgement,
+            ));
+            descendant_finalizations.push(waiter);
+        }
+        select! {
+            acknowledgements = futures::future::join_all(descendant_finalizations) => {
+                for acknowledgement in acknowledgements {
+                    acknowledgement.expect("descendant block should be durable");
+                }
+            },
+            _ = context.sleep(Duration::from_secs(2)) => {
+                panic!("descendant batches did not finalize from their original ancestry");
+            },
+        }
+
         let committed = <MultiDatabaseSet<deterministic::Context> as DatabaseSet<
             deterministic::Context,
         >>::committed_targets(&databases)
         .await;
         let expected =
-            <GatedMultiApp as Application<deterministic::Context>>::sync_targets(&blocks[2]);
+            <GatedMultiApp as Application<deterministic::Context>>::sync_targets(&blocks[5]);
         assert_eq!(committed.0, expected.0, "full QMDB target diverged");
         assert_eq!(committed.1, expected.1, "compact QMDB target diverged");
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1391,19 +1391,10 @@ where
             v.extend(parent.ancestors());
             v
         });
-        // The DB boundary is inherited unless older ancestors were applied and freed, truncating
-        // the weak parent chain. The oldest live ancestor's base then names the boundary directly.
-        // For A -> B -> C with A applied and dropped, `ancestors()` yields [B]. B's items start at
-        // A's size, so B's `base` is the boundary.
-        let inherited = self.base.db();
-        let db_state = ancestors.last().map_or(inherited, |oldest| {
-            let oldest_base = oldest.bounds.base;
-            if oldest_base.size > inherited.size {
-                oldest_base
-            } else {
-                inherited
-            }
-        });
+        let db_state = batch_chain::effective_db_boundary(
+            self.base.db(),
+            ancestors.last().map(|oldest| oldest.bounds.base),
+        );
         let m = Merkleizer {
             journal_batch: self.journal_batch,
             ancestors,

--- a/storage/src/qmdb/batch_chain.rs
+++ b/storage/src/qmdb/batch_chain.rs
@@ -169,6 +169,17 @@ where
         .collect()
 }
 
+/// Advance the inherited DB boundary past applied ancestors no longer reachable
+/// through the weak parent chain.
+pub(crate) fn effective_db_boundary<F: Family, D: Digest>(
+    inherited: Commitment<F, D>,
+    oldest_live_base: Option<Commitment<F, D>>,
+) -> Commitment<F, D> {
+    oldest_live_base
+        .filter(|base| base.size > inherited.size)
+        .unwrap_or(inherited)
+}
+
 /// Validate that a batch can be applied to the database at the given [`Commitment`].
 ///
 /// A batch is applicable if the database has not advanced since the batch was created, if all

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -247,8 +247,13 @@ where
     {
         let base = self.base.size;
 
-        // Capture the DB boundary before `self` is consumed below.
-        let boundary = self.db();
+        let live_ancestors: Vec<_> =
+            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors())
+                .collect();
+        let boundary = batch_chain::effective_db_boundary(
+            self.db(),
+            live_ancestors.last().map(|oldest| oldest.bounds.base),
+        );
 
         // Build operations: one Set per key, then Commit. `self.mutations` is a BTreeMap, so
         // iteration yields keys in sorted order, which `diff` relies on for binary search.
@@ -278,9 +283,7 @@ where
         // Compute the batch chain bounds.
         let mut ancestor_diffs = Vec::new();
         let mut ancestors = Vec::new();
-        for batch in
-            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors())
-        {
+        for batch in live_ancestors {
             ancestor_diffs.push(Arc::clone(&batch.diff));
             ancestors.push(batch_chain::AncestorBounds {
                 floor: batch.bounds.inactivity_floor,

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -224,8 +224,13 @@ where
         C: Clone + Send + Sync + 'static,
         Operation<F, K, V>: Read<Cfg = C>,
     {
-        // Capture the DB boundary before `self` is consumed below.
-        let boundary = self.db();
+        let live_ancestors: Vec<_> =
+            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors())
+                .collect();
+        let boundary = batch_chain::effective_db_boundary(
+            self.db(),
+            live_ancestors.last().map(|oldest| oldest.bounds.base),
+        );
 
         let mut ops: Vec<Operation<F, K, V>> = Vec::with_capacity(self.mutations.len() + 1);
         for (key, value) in self.mutations {
@@ -244,10 +249,8 @@ where
         .await
         .expect("inactive_peaks computed from batch size");
 
-        let ancestors =
-            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors());
         let ancestors = batch_chain::collect_ancestor_bounds(
-            ancestors,
+            live_ancestors,
             |batch| batch.bounds.inactivity_floor,
             |batch| batch.commitment(),
         );
@@ -888,6 +891,38 @@ mod tests {
             let (db, _) = db.apply_batch(batch_a).unwrap();
             assert_eq!(db.root(), expected_root);
             assert!(matches!(db.apply_batch(batch_b), Err(Error::StaleBatch)));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_delayed_merkleize_after_ancestor_apply() {
+        deterministic::Runner::default().start(|context| async move {
+            let db = open_db::<mmr::Family>(context.child("db"), "immutable-delayed-child").await;
+            let key1 = Sha256::hash(&[&[1]]);
+            let key2 = Sha256::hash(&[&[2]]);
+            let key3 = Sha256::hash(&[&[3]]);
+            let value1 = Sha256::fill(10u8);
+            let value2 = Sha256::fill(20u8);
+            let value3 = Sha256::fill(30u8);
+
+            let a = db
+                .new_batch()
+                .set(key1, value1)
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let b = a
+                .new_batch::<Sha256>()
+                .set(key2, value2)
+                .merkleize(&db, None, Location::new(0))
+                .await;
+            let c = b.new_batch::<Sha256>().set(key3, value3);
+
+            let (db, _) = db.apply_batch(a).unwrap();
+            let c = c.merkleize(&db, None, Location::new(0)).await;
+            let expected_root = c.root();
+            let (db, _) = db.apply_batch(c).unwrap();
+
+            assert_eq!(db.root(), expected_root);
         });
     }
 

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -2534,6 +2534,51 @@ pub(super) mod test {
     }
 
     #[boxed]
+    pub(crate) async fn test_immutable_delayed_merkleize_after_ancestor_apply<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
+        C::Item: EncodeShared,
+    {
+        let db = open_db(context.child("db")).await;
+
+        let key1 = Sha256::hash(&[&[1]]);
+        let key2 = Sha256::hash(&[&[2]]);
+        let key3 = Sha256::hash(&[&[3]]);
+        let v1 = Sha256::fill(1u8);
+        let v2 = Sha256::fill(2u8);
+        let v3 = Sha256::fill(3u8);
+
+        let a = db
+            .new_batch()
+            .set(key1, v1)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let b = a
+            .new_batch::<Sha256>()
+            .set(key2, v2)
+            .merkleize(&db, None, Location::new(0))
+            .await;
+        let c = b.new_batch::<Sha256>().set(key3, v3);
+
+        let (db, _) = db.apply_batch(a).await.unwrap();
+        let c = c.merkleize(&db, None, Location::new(0)).await;
+        let expected_root = c.root();
+        let (db, _) = db.apply_batch(c).await.unwrap();
+
+        assert_eq!(db.root(), expected_root);
+        assert_eq!(db.get(&key1).await.unwrap(), Some(v1));
+        assert_eq!(db.get(&key2).await.unwrap(), Some(v2));
+        assert_eq!(db.get(&key3).await.unwrap(), Some(v3));
+
+        db.destroy().await.unwrap();
+    }
+
+    #[boxed]
     pub(crate) async fn test_immutable_sequential_commit_parent_then_child<F: Family, V, C>(
         context: deterministic::Context,
         open_db: impl Fn(

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -545,6 +545,15 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_variable_delayed_merkleize_after_ancestor_apply() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            test::test_immutable_delayed_merkleize_after_ancestor_apply(ctx, open::<mmr::Family>)
+                .await;
+        });
+    }
+
+    #[test_traced]
     fn test_variable_child_root_matches_pending_and_committed() {
         let executor = deterministic::Runner::default();
         executor.start(|ctx| async move {

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -267,8 +267,13 @@ where
         E: Context,
         C: Mutable<Item = Operation<F, V>>,
     {
-        // Capture the DB boundary before `self` is consumed below.
-        let boundary = self.db();
+        let live_ancestors: Vec<_> =
+            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors())
+                .collect();
+        let boundary = batch_chain::effective_db_boundary(
+            self.db(),
+            live_ancestors.last().map(|oldest| oldest.bounds.base),
+        );
 
         // Build operations: one Append per value, then Commit.
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
@@ -289,10 +294,8 @@ where
             .expect("inactive_peaks computed from batch size");
 
         // Compute the batch chain bounds.
-        let ancestors =
-            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors());
         let ancestors = batch_chain::collect_ancestor_bounds(
-            ancestors,
+            live_ancestors,
             |batch| batch.bounds.inactivity_floor,
             |batch| batch.commitment(),
         );

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -213,8 +213,13 @@ where
         C: Clone + Send + Sync + 'static,
         Operation<F, V>: Read<Cfg = C>,
     {
-        // Capture the DB boundary before `self` is consumed below.
-        let boundary = self.db();
+        let live_ancestors: Vec<_> =
+            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors())
+                .collect();
+        let boundary = batch_chain::effective_db_boundary(
+            self.db(),
+            live_ancestors.last().map(|oldest| oldest.bounds.base),
+        );
 
         let mut ops: Vec<Operation<F, V>> = Vec::with_capacity(self.appends.len() + 1);
         for value in self.appends {
@@ -233,10 +238,8 @@ where
         .await
         .expect("inactive_peaks computed from batch size");
 
-        let ancestors =
-            batch_chain::parent_and_ancestors(self.parent.as_ref(), |parent| parent.ancestors());
         let ancestors = batch_chain::collect_ancestor_bounds(
-            ancestors,
+            live_ancestors,
             |batch| batch.bounds.inactivity_floor,
             |batch| batch.commitment(),
         );
@@ -1310,6 +1313,33 @@ mod tests {
             let (db, _) = db.apply_batch(batch_a).unwrap();
             assert_eq!(db.root(), expected_root);
             assert!(matches!(db.apply_batch(batch_b), Err(Error::StaleBatch)));
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_compact_delayed_merkleize_after_ancestor_apply() {
+        deterministic::Runner::default().start(|context| async move {
+            let db = open_db::<mmr::Family>(context.child("db"), "keyless-delayed-child").await;
+            let floor = db.inactivity_floor_loc();
+
+            let a = db
+                .new_batch()
+                .append(U64::new(1))
+                .merkleize(&db, None, floor)
+                .await;
+            let b = a
+                .new_batch::<Sha256>()
+                .append(U64::new(2))
+                .merkleize(&db, None, floor)
+                .await;
+            let c = b.new_batch::<Sha256>().append(U64::new(3));
+
+            let (db, _) = db.apply_batch(a).unwrap();
+            let c = c.merkleize(&db, None, floor).await;
+            let expected_root = c.root();
+            let (db, _) = db.apply_batch(c).unwrap();
+
+            assert_eq!(db.root(), expected_root);
         });
     }
 

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -1350,6 +1350,43 @@ pub(crate) mod tests {
     }
 
     #[boxed]
+    pub(crate) async fn test_keyless_delayed_merkleize_after_ancestor_apply<
+        F: Family,
+        V,
+        C,
+        H,
+        S: Strategy,
+    >(
+        db: TestKeyless<F, V, C, H, S>,
+    ) where
+        V: ValueEncoding<Value: TestValue>,
+        C: Mutable<Item = Operation<F, V>>,
+        H: Hasher,
+        Operation<F, V>: EncodeShared,
+    {
+        let floor = db.inactivity_floor_loc();
+        let a = db
+            .new_batch()
+            .append(V::Value::make(10))
+            .merkleize(&db, None, floor)
+            .await;
+        let b = a
+            .new_batch::<H>()
+            .append(V::Value::make(20))
+            .merkleize(&db, None, floor)
+            .await;
+        let c = b.new_batch::<H>().append(V::Value::make(30));
+
+        let (db, _) = db.apply_batch(a).await.unwrap();
+        let c = c.merkleize(&db, None, floor).await;
+        let expected_root = c.root();
+        let (db, _) = db.apply_batch(c).await.unwrap();
+
+        assert_eq!(db.root(), expected_root);
+        db.destroy().await.unwrap();
+    }
+
+    #[boxed]
     pub(crate) async fn test_keyless_to_batch<F: Family, V, C, S: Strategy>(
         db: TestKeyless<F, V, C, Sha256, S>,
     ) where

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -527,6 +527,14 @@ mod test {
     }
 
     #[test_traced]
+    fn test_delayed_merkleize_after_ancestor_apply() {
+        deterministic::Runner::default().start(|ctx| async move {
+            let db = open_db::<mmr::Family>(ctx.child("db")).await;
+            tests::test_keyless_delayed_merkleize_after_ancestor_apply(db).await;
+        });
+    }
+
+    #[test_traced]
     fn test_keyless_to_batch() {
         deterministic::Runner::default().start(|ctx| async move {
             let db = open_db::<mmr::Family>(ctx.child("db")).await;


### PR DESCRIPTION
Depends on #4399.

## Summary

Refines Stateful finalization so descendant verification keeps using its original QMDB batch ancestry instead of waiting for database application and rebuilding from committed state.

- Retains a cheap clone of the finalizing winner while another clone is applied. Exact-winner reconstruction owners and waiters are joined, and compatible descendants continue from their original parent-bound batches without duplicate reconstruction, replay, or rebasing.
- Reserves missing winner reconstruction in the replay single-flight registry, ensuring finalization reconstructs an unavailable winner at most once.
- Removes the queued-finalization fence and committed-state apply waiters. Completed verdicts remain relative to their supplied inputs, and a queued finalization becomes a boundary only when it is processed. Unknown or unsafe work is still retried, incompatible forks are rejected, and pruning still fully quiesces verification.
- Advances the effective QMDB database boundary when applied ancestors disappear from weak batch chains, preserving delayed descendants across Any and full and compact Immutable and Keyless databases.
- Adds deterministic winner and descendant coverage, a real full-plus-compact two-QMDB finalization test, and a regression proving that a batch commitment is not a historical read view.

## API impact

`ManagedDb::Merkleized` and `DatabaseSet::Merkleized` must be cheap `Clone` handles to the same sealed branch state.

This adds no dependencies and changes no encoded, wire, or storage formats.

## Validation

- `just test -p commonware-glue` (302 passed)
- `just test -p commonware-storage` (2915 passed)
- `just clippy -p commonware-glue`
- `just clippy -p commonware-storage`
- `just check-stability`
- `just check-fmt`
