### PR TITLE
[glue] Remove mutable database sharing

### DIFF
--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -11,7 +11,7 @@ use commonware_glue::{
     dkg::reshare::Input as ReshareInput,
     stateful::{
         Application, Input, Proposed,
-        db::{DatabaseSet, Merkleized as _, Unmerkleized as _},
+        db::{DatabaseSet, Merkleized as _, MerkleizedOf, Unmerkleized as _, UnmerkleizedOf},
     },
 };
 use commonware_runtime::{BufferPooler, Clock, Metrics, Spawner, Storage};
@@ -36,8 +36,8 @@ impl App {
 
     async fn execute<E: Spawner + Metrics + Clock + Storage + BufferPooler>(
         height: Height,
-        batches: <Database<E> as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Database<E> as DatabaseSet<E>>::Merkleized {
+        batches: UnmerkleizedOf<Database<E>, E>,
+    ) -> MerkleizedOf<Database<E>, E> {
         batches
             .write(HEIGHT_KEY, Some(U64::new(height.get())))
             .merkleize()
@@ -65,7 +65,7 @@ where
         &mut self,
         context: (E, Self::Context),
         mut ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
+        batches: UnmerkleizedOf<Self::Databases, E>,
         input: Input<Self::Input, Self::Provider>,
     ) -> Option<Proposed<Self, E>> {
         // The `reshare::Application` wrapper selected and fetched the payload.
@@ -89,8 +89,8 @@ where
         &mut self,
         _context: (E, Self::Context),
         mut ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> Option<MerkleizedOf<Self::Databases, E>> {
         // Validation from higher layers:
         // - Epoch validation is handled by `Deferred`
         // - QMDB root / range validation is handled by `stateful::Application`
@@ -105,8 +105,8 @@ where
         &mut self,
         _context: (E, Self::Context),
         block: &Self::Block,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> MerkleizedOf<Self::Databases, E> {
         Self::execute(block.height(), batches).await
     }
 

--- a/examples/reshare/src/types.rs
+++ b/examples/reshare/src/types.rs
@@ -28,7 +28,7 @@ use commonware_cryptography::{
 use commonware_formatting::{from_hex, hex};
 use commonware_glue::{
     dkg::{self, ParticipantsProvider, Registrar as RegistrarTrait, ReshareBlock, types::Payload},
-    stateful::db::{Shared, SyncEngineConfig},
+    stateful::db::{Single, SyncEngineConfig},
 };
 use commonware_parallel::Sequential;
 use commonware_runtime::{Buf, BufMut, Quota, buffer::paged::CacheRef};
@@ -62,8 +62,8 @@ use tracing::info;
 pub type Scheme = simplex::scheme::bls12381_threshold::vrf::Scheme<ed25519::PublicKey, MinSig>;
 /// QMDB holding the application state.
 pub type Qmdb<E> = fixed::Db<mmr::Family, E, U64, U64, Sha256, TwoCap, Sequential>;
-/// Shared handle to the application QMDB.
-pub type Database<E> = Shared<Qmdb<E>>;
+/// Database set containing a single QMDB.
+pub type Database<E> = Single<Qmdb<E>>;
 /// Globally unique namespace for every message signed by this example.
 pub const NAMESPACE: &[u8] = b"_COMMONWARE_RESHARE_EXAMPLE";
 /// Number of blocks in each epoch.

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -23,8 +23,8 @@ use crate::{
         Application, Config as StatefulConfig, Input, Proposed, Stateful as StatefulActor,
         SyncPlan,
         db::{
-            DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
-            p2p as qmdb_resolver,
+            DatabaseSet, HandlesOf, Merkleized as _, MerkleizedOf, SyncEngineConfig,
+            Unmerkleized as _, UnmerkleizedOf, p2p as qmdb_resolver,
         },
     },
 };
@@ -97,7 +97,7 @@ use std::{
 
 type Qmdb<E> =
     fixed::Db<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, TwoCap, Sequential>;
-type Database<E> = Shared<Qmdb<E>>;
+type Database<E> = crate::stateful::db::Single<Qmdb<E>>;
 type Scheme = simplex::scheme::bls12381_threshold::vrf::Scheme<ed25519::PublicKey, MinPk>;
 type MarshalVariant = Standard<Block>;
 type Marshal = MarshalMailbox<Scheme, MarshalVariant>;
@@ -362,8 +362,8 @@ struct App {
 impl App {
     async fn execute<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler>(
         height: Height,
-        mut batches: <Database<E> as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Database<E> as DatabaseSet<E>>::Merkleized {
+        mut batches: UnmerkleizedOf<Database<E>, E>,
+    ) -> MerkleizedOf<Database<E>, E> {
         let key = Sha256::hash(&[b"height"]);
         batches = batches.write(key, Some(u64_to_digest(height.get())));
         batches.merkleize().await.unwrap()
@@ -386,7 +386,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         &mut self,
         context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
+        batches: UnmerkleizedOf<Self::Databases, E>,
         input: Input<Self::Input, Self::Provider>,
     ) -> Option<Proposed<Self, E>> {
         let parent = ancestry.peek()?.clone();
@@ -410,11 +410,11 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         &mut self,
         _context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> Option<MerkleizedOf<Self::Databases, E>> {
         // Reshare final-block payload validation is enforced by the surrounding
         // reshare::Application wrapper; this inner app only executes state.
-        let tip = ancestry.peek()?.clone();
+        let tip = ancestry.peek().cloned()?;
         let merkleized = Self::execute(tip.height(), batches).await;
         Some(merkleized)
     }
@@ -423,8 +423,8 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         &mut self,
         _context: (E, Self::Context),
         block: &Self::Block,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> MerkleizedOf<Self::Databases, E> {
         Self::execute(block.height(), batches).await
     }
 
@@ -432,7 +432,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
-        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+        _handles: HandlesOf<Self::Databases, E>,
     ) {
         self.processed
             .lock()

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -22,8 +22,6 @@ use rand_core::Rng;
 use std::{collections::VecDeque, sync::Arc};
 use tracing::{Span, info_span};
 
-type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
-
 /// A verification is scoped to its caller.
 pub(in crate::stateful::actor) struct Verification {
     response: oneshot::Sender<bool>,
@@ -71,15 +69,6 @@ where
         span: Span,
         block: Arc<A::Block>,
         acknowledgement: Exact,
-        retry_mailbox: RetryMailbox<E, A>,
-    },
-
-    /// Requests the attached database set.
-    ///
-    /// The actor replies once the database set has been attached to the
-    /// serving stateful actor, or immediately if that has already happened.
-    SubscribeDatabases {
-        response: oneshot::Sender<A::Databases>,
     },
 }
 
@@ -92,7 +81,6 @@ where
         match self {
             Self::Propose { response, .. } => response.is_closed(),
             Self::Verify { verification, .. } => verification.is_cancelled(),
-            Self::SubscribeDatabases { response } => response.is_closed(),
             Self::Finalized { .. } => false,
         }
     }
@@ -164,7 +152,6 @@ where
     A: Application<E>,
 {
     sender: Sender<Message<E, A>>,
-    retry_mailbox: RetryMailbox<E, A>,
 }
 
 impl<E, A> Clone for Mailbox<E, A>
@@ -175,7 +162,6 @@ where
     fn clone(&self) -> Self {
         Self {
             sender: self.sender.clone(),
-            retry_mailbox: self.retry_mailbox.clone(),
         }
     }
 }
@@ -186,45 +172,8 @@ where
     A: Application<E>,
 {
     /// Create a mailbox from the send half of the actor's message channel.
-    pub(super) fn new(sender: Sender<Message<E, A>>) -> Self {
-        let retry_sender = sender.clone();
-        let retry_mailbox = Arc::new(move |message| {
-            let _ = retry_sender.enqueue(message);
-        });
-        Self {
-            sender,
-            retry_mailbox,
-        }
-    }
-}
-
-impl<E, A> Mailbox<E, A>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-{
-    /// Wait for the attached database set.
-    ///
-    /// This resolves once startup handoff has attached the database set to the
-    /// serving actor. Late callers receive the current database set
-    /// immediately.
-    ///
-    /// ## Safety
-    ///
-    /// Holders must never manually prune these databases. Stateful uses
-    /// [`Config::prune_config`](crate::stateful::Config::prune_config) to
-    /// schedule safe pruning without pruning past the rewind window needed for
-    /// crash reconciliation. With pruning enabled, glue keeps a
-    /// `max_pending_acks + 1` finalized-target window plus the configured
-    /// extra block windows before pruning.
-    pub async fn subscribe_databases(&self) -> A::Databases {
-        let (response, receiver) = oneshot::channel();
-        let _ = self
-            .sender
-            .enqueue(Message::SubscribeDatabases { response });
-        receiver
-            .await
-            .expect("stateful actor dropped during subscribe_databases")
+    pub(super) const fn new(sender: Sender<Message<E, A>>) -> Self {
+        Self { sender }
     }
 }
 
@@ -306,7 +255,6 @@ where
                     span,
                     block,
                     acknowledgement,
-                    retry_mailbox: self.retry_mailbox.clone(),
                 }
             }
         };

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -250,13 +250,12 @@ where
             sync_metadata,
             syncer: syncer_mailbox,
             deferred_verifications: Vec::new(),
-            database_subscribers: Vec::new(),
             artifact: None,
-            snapshot_publisher: self.snapshot_publisher,
             sync_completed,
             pending_finalizations: Default::default(),
             pruning: self.pruning,
             metrics,
+            snapshot_publisher: self.snapshot_publisher,
         };
         let _ = join!(syncer.start(), syncing.start());
     }
@@ -281,7 +280,7 @@ where
 
         // Publish now so serving does not wait for the first post-restart
         // finalization.
-        processor
+        let processor = processor
             .publish_snapshot(&mut self.snapshot_publisher)
             .await;
         Processing {
@@ -289,12 +288,10 @@ where
             mailbox: self.mailbox,
             provider: self.provider,
             marshal,
-            processor,
             snapshot_publisher: self.snapshot_publisher,
-            deferred_verifications: Vec::new(),
             skip_finalized_until,
         }
-        .start()
+        .start(processor, Vec::new())
         .await
     }
 }

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -1,3 +1,20 @@
+//! The post-sync processing loop of the stateful actor.
+//!
+//! The loop owns the database set and is the only thing that mutates it.
+//! Verification jobs hold read handles instead, so they are never cancelled: a
+//! job that is mid-read when a finalized block arrives finishes that read, the
+//! apply runs, and the job continues against the state it installs.
+//!
+//! Each finalized block is applied to the databases, its flush deferred to a
+//! pool, and a snapshot of the applied state staged for publication. The loop
+//! publishes the snapshot and acknowledges the block to marshal only once the
+//! flush is durable, so readers and marshal's floor never get ahead of disk.
+//!
+//! Pruning and fresh post-prune captures are maintenance, run only while the
+//! mailbox is idle. A prune waits until the pruned range is durable, and leaves
+//! the served snapshot stale until a post-prune capture publishes (see
+//! [`Publisher`]).
+
 use crate::stateful::{
     Application, Input,
     actor::{
@@ -19,9 +36,9 @@ use commonware_consensus::{
     types::Height,
 };
 use commonware_cryptography::certificate::Scheme;
-use commonware_macros::{select, select_loop};
+use commonware_macros::select;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
-use commonware_utils::{Acknowledgement as _, channel::fallible::OneshotExt, futures::Pool};
+use commonware_utils::{Acknowledgement as _, futures::Pool};
 use futures::{
     FutureExt as _,
     future::{Either, ready},
@@ -37,34 +54,6 @@ enum Step<M, P> {
     Message(M),
     Prune(P),
     Refresh,
-}
-
-fn requeue_verifications<E, A>(
-    mailbox: &(dyn Fn(Message<E, A>) + Send + Sync),
-    requests: Vec<VerificationRequest<E, A>>,
-) where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-{
-    // FIFO puts each retry behind work accepted while the mutation ran and
-    // ahead of later arrivals, without waiting for the mailbox to become idle.
-    for VerificationRequest {
-        span,
-        context,
-        ancestry,
-        verification,
-    } in requests
-    {
-        if verification.is_cancelled() {
-            continue;
-        }
-        mailbox(Message::Verify {
-            span,
-            context,
-            ancestry,
-            verification,
-        });
-    }
 }
 
 pub(super) struct Processing<E, A, S, V>
@@ -86,14 +75,8 @@ where
     /// Marshal mailbox used for lazy block lookup.
     pub(super) marshal: MarshalMailbox<S, V>,
 
-    /// The processing state of the actor.
-    pub(super) processor: Processor<E, A>,
-
     /// Publishes the latest durable capture of snapshots for serving.
     pub(super) snapshot_publisher: Publisher<SnapshotsOf<A::Databases, E>>,
-
-    /// Verification requests deferred until processing starts.
-    pub(super) deferred_verifications: Vec<VerificationRequest<E, A>>,
 
     /// Finalized marshal blocks at or below this height were already reflected
     /// in the selected database anchor and should be acknowledged only.
@@ -102,105 +85,125 @@ where
 
 impl<E, A, S, V> Processing<E, A, S, V>
 where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-    S: Scheme,
-    V: Variant<ApplicationBlock = A::Block>,
+    E: Rng + Spawner + Metrics + Clock + 'static,
+    A: Application<E> + 'static,
+    S: Scheme + 'static,
+    V: Variant<ApplicationBlock = A::Block> + 'static,
     MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
 {
-    pub async fn start(mut self) {
-        let mut pending_prune = None;
-        let mut deferred_message = None;
-        let mut verifications = Verifications::new(self.marshal.clone());
-        for request in std::mem::take(&mut self.deferred_verifications) {
-            verifications.schedule(self.processor.verifier(), request);
-        }
-
+    /// Run the loop until shutdown.
+    ///
+    /// `deferred` holds verification requests that arrived during state sync
+    /// and have not started yet.
+    pub async fn start(
+        mut self,
+        mut processor: Processor<E, A>,
+        deferred: Vec<VerificationRequest<E, A>>,
+    ) {
         // Deferred finalize flushes, each releasing its block's marshal
         // acknowledgement once the flush completes (see `Barrier`).
         let mut syncs = Pool::<(Height, bool)>::default();
-        select_loop! {
-            self.context,
-            on_start => {
-                // Observe every already-completed flush (releasing its marshal
-                // acknowledgement and publishing its capture) before taking the
-                // next unit of work, so acknowledgements keep flowing even while
-                // the mailbox is never idle.
-                while let Some((height, durable)) = syncs.next_completed().now_or_never() {
-                    if !durable {
-                        return;
-                    }
-                    self.snapshot_publisher.complete(height);
+
+        // A prune becomes due at a finalization and runs once the mailbox idles.
+        let mut pending_prune = None;
+
+        // One signal for the actor's whole life. Re-creating it per iteration
+        // would record an extra auditor event on the deterministic runtime each
+        // time.
+        let mut shutdown = self.context.stopped();
+
+        let mut deferred_message = None;
+        let mut verifications = Verifications::new(self.marshal.clone());
+        for request in deferred {
+            verifications.schedule(processor.verifier(), request);
+        }
+
+        loop {
+            // Observe every already-completed flush (releasing its marshal
+            // acknowledgement) before taking the next unit of work.
+            while let Some((height, durable)) = syncs.next_completed().now_or_never() {
+                if !durable {
+                    return;
                 }
+                self.snapshot_publisher.complete(height);
+            }
 
-                // Publish completed verdicts before admitting another message.
-                // A later finalization cannot retroactively invalidate them.
-                verifications.complete_ready();
+            // Publish completed verdicts before admitting another message, so
+            // continuous mailbox traffic cannot starve them under the biased
+            // `select!`.
+            verifications.complete_ready();
 
-                // A message deferred by an active proposal is the FIFO barrier
-                // for subsequent mailbox work, so handle it before later arrivals.
-                let message = match deferred_message.take() {
-                    Some(message) => Ok(message),
-                    None => self.mailbox.try_recv(),
-                };
+            // A message deferred by an active proposal is the FIFO barrier
+            // for subsequent mailbox work, so handle it before later arrivals.
+            let message = match deferred_message.take() {
+                Some(message) => Ok(message),
+                None => self.mailbox.try_recv(),
+            };
 
-                // Pruning and fresh captures are non-critical work, run only when the
-                // mailbox is idle and never raced against it. If a message is ready,
-                // it is always processed immediately.
-                let next = match message {
-                    Ok(message) => Either::Left(ready(Some(Step::Message(message)))),
-                    Err(TryRecvError::Empty) => {
-                        match pending_prune.take() {
-                            // No message, but a prune is queued: run it.
-                            Some(prune) => Either::Left(ready(Some(Step::Prune(prune)))),
-                            // The served snapshot is stale and every flush drained.
-                            None if self.snapshot_publisher.needs_refresh() => {
-                                Either::Left(ready(Some(Step::Refresh)))
-                            }
-                            // No message and nothing to prune: wait on the mailbox, driving flush
-                            // completions while idle.
-                            None => {
-                                let mailbox = &mut self.mailbox;
-                                let syncs = &mut syncs;
-                                let snapshot_publisher = &mut self.snapshot_publisher;
-                                let verifications = &mut verifications;
-                                Either::Right(async move {
-                                    loop {
-                                        select! {
-                                            message = mailbox.recv() => {
-                                                break message.map(Step::Message);
-                                            },
-                                            (height, durable) = syncs.next_completed() => {
-                                                if !durable {
-                                                    return None;
-                                                }
-                                                snapshot_publisher.complete(height);
-                                                if snapshot_publisher.needs_refresh() {
-                                                    break Some(Step::Refresh);
-                                                }
-                                            },
-                                            _ = verifications.next_completed() => {
-                                                continue;
-                                            },
+            // Pruning and fresh captures are non-critical work, run only when the
+            // mailbox is idle. If a message is ready, it is always processed
+            // immediately.
+            let next = match message {
+                // A message is ready: handle it now, regardless of any queued prune.
+                Ok(message) => Either::Left(ready(Some(Step::Message(message)))),
+                Err(TryRecvError::Empty) => match pending_prune.take() {
+                    // No message, but a prune is queued: run it.
+                    Some(prune) => Either::Left(ready(Some(Step::Prune(prune)))),
+                    // The served snapshot is stale and every flush drained.
+                    None if self.snapshot_publisher.needs_refresh() => {
+                        Either::Left(ready(Some(Step::Refresh)))
+                    }
+                    // No message and nothing to prune: wait on the mailbox, driving
+                    // flush completions and verification jobs while idle.
+                    None => {
+                        let mailbox = &mut self.mailbox;
+                        let syncs = &mut syncs;
+                        let snapshot_publisher = &mut self.snapshot_publisher;
+                        let verifications = &mut verifications;
+                        Either::Right(async move {
+                            loop {
+                                select! {
+                                    message = mailbox.recv() => {
+                                        if message.is_none() {
+                                            debug!("mailbox closed, stopping processing");
                                         }
-                                    }
-                                })
+                                        break message.map(Step::Message);
+                                    },
+                                    (height, durable) = syncs.next_completed() => {
+                                        if !durable {
+                                            return None;
+                                        }
+                                        snapshot_publisher.complete(height);
+                                        if snapshot_publisher.needs_refresh() {
+                                            break Some(Step::Refresh);
+                                        }
+                                    },
+                                    _ = verifications.next_completed() => {
+                                        continue;
+                                    },
+                                }
                             }
-                        }
+                        })
                     }
-                    Err(TryRecvError::Disconnected) => {
-                        debug!("mailbox closed, stopping processing");
-                        return;
-                    }
-                };
-            },
-            on_stopped => {
-                debug!("shutdown signal received, stopping processing");
-            },
-            Some(step) = next else {
-                debug!("mailbox closed, stopping processing");
-                break;
-            } => match step {
+                },
+                Err(TryRecvError::Disconnected) => {
+                    debug!("mailbox closed, stopping processing");
+                    return;
+                }
+            };
+
+            let step = select! {
+                _ = &mut shutdown => {
+                    debug!("shutdown signal received, stopping processing");
+                    return;
+                },
+                step = next => step,
+            };
+            let Some(step) = step else {
+                return;
+            };
+
+            match step {
                 Step::Message(Message::Propose {
                     span,
                     context,
@@ -208,25 +211,22 @@ where
                     upstream,
                     response,
                 }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.propose");
+                    let span = info_span!(parent: &span, "stateful.actor.propose");
                     let input = Input {
                         upstream,
                         provider: self.provider.clone(),
                     };
-                    let verifier = self.processor.verifier();
                     let actor_context = self.context.as_present();
-                    let marshal = self.marshal.clone();
-                    let proposal = self
-                        .processor
+                    let proposal = processor
                         .propose(
                             actor_context,
-                            marshal.clone(),
+                            self.marshal.clone(),
                             context,
                             ancestry,
                             input,
                             response,
                         )
-                        .instrument(process);
+                        .instrument(span);
                     futures::pin_mut!(proposal);
                     let mut receive_messages = true;
                     loop {
@@ -240,7 +240,7 @@ where
                                         ancestry,
                                         verification,
                                     }) => verifications.schedule(
-                                        verifier.clone(),
+                                        processor.verifier(),
                                         VerificationRequest {
                                             span,
                                             context,
@@ -249,9 +249,9 @@ where
                                         },
                                     ),
                                     Some(message) => {
-                                        // Only verification may overtake an active proposal. The
-                                        // first other message becomes a FIFO barrier for later
-                                        // mailbox work.
+                                        // Only verification may overtake an active
+                                        // proposal. The first other message becomes a
+                                        // FIFO barrier for later mailbox work.
                                         deferred_message = Some(message);
                                         receive_messages = false;
                                     }
@@ -274,7 +274,7 @@ where
                     verification,
                 }) => {
                     verifications.schedule(
-                        self.processor.verifier(),
+                        processor.verifier(),
                         VerificationRequest {
                             span,
                             context,
@@ -287,84 +287,72 @@ where
                     span,
                     block,
                     acknowledgement,
-                    retry_mailbox,
+                    ..
                 }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.finalized");
+                    let span = info_span!(parent: &span, "stateful.actor.finalized");
                     if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
+                        let notify =
+                            processor.notify_finalized(self.context.as_present(), block.as_ref());
                         async {
-                            verifications
-                                .drive(self.processor.notify_finalized(
-                                    self.context.as_present(),
-                                    block.as_ref(),
-                                ))
-                                .await;
+                            verifications.drive(notify).await;
                             acknowledgement.acknowledge();
                         }
-                        .instrument(process)
+                        .instrument(span)
                         .await;
-                    } else {
-                        let boundary = self.processor.finalization_boundary(block.as_ref());
-                        let (retry, reject) = verifications
-                            .quiesce_where(|progress| boundary.disposition(progress))
-                            .await;
-                        drop(boundary);
-                        async {
-                            let applied = verifications
-                                .drive(self.processor.finalize(&self.context, block.as_ref()))
-                                .await;
-                            let Some(Applied {
-                                snapshots,
-                                barrier,
-                                prune,
-                            }) = applied
-                            else {
-                                // Duplicate report: marshal redelivers a processed
-                                // height only after a restart, where startup aligned
-                                // the databases to durable state.
-                                acknowledgement.acknowledge();
-                                return;
-                            };
-                            debug!(
-                                height = block.height().get(),
-                                "applied finalized database batch"
-                            );
+                        continue;
+                    }
 
-                            // The snapshot publishes and marshal is acknowledged
-                            // only once the batch's flush completes, so neither
-                            // served state nor marshal's processed floor gets
-                            // ahead of what is on disk (the startup rewind
-                            // contract), without blocking the loop on the flush.
-                            // Marshal's ack window bounds the flush backlog. A
-                            // false `Barrier::durable` leaves the block
-                            // unacknowledged, and marshal redelivers it on restart.
-                            let height = block.height();
-                            self.snapshot_publisher.stage(height, snapshots);
-                            syncs.push(async move {
-                                let durable = barrier.durable().await;
-                                if durable {
-                                    acknowledgement.acknowledge();
-                                }
-                                (height, durable)
-                            });
-                            if let Some(prune) = prune {
-                                pending_prune = Some((prune, retry_mailbox.clone()));
-                            }
-                        }
-                        .instrument(process)
+                    // The apply owns mutation. Live verification jobs pause at
+                    // their next batch operation and resume afterward, so they
+                    // keep being polled throughout.
+                    let applied;
+                    (processor, applied) = verifications
+                        .drive(processor.finalize(self.context.as_present(), block.as_ref()))
+                        .instrument(span.clone())
                         .await;
-                        for verification in reject {
-                            verification.respond(false);
+
+                    // Keep the publication bookkeeping under the same span.
+                    let _span = span.entered();
+                    let Some(Applied {
+                        snapshots,
+                        barrier,
+                        prune,
+                    }) = applied
+                    else {
+                        // Duplicate report: marshal redelivers a processed height
+                        // only after a restart, where startup aligned the databases
+                        // to durable state.
+                        acknowledgement.acknowledge();
+                        continue;
+                    };
+                    debug!(
+                        height = block.height().get(),
+                        "applied finalized database batch"
+                    );
+
+                    // The snapshot publishes and marshal is acknowledged only
+                    // once the flush completes, so neither served state nor
+                    // marshal's processed floor gets ahead of what is on disk.
+                    // Marshal's ack window bounds the flush backlog, and
+                    // unacknowledged blocks are redelivered on restart.
+                    let height = block.height();
+                    self.snapshot_publisher.stage(height, snapshots);
+                    syncs.push(async move {
+                        let durable = barrier.durable().await;
+                        if durable {
+                            acknowledgement.acknowledge();
                         }
-                        requeue_verifications(retry_mailbox.as_ref(), retry);
+                        (height, durable)
+                    });
+                    if let Some(prune) = prune {
+                        pending_prune = Some(prune);
                     }
                 }
-                Step::Message(Message::SubscribeDatabases { response }) => {
-                    response.send_lossy(self.processor.databases().clone());
-                }
-                Step::Prune((prune, retry_mailbox)) => {
-                    // The prune target must be durable, but later blocks remain available in
-                    // marshal for replay and do not delay maintenance. Verification may complete
-                    // during this wait. Later mailbox work remains ordered behind the prune.
+                Step::Prune(prune) => {
+                    // The prune target must be durable, but later blocks remain
+                    // available in marshal for replay and do not delay
+                    // maintenance. Later mailbox work stays ordered behind the
+                    // prune.
                     while self.snapshot_publisher.blocks_prune(prune.barrier_height) {
                         select! {
                             (height, durable) = syncs.next_completed() => {
@@ -376,36 +364,28 @@ where
                             _ = verifications.next_completed() => {},
                         }
                     }
-                    let retry = verifications.quiesce().await;
-                    assert!(
-                        self.processor.replays_idle(),
-                        "verification replay remained active after quiescence"
-                    );
-                    prune
-                        .run(self.processor.databases(), &self.marshal)
+
+                    processor = verifications
+                        .drive(processor.prune(prune, &self.marshal))
                         .await;
                     // The published snapshot predates this prune and keeps the pruned
                     // storage alive, as do snapshots staged before it.
                     self.snapshot_publisher.mark_stale();
                     if self.snapshot_publisher.needs_refresh() {
-                        self.processor
-                            .publish_snapshot(&mut self.snapshot_publisher)
+                        processor = verifications
+                            .drive(processor.publish_snapshot(&mut self.snapshot_publisher))
                             .await;
                     }
-                    requeue_verifications(retry_mailbox.as_ref(), retry);
                 }
                 Step::Refresh => {
                     // The served snapshot went stale at the last prune and no
                     // later flush replaced it. Every flush has drained, so the
                     // applied state is durable and can publish directly.
-                    verifications
-                        .drive(
-                            self.processor
-                                .publish_snapshot(&mut self.snapshot_publisher),
-                        )
+                    processor = verifications
+                        .drive(processor.publish_snapshot(&mut self.snapshot_publisher))
                         .await;
                 }
-            },
+            }
         }
     }
 }
@@ -435,8 +415,8 @@ mod tests {
             processor::{Processor, Pruning},
         },
         db::{
-            DatabaseSet, Shared,
-            snapshot::{self, Publisher},
+            HandlesOf, Single, SnapshotsOf,
+            snapshot::{Publisher, Reader},
         },
         tests::{
             fixtures,
@@ -622,7 +602,7 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
-            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+            _handles: HandlesOf<Self::Databases, deterministic::Context>,
         ) {
             let gate = self.finalized_gate.lock().take();
             if let Some(mut gate) = gate {
@@ -651,7 +631,7 @@ mod tests {
         app: GatedApp,
     ) -> (
         Mailbox<deterministic::Context, GatedApp>,
-        snapshot::Reader<u64>,
+        Reader<SnapshotsOf<TestDatabases, deterministic::Context>>,
         Box<dyn std::any::Any>,
         Handle<()>,
     ) {
@@ -675,24 +655,22 @@ mod tests {
             None,
         );
         let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
-        let (publisher, reader) = Publisher::new(context);
+        let publication_context = context.child("publication");
+        let (publisher, reader) = Publisher::new(&publication_context);
         let processing = Processing {
             context: ContextCell::new(context.child("processing")),
             mailbox: receiver,
             provider: (),
             marshal: marshal.mailbox,
-            processor,
             snapshot_publisher: publisher,
-            deferred_verifications: Vec::new(),
             skip_finalized_until: None,
         };
-        let actor = context.child("loop").spawn(move |_| processing.start());
+        let actor = context
+            .child("loop")
+            .spawn(move |_| processing.start(processor, Vec::new()));
         (Mailbox::new(sender), reader, marshal.guards, actor)
     }
 
-    /// Spawn a [`Processing`] loop over a gated [`TestDb`], returning its
-    /// mailbox, flush controls, a guard keeping the (never-started) marshal
-    /// actor's mailbox open, and the processing actor handle.
     async fn spawn_processing(
         context: &deterministic::Context,
         prefix: &str,
@@ -700,7 +678,7 @@ mod tests {
     ) -> (
         Mailbox<deterministic::Context, GatedApp>,
         FlushControl,
-        snapshot::Reader<u64>,
+        Reader<u64>,
         Box<dyn std::any::Any>,
         Handle<()>,
     ) {
@@ -715,7 +693,7 @@ mod tests {
     ) -> (
         Mailbox<deterministic::Context, GatedApp>,
         FlushControl,
-        snapshot::Reader<u64>,
+        Reader<u64>,
         Box<dyn std::any::Any>,
         Handle<()>,
     ) {
@@ -730,9 +708,8 @@ mod tests {
             false,
         )
         .await;
-
         let control = FlushControl::default();
-        let databases = Shared::new("test", TestDb::gated(control.clone()));
+        let databases = Single::from(TestDb::gated(control.clone()));
         let pruning = prune_config
             .map(|config| Pruning::build(config, marshal.mailbox.max_pending_acks(), 0));
         let app = GatedApp {
@@ -748,20 +725,20 @@ mod tests {
             StatefulMetrics::new(context),
             pruning,
         );
-        let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
         let (mut publisher, reader) = Publisher::new(context);
-        processor.publish_snapshot(&mut publisher).await;
+        let processor = processor.publish_snapshot(&mut publisher).await;
+        let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
         let processing = Processing {
             context: ContextCell::new(context.child("processing")),
             mailbox: receiver,
             provider: (),
             marshal: marshal.mailbox,
-            processor,
             snapshot_publisher: publisher,
-            deferred_verifications: Vec::new(),
             skip_finalized_until: None,
         };
-        let actor = context.child("loop").spawn(move |_| processing.start());
+        let actor = context
+            .child("loop")
+            .spawn(move |_| processing.start(processor, Vec::new()));
         (Mailbox::new(sender), control, reader, marshal.guards, actor)
     }
 
@@ -1015,7 +992,7 @@ mod tests {
     #[test]
     fn conflicting_processed_block_is_rejected() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let (mut mailbox, control, _reader, _marshal, actor) =
+            let (mut mailbox, control, _source, _marshal, actor) =
                 spawn_processing(&context, "conflicting-processed", None).await;
             let genesis = TestBlock::new(0, 0);
             let canonical = TestBlock::child(&genesis, 1);
@@ -1045,66 +1022,6 @@ mod tests {
                     .await,
                 "conflicting block at the processed height must be rejected",
             );
-            actor.abort();
-        });
-    }
-
-    #[test]
-    fn pending_proposal_does_not_block_active_verification() {
-        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let (verify_gate, verify_started, verify_release) = application_gate();
-            let (proposal_gate, proposal_started, proposal_release) = application_gate();
-            let app = GatedApp {
-                verify_gates: Arc::new(Mutex::new(VecDeque::from([verify_gate]))),
-                proposal_gate: Arc::new(Mutex::new(Some(proposal_gate))),
-                verify_valid: true,
-                observed_contexts: Arc::default(),
-            };
-            let (mut mailbox, _reader, _marshal, actor) =
-                spawn_gated_application(&context, "propose-verify", app).await;
-
-            let genesis = TestBlock::new(0, 0);
-            let block = TestBlock::child(&genesis, 1);
-            let mut verifier = mailbox.clone();
-            let verify_genesis = genesis.clone();
-            let consensus_context = block.context();
-            let mut verify = Box::pin(verifier.verify(
-                (context.child("verify"), consensus_context),
-                ancestry::from_iter([Arc::new(block), Arc::new(verify_genesis)]),
-            ));
-            let subscriber = mailbox.clone();
-            assert!(poll!(&mut verify).is_pending());
-            verify_started.await.expect("verification should start");
-
-            let proposal_context = TestBlock::child(&genesis, 2).context();
-            let mut proposal = Box::pin(mailbox.propose(
-                (context.child("propose"), proposal_context),
-                ancestry::from_iter([Arc::new(genesis)]),
-                (),
-            ));
-            assert!(poll!(&mut proposal).is_pending());
-            proposal_started.await.expect("proposal should start");
-            let mut databases = Box::pin(subscriber.subscribe_databases());
-            assert!(poll!(&mut databases).is_pending());
-            context.sleep(Duration::from_millis(10)).await;
-            verify_release
-                .send(())
-                .expect("verification should remain active");
-            select! {
-                result = &mut verify => {
-                    assert!(result);
-                },
-                _ = context.sleep(Duration::from_millis(100)) => {
-                    panic!("pending proposal blocked active verification");
-                },
-            }
-            assert!(poll!(&mut databases).is_pending());
-
-            proposal_release
-                .send(())
-                .expect("proposal should remain active");
-            assert!(proposal.await.is_none());
-            drop(databases.await);
             actor.abort();
         });
     }
@@ -1247,17 +1164,12 @@ mod tests {
     }
 
     #[test]
-    fn finalization_keeps_compatible_verification_active() {
+    fn finalization_keeps_compatible_verification_running() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let (parent_gate, parent_started, parent_release) = application_gate();
             let (child_gate, child_started, child_release) = application_gate();
-            let (retry_gate, _retry_started, _retry_release) = application_gate();
             let app = GatedApp {
-                verify_gates: Arc::new(Mutex::new(VecDeque::from([
-                    parent_gate,
-                    child_gate,
-                    retry_gate,
-                ]))),
+                verify_gates: Arc::new(Mutex::new(VecDeque::from([parent_gate, child_gate]))),
                 proposal_gate: Arc::new(Mutex::new(None)),
                 verify_valid: true,
                 observed_contexts: Arc::default(),
@@ -1300,19 +1212,22 @@ mod tests {
             waiter
                 .await
                 .expect("finalized parent should be acknowledged");
+
+            // The apply does not touch the child's attempt. It is still waiting
+            // in the application and answers from that same attempt.
             child_release
                 .send(())
-                .expect("compatible verification should remain active");
+                .expect("the attempt should still be live after the apply");
             assert!(verify_child.await);
             actor.abort();
         });
     }
 
     #[test]
-    fn finalization_invalidates_incompatible_verification() {
+    fn finalization_refuses_incompatible_verification_result() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let (fork_gate, fork_started, fork_release) = application_gate();
-            let (child_gate, child_started, mut child_release) = application_gate();
+            let (child_gate, child_started, child_release) = application_gate();
             let app = GatedApp {
                 verify_gates: Arc::new(Mutex::new(VecDeque::from([fork_gate, child_gate]))),
                 proposal_gate: Arc::new(Mutex::new(None)),
@@ -1353,12 +1268,6 @@ mod tests {
 
             let (acknowledgement, waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(winner), acknowledgement));
-            select! {
-                _ = child_release.closed() => {},
-                _ = context.sleep(Duration::from_millis(100)) => {
-                    panic!("incompatible verification was not cancelled");
-                },
-            }
             let mut waiter = Box::pin(waiter);
             select! {
                 result = &mut waiter => {
@@ -1368,12 +1277,19 @@ mod tests {
                     panic!("winning block was not acknowledged");
                 },
             }
+
+            // The losing child runs to completion. Its parent is gone from the
+            // pending set, so caching its result is refused and the verdict is
+            // false.
+            child_release
+                .send(())
+                .expect("the attempt should still be live after the apply");
             select! {
                 valid = &mut verify_child => {
                     assert!(!valid, "verification on a finalized-away fork must fail");
                 },
                 _ = context.sleep(Duration::from_millis(100)) => {
-                    panic!("incompatible verification retry did not resolve");
+                    panic!("incompatible verification did not resolve");
                 },
             }
             actor.abort();
@@ -1385,7 +1301,7 @@ mod tests {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let (parent_gate, parent_started, parent_release) = application_gate();
             let (child_gate, child_started, child_release) = application_gate();
-            let (grandchild_gate, grandchild_started, mut grandchild_release) = application_gate();
+            let (grandchild_gate, grandchild_started, grandchild_release) = application_gate();
             let app = GatedApp {
                 verify_gates: Arc::new(Mutex::new(VecDeque::from([
                     parent_gate,
@@ -1448,8 +1364,10 @@ mod tests {
 
             let (acknowledgement, waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(winner), acknowledgement));
-            grandchild_release.closed().await;
             waiter.await.expect("winning block should be acknowledged");
+            grandchild_release
+                .send(())
+                .expect("the attempt should still be live after the apply");
 
             let result = select! {
                 valid = &mut verify_grandchild => Some(valid),
@@ -1501,17 +1419,19 @@ mod tests {
             );
             let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
             let mut mailbox = Mailbox::new(sender);
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
+                snapshot_publisher: publisher,
                 skip_finalized_until: Some(finalized.height()),
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, Vec::new()));
 
             let mut verifier = mailbox.clone();
             let mut verify_child = Box::pin(verifier.verify(
@@ -1619,17 +1539,19 @@ mod tests {
             };
 
             // Resume the deferred verification after state sync.
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: vec![request],
+                snapshot_publisher: publisher,
                 skip_finalized_until: Some(Height::new(0)),
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, vec![request]));
 
             started.await.expect("deferred verification should resume");
             release
@@ -1646,7 +1568,7 @@ mod tests {
     }
 
     #[test]
-    fn finalization_reuses_active_replay() {
+    fn finalization_does_not_wait_for_a_shared_replay() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let parent = TestBlock::child(&genesis, 1);
@@ -1686,17 +1608,19 @@ mod tests {
             );
             let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
             let mut mailbox = Mailbox::new(sender);
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
+                snapshot_publisher: publisher,
                 skip_finalized_until: None,
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, Vec::new()));
 
             let consensus_context = first_child.context();
             let mut first_verifier = mailbox.clone();
@@ -1713,33 +1637,45 @@ mod tests {
             assert!(poll!(&mut second).is_pending());
             apply_started.await.expect("replay should start");
             context.sleep(Duration::from_millis(10)).await;
+            assert_eq!(
+                apply_calls.load(Ordering::SeqCst),
+                1,
+                "siblings needing the same parent should share one replay",
+            );
 
             let (acknowledgement, waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(parent), acknowledgement));
             context.sleep(Duration::from_millis(10)).await;
-            apply_release
-                .send(())
-                .expect("finalization should keep the replay active");
-            verify_started
-                .await
-                .expect("compatible verification should start");
+
+            // The apply does not wait for the shared replay. Because that replay
+            // has not cached the winner yet, the finalization reconstructs it.
             finalized_started
                 .await
                 .expect("finalization hook should start");
-            context.sleep(Duration::from_millis(10)).await;
-            assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
-            verify_release
-                .send(())
-                .expect("compatible verification should remain active");
-            assert!(first.await);
             finalized_release
                 .send(())
                 .expect("finalization hook should remain active");
             waiter
                 .await
                 .expect("finalized parent should be acknowledged");
+
+            // The shared replay is still live afterward. Its parent is now the
+            // processed anchor, so both siblings continue from it.
+            apply_release
+                .send(())
+                .expect("the shared replay should still be live after the apply");
+            verify_started
+                .await
+                .expect("verification should reach the application");
+            let _ = verify_release.send(());
+            assert!(first.await);
             assert!(second.await);
-            assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(
+                apply_calls.load(Ordering::SeqCst),
+                2,
+                "the finalization reconstructs the winner once, and the siblings \
+                 need no further replay",
+            );
             assert_eq!(verify_calls.load(Ordering::SeqCst), 2);
             actor.abort();
             drop(marshal.guards);
@@ -1785,17 +1721,19 @@ mod tests {
             );
             let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
             let mut mailbox = Mailbox::new(sender);
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
+                snapshot_publisher: publisher,
                 skip_finalized_until: None,
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, Vec::new()));
 
             let mut child_verifier = mailbox.clone();
             let mut verify_child = Box::pin(child_verifier.verify(
@@ -1817,18 +1755,13 @@ mod tests {
             );
 
             let (acknowledgement, waiter) = Exact::handle();
-            let mut waiter = Box::pin(waiter);
             let _ = mailbox.report(Update::Block(Arc::new(finalized), acknowledgement));
-            assert!(
-                poll!(&mut waiter).is_pending(),
-                "finalization must wait for the existing winner computation",
-            );
+            waiter
+                .await
+                .expect("the cached winner should finalize while its replay runs");
             replay_release
                 .send(())
                 .expect("winner replay should remain active");
-            waiter
-                .await
-                .expect("cached winner should finalize after replay completes");
             let valid = verify_child.await;
             actor.abort();
             drop(marshal.guards);
@@ -1839,7 +1772,7 @@ mod tests {
     }
 
     #[test]
-    fn consecutive_finalizations_preserve_descendant_replay() {
+    fn consecutive_finalizations_retry_descendant_replay() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let first = TestBlock::child(&genesis, 1);
@@ -1879,17 +1812,19 @@ mod tests {
             );
             let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
             let mut mailbox = Mailbox::new(sender);
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
+                snapshot_publisher: publisher,
                 skip_finalized_until: None,
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, Vec::new()));
 
             let mut child_verifier = mailbox.clone();
             let mut verify_child = Box::pin(child_verifier.verify(
@@ -1924,26 +1859,32 @@ mod tests {
                 .expect("first finalized block should be acknowledged");
             verify_started
                 .await
-                .expect("descendant verification should start");
-            assert!(poll!(&mut verify_child).is_pending());
+                .expect("descendant verification should re-run after the first finalization");
 
             let (acknowledgement, second_waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(second), acknowledgement));
             second_waiter
                 .await
                 .expect("second finalized block should be acknowledged");
-            verify_release
-                .send(())
-                .expect("descendant verification should remain active");
+            // Each cancellation drops the attempt holding this gate, so releasing
+            // it is best-effort.
+            let _ = verify_release.send(());
             let valid = verify_child.await;
             actor.abort();
             drop(marshal.guards);
             assert!(
                 valid,
-                "descendant replay must remain valid across consecutive finalizations",
+                "a descendant of both finalized blocks must verify, not be rejected",
             );
-            assert_eq!(apply_calls.load(Ordering::SeqCst), 2);
-            assert_eq!(verify_calls.load(Ordering::SeqCst), 2);
+            assert!(
+                verify_calls.load(Ordering::SeqCst) > 1,
+                "the descendant should have re-run against the applied state",
+            );
+            assert_eq!(
+                apply_calls.load(Ordering::SeqCst),
+                2,
+                "replay should not repeat work already cached as pending state",
+            );
         });
     }
 
@@ -1986,17 +1927,19 @@ mod tests {
             );
             let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
             let mut mailbox = Mailbox::new(sender);
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
+                snapshot_publisher: publisher,
                 skip_finalized_until: None,
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, Vec::new()));
 
             let mut first_verifier = mailbox.clone();
             let mut first_attempt = Box::pin(first_verifier.verify(
@@ -2061,7 +2004,7 @@ mod tests {
     }
 
     #[test]
-    fn pruning_quiesces_replay_before_database_prune() {
+    fn pruning_does_not_disturb_a_live_replay() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let block1 = TestBlock::child(&genesis, 1);
@@ -2079,12 +2022,11 @@ mod tests {
                 true,
             )
             .await;
-            let (first_gate, first_started, mut first_release) = application_gate();
-            let (second_gate, second_started, second_release) = application_gate();
+            let (replay_gate, replay_started, replay_release) = application_gate();
             let apply_calls = Arc::new(AtomicUsize::new(0));
             let verify_calls = Arc::new(AtomicUsize::new(0));
             let app = ReplayGatedApp {
-                gates: Arc::new(Mutex::new(VecDeque::from([first_gate, second_gate]))),
+                gates: Arc::new(Mutex::new(VecDeque::from([replay_gate]))),
                 verify_gate: Arc::new(Mutex::new(None)),
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: parent.height(),
@@ -2092,7 +2034,7 @@ mod tests {
                 verify_calls: verify_calls.clone(),
             };
             let control = FlushControl::default();
-            let databases = Shared::new("prune-replay", TestDb::gated(control.clone()));
+            let databases = Single::from(TestDb::gated(control.clone()));
             let pruning = Pruning::build(
                 PruneConfig {
                     maintenance_interval: NZUsize!(1),
@@ -2111,17 +2053,19 @@ mod tests {
             );
             let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
             let mut mailbox = Mailbox::new(sender);
+            let publication_context = context.child("publication");
+            let (publisher, _reader) = Publisher::new(&publication_context);
             let processing = Processing {
                 context: ContextCell::new(context.child("processing")),
                 mailbox: receiver,
                 provider: (),
                 marshal: marshal.mailbox.clone(),
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
+                snapshot_publisher: publisher,
                 skip_finalized_until: None,
             };
-            let actor = context.child("loop").spawn(move |_| processing.start());
+            let actor = context
+                .child("loop")
+                .spawn(move |_| processing.start(processor, Vec::new()));
 
             let (acknowledgement, waiter1) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(block1), acknowledgement));
@@ -2139,7 +2083,9 @@ mod tests {
             assert!(poll!(&mut verify).is_pending());
 
             select! {
-                result = first_started => result.expect("verification should start before pruning"),
+                result = replay_started => {
+                    result.expect("verification should start before pruning");
+                },
                 _ = context.sleep(Duration::from_millis(100)) => {
                     panic!(
                         "verification did not start: flushes={} pruned={}",
@@ -2154,20 +2100,22 @@ mod tests {
                 .send(Ok(()))
                 .expect("target flush should be pending");
             waiter1.await.expect("target block should be acknowledged");
-            first_release.closed().await;
+
+            // The prune runs while the replay is still parked in the
+            // application, and the replay then finishes on its first attempt.
             while control.pruned.lock().is_empty() {
                 context.sleep(Duration::from_millis(10)).await;
             }
-
-            second_started
-                .await
-                .expect("live replay should restart after pruning");
-            second_release
+            replay_release
                 .send(())
-                .expect("restarted replay should remain active");
+                .expect("the replay should still be live after pruning");
             assert!(verify.await);
             assert_eq!(control.pruned.lock().clone(), vec![1]);
-            assert_eq!(apply_calls.load(Ordering::SeqCst), 4);
+            assert_eq!(
+                apply_calls.load(Ordering::SeqCst),
+                3,
+                "two finalizations reconstruct their own blocks, plus the replay",
+            );
             assert_eq!(verify_calls.load(Ordering::SeqCst), 1);
 
             let release = control.flushes.lock().remove(0);
@@ -2178,154 +2126,13 @@ mod tests {
         });
     }
 
-    #[test]
-    fn prune_retries_wait_for_queued_finalization() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let genesis = TestBlock::new(0, 0);
-            let block1 = TestBlock::child(&genesis, 1);
-            let block2 = TestBlock::child(&block1, 2);
-            let losing = TestBlock::child(&block2, 3);
-            let winner = TestBlock::child(&block2, 4);
-            let mut signing = context.child("signing");
-            let scheme = scheme_mocks::fixture(&mut signing, b"prune-retry", 1).schemes[0].clone();
-            let marshal = fixtures::marshal_fixture(
-                context.child("marshal"),
-                "prune-retry",
-                scheme,
-                None,
-                NZUsize!(1),
-                false,
-            )
-            .await;
-            let (verify_gate, verify_started, mut verify_release) = application_gate();
-            let (proposal_gate, proposal_started, proposal_release) = application_gate();
-            let observed_contexts: Arc<Mutex<Vec<Name>>> = Arc::default();
-            let app = GatedApp {
-                verify_gates: Arc::new(Mutex::new(VecDeque::from([verify_gate]))),
-                proposal_gate: Arc::new(Mutex::new(Some(proposal_gate))),
-                verify_valid: true,
-                observed_contexts: observed_contexts.clone(),
-            };
-            let control = FlushControl::default();
-            let (prune_started, prune_release) = control.gate_prune();
-            let databases = Shared::new("prune-retry", TestDb::gated(control.clone()));
-            let pruning = Pruning::build(
-                PruneConfig {
-                    maintenance_interval: NZUsize!(1),
-                    retained_marshal_blocks: 0,
-                    retained_qmdb_blocks: 0,
-                },
-                1,
-                0,
-            );
-            let processor = Processor::new(
-                app,
-                databases,
-                anchor(0, 0),
-                StatefulMetrics::new(&context),
-                Some(pruning),
-            );
-            let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
-            let mut mailbox = Mailbox::new(sender);
-            let processing = Processing {
-                context: ContextCell::new(context.child("processing")),
-                mailbox: receiver,
-                provider: (),
-                marshal: marshal.mailbox,
-                processor,
-                snapshot_publisher: Publisher::new(&context).0,
-                deferred_verifications: Vec::new(),
-                skip_finalized_until: None,
-            };
-            let actor = context.child("loop").spawn(move |_| processing.start());
-
-            let (acknowledgement, waiter1) = Exact::handle();
-            let _ = mailbox.report(Update::Block(Arc::new(block1), acknowledgement));
-            let (acknowledgement, waiter2) = Exact::handle();
-            let _ = mailbox.report(Update::Block(Arc::new(block2.clone()), acknowledgement));
-            let mut verifier = mailbox.clone();
-            let mut verify = Box::pin(verifier.verify(
-                (context.child("verify"), losing.context()),
-                ancestry::from_iter([Arc::new(losing), Arc::new(block2)]),
-            ));
-            assert!(poll!(&mut verify).is_pending());
-            verify_started
-                .await
-                .expect("verification should start before pruning");
-
-            while control.flushes.lock().len() < 2 {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-            control
-                .flushes
-                .lock()
-                .remove(0)
-                .send(Ok(()))
-                .expect("target flush should remain pending");
-            waiter1.await.expect("target block should be acknowledged");
-            prune_started.await.expect("prune should start");
-            verify_release.closed().await;
-
-            let (acknowledgement, winner_waiter) = Exact::handle();
-            let _ = mailbox.report(Update::Block(Arc::new(winner.clone()), acknowledgement));
-            let proposal_context = TestBlock::child(&winner, 5).context();
-            let mut proposer = mailbox.clone();
-            let mut proposal = Box::pin(proposer.propose(
-                (context.child("propose"), proposal_context),
-                ancestry::from_iter([Arc::new(winner)]),
-                (),
-            ));
-            assert!(poll!(&mut proposal).is_pending());
-            prune_release.send(()).expect("prune should remain active");
-            proposal_started
-                .await
-                .expect("proposal queued behind finalization should start");
-
-            let subscriber = mailbox.clone();
-            let mut databases = Box::pin(subscriber.subscribe_databases());
-            assert!(poll!(&mut databases).is_pending());
-
-            let result = select! {
-                valid = &mut verify => Some(valid),
-                _ = context.sleep(Duration::from_millis(100)) => None,
-            };
-            assert_eq!(
-                result,
-                Some(false),
-                "prune retry must observe the queued finalization",
-            );
-            assert!(poll!(&mut databases).is_pending());
-            assert_eq!(observed_contexts.lock().len(), 1);
-            assert_eq!(control.pruned.lock().as_slice(), [1]);
-
-            proposal_release
-                .send(())
-                .expect("proposal should remain active");
-            assert!(proposal.await.is_none());
-            drop(databases.await);
-
-            while control.flushes.lock().len() < 2 {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-            for release in control.flushes.lock().drain(..) {
-                release
-                    .send(Ok(()))
-                    .expect("finalize flush should remain pending");
-            }
-            waiter2.await.expect("block 2 should be acknowledged");
-            winner_waiter.await.expect("winner should be acknowledged");
-            actor.abort();
-            drop(marshal.guards);
-        });
-    }
-
     /// Pruning waits for the flush that covers its target without waiting for newer state.
     #[test]
     fn prune_waits_only_for_target_flush() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
             // Marshal only receives prune requests here. Its actor never runs.
             let (verify_gate, verify_started, verify_release) = application_gate();
-            let (mut mailbox, control, _reader, _marshal, _actor) = spawn_processing_with_gates(
+            let (mut mailbox, control, source, _marshal, _actor) = spawn_processing_with_gates(
                 &context,
                 "gated-prune",
                 Some(PruneConfig {
@@ -2369,6 +2176,11 @@ mod tests {
                 poll!(&mut waiter1).is_pending() && poll!(&mut waiter2).is_pending(),
                 "acknowledgements must wait for pending flushes",
             );
+            assert_eq!(
+                source.latest(),
+                Some(0),
+                "only the startup capture may serve before a block flush is durable",
+            );
 
             // Block 2 filled the retention window, but pruning must remain blocked behind the
             // target at block 1.
@@ -2394,6 +2206,11 @@ mod tests {
             let release = control.flushes.lock().remove(0);
             let _ = release.send(Ok(()));
             waiter1.await.expect("block 1 acknowledgement");
+            assert_eq!(
+                source.latest(),
+                Some(1),
+                "block 1's capture must serve once durable",
+            );
             while control.pruned.lock().is_empty() {
                 context.sleep(Duration::from_millis(10)).await;
             }
@@ -2407,252 +2224,10 @@ mod tests {
             let release = control.flushes.lock().remove(0);
             let _ = release.send(Ok(()));
             waiter2.await.expect("block 2 acknowledgement");
-        });
-    }
-
-    /// An aborted target flush must stop processing before pruning can discard its recovery state.
-    #[test]
-    fn aborted_target_flush_prevents_prune() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _reader, _marshal, actor) = spawn_processing(
-                &context,
-                "gated-aborted-prune",
-                Some(PruneConfig {
-                    maintenance_interval: NZUsize!(1),
-                    retained_marshal_blocks: 0,
-                    retained_qmdb_blocks: 0,
-                }),
-            )
-            .await;
-
-            let (acknowledgement, waiter1) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(1, 1)),
-                acknowledgement,
-            ));
-            let (acknowledgement, waiter2) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(2, 2)),
-                acknowledgement,
-            ));
-            while control.flushes.lock().len() < 2 {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-
-            drop(control.flushes.lock().remove(0));
-            actor.await.expect("processing actor should stop");
             assert!(
-                waiter1.await.is_err(),
-                "aborted target flush must cancel the first acknowledgement",
+                source.latest().is_some_and(|served| served > 1),
+                "block 2's capture must serve once durable",
             );
-            assert!(
-                waiter2.await.is_err(),
-                "aborted target flush must cancel the second acknowledgement",
-            );
-            assert!(
-                control.pruned.lock().is_empty(),
-                "aborted flush must prevent pruning",
-            );
-        });
-    }
-
-    /// While the loop is idle, a completed flush must release its acknowledgement without
-    /// displacing a simultaneously reported block, while an incomplete flush must cancel its
-    /// acknowledgement when processing stops.
-    #[test]
-    fn idle_acks_follow_flush_outcome() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _reader, _marshal, actor) =
-                spawn_processing(&context, "gated-idle", None).await;
-
-            // Park the loop idle with block 1's flush pending.
-            let (acknowledgement, mut waiter1) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(1, 1)),
-                acknowledgement,
-            ));
-            while control.flushes.lock().is_empty() {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-            assert!(poll!(&mut waiter1).is_pending());
-            context.sleep(Duration::from_millis(50)).await;
-
-            // Release the flush and report block 2 in the same scheduling
-            // window: the completion must fire block 1's acknowledgement
-            // without displacing the new message.
-            let release = control.flushes.lock().remove(0);
-            let _ = release.send(Ok(()));
-            let (acknowledgement, waiter2) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(2, 2)),
-                acknowledgement,
-            ));
-            waiter1.await.expect("block 1 acknowledgement");
-            while control.flushes.lock().is_empty() {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-            context.sleep(Duration::from_millis(50)).await;
-
-            // Dropping block 2's release resolves its flush as shutdown. The
-            // acknowledgement is canceled so marshal stops without advancing
-            // its floor past unflushed state.
-            drop(control.flushes.lock().remove(0));
-            actor.await.expect("processing actor should stop");
-            assert!(
-                waiter2.await.is_err(),
-                "unflushed block acknowledgement must be canceled",
-            );
-        });
-    }
-
-    #[test]
-    fn ready_aborted_flush_stops_processing() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _reader, _marshal, actor) =
-                spawn_processing(&context, "gated-ready-abort", None).await;
-
-            let (acknowledgement, waiter1) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(1, 1)),
-                acknowledgement,
-            ));
-            while control.flushes.lock().is_empty() {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-
-            let (acknowledgement, waiter2) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(2, 2)),
-                acknowledgement,
-            ));
-            drop(control.flushes.lock().remove(0));
-
-            actor.await.expect("processing actor should stop");
-            assert_eq!(control.flushes.lock().len(), 1);
-            assert!(
-                waiter1.await.is_err(),
-                "the active unflushed acknowledgement must be canceled",
-            );
-            assert!(
-                waiter2.await.is_err(),
-                "the queued unflushed acknowledgement must be canceled",
-            );
-        });
-    }
-
-    /// Stopping processing with a flush in flight must cancel marshal's acknowledgement.
-    #[test]
-    fn shutdown_cancels_pending_flush_ack() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _reader, _marshal, actor) =
-                spawn_processing(&context, "gated-shutdown", None).await;
-
-            let (acknowledgement, waiter) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(1, 1)),
-                acknowledgement,
-            ));
-            while control.flushes.lock().is_empty() {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-
-            drop(mailbox);
-            actor.await.expect("processing actor should stop");
-            assert!(
-                waiter.await.is_err(),
-                "shutdown must cancel in-flight acknowledgements",
-            );
-        });
-    }
-
-    /// A flush failure must panic the processing loop with the database identified and leave the
-    /// block unacknowledged.
-    #[test]
-    #[should_panic(expected = "database finalize flush failed (type")]
-    fn flush_failure_panics_processing() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _reader, _marshal, _actor) =
-                spawn_processing(&context, "gated-failure", None).await;
-
-            let (acknowledgement, _waiter) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(1, 1)),
-                acknowledgement,
-            ));
-            while control.flushes.lock().is_empty() {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-            let release = control.flushes.lock().remove(0);
-            let _ = release.send(Err(RuntimeError::WriteFailed));
-
-            // The pooled flush future panics when the loop next polls it.
-            loop {
-                context.sleep(Duration::from_millis(100)).await;
-            }
-        });
-    }
-
-    #[test]
-    fn skip_finalized_block_skips_through_target_height() {
-        let mut skip_until = Some(Height::new(3));
-
-        assert!(skip_finalized_block(&mut skip_until, Height::new(1)));
-        assert_eq!(skip_until, Some(Height::new(3)));
-        assert!(skip_finalized_block(&mut skip_until, Height::new(3)));
-        assert_eq!(skip_until, None);
-        assert!(!skip_finalized_block(&mut skip_until, Height::new(4)));
-    }
-
-    #[test]
-    fn skip_finalized_block_clears_stale_target() {
-        let mut skip_until = Some(Height::new(3));
-
-        assert!(!skip_finalized_block(&mut skip_until, Height::new(4)));
-        assert_eq!(skip_until, None);
-    }
-
-    /// A later flush completing first releases its acknowledgement, but nothing
-    /// serves until every earlier flush lands. The frontier then publishes the
-    /// newest capture, superseding the earlier one.
-    #[test]
-    fn out_of_order_flush_publishes_at_the_frontier() {
-        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, source, _marshal, _actor) =
-                spawn_processing(&context, "gated-out-of-order", None).await;
-
-            let (acknowledgement, mut waiter1) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(1, 1)),
-                acknowledgement,
-            ));
-            let (acknowledgement, waiter2) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(TestBlock::new(2, 2)),
-                acknowledgement,
-            ));
-            while control.flushes.lock().len() < 2 {
-                context.sleep(Duration::from_millis(10)).await;
-            }
-
-            // Block 2's flush lands first: its acknowledgement releases, but
-            // serving stays behind block 1's pending flush.
-            let release = control.flushes.lock().remove(1);
-            let _ = release.send(Ok(()));
-            waiter2.await.expect("block 2 acknowledgement");
-            assert_eq!(
-                source.latest(),
-                Some(0),
-                "nothing may serve past a pending earlier flush",
-            );
-            assert!(poll!(&mut waiter1).is_pending());
-
-            // Block 1 lands: the frontier jumps to block 2's capture.
-            let release = control.flushes.lock().remove(0);
-            let _ = release.send(Ok(()));
-            waiter1.await.expect("block 1 acknowledgement");
-            while source.latest() != Some(2) {
-                context.sleep(Duration::from_millis(10)).await;
-            }
         });
     }
 
@@ -2783,5 +2358,268 @@ mod tests {
                 "block 3's own publish must replace the stale snapshot without a separate capture",
             );
         });
+    }
+
+    /// An aborted target flush must stop processing before pruning can discard its recovery state.
+    #[test]
+    fn aborted_target_flush_prevents_prune() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, actor) = spawn_processing(
+                &context,
+                "gated-aborted-prune",
+                Some(PruneConfig {
+                    maintenance_interval: NZUsize!(1),
+                    retained_marshal_blocks: 0,
+                    retained_qmdb_blocks: 0,
+                }),
+            )
+            .await;
+
+            let (acknowledgement, waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().len() < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            drop(control.flushes.lock().remove(0));
+            actor.await.expect("processing actor should stop");
+            assert!(
+                waiter1.await.is_err(),
+                "aborted target flush must cancel the first acknowledgement",
+            );
+            assert!(
+                waiter2.await.is_err(),
+                "aborted target flush must cancel the second acknowledgement",
+            );
+            assert!(
+                control.pruned.lock().is_empty(),
+                "aborted flush must prevent pruning",
+            );
+            assert!(
+                source.latest().is_none(),
+                "an aborted capture must never serve",
+            );
+        });
+    }
+
+    /// A later flush completing first releases its acknowledgement, but nothing
+    /// serves until every earlier flush lands. The frontier then publishes the
+    /// newest capture, superseding the earlier one.
+    #[test]
+    fn out_of_order_flush_publishes_at_the_frontier() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, _actor) =
+                spawn_processing(&context, "gated-out-of-order", None).await;
+
+            let (acknowledgement, mut waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().len() < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            // Block 2's flush lands first: its acknowledgement releases, but
+            // serving stays behind block 1's pending flush.
+            let release = control.flushes.lock().remove(1);
+            let _ = release.send(Ok(()));
+            waiter2.await.expect("block 2 acknowledgement");
+            assert_eq!(
+                source.latest(),
+                Some(0),
+                "nothing may serve past a pending earlier flush",
+            );
+            assert!(poll!(&mut waiter1).is_pending());
+
+            // Block 1 lands: the frontier jumps to block 2's capture.
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter1.await.expect("block 1 acknowledgement");
+            while source.latest() != Some(2) {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+        });
+    }
+
+    /// While the loop is idle, a completed flush must release its acknowledgement without
+    /// displacing a simultaneously reported block, while an incomplete flush must cancel its
+    /// acknowledgement when processing stops.
+    #[test]
+    fn idle_acks_follow_flush_outcome() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, actor) =
+                spawn_processing(&context, "gated-idle", None).await;
+
+            // Park the loop idle with block 1's flush pending.
+            let (acknowledgement, mut waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert!(poll!(&mut waiter1).is_pending());
+            context.sleep(Duration::from_millis(50)).await;
+
+            // Release the flush and report block 2 in the same scheduling
+            // window: the completion must fire block 1's acknowledgement
+            // without displacing the new message.
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            waiter1.await.expect("block 1 acknowledgement");
+            assert_eq!(
+                source.latest(),
+                Some(1),
+                "the durable capture must serve while the loop idles",
+            );
+            while control.flushes.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            context.sleep(Duration::from_millis(50)).await;
+
+            // Dropping block 2's release resolves its flush as shutdown. The
+            // acknowledgement is canceled so marshal stops without advancing
+            // its floor past unflushed state.
+            drop(control.flushes.lock().remove(0));
+            actor.await.expect("processing actor should stop");
+            assert!(
+                waiter2.await.is_err(),
+                "unflushed block acknowledgement must be canceled",
+            );
+            assert!(
+                source.latest().is_none(),
+                "sources must decline after the loop stops",
+            );
+        });
+    }
+
+    #[test]
+    fn ready_aborted_flush_stops_processing() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, _source, _marshal, actor) =
+                spawn_processing(&context, "gated-ready-abort", None).await;
+
+            let (acknowledgement, waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            drop(control.flushes.lock().remove(0));
+
+            actor.await.expect("processing actor should stop");
+            assert_eq!(control.flushes.lock().len(), 1);
+            assert!(
+                waiter1.await.is_err(),
+                "the active unflushed acknowledgement must be canceled",
+            );
+            assert!(
+                waiter2.await.is_err(),
+                "the queued unflushed acknowledgement must be canceled",
+            );
+        });
+    }
+
+    /// Stopping processing with a flush in flight must cancel marshal's acknowledgement.
+    #[test]
+    fn shutdown_cancels_pending_flush_ack() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, actor) =
+                spawn_processing(&context, "gated-shutdown", None).await;
+
+            let (acknowledgement, waiter) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            drop(mailbox);
+            actor.await.expect("processing actor should stop");
+            assert!(
+                waiter.await.is_err(),
+                "shutdown must cancel in-flight acknowledgements",
+            );
+            assert!(
+                source.latest().is_none(),
+                "a capture whose flush never completed must never serve",
+            );
+        });
+    }
+
+    /// A flush failure must panic the processing loop with the database identified and leave the
+    /// block unacknowledged.
+    #[test]
+    #[should_panic(expected = "database finalize flush failed (type")]
+    fn flush_failure_panics_processing() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, _source, _marshal, _actor) =
+                spawn_processing(&context, "gated-failure", None).await;
+
+            let (acknowledgement, _waiter) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Err(RuntimeError::WriteFailed));
+
+            // The pooled flush future panics when the loop next polls it.
+            loop {
+                context.sleep(Duration::from_millis(100)).await;
+            }
+        });
+    }
+
+    #[test]
+    fn skip_finalized_block_skips_through_target_height() {
+        let mut skip_until = Some(Height::new(3));
+
+        assert!(skip_finalized_block(&mut skip_until, Height::new(1)));
+        assert_eq!(skip_until, Some(Height::new(3)));
+        assert!(skip_finalized_block(&mut skip_until, Height::new(3)));
+        assert_eq!(skip_until, None);
+        assert!(!skip_finalized_block(&mut skip_until, Height::new(4)));
+    }
+
+    #[test]
+    fn skip_finalized_block_clears_stale_target() {
+        let mut skip_until = Some(Height::new(3));
+
+        assert!(!skip_finalized_block(&mut skip_until, Height::new(4)));
+        assert_eq!(skip_until, None);
     }
 }

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -1,3 +1,11 @@
+//! The state-sync phase of the stateful actor.
+//!
+//! Finalized blocks are retained with their acknowledgements while a sync runs,
+//! and each newly finalized block becomes the live sync target once marshal's
+//! ack window fills. When sync completes, retained blocks are classified
+//! against the artifact's anchor, applied durably, and the loop hands off to
+//! [`Processing`].
+
 use crate::stateful::{
     Application,
     actor::{
@@ -79,13 +87,10 @@ where
     /// Verification requests deferred until state sync completes.
     pub(super) deferred_verifications: Vec<VerificationRequest<E, A>>,
 
-    /// Open subscriptions to the synced databases.
-    pub(super) database_subscribers: Vec<oneshot::Sender<A::Databases>>,
-
     /// The cached [`SyncResult`], populated when sync completes.
     pub(super) artifact: Option<SyncResult<E, A>>,
 
-    /// Publishes the latest durable capture of snapshots.
+    /// Publishes the latest durable capture of snapshots for serving.
     pub(super) snapshot_publisher: Publisher<SnapshotsOf<A::Databases, E>>,
 
     /// Signals that the syncer has produced a usable artifact.
@@ -115,8 +120,6 @@ where
             on_start => {
                 self.deferred_verifications
                     .retain(|request| !request.verification.is_cancelled());
-                self.database_subscribers
-                    .retain(|subscriber| !subscriber.is_closed());
             },
             on_stopped => {
                 debug!("processor received shutdown signal");
@@ -185,13 +188,6 @@ where
                         return;
                     }
                 }
-                Message::SubscribeDatabases { response } => {
-                    self.database_subscribers
-                        .retain(|subscriber| !subscriber.is_closed());
-                    if !response.is_closed() {
-                        self.database_subscribers.push(response);
-                    }
-                }
             },
         }
     }
@@ -245,15 +241,33 @@ where
 
     /// Record `block` as the live sync target.
     async fn update_target(mut self, block: &Arc<A::Block>) -> (Self, bool) {
-        let artifact = select! {
+        let outcome = select! {
             _ = self.context.stopped() => return (self, false),
-            artifact = self.syncer.update_targets(
+            outcome = self.syncer.update_targets(
                 Anchor::from(block.as_ref()),
                 A::sync_targets(block.as_ref()),
-            ) => artifact,
+            ) => outcome,
         };
-        if let Some(artifact) = artifact {
-            self.artifact = Some(artifact);
+        match outcome {
+            syncer::UpdateOutcome::Observed => {}
+            syncer::UpdateOutcome::SyncCompleted => {
+                // The syncer sent the artifact on the completion channel. Collect it
+                // here so the pending finalizations are handed off under the newest
+                // recorded target.
+                let artifact = select! {
+                    _ = self.context.stopped() => return (self, false),
+                    artifact = &mut self.sync_completed => match artifact {
+                        Ok(artifact) => artifact,
+                        Err(_) => {
+                            // The consumed receiver must not be polled again. Leave a
+                            // dead one so the loop's completion arm logs and stops.
+                            self.sync_completed = oneshot::channel().1;
+                            return (self, false);
+                        }
+                    },
+                };
+                self.artifact = Some(artifact);
+            }
         }
         (self, true)
     }
@@ -307,27 +321,31 @@ where
 
     /// Transitions to [`Processing`] state once the database set has converged
     /// on the state sync [`Anchor`].
-    async fn transition(
-        mut self,
-        handoffs: impl IntoIterator<Item = FinalizedHandoff<Arc<A::Block>>>,
-    ) {
-        let artifact = self.artifact.take().expect("transition must have artifact");
-        let mut completed_height = artifact.anchor.height;
+    async fn transition(self, handoffs: impl IntoIterator<Item = FinalizedHandoff<Arc<A::Block>>>) {
+        let Self {
+            context,
+            mailbox,
+            application,
+            provider,
+            marshal,
+            sync_metadata,
+            syncer: _,
+            deferred_verifications,
+            artifact,
+            mut snapshot_publisher,
+            sync_completed: _,
+            pending_finalizations: _,
+            pruning,
+            metrics,
+        } = self;
+        let SyncResult { databases, anchor } = artifact.expect("transition must have artifact");
+        let mut completed_height = anchor.height;
 
-        let _ = self.metrics.sync_done.try_set(1);
-        let mut processor = Processor::new(
-            self.application,
-            artifact.databases,
-            artifact.anchor,
-            self.metrics,
-            self.pruning,
-        );
-
+        let _ = metrics.sync_done.try_set(1);
+        let mut processor = Processor::new(application, databases, anchor, metrics, pruning);
         // Publish now so serving does not wait for the first post-sync
         // finalization.
-        processor
-            .publish_snapshot(&mut self.snapshot_publisher)
-            .await;
+        processor = processor.publish_snapshot(&mut snapshot_publisher).await;
 
         let mut pending_prune = None;
 
@@ -336,19 +354,20 @@ where
                 FinalizedHandoff::Covered(block, acknowledgement)
                 | FinalizedHandoff::Reflected(block, acknowledgement) => {
                     processor
-                        .notify_finalized(self.context.as_present(), block.as_ref())
+                        .notify_finalized(context.as_present(), block.as_ref())
                         .await;
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
+                    let applied;
+                    (processor, applied) = processor
+                        .finalize(context.as_present(), block.as_ref())
+                        .await;
                     let Applied {
                         snapshots,
                         barrier,
                         prune,
-                    } = processor
-                        .finalize(self.context.as_present(), block.as_ref())
-                        .await
-                        .expect("sync handoff block cannot be a duplicate");
+                    } = applied.expect("sync handoff block cannot be a duplicate");
 
                     // The processing loop's flush pool does not exist yet, so observe the
                     // deferred flush inline. Keep state-sync metadata in progress until every
@@ -356,8 +375,7 @@ where
                     if !barrier.durable().await {
                         return;
                     }
-                    self.snapshot_publisher
-                        .publish_now(block.height(), snapshots);
+                    snapshot_publisher.publish_now(block.height(), snapshots);
                     acknowledgement.acknowledge();
                     pending_prune = prune.or(pending_prune);
                     completed_height = block.height();
@@ -370,32 +388,24 @@ where
         }
 
         // Every applied handoff is durable, so completion can advance through the last one before
-        // pruning or exposing the databases to other actors.
-        self.sync_metadata = self.sync_metadata.set_complete(completed_height).await;
+        // pruning.
+        let _ = sync_metadata.set_complete(completed_height).await;
         if let Some(prune) = pending_prune {
-            prune.run(processor.databases(), &self.marshal).await;
+            processor = processor.prune(prune, &marshal).await;
             // Republish so serving stops pinning the pruned state. Every handoff
             // barrier was awaited above, so the fresh capture is already durable.
-            processor
-                .publish_snapshot(&mut self.snapshot_publisher)
-                .await;
-        }
-
-        for subscriber in self.database_subscribers.drain(..) {
-            subscriber.send_lossy(processor.databases().clone());
+            processor = processor.publish_snapshot(&mut snapshot_publisher).await;
         }
 
         Processing {
-            context: self.context,
-            mailbox: self.mailbox,
-            provider: self.provider,
-            marshal: self.marshal,
-            processor,
-            snapshot_publisher: self.snapshot_publisher,
-            deferred_verifications: self.deferred_verifications,
+            context,
+            mailbox,
+            provider,
+            marshal,
+            snapshot_publisher,
             skip_finalized_until: Some(completed_height),
         }
-        .start()
+        .start(processor, deferred_verifications)
         .await
     }
 }
@@ -412,7 +422,10 @@ mod tests {
             processor::Pruning,
             syncer::{self, StateSyncMetadata, SyncResult},
         },
-        db::{Anchor, Shared, snapshot::Publisher},
+        db::{
+            Anchor, Single,
+            snapshot::{Publisher, Reader},
+        },
         tests::{
             fixtures::{self, MarshalFixture},
             mocks::{
@@ -451,6 +464,7 @@ mod tests {
         E: rand_core::Rng + commonware_runtime::Spawner + commonware_storage::Context,
     {
         syncing: Syncing<E, TestApp, TestScheme, TestVariant>,
+        reader: Reader<u64>,
     }
 
     impl TestHarness<deterministic::Context> {
@@ -499,6 +513,7 @@ mod tests {
             }
 
             let (acknowledgement, mut newest_waiter) = Exact::handle();
+            let reader = self.reader.clone();
             let process = context.child("full_window").spawn(move |_| {
                 self.syncing
                     .process_finalized(Arc::new(TestBlock::new(10, 12)), acknowledgement)
@@ -512,7 +527,7 @@ mod tests {
                 assert!(poll!(waiter).is_pending());
             }
             assert!(poll!(&mut newest_waiter).is_pending());
-            assert!(response.send(None).is_ok());
+            assert!(response.send(syncer::UpdateOutcome::Observed).is_ok());
             for waiter in &mut waiters {
                 assert!(poll!(waiter).is_pending());
             }
@@ -529,7 +544,7 @@ mod tests {
             }
             assert!(newest_waiter.await.is_ok());
             assert!(syncing.pending_finalizations.is_empty());
-            Self { syncing }
+            Self { syncing, reader }
         }
     }
 
@@ -552,6 +567,7 @@ mod tests {
             let (syncer_sender, syncer_receiver) =
                 actor_mailbox::new(syncing_context.child("syncer_mailbox"), NZUsize!(1));
             let (sync_complete, sync_completed) = oneshot::channel();
+            let (snapshot_publisher, snapshot_reader) = Publisher::new(&syncing_context);
 
             let harness = Self {
                 syncing: Syncing {
@@ -563,14 +579,14 @@ mod tests {
                     sync_metadata: StateSyncMetadata::init(&syncing_context, "syncing-test").await,
                     syncer: syncer::Mailbox::new(syncer_sender),
                     deferred_verifications: Vec::new(),
-                    database_subscribers: Vec::new(),
                     artifact: None,
-                    snapshot_publisher: Publisher::new(&syncing_context).0,
+                    snapshot_publisher,
                     sync_completed,
                     pending_finalizations: VecDeque::new(),
                     pruning: None,
                     metrics: StatefulMetrics::new(&context),
                 },
+                reader: snapshot_reader,
             };
             (
                 harness,
@@ -606,6 +622,7 @@ mod tests {
             let (syncer_sender, _syncer_receiver) =
                 actor_mailbox::new(context.child("syncer_mailbox"), NZUsize!(1));
             let (_sync_complete, sync_completed) = oneshot::channel();
+            let (snapshot_publisher, snapshot_reader) = Publisher::new(&syncing_context);
 
             Self {
                 syncing: Syncing {
@@ -617,17 +634,17 @@ mod tests {
                     sync_metadata: StateSyncMetadata::init(&syncing_context, "syncing-test").await,
                     syncer: syncer::Mailbox::new(syncer_sender),
                     deferred_verifications: Vec::new(),
-                    database_subscribers: Vec::new(),
                     artifact: Some(SyncResult {
                         databases: test_databases(),
                         anchor,
                     }),
-                    snapshot_publisher: Publisher::new(&syncing_context).0,
+                    snapshot_publisher,
                     sync_completed,
                     pending_finalizations: VecDeque::new(),
                     pruning: None,
                     metrics: StatefulMetrics::new(&context),
                 },
+                reader: snapshot_reader,
             }
         }
     }
@@ -731,7 +748,7 @@ mod tests {
                 .artifact
                 .as_mut()
                 .expect("harness must contain a sync artifact")
-                .databases = Shared::new("test", TestDb::gated(control.clone()));
+                .databases = Single::from(TestDb::gated(control.clone()));
 
             // Completion metadata must not be written until the handoff batch is durable.
             pending.arm();
@@ -739,6 +756,7 @@ mod tests {
             let (reflected_acknowledgement, mut reflected_waiter) = Exact::handle();
             let (first_acknowledgement, mut first_waiter) = Exact::handle();
             let (second_acknowledgement, mut second_waiter) = Exact::handle();
+            let reader = harness.reader.clone();
             let transition = context.child("transition").spawn(move |_| {
                 harness.syncing.transition([
                     FinalizedHandoff::Reflected(
@@ -764,6 +782,11 @@ mod tests {
                 0,
                 "completion metadata must not be written before the handoff is durable",
             );
+            assert_eq!(
+                reader.latest(),
+                Some(0),
+                "the synced state must serve as the first capture before any handoff flush",
+            );
             let first_flush = control.flushes.lock().remove(0);
             first_flush
                 .send(Ok(()))
@@ -773,6 +796,11 @@ mod tests {
             }
             assert!(poll!(&mut first_waiter).is_ready());
             assert!(poll!(&mut second_waiter).is_pending());
+            assert_eq!(
+                reader.latest(),
+                Some(1),
+                "each handoff capture must serve once its flush is durable",
+            );
             let second_flush = control.flushes.lock().remove(0);
             second_flush
                 .send(Ok(()))
@@ -803,10 +831,9 @@ mod tests {
     fn aborted_handoff_flush_cancels_ack_and_keeps_sync_incomplete() {
         deterministic::Runner::default().start(|context| async move {
             let mut harness = TestHarness::new(context.child("harness"), anchor(7, 9)).await;
-            let databases = Shared::new(
-                "test",
-                TestDb::with_finalize(Handle::ready(Err(RuntimeError::Aborted))),
-            );
+            let databases = Single::from(TestDb::with_finalize(Handle::ready(Err(
+                RuntimeError::Aborted,
+            ))));
             harness
                 .syncing
                 .artifact
@@ -826,6 +853,11 @@ mod tests {
             assert!(
                 waiter.await.is_err(),
                 "an aborted handoff must cancel marshal's acknowledgement",
+            );
+            assert!(
+                harness.reader.latest().is_none(),
+                "the aborted capture must never serve, and the reader must decline \
+                 once the writer is gone",
             );
             let reopened =
                 StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, "syncing-test")
@@ -853,7 +885,7 @@ mod tests {
                 true,
             )
             .await;
-            let (harness, _mailbox, mut syncer_receiver, _sync_complete) =
+            let (harness, _mailbox, mut syncer_receiver, sync_complete) =
                 TestHarness::new_syncing(context.child("harness"), marshal).await;
 
             let (acknowledgement, mut waiter) = Exact::handle();
@@ -869,12 +901,16 @@ mod tests {
             };
             assert!(poll!(&mut waiter).is_pending());
             assert!(
-                response
-                    .send(Some(SyncResult {
+                sync_complete
+                    .send(SyncResult {
                         databases: test_databases(),
                         anchor: anchor(7, 9),
-                    }))
+                    })
                     .is_ok(),
+                "completion receiver must be alive",
+            );
+            assert!(
+                response.send(syncer::UpdateOutcome::SyncCompleted).is_ok(),
                 "target update must still await its response",
             );
             drop(update);

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -2,7 +2,7 @@ use crate::stateful::{
     Application,
     actor::{
         core::mailbox::Verification,
-        processor::{Disposition, PendingDigest, VerificationProgress, Verifier},
+        processor::{VerificationResult, Verifier},
     },
 };
 use commonware_consensus::marshal::{
@@ -12,13 +12,13 @@ use commonware_consensus::marshal::{
 use commonware_cryptography::certificate::Scheme;
 use commonware_macros::select;
 use commonware_runtime::{Clock, Metrics, Spawner};
-use commonware_utils::{channel::oneshot, futures::Pool};
+use commonware_utils::futures::Pool;
 use futures::FutureExt as _;
 use rand_core::Rng;
-use std::{collections::BTreeMap, future::Future};
+use std::future::Future;
 use tracing::{Instrument as _, Span, info_span};
 
-/// A verification request that can be deferred or retried.
+/// A verification request handed to a job.
 pub(super) struct Request<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -30,122 +30,71 @@ where
     pub(super) verification: Verification,
 }
 
-enum JobResult<E, A>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-{
-    Finished {
-        id: u64,
-        request: Request<E, A>,
-        valid: Option<bool>,
-    },
-    Invalidated {
-        id: u64,
-        request: Request<E, A>,
-    },
-}
-
-impl<E, A> JobResult<E, A>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-{
-    const fn id(&self) -> u64 {
-        match self {
-            Self::Finished { id, .. } | Self::Invalidated { id, .. } => *id,
-        }
-    }
-}
-
-struct JobControl<D: Copy> {
-    invalidation: Option<oneshot::Sender<()>>,
-    progress: VerificationProgress<D>,
-}
-
-/// Owns independently-polled verification requests and their cancellation handles.
-pub(super) struct Handler<E, A, S, V>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-    S: Scheme,
-    V: Variant<ApplicationBlock = A::Block>,
-{
+/// Owns independently-polled verification jobs.
+///
+/// A job runs to its own conclusion. The only thing that ends one early is its
+/// caller leaving.
+pub(super) struct Handler<S: Scheme, V: Variant> {
     marshal: MarshalMailbox<S, V>,
-    jobs: Pool<JobResult<E, A>>,
-    controls: BTreeMap<u64, JobControl<PendingDigest<A, E>>>,
-    next_id: u64,
+    jobs: Pool<(Verification, VerificationResult)>,
 }
 
-impl<E, A, S, V> Handler<E, A, S, V>
+impl<S, V> Handler<S, V>
 where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-    S: Scheme,
-    V: Variant<ApplicationBlock = A::Block>,
-    MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
+    S: Scheme + 'static,
+    V: Variant + 'static,
 {
     pub(super) fn new(marshal: MarshalMailbox<S, V>) -> Self {
         Self {
             marshal,
             jobs: Pool::default(),
-            controls: BTreeMap::new(),
-            next_id: 0,
         }
     }
 
-    pub(super) fn schedule(&mut self, mut verifier: Verifier<E, A>, mut request: Request<E, A>) {
-        let id = self.next_id;
-        self.next_id = self
-            .next_id
-            .checked_add(1)
-            .expect("verification request ID overflowed");
-        let (invalidate, invalidated) = oneshot::channel();
-        let progress = VerificationProgress::default();
-        assert!(
-            self.controls
-                .insert(
-                    id,
-                    JobControl {
-                        invalidation: Some(invalidate),
-                        progress: progress.clone(),
-                    },
-                )
-                .is_none()
-        );
-
+    /// Starts verifying a request as a job the actor loop polls alongside its
+    /// own work.
+    pub(super) fn schedule<E, A>(
+        &mut self,
+        mut verifier: Verifier<E, A>,
+        mut request: Request<E, A>,
+    ) where
+        E: Rng + Spawner + Metrics + Clock + 'static,
+        A: Application<E> + 'static,
+        V: Variant<ApplicationBlock = A::Block>,
+        MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
+    {
         let marshal = self.marshal.clone();
         let process = info_span!(parent: &request.span, "stateful.actor.verify");
         self.jobs.push(
             async move {
-                let ancestry = request.ancestry.clone();
-                select! {
-                    _ = invalidated => JobResult::Invalidated { id, request },
-                    valid = verifier.run(
+                let outcome = verifier
+                    .run(
                         &request.context.0,
                         marshal,
-                        request.context.1.clone(),
-                        ancestry,
-                        &progress,
+                        request.context.1,
+                        request.ancestry,
                         &mut request.verification,
-                    ) => JobResult::Finished { id, request, valid },
-                }
+                    )
+                    .await;
+                (request.verification, outcome)
             }
             .instrument(process),
         );
     }
 
+    /// Answers every job that has already finished, without waiting.
     pub(super) fn complete_ready(&mut self) {
         while let Some(result) = self.jobs.next_completed().now_or_never() {
-            self.handle(result);
+            Self::respond(result);
         }
     }
 
     pub(super) async fn next_completed(&mut self) {
         let result = self.jobs.next_completed().await;
-        self.handle(result);
+        Self::respond(result);
     }
 
+    /// Runs `operation` while still answering verification jobs.
     pub(super) async fn drive<T>(&mut self, operation: impl Future<Output = T>) -> T {
         futures::pin_mut!(operation);
         loop {
@@ -156,75 +105,10 @@ where
         }
     }
 
-    /// Cancels every active attempt and waits for verification work to stop.
-    ///
-    /// Pruning uses this full barrier because it can remove history needed by
-    /// every branch. Live requests are returned for rescheduling afterward.
-    pub(super) async fn quiesce(&mut self) -> Vec<Request<E, A>> {
-        let (retry, reject) = self.quiesce_where(|_| Disposition::Retry).await;
-        assert!(reject.is_empty());
-        retry
-    }
-
-    pub(super) async fn quiesce_where(
-        &mut self,
-        disposition: impl Fn(&VerificationProgress<PendingDigest<A, E>>) -> Disposition,
-    ) -> (Vec<Request<E, A>>, Vec<Verification>) {
-        let mut pending = BTreeMap::new();
-        for (&id, control) in &mut self.controls {
-            let disposition = disposition(&control.progress);
-            if disposition == Disposition::Retain {
-                continue;
-            }
-            assert!(control.invalidation.take().is_some());
-            assert!(pending.insert(id, disposition).is_none());
-        }
-
-        let mut retry = Vec::with_capacity(pending.len());
-        let mut reject = Vec::with_capacity(pending.len());
-        while !pending.is_empty() {
-            let result = self.jobs.next_completed().await;
-            let id = result.id();
-            let Some(disposition) = pending.remove(&id) else {
-                self.handle(result);
-                continue;
-            };
-            let control = self
-                .controls
-                .remove(&id)
-                .expect("completed verification must have an invalidation handle");
-            assert!(control.invalidation.is_none());
-            let request = match result {
-                JobResult::Finished { request, .. } | JobResult::Invalidated { request, .. } => {
-                    request
-                }
-            };
-            match disposition {
-                Disposition::Retain => {
-                    unreachable!("retained verification cannot be invalidated")
-                }
-                Disposition::Retry => {
-                    if !request.verification.is_cancelled() {
-                        retry.push(request);
-                    }
-                }
-                Disposition::Reject => reject.push(request.verification),
-            }
-        }
-        (retry, reject)
-    }
-
-    fn handle(&mut self, result: JobResult<E, A>) {
-        let control = self
-            .controls
-            .remove(&result.id())
-            .expect("completed verification must have an invalidation handle");
-        assert!(control.invalidation.is_some());
-        let JobResult::Finished { request, valid, .. } = result else {
-            panic!("verification cannot finish through the actor loop after invalidation");
-        };
-        if let Some(valid) = valid {
-            request.verification.respond(valid);
+    fn respond((verification, outcome): (Verification, VerificationResult)) {
+        match outcome {
+            VerificationResult::Decided(valid) => verification.respond(valid),
+            VerificationResult::Cancelled => {}
         }
     }
 }

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1,8 +1,7 @@
 //! Speculative execution engine for the [`Stateful`](super::Stateful) actor.
 //!
 //! The [`Processor`] owns the in-memory pending-tip DAG and the applied
-//! database set. It is the workhorse behind the actor's `Processing` mode,
-//! handling three operations:
+//! database set, and does the work behind the actor's `Processing` mode:
 //!
 //! - Propose/Verify: fork unmerkleized batches from a parent's pending
 //!   state (or from applied state), delegate to the [`Application`], and
@@ -14,18 +13,21 @@
 //!   inserting each intermediate result into the pending map.
 //!
 //! - Finalization: apply the winning fork's merkleized batches to the
-//!   databases and start flushing them (durability is reported via
-//!   [`Barrier`]), retaining only pending descendants of the finalized
+//!   databases, start flushing them (durability is reported via [`Barrier`]),
+//!   capture a snapshot of the database set for publication (returned in
+//!   [`Applied`]), then retain only pending descendants of the finalized
 //!   winner.
 //!
-//! Verification jobs are polled independently and scoped to their callers.
-//! Verification-owned lazy recovery shares [`Application::apply`] by block
-//! digest. Proposal recovery remains actor-owned.
-
+//! - Maintenance: [`Processor::prune`] runs due prunes and
+//!   [`Processor::publish_snapshot`] publishes a fresh capture afterwards.
+//!
 use crate::stateful::{
     Application, Input, Proposed, PruneConfig,
     actor::{core::Verification, metrics::Metrics as StatefulMetrics},
-    db::{Anchor, Barrier, DatabaseSet, SnapshotsOf, snapshot::Publisher},
+    db::{
+        Anchor, Barrier, DatabaseSet, HandlesOf, MerkleizedOf, SnapshotsOf, SyncTargetsOf,
+        UnmerkleizedOf, live::Closed, snapshot::Publisher,
+    },
 };
 use commonware_consensus::{
     Block, CertifiableBlock, Heightable, Roundable,
@@ -51,19 +53,17 @@ use rand_core::Rng;
 use std::{
     collections::{BTreeMap, HashSet, VecDeque},
     future::Future,
-    hash::Hash,
     sync::Arc,
 };
-use tracing::{debug, warn};
+use tracing::{Instrument as _, debug, info_span, warn};
 
 mod verifier;
 pub(super) use verifier::Verifier;
 
 pub(super) type PendingDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
-type PendingBatches<A, E> = <<A as Application<E>>::Databases as DatabaseSet<E>>::Merkleized;
+type PendingBatches<A, E> = MerkleizedOf<<A as Application<E>>::Databases, E>;
 type PendingMap<A, E> = BTreeMap<PendingDigest<A, E>, PendingEntry<A, E>>;
-pub(super) type PendingSyncTargets<A, E> =
-    <<A as Application<E>>::Databases as DatabaseSet<E>>::SyncTargets;
+pub(super) type PendingSyncTargets<A, E> = SyncTargetsOf<<A as Application<E>>::Databases, E>;
 type DeferredPrune<T> = Option<Prune<T>>;
 type ReplayResult = Result<(), PrepareBatchesError>;
 type ReplayWaiterSlots = Vec<Option<oneshot::Sender<ReplayResult>>>;
@@ -79,111 +79,12 @@ struct ReplayFlight {
     vacant_slots: Vec<usize>,
 }
 
-/// Last observed phase used to classify live verification across finalization.
-#[derive(Clone, Copy)]
-enum VerificationPhase<D> {
-    Acquiring,
-    Replaying { digest: D, parent: D, round: Round },
-    Verifying { digest: D, parent: D, round: Round },
-}
-
-/// How tracked verification work crosses an incoming finalization.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum Disposition {
-    /// Continue polling work proven to descend from the finalized block.
-    Retain,
-    /// Re-evaluate work whose branch is unknown or whose active phase cannot cross finalization.
-    Retry,
-    /// Return false for work already proven to use an incompatible parent.
-    Reject,
-}
-
-/// Progress needed to decide whether an active verification remains valid
-/// across an incoming finalization.
-#[derive(Clone)]
-pub(super) struct VerificationProgress<D: Copy>(Arc<Mutex<VerificationPhase<D>>>);
-
-impl<D: Copy> Default for VerificationProgress<D> {
-    fn default() -> Self {
-        Self(Arc::new(Mutex::new(VerificationPhase::Acquiring)))
-    }
-}
-
-impl<D: Copy> VerificationProgress<D> {
-    fn replaying(&self, digest: D, parent: D, round: Round) {
-        *self.0.lock() = VerificationPhase::Replaying {
-            digest,
-            parent,
-            round,
-        };
-    }
-
-    fn verifying(&self, digest: D, parent: D, round: Round) {
-        *self.0.lock() = VerificationPhase::Verifying {
-            digest,
-            parent,
-            round,
-        };
-    }
-
-    fn phase(&self) -> VerificationPhase<D> {
-        *self.0.lock()
-    }
-}
-
-/// Pending parents whose branch-scoped batches remain valid after one
-/// finalized block is applied.
-///
-/// Marshal delivers finalized blocks in height order. Canonical older blocks
-/// are therefore already covered by the processed anchor and resolve while
-/// their verification is still acquiring. The exact processed phase is the
-/// only older replay or verification phase that can survive from the preceding
-/// finalization.
-pub(super) struct FinalizationBoundary<D> {
-    digest: D,
-    round: Round,
-    processed_digest: D,
-    processed_round: Round,
-    compatible: HashSet<D>,
-}
-
-impl<D: Copy + Eq + Hash> FinalizationBoundary<D> {
-    pub(super) fn disposition(&self, progress: &VerificationProgress<D>) -> Disposition {
-        match progress.phase() {
-            VerificationPhase::Acquiring => Disposition::Retry,
-            VerificationPhase::Replaying {
-                digest,
-                parent,
-                round,
-            } => {
-                if digest == self.processed_digest && round == self.processed_round {
-                    return Disposition::Retry;
-                }
-                match digest == self.digest {
-                    true => Disposition::Retain,
-                    false if round > self.round && self.compatible.contains(&parent) => {
-                        Disposition::Retain
-                    }
-                    false => Disposition::Reject,
-                }
-            }
-            VerificationPhase::Verifying {
-                digest,
-                parent,
-                round,
-            } => {
-                if digest == self.digest
-                    || (digest == self.processed_digest && round == self.processed_round)
-                {
-                    Disposition::Retry
-                } else if round > self.round && self.compatible.contains(&parent) {
-                    Disposition::Retain
-                } else {
-                    Disposition::Reject
-                }
-            }
-        }
-    }
+/// What one verification attempt concluded.
+pub(in crate::stateful::actor) enum VerificationResult {
+    /// A verdict to return to the caller.
+    Decided(bool),
+    /// The caller left, so there is nothing left to answer.
+    Cancelled,
 }
 
 /// Cached speculative state for a block digest.
@@ -198,10 +99,6 @@ where
 }
 
 /// Speculative state shared by independently-polled verification jobs.
-///
-/// During finalization, the winning batch remains available as a branch parent
-/// while a clone is applied. `finalizing_compatible` admits late state only
-/// when its recorded parent already belongs to that branch.
 struct ExecutionState<A, E>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -211,12 +108,6 @@ where
     pending: PendingMap<A, E>,
     /// Latest canonical anchor whose finalization hook has completed.
     last_processed: Anchor<PendingDigest<A, E>>,
-    /// Winner currently being applied, if finalization is active.
-    finalizing: Option<Anchor<PendingDigest<A, E>>>,
-    /// Winner batch retained while a clone is applied to the databases.
-    finalizing_batch: Option<PendingBatches<A, E>>,
-    /// Winner and descendants allowed in pending state during finalization.
-    finalizing_compatible: HashSet<PendingDigest<A, E>>,
 }
 
 /// Returns the winner and pending descendants whose state survives finalization.
@@ -258,13 +149,16 @@ where
     compatible
 }
 
-/// Shared execution inputs and actor-owned speculative state.
+/// Read capability and speculative state, shared by every verification job.
+///
+/// Deliberately carries no authority to mutate the database set. Jobs holding
+/// one are therefore `'static` and can outlive any number of applies.
 struct Execution<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
 {
-    databases: A::Databases,
+    handles: HandlesOf<A::Databases, E>,
     state: Arc<Mutex<ExecutionState<A, E>>>,
     metrics: StatefulMetrics,
 }
@@ -276,7 +170,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            databases: self.databases.clone(),
+            handles: self.handles.clone(),
             state: self.state.clone(),
             metrics: self.metrics.clone(),
         }
@@ -291,12 +185,6 @@ struct ReplayFlights<D: Copy + Ord> {
     entries: ReplayRegistry<D>,
 }
 
-#[derive(Clone, Copy)]
-struct ReplayTracking<'a, D: Copy + Ord> {
-    flights: &'a ReplayFlights<D>,
-    progress: &'a VerificationProgress<D>,
-}
-
 impl<D: Copy + Ord> Default for ReplayFlights<D> {
     fn default() -> Self {
         Self {
@@ -306,10 +194,6 @@ impl<D: Copy + Ord> Default for ReplayFlights<D> {
 }
 
 impl<D: Copy + Ord> ReplayFlights<D> {
-    fn is_empty(&self) -> bool {
-        self.entries.lock().is_empty()
-    }
-
     fn waiter(&self, digest: D, flight: &mut ReplayFlight) -> ReplayWaiter<D> {
         let (sender, completion) = oneshot::channel();
         let waiters = &mut flight.waiters;
@@ -362,7 +246,7 @@ impl<D: Copy + Ord> ReplayFlights<D> {
     }
 }
 
-/// Outcome of requesting shared replay work for one block digest.
+/// Result of requesting shared replay work for one block digest.
 enum ReplayClaim<D: Copy + Ord> {
     /// State for the digest is already available.
     Ready,
@@ -370,13 +254,6 @@ enum ReplayClaim<D: Copy + Ord> {
     Owner(ReplayOwner<D>),
     /// Another caller owns the replay flight.
     Wait(ReplayWaiter<D>),
-}
-
-/// Claim on the finalizing winner's batch construction.
-enum FinalizationClaim<D: Copy + Ord> {
-    Cached,
-    Wait(ReplayWaiter<D>),
-    Reconstruct(ReplayOwner<D>),
 }
 
 /// Registration that removes its own waiter slot when dropped.
@@ -458,6 +335,14 @@ enum PrepareBatchesError {
     Incomplete,
     /// The attempt was cancelled while waiting.
     Cancelled,
+    /// The databases' writer closed because their owner is shutting down.
+    Closed,
+}
+
+impl From<Closed> for PrepareBatchesError {
+    fn from(_: Closed) -> Self {
+        Self::Closed
+    }
 }
 
 /// Provides a cancellation signal for speculative actor work.
@@ -495,23 +380,6 @@ pub(super) struct Prune<T> {
     marshal_height: Height,
     pub(super) barrier_height: Height,
     qmdb_target: T,
-}
-
-impl<T> Prune<T> {
-    /// Run database and marshal pruning.
-    ///
-    /// Every finalize barrier through `barrier_height` is durable before this runs. The marshal
-    /// prune that follows retains every later block a restart could replay.
-    pub(super) async fn run<E, DBs, S, V>(self, databases: &DBs, marshal: &MarshalMailbox<S, V>)
-    where
-        E: Rng + Spawner + Metrics + Clock,
-        DBs: DatabaseSet<E, SyncTargets = T>,
-        S: Scheme,
-        V: MarshalVariant,
-    {
-        databases.prune(&self.qmdb_target).await;
-        marshal.prune(self.marshal_height);
-    }
 }
 
 /// Tracks the configured prune cadence and finalized sync targets needed to
@@ -614,6 +482,7 @@ where
     A: Application<E>,
 {
     app: A,
+    databases: A::Databases,
     execution: Execution<E, A>,
     replays: ReplayFlights<PendingDigest<A, E>>,
     pruning: Option<Pruning<PendingSyncTargets<A, E>>>,
@@ -624,8 +493,8 @@ where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
 {
-    /// Create a new processor with the given application, databases, and
-    /// the last finalized block's anchor.
+    /// Create a new processor with the given application, databases, and the
+    /// last finalized block's anchor.
     pub(super) fn new(
         app: A,
         databases: A::Databases,
@@ -636,71 +505,70 @@ where
         Self {
             app,
             execution: Execution {
-                databases,
+                handles: databases.handles(),
                 state: Arc::new(Mutex::new(ExecutionState {
                     pending: BTreeMap::new(),
                     last_processed,
-                    finalizing: None,
-                    finalizing_batch: None,
-                    finalizing_compatible: HashSet::new(),
                 })),
                 metrics,
             },
+            databases,
             replays: ReplayFlights::default(),
             pruning,
         }
     }
 
-    /// Creates a verifier for an independently-polled request.
-    pub(super) fn verifier(&self) -> Verifier<E, A> {
-        Verifier {
-            app: self.app.clone(),
-            execution: self.execution.clone(),
-            replays: self.replays.clone(),
-        }
+    /// The height of the last finalized block applied to the databases.
+    pub(super) fn processed_height(&self) -> Height {
+        self.execution.last_processed().height
     }
 
-    /// Returns whether every verification-owned replay has released its owner.
-    pub(super) fn replays_idle(&self) -> bool {
-        self.replays.is_empty()
-    }
-
-    /// Snapshot the pending bases that remain branch-valid after `block` is
-    /// finalized.
-    pub(super) fn finalization_boundary(
-        &self,
-        block: &A::Block,
-    ) -> FinalizationBoundary<PendingDigest<A, E>> {
-        let digest = block.digest();
-        let round = block.context().round();
-        let state = self.execution.state.lock();
-        FinalizationBoundary {
-            digest,
-            round,
-            processed_digest: state.last_processed.digest,
-            processed_round: state.last_processed.round,
-            compatible: compatible_pending(&state, digest, round),
-        }
-    }
-
-    /// Returns a reference to the database set.
-    pub(super) const fn databases(&self) -> &A::Databases {
-        &self.execution.databases
+    /// Prune `self.databases` and `marshal` to the `prune` target.
+    ///
+    /// # Invariant
+    ///
+    /// Databases must be durable through `prune.barrier_height`.
+    pub(super) async fn prune<S, V>(
+        mut self,
+        prune: Prune<PendingSyncTargets<A, E>>,
+        marshal: &MarshalMailbox<S, V>,
+    ) -> Self
+    where
+        S: Scheme,
+        V: MarshalVariant,
+    {
+        self.databases = self.databases.prune(&prune.qmdb_target).await;
+        marshal.prune(prune.marshal_height);
+        self
     }
 
     /// Capture a snapshot of the database set's applied state and publish it
     /// at the processed height.
-    pub(super) fn publish_snapshot<'p>(
+    pub(super) async fn publish_snapshot(
+        mut self,
+        publisher: &mut Publisher<SnapshotsOf<A::Databases, E>>,
+    ) -> Self {
+        let snapshots;
+        (self.databases, snapshots) = self.databases.snapshot().await;
+        publisher.publish_now(self.processed_height(), snapshots);
+        self
+    }
+
+    #[cfg(test)]
+    fn handles(&self) -> HandlesOf<A::Databases, E> {
+        self.execution.handles.clone()
+    }
+
+    #[cfg(test)]
+    fn cache_pending(
         &self,
-        publisher: &'p mut Publisher<SnapshotsOf<A::Databases, E>>,
-    ) -> impl Future<Output = ()> + Send + 'p {
-        // Clones the set so the future is `Send` without `A: Sync`.
-        let databases = self.execution.databases.clone();
-        let height = self.execution.last_processed().height;
-        async move {
-            let snapshots = databases.snapshot().await;
-            publisher.publish_now(height, snapshots);
-        }
+        digest: PendingDigest<A, E>,
+        parent: PendingDigest<A, E>,
+        round: Round,
+        merkleized: PendingBatches<A, E>,
+    ) -> bool {
+        self.execution
+            .cache_pending(digest, parent, round, merkleized)
     }
 
     #[cfg(test)]
@@ -719,132 +587,12 @@ where
         self.execution.update_pending_metric();
     }
 
-    /// Prepare parent-relative batches and delegate to the application to
-    /// build a new block proposal. The resulting block and its merkleized
-    /// state are cached in `pending`. Sends `None` on `response` if the
-    /// ancestry is invalid or the application declines to propose.
-    pub(super) async fn propose<S, V>(
-        &mut self,
-        context: &E,
-        marshal: MarshalMailbox<S, V>,
-        (runtime_context, consensus_context): (E, A::Context),
-        mut ancestry: impl Ancestry<A::Block>,
-        input: Input<A::Input, A::Provider>,
-        mut response: oneshot::Sender<Option<A::Block>>,
-    ) where
-        S: Scheme,
-        V: MarshalVariant<ApplicationBlock = A::Block>,
-        MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
-    {
-        let timer = self.execution.metrics.propose_duration.timer(context);
-
-        let parent = match fetch_ancestor(&mut response, &mut ancestry).await {
-            Some(Some(parent)) => parent,
-            Some(None) => {
-                response.send_lossy(None);
-                return;
-            }
-            None => {
-                debug!("proposal request cancelled before initial ancestry arrived");
-                return;
-            }
-        };
-        let parent_digest = parent.digest();
-        let ancestry = marshal_ancestry::with_prefix([Arc::clone(&parent)], ancestry);
-
-        let round = consensus_context.round();
-        let batches = match self
-            .prepare_batches(context, marshal, parent, &mut response)
-            .await
-        {
-            Ok(batches) => batches,
-            Err(PrepareBatchesError::Invalid) => {
-                response.send_lossy(None);
-                return;
-            }
-            Err(PrepareBatchesError::Incomplete) => {
-                debug!(
-                    ?parent_digest,
-                    "proposal request waiting on incomplete ancestry during prepare_batches"
-                );
-                response.closed().await;
-                return;
-            }
-            Err(PrepareBatchesError::Cancelled) => {
-                debug!(
-                    ?parent_digest,
-                    "proposal request cancelled during prepare_batches"
-                );
-                return;
-            }
-        };
-
-        let proposed = match await_or_cancel(
-            &mut response,
-            self.app.propose(
-                (runtime_context, consensus_context),
-                ancestry,
-                batches,
-                input,
-            ),
-        )
-        .await
-        {
-            Some(result) => result,
-            None => {
-                debug!(?parent_digest, "proposal request cancelled during propose");
-                return;
-            }
-        };
-
-        let Some(Proposed { block, merkleized }) = proposed else {
-            response.send_lossy(None);
-            return;
-        };
-        assert!(
-            A::Databases::matches_sync_targets(&merkleized, &A::sync_targets(&block)),
-            "proposed state must match block commitments",
-        );
-        assert!(
-            self.cache_pending(block.digest(), parent_digest, round, merkleized),
-            "proposal parent must remain compatible until the proposal completes",
-        );
-        self.execution.update_pending_metric();
-        timer.observe(context);
-        response.send_lossy(Some(block));
-    }
-
-    /// Ensure parent state exists, then prepare unmerkleized batches for execution.
-    #[tracing::instrument(
-        name = "stateful.processor.prepare_batches",
-        level = "info",
-        skip_all,
-        fields(parent = %parent.digest())
-    )]
-    async fn prepare_batches<S, V, C>(
-        &mut self,
-        context: &E,
-        marshal: MarshalMailbox<S, V>,
-        parent: Arc<A::Block>,
-        cancellation: &mut C,
-    ) -> Result<<A::Databases as DatabaseSet<E>>::Unmerkleized, PrepareBatchesError>
-    where
-        S: Scheme,
-        V: MarshalVariant<ApplicationBlock = A::Block>,
-        MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
-        C: Cancellation,
-    {
-        self.execution
-            .prepare_batches(&mut self.app, context, marshal, parent, cancellation, None)
-            .await
-    }
-
     /// Fork unmerkleized batches from known parent state.
     #[cfg(test)]
     async fn fork_batches(
         &self,
         parent: &<A::Block as Digestible>::Digest,
-    ) -> Result<<A::Databases as DatabaseSet<E>>::Unmerkleized, PrepareBatchesError> {
+    ) -> Result<UnmerkleizedOf<A::Databases, E>, PrepareBatchesError> {
         self.execution.fork_batches(parent).await
     }
 
@@ -868,15 +616,22 @@ where
 
     /// Apply finalized state, start persisting it, and prune dead in-memory forks.
     ///
-    /// Returns [`None`] when the block was already processed (a duplicate
-    /// report).
+    /// Returns the processor, the snapshot to publish, the barrier proving that
+    /// snapshot durable, and any prune now due. [`None`] means the block was
+    /// already applied, which happens when marshal reports it twice.
+    ///
+    /// The block's state comes from its verification when that is cached, and is
+    /// replayed here otherwise. Verification jobs keep running throughout, so
+    /// this leaves the block reachable as a parent until the anchor moves.
     pub(super) async fn finalize(
-        &mut self,
+        mut self,
         context: &E,
         block: &A::Block,
-    ) -> Option<Applied<PendingSyncTargets<A, E>, SnapshotsOf<A::Databases, E>>> {
-        let finalized = Anchor::from(block);
-        let (height, digest) = (finalized.height, finalized.digest);
+    ) -> (
+        Self,
+        Option<Applied<PendingSyncTargets<A, E>, SnapshotsOf<A::Databases, E>>>,
+    ) {
+        let (height, digest) = (block.height(), block.digest());
         let last_processed = self.execution.last_processed();
         if height < last_processed.height {
             panic!(
@@ -890,102 +645,86 @@ where
                 digest, last_processed.digest,
                 "received conflicting finalized block at processed height",
             );
-            return None;
+            return (self, None);
         }
 
         let timer = self.execution.metrics.finalize_duration.timer(context);
         let block_context = block.context();
+        let round = block_context.round();
         let sync_targets = A::sync_targets(block);
-        self.execution.begin_finalization(finalized);
 
-        // Marshal finalization is ordered. If the winner is not cached,
-        // reconstruct its batch from the current finalized database state.
+        // Marshal finalization is ordered. A pending miss means we can replay
+        // this block on top of finalized state.
         //
-        // Safety contract: reconstructed `Application::apply` output must
-        // match the block commitments previously enforced by `Application::verify`.
-        let reconstruction = loop {
-            match self
-                .execution
-                .claim_finalization_batch(&self.replays, digest)
-            {
-                FinalizationClaim::Cached => break None,
-                FinalizationClaim::Reconstruct(owner) => break Some(owner),
-                FinalizationClaim::Wait(mut waiter) => match (&mut waiter.completion).await {
-                    Ok(Ok(())) | Err(_) => continue,
-                    Ok(Err(error)) => {
-                        warn!(
-                            ?digest,
-                            ?error,
-                            "finalization could not reuse active verification replay"
-                        );
-                        continue;
-                    }
-                },
+        // The entry stays in the pending map until the retention sweep below.
+        // Verification jobs run throughout this call, and one that forks from
+        // this block must find it rather than rebuild it on top of itself.
+        //
+        // Safety contract: replayed `Application::apply` output must match the
+        // block commitments previously enforced by `Application::verify`.
+        let batch = match self.execution.pending_batch(&digest) {
+            Some(merkleized) => merkleized,
+            None => {
+                let batches = A::Databases::new_batches(&self.execution.handles)
+                    .await
+                    .unwrap_or_else(|_| unreachable!("the executor owns the databases' gates"));
+                let batch = self
+                    .app
+                    .apply(
+                        (context.child("finalize_replay"), block_context),
+                        block,
+                        batches,
+                    )
+                    .await;
+                assert!(
+                    A::Databases::matches_sync_targets(&batch, &sync_targets),
+                    "finalize replay state root must match block commitments",
+                );
+                batch
             }
         };
-        let reconstructed = if reconstruction.is_none() {
-            None
-        } else {
-            let batches = self.execution.databases.new_batches().await;
-            let batch = self
-                .app
-                .apply(
-                    (context.child("finalize_reconstruct"), block_context),
-                    block,
-                    batches,
-                )
-                .await;
-            assert!(
-                A::Databases::matches_sync_targets(&batch, &sync_targets),
-                "finalize reconstruction must match block commitments",
-            );
-            Some(batch)
-        };
 
-        let batch = self
-            .execution
-            .secure_finalization_batch(digest, reconstructed);
-        if let Some(owner) = reconstruction {
-            owner.finish(Ok(()));
-        }
-        let (snapshots, barrier) = self.execution.databases.finalize(batch).await;
+        let (snapshots, barrier);
+        (self.databases, snapshots, barrier) = self.databases.finalize(batch).await;
         self.notify_finalized(context, block).await;
         let prune = self
             .pruning
             .as_mut()
             .and_then(|pruning| pruning.observe_finalized(height, sync_targets));
-        self.execution.finish_finalization(finalized);
+        self.execution.advance_to_finalized(Anchor {
+            height,
+            round,
+            digest,
+        });
         timer.observe(context);
 
-        Some(Applied {
-            snapshots,
-            barrier,
-            prune,
-        })
+        (
+            self,
+            Some(Applied {
+                snapshots,
+                barrier,
+                prune,
+            }),
+        )
     }
 
     /// Notify the application that marshal delivered a finalized block already
     /// reflected in the database set.
-    pub(super) async fn notify_finalized(&mut self, context: &E, block: &A::Block) {
-        self.app
-            .finalized(
+    pub(super) fn notify_finalized(
+        &self,
+        context: &E,
+        block: &A::Block,
+    ) -> impl Future<Output = ()> + Send {
+        let mut app = self.app.clone();
+        let handles = self.execution.handles.clone();
+        async move {
+            app.finalized(
                 (context.child("finalized"), block.context()),
                 block,
-                self.execution.databases.readers(),
+                handles,
             )
             .await;
-    }
-
-    /// Cache merkleized pending state for a block digest.
-    fn cache_pending(
-        &self,
-        digest: PendingDigest<A, E>,
-        parent: PendingDigest<A, E>,
-        round: Round,
-        merkleized: PendingBatches<A, E>,
-    ) -> bool {
-        self.execution
-            .cache_pending(digest, parent, round, merkleized)
+        }
     }
 }
 
@@ -996,63 +735,6 @@ where
 {
     fn last_processed(&self) -> Anchor<PendingDigest<A, E>> {
         self.state.lock().last_processed
-    }
-
-    /// Records the compatible pending state for a serialized finalization.
-    fn begin_finalization(&self, anchor: Anchor<PendingDigest<A, E>>) {
-        let mut state = self.state.lock();
-        let compatible = compatible_pending(&state, anchor.digest, anchor.round);
-        assert!(
-            state.finalizing.replace(anchor).is_none(),
-            "finalization must be serialized",
-        );
-        assert!(state.finalizing_batch.is_none());
-        assert!(state.finalizing_compatible.is_empty());
-        state.finalizing_compatible = compatible;
-    }
-
-    /// Retain the winner as a branch parent and discard incompatible state.
-    fn secure_finalization_batch(
-        &self,
-        digest: PendingDigest<A, E>,
-        reconstructed: Option<PendingBatches<A, E>>,
-    ) -> PendingBatches<A, E> {
-        let mut state = self.state.lock();
-        assert_eq!(
-            state.finalizing.map(|anchor| anchor.digest),
-            Some(digest),
-            "secured batch must match active finalization",
-        );
-        assert!(state.finalizing_batch.is_none());
-        let ExecutionState {
-            pending,
-            finalizing_batch,
-            finalizing_compatible,
-            ..
-        } = &mut *state;
-        let batch = pending
-            .remove(&digest)
-            .map(|entry| entry.merkleized)
-            .or(reconstructed)
-            .expect("finalization must have a cached or reconstructed batch");
-        *finalizing_batch = Some(batch.clone());
-        let before = pending.len();
-        pending.retain(|candidate_digest, _| finalizing_compatible.contains(candidate_digest));
-        let pruned = before - pending.len();
-        let pending = pending.len();
-        drop(state);
-        self.metrics.pruned_forks.inc_by(pruned as u64);
-        let _ = self.metrics.pending_blocks.try_set(pending);
-        batch
-    }
-
-    /// Publish the finalized anchor after its application hook completes.
-    fn finish_finalization(&self, finalized: Anchor<PendingDigest<A, E>>) {
-        let mut state = self.state.lock();
-        assert_eq!(state.finalizing.take(), Some(finalized));
-        assert!(state.finalizing_batch.take().is_some());
-        state.finalizing_compatible.clear();
-        state.last_processed = finalized;
     }
 
     fn summary(&self) -> (Anchor<PendingDigest<A, E>>, usize) {
@@ -1086,35 +768,17 @@ where
             return true;
         }
 
-        // A replay can finish after another copy supplied the batch consumed by finalization.
-        // Treat it as cached without reinserting the finalized batch.
-        let winner_already_retained = state.finalizing.is_some_and(|finalizing| {
-            state.finalizing_batch.is_some()
-                && finalizing.digest == digest
-                && finalizing.round == round
-        });
-        if winner_already_retained
-            || (state.last_processed.digest == digest && state.last_processed.round == round)
-        {
+        // A replay of the block the anchor now sits on is already reflected in
+        // applied state.
+        if state.last_processed.digest == digest && state.last_processed.round == round {
             return true;
         }
 
-        // The processed anchor is not advanced until the application hook returns. Retained
-        // descendants may cache state during that interval, but new work on the old anchor may not.
-        let compatible = state.finalizing.map_or_else(
-            || {
-                round > state.last_processed.round
-                    && (parent == state.last_processed.digest
-                        || state.pending.contains_key(&parent))
-            },
-            |finalizing| {
-                (digest == finalizing.digest
-                    && round == finalizing.round
-                    && (parent == state.last_processed.digest
-                        || state.pending.contains_key(&parent)))
-                    || (round > finalizing.round && state.finalizing_compatible.contains(&parent))
-            },
-        );
+        // Verification runs across finalizations, so a verdict can land against
+        // a newer anchor and pending set than the one it started from. This is
+        // where such a result is refused: its branch is no longer reachable.
+        let compatible = round > state.last_processed.round
+            && (parent == state.last_processed.digest || state.pending.contains_key(&parent));
         if !compatible {
             return false;
         }
@@ -1126,32 +790,7 @@ where
                 merkleized,
             },
         );
-        if state.finalizing.is_some() {
-            state.finalizing_compatible.insert(digest);
-        }
         true
-    }
-
-    /// Finds, joins, or reserves construction of the finalizing winner batch.
-    ///
-    /// Replay completion only tells the caller to check the cache again: the
-    /// owner caches the batch before notifying its waiters. Execution state is
-    /// always locked before the replay registry when both are inspected.
-    fn claim_finalization_batch(
-        &self,
-        replays: &ReplayFlights<PendingDigest<A, E>>,
-        digest: PendingDigest<A, E>,
-    ) -> FinalizationClaim<PendingDigest<A, E>> {
-        let state = self.state.lock();
-        let mut entries = replays.entries.lock();
-        if let Some(flight) = entries.get_mut(&digest) {
-            return FinalizationClaim::Wait(replays.waiter(digest, flight));
-        }
-        if state.pending.contains_key(&digest) {
-            FinalizationClaim::Cached
-        } else {
-            FinalizationClaim::Reconstruct(replays.register_owner(digest, &mut entries))
-        }
     }
 
     /// Reuses known state, joins an active replay, or claims replay ownership.
@@ -1164,13 +803,7 @@ where
         digest: PendingDigest<A, E>,
     ) -> ReplayClaim<PendingDigest<A, E>> {
         let state = self.state.lock();
-        if state.last_processed.digest == digest
-            || state.pending.contains_key(&digest)
-            || (state.finalizing_batch.is_some()
-                && state
-                    .finalizing
-                    .is_some_and(|finalizing| finalizing.digest == digest))
-        {
+        if state.last_processed.digest == digest || state.pending.contains_key(&digest) {
             return ReplayClaim::Ready;
         }
 
@@ -1182,47 +815,28 @@ where
         ReplayClaim::Owner(replays.register_owner(digest, &mut entries))
     }
 
-    /// Whether finalization supersedes a winner replay's terminal failure.
-    fn finalization_recovers_replay(&self, digest: PendingDigest<A, E>) -> bool {
-        let state = self.state.lock();
-        state.last_processed.digest == digest
-            || state
-                .finalizing
-                .is_some_and(|finalizing| finalizing.digest == digest)
-    }
-
     /// Forks batches from a known parent.
     async fn fork_batches(
         &self,
         parent: &PendingDigest<A, E>,
-    ) -> Result<<A::Databases as DatabaseSet<E>>::Unmerkleized, PrepareBatchesError> {
+    ) -> Result<UnmerkleizedOf<A::Databases, E>, PrepareBatchesError> {
         {
             let state = self.state.lock();
             if let Some(entry) = state.pending.get(parent) {
                 return Ok(A::Databases::fork_batches(&entry.merkleized));
-            }
-            if state
-                .finalizing
-                .is_some_and(|finalizing| finalizing.digest == *parent)
-            {
-                let batch = state
-                    .finalizing_batch
-                    .as_ref()
-                    .ok_or(PrepareBatchesError::Invalid)?;
-                return Ok(A::Databases::fork_batches(batch));
             }
             if state.last_processed.digest != *parent {
                 return Err(PrepareBatchesError::Invalid);
             }
         }
 
-        Ok(self.databases.new_batches().await)
+        Ok(A::Databases::new_batches(&self.handles).await?)
     }
 
     /// Replays one certified block and caches its commitment-matching state.
     ///
-    /// Cancellation caches nothing. A commitment mismatch or state that cannot
-    /// be cached across active finalization makes the ancestry invalid.
+    /// Cancellation caches nothing. A commitment mismatch, or state that the
+    /// applied anchor has already moved past, makes the ancestry invalid.
     async fn replay_block<C>(
         &self,
         app: &mut A,
@@ -1238,11 +852,7 @@ where
         let consensus_context = block.context();
         let round = consensus_context.round();
 
-        let Some(batches) = await_or_cancel(cancellation, self.fork_batches(&parent_digest)).await
-        else {
-            return Err(PrepareBatchesError::Cancelled);
-        };
-        let batches = batches?;
+        let batches = self.fork_batches(&parent_digest).await?;
 
         let Some(merkleized) = await_or_cancel(
             cancellation,
@@ -1283,17 +893,16 @@ where
         target_digest: PendingDigest<A, E>,
         block: Arc<A::Block>,
         cancellation: &mut C,
-        replay: ReplayTracking<'_, PendingDigest<A, E>>,
+        replays: &ReplayFlights<PendingDigest<A, E>>,
     ) -> ReplayResult
     where
         C: Cancellation,
     {
-        let (digest, parent, round) = (block.digest(), block.parent(), block.context().round());
+        let digest = block.digest();
         loop {
-            match self.claim_replay(replay.flights, digest) {
+            match self.claim_replay(replays, digest) {
                 ReplayClaim::Ready => return Ok(()),
                 ReplayClaim::Owner(owner) => {
-                    replay.progress.replaying(digest, parent, round);
                     let result = self
                         .replay_block(
                             app,
@@ -1309,7 +918,6 @@ where
                     return result;
                 }
                 ReplayClaim::Wait(mut waiter) => {
-                    replay.progress.replaying(digest, parent, round);
                     let Some(completion) =
                         await_or_cancel(cancellation, &mut waiter.completion).await
                     else {
@@ -1317,12 +925,7 @@ where
                     };
                     match completion {
                         Ok(Ok(())) | Err(_) => continue,
-                        Ok(Err(error)) => {
-                            if self.finalization_recovers_replay(digest) {
-                                continue;
-                            }
-                            return Err(error);
-                        }
+                        Ok(Err(error)) => return Err(error),
                     }
                 }
             }
@@ -1331,7 +934,7 @@ where
 
     /// Ensures parent state exists and forks batches for speculative execution.
     ///
-    /// Verification supplies replay tracking to share reconstruction by block
+    /// Verification supplies the replay registry to share reconstruction by block
     /// digest, while proposals reconstruct independently. `fork_batches`
     /// revalidates the parent after reconstruction in case finalization
     /// advanced meanwhile.
@@ -1342,7 +945,7 @@ where
         marshal: MarshalMailbox<S, V>,
         parent: Arc<A::Block>,
         cancellation: &mut C,
-        replay: Option<ReplayTracking<'_, PendingDigest<A, E>>>,
+        replays: Option<&ReplayFlights<PendingDigest<A, E>>>,
     ) -> Result<<A::Databases as DatabaseSet<E>>::Unmerkleized, PrepareBatchesError>
     where
         S: Scheme,
@@ -1357,13 +960,11 @@ where
                 || state.pending.contains_key(&parent_digest)
         };
         if !known {
-            self.rebuild_pending(app, context, marshal, parent, cancellation, replay)
+            self.rebuild_pending(app, context, marshal, parent, cancellation, replays)
                 .await?;
         }
 
-        await_or_cancel(cancellation, self.fork_batches(&parent_digest))
-            .await
-            .ok_or(PrepareBatchesError::Cancelled)?
+        self.fork_batches(&parent_digest).await
     }
 
     /// Rebuilds missing ancestry through `target`.
@@ -1378,7 +979,7 @@ where
         provider: P,
         target: Arc<A::Block>,
         cancellation: &mut C,
-        replay: Option<ReplayTracking<'_, PendingDigest<A, E>>>,
+        replays: Option<&ReplayFlights<PendingDigest<A, E>>>,
     ) -> Result<(), PrepareBatchesError>
     where
         P: BlockProvider<Block = A::Block> + Clone,
@@ -1449,8 +1050,8 @@ where
 
         let depth = replay_path.len();
         for block in replay_path.into_iter().rev() {
-            if let Some(replay) = replay {
-                self.replay_block_shared(app, context, target_digest, block, cancellation, replay)
+            if let Some(replays) = replays {
+                self.replay_block_shared(app, context, target_digest, block, cancellation, replays)
                     .await?;
             } else {
                 self.replay_block(app, context, target_digest, block, cancellation)
@@ -1462,6 +1063,164 @@ where
         let _ = self.metrics.rebuild_pending_depth.try_set(depth);
         timer.observe(context);
         Ok(())
+    }
+
+    /// Take the cached merkleized batch for `digest`, if it was executed.
+    fn pending_batch(&self, digest: &PendingDigest<A, E>) -> Option<PendingBatches<A, E>> {
+        self.state
+            .lock()
+            .pending
+            .get(digest)
+            .map(|entry| entry.merkleized.clone())
+    }
+
+    /// Move the anchor to a finalized block and drop the pending state that
+    /// block invalidates. A pending block survives only when it descends from
+    /// the anchor and was created after its round.
+    ///
+    /// Both halves happen under one lock. Verification jobs read this state
+    /// while a block applies, and a job that saw the pending set already swept
+    /// but the anchor not yet moved would reject work that is still valid.
+    fn advance_to_finalized(&self, anchor: Anchor<PendingDigest<A, E>>) {
+        let mut state = self.state.lock();
+        let compatible = compatible_pending(&state, anchor.digest, anchor.round);
+        let before = state.pending.len();
+        state
+            .pending
+            .retain(|digest, entry| entry.round > anchor.round && compatible.contains(digest));
+        let pruned = before - state.pending.len();
+        let remaining = state.pending.len();
+        state.last_processed = anchor;
+        drop(state);
+        self.metrics.pruned_forks.inc_by(pruned as u64);
+        let _ = self.metrics.pending_blocks.try_set(remaining);
+    }
+}
+
+impl<E, A> Processor<E, A>
+where
+    E: Rng + Spawner + Metrics + Clock,
+    A: Application<E>,
+{
+    /// Creates a verifier for an independently-polled request.
+    pub(super) fn verifier(&self) -> Verifier<E, A> {
+        Verifier {
+            app: self.app.clone(),
+            execution: self.execution.clone(),
+            replays: self.replays.clone(),
+        }
+    }
+
+    /// Prepare parent-relative batches and delegate to the application to
+    /// build a new block proposal. The resulting block and its merkleized
+    /// state are cached in `pending`. Sends `None` on `response` if the
+    /// ancestry is invalid or the application declines to propose.
+    pub(super) fn propose<S, V>(
+        &self,
+        context: &E,
+        marshal: MarshalMailbox<S, V>,
+        (runtime_context, consensus_context): (E, A::Context),
+        mut ancestry: impl Ancestry<A::Block>,
+        input: Input<A::Input, A::Provider>,
+        mut response: oneshot::Sender<Option<A::Block>>,
+    ) -> impl Future<Output = ()> + Send
+    where
+        S: Scheme,
+        V: MarshalVariant<ApplicationBlock = A::Block>,
+        MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
+    {
+        let mut app = self.app.clone();
+        let execution = &self.execution;
+        async move {
+            let timer = execution.metrics.propose_duration.timer(context);
+
+            let parent = match fetch_ancestor(&mut response, &mut ancestry).await {
+                Some(Some(parent)) => parent,
+                Some(None) => {
+                    response.send_lossy(None);
+                    return;
+                }
+                None => {
+                    debug!("proposal request cancelled before initial ancestry arrived");
+                    return;
+                }
+            };
+            let parent_digest = parent.digest();
+            let prepare = info_span!(
+                "stateful.processor.prepare_batches",
+                parent = %parent_digest,
+            );
+            let ancestry = marshal_ancestry::with_prefix([Arc::clone(&parent)], ancestry);
+
+            let round = consensus_context.round();
+            let batches = match execution
+                .prepare_batches(&mut app, context, marshal, parent, &mut response, None)
+                .instrument(prepare)
+                .await
+            {
+                Ok(batches) => batches,
+                Err(PrepareBatchesError::Invalid) => {
+                    response.send_lossy(None);
+                    return;
+                }
+                Err(PrepareBatchesError::Incomplete) => {
+                    debug!(
+                        ?parent_digest,
+                        "proposal request waiting on incomplete ancestry during prepare_batches"
+                    );
+                    response.closed().await;
+                    return;
+                }
+                Err(PrepareBatchesError::Cancelled) => {
+                    debug!(
+                        ?parent_digest,
+                        "proposal request cancelled during prepare_batches"
+                    );
+                    return;
+                }
+                Err(PrepareBatchesError::Closed) => {
+                    debug!(
+                        ?parent_digest,
+                        "proposal found the databases closed during shutdown"
+                    );
+                    return;
+                }
+            };
+
+            let proposed = match await_or_cancel(
+                &mut response,
+                app.propose(
+                    (runtime_context, consensus_context),
+                    ancestry,
+                    batches,
+                    input,
+                ),
+            )
+            .await
+            {
+                Some(result) => result,
+                None => {
+                    debug!(?parent_digest, "proposal request cancelled during propose");
+                    return;
+                }
+            };
+
+            let Some(Proposed { block, merkleized }) = proposed else {
+                response.send_lossy(None);
+                return;
+            };
+            assert!(
+                A::Databases::matches_sync_targets(&merkleized, &A::sync_targets(&block)),
+                "proposed state must match block commitments",
+            );
+            assert!(
+                execution.cache_pending(block.digest(), parent_digest, round, merkleized),
+                "proposal parent must remain compatible until the proposal completes",
+            );
+            execution.update_pending_metric();
+            timer.observe(context);
+            response.send_lossy(Some(block));
+        }
     }
 }
 
@@ -1537,13 +1296,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        Applied, Disposition, FinalizationBoundary, PrepareBatchesError, Processor, Prune, Pruning,
-        ReplayClaim, ReplayFlights, ReplayTracking, VerificationProgress, fetch_ancestor,
+        Applied, PrepareBatchesError, Processor, Prune, Pruning, ReplayClaim, ReplayFlights,
+        fetch_ancestor,
     };
     use crate::stateful::{
         Application, Input, Proposed, PruneConfig,
         actor::metrics::Metrics as StatefulMetrics,
-        db::{Anchor, DatabaseSet, Merkleized as _, Shared, Unmerkleized as _},
+        db::{
+            Anchor, DatabaseSet, HandlesOf, Merkleized as _, MerkleizedOf, SyncTargetsOf,
+            UnmerkleizedOf,
+        },
     };
     use commonware_codec::{Encode, EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
     use commonware_consensus::{
@@ -1558,8 +1320,7 @@ mod tests {
     use commonware_macros::{boxed, select};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        Clock as _, ContextCell, Runner as _, Supervisor as _, buffer::paged::CacheRef,
-        deterministic,
+        ContextCell, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
     };
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedLogConfig,
@@ -1572,7 +1333,7 @@ mod tests {
     };
     use futures::StreamExt;
     use std::{
-        collections::{BTreeMap, HashSet, VecDeque},
+        collections::{BTreeMap, VecDeque},
         future::Future,
         num::NonZeroUsize,
         sync::{
@@ -1590,41 +1351,9 @@ mod tests {
 
     type Qmdb<E> =
         any::unordered::fixed::Db<mmr::Family, E, Digest, Digest, Sha256, TwoCap, Sequential>;
-    type DbSet<E> = Shared<Qmdb<E>>;
+    type TestSet<E> = crate::stateful::db::Single<Qmdb<E>>;
     type TestMerkleized =
-        <DbSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::Merkleized;
-
-    #[test]
-    fn finalization_dispositions_preserve_winner_and_descendant_work() {
-        let boundary = FinalizationBoundary {
-            digest: 10,
-            round: Round::new(Epoch::zero(), View::new(10)),
-            processed_digest: 9,
-            processed_round: Round::new(Epoch::zero(), View::new(9)),
-            compatible: HashSet::from([10, 11]),
-        };
-        let progress = VerificationProgress::default();
-        assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
-
-        progress.replaying(9, 8, Round::new(Epoch::zero(), View::new(9)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
-
-        progress.replaying(10, 1, Round::new(Epoch::zero(), View::new(10)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Retain,);
-        progress.replaying(12, 11, Round::new(Epoch::zero(), View::new(11)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Retain,);
-        progress.replaying(20, 19, Round::new(Epoch::zero(), View::new(11)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Reject,);
-
-        progress.verifying(9, 8, Round::new(Epoch::zero(), View::new(9)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
-        progress.verifying(10, 1, Round::new(Epoch::zero(), View::new(10)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Retry,);
-        progress.verifying(12, 11, Round::new(Epoch::zero(), View::new(11)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Retain,);
-        progress.verifying(20, 19, Round::new(Epoch::zero(), View::new(11)));
-        assert_eq!(boundary.disposition(&progress), Disposition::Reject,);
-    }
+        <TestSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::Merkleized;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct Block {
@@ -1782,10 +1511,6 @@ mod tests {
             gate.started.send(()).expect("test must await replay");
             let _ = (&mut gate.release).await;
         }
-
-        fn calls(&self) -> usize {
-            self.calls.load(Ordering::SeqCst)
-        }
     }
 
     fn apply_gate() -> (ApplyGate, oneshot::Receiver<()>, oneshot::Sender<()>) {
@@ -1805,7 +1530,6 @@ mod tests {
     struct ExecutionApp {
         genesis: Block,
         finalized_observer: Option<Arc<Mutex<Vec<u64>>>>,
-        apply_probe: Option<ApplicationProbe>,
         finalized_probe: Option<ApplicationProbe>,
     }
 
@@ -1814,7 +1538,6 @@ mod tests {
             Self {
                 genesis: Block::genesis(),
                 finalized_observer: None,
-                apply_probe: None,
                 finalized_probe: None,
             }
         }
@@ -1825,7 +1548,6 @@ mod tests {
                 Self {
                     genesis: Block::genesis(),
                     finalized_observer: Some(finalized_values.clone()),
-                    apply_probe: None,
                     finalized_probe: None,
                 },
                 finalized_values,
@@ -1835,9 +1557,8 @@ mod tests {
         async fn execute(
             height: Height,
             view: View,
-            mut batches: <DbSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::Unmerkleized,
-        ) -> <DbSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::Merkleized
-        {
+            mut batches: UnmerkleizedOf<TestSet<deterministic::Context>, deterministic::Context>,
+        ) -> MerkleizedOf<TestSet<deterministic::Context>, deterministic::Context> {
             let current_counter = batches
                 .get(&counter_key())
                 .await
@@ -1845,7 +1566,9 @@ mod tests {
                 .map_or(0, |digest| digest_to_u64(&digest));
             batches = batches.write(counter_key(), Some(u64_to_digest(current_counter + 1)));
             batches = batches.write(height_key(height), Some(u64_to_digest(view.get())));
-            batches.merkleize().await.expect("merkleize should succeed")
+            crate::stateful::db::Unmerkleized::merkleize(batches)
+                .await
+                .expect("merkleize should succeed")
         }
     }
 
@@ -1853,7 +1576,7 @@ mod tests {
         type SigningScheme = MockScheme<ed25519::PublicKey>;
         type Context = TestContext;
         type Block = Block;
-        type Databases = DbSet<deterministic::Context>;
+        type Databases = TestSet<deterministic::Context>;
         type Provider = ();
         type Input = ();
 
@@ -1865,7 +1588,7 @@ mod tests {
             &mut self,
             context: (deterministic::Context, Self::Context),
             ancestry: impl Ancestry<Self::Block>,
-            batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
+            batches: UnmerkleizedOf<Self::Databases, deterministic::Context>,
             _input: Input<Self::Input, Self::Provider>,
         ) -> Option<Proposed<Self, deterministic::Context>> {
             let mut ancestry = Box::pin(ancestry);
@@ -1891,8 +1614,8 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             ancestry: impl Ancestry<Self::Block>,
-            batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
-        ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
+            batches: UnmerkleizedOf<Self::Databases, deterministic::Context>,
+        ) -> Option<MerkleizedOf<Self::Databases, deterministic::Context>> {
             let mut ancestry = Box::pin(ancestry);
             let block = ancestry.next().await?;
             let merkleized =
@@ -1907,11 +1630,8 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
-            batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
-        ) -> <Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized {
-            if let Some(probe) = &self.apply_probe {
-                probe.call(block.digest()).await;
-            }
+            batches: UnmerkleizedOf<Self::Databases, deterministic::Context>,
+        ) -> MerkleizedOf<Self::Databases, deterministic::Context> {
             Self::execute(block.height(), block.context.round.view(), batches).await
         }
 
@@ -1919,16 +1639,18 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
-            readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+            handles: HandlesOf<Self::Databases, deterministic::Context>,
         ) {
             if let Some(probe) = &self.finalized_probe {
                 probe.call(block.digest()).await;
             }
-            let Some(observer) = self.finalized_observer.clone() else {
+            let Some(observer) = &self.finalized_observer else {
                 return;
             };
-            let db = readers.read().await;
-            let value = db
+            let value = handles
+                .read()
+                .await
+                .expect("writer is live")
                 .get(&height_key(block.height()))
                 .await
                 .expect("database read should succeed")
@@ -1938,7 +1660,7 @@ mod tests {
 
         fn sync_targets(
             block: &Self::Block,
-        ) -> <Self::Databases as DatabaseSet<deterministic::Context>>::SyncTargets {
+        ) -> SyncTargetsOf<Self::Databases, deterministic::Context> {
             Target::new(block.state_root, block.range.clone())
         }
     }
@@ -2049,10 +1771,19 @@ mod tests {
             config: any::FixedConfig<TwoCap, Sequential>,
             app: ExecutionApp,
         ) -> Self {
-            let databases = <DbSet<deterministic::Context> as DatabaseSet<
-                deterministic::Context,
-            >>::init(context.child("db_set"), config.clone())
-            .await;
+            Self::with_app_pruned(context, provider, config, app, None).await
+        }
+
+        async fn with_app_pruned(
+            context: deterministic::Context,
+            provider: MapProvider,
+            config: any::FixedConfig<TwoCap, Sequential>,
+            app: ExecutionApp,
+            prune_config: Option<PruneConfig>,
+        ) -> Self {
+            let databases =
+                TestSet::<deterministic::Context>::init(context.child("db_set"), config.clone())
+                    .await;
             let metrics = StatefulMetrics::new(&context);
             Self {
                 context_cell: ContextCell::new(context),
@@ -2065,7 +1796,7 @@ mod tests {
                         digest: Block::genesis().digest(),
                     },
                     metrics,
-                    None,
+                    prune_config.map(|config| Pruning::build(config, 1, 0)),
                 ),
                 provider,
                 db_config: config,
@@ -2111,51 +1842,56 @@ mod tests {
         /// Returns whether the block was newly applied (`false` for a
         /// duplicate report).
         #[boxed]
-        async fn finalize(&mut self, block: Block) -> bool {
-            let Some(Applied { barrier, .. }) = self
+        async fn finalize(mut self, block: Block) -> (Self, bool) {
+            let applied;
+            (self.processor, applied) = self
                 .processor
                 .finalize(self.context_cell.as_present(), &block)
-                .await
-            else {
-                return false;
+                .await;
+            let Some(Applied { barrier, .. }) = applied else {
+                return (self, false);
             };
             assert!(barrier.durable().await, "finalize flush must complete");
-            true
+            (self, true)
         }
 
         #[boxed]
         async fn finalize_with_prune(
-            &mut self,
+            mut self,
             block: Block,
-        ) -> Option<
-            Prune<
-                <DbSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::SyncTargets,
-            >,
-        > {
-            let Applied {
-                snapshots: _,
-                barrier,
-                prune,
-            } = self
+        ) -> (
+            Self,
+            Option<Prune<SyncTargetsOf<TestSet<deterministic::Context>, deterministic::Context>>>,
+        ) {
+            let applied;
+            (self.processor, applied) = self
                 .processor
                 .finalize(self.context_cell.as_present(), &block)
-                .await
-                .expect("finalized block must apply");
+                .await;
+            let Applied { barrier, prune, .. } = applied.expect("finalized block must apply");
             assert!(barrier.durable().await, "finalize flush must complete");
-            prune
+            (self, prune)
         }
 
         async fn height_value(&self, height: Height) -> Option<u64> {
-            let db = self.processor.databases().read().await;
-            db.get(&height_key(height))
+            self.processor
+                .handles()
+                .read()
+                .await
+                .expect("writer is live")
+                .get(&height_key(height))
                 .await
                 .expect("database read should succeed")
                 .map(|value| digest_to_u64(&value))
         }
 
         async fn counter_value(&self) -> Option<u64> {
-            let db = self.processor.databases().read().await;
-            db.get(&counter_key())
+            self.processor
+                .handles()
+                .read()
+                .await
+                .expect("writer is live")
+                .get(&counter_key())
                 .await
                 .expect("database read should succeed")
                 .map(|value| digest_to_u64(&value))
@@ -2352,31 +2088,23 @@ mod tests {
             let provider = MapProvider::default();
             let config = qmdb_config("db_config", &context);
             let app = ExecutionApp::new();
-            let mut harness = Harness::with_app(context, provider, config, app).await;
-            harness.processor = Processor::new(
-                ExecutionApp::new(),
-                harness.processor.databases().clone(),
-                Anchor {
-                    height: Height::zero(),
-                    round: Block::genesis().context().round,
-                    digest: Block::genesis().digest(),
-                },
-                StatefulMetrics::new(harness.context_cell.as_present()),
-                Some(Pruning::build(
-                    PruneConfig {
-                        maintenance_interval: NZUsize!(1),
-                        retained_marshal_blocks: 1,
-                        retained_qmdb_blocks: 1,
-                    },
-                    1,
-                    0,
-                )),
-            );
+            let mut harness = Harness::with_app_pruned(
+                context,
+                provider,
+                config,
+                app,
+                Some(PruneConfig {
+                    maintenance_interval: NZUsize!(1),
+                    retained_marshal_blocks: 1,
+                    retained_qmdb_blocks: 1,
+                }),
+            )
+            .await;
 
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            let prune = harness.finalize_with_prune(block1).await;
+            let (_, prune) = harness.finalize_with_prune(block1).await;
             assert_eq!(
                 prune, None,
                 "pruning should wait for the full retention window",
@@ -2396,10 +2124,9 @@ mod tests {
             assert!(harness.processor.pending_contains(&winner.digest()));
             assert!(harness.processor.pending_contains(&loser.digest()));
 
-            assert!(
-                harness.finalize(winner.clone()).await,
-                "finalization should persist winner state",
-            );
+            let applied;
+            (harness, applied) = harness.finalize(winner.clone()).await;
+            assert!(applied, "finalization should persist winner state");
             assert!(
                 !harness.processor.pending_contains(&loser.digest()),
                 "losing fork at finalized round should be pruned",
@@ -2423,10 +2150,9 @@ mod tests {
             assert!(harness.processor.pending_contains(&loser.digest()));
             assert!(harness.processor.pending_contains(&loser_child.digest()));
 
-            assert!(
-                harness.finalize(winner.clone()).await,
-                "finalization should persist winner state",
-            );
+            let applied;
+            (harness, applied) = harness.finalize(winner.clone()).await;
+            assert!(applied, "finalization should persist winner state");
             assert!(
                 !harness.processor.pending_contains(&loser.digest()),
                 "losing fork at finalized round should be pruned",
@@ -2438,466 +2164,22 @@ mod tests {
         });
     }
 
+    /// A verification job holds an [`Execution`] and keeps running while a
+    /// block is applied. The block being finalized must stay reachable as a
+    /// parent for that whole window, otherwise a job that forks from it
+    /// mid-apply rebuilds it on top of itself and rejects a valid descendant.
     #[test]
-    fn execution_finalization_prunes_before_finalized_hook_completes() {
-        deterministic::Runner::default().start(|context| async move {
-            let mut harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let loser = harness.stage_pending_child(&block1, View::new(2)).await;
-            let winner = harness.stage_pending_child(&block1, View::new(3)).await;
-            let winner_child = harness.stage_pending_child(&winner, View::new(4)).await;
-            let (gate, started, release) = apply_gate();
-            harness.processor.app.finalized_probe =
-                Some(ApplicationProbe::new(winner.digest(), [gate]));
-            let execution = harness.processor.execution.clone();
-
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &winner),
-            );
-            assert!(futures::poll!(&mut finalize).is_pending());
-            started.await.expect("finalized hook should start");
-
-            assert!(execution.pending_contains(&winner_child.digest()));
-            assert!(!execution.pending_contains(&block1.digest()));
-            assert!(!execution.pending_contains(&loser.digest()));
-
-            release
-                .send(())
-                .expect("finalized hook should remain active");
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-        });
-    }
-
-    #[test]
-    fn execution_forks_from_finalizing_winner_before_database_apply() {
+    fn finalized_block_stays_forkable_while_it_applies() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();
             let winner = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let databases = harness.processor.databases().clone();
-            let read = databases.read().await;
+
+            // A job's view of the world, taken before the apply starts.
             let execution = harness.processor.execution.clone();
 
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &winner),
-            );
-            assert!(futures::poll!(&mut finalize).is_pending());
-
-            let winner_digest = winner.digest();
-            let mut fork = Box::pin(execution.fork_batches(&winner_digest));
-            let forked = match futures::poll!(&mut fork) {
-                std::task::Poll::Ready(forked) => forked,
-                std::task::Poll::Pending => {
-                    panic!("finalizing winner should remain available for child batches")
-                }
-            };
-            assert!(forked.is_ok(), "finalizing winner should remain forkable");
-
-            drop(read);
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-        });
-    }
-
-    #[test]
-    fn execution_late_winner_publication_is_a_noop() {
-        deterministic::Runner::default().start(|context| async move {
-            let mut harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let view = View::new(1);
-            let round = Round::new(Epoch::zero(), view);
-            let (winner, initial_batch) = harness.build_child(&genesis, view).await;
-            let (_, during_finalization_batch) = harness.build_child(&genesis, view).await;
-            let (_, after_finalization_batch) = harness.build_child(&genesis, view).await;
-            assert!(harness.processor.cache_pending(
-                winner.digest(),
-                genesis.digest(),
-                round,
-                initial_batch,
-            ));
-
-            let (gate, started, release) = apply_gate();
-            harness.processor.app.finalized_probe =
-                Some(ApplicationProbe::new(winner.digest(), [gate]));
-            let execution = harness.processor.execution.clone();
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &winner),
-            );
-            assert!(futures::poll!(&mut finalize).is_pending());
-            started.await.expect("finalized hook should start");
-
-            assert!(execution.cache_pending(
-                winner.digest(),
-                genesis.digest(),
-                round,
-                during_finalization_batch,
-            ));
-            assert!(!execution.pending_contains(&winner.digest()));
-
-            release
-                .send(())
-                .expect("finalized hook should remain active");
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-
-            assert!(execution.cache_pending(
-                winner.digest(),
-                genesis.digest(),
-                round,
-                after_finalization_batch,
-            ));
-            assert!(!execution.pending_contains(&winner.digest()));
-        });
-    }
-
-    #[test]
-    fn execution_descendant_replay_survives_finalized_parent_removal() {
-        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let mut harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let parent = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let (child, _) = harness.build_child(&parent, View::new(2)).await;
-
-            let (owner_gate, owner_started, mut owner_release) = apply_gate();
-            let (retry_gate, retry_started, retry_release) = apply_gate();
-            harness.processor.app.apply_probe = Some(ApplicationProbe::new(
-                child.digest(),
-                [owner_gate, retry_gate],
-            ));
-            let (finalized_gate, finalized_started, finalized_release) = apply_gate();
-            harness.processor.app.finalized_probe =
-                Some(ApplicationProbe::new(parent.digest(), [finalized_gate]));
-
-            let execution = harness.processor.execution.clone();
-            let replays = harness.processor.replays.clone();
-            let mut owner_app = harness.processor.app.clone();
-            let mut waiter_app = harness.processor.app.clone();
-            let replay_context = harness.context_cell.as_present();
-            let owner_progress = VerificationProgress::default();
-            let waiter_progress = VerificationProgress::default();
-            let (mut owner_cancellation, owner_alive) = oneshot::channel::<()>();
-            let (mut waiter_cancellation, _waiter_alive) = oneshot::channel::<()>();
-
-            let mut owner = Box::pin(execution.replay_block_shared(
-                &mut owner_app,
-                replay_context,
-                child.digest(),
-                Arc::new(child.clone()),
-                &mut owner_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &owner_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut owner).is_pending());
-            owner_started.await.expect("replay owner should start");
-
-            let mut waiter = Box::pin(execution.replay_block_shared(
-                &mut waiter_app,
-                replay_context,
-                child.digest(),
-                Arc::new(child.clone()),
-                &mut waiter_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &waiter_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut waiter).is_pending());
-            let boundary = harness.processor.finalization_boundary(&parent);
-            assert_eq!(boundary.disposition(&owner_progress), Disposition::Retain,);
-            assert_eq!(boundary.disposition(&waiter_progress), Disposition::Retain,);
-
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &parent),
-            );
-            assert!(futures::poll!(&mut finalize).is_pending());
-            finalized_started
-                .await
-                .expect("finalized hook should start");
-
-            drop(owner_alive);
-            assert_eq!(owner.await, Err(PrepareBatchesError::Cancelled));
-            owner_release.closed().await;
-
-            select! {
-                result = &mut waiter => {
-                    panic!("retained replay failed after owner cancellation: {result:?}");
-                },
-                result = retry_started => {
-                    result.expect("retained replay should restart from finalized state");
-                },
-            }
-            retry_release
-                .send(())
-                .expect("retried replay should remain active");
-            assert_eq!(waiter.await, Ok(()));
-
-            finalized_release
-                .send(())
-                .expect("finalized hook should remain active");
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-        });
-    }
-
-    #[test]
-    fn finalized_reader_preserves_retained_replay_base() {
-        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let (mut harness, finalized_values) =
-                Harness::new_with_finalized_observer(context).await;
-            let genesis = Block::genesis();
-            let parent = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let (child, _) = harness.build_child(&parent, View::new(2)).await;
-
-            let (owner_gate, owner_started, mut owner_release) = apply_gate();
-            let (retry_gate, retry_started, retry_release) = apply_gate();
-            harness.processor.app.apply_probe = Some(ApplicationProbe::new(
-                child.digest(),
-                [owner_gate, retry_gate],
-            ));
-            let (finalized_gate, finalized_started, finalized_release) = apply_gate();
-            harness.processor.app.finalized_probe =
-                Some(ApplicationProbe::new(parent.digest(), [finalized_gate]));
-
-            let execution = harness.processor.execution.clone();
-            let replays = harness.processor.replays.clone();
-            let mut owner_app = harness.processor.app.clone();
-            let mut waiter_app = harness.processor.app.clone();
-            let replay_context = harness.context_cell.as_present();
-            let owner_progress = VerificationProgress::default();
-            let waiter_progress = VerificationProgress::default();
-            let (mut owner_cancellation, owner_alive) = oneshot::channel::<()>();
-            let (mut waiter_cancellation, _waiter_alive) = oneshot::channel::<()>();
-
-            let mut owner = Box::pin(execution.replay_block_shared(
-                &mut owner_app,
-                replay_context,
-                child.digest(),
-                Arc::new(child.clone()),
-                &mut owner_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &owner_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut owner).is_pending());
-            owner_started.await.expect("replay owner should start");
-
-            let mut waiter = Box::pin(execution.replay_block_shared(
-                &mut waiter_app,
-                replay_context,
-                child.digest(),
-                Arc::new(child),
-                &mut waiter_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &waiter_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut waiter).is_pending());
-
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &parent),
-            );
-            assert!(futures::poll!(&mut finalize).is_pending());
-            finalized_started
-                .await
-                .expect("finalized hook should start");
-
-            drop(owner_alive);
-            assert_eq!(owner.await, Err(PrepareBatchesError::Cancelled));
-            owner_release.closed().await;
-            select! {
-                result = &mut waiter => {
-                    panic!("retained replay failed after owner cancellation: {result:?}");
-                },
-                result = retry_started => {
-                    result.expect("retained replay should restart from finalized state");
-                },
-            }
-
-            finalized_release
-                .send(())
-                .expect("finalized hook should remain active");
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-            assert_eq!(finalized_values.lock().as_slice(), [1]);
-
-            retry_release
-                .send(())
-                .expect("retried replay should remain active");
-            assert_eq!(waiter.await, Ok(()));
-        });
-    }
-
-    #[test]
-    fn execution_finalize_self_applies_after_cancelled_winner_replay() {
-        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let mut harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let (winner, _) = harness.build_child(&genesis, View::new(1)).await;
-
-            let (owner_gate, owner_started, mut owner_release) = apply_gate();
-            let probe = ApplicationProbe::new(winner.digest(), [owner_gate]);
-            harness.processor.app.apply_probe = Some(probe.clone());
-
-            let execution = harness.processor.execution.clone();
-            let replays = harness.processor.replays.clone();
-            let mut owner_app = harness.processor.app.clone();
-            let replay_context = harness.context_cell.as_present();
-            let (mut owner_cancellation, owner_alive) = oneshot::channel::<()>();
-            let owner_progress = VerificationProgress::default();
-
-            let mut owner = Box::pin(execution.replay_block_shared(
-                &mut owner_app,
-                replay_context,
-                winner.digest(),
-                Arc::new(winner.clone()),
-                &mut owner_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &owner_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut owner).is_pending());
-            owner_started.await.expect("winner replay should start");
-
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &winner),
-            );
-            assert!(
-                futures::poll!(&mut finalize).is_pending(),
-                "finalization should wait on the active winner replay",
-            );
-
-            drop(owner_alive);
-            assert_eq!(owner.await, Err(PrepareBatchesError::Cancelled));
-            owner_release.closed().await;
-
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-            assert_eq!(
-                probe.calls(),
-                2,
-                "finalization must reconstruct the winner after the owner cancels",
-            );
-            assert_eq!(harness.processor.last_processed().digest, winner.digest());
-            assert!(harness.processor.replays_idle());
-        });
-    }
-
-    #[test]
-    fn execution_replay_waiter_recovers_from_invalid_finalizing_winner() {
-        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let mut harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let (winner, _) = harness.build_child(&genesis, View::new(1)).await;
-            let probe = ApplicationProbe::new(winner.digest(), std::iter::empty());
-            harness.processor.app.apply_probe = Some(probe.clone());
-
-            let owner = match harness
-                .processor
-                .execution
-                .claim_replay(&harness.processor.replays, winner.digest())
-            {
-                ReplayClaim::Owner(owner) => owner,
-                _ => panic!("winner replay claim should own the flight"),
-            };
-
-            let execution = harness.processor.execution.clone();
-            let replays = harness.processor.replays.clone();
-            let mut waiter_app = harness.processor.app.clone();
-            let replay_context = harness.context_cell.as_present();
-            let waiter_progress = VerificationProgress::default();
-            let (mut waiter_cancellation, _waiter_alive) = oneshot::channel::<()>();
-            let mut waiter = Box::pin(execution.replay_block_shared(
-                &mut waiter_app,
-                replay_context,
-                winner.digest(),
-                Arc::new(winner.clone()),
-                &mut waiter_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &waiter_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut waiter).is_pending());
-
-            let mut finalize = Box::pin(
-                harness
-                    .processor
-                    .finalize(harness.context_cell.as_present(), &winner),
-            );
-            assert!(
-                futures::poll!(&mut finalize).is_pending(),
-                "finalization should wait on the active winner replay",
-            );
-
-            owner.finish(Err(PrepareBatchesError::Invalid));
-            assert_eq!(
-                waiter.await,
-                Ok(()),
-                "retained waiter should join recovery of the finalizing winner",
-            );
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
-            assert!(barrier.durable().await, "finalize flush must complete");
-            assert_eq!(probe.calls(), 1, "winner should be reconstructed once");
-            assert_eq!(harness.processor.last_processed().digest, winner.digest());
-            assert!(harness.processor.replays_idle());
-        });
-    }
-
-    #[test]
-    fn execution_finalization_waits_for_active_cached_winner_replay() {
-        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let mut harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let (winner, merkleized) = harness.build_child(&genesis, View::new(1)).await;
-
-            let owner = match harness
-                .processor
-                .execution
-                .claim_replay(&harness.processor.replays, winner.digest())
-            {
-                ReplayClaim::Owner(owner) => owner,
-                _ => panic!("winner replay should own the flight"),
-            };
-            assert!(harness.processor.cache_pending(
-                winner.digest(),
-                genesis.digest(),
-                winner.context().round,
-                merkleized,
-            ));
-
+            // Park the finalization inside its `finalized` hook: the database
+            // apply is done, and the anchor has not moved yet.
             let (gate, mut started, release) = apply_gate();
             harness.processor.app.finalized_probe =
                 Some(ApplicationProbe::new(winner.digest(), [gate]));
@@ -2906,144 +2188,55 @@ mod tests {
                     .processor
                     .finalize(harness.context_cell.as_present(), &winner),
             );
-
             select! {
-                _ = &mut finalize => {
-                    panic!("finalization bypassed active winner replay");
-                },
-                result = &mut started => {
-                    result.expect("finalized hook should remain reachable");
-                    panic!("finalization reached the application hook before replay completed");
-                },
-                _ = harness.context_cell.as_present().sleep(Duration::from_millis(10)) => {},
+                _ = &mut finalize => panic!("finalize completed before its hook returned"),
+                result = &mut started => result.expect("finalized hook should start"),
             }
 
-            owner.finish(Ok(()));
-            select! {
-                result = &mut started => {
-                    result.expect("finalized hook should start after replay completes");
-                },
-                _ = &mut finalize => {
-                    panic!("finalization completed before its application hook");
-                },
-            }
+            assert!(
+                execution.fork_batches(&winner.digest()).await.is_ok(),
+                "the applying block must stay forkable for jobs that are still running",
+            );
+
             release
                 .send(())
                 .expect("finalized hook should remain active");
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
+            let (_processor, applied) = finalize.await;
+            let Applied { barrier, .. } = applied.expect("finalized block should be newly applied");
             assert!(barrier.durable().await, "finalize flush must complete");
         });
     }
 
     #[test]
-    fn execution_replay_waiter_reuses_retained_finalizing_winner() {
+    fn execution_finalize_awaits_its_finalized_hook() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();
-            let (winner, _) = harness.build_child(&genesis, View::new(1)).await;
+            let block = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            let (replay_gate, replay_started, replay_release) = apply_gate();
-            let probe = ApplicationProbe::new(winner.digest(), [replay_gate]);
-            harness.processor.app.apply_probe = Some(probe.clone());
-            let (finalized_gate, finalized_started, finalized_release) = apply_gate();
+            let (gate, mut started, release) = apply_gate();
             harness.processor.app.finalized_probe =
-                Some(ApplicationProbe::new(winner.digest(), [finalized_gate]));
-
-            let execution = harness.processor.execution.clone();
-            let replays = harness.processor.replays.clone();
-            let mut owner_app = harness.processor.app.clone();
-            let mut waiter_app = harness.processor.app.clone();
-            let replay_context = harness.context_cell.as_present();
-            let owner_progress = VerificationProgress::default();
-            let waiter_progress = VerificationProgress::default();
-            let (mut owner_cancellation, _owner_alive) = oneshot::channel::<()>();
-            let (mut waiter_cancellation, _waiter_alive) = oneshot::channel::<()>();
-
-            let mut owner = Box::pin(execution.replay_block_shared(
-                &mut owner_app,
-                replay_context,
-                winner.digest(),
-                Arc::new(winner.clone()),
-                &mut owner_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &owner_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut owner).is_pending());
-            replay_started.await.expect("winner replay should start");
-
-            let mut waiter = Box::pin(execution.replay_block_shared(
-                &mut waiter_app,
-                replay_context,
-                winner.digest(),
-                Arc::new(winner.clone()),
-                &mut waiter_cancellation,
-                ReplayTracking {
-                    flights: &replays,
-                    progress: &waiter_progress,
-                },
-            ));
-            assert!(futures::poll!(&mut waiter).is_pending());
-
+                Some(ApplicationProbe::new(block.digest(), [gate]));
             let mut finalize = Box::pin(
                 harness
                     .processor
-                    .finalize(harness.context_cell.as_present(), &winner),
+                    .finalize(harness.context_cell.as_present(), &block),
             );
-            assert!(futures::poll!(&mut finalize).is_pending());
-
-            replay_release
-                .send(())
-                .expect("winner replay should remain active");
-            assert_eq!(owner.await, Ok(()));
             select! {
-                result = finalized_started => {
-                    result.expect("finalized hook should start");
-                },
                 _ = &mut finalize => {
-                    panic!("finalization completed before its application hook");
+                    panic!("finalize completed before its finalized hook returned");
+                },
+                result = &mut started => {
+                    result.expect("finalized hook should start");
                 },
             }
 
-            assert_eq!(
-                waiter.await,
-                Ok(()),
-                "waiter should reuse the retained winner batch",
-            );
-            assert_eq!(probe.calls(), 1, "winner should be reconstructed once");
-
-            finalized_release
+            release
                 .send(())
                 .expect("finalized hook should remain active");
-            let Applied { barrier, .. } = finalize
-                .await
-                .expect("finalized block should be newly applied");
+            let (_processor, applied) = finalize.await;
+            let Applied { barrier, .. } = applied.expect("finalized block should be newly applied");
             assert!(barrier.durable().await, "finalize flush must complete");
-        });
-    }
-
-    #[test]
-    fn execution_finalization_reserves_missing_winner_reconstruction() {
-        deterministic::Runner::default().start(|context| async move {
-            let harness = Harness::new(context).await;
-            let genesis = Block::genesis();
-            let (winner, _) = harness.build_child(&genesis, View::new(1)).await;
-            let execution = harness.processor.execution.clone();
-            let replays = harness.processor.replays.clone();
-
-            execution.begin_finalization(Anchor::from(&winner));
-            let finalization = execution.claim_finalization_batch(&replays, winner.digest());
-            assert!(
-                matches!(
-                    execution.claim_replay(&replays, winner.digest()),
-                    ReplayClaim::Wait(_),
-                ),
-                "missing winner reconstruction must remain single-flight",
-            );
-            drop(finalization);
         });
     }
 
@@ -3058,7 +2251,9 @@ mod tests {
             let late_view = View::new(4);
             let (late_child, merkleized) = harness.build_child(&loser, late_view).await;
 
-            assert!(harness.finalize(winner).await);
+            let applied;
+            (harness, applied) = harness.finalize(winner).await;
+            assert!(applied);
             assert!(
                 !harness.processor.cache_pending(
                     late_child.digest(),
@@ -3078,7 +2273,9 @@ mod tests {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             let block3 = harness.stage_pending_child(&block2, View::new(3)).await;
@@ -3133,7 +2330,7 @@ mod tests {
                     .claim_replay(&replays, harness.processor.last_processed().digest),
                 ReplayClaim::Ready,
             ));
-            assert!(replays.is_empty());
+            assert!(replays.entries.lock().is_empty());
 
             let owner = match harness.processor.execution.claim_replay(&replays, digest) {
                 ReplayClaim::Owner(owner) => owner,
@@ -3184,7 +2381,7 @@ mod tests {
                 "dropped replay waiters must leave reusable vacant slots",
             );
             drop(owner);
-            assert!(replays.is_empty());
+            assert!(replays.entries.lock().is_empty());
         });
     }
 
@@ -3224,7 +2421,7 @@ mod tests {
             drop(second);
             drop(replacement);
             drop(owner);
-            assert!(replays.is_empty());
+            assert!(replays.entries.lock().is_empty());
         });
     }
 
@@ -3263,205 +2460,8 @@ mod tests {
 
             drop(current_waiter);
             drop(second_owner);
-            assert!(replays.is_empty());
+            assert!(replays.entries.lock().is_empty());
         });
-    }
-
-    #[test]
-    fn overlapping_rebuilds_share_replay_after_owner_cancellation() {
-        deterministic::Runner::timed(std::time::Duration::from_secs(5)).start(
-            |context| async move {
-                let mut harness = Harness::new(context.child("harness")).await;
-                let genesis = Block::genesis();
-                let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-                let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
-                let block3 = harness.stage_pending_child(&block2, View::new(3)).await;
-                harness.processor.clear_pending();
-                harness.provider.insert(genesis);
-
-                let (first_gate, first_started, mut first_release) = apply_gate();
-                let (retry_gate, retry_started, retry_release) = apply_gate();
-                let (duplicate_gate, mut duplicate_started, _duplicate_release) = apply_gate();
-                let probe = ApplicationProbe::new(
-                    block1.digest(),
-                    [first_gate, retry_gate, duplicate_gate],
-                );
-                harness.processor.app.apply_probe = Some(probe.clone());
-
-                let first_execution = harness.processor.execution.clone();
-                let second_execution = harness.processor.execution.clone();
-                let third_execution = harness.processor.execution.clone();
-                let fourth_execution = harness.processor.execution.clone();
-                let mut first_app = harness.processor.app.clone();
-                let mut second_app = harness.processor.app.clone();
-                let mut third_app = harness.processor.app.clone();
-                let mut fourth_app = harness.processor.app.clone();
-                let first_provider = harness.provider.clone();
-                let second_provider = harness.provider.clone();
-                let third_provider = harness.provider.clone();
-                let fourth_provider = harness.provider.clone();
-                let first_replays = harness.processor.replays.clone();
-                let second_replays = harness.processor.replays.clone();
-                let third_replays = harness.processor.replays.clone();
-                let fourth_replays = harness.processor.replays.clone();
-                let (mut first_cancellation, first_live) = oneshot::channel::<bool>();
-                let (mut second_cancellation, second_live) = oneshot::channel::<bool>();
-                let (mut third_cancellation, third_live) = oneshot::channel::<bool>();
-                let (mut fourth_cancellation, fourth_live) = oneshot::channel::<bool>();
-                let first_progress = VerificationProgress::default();
-                let second_progress = VerificationProgress::default();
-                let third_progress = VerificationProgress::default();
-                let fourth_progress = VerificationProgress::default();
-
-                let mut first = Box::pin(first_execution.rebuild_pending(
-                    &mut first_app,
-                    &context,
-                    first_provider,
-                    Arc::new(block2.clone()),
-                    &mut first_cancellation,
-                    Some(ReplayTracking {
-                        flights: &first_replays,
-                        progress: &first_progress,
-                    }),
-                ));
-                select! {
-                    result = &mut first => panic!("first rebuild completed before replay gate: {result:?}"),
-                    result = first_started => result.expect("first replay should start"),
-                }
-
-                let mut second = Box::pin(second_execution.rebuild_pending(
-                    &mut second_app,
-                    &context,
-                    second_provider,
-                    Arc::new(block2.clone()),
-                    &mut second_cancellation,
-                    Some(ReplayTracking {
-                        flights: &second_replays,
-                        progress: &second_progress,
-                    }),
-                ));
-                let mut third = Box::pin(third_execution.rebuild_pending(
-                    &mut third_app,
-                    &context,
-                    third_provider,
-                    Arc::new(block3),
-                    &mut third_cancellation,
-                    Some(ReplayTracking {
-                        flights: &third_replays,
-                        progress: &third_progress,
-                    }),
-                ));
-                let mut fourth = Box::pin(fourth_execution.rebuild_pending(
-                    &mut fourth_app,
-                    &context,
-                    fourth_provider,
-                    Arc::new(block2),
-                    &mut fourth_cancellation,
-                    Some(ReplayTracking {
-                        flights: &fourth_replays,
-                        progress: &fourth_progress,
-                    }),
-                ));
-                let mut waiters_registered = false;
-                for _ in 0..100 {
-                    waiters_registered = harness
-                        .processor
-                        .replays
-                        .entries
-                        .lock()
-                        .get(&block1.digest())
-                        .is_some_and(|flight| flight.waiters.len() == 3);
-                    if waiters_registered {
-                        break;
-                    }
-                    select! {
-                        result = &mut first => panic!("first rebuild completed before cancellation: {result:?}"),
-                        result = &mut second => panic!("second rebuild completed before cancellation: {result:?}"),
-                        result = &mut third => panic!("third rebuild completed before cancellation: {result:?}"),
-                        result = &mut fourth => panic!("fourth rebuild completed before cancellation: {result:?}"),
-                        result = &mut duplicate_started => {
-                            result.expect("duplicate replay signal should remain available");
-                            panic!("overlapping rebuilds executed the same ancestor concurrently");
-                        },
-                        _ = context.sleep(std::time::Duration::from_millis(1)) => {},
-                    }
-                }
-                assert!(
-                    waiters_registered,
-                    "overlapping replays should wait for the current owner"
-                );
-                assert_eq!(probe.calls(), 1);
-
-                drop(fourth_live);
-                let fourth_result = select! {
-                    result = &mut fourth => result,
-                    result = &mut first => panic!("owner completed while cancelling waiter: {result:?}"),
-                    result = &mut second => panic!("live waiter completed while cancelling peer: {result:?}"),
-                    result = &mut third => panic!("live waiter completed while cancelling peer: {result:?}"),
-                    _ = context.sleep(std::time::Duration::from_secs(1)) => {
-                        panic!("cancelled replay waiter did not stop");
-                    },
-                };
-                assert_eq!(fourth_result, Err(PrepareBatchesError::Cancelled));
-                assert!(
-                    harness
-                        .processor
-                        .replays
-                        .entries
-                        .lock()
-                        .get(&block1.digest())
-                        .is_some_and(|flight| {
-                            flight.waiters.iter().flatten().count() == 2
-                                && flight.vacant_slots.len() == 1
-                        }),
-                    "cancelled waiter must unregister while the owner remains active",
-                );
-
-                drop(first_live);
-                let first_result = select! {
-                    result = &mut first => result,
-                    result = &mut second => panic!("waiter completed before owner cancellation: {result:?}"),
-                    result = &mut third => panic!("waiter completed before owner cancellation: {result:?}"),
-                    _ = context.sleep(std::time::Duration::from_secs(1)) => {
-                        panic!("cancelled replay owner did not stop");
-                    },
-                };
-                assert_eq!(first_result, Err(PrepareBatchesError::Cancelled));
-                first_release.closed().await;
-                select! {
-                    result = &mut second => panic!("waiter completed before retry gate: {result:?}"),
-                    result = &mut third => panic!("waiter completed before retry gate: {result:?}"),
-                    result = retry_started => result.expect("live waiter should acquire replay ownership"),
-                    result = &mut duplicate_started => {
-                        result.expect("duplicate replay signal should remain available");
-                        panic!("multiple waiters acquired replay ownership");
-                    },
-                    _ = context.sleep(std::time::Duration::from_secs(1)) => {
-                        panic!("live waiter did not retry cancelled replay");
-                    },
-                }
-
-                retry_release
-                    .send(())
-                    .expect("retried replay should still be running");
-                let completed = futures::future::join(second, third);
-                let (second_result, third_result) = select! {
-                    result = &mut duplicate_started => {
-                        result.expect("duplicate replay signal should remain available");
-                        panic!("successful replay was not shared with every waiter");
-                    },
-                    result = completed => result,
-                    _ = context.sleep(std::time::Duration::from_secs(1)) => {
-                        panic!("waiting rebuilds did not complete");
-                    },
-                };
-                assert_eq!(second_result, Ok(()));
-                assert_eq!(third_result, Ok(()));
-                assert_eq!(probe.calls(), 2);
-                assert!(harness.processor.replays_idle());
-                drop((second_live, third_live));
-            },
-        );
     }
 
     #[test]
@@ -3474,7 +2474,9 @@ mod tests {
             let mut parent = genesis;
             for view in 1..=5 {
                 let block = harness.stage_pending_child(&parent, View::new(view)).await;
-                assert!(harness.finalize(block.clone()).await);
+                let applied;
+                (harness, applied) = harness.finalize(block.clone()).await;
+                assert!(applied);
                 parent = block.clone();
                 chain.push(block);
             }
@@ -3515,7 +2517,9 @@ mod tests {
             let genesis = Block::genesis();
 
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             let mut block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             harness.processor.clear_pending();
@@ -3552,7 +2556,9 @@ mod tests {
             let genesis = Block::genesis();
 
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             let gap_height = Height::new(3);
             let gap_view = View::new(3);
@@ -3605,7 +2611,9 @@ mod tests {
             let mut harness = Harness::new(context.child("harness")).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             let block3 = harness.stage_pending_child(&block2, View::new(3)).await;
@@ -3643,7 +2651,9 @@ mod tests {
             let canonical = harness.stage_pending_child(&genesis, View::new(1)).await;
             let conflicting = harness.stage_pending_child(&genesis, View::new(2)).await;
 
-            assert!(harness.finalize(canonical).await);
+            let applied;
+            (harness, applied) = harness.finalize(canonical).await;
+            assert!(applied);
 
             let _ = harness.finalize(conflicting).await;
         });
@@ -3656,8 +2666,12 @@ mod tests {
             let genesis = Block::genesis();
             let canonical = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            assert!(harness.finalize(canonical.clone()).await);
-            assert!(!harness.finalize(canonical).await);
+            let applied;
+            (harness, applied) = harness.finalize(canonical.clone()).await;
+            assert!(applied);
+            let applied;
+            (harness, applied) = harness.finalize(canonical).await;
+            assert!(!applied);
             assert_eq!(harness.counter_value().await, Some(1));
         });
     }
@@ -3669,7 +2683,9 @@ mod tests {
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            assert!(harness.finalize(block1).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1).await;
+            assert!(applied);
             assert_eq!(harness.counter_value().await, Some(1));
             assert_eq!(
                 harness
@@ -3690,8 +2706,11 @@ mod tests {
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
 
-            assert!(harness.finalize(block1).await);
-            assert!(harness.finalize(block2).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1).await;
+            assert!(applied);
+            let (_, applied) = harness.finalize(block2).await;
+            assert!(applied);
             assert_eq!(
                 finalized_values.lock().clone(),
                 vec![1, 2],
@@ -3708,7 +2727,9 @@ mod tests {
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             finalized_values.lock().clear();
             harness
@@ -3724,8 +2745,8 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "finalize reconstruction must match block commitments")]
-    fn execution_finalize_reconstruction_rejects_state_root_mismatch() {
+    #[should_panic(expected = "finalize replay state root must match block commitments")]
+    fn execution_finalize_replay_rejects_state_root_mismatch() {
         deterministic::Runner::default().start(|context| async move {
             let mut harness = Harness::new(context).await;
             let genesis = Block::genesis();
@@ -3754,7 +2775,9 @@ mod tests {
             let mut harness = Harness::new(context.child("harness")).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             harness.processor.clear_pending();
@@ -3783,7 +2806,9 @@ mod tests {
             let mut harness = Harness::new(context.child("harness")).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            assert!(harness.finalize(block1.clone()).await);
+            let applied;
+            (harness, applied) = harness.finalize(block1.clone()).await;
+            assert!(applied);
 
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
             harness.processor.clear_pending();

--- a/glue/src/stateful/actor/processor/verifier.rs
+++ b/glue/src/stateful/actor/processor/verifier.rs
@@ -1,6 +1,6 @@
 use super::{
     Application, Cancellation, Execution, PendingDigest, PrepareBatchesError, ReplayFlights,
-    ReplayTracking, VerificationProgress, await_or_cancel, fetch_ancestor, is_already_processed,
+    VerificationResult, await_or_cancel, fetch_ancestor, is_already_processed,
 };
 use crate::stateful::{actor::core::Verification, db::DatabaseSet};
 use commonware_consensus::{
@@ -54,6 +54,9 @@ where
 }
 
 /// Executes one independently-polled verification request.
+///
+/// Carries only read capability and speculative state, so a job outlives any
+/// number of applies. Its batch operations pause while one is running.
 pub(in crate::stateful::actor) struct Verifier<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -91,9 +94,8 @@ where
         marshal: MarshalMailbox<S, V>,
         consensus_context: A::Context,
         ancestry: impl Ancestry<A::Block>,
-        progress: &VerificationProgress<PendingDigest<A, E>>,
         verification: &mut Verification,
-    ) -> Option<bool>
+    ) -> VerificationResult
     where
         S: Scheme,
         V: MarshalVariant<ApplicationBlock = A::Block>,
@@ -109,18 +111,18 @@ where
             Some(None) => {
                 debug!("verification request waiting on incomplete block ancestry");
                 verification.cancelled().await;
-                return None;
+                return VerificationResult::Cancelled;
             }
             None => {
                 debug!("verification request cancelled before initial block arrived");
-                return None;
+                return VerificationResult::Cancelled;
             }
         };
         let block_digest = block.digest();
 
         if self.execution.pending_contains(&block_digest) {
             timer.observe(context);
-            return Some(true);
+            return VerificationResult::Decided(true);
         }
 
         // A finalized candidate cannot be re-executed against newer database
@@ -132,31 +134,23 @@ where
             ProcessedBlock::Continue => {}
             ProcessedBlock::Accepted => {
                 timer.observe(context);
-                return Some(true);
+                return VerificationResult::Decided(true);
             }
-            ProcessedBlock::Rejected => return Some(false),
-            ProcessedBlock::Cancelled => return None,
+            ProcessedBlock::Rejected => return VerificationResult::Decided(false),
+            ProcessedBlock::Cancelled => return VerificationResult::Cancelled,
         }
 
         // Reconstruct the candidate's parent state. This is the only phase
         // shared across requests, keyed by the acquired parent's block digest.
         let parent = match self
-            .prepare_parent(
-                context,
-                marshal,
-                block_digest,
-                &mut ancestry,
-                progress,
-                verification,
-            )
+            .prepare_parent(context, marshal, block_digest, &mut ancestry, verification)
             .await
         {
             Ok(parent) => parent,
-            Err(PrepareFailure::Invalid) => return Some(false),
-            Err(PrepareFailure::Cancelled) => return None,
+            Err(PrepareFailure::Invalid) => return VerificationResult::Decided(false),
+            Err(PrepareFailure::Cancelled) => return VerificationResult::Cancelled,
         };
 
-        progress.verifying(block_digest, parent.digest, consensus_context.round());
         let result = self
             .verify(
                 context,
@@ -167,7 +161,7 @@ where
                 verification,
             )
             .await;
-        if result == Some(true) {
+        if matches!(result, VerificationResult::Decided(true)) {
             timer.observe(context);
         }
         result
@@ -199,6 +193,13 @@ where
                 );
                 ProcessedBlock::Cancelled
             }
+            Err(PrepareBatchesError::Closed) => {
+                debug!(
+                    ?block_digest,
+                    "verification request found the databases closed during shutdown"
+                );
+                ProcessedBlock::Cancelled
+            }
             Err(PrepareBatchesError::Incomplete) => {
                 debug!(
                     ?block_digest,
@@ -223,7 +224,6 @@ where
         marshal: MarshalMailbox<S, V>,
         block_digest: PendingDigest<A, E>,
         ancestry: &mut impl Ancestry<A::Block>,
-        progress: &VerificationProgress<PendingDigest<A, E>>,
         verification: &mut Verification,
     ) -> Result<PreparedParent<A, E>, PrepareFailure>
     where
@@ -239,8 +239,8 @@ where
                     "verification request waiting on incomplete parent ancestry"
                 );
 
-                // As with incomplete candidate ancestry, only cancellation or
-                // actor-driven invalidation should release this pending request.
+                // As with incomplete candidate ancestry, only the caller
+                // leaving should release this pending request.
                 verification.cancelled().await;
                 return Err(PrepareFailure::Cancelled);
             }
@@ -261,10 +261,7 @@ where
                 marshal,
                 block.clone(),
                 verification,
-                Some(ReplayTracking {
-                    flights: &self.replays,
-                    progress,
-                }),
+                Some(&self.replays),
             )
             .await
         {
@@ -296,6 +293,13 @@ where
                 );
                 return Err(PrepareFailure::Cancelled);
             }
+            Err(PrepareBatchesError::Closed) => {
+                debug!(
+                    parent_digest = ?digest,
+                    "verification found the databases closed during shutdown"
+                );
+                return Err(PrepareFailure::Cancelled);
+            }
         };
 
         Ok(PreparedParent {
@@ -314,7 +318,7 @@ where
         parent: PreparedParent<A, E>,
         ancestry: impl Ancestry<A::Block>,
         verification: &mut Verification,
-    ) -> Option<bool> {
+    ) -> VerificationResult {
         let block_digest = block.digest();
         let round = consensus_context.round();
 
@@ -340,7 +344,7 @@ where
                     parent_digest = ?parent.digest,
                     "verification request cancelled during verify"
                 );
-                return None;
+                return VerificationResult::Cancelled;
             }
         };
 
@@ -348,9 +352,9 @@ where
             warn!(
                 parent_digest = ?parent.digest,
                 ?block_digest,
-                "verification rejected: app.verify returned None"
+                "verification rejected: application returned None"
             );
-            return Some(false);
+            return VerificationResult::Decided(false);
         };
         let tail = info_span!(
             "stateful.processor.match_commitments",
@@ -367,7 +371,7 @@ where
                 ?block_digest,
                 "verification rejected: verified state must match block commitments"
             );
-            return Some(false);
+            return VerificationResult::Decided(false);
         }
         if !self
             .execution
@@ -378,11 +382,11 @@ where
                 ?block_digest,
                 "verification result became incompatible before caching"
             );
-            return Some(false);
+            return VerificationResult::Decided(false);
         }
         self.execution.update_pending_metric();
         drop(block);
         drop(tail);
-        Some(true)
+        VerificationResult::Decided(true)
     }
 }

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -1,11 +1,11 @@
 use super::{
     BlockDigest, SyncResult,
-    mailbox::{Mailbox, Message},
+    mailbox::{Mailbox, Message, UpdateOutcome},
     resolve_state_sync_floor,
 };
 use crate::stateful::{
     Application,
-    db::{Anchor, DatabaseSet, StateSyncSet, SyncEngineConfig},
+    db::{DatabaseSet, StateSyncSet, SyncEngineConfig},
 };
 use commonware_actor::mailbox::{self as actor_mailbox, Receiver};
 use commonware_consensus::{
@@ -70,9 +70,6 @@ where
     /// The mailbox.
     mailbox: Receiver<Message<E, A>>,
 
-    /// The produced state sync artifact, if complete.
-    artifact: Option<SyncResult<E, A>>,
-
     /// Database configuration for the managed set.
     db_config: <A::Databases as DatabaseSet<E>>::Config,
 
@@ -108,7 +105,6 @@ where
             Self {
                 context: ContextCell::new(config.context),
                 mailbox: receiver,
-                artifact: None,
                 db_config: config.db_config,
                 sync_config: config.sync_config,
                 resolvers: config.resolvers,
@@ -148,18 +144,15 @@ where
             },
             result = &mut state_sync_task => match result {
                 Ok((databases, anchor)) => {
-                    Self::publish_artifact(
-                        &mut self.artifact,
-                        &mut self.sync_complete,
-                        databases,
-                        anchor,
-                    );
+                    if let Some(sync_complete) = self.sync_complete.take() {
+                        sync_complete.send_lossy(SyncResult { databases, anchor });
+                    }
                     state_sync_task = None.into();
 
                     // A tip update enqueued after the coordinator's final drain has no
                     // receiver left to record it or release its observation barrier.
                     // Dropping the sender frees the ring buffer, so the observer of any
-                    // queued update retries and receives the artifact.
+                    // queued update retries and learns sync completed.
                     tip_updates_tx = None;
                 }
                 Err(err) => {
@@ -171,13 +164,13 @@ where
                 break;
             } => match message {
                 Message::UpdateTargets { update, response } => {
-                    if let Some(artifact) = self.artifact.clone() {
-                        response.send_lossy(Some(artifact));
+                    if self.sync_complete.is_none() {
+                        response.send_lossy(UpdateOutcome::SyncCompleted);
                         continue;
                     }
 
                     // If sync had already completed, the state-sync branch above would
-                    // have published `self.artifact` before this mailbox branch ran.
+                    // have consumed the completion sender before this mailbox branch ran.
                     let tip_updates = tip_updates_tx
                         .as_mut()
                         .expect("ring sender lives until the artifact is published");
@@ -188,38 +181,24 @@ where
                         // publish its artifact", not as a hard failure.
                         match (&mut state_sync_task).await {
                             Ok((databases, anchor)) => {
-                                Self::publish_artifact(
-                                    &mut self.artifact,
-                                    &mut self.sync_complete,
-                                    databases,
-                                    anchor,
-                                );
                                 state_sync_task = None.into();
+                                let sync_complete = self
+                                    .sync_complete
+                                    .take()
+                                    .expect("completion sender present until sync completes");
+                                sync_complete.send_lossy(SyncResult { databases, anchor });
+                                response.send_lossy(UpdateOutcome::SyncCompleted);
                             }
                             Err(err) => {
                                 panic!("state sync task failed: {err:?}");
                             }
                         }
                         tip_updates_tx = None;
-                        response.send_lossy(self.artifact.clone());
                         continue;
                     }
-                    response.send_lossy(None);
+                    response.send_lossy(UpdateOutcome::Observed);
                 }
             },
-        }
-    }
-
-    fn publish_artifact(
-        artifact: &mut Option<SyncResult<E, A>>,
-        sync_complete: &mut Option<oneshot::Sender<SyncResult<E, A>>>,
-        databases: A::Databases,
-        anchor: Anchor<BlockDigest<A, E>>,
-    ) {
-        let sync_result = SyncResult { databases, anchor };
-        *artifact = Some(sync_result.clone());
-        if let Some(sync_complete) = sync_complete.take() {
-            sync_complete.send_lossy(sync_result);
         }
     }
 }
@@ -229,7 +208,7 @@ mod tests {
     use super::{Config, Syncer, resolve_state_sync_floor};
     use crate::stateful::{
         Application, Input, Proposed,
-        actor::syncer::{StateSyncMetadata, init_databases_from_marshal},
+        actor::syncer::{StateSyncMetadata, UpdateOutcome, init_databases_from_marshal},
         db::{Anchor, Barrier, DatabaseSet, StateSyncSet, SyncEngineConfig, TipUpdate},
         tests::{
             fixtures::{self, MarshalFixture},
@@ -266,10 +245,10 @@ mod tests {
     impl DatabaseSet<deterministic::Context> for WedgeSet {
         type Unmerkleized = TestUnmerkleized;
         type Merkleized = TestMerkleized;
-        type Readers = ();
         type Snapshots = ();
         type Config = u64;
         type SyncTargets = u64;
+        type Handles = ();
 
         async fn init(_context: deterministic::Context, config: Self::Config) -> Self {
             Self(config)
@@ -279,7 +258,11 @@ mod tests {
             0
         }
 
-        async fn new_batches(&self) -> Self::Unmerkleized {
+        fn handles(&self) -> Self::Handles {}
+
+        async fn new_batches(
+            _handles: &Self::Handles,
+        ) -> Result<Self::Unmerkleized, crate::stateful::db::live::Closed> {
             unreachable!("WedgeSet only serves the syncer harness")
         }
 
@@ -291,26 +274,25 @@ mod tests {
             unreachable!("WedgeSet only serves the syncer harness")
         }
 
-        fn readers(&self) -> Self::Readers {}
-
-        async fn finalize(&self, _batches: Self::Merkleized) -> (Self::Snapshots, Barrier) {
+        async fn finalize(self, _batches: Self::Merkleized) -> (Self, Self::Snapshots, Barrier) {
             unreachable!("WedgeSet only serves the syncer harness")
         }
 
-        async fn snapshot(&self) -> Self::Snapshots {
+        async fn snapshot(self) -> (Self, Self::Snapshots) {
+            (self, ())
+        }
+
+        async fn prune(self, _targets: &Self::SyncTargets) -> Self {
             unreachable!("WedgeSet only serves the syncer harness")
         }
 
-        async fn prune(&self, _targets: &Self::SyncTargets) {
-            unreachable!("WedgeSet only serves the syncer harness")
-        }
-
-        async fn committed_targets(&self) -> Self::SyncTargets {
+        async fn applied_targets(&self) -> Self::SyncTargets {
             self.0
         }
 
-        async fn rewind_to_targets(&self, targets: Self::SyncTargets) {
+        async fn rewind_to_targets(self, targets: Self::SyncTargets) -> Self {
             assert_eq!(targets, self.0, "test database cannot rewind");
+            self
         }
     }
 
@@ -462,7 +444,7 @@ mod tests {
             .await;
 
             assert_eq!(startup.sync.anchor.height, Height::new(2));
-            assert_eq!(startup.sync.databases.committed_targets().await, 2);
+            assert_eq!(startup.sync.databases.applied_targets().await, 2);
             assert_eq!(startup.skip_finalized_until, Some(Height::new(2)));
         });
     }
@@ -770,14 +752,16 @@ mod tests {
 
             // The update is forwarded into the ring buffer and its observation parks before
             // the sync task completes (the task's clock only advances at quiescence). The
-            // stranded observation must resolve through a retry that returns the artifact.
+            // stranded observation must resolve through a retry that reports completion,
+            // with the artifact arriving on the completion channel.
             let update = context
                 .child("update")
                 .spawn(move |_| async move { mailbox.update_targets(anchor(1, 1), 1).await });
-            let result = update.await.expect("update task failed");
-            assert!(
-                matches!(&result, Some(artifact) if artifact.anchor.height == Height::zero()),
-                "stranded update must resolve to the completed artifact",
+            let outcome = update.await.expect("update task failed");
+            assert_eq!(
+                outcome,
+                UpdateOutcome::SyncCompleted,
+                "stranded update must report the completed sync"
             );
 
             let artifact = sync_completed.await.expect("artifact must publish");

--- a/glue/src/stateful/actor/syncer/mailbox.rs
+++ b/glue/src/stateful/actor/syncer/mailbox.rs
@@ -1,6 +1,5 @@
 //! [`Syncer`](super::Syncer) actor ingress.
 
-use super::SyncResult;
 use crate::stateful::{
     Application,
     db::{Anchor, DatabaseSet, TipUpdate},
@@ -14,6 +13,17 @@ use rand_core::Rng;
 type SyncTargets<E, A> = <<A as Application<E>>::Databases as DatabaseSet<E>>::SyncTargets;
 type BlockDigest<E, A> = <<A as Application<E>>::Block as Digestible>::Digest;
 
+/// Reply to [`Mailbox::update_targets`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum UpdateOutcome {
+    /// The live sync coordinator recorded the update, so the eventual sync
+    /// artifact reflects this target or a newer one.
+    Observed,
+    /// State sync already completed, so no coordinator remains to record the
+    /// update. The artifact is on the completion channel.
+    SyncCompleted,
+}
+
 pub(crate) enum Message<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -21,7 +31,8 @@ where
 {
     UpdateTargets {
         update: TipUpdate<BlockDigest<E, A>, SyncTargets<E, A>>,
-        response: oneshot::Sender<Option<SyncResult<E, A>>>,
+        /// Reports whether the update was recorded or sync already completed.
+        response: oneshot::Sender<UpdateOutcome>,
     },
 }
 
@@ -78,49 +89,51 @@ where
 
     /// Sends a target update and waits until the live sync coordinator records it.
     ///
-    /// If sync already completed before the update could be observed, returns the
-    /// completed artifact instead.
+    /// If sync already completed, the artifact arrives on the completion channel.
     pub async fn update_targets(
         &self,
         anchor: Anchor<BlockDigest<E, A>>,
         targets: SyncTargets<E, A>,
-    ) -> Option<SyncResult<E, A>> {
+    ) -> UpdateOutcome {
         loop {
             let (update, observed) = TipUpdate::with_observation(anchor, targets.clone());
             let (response, receiver) = oneshot::channel();
-            let _ = self
+            let feedback = self
                 .sender
                 .enqueue(Message::UpdateTargets { update, response });
+            assert!(
+                feedback.accepted(),
+                "syncer must outlive update_targets callers",
+            );
 
-            match receiver
-                .await
-                .expect("Syncer should respond to update_targets")
-            {
-                Some(artifact) => return Some(artifact),
-                None => {
-                    // Wait until the live sync coordinator has recorded the new tip update.
-                    // Enqueueing it into Syncer is not enough to prove the eventual sync
-                    // artifact includes the target or to discard its handoff state.
-                    if observed.await.is_ok() {
-                        return None;
-                    }
-
-                    // The active coordinator dropped before recording this update.
-                    // Retry so Syncer can either hand the update to the next coordinator
-                    // or report the completed sync artifact.
-                }
+            let Ok(outcome) = receiver.await else {
+                // A newer queued update displaced this one before the syncer saw
+                // it (the queue keeps only the newest update), or the syncer died
+                // with the message queued.
+                continue;
+            };
+            if outcome == UpdateOutcome::SyncCompleted {
+                return outcome;
             }
+
+            // Wait until the live sync coordinator has recorded the new tip update.
+            // Enqueueing it into Syncer is not enough to prove the eventual sync
+            // artifact includes the target or to discard its handoff state.
+            if observed.await.is_ok() {
+                return UpdateOutcome::Observed;
+            }
+
+            // The active coordinator dropped before recording this update.
+            // Retry so Syncer can either hand the update to the next coordinator
+            // or report the completed sync.
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{Mailbox, Message};
-    use crate::stateful::{
-        actor::syncer::SyncResult,
-        tests::mocks::{TestApp, anchor, test_databases},
-    };
+    use super::{Mailbox, Message, UpdateOutcome};
+    use crate::stateful::tests::mocks::{TestApp, anchor};
     use commonware_actor::mailbox as actor_mailbox;
     use commonware_runtime::{Runner as _, Supervisor as _, deterministic};
     use commonware_utils::NZUsize;
@@ -139,35 +152,64 @@ mod tests {
                 panic!("first update should be sent");
             };
             assert!(
-                response.send(None).is_ok(),
+                response.send(UpdateOutcome::Observed).is_ok(),
                 "response receiver should be alive"
             );
             drop(update);
 
             assert!(update_targets.as_mut().now_or_never().is_none());
 
-            let expected = SyncResult::<deterministic::Context, TestApp> {
-                databases: test_databases(),
-                anchor: anchor(8, 10),
-            };
             let Some(Message::UpdateTargets { response, .. }) = receiver.recv().await else {
                 panic!("dropped observation should trigger a retry");
             };
             assert!(
-                response.send(Some(expected.clone())).is_ok(),
+                response.send(UpdateOutcome::SyncCompleted).is_ok(),
                 "response receiver should be alive"
             );
 
-            let result = update_targets.await;
             assert_eq!(
-                result.expect("retry should return artifact").anchor,
-                expected.anchor
+                update_targets.await,
+                UpdateOutcome::SyncCompleted,
+                "retry should report the completed sync"
             );
         });
     }
 
     #[test]
-    fn update_targets_returns_none_only_after_observation_is_recorded() {
+    fn update_targets_retries_when_response_is_displaced() {
+        deterministic::Runner::default().start(|context| async move {
+            let (sender, mut receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mailbox = Mailbox::<deterministic::Context, TestApp>::new(sender);
+            let mut update_targets = Box::pin(mailbox.update_targets(anchor(7, 9), 7));
+
+            assert!(update_targets.as_mut().now_or_never().is_none());
+
+            // Drop the message without responding, as overflow displacement does.
+            let Some(message) = receiver.recv().await else {
+                panic!("first update should be sent");
+            };
+            drop(message);
+
+            assert!(update_targets.as_mut().now_or_never().is_none());
+
+            let Some(Message::UpdateTargets { response, .. }) = receiver.recv().await else {
+                panic!("displaced response should trigger a retry");
+            };
+            assert!(
+                response.send(UpdateOutcome::SyncCompleted).is_ok(),
+                "response receiver should be alive"
+            );
+
+            assert_eq!(
+                update_targets.await,
+                UpdateOutcome::SyncCompleted,
+                "retry should report the completed sync"
+            );
+        });
+    }
+
+    #[test]
+    fn update_targets_resolves_only_after_observation_is_recorded() {
         deterministic::Runner::default().start(|context| async move {
             let (sender, mut receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(1));
             let mailbox = Mailbox::<deterministic::Context, TestApp>::new(sender);
@@ -179,7 +221,7 @@ mod tests {
                 panic!("update should be sent");
             };
             assert!(
-                response.send(None).is_ok(),
+                response.send(UpdateOutcome::Observed).is_ok(),
                 "response receiver should be alive"
             );
 
@@ -187,7 +229,11 @@ mod tests {
 
             update.record(|_, _| {});
 
-            assert!(update_targets.await.is_none());
+            assert_eq!(
+                update_targets.await,
+                UpdateOutcome::Observed,
+                "recorded update should report observation"
+            );
         });
     }
 }

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -25,7 +25,7 @@ mod actor;
 pub(crate) use actor::{Config, Syncer};
 
 pub(crate) mod mailbox;
-pub(crate) use mailbox::Mailbox;
+pub(crate) use mailbox::{Mailbox, UpdateOutcome};
 
 mod plan;
 pub use plan::SyncPlan;
@@ -131,23 +131,10 @@ where
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
 {
-    /// The database handle set.
+    /// The owned database set produced by sync.
     pub databases: A::Databases,
     /// The anchor at which state sync completed.
     pub anchor: Anchor<BlockDigest<A, E>>,
-}
-
-impl<E, A> Clone for SyncResult<E, A>
-where
-    E: Rng + Spawner + Metrics + Clock,
-    A: Application<E>,
-{
-    fn clone(&self) -> Self {
-        Self {
-            databases: self.databases.clone(),
-            anchor: self.anchor,
-        }
-    }
 }
 
 /// Resolved state sync floor data derived from the selected finalization and marshal progress.
@@ -418,20 +405,18 @@ where
         .chain((floor_block.height() > marshal_floor).then_some(floor_block.height()))
         .max();
 
-    let databases = A::Databases::init(context.child("db_set"), db_config).await;
+    let mut databases = A::Databases::init(context.child("db_set"), db_config).await;
     let processed_targets = A::sync_targets(&floor_block);
 
-    // In the case that the committed targets do not match the marshal floor, we may
+    // In the case that the applied targets do not match the marshal floor, we may
     // have suffered a crash that left the set in an inconsistent state. In this case,
     // we attempt to repair by rewinding the databases back to the marshal floor. If
     // the rewind fails to produce a consistent state, we must crash. This can occur
     // if the databases were corrupted or pruned too aggressively.
-    let committed = databases.committed_targets().await;
-    if committed != processed_targets {
-        databases.rewind_to_targets(processed_targets.clone()).await;
-        let rewound_targets = databases.committed_targets().await;
+    if databases.applied_targets().await != processed_targets {
+        databases = databases.rewind_to_targets(processed_targets.clone()).await;
         assert!(
-            rewound_targets == processed_targets,
+            databases.applied_targets().await == processed_targets,
             "databases must be consistent with marshal floor after rewind"
         );
     }

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -1,13 +1,13 @@
 //! [`ManagedDb`] implementation for QMDB [`any`](commonware_storage::qmdb::any) databases.
 //!
 //! The QMDB batch API passes `&db` to `get()` and `merkleize()` for
-//! read-through to applied state. This module provides wrapper types
-//! that capture a [`Shared`] database handle alongside the raw batch so the
-//! [`Unmerkleized`](super::Unmerkleized) and [`Merkleized`](super::Merkleized)
-//! traits can be implemented without a DB parameter.
+//! read-through to applied state. The wrapper types here hold a [`Reader`]
+//! to their database and lease it for each such call, so a batch stays usable
+//! across applies of compatible batches and never delays a mutation by more
+//! than one storage call.
 
 use crate::stateful::db::{
-    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    Closed, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Reader, StateSyncDb,
     SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{Codec, Read as CodecRead};
@@ -48,44 +48,45 @@ use std::{
 // Matches commonware_storage::qmdb::any::BITMAP_CHUNK_BYTES, which is crate-private.
 const ANY_BITMAP_CHUNK_BYTES: usize = 64;
 
-/// Wraps a QMDB [`UnmerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Unmerkleized`](super::Unmerkleized) trait.
+/// The `any` database type the wrapper batches read through.
+type AnyDb<F, E, C, I, H, U, S> = Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>;
+
+/// Wraps a QMDB [`UnmerkleizedBatch`] to implement [`Unmerkleized`](super::Unmerkleized).
 pub struct AnyUnmerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, S>,
-    db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
     metadata: Option<U::Value>,
+    handle: Reader<AnyDb<F, E, C, I, H, U, S>>,
 }
 
-/// Staged batch returned by [`AnyUnmerkleized::stage`], wrapping a QMDB [`Staged`] with a
-/// reference to the parent database.
+/// Staged batch returned by [`AnyUnmerkleized::stage`], wrapping a QMDB [`Staged`].
 ///
-/// Like any speculative batch, this handle is a branch-scoped view of the shared database: it
-/// stays valid only while every batch finalized on the database is an ancestor of this batch
-/// (see [`MerkleizedBatch`]'s branch-validity contract).
+/// A branch-scoped view of the database. It stays valid only while every batch finalized on
+/// the database is an ancestor of this batch (see [`MerkleizedBatch`]'s branch-validity
+/// contract).
 pub struct AnyStaged<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     staged: Staged<F, H, U, S>,
-    db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
     metadata: Option<U::Value>,
+    handle: Reader<AnyDb<F, E, C, I, H, U, S>>,
 }
 
 /// Key-value operations shared by both `any` update kinds.
@@ -93,10 +94,10 @@ impl<F, E, C, I, H, U, S> AnyUnmerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -109,16 +110,18 @@ where
 
     /// Read a value by key, falling back to applied state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get(key, &db).await
+        self.batch
+            .get(key, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values by key, falling back to applied state.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get_many(keys, &db).await
+        self.batch
+            .get_many(keys, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values and return a staged batch for the same keys.
@@ -130,19 +133,18 @@ where
     ) -> Result<(Vec<Option<U::Value>>, AnyStaged<F, E, C, I, H, U, S>), Error<F>> {
         let Self {
             batch,
-            db,
             metadata,
+            handle,
         } = self;
-        let (values, staged) = {
-            let guard = db.read().await;
-            batch.stage(keys, &guard).await?
-        };
+        let (values, staged) = batch
+            .stage(keys, &*handle.read().await.map_err(Closed::storage)?)
+            .await?;
         Ok((
             values,
             AnyStaged {
                 staged,
-                db,
                 metadata,
+                handle,
             },
         ))
     }
@@ -154,50 +156,30 @@ where
     }
 }
 
-/// Wraps a QMDB [`MerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Merkleized`](super::Merkleized) trait.
+/// Wraps a QMDB [`MerkleizedBatch`] to implement [`Merkleized`](super::Merkleized).
 pub struct AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, U, S>>,
-    db: Shared<Db<F, E, C, I, H, U, ANY_BITMAP_CHUNK_BYTES, S>>,
-}
-
-impl<F, E, C, I, H, U, S> Clone for AnyMerkleized<F, E, C, I, H, U, S>
-where
-    F: Family,
-    E: Context,
-    U: Update,
-    C: Contiguous<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-            db: self.db.clone(),
-        }
-    }
+    handle: Reader<AnyDb<F, E, C, I, H, U, S>>,
 }
 
 impl<F, E, C, I, H, U, S> Deref for AnyUnmerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -208,14 +190,33 @@ where
     }
 }
 
+impl<F, E, C, I, H, U, S> Clone for AnyMerkleized<F, E, C, I, H, U, S>
+where
+    F: Family,
+    E: Context,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    U: Update,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            handle: self.handle.clone(),
+        }
+    }
+}
+
 impl<F, E, C, I, H, U, S> Deref for AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -231,10 +232,10 @@ impl<F, E, C, I, H, U, S> AnyStaged<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -257,20 +258,19 @@ where
     ) -> Result<(Range<usize>, Vec<Option<U::Value>>, Self), Error<F>> {
         let Self {
             staged,
-            db,
             metadata,
+            handle,
         } = self;
-        let (range, values, staged) = {
-            let guard = db.read().await;
-            staged.expand(keys, &guard).await?
-        };
+        let (range, values, staged) = staged
+            .expand(keys, &*handle.read().await.map_err(Closed::storage)?)
+            .await?;
         Ok((
             range,
             values,
             Self {
                 staged,
-                db,
                 metadata,
+                handle,
             },
         ))
     }
@@ -281,11 +281,11 @@ impl<F, E, C, I, H, K, V, S> AnyStaged<F, E, C, I, H, unordered::Update<K, V>, S
 where
     F: Family,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, unordered::Update<K, V>>: Codec,
 {
@@ -309,14 +309,18 @@ where
     ) -> Result<AnyMerkleized<F, E, C, I, H, unordered::Update<K, V>, S>, Error<F>> {
         let Self {
             staged,
-            db,
             metadata,
+            handle,
         } = self;
-        let inner = {
-            let guard = db.read().await;
-            staged.merkleize(updates, upserts, metadata, &guard).await?
-        };
-        Ok(AnyMerkleized { inner, db })
+        let inner = staged
+            .merkleize(
+                updates,
+                upserts,
+                metadata,
+                &*handle.read().await.map_err(Closed::storage)?,
+            )
+            .await?;
+        Ok(AnyMerkleized { inner, handle })
     }
 }
 
@@ -325,11 +329,11 @@ impl<F, E, C, I, H, K, V, S> AnyStaged<F, E, C, I, H, ordered::Update<K, V>, S>
 where
     F: Family,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, ordered::Update<K, V>>: Codec,
 {
@@ -353,14 +357,18 @@ where
     ) -> Result<AnyMerkleized<F, E, C, I, H, ordered::Update<K, V>, S>, Error<F>> {
         let Self {
             staged,
-            db,
             metadata,
+            handle,
         } = self;
-        let inner = {
-            let guard = db.read().await;
-            staged.merkleize(updates, upserts, metadata, &guard).await?
-        };
-        Ok(AnyMerkleized { inner, db })
+        let inner = staged
+            .merkleize(
+                updates,
+                upserts,
+                metadata,
+                &*handle.read().await.map_err(Closed::storage)?,
+            )
+            .await?;
+        Ok(AnyMerkleized { inner, handle })
     }
 }
 
@@ -369,25 +377,27 @@ impl<F, E, C, I, H, U, S> AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     /// Read a value by key, falling back to applied state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get(key, &db).await
+        self.inner
+            .get(key, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values by key, falling back to applied state.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get_many(keys, &db).await
+        self.inner
+            .get_many(keys, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 }
 
@@ -397,11 +407,11 @@ impl<F, E, C, I, H, K, V, S> UnmerkleizedTrait
 where
     F: Family,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, unordered::Update<K, V>>: Codec,
 {
@@ -409,12 +419,15 @@ where
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
-        Ok(AnyMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        let Self {
+            batch,
+            metadata,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(&*handle.read().await.map_err(Closed::storage)?, metadata)
+            .await?;
+        Ok(AnyMerkleized { inner, handle })
     }
 }
 
@@ -424,11 +437,11 @@ impl<F, E, C, I, H, K, V, S> UnmerkleizedTrait
 where
     F: Family,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, ordered::Update<K, V>>: Codec,
 {
@@ -436,12 +449,15 @@ where
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
-        Ok(AnyMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        let Self {
+            batch,
+            metadata,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(&*handle.read().await.map_err(Closed::storage)?, metadata)
+            .await?;
+        Ok(AnyMerkleized { inner, handle })
     }
 }
 
@@ -450,17 +466,15 @@ impl<F, E, C, I, H, U, S> MerkleizedTrait for AnyMerkleized<F, E, C, I, H, U, S>
 where
     F: Family,
     E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>> + 'static,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
-    AnyUnmerkleized<F, E, C, I, H, U, S>: UnmerkleizedTrait,
 {
     type Digest = H::Digest;
     type Unmerkleized = AnyUnmerkleized<F, E, C, I, H, U, S>;
-
     fn root(&self) -> H::Digest {
         self.inner.root()
     }
@@ -468,20 +482,13 @@ where
     fn new_batch(&self) -> Self::Unmerkleized {
         AnyUnmerkleized {
             batch: self.inner.new_batch::<H>(),
-            db: self.db.clone(),
             metadata: None,
+            handle: self.handle.clone(),
         }
     }
 }
 
 /// Implement [`ManagedDb`] for unordered QMDB databases with fixed-size values.
-///
-/// `new_batch` captures the [`Shared`] database handle in the returned
-/// wrapper so that `get()` and `merkleize()` can read through to
-/// applied state.
-///
-/// `finalize` applies the merkleized batch's changeset and starts
-/// persisting it, reporting durability on the returned handle.
 impl<F, E, K, V, H, T, S> ManagedDb<E>
     for Db<
         F,
@@ -537,13 +544,13 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        AnyUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let batch = handle.read().await?.new_batch();
+        Ok(AnyUnmerkleized {
+            batch,
             metadata: None,
-        }
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -657,13 +664,13 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        AnyUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let batch = handle.read().await?.new_batch();
+        Ok(AnyUnmerkleized {
+            batch,
             metadata: None,
-        }
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -810,6 +817,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stateful::db::{DatabaseSet, Single};
+    use commonware_codec::Encode as _;
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_parallel::Sequential;
     use commonware_runtime::{
@@ -820,8 +829,12 @@ mod tests {
     };
     use commonware_storage::{
         journal::contiguous::fixed::Config as FixedJournalConfig,
-        merkle::{full::Config as MerkleConfig, mmr},
-        qmdb::any::unordered::fixed,
+        merkle::{Location, full::Config as MerkleConfig, mmr},
+        qmdb::{
+            self,
+            any::unordered::fixed,
+            sync::{Request, Response, Source as SyncSource},
+        },
         translator::TwoCap,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};
@@ -857,41 +870,11 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unmerkleized_batch_falls_through_to_applied_state() {
-        deterministic::Runner::default().start(|context| async move {
-            let config = fixed_config("unordered-fixed-live-fallback", &context);
-            let db = <UnorderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
-                .await
-                .unwrap();
-            let db = Shared::new("test", db);
-
-            let key = Sha256::hash(&[b"key"]);
-            let value = Sha256::hash(&[b"winner"]);
-            let pre_finalization = db.new_batch_for_test::<_>().await;
-            let winner = db.new_batch_for_test::<_>().await.write(key, Some(value));
-            let winner = crate::stateful::db::Unmerkleized::merkleize(winner)
-                .await
-                .unwrap();
-
-            let (slot, database) = db.write().await;
-            let (database, _snapshot, sync) =
-                <UnorderedFixedDb as ManagedDb<_>>::finalize(database, winner)
-                    .await
-                    .unwrap();
-            slot.put(database);
-            sync.await.expect("finalize flush failed");
-
-            // The batch commitment does not provide a historical database view.
-            assert_eq!(pre_finalization.get(&key).await.unwrap(), Some(value));
-        });
-    }
-
     /// The glue staged wrapper (`AnyUnmerkleized::stage` -> `AnyStaged::expand` ->
     /// `AnyStaged::merkleize`) must return the same values and root as an explicit `get_many` +
     /// `write` + `merkleize`, including a staged delete, an upsert, and metadata flow (both set
     /// on the staged handle via `with_metadata` and carried from before staging). This guards
-    /// metadata flow and db-handle pairing through the wrapper.
+    /// metadata flow through the wrapper.
     #[test]
     fn unordered_fixed_staged_merkleize_matches_explicit_writes() {
         deterministic::Runner::default().start(|context| async move {
@@ -899,29 +882,23 @@ mod tests {
             let db = <UnorderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
-
+            let set = Single::from(db);
             let key = |i: u64| Sha256::hash(&[&i.to_be_bytes()]);
             let val = |i: u64| Sha256::hash(&[&(i + 10_000).to_be_bytes()]);
             let metadata = Sha256::hash(&[b"metadata"]);
 
             // Seed keys 0..50 and finalize.
-            let mut seed = db.new_batch_for_test::<_>().await;
+            let mut seed = <UnorderedFixedDb as ManagedDb<_>>::new_batch(set.handle())
+                .await
+                .expect("writer is live");
             for i in 0..50u64 {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(seed)
                 .await
                 .unwrap();
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <UnorderedFixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
+            let (set, _, barrier) = DatabaseSet::finalize(set, merkleized).await;
+            assert!(barrier.durable().await, "finalize flush failed");
 
             // Read set: key(1) updated, key(2) deleted, key(999) missing -> created.
             let read_keys = [key(1), key(2), key(999)];
@@ -930,7 +907,9 @@ mod tests {
             let upserts = vec![(key(3), Some(val(1_002)))];
 
             // Explicit path.
-            let mut explicit = db.new_batch_for_test::<_>().await;
+            let mut explicit = <UnorderedFixedDb as ManagedDb<_>>::new_batch(set.handle())
+                .await
+                .expect("writer is live");
             let explicit_values = explicit.get_many(&keys).await.unwrap();
             for (slot, value) in &indexed_updates {
                 explicit = explicit.write(read_keys[*slot], *value);
@@ -945,7 +924,9 @@ mod tests {
                     .root();
 
             // Staged path, with metadata set on the staged handle.
-            let staged_batch = db.new_batch_for_test::<_>().await;
+            let staged_batch = <UnorderedFixedDb as ManagedDb<_>>::new_batch(set.handle())
+                .await
+                .expect("writer is live");
             let split = 2;
             let (mut staged_values, staged) = staged_batch.stage(&keys[..split]).await.unwrap();
             let (range, suffix_values, staged) = staged.expand(&keys[split..]).await.unwrap();
@@ -962,7 +943,10 @@ mod tests {
             assert_eq!(explicit_root, staged_root);
 
             // Metadata set before staging must be carried through to staged merkleize.
-            let carried_batch = db.new_batch_for_test::<_>().await.with_metadata(metadata);
+            let carried_batch = <UnorderedFixedDb as ManagedDb<_>>::new_batch(set.handle())
+                .await
+                .expect("writer is live")
+                .with_metadata(metadata);
             let (carried_values, staged) = carried_batch.stage(&keys).await.unwrap();
             let carried_root = staged
                 .merkleize(indexed_updates.clone(), upserts.clone())
@@ -984,9 +968,10 @@ mod tests {
         Sequential,
     >;
 
-    /// `finalize` must return, with the batch readable through the shared
-    /// handle, while its flush is still parked at the storage layer.
-    /// Durability is reported only on the returned handle.
+    /// `finalize` must return, with the batch readable through the set's
+    /// handles, while its flush is still parked at the storage layer.
+    /// Durability is reported only on the returned barrier, and the captured
+    /// snapshot must already prove the post-apply state.
     #[test]
     fn finalize_defers_flush_to_returned_handle() {
         deterministic::Runner::default().start(|context| async move {
@@ -1002,36 +987,69 @@ mod tests {
             )
             .await
             .unwrap();
-            let db = Shared::new("test", db);
+            let set = Single::from(db);
 
             let key = Sha256::hash(&[b"key"]);
             let value = Sha256::hash(&[b"value"]);
-            let batch = db.new_batch_for_test::<_>().await.write(key, Some(value));
+            let batch = <DelayedFixedDb as ManagedDb<_>>::new_batch(set.handle())
+                .await
+                .expect("writer is live")
+                .write(key, Some(value));
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
                 .await
                 .unwrap();
-
-            let (slot, database) = db.write().await;
-            let (database, _snapshot, sync) =
-                <DelayedFixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
-            slot.put(database);
+            let (set, snapshot, barrier) = DatabaseSet::finalize(set, merkleized).await;
 
             // The flush is parked, yet the batch is already readable.
             assert!(
                 pending.starts() > pending.completions(),
                 "finalize must leave its flush parked",
             );
-            {
-                let guard = db.read().await;
-                assert_eq!(guard.get(&key).await.unwrap(), Some(value));
-            }
+            let db = set.handle();
+            assert_eq!(
+                db.read()
+                    .await
+                    .expect("writer is live")
+                    .get(&key)
+                    .await
+                    .unwrap(),
+                Some(value)
+            );
+
+            // The snapshot freezes at the post-apply boundary and proves the
+            // just-applied state, independent of durability.
+            let size = Location::new(snapshot.bounds().end);
+            assert_eq!(
+                size,
+                db.read().await.expect("writer is live").bounds().end,
+                "snapshot must cover the applied batch"
+            );
+            let (response, _) = SyncSource::serve(
+                &*snapshot,
+                Request::Boundary {
+                    size,
+                    start: size - 1,
+                },
+            )
+            .await
+            .expect("captured snapshot must serve its tip");
+            let Response::Boundary { proof, op, .. } = response else {
+                panic!("expected a boundary response");
+            };
+            let root = proof
+                .reconstruct_root(&qmdb::hasher::<Sha256>(), &[op.encode()], size - 1)
+                .expect("served proof must reconstruct");
+            assert_eq!(
+                root,
+                db.read().await.expect("writer is live").root(),
+                "snapshot must prove the post-apply root"
+            );
 
             release_pending_syncs(&pending);
-            drive_pending_syncs(&pending, sync)
-                .await
-                .expect("flush must succeed once released");
+            assert!(
+                drive_pending_syncs(&pending, barrier.durable()).await,
+                "flush must succeed once released"
+            );
         });
     }
 }

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1,13 +1,13 @@
 //! [`ManagedDb`] implementation for QMDB [`current`](commonware_storage::qmdb::current) databases.
 //!
 //! The QMDB batch API passes `&db` to `get()` and `merkleize()` for
-//! read-through to applied state. This module provides wrapper types
-//! that capture a [`Shared`] database handle alongside the raw batch so the
-//! [`Unmerkleized`](super::Unmerkleized) and [`Merkleized`](super::Merkleized)
-//! traits can be implemented without a DB parameter.
+//! read-through to applied state. The wrapper types here hold a [`Reader`]
+//! to their database and lease it for each such call, so a batch stays usable
+//! across applies of compatible batches and never delays a mutation by more
+//! than one storage call.
 
 use crate::stateful::db::{
-    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    Closed, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Reader, StateSyncDb,
     SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{Codec, Read as CodecRead};
@@ -48,44 +48,42 @@ use std::{
     sync::Arc,
 };
 
-/// Wraps a QMDB [`UnmerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Unmerkleized`](super::Unmerkleized) trait.
+/// Wraps a QMDB [`UnmerkleizedBatch`] to implement [`Unmerkleized`](super::Unmerkleized).
 pub struct CurrentUnmerkleized<F, E, C, I, H, U, const N: usize, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, N, S>,
-    db: Shared<Db<F, E, C, I, H, U, N, S>>,
     metadata: Option<U::Value>,
+    handle: Reader<Db<F, E, C, I, H, U, N, S>>,
 }
 
-/// Staged batch returned by [`CurrentUnmerkleized::stage`], wrapping a QMDB [`Staged`] with a
-/// reference to the parent database.
+/// Staged batch returned by [`CurrentUnmerkleized::stage`], wrapping a QMDB [`Staged`].
 ///
-/// Like any speculative batch, this handle is a branch-scoped view of the shared database: it
-/// stays valid only while every batch finalized on the database is an ancestor of this batch
-/// (see [`MerkleizedBatch`]'s branch-validity contract).
+/// A branch-scoped view of the database. It stays valid only while every batch finalized on
+/// the database is an ancestor of this batch (see [`MerkleizedBatch`]'s branch-validity
+/// contract).
 pub struct CurrentStaged<F, E, C, I, H, U, const N: usize, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     staged: Staged<F, H, U, N, S>,
-    db: Shared<Db<F, E, C, I, H, U, N, S>>,
     metadata: Option<U::Value>,
+    handle: Reader<Db<F, E, C, I, H, U, N, S>>,
 }
 
 /// Key-value operations shared by both `current` update kinds.
@@ -93,10 +91,10 @@ impl<F, E, C, I, H, U, const N: usize, S> CurrentUnmerkleized<F, E, C, I, H, U, 
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -109,16 +107,18 @@ where
 
     /// Read a value by key, falling back to applied state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get(key, &db).await
+        self.batch
+            .get(key, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values by key, falling back to applied state.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get_many(keys, &db).await
+        self.batch
+            .get_many(keys, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values and return a staged batch for the same keys.
@@ -130,19 +130,18 @@ where
     ) -> Result<(Vec<Option<U::Value>>, CurrentStaged<F, E, C, I, H, U, N, S>), Error<F>> {
         let Self {
             batch,
-            db,
             metadata,
+            handle,
         } = self;
-        let (values, staged) = {
-            let guard = db.read().await;
-            batch.stage(keys, &guard).await?
-        };
+        let (values, staged) = batch
+            .stage(keys, &*handle.read().await.map_err(Closed::storage)?)
+            .await?;
         Ok((
             values,
             CurrentStaged {
                 staged,
-                db,
                 metadata,
+                handle,
             },
         ))
     }
@@ -154,50 +153,30 @@ where
     }
 }
 
-/// Wraps a QMDB [`MerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Merkleized`](super::Merkleized) trait.
+/// Wraps a QMDB [`MerkleizedBatch`] to implement [`Merkleized`](super::Merkleized).
 pub struct CurrentMerkleized<F, E, C, I, H, U, const N: usize, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, U, N, S>>,
-    db: Shared<Db<F, E, C, I, H, U, N, S>>,
-}
-
-impl<F, E, C, I, H, U, const N: usize, S> Clone for CurrentMerkleized<F, E, C, I, H, U, N, S>
-where
-    F: Graftable,
-    E: Context,
-    U: Update,
-    C: Contiguous<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    fn clone(&self) -> Self {
-        Self {
-            inner: Arc::clone(&self.inner),
-            db: self.db.clone(),
-        }
-    }
+    handle: Reader<Db<F, E, C, I, H, U, N, S>>,
 }
 
 impl<F, E, C, I, H, U, const N: usize, S> Deref for CurrentUnmerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -208,14 +187,33 @@ where
     }
 }
 
+impl<F, E, C, I, H, U, const N: usize, S> Clone for CurrentMerkleized<F, E, C, I, H, U, N, S>
+where
+    F: Graftable,
+    E: Context,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    U: Update,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            handle: self.handle.clone(),
+        }
+    }
+}
+
 impl<F, E, C, I, H, U, const N: usize, S> Deref for CurrentMerkleized<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -231,10 +229,10 @@ impl<F, E, C, I, H, U, const N: usize, S> CurrentStaged<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -257,20 +255,19 @@ where
     ) -> Result<(Range<usize>, Vec<Option<U::Value>>, Self), Error<F>> {
         let Self {
             staged,
-            db,
             metadata,
+            handle,
         } = self;
-        let (range, values, staged) = {
-            let guard = db.read().await;
-            staged.expand(keys, &guard).await?
-        };
+        let (range, values, staged) = staged
+            .expand(keys, &*handle.read().await.map_err(Closed::storage)?)
+            .await?;
         Ok((
             range,
             values,
             Self {
                 staged,
-                db,
                 metadata,
+                handle,
             },
         ))
     }
@@ -282,11 +279,11 @@ impl<F, E, C, I, H, K, V, const N: usize, S>
 where
     F: Graftable,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, unordered::Update<K, V>>: Codec,
 {
@@ -310,14 +307,18 @@ where
     ) -> Result<CurrentMerkleized<F, E, C, I, H, unordered::Update<K, V>, N, S>, Error<F>> {
         let Self {
             staged,
-            db,
             metadata,
+            handle,
         } = self;
-        let inner = {
-            let guard = db.read().await;
-            staged.merkleize(updates, upserts, metadata, &guard).await?
-        };
-        Ok(CurrentMerkleized { inner, db })
+        let inner = staged
+            .merkleize(
+                updates,
+                upserts,
+                metadata,
+                &*handle.read().await.map_err(Closed::storage)?,
+            )
+            .await?;
+        Ok(CurrentMerkleized { inner, handle })
     }
 }
 
@@ -327,11 +328,11 @@ impl<F, E, C, I, H, K, V, const N: usize, S>
 where
     F: Graftable,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, ordered::Update<K, V>>: Codec,
 {
@@ -355,14 +356,18 @@ where
     ) -> Result<CurrentMerkleized<F, E, C, I, H, ordered::Update<K, V>, N, S>, Error<F>> {
         let Self {
             staged,
-            db,
             metadata,
+            handle,
         } = self;
-        let inner = {
-            let guard = db.read().await;
-            staged.merkleize(updates, upserts, metadata, &guard).await?
-        };
-        Ok(CurrentMerkleized { inner, db })
+        let inner = staged
+            .merkleize(
+                updates,
+                upserts,
+                metadata,
+                &*handle.read().await.map_err(Closed::storage)?,
+            )
+            .await?;
+        Ok(CurrentMerkleized { inner, handle })
     }
 }
 
@@ -371,25 +376,27 @@ impl<F, E, C, I, H, U, const N: usize, S> CurrentMerkleized<F, E, C, I, H, U, N,
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
     /// Read a value by key, falling back to applied state.
     pub async fn get(&self, key: &U::Key) -> Result<Option<U::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get(key, &db).await
+        self.inner
+            .get(key, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values by key, falling back to applied state.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&U::Key]) -> Result<Vec<Option<U::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get_many(keys, &db).await
+        self.inner
+            .get_many(keys, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 }
 
@@ -399,11 +406,11 @@ impl<F, E, C, I, H, K, V, const N: usize, S> UnmerkleizedTrait
 where
     F: Graftable,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, unordered::Update<K, V>>>,
     I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, unordered::Update<K, V>>: Codec,
 {
@@ -411,12 +418,15 @@ where
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
-        Ok(CurrentMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        let Self {
+            batch,
+            metadata,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(&*handle.read().await.map_err(Closed::storage)?, metadata)
+            .await?;
+        Ok(CurrentMerkleized { inner, handle })
     }
 }
 
@@ -426,11 +436,11 @@ impl<F, E, C, I, H, K, V, const N: usize, S> UnmerkleizedTrait
 where
     F: Graftable,
     E: Context,
-    K: Key,
-    V: ValueEncoding + 'static,
     C: Mutable<Item = Operation<F, ordered::Update<K, V>>>,
     I: OrderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
+    K: Key,
+    V: ValueEncoding + 'static,
     S: Strategy,
     Operation<F, ordered::Update<K, V>>: Codec,
 {
@@ -438,12 +448,15 @@ where
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self.batch.merkleize(&db, self.metadata).await?;
-        Ok(CurrentMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        let Self {
+            batch,
+            metadata,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(&*handle.read().await.map_err(Closed::storage)?, metadata)
+            .await?;
+        Ok(CurrentMerkleized { inner, handle })
     }
 }
 
@@ -453,17 +466,15 @@ impl<F, E, C, I, H, U, const N: usize, S> MerkleizedTrait
 where
     F: Graftable,
     E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>> + 'static,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
-    CurrentUnmerkleized<F, E, C, I, H, U, N, S>: UnmerkleizedTrait,
 {
     type Digest = H::Digest;
     type Unmerkleized = CurrentUnmerkleized<F, E, C, I, H, U, N, S>;
-
     fn root(&self) -> H::Digest {
         self.inner.root()
     }
@@ -471,8 +482,8 @@ where
     fn new_batch(&self) -> Self::Unmerkleized {
         CurrentUnmerkleized {
             batch: self.inner.new_batch::<H>(),
-            db: self.db.clone(),
             metadata: None,
+            handle: self.handle.clone(),
         }
     }
 }
@@ -535,13 +546,13 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        CurrentUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let batch = handle.read().await?.new_batch();
+        Ok(CurrentUnmerkleized {
+            batch,
             metadata: None,
-        }
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -648,13 +659,13 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        CurrentUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let batch = handle.read().await?.new_batch();
+        Ok(CurrentUnmerkleized {
+            batch,
             metadata: None,
-        }
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -843,13 +854,13 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        CurrentUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let batch = handle.read().await?.new_batch();
+        Ok(CurrentUnmerkleized {
+            batch,
             metadata: None,
-        }
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -965,13 +976,13 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        CurrentUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let batch = handle.read().await?.new_batch();
+        Ok(CurrentUnmerkleized {
+            batch,
             metadata: None,
-        }
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -1217,6 +1228,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stateful::db::{DatabaseSet, Single, live::Writer};
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::boxed;
     use commonware_parallel::Sequential;
@@ -1237,13 +1249,25 @@ mod tests {
     use commonware_utils::{NZU16, NZU64, NZUsize, non_empty_range};
     use std::num::{NonZeroU16, NonZeroUsize};
 
-    /// Finalize `batch` into `db` and wait for the deferred flush, boxing the future
+    /// A fresh batch over the set's single database.
+    async fn new_batch<D: ManagedDb<deterministic::Context> + 'static>(
+        set: &Single<D>,
+    ) -> D::Unmerkleized {
+        <Single<D> as DatabaseSet<deterministic::Context>>::new_batches(&set.handles())
+            .await
+            .expect("writer is live")
+    }
+
+    /// Finalize `batch` into `set` and wait for the deferred flush, boxing the future
     /// ([`ManagedDb::finalize`] embeds the database in its state machine).
     #[boxed]
-    async fn finalize<D: ManagedDb<deterministic::Context>>(db: D, batch: D::Merkleized) -> D {
-        let (db, _snapshot, sync) = D::finalize(db, batch).await.unwrap();
-        sync.await.expect("finalize flush failed");
-        db
+    async fn finalize<D: ManagedDb<deterministic::Context> + 'static>(
+        set: Single<D>,
+        batch: D::Merkleized,
+    ) -> Single<D> {
+        let (set, _, barrier) = DatabaseSet::finalize(set, batch).await;
+        assert!(barrier.durable().await, "finalize flush failed");
+        set
     }
 
     type FixedDb = fixed::Db<
@@ -1351,8 +1375,8 @@ mod tests {
         assert_managed_db::<OrderedVariableDb>();
         assert_state_sync_db::<OrderedFixedDb, Arc<OrderedFixedDb>>();
         assert_state_sync_db::<OrderedVariableDb, Arc<OrderedVariableDb>>();
-        assert_database_set::<Shared<OrderedFixedDb>>();
-        assert_database_set::<Shared<OrderedVariableDb>>();
+        assert_database_set::<crate::stateful::db::Single<OrderedFixedDb>>();
+        assert_database_set::<crate::stateful::db::Single<OrderedVariableDb>>();
     }
 
     #[test]
@@ -1362,14 +1386,13 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
+            let set = Single::from(db);
             let key = Sha256::hash(&[b"key"]);
             let value = Sha256::hash(&[b"value"]);
             let metadata = Sha256::hash(&[b"metadata"]);
             let missing = Sha256::hash(&[b"missing"]);
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = new_batch(&set)
                 .await
                 .write(key, Some(value))
                 .with_metadata(metadata);
@@ -1378,20 +1401,35 @@ mod tests {
                 .unwrap();
             let expected_root = merkleized.root();
 
-            {
-                let (slot, database) = db.write().await;
-                slot.put(finalize::<OrderedFixedDb>(database, merkleized).await);
-            }
+            let (set, snapshot, barrier) = DatabaseSet::finalize(set, merkleized).await;
+            assert!(barrier.durable().await, "finalize flush failed");
 
-            let guard = db.read().await;
-            assert_eq!(guard.root(), expected_root);
-            assert_eq!(guard.get(&key).await.unwrap(), Some(value));
+            let db = set.handle();
+            assert_eq!(
+                db.read().await.expect("writer is live").root(),
+                expected_root
+            );
+            assert_eq!(
+                db.read()
+                    .await
+                    .expect("writer is live")
+                    .get(&key)
+                    .await
+                    .unwrap(),
+                Some(value)
+            );
+            assert_eq!(
+                mmr::Location::new(snapshot.bounds().end),
+                db.read().await.expect("writer is live").bounds().end,
+                "captured snapshot must cover the applied batch",
+            );
 
-            let proof = guard.exclusion_proof(&missing).await.unwrap();
+            let db = db.read().await.expect("writer is live");
+            let proof = db.exclusion_proof(&missing).await.unwrap();
             assert!(OrderedFixedDb::verify_exclusion_proof(
                 &missing,
                 &proof,
-                &guard.root(),
+                &db.root(),
             ));
         });
     }
@@ -1400,7 +1438,7 @@ mod tests {
     /// `CurrentStaged::merkleize`) must return the same values and root as an explicit `get_many` +
     /// `write` + `merkleize`, including a staged delete, an upsert, and metadata flow (both set
     /// on the staged handle via `with_metadata` and carried from before staging). This guards
-    /// metadata flow and db-handle pairing through the wrapper.
+    /// metadata flow through the wrapper.
     #[test]
     fn ordered_fixed_staged_merkleize_matches_explicit_writes() {
         deterministic::Runner::default().start(|context| async move {
@@ -1408,24 +1446,21 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
+            let set = Single::from(db);
 
             let key = |i: u64| Sha256::hash(&[&i.to_be_bytes()]);
             let val = |i: u64| Sha256::hash(&[&(i + 10_000).to_be_bytes()]);
             let metadata = Sha256::hash(&[b"metadata"]);
 
             // Seed keys 0..50 and finalize.
-            let mut seed = db.new_batch_for_test::<_>().await;
+            let mut seed = new_batch(&set).await;
             for i in 0..50u64 {
                 seed = seed.write(key(i), Some(val(i)));
             }
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(seed)
                 .await
                 .unwrap();
-            {
-                let (slot, database) = db.write().await;
-                slot.put(finalize::<OrderedFixedDb>(database, merkleized).await);
-            }
+            let set = finalize::<OrderedFixedDb>(set, merkleized).await;
 
             // Read set: key(1) updated, key(2) deleted, key(999) missing -> created.
             let read_keys = [key(1), key(2), key(999)];
@@ -1434,7 +1469,7 @@ mod tests {
             let upserts = vec![(key(3), Some(val(1_002)))];
 
             // Explicit path.
-            let mut explicit = db.new_batch_for_test::<_>().await;
+            let mut explicit = new_batch(&set).await;
             let explicit_values = explicit.get_many(&keys).await.unwrap();
             for (slot, value) in &indexed_updates {
                 explicit = explicit.write(read_keys[*slot], *value);
@@ -1449,7 +1484,7 @@ mod tests {
                     .root();
 
             // Staged path, with metadata set on the staged handle.
-            let staged_batch = db.new_batch_for_test::<_>().await;
+            let staged_batch = new_batch(&set).await;
             let split = 2;
             let (mut staged_values, staged) = staged_batch.stage(&keys[..split]).await.unwrap();
             let (range, suffix_values, staged) = staged.expand(&keys[split..]).await.unwrap();
@@ -1466,7 +1501,7 @@ mod tests {
             assert_eq!(explicit_root, staged_root);
 
             // Metadata set before staging must be carried through to staged merkleize.
-            let carried_batch = db.new_batch_for_test::<_>().await.with_metadata(metadata);
+            let carried_batch = new_batch(&set).await.with_metadata(metadata);
             let (carried_values, staged) = carried_batch.stage(&keys).await.unwrap();
             let carried_root = staged
                 .merkleize(indexed_updates.clone(), upserts.clone())
@@ -1485,14 +1520,13 @@ mod tests {
             let db = <OrderedVariableDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
+            let set = Single::from(db);
             let key = Sha256::hash(&[b"key"]);
             let value = Sha256::hash(&[b"value"]);
             let metadata = Sha256::hash(&[b"metadata"]);
             let missing = Sha256::hash(&[b"missing"]);
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = new_batch(&set)
                 .await
                 .write(key, Some(value))
                 .with_metadata(metadata);
@@ -1501,20 +1535,29 @@ mod tests {
                 .unwrap();
             let expected_root = merkleized.root();
 
-            {
-                let (slot, database) = db.write().await;
-                slot.put(finalize::<OrderedVariableDb>(database, merkleized).await);
-            }
+            let set = finalize::<OrderedVariableDb>(set, merkleized).await;
 
-            let guard = db.read().await;
-            assert_eq!(guard.root(), expected_root);
-            assert_eq!(guard.get(&key).await.unwrap(), Some(value));
+            let db = set.handle();
+            assert_eq!(
+                db.read().await.expect("writer is live").root(),
+                expected_root
+            );
+            assert_eq!(
+                db.read()
+                    .await
+                    .expect("writer is live")
+                    .get(&key)
+                    .await
+                    .unwrap(),
+                Some(value)
+            );
 
-            let proof = guard.exclusion_proof(&missing).await.unwrap();
+            let db = db.read().await.expect("writer is live");
+            let proof = db.exclusion_proof(&missing).await.unwrap();
             assert!(OrderedVariableDb::verify_exclusion_proof(
                 &missing,
                 &proof,
-                &guard.root(),
+                &db.root(),
             ));
         });
     }
@@ -1526,15 +1569,16 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config.clone())
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
             let key = Sha256::hash(&[b"key"]);
             let value = Sha256::hash(&[b"value"]);
             let metadata = Sha256::hash(&[b"metadata"]);
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <OrderedFixedDb as ManagedDb<_>>::new_batch(handle)
                 .await
+                .expect("writer is live")
                 .write(key, Some(value))
                 .with_metadata(metadata);
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
@@ -1581,59 +1625,35 @@ mod tests {
             let db = <OrderedFixedDb as ManagedDb<_>>::init(context.child("db"), config)
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
+            let set = Single::from(db);
 
             let key1 = Sha256::hash(&[b"key1"]);
             let value1 = Sha256::hash(&[b"value1"]);
             let metadata1 = Sha256::hash(&[b"metadata1"]);
-            let batch1 = db
-                .new_batch_for_test::<_>()
+            let batch1 = new_batch(&set)
                 .await
                 .write(key1, Some(value1))
                 .with_metadata(metadata1);
             let merkleized1 = crate::stateful::db::Unmerkleized::merkleize(batch1)
                 .await
                 .unwrap();
-            {
-                let (slot, database) = db.write().await;
-                slot.put(finalize::<OrderedFixedDb>(database, merkleized1).await);
-            }
-            let target_after_first = {
-                let guard = db.read().await;
-                <OrderedFixedDb as ManagedDb<_>>::sync_target(&guard)
-            };
+            let set = finalize::<OrderedFixedDb>(set, merkleized1).await;
+            let target_after_first = set.applied_targets().await;
 
             let key2 = Sha256::hash(&[b"key2"]);
             let value2 = Sha256::hash(&[b"value2"]);
             let metadata2 = Sha256::hash(&[b"metadata2"]);
-            let batch2 = db
-                .new_batch_for_test::<_>()
+            let batch2 = new_batch(&set)
                 .await
                 .write(key2, Some(value2))
                 .with_metadata(metadata2);
             let merkleized2 = crate::stateful::db::Unmerkleized::merkleize(batch2)
                 .await
                 .unwrap();
-            {
-                let (slot, database) = db.write().await;
-                slot.put(finalize::<OrderedFixedDb>(database, merkleized2).await);
-            }
+            let set = finalize::<OrderedFixedDb>(set, merkleized2).await;
 
-            {
-                let (slot, database) = db.write().await;
-                slot.put(
-                    <OrderedFixedDb as ManagedDb<_>>::rewind_to_target(
-                        database,
-                        target_after_first.clone(),
-                    )
-                    .await
-                    .unwrap(),
-                );
-            }
-            let target_after_rewind = {
-                let guard = db.read().await;
-                <OrderedFixedDb as ManagedDb<_>>::sync_target(&guard)
-            };
+            let set = set.rewind_to_targets(target_after_first.clone()).await;
+            let target_after_rewind = set.applied_targets().await;
             assert_eq!(target_after_rewind, target_after_first);
         });
     }
@@ -1645,15 +1665,16 @@ mod tests {
             let db = FixedDb::init(context.child("db"), config.clone())
                 .await
                 .unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
             let key = Sha256::hash(&[b"key"]);
             let value = Sha256::hash(&[b"value"]);
             let metadata = Sha256::hash(&[b"metadata"]);
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle)
                 .await
+                .expect("writer is live")
                 .write(key, Some(value))
                 .with_metadata(metadata);
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -5,7 +5,7 @@
 //! adapters expose set and merkleization operations but no historical reads.
 
 use crate::stateful::db::{
-    BatchContext, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
+    Closed, ManagedDb, Merkleized as MerkleizedTrait, Reader, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait, sync_compact_db,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
@@ -24,40 +24,38 @@ use commonware_storage::{
             initial_root, variable,
         },
         operation::Key,
-        sync::{self},
+        sync,
     },
 };
 use commonware_utils::{Array, channel::mpsc};
 use std::{ops::Deref, sync::Arc};
 
 /// Wraps an unjournaled immutable batch before merkleization.
-pub struct ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C = ()>
+pub struct ImmutableUnjournaledUnmerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     batch: CompactUnmerkleizedBatch<F, H, K, V, S>,
-    db: Shared<CompactDb<F, E, K, V, H, C, S>>,
     metadata: Option<V::Value>,
     inactivity_floor: Location<F>,
+    handle: Reader<CompactDb<F, E, K, V, H, C, S>>,
 }
 
-impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
+impl<F, E, K, V, H, C, S> Deref for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
@@ -68,15 +66,14 @@ where
     }
 }
 
-impl<F, E, K, V, H, S, C> ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
+impl<F, E, K, V, H, C, S> ImmutableUnjournaledUnmerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
@@ -100,51 +97,48 @@ where
 }
 
 /// Wraps an unjournaled immutable batch after merkleization.
-pub struct ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C = ()>
+pub struct ImmutableUnjournaledMerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     inner: Arc<CompactMerkleizedBatch<F, H::Digest, K, V, S>>,
-    db: Shared<CompactDb<F, E, K, V, H, C, S>>,
+    handle: Reader<CompactDb<F, E, K, V, H, C, S>>,
 }
 
-impl<F, E, K, V, H, S, C> Clone for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
+impl<F, E, K, V, H, C, S> Clone for ImmutableUnjournaledMerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     fn clone(&self) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
-            db: self.db.clone(),
+            inner: self.inner.clone(),
+            handle: self.handle.clone(),
         }
     }
 }
 
-impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
+impl<F, E, K, V, H, C, S> Deref for ImmutableUnjournaledMerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
@@ -155,50 +149,52 @@ where
     }
 }
 
-impl<F, E, K, V, H, S, C> UnmerkleizedTrait
-    for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
+impl<F, E, K, V, H, C, S> UnmerkleizedTrait
+    for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
-    type Merkleized = ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>;
+    type Merkleized = ImmutableUnjournaledMerkleized<F, E, K, V, H, C, S>;
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self
-            .batch
-            .merkleize(&db, self.metadata, self.inactivity_floor)
+        let Self {
+            batch,
+            metadata,
+            inactivity_floor,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(
+                &*handle.read().await.map_err(Closed::storage)?,
+                metadata,
+                inactivity_floor,
+            )
             .await;
-        Ok(ImmutableUnjournaledMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        Ok(ImmutableUnjournaledMerkleized { inner, handle })
     }
 }
 
-impl<F, E, K, V, H, S, C> MerkleizedTrait for ImmutableUnjournaledMerkleized<F, E, K, V, H, S, C>
+impl<F, E, K, V, H, C, S> MerkleizedTrait for ImmutableUnjournaledMerkleized<F, E, K, V, H, C, S>
 where
     F: Family,
     E: Context,
     K: Key,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, K, V>: EncodeShared,
-    Operation<F, K, V>: CodecRead<Cfg = C>,
+    Operation<F, K, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     type Digest = H::Digest;
-    type Unmerkleized = ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>;
-
+    type Unmerkleized = ImmutableUnjournaledUnmerkleized<F, E, K, V, H, C, S>;
     fn root(&self) -> H::Digest {
         self.inner.root()
     }
@@ -206,9 +202,9 @@ where
     fn new_batch(&self) -> Self::Unmerkleized {
         ImmutableUnjournaledUnmerkleized {
             batch: self.inner.new_batch::<H>(),
-            db: self.db.clone(),
             metadata: None,
             inactivity_floor: self.inner.bounds().inactivity_floor,
+            handle: self.handle.clone(),
         }
     }
 }
@@ -223,8 +219,8 @@ where
     S: Strategy,
     Operation<F, K, FixedEncoding<V>>: EncodeShared + CodecRead<Cfg = ()>,
 {
-    type Unmerkleized = ImmutableUnjournaledUnmerkleized<F, E, K, FixedEncoding<V>, H, S, ()>;
-    type Merkleized = ImmutableUnjournaledMerkleized<F, E, K, FixedEncoding<V>, H, S, ()>;
+    type Unmerkleized = ImmutableUnjournaledUnmerkleized<F, E, K, FixedEncoding<V>, H, (), S>;
+    type Merkleized = ImmutableUnjournaledMerkleized<F, E, K, FixedEncoding<V>, H, (), S>;
     type Error = Error<F>;
     type Config = fixed::CompactConfig<S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
@@ -241,14 +237,17 @@ where
         }
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        ImmutableUnjournaledUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(ImmutableUnjournaledUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -301,8 +300,8 @@ where
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
-    type Unmerkleized = ImmutableUnjournaledUnmerkleized<F, E, K, VariableEncoding<V>, H, S, C>;
-    type Merkleized = ImmutableUnjournaledMerkleized<F, E, K, VariableEncoding<V>, H, S, C>;
+    type Unmerkleized = ImmutableUnjournaledUnmerkleized<F, E, K, VariableEncoding<V>, H, C, S>;
+    type Merkleized = ImmutableUnjournaledMerkleized<F, E, K, VariableEncoding<V>, H, C, S>;
     type Error = Error<F>;
     type Config = variable::CompactConfig<C, S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
@@ -319,14 +318,17 @@ where
         }
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        ImmutableUnjournaledUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(ImmutableUnjournaledUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -446,6 +448,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stateful::db::{DatabaseSet, Single, SyncEngineConfig};
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::select;
     use commonware_parallel::Sequential;
@@ -458,7 +461,7 @@ mod tests {
         merkle::{full::Config as MerkleConfig, mmr},
         translator::TwoCap,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize};
+    use commonware_utils::{NZU16, NZU64, NZUsize, channel::mpsc};
     use futures::pin_mut;
     use std::time::Duration;
 
@@ -580,14 +583,14 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "managed-db");
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Shared::new("test", db);
             let key = Sha256::hash(&[&[1]]);
             let value = Sha256::hash(&[&[2]]);
             let metadata = Sha256::hash(&[&[3]]);
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let set = Single::from(db);
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(set.handle())
                 .await
+                .expect("writer is live")
                 .set(key, value)
                 .with_inactivity_floor(mmr::Location::new(1))
                 .with_metadata(metadata);
@@ -596,23 +599,23 @@ mod tests {
                 .unwrap();
             let expected_root = merkleized.root();
 
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
+            let (set, snapshot, barrier) = DatabaseSet::finalize(set, merkleized).await;
+            assert!(barrier.durable().await, "finalize flush failed");
 
-            let guard = db.read().await;
-            assert_eq!(guard.root(), expected_root);
-            assert_eq!(guard.get_metadata(), Some(metadata));
+            let db = set.handle();
+            let db = db.read().await.expect("writer is live");
+            assert_eq!(db.root(), expected_root);
+            assert_eq!(db.get_metadata(), Some(metadata));
 
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
-            assert_eq!(target.root, guard.root());
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&db);
+            assert_eq!(target.root, db.root());
             assert_eq!(target.size, mmr::Location::new(3));
+            assert_eq!(
+                snapshot.root(),
+                expected_root,
+                "captured snapshot must carry the applied root",
+            );
+            assert_eq!(snapshot.size(), mmr::Location::new(3));
         });
     }
 

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -2,11 +2,12 @@
 //! [`immutable`](commonware_storage::qmdb::immutable) databases.
 //!
 //! Immutable databases support adding new keyed values but not updates or
-//! deletions. The wrapper types here capture a [`Shared`] database handle
-//! so the batch API can read through to applied state.
+//! deletions. Keyed batch reads lease the database through the batch's
+//! [`Reader`] because the immutable proof snapshot carries no keyed
+//! index.
 
 use crate::stateful::db::{
-    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    Closed, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Reader, StateSyncDb,
     SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{Codec, EncodeShared, Read as CodecRead};
@@ -35,11 +36,11 @@ use commonware_storage::{
 use commonware_utils::{Array, channel::mpsc, non_empty_range};
 use std::{ops::Deref, sync::Arc};
 
-/// Shared handle to an immutable database.
-type ImmutableDbHandle<F, E, K, V, C, H, T, S> = Shared<Immutable<F, E, K, V, C, H, T, S>>;
+/// Read handle over the immutable database a wrapper batch reads through.
+type DbHandle<F, E, K, V, C, H, T, S> = Reader<Immutable<F, E, K, V, C, H, T, S>>;
 
-/// Wraps an immutable [`UnmerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Unmerkleized`](crate::stateful::db::Unmerkleized) trait.
+/// Wraps an immutable [`UnmerkleizedBatch`] to implement
+/// [`Unmerkleized`](crate::stateful::db::Unmerkleized).
 pub struct ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
@@ -53,9 +54,9 @@ where
     Operation<F, K, V>: EncodeShared,
 {
     batch: UnmerkleizedBatch<F, H, K, V, S>,
-    db: ImmutableDbHandle<F, E, K, V, C, H, T, S>,
     metadata: Option<V::Value>,
     inactivity_floor: Location<F>,
+    handle: DbHandle<F, E, K, V, C, H, T, S>,
 }
 
 impl<F, E, K, V, C, H, T, S> Deref for ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
@@ -104,16 +105,18 @@ where
 
     /// Read a value by key, falling back to applied state.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get(key, &db).await
+        self.batch
+            .get(key, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values by key, falling back to applied state.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get_many(keys, &db).await
+        self.batch
+            .get_many(keys, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Set `key` to `value` in the speculative batch.
@@ -123,8 +126,8 @@ where
     }
 }
 
-/// Wraps an immutable [`MerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Merkleized`](crate::stateful::db::Merkleized) trait.
+/// Wraps an immutable [`MerkleizedBatch`] to implement
+/// [`Merkleized`](crate::stateful::db::Merkleized).
 pub struct ImmutableMerkleized<F, E, K, V, C, H, T, S>
 where
     F: Family,
@@ -138,7 +141,7 @@ where
     Operation<F, K, V>: EncodeShared,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, K, V, S>>,
-    db: ImmutableDbHandle<F, E, K, V, C, H, T, S>,
+    handle: DbHandle<F, E, K, V, C, H, T, S>,
 }
 
 impl<F, E, K, V, C, H, T, S> Clone for ImmutableMerkleized<F, E, K, V, C, H, T, S>
@@ -155,8 +158,8 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
-            db: self.db.clone(),
+            inner: self.inner.clone(),
+            handle: self.handle.clone(),
         }
     }
 }
@@ -194,16 +197,18 @@ where
 {
     /// Read a value by key, falling back to applied state.
     pub async fn get(&self, key: &K) -> Result<Option<V::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get(key, &db).await
+        self.inner
+            .get(key, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 
     /// Read multiple values by key, falling back to applied state.
     ///
     /// Returns results in the same order as the input keys.
     pub async fn get_many(&self, keys: &[&K]) -> Result<Vec<Option<V::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get_many(keys, &db).await
+        self.inner
+            .get_many(keys, &*self.handle.read().await.map_err(Closed::storage)?)
+            .await
     }
 }
 
@@ -223,15 +228,20 @@ where
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self
-            .batch
-            .merkleize(&db, self.metadata, self.inactivity_floor)
+        let Self {
+            batch,
+            metadata,
+            inactivity_floor,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(
+                &*handle.read().await.map_err(Closed::storage)?,
+                metadata,
+                inactivity_floor,
+            )
             .await;
-        Ok(ImmutableMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        Ok(ImmutableMerkleized { inner, handle })
     }
 }
 
@@ -249,7 +259,6 @@ where
 {
     type Digest = H::Digest;
     type Unmerkleized = ImmutableUnmerkleized<F, E, K, V, C, H, T, S>;
-
     fn root(&self) -> H::Digest {
         self.inner.root()
     }
@@ -257,9 +266,9 @@ where
     fn new_batch(&self) -> Self::Unmerkleized {
         ImmutableUnmerkleized {
             batch: self.inner.new_batch::<H>(),
-            db: self.db.clone(),
             metadata: None,
             inactivity_floor: self.inner.bounds().inactivity_floor,
+            handle: self.handle.clone(),
         }
     }
 }
@@ -310,14 +319,17 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        ImmutableUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(ImmutableUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -413,14 +425,17 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        ImmutableUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(ImmutableUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -5,7 +5,7 @@
 //! adapters expose append and merkleization operations but no historical reads.
 
 use crate::stateful::db::{
-    BatchContext, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
+    Closed, ManagedDb, Merkleized as MerkleizedTrait, Reader, StateSyncDb, SyncEngineConfig,
     Unmerkleized as UnmerkleizedTrait, sync_compact_db,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
@@ -23,38 +23,36 @@ use commonware_storage::{
             CompactDb, CompactMerkleizedBatch, CompactUnmerkleizedBatch, Operation, fixed,
             initial_root, variable,
         },
-        sync::{self},
+        sync,
     },
 };
 use commonware_utils::channel::mpsc;
 use std::{ops::Deref, sync::Arc};
 
 /// Wraps an unjournaled keyless batch before merkleization.
-pub struct KeylessUnjournaledUnmerkleized<F, E, V, H, S, C = ()>
+pub struct KeylessUnjournaledUnmerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     batch: CompactUnmerkleizedBatch<F, H, V, S>,
-    db: Shared<CompactDb<F, E, V, H, C, S>>,
     metadata: Option<V::Value>,
     inactivity_floor: Location<F>,
+    handle: Reader<CompactDb<F, E, V, H, C, S>>,
 }
 
-impl<F, E, V, H, S, C> Deref for KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
+impl<F, E, V, H, C, S> Deref for KeylessUnjournaledUnmerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
@@ -65,14 +63,13 @@ where
     }
 }
 
-impl<F, E, V, H, S, C> KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
+impl<F, E, V, H, C, S> KeylessUnjournaledUnmerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
@@ -96,48 +93,45 @@ where
 }
 
 /// Wraps an unjournaled keyless batch after merkleization.
-pub struct KeylessUnjournaledMerkleized<F, E, V, H, S, C = ()>
+pub struct KeylessUnjournaledMerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     inner: Arc<CompactMerkleizedBatch<F, H::Digest, V, S>>,
-    db: Shared<CompactDb<F, E, V, H, C, S>>,
+    handle: Reader<CompactDb<F, E, V, H, C, S>>,
 }
 
-impl<F, E, V, H, S, C> Clone for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
+impl<F, E, V, H, C, S> Clone for KeylessUnjournaledMerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     fn clone(&self) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
-            db: self.db.clone(),
+            inner: self.inner.clone(),
+            handle: self.handle.clone(),
         }
     }
 }
 
-impl<F, E, V, H, S, C> Deref for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
+impl<F, E, V, H, C, S> Deref for KeylessUnjournaledMerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
@@ -148,47 +142,49 @@ where
     }
 }
 
-impl<F, E, V, H, S, C> UnmerkleizedTrait for KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
+impl<F, E, V, H, C, S> UnmerkleizedTrait for KeylessUnjournaledUnmerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
-    type Merkleized = KeylessUnjournaledMerkleized<F, E, V, H, S, C>;
+    type Merkleized = KeylessUnjournaledMerkleized<F, E, V, H, C, S>;
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self
-            .batch
-            .merkleize(&db, self.metadata, self.inactivity_floor)
+        let Self {
+            batch,
+            metadata,
+            inactivity_floor,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(
+                &*handle.read().await.map_err(Closed::storage)?,
+                metadata,
+                inactivity_floor,
+            )
             .await;
-        Ok(KeylessUnjournaledMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        Ok(KeylessUnjournaledMerkleized { inner, handle })
     }
 }
 
-impl<F, E, V, H, S, C> MerkleizedTrait for KeylessUnjournaledMerkleized<F, E, V, H, S, C>
+impl<F, E, V, H, C, S> MerkleizedTrait for KeylessUnjournaledMerkleized<F, E, V, H, C, S>
 where
     F: Family,
     E: Context,
     V: ValueEncoding,
     H: Hasher,
-    Operation<F, V>: EncodeShared,
-    Operation<F, V>: CodecRead<Cfg = C>,
+    Operation<F, V>: EncodeShared + CodecRead<Cfg = C>,
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
     type Digest = H::Digest;
-    type Unmerkleized = KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>;
-
+    type Unmerkleized = KeylessUnjournaledUnmerkleized<F, E, V, H, C, S>;
     fn root(&self) -> H::Digest {
         self.inner.root()
     }
@@ -196,9 +192,9 @@ where
     fn new_batch(&self) -> Self::Unmerkleized {
         KeylessUnjournaledUnmerkleized {
             batch: self.inner.new_batch::<H>(),
-            db: self.db.clone(),
             metadata: None,
             inactivity_floor: self.inner.bounds().inactivity_floor,
+            handle: self.handle.clone(),
         }
     }
 }
@@ -212,8 +208,8 @@ where
     S: Strategy,
     Operation<F, FixedEncoding<V>>: EncodeShared + CodecRead<Cfg = ()>,
 {
-    type Unmerkleized = KeylessUnjournaledUnmerkleized<F, E, FixedEncoding<V>, H, S, ()>;
-    type Merkleized = KeylessUnjournaledMerkleized<F, E, FixedEncoding<V>, H, S, ()>;
+    type Unmerkleized = KeylessUnjournaledUnmerkleized<F, E, FixedEncoding<V>, H, (), S>;
+    type Merkleized = KeylessUnjournaledMerkleized<F, E, FixedEncoding<V>, H, (), S>;
     type Error = Error<F>;
     type Config = fixed::CompactConfig<S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
@@ -230,14 +226,17 @@ where
         }
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        KeylessUnjournaledUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(KeylessUnjournaledUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -289,8 +288,8 @@ where
     C: Clone + Send + Sync + 'static,
     S: Strategy,
 {
-    type Unmerkleized = KeylessUnjournaledUnmerkleized<F, E, VariableEncoding<V>, H, S, C>;
-    type Merkleized = KeylessUnjournaledMerkleized<F, E, VariableEncoding<V>, H, S, C>;
+    type Unmerkleized = KeylessUnjournaledUnmerkleized<F, E, VariableEncoding<V>, H, C, S>;
+    type Merkleized = KeylessUnjournaledMerkleized<F, E, VariableEncoding<V>, H, C, S>;
     type Error = Error<F>;
     type Config = variable::CompactConfig<C, S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
@@ -307,14 +306,17 @@ where
         }
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        KeylessUnjournaledUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(KeylessUnjournaledUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -432,6 +434,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stateful::{
+        db::{SyncEngineConfig, live::Writer},
+        tests::mocks::finalize,
+    };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::select;
     use commonware_parallel::Sequential;
@@ -444,7 +450,7 @@ mod tests {
         merkle::{full::Config as MerkleConfig, mmr},
         qmdb::keyless as storage_keyless,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
+    use commonware_utils::{NZU16, NZU64, NZUsize, channel::mpsc, sequence::U64};
     use futures::pin_mut;
     use std::time::Duration;
 
@@ -574,11 +580,12 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "managed-db");
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle.clone())
                 .await
+                .expect("writer is live")
                 .append(U64::new(7))
                 .with_inactivity_floor(mmr::Location::new(1))
                 .with_metadata(U64::new(9));
@@ -587,23 +594,22 @@ mod tests {
                 .unwrap();
             let expected_root = merkleized.root();
 
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
+            let (_writer, snapshot, durability) = finalize(writer, merkleized).await;
+            durability.await.expect("finalize flush failed");
 
-            let guard = db.read().await;
-            assert_eq!(guard.root(), expected_root);
-            assert_eq!(guard.get_metadata(), Some(U64::new(9)));
+            let db = handle.read().await.expect("writer is live");
+            assert_eq!(db.root(), expected_root);
+            assert_eq!(db.get_metadata(), Some(U64::new(9)));
 
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
-            assert_eq!(target.root, guard.root());
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&db);
+            assert_eq!(target.root, db.root());
             assert_eq!(target.size, mmr::Location::new(3));
+            assert_eq!(
+                snapshot.root(),
+                expected_root,
+                "captured snapshot must carry the applied root",
+            );
+            assert_eq!(snapshot.size(), mmr::Location::new(3));
         });
     }
 
@@ -612,11 +618,12 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config(&context, "matches-sync-target");
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle)
                 .await
+                .expect("writer is live")
                 .append(U64::new(7))
                 .with_inactivity_floor(mmr::Location::new(1))
                 .with_metadata(U64::new(9));

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -2,12 +2,11 @@
 //! [`keyless`](commonware_storage::qmdb::keyless) databases.
 //!
 //! Keyless databases are append-only. Operations are addressed by
-//! [`Location`] rather than by key.
-//! The wrapper types here capture a [`Shared`] database handle so the batch API
-//! can read through to applied state.
+//! [`Location`] rather than by key. Positional batch reads lease the
+//! database through the batch's [`Reader`].
 
 use crate::stateful::db::{
-    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    Closed, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Reader, StateSyncDb,
     SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
@@ -34,8 +33,8 @@ use commonware_storage::{
 use commonware_utils::{channel::mpsc, non_empty_range};
 use std::{ops::Deref, sync::Arc};
 
-/// Wraps a keyless [`UnmerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Unmerkleized`](crate::stateful::db::Unmerkleized) trait.
+/// Wraps a keyless [`UnmerkleizedBatch`] to implement
+/// [`Unmerkleized`](crate::stateful::db::Unmerkleized).
 pub struct KeylessUnmerkleized<F, E, V, C, H, S>
 where
     F: Family,
@@ -47,9 +46,9 @@ where
     Operation<F, V>: EncodeShared,
 {
     batch: UnmerkleizedBatch<F, H, V, S>,
-    db: Shared<Keyless<F, E, V, C, H, S>>,
     metadata: Option<V::Value>,
     inactivity_floor: Location<F>,
+    handle: Reader<Keyless<F, E, V, C, H, S>>,
 }
 
 impl<F, E, V, C, H, S> Deref for KeylessUnmerkleized<F, E, V, C, H, S>
@@ -94,8 +93,12 @@ where
 
     /// Read a value by location, falling back to applied state.
     pub async fn get(&self, location: Location<F>) -> Result<Option<V::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get(location, &db).await
+        self.batch
+            .get(
+                location,
+                &*self.handle.read().await.map_err(Closed::storage)?,
+            )
+            .await
     }
 
     /// Read multiple values by location, falling back to applied state.
@@ -106,8 +109,12 @@ where
         &self,
         locations: &[Location<F>],
     ) -> Result<Vec<Option<V::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.batch.get_many(locations, &db).await
+        self.batch
+            .get_many(
+                locations,
+                &*self.handle.read().await.map_err(Closed::storage)?,
+            )
+            .await
     }
 
     /// Append a value to the speculative batch.
@@ -117,8 +124,8 @@ where
     }
 }
 
-/// Wraps a keyless [`MerkleizedBatch`] with a reference to the parent
-/// database, implementing the [`Merkleized`](crate::stateful::db::Merkleized) trait.
+/// Wraps a keyless [`MerkleizedBatch`] to implement
+/// [`Merkleized`](crate::stateful::db::Merkleized).
 pub struct KeylessMerkleized<F, E, V, C, H, S>
 where
     F: Family,
@@ -130,7 +137,7 @@ where
     Operation<F, V>: EncodeShared,
 {
     inner: Arc<MerkleizedBatch<F, H::Digest, V, S>>,
-    db: Shared<Keyless<F, E, V, C, H, S>>,
+    handle: Reader<Keyless<F, E, V, C, H, S>>,
 }
 
 impl<F, E, V, C, H, S> Clone for KeylessMerkleized<F, E, V, C, H, S>
@@ -145,8 +152,8 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            inner: Arc::clone(&self.inner),
-            db: self.db.clone(),
+            inner: self.inner.clone(),
+            handle: self.handle.clone(),
         }
     }
 }
@@ -180,8 +187,12 @@ where
 {
     /// Read a value by location, falling back to applied state.
     pub async fn get(&self, location: Location<F>) -> Result<Option<V::Value>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get(location, &db).await
+        self.inner
+            .get(
+                location,
+                &*self.handle.read().await.map_err(Closed::storage)?,
+            )
+            .await
     }
 
     /// Read multiple values by location, falling back to applied state.
@@ -192,8 +203,12 @@ where
         &self,
         locations: &[Location<F>],
     ) -> Result<Vec<Option<V::Value>>, Error<F>> {
-        let db = self.db.read().await;
-        self.inner.get_many(locations, &db).await
+        self.inner
+            .get_many(
+                locations,
+                &*self.handle.read().await.map_err(Closed::storage)?,
+            )
+            .await
     }
 }
 
@@ -211,15 +226,20 @@ where
     type Error = Error<F>;
 
     async fn merkleize(self) -> Result<Self::Merkleized, Error<F>> {
-        let db = self.db.read().await;
-        let merkleized = self
-            .batch
-            .merkleize(&db, self.metadata, self.inactivity_floor)
+        let Self {
+            batch,
+            metadata,
+            inactivity_floor,
+            handle,
+        } = self;
+        let inner = batch
+            .merkleize(
+                &*handle.read().await.map_err(Closed::storage)?,
+                metadata,
+                inactivity_floor,
+            )
             .await;
-        Ok(KeylessMerkleized {
-            inner: merkleized,
-            db: self.db.clone(),
-        })
+        Ok(KeylessMerkleized { inner, handle })
     }
 }
 
@@ -235,7 +255,6 @@ where
 {
     type Digest = H::Digest;
     type Unmerkleized = KeylessUnmerkleized<F, E, V, C, H, S>;
-
     fn root(&self) -> H::Digest {
         self.inner.root()
     }
@@ -243,9 +262,9 @@ where
     fn new_batch(&self) -> Self::Unmerkleized {
         KeylessUnmerkleized {
             batch: self.inner.new_batch::<H>(),
-            db: self.db.clone(),
             metadata: None,
             inactivity_floor: self.inner.bounds().inactivity_floor,
+            handle: self.handle.clone(),
         }
     }
 }
@@ -278,14 +297,17 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        KeylessUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(KeylessUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -374,14 +396,17 @@ where
         )
     }
 
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        let (database, shared) = database.into_parts();
-        KeylessUnmerkleized {
-            batch: database.new_batch(),
-            db: shared,
+    async fn new_batch(handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        let (batch, inactivity_floor) = {
+            let db = handle.read().await?;
+            (db.new_batch(), db.inactivity_floor_loc())
+        };
+        Ok(KeylessUnmerkleized {
+            batch,
             metadata: None,
-            inactivity_floor: database.inactivity_floor_loc(),
-        }
+            inactivity_floor,
+            handle,
+        })
     }
 
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool {
@@ -503,14 +528,17 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stateful::{db::live::Writer, tests::mocks::finalize};
     use commonware_cryptography::Sha256;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
         BufferPooler, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
     };
     use commonware_storage::{
-        journal::contiguous::fixed::Config as FixedJournalConfig,
-        merkle::full::Config as MerkleConfig, mmr, qmdb::keyless as storage_keyless,
+        journal::contiguous::{Contiguous as _, fixed::Config as FixedJournalConfig},
+        merkle::full::Config as MerkleConfig,
+        mmr,
+        qmdb::keyless as storage_keyless,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, non_empty_range, sequence::U64};
     use std::num::{NonZeroU16, NonZeroUsize};
@@ -563,11 +591,12 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config("stateful-keyless-managed-db", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle.clone())
                 .await
+                .expect("writer is live")
                 .append(U64::new(7))
                 .with_inactivity_floor(mmr::Location::new(1))
                 .with_metadata(U64::new(9));
@@ -575,27 +604,25 @@ mod tests {
                 .await
                 .unwrap();
 
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
+            let (_writer, snapshot, durability) = finalize(writer, merkleized).await;
+            durability.await.expect("finalize flush failed");
 
-            let guard = db.read().await;
+            let db = handle.read().await.expect("writer is live");
             assert_eq!(
-                guard.get(mmr::Location::new(1)).await.unwrap(),
+                db.get(mmr::Location::new(1)).await.unwrap(),
                 Some(U64::new(7))
             );
-            assert_eq!(guard.get_metadata().await.unwrap(), Some(U64::new(9)));
+            assert_eq!(db.get_metadata().await.unwrap(), Some(U64::new(9)));
 
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
-            assert_eq!(target.root, guard.root());
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&db);
+            assert_eq!(target.root, db.root());
             assert_eq!(target.range.start(), mmr::Location::new(1));
             assert_eq!(target.range.end(), mmr::Location::new(3));
+            assert_eq!(
+                mmr::Location::new(snapshot.bounds().end),
+                *target.range.end(),
+                "captured snapshot must cover the applied batch",
+            );
         });
     }
 
@@ -604,11 +631,12 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config("stateful-keyless-matches-sync-target", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle)
                 .await
+                .expect("writer is live")
                 .append(U64::new(7))
                 .with_inactivity_floor(mmr::Location::new(1))
                 .with_metadata(U64::new(9));
@@ -658,43 +686,35 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let config = fixed_config("stateful-keyless-floor-carry", &context);
             let db = FixedDb::init(context.child("db"), config).await.unwrap();
-            let db = Shared::new("test", db);
+            let writer = Writer::new(db);
+            let handle = writer.reader();
 
-            let batch = db
-                .new_batch_for_test::<_>()
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle.clone())
                 .await
+                .expect("writer is live")
                 .append(U64::new(7))
                 .with_inactivity_floor(mmr::Location::new(1));
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
                 .await
                 .unwrap();
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
+            let (writer, _, durability) = finalize(writer, merkleized).await;
+            durability.await.expect("finalize flush failed");
 
             // A fresh batch without an explicit floor must commit at the raised
             // floor instead of regressing it to zero.
-            let batch = db.new_batch_for_test::<_>().await.append(U64::new(8));
+            let batch = <FixedDb as ManagedDb<_>>::new_batch(handle.clone())
+                .await
+                .expect("writer is live")
+                .append(U64::new(8));
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
                 .await
                 .unwrap();
             let fork = MerkleizedTrait::new_batch(&merkleized);
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&*db.read().await);
+            let (writer, _, durability) = finalize(writer, merkleized).await;
+            durability.await.expect("finalize flush failed");
+            let target = <FixedDb as ManagedDb<_>>::sync_target(
+                &*handle.read().await.expect("writer is live"),
+            );
             assert_eq!(target.range.start(), mmr::Location::new(1));
 
             // The same holds for a batch forked from a merkleized parent.
@@ -702,16 +722,11 @@ mod tests {
             let merkleized = crate::stateful::db::Unmerkleized::merkleize(fork)
                 .await
                 .unwrap();
-            {
-                let (slot, database) = db.write().await;
-                let (database, _snapshot, sync) =
-                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                        .await
-                        .unwrap();
-                slot.put(database);
-                sync.await.expect("finalize flush failed");
-            }
-            let target = <FixedDb as ManagedDb<_>>::sync_target(&*db.read().await);
+            let (_writer, _, durability) = finalize(writer, merkleized).await;
+            durability.await.expect("finalize flush failed");
+            let target = <FixedDb as ManagedDb<_>>::sync_target(
+                &*handle.read().await.expect("writer is live"),
+            );
             assert_eq!(target.range.start(), mmr::Location::new(1));
         });
     }

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -32,9 +32,7 @@
 //! Two invariants keep this sound. A batch handed to [`ManagedDb::finalize`]
 //! must not read through its own reader, because that call runs while the
 //! write side is held. And the set must outlive every batch, because dropping
-//! the [`Writer`] closes it and parks later reads. Both hold structurally today,
-//! because the set holds the [`Writer`] and every reader lives in a batch the
-//! set outlives.
+//! the [`Writer`] closes it and later reads return [`Closed`].
 //!
 //! # State Sync
 //!
@@ -199,8 +197,8 @@ pub trait Merkleized: Clone + Sized + Send + Sync {
 /// Mutating methods take the database by value and return it on success. If a mutating
 /// method returns an error, or its future is dropped before it finishes, the database is
 /// gone: state that was not yet durable is discarded, but everything already on disk stays
-/// recoverable. Behind a writer that leaves the database poisoned, so later reads park
-/// rather than observe a database that is missing.
+/// recoverable. Behind a writer that leaves the database poisoned, so later reads return
+/// [`Closed`] rather than observe a database that is missing.
 pub trait ManagedDb<E>: Send + Sync + Sized {
     /// An in-progress batch of mutations that has not yet been merkleized.
     type Unmerkleized: Unmerkleized<Merkleized = Self::Merkleized>;

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -9,10 +9,32 @@
 //! 1. [`Unmerkleized`]: mutable, in-progress batch (concrete types expose reads and writes).
 //! 2. [`Merkleized`]: a sealed batch with a computed root.
 //! 3. Finalization: apply the sealed batch and start persisting it via
-//!    [`ManagedDb::finalize`], observing durability via [`Barrier`].
+//!    [`ManagedDb::finalize`], observing durability via [`Barrier`]. Finalize also
+//!    captures each database's serving snapshot, published for resolver serving (see
+//!    [`Reader`]) once the barrier proves the capture durable.
 //!
 //! [`DatabaseSet`] groups one or more [`ManagedDb`] instances into one logical
 //! unit for execution and commit.
+//!
+//! # Read access and mutation
+//!
+//! Each database sits behind a [`Writer`] that owns it. The set holds the only
+//! [`Writer`], which is not [`Clone`], so mutation is uniquely permitted.
+//! Batches hold a [`Reader`], which is freely cloned and grants a read guard
+//! covering exactly one storage call.
+//!
+//! Because a guard never spans application code, a mutation waits at most one
+//! storage call to start, and work holding a reader is never cancelled: it
+//! pauses at its next read and resumes once the mutation completes. A mutation
+//! that is interrupted poisons the writer and destroys it, which is reachable
+//! only while the mutating task is being torn down.
+//!
+//! Two invariants keep this sound. A batch handed to [`ManagedDb::finalize`]
+//! must not read through its own reader, because that call runs while the
+//! write side is held. And the set must outlive every batch, because dropping
+//! the [`Writer`] closes it and parks later reads. Both hold structurally today,
+//! because the set holds the [`Writer`] and every reader lives in a batch the
+//! set outlives.
 //!
 //! # State Sync
 //!
@@ -84,22 +106,20 @@ use commonware_macros::select;
 use commonware_runtime::{Error as RuntimeError, Handle, Metrics, Spawner, reschedule};
 use commonware_storage::{
     journal::{authenticated, contiguous::Snapshottable},
-    qmdb::sync::{self, FeedbackTx, Request, Response, Source},
+    merkle::Family,
+    qmdb::{self, sync},
 };
-use commonware_utils::{
-    channel::{fallible::AsyncFallibleExt, mpsc, oneshot, ring},
-    sync::{AsyncRwLockReadGuard, AsyncRwLockWriteGuard, TracedAsyncRwLock},
-};
+use commonware_utils::channel::{fallible::AsyncFallibleExt, mpsc, oneshot, ring};
 use futures::{
     future::{Either, pending, try_join_all},
     join,
 };
+use live::{Closed, Reader, Writer};
 use std::{
     collections::BTreeMap,
     fmt::Debug,
     future::Future,
     num::{NonZeroU64, NonZeroUsize},
-    ops::Deref,
     sync::Arc,
 };
 use tracing::debug;
@@ -114,177 +134,10 @@ pub mod live;
 pub mod p2p;
 pub mod snapshot;
 
-/// A database shared across tasks.
-///
-/// Owned mutations (finalize, prune, rewind) take the database out of the cell under the
-/// write lock ([Self::write]) and put it back on success ([WriteSlot::put]); a failure,
-/// panic, or cancellation mid-operation leaves the cell empty permanently, and every
-/// later [Self::read] or [Self::write] panics: a lost database is fatal here by design;
-/// restart to recover. Serve calls instead report the source as missing, so remote
-/// sync degrades without crashing.
-pub struct Shared<DB>(Inner<DB>);
-
-/// The lock wrapped by [`Shared`]. Storage implements its sync source traits on
-/// this shape, so [`Shared`]'s source impls delegate to it.
-type Inner<DB> = Arc<TracedAsyncRwLock<Option<DB>>>;
-
-impl<DB> Clone for Shared<DB> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
-    }
-}
-
-/// Message used when a [`Shared`] cell is empty.
-const DB_LOST_MSG: &str =
-    "database was lost by an earlier failed or interrupted operation; restart to recover";
-
-impl<DB> Shared<DB> {
-    /// Create a cell holding `db`, identified by `label` in lock traces.
-    pub fn new(label: &'static str, db: DB) -> Self {
-        Self(Arc::new(TracedAsyncRwLock::new(label, Some(db))))
-    }
-
-    /// Acquire shared read access to the database.
-    ///
-    /// The lock is write-preferring: once a writer is queued, new readers wait
-    /// behind it. Holding a guard across an await that acquires this cell
-    /// again therefore deadlocks once a writer arrives in between.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the database was lost by an earlier failed or interrupted mutation.
-    pub async fn read(&self) -> ReadGuard<'_, DB> {
-        ReadGuard(AsyncRwLockReadGuard::map(self.0.read().await, |db| {
-            db.as_ref().expect(DB_LOST_MSG)
-        }))
-    }
-
-    /// Take the database out for a by-value mutation.
-    ///
-    /// The returned [`WriteSlot`] holds the cell locked and empty until
-    /// [`WriteSlot::put`] restores the database. Dropping the slot without a put
-    /// leaves the database lost.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the database was lost by an earlier failed or interrupted mutation.
-    pub async fn write(&self) -> (WriteSlot<'_, DB>, DB) {
-        let mut guard = self.0.write().await;
-        let db = guard.take().expect(DB_LOST_MSG);
-        (WriteSlot(guard), db)
-    }
-
-    async fn read_locked(&self) -> ReadLocked<'_, DB> {
-        ReadLocked {
-            database: self.0.read().await,
-            shared: self,
-        }
-    }
-
-    #[cfg(test)]
-    async fn new_batch_for_test<E>(&self) -> <DB as ManagedDb<E>>::Unmerkleized
-    where
-        DB: ManagedDb<E>,
-    {
-        let database = self.read_locked().await;
-        DB::new_batch(database.batch_context())
-    }
-}
-
-/// Read-only access to a database managed by [`Stateful`](super::Stateful).
-///
-/// Unlike [`Shared`], this handle cannot acquire a write slot or construct and
-/// finalize batches. Applications receive readers in
-/// [`Application::finalized`](super::Application::finalized) so observing
-/// finalized state cannot invalidate concurrent speculative batches.
-///
-/// ```compile_fail
-/// use commonware_glue::stateful::db::Reader;
-///
-/// async fn mutate<DB>(reader: Reader<DB>) {
-///     let _ = reader.write().await;
-/// }
-/// ```
-pub struct Reader<DB>(Shared<DB>);
-
-impl<DB> Reader<DB> {
-    /// Acquire shared read access to the database.
-    ///
-    /// The guard follows the same write-preferring lock discipline as
-    /// [`Shared::read`].
-    pub async fn read(&self) -> ReadGuard<'_, DB> {
-        self.0.read().await
-    }
-}
-
-/// Shared read access to a [`Shared`] database.
-pub struct ReadGuard<'a, DB>(AsyncRwLockReadGuard<'a, DB>);
-
-impl<DB> Deref for ReadGuard<'_, DB> {
-    type Target = DB;
-
-    fn deref(&self) -> &DB {
-        &self.0
-    }
-}
-
-/// An exclusively locked [`Shared`] cell whose database has been taken out.
-pub struct WriteSlot<'a, DB>(AsyncRwLockWriteGuard<'a, Option<DB>>);
-
-impl<DB> WriteSlot<'_, DB> {
-    /// Restore the database, making it visible to other tasks again.
-    pub fn put(mut self, db: DB) {
-        *self.0 = Some(db);
-    }
-}
-
-/// Origin-bound read access used to construct a database batch.
-struct ReadLocked<'a, DB> {
-    database: AsyncRwLockReadGuard<'a, Option<DB>>,
-    shared: &'a Shared<DB>,
-}
-
-impl<DB> ReadLocked<'_, DB> {
-    fn batch_context(&self) -> BatchContext<'_, DB> {
-        BatchContext {
-            database: self.database.as_ref().expect(DB_LOST_MSG),
-            shared: Shared::clone(self.shared),
-        }
-    }
-}
-
-/// Origin-bound database access for synchronous batch construction.
-///
-/// Only [`DatabaseSet`] can create this capability. Its borrow prevents a
-/// [`ManagedDb`] implementation from retaining the set's read lock in the
-/// returned batch.
-pub struct BatchContext<'a, DB> {
-    database: &'a DB,
-    shared: Shared<DB>,
-}
-
-impl<'a, DB> BatchContext<'a, DB> {
-    /// Split the capability into applied state and its matching shared handle.
-    pub fn into_parts(self) -> (&'a DB, Shared<DB>) {
-        (self.database, self.shared)
-    }
-}
-
-impl<DB> Source for Shared<DB>
-where
-    DB: Send + Sync + 'static,
-    Inner<DB>: Source,
-{
-    type Family = <Inner<DB> as Source>::Family;
-    type Digest = <Inner<DB> as Source>::Digest;
-    type Op = <Inner<DB> as Source>::Op;
-    type Error = <Inner<DB> as Source>::Error;
-
-    async fn serve(
-        &self,
-        request: Request<Self::Family>,
-    ) -> Result<(Response<Self::Family, Self::Op, Self::Digest>, FeedbackTx), Self::Error> {
-        self.0.serve(request).await
+impl Closed {
+    /// The storage-facing rendering of a closed writer.
+    pub(crate) const fn storage<F: Family>(self) -> qmdb::Error<F> {
+        qmdb::Error::Runtime(commonware_runtime::Error::Closed)
     }
 }
 
@@ -292,7 +145,9 @@ where
 ///
 /// Concrete types provide key-value operations (`get`, `write`, `set`,
 /// `append`, etc.) as inherent methods; the generic wrapper only needs
-/// [`merkleize`](Self::merkleize).
+/// [`merkleize`](Self::merkleize). Batches carry a [`Reader`] to the
+/// database they were created from, so every operation reads the right
+/// database and no operation can delay a mutation by more than one call.
 pub trait Unmerkleized: Sized + Send {
     /// The merkleized batch produced by [`merkleize`](Self::merkleize).
     type Merkleized: Merkleized;
@@ -309,20 +164,22 @@ pub trait Unmerkleized: Sized + Send {
 ///
 /// The application uses [`root`](Self::root) in block headers, and the wrapper
 /// later finalizes this batch.
-pub trait Merkleized: Sized + Send + Sync {
+///
+/// Implementations are handles over shared batch state, so [`Clone`] is cheap.
+/// The wrapper relies on it to keep a block forkable while that same block is
+/// being applied.
+pub trait Merkleized: Clone + Sized + Send + Sync {
     /// The digest type used for the state root.
     type Digest: Digest;
 
     /// The unmerkleized batch type produced by [`new_batch`](Self::new_batch).
-    type Unmerkleized: Unmerkleized;
+    type Unmerkleized: Send;
 
     /// The canonical state root committed in block headers.
     fn root(&self) -> Self::Digest;
 
     /// Create a child unmerkleized batch that reads through this batch's
     /// pending changes before falling back to the applied database state.
-    ///
-    /// In QMDB, this maps to `merkleized_batch.new_batch()`.
     fn new_batch(&self) -> Self::Unmerkleized;
 }
 
@@ -331,8 +188,8 @@ pub trait Merkleized: Sized + Send + Sync {
 /// Implementations create new batches from applied state and apply finalized
 /// batches back to storage, deferring each batch's flush to a returned handle.
 ///
-/// [`new_batch`](Self::new_batch) consumes origin-bound read access so batch
-/// types can snapshot applied state and retain the matching [`Shared`] handle.
+/// Batches carry a [`Reader`] to their database. Reads acquire a short
+/// lease per call and fall back from pending batch state to applied state.
 ///
 /// `E` is a trait generic (not an associated type), so one database type can
 /// work across runtimes that satisfy the bounds.
@@ -342,18 +199,18 @@ pub trait Merkleized: Sized + Send + Sync {
 /// Mutating methods take the database by value and return it on success. If a mutating
 /// method returns an error, or its future is dropped before it finishes, the database is
 /// gone: state that was not yet durable is discarded, but everything already on disk stays
-/// recoverable.
+/// recoverable. Behind a writer that leaves the database poisoned, so later reads park
+/// rather than observe a database that is missing.
 pub trait ManagedDb<E>: Send + Sync + Sized {
     /// An in-progress batch of mutations that has not yet been merkleized.
-    type Unmerkleized: Unmerkleized;
+    type Unmerkleized: Unmerkleized<Merkleized = Self::Merkleized>;
 
     /// A batch whose root has been computed but has not yet been applied to
     /// the underlying database.
     ///
     /// Constrained so that [`Merkleized::new_batch`] produces the same
     /// [`Unmerkleized`] type as [`ManagedDb::new_batch`](Self::new_batch).
-    /// Cloning must preserve the same sealed branch state and should be cheap.
-    type Merkleized: Clone + Merkleized<Unmerkleized = Self::Unmerkleized>;
+    type Merkleized: Merkleized<Unmerkleized = Self::Unmerkleized>;
 
     /// The error type returned by fallible operations.
     type Error: Debug + Send;
@@ -380,13 +237,14 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// This must match [`sync_target`](Self::sync_target) after opening an empty partition.
     fn initial_sync_target() -> Self::SyncTarget;
 
-    /// Create a new unmerkleized batch rooted at the read-locked database's
-    /// applied state.
+    /// Create a new unmerkleized batch rooted at the database's applied
+    /// state.
     ///
-    /// This method must return without retaining `database`, releasing its read
-    /// lock before the batch performs any lazy read-through work. Batch types
-    /// can retain the matching handle returned by [`BatchContext::into_parts`].
-    fn new_batch(database: BatchContext<'_, Self>) -> Self::Unmerkleized;
+    /// The batch keeps `handle` and leases the database through it on every
+    /// read, so it stays valid across applies of compatible batches.
+    fn new_batch(
+        handle: Reader<Self>,
+    ) -> impl Future<Output = Result<Self::Unmerkleized, Closed>> + Send;
 
     /// Return true if a merkleized batch matches a sync target.
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool;
@@ -512,45 +370,38 @@ impl Barrier {
     }
 }
 
-/// A collection of individually locked [`ManagedDb`] instances.
+/// A collection of [`ManagedDb`] instances.
 ///
-/// Each database is wrapped in [`Shared`], so the set is cheap to
-/// clone and each database can be shared without a global lock.
-/// Multi-database mutations must not hold one member's writer while waiting
-/// to acquire another. Readers may span members in the opposite order.
-///
-/// `E` is a trait generic (not an associated type), so one set type can work
-/// across runtimes that satisfy the bounds.
-pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
-    /// Tuple of [`ManagedDb::Unmerkleized`] for every database in the set.
+/// Every method treats a database error as fatal and panics. Deferred flush
+/// failures surface later, through [`Barrier`].
+pub trait DatabaseSet<E>: Send + Sync + Sized + 'static {
+    /// One [`ManagedDb::Unmerkleized`] per database: scalar under [`Single`], a tuple
+    /// for tuple sets.
     type Unmerkleized: Send;
 
-    /// Tuple of [`ManagedDb::Merkleized`] for every database in the set.
-    /// Cloning must preserve the same sealed branch state and should be cheap.
-    type Merkleized: Clone + Send + Sync;
-
-    /// Read-only handles for observing the applied database state.
+    /// One [`ManagedDb::Merkleized`] per database, shaped like [`Self::Unmerkleized`].
     ///
-    /// Implementations must not expose mutation capabilities through this
-    /// type. In particular, readers must not construct, finalize, prune, or
-    /// rewind database batches.
-    type Readers: Send;
+    /// [`Clone`] is cheap (see [`Merkleized`]) and the wrapper uses it to keep a
+    /// block forkable while that block is being applied.
+    type Merkleized: Clone + Send + Sync;
 
     /// One [`ManagedDb::Snapshot`] per database, shaped like [`Self::Unmerkleized`].
     type Snapshots: Send + Sync + 'static;
 
-    /// Configuration needed to construct every database in the set.
-    ///
-    /// - Single database sets use that database's [`ManagedDb::Config`].
-    /// - Multi-database tuple sets use a tuple of per-database configs
-    ///   `(Db1::Config, Db2::Config, ...)`.
+    /// Configuration needed to construct every database in the set: the database's
+    /// [`ManagedDb::Config`] under [`Single`], a tuple of per-database configs for
+    /// tuple sets.
     type Config: Send;
 
-    /// Per-database sync targets extracted from a finalized block.
-    ///
-    /// For a single-database set this is one target. For multi-database sets it is a tuple of
-    /// targets, one per database.
+    /// Per-database sync targets extracted from a finalized block, shaped like
+    /// [`Self::Config`].
     type SyncTargets: Clone + PartialEq + Send + Sync;
+
+    /// One [`Reader`] per database, shaped like [`Self::Unmerkleized`].
+    ///
+    /// Handles are cloned into batches, and hooks that read applied state
+    /// directly acquire leases through them.
+    type Handles: Clone + Send + Sync + 'static;
 
     /// Construct the database set from its configuration.
     fn init(context: E, config: Self::Config) -> impl Future<Output = Self> + Send;
@@ -558,22 +409,30 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// Return the sync targets produced by a newly initialized database set.
     fn initial_sync_targets() -> Self::SyncTargets;
 
+    /// Read handles over the set's databases.
+    fn handles(&self) -> Self::Handles;
+
     /// Create unmerkleized batches from each database's applied state.
     ///
-    /// Implementations must release every read lock before the returned
-    /// batches perform lazy reads.
-    fn new_batches(&self) -> impl Future<Output = Self::Unmerkleized> + Send;
+    /// Takes handles rather than `&self` because verification jobs build
+    /// batches without holding the set. Methods that do take the set are the
+    /// ones only its owner calls.
+    fn new_batches(
+        handles: &Self::Handles,
+    ) -> impl Future<Output = Result<Self::Unmerkleized, Closed>> + Send;
 
     /// Create child unmerkleized batches from a pending merkleized parent.
     ///
-    /// No lock is needed; reads come from the in-memory merkleized state.
+    /// Reads come from the in-memory merkleized state.
     fn fork_batches(parent: &Self::Merkleized) -> Self::Unmerkleized;
 
-    /// Return true if merkleized batches match the sync targets.
+    /// Return true if merkleized batches match the given sync targets.
     fn matches_sync_targets(batches: &Self::Merkleized, targets: &Self::SyncTargets) -> bool;
 
-    /// Return read-only handles for every database in the set.
-    fn readers(&self) -> Self::Readers;
+    /// Return sync targets for the set's currently applied state.
+    ///
+    /// Applied state may be ahead of durable state while a flush is pending.
+    fn applied_targets(&self) -> impl Future<Output = Self::SyncTargets> + Send;
 
     /// Apply each merkleized batch's changeset to its underlying database, capture each
     /// database's snapshot, and begin persisting them.
@@ -581,42 +440,22 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// Returns once every database reflects its batch. The captured set snapshot must
     /// not be served before the returned [`Barrier`] proves it durable, and every
     /// barrier must be awaited (see [`Barrier`]).
-    ///
-    /// Cancelling the future mid-flight loses the databases whose mutations
-    /// were in progress (see [Shared]); every later access panics.
     fn finalize(
-        &self,
+        self,
         batches: Self::Merkleized,
-    ) -> impl Future<Output = (Self::Snapshots, Barrier)> + Send;
+    ) -> impl Future<Output = (Self, Self::Snapshots, Barrier)> + Send;
 
     /// Capture a snapshot of every database's current applied state.
     ///
     /// A snapshot can include state that is not yet durably persisted.
-    ///
-    /// Cancelling the future mid-flight loses the databases whose mutations
-    /// were in progress (see [Shared]); every later access panics.
-    fn snapshot(&self) -> impl Future<Output = Self::Snapshots> + Send;
+    fn snapshot(self) -> impl Future<Output = (Self, Self::Snapshots)> + Send;
 
-    /// Prune each database to the provided per-database targets.
-    ///
-    /// The finalized state represented by `targets` must already be durable. Barriers for later
-    /// finalized state may still be pending, so implementations must coordinate pruning with those
-    /// in-flight writes. Pruning effects must be durable before this call returns.
-    ///
-    /// Cancelling the future mid-flight loses the databases whose mutations
-    /// were in progress (see [Shared]); every later access panics.
-    fn prune(&self, targets: &Self::SyncTargets) -> impl Future<Output = ()> + Send;
-
-    /// Return sync targets for the set's current applied state.
-    fn committed_targets(&self) -> impl Future<Output = Self::SyncTargets> + Send;
+    /// Prune each database to the provided per-database targets (see
+    /// [`ManagedDb::prune`] for the durability contract).
+    fn prune(self, targets: &Self::SyncTargets) -> impl Future<Output = Self> + Send;
 
     /// Rewind the set to the provided per-database targets.
-    ///
-    /// Rewind failures are fatal for startup recovery and therefore panic.
-    ///
-    /// Cancelling the future mid-flight loses the databases whose mutations
-    /// were in progress (see [Shared]); every later access panics.
-    fn rewind_to_targets(&self, targets: Self::SyncTargets) -> impl Future<Output = ()> + Send;
+    fn rewind_to_targets(self, targets: Self::SyncTargets) -> impl Future<Output = Self> + Send;
 }
 
 /// The snapshot a log-backed QMDB database produces, shared for serving.
@@ -627,8 +466,112 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
 pub type LogSnapshot<F, E, C, H> =
     Arc<authenticated::Snapshot<F, E, <C as Snapshottable>::Reader, H>>;
 
+/// Syntactic sugar for the type of unmerkleized batches used by a given [DatabaseSet] D.
+pub type UnmerkleizedOf<D, E> = <D as DatabaseSet<E>>::Unmerkleized;
+
+/// Syntactic sugar for the type of merkleized batches used by a given [DatabaseSet] D.
+pub type MerkleizedOf<D, E> = <D as DatabaseSet<E>>::Merkleized;
+
 /// Syntactic sugar for the type of published snapshot used by a given [DatabaseSet] D.
 pub type SnapshotsOf<D, E> = <D as DatabaseSet<E>>::Snapshots;
+
+/// Syntactic sugar for the type of sync targets used by a given [DatabaseSet] D.
+pub type SyncTargetsOf<D, E> = <D as DatabaseSet<E>>::SyncTargets;
+
+/// Syntactic sugar for the type of read handles used by a given [DatabaseSet] D.
+pub type HandlesOf<D, E> = <D as DatabaseSet<E>>::Handles;
+
+/// A one-database set.
+///
+/// The set holds the sole [`Writer`], cloning [`Reader`]s into batches.
+pub struct Single<T> {
+    writer: Writer<T>,
+}
+
+impl<T> From<T> for Single<T> {
+    fn from(database: T) -> Self {
+        Self {
+            writer: Writer::new(database),
+        }
+    }
+}
+
+impl<T> Single<T> {
+    /// A reader of the set's database.
+    ///
+    /// Same reader as [`DatabaseSet::handles`], reachable without naming the
+    /// runtime the set is used with.
+    pub fn handle(&self) -> Reader<T> {
+        self.writer.reader()
+    }
+}
+
+impl<E, T> DatabaseSet<E> for Single<T>
+where
+    E: Send + Sync + Metrics,
+    T: ManagedDb<E> + 'static,
+{
+    type Unmerkleized = T::Unmerkleized;
+    type Merkleized = T::Merkleized;
+    type Config = T::Config;
+    type SyncTargets = T::SyncTarget;
+    type Snapshots = T::Snapshot;
+    type Handles = Reader<T>;
+
+    async fn init(context: E, config: Self::Config) -> Self {
+        match T::init(context.child("db"), config).await {
+            Ok(database) => Self::from(database),
+            Err(err) => panic!(
+                "database init failed (type {}): {err:?}",
+                core::any::type_name::<T>(),
+            ),
+        }
+    }
+
+    fn initial_sync_targets() -> Self::SyncTargets {
+        T::initial_sync_target()
+    }
+
+    fn handles(&self) -> Self::Handles {
+        self.handle()
+    }
+
+    async fn new_batches(handles: &Self::Handles) -> Result<Self::Unmerkleized, Closed> {
+        T::new_batch(handles.clone()).await
+    }
+
+    fn fork_batches(parent: &Self::Merkleized) -> Self::Unmerkleized {
+        parent.new_batch()
+    }
+
+    fn matches_sync_targets(batches: &Self::Merkleized, targets: &Self::SyncTargets) -> bool {
+        T::matches_sync_target(batches, targets)
+    }
+
+    async fn applied_targets(&self) -> Self::SyncTargets {
+        self.writer.read().await.sync_target()
+    }
+
+    async fn finalize(self, batches: Self::Merkleized) -> (Self, Self::Snapshots, Barrier) {
+        let (member, snapshot, sync) = finalize_or_panic(self, batches, None).await;
+        let barrier = Barrier {
+            syncs: vec![(core::any::type_name::<T>(), None, sync)],
+        };
+        (member, snapshot, barrier)
+    }
+
+    async fn snapshot(self) -> (Self, Self::Snapshots) {
+        snapshot_or_panic(self, None).await
+    }
+
+    async fn prune(self, targets: &Self::SyncTargets) -> Self {
+        prune_or_panic(self, targets, None).await
+    }
+
+    async fn rewind_to_targets(self, targets: Self::SyncTargets) -> Self {
+        rewind_or_panic(self, targets, None).await
+    }
+}
 
 /// Parameters for a one-time state-sync pass.
 #[derive(Clone, Copy, Debug)]
@@ -651,7 +594,7 @@ pub struct SyncEngineConfig {
 }
 
 /// A [`ManagedDb`] with a state-sync entrypoint.
-pub trait StateSyncDb<E, R>: ManagedDb<E> {
+pub trait StateSyncDb<E, S>: ManagedDb<E> {
     /// Error returned by the state-sync engine for this database.
     type SyncError: Debug + Send;
 
@@ -660,7 +603,7 @@ pub trait StateSyncDb<E, R>: ManagedDb<E> {
     fn sync_db(
         context: E,
         config: Self::Config,
-        source: R,
+        source: S,
         target: Self::SyncTarget,
         tip_updates: mpsc::Receiver<Self::SyncTarget>,
         finish: Option<mpsc::Receiver<()>>,
@@ -743,7 +686,7 @@ impl<D: Digest, T> TipUpdate<D, T> {
 /// `D` is the block digest type. Each set of sync targets is paired
 /// with an [`Anchor`] identifying the block that produced those targets.
 /// On convergence, `sync` returns the anchor that all databases agreed on.
-pub trait StateSyncSet<E, R, D>: DatabaseSet<E>
+pub trait StateSyncSet<E, S, D>: DatabaseSet<E>
 where
     D: Digest,
 {
@@ -756,7 +699,7 @@ where
     fn sync(
         context: E,
         config: Self::Config,
-        sources: R,
+        sources: S,
         anchor: Anchor<D>,
         targets: Self::SyncTargets,
         tip_updates: ring::Receiver<TipUpdate<D, Self::SyncTargets>>,
@@ -764,76 +707,11 @@ where
     ) -> impl Future<Output = Result<(Self, Anchor<D>), Self::Error>> + Send;
 }
 
-/// Implement [`DatabaseSet`] for a single [`ManagedDb`] behind a lock.
-impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Shared<T> {
-    type Unmerkleized = T::Unmerkleized;
-    type Merkleized = T::Merkleized;
-    type Readers = Reader<T>;
-    type Snapshots = T::Snapshot;
-    type Config = T::Config;
-    type SyncTargets = T::SyncTarget;
-
-    async fn init(context: E, config: Self::Config) -> Self {
-        let db = T::init(context, config)
-            .await
-            .expect("database init failed");
-        Self::new("stateful.db", db)
-    }
-
-    fn initial_sync_targets() -> Self::SyncTargets {
-        T::initial_sync_target()
-    }
-
-    async fn new_batches(&self) -> Self::Unmerkleized {
-        let database = self.read_locked().await;
-        T::new_batch(database.batch_context())
-    }
-
-    fn fork_batches(parent: &Self::Merkleized) -> Self::Unmerkleized {
-        parent.new_batch()
-    }
-
-    fn matches_sync_targets(batches: &Self::Merkleized, targets: &Self::SyncTargets) -> bool {
-        T::matches_sync_target(batches, targets)
-    }
-
-    fn readers(&self) -> Self::Readers {
-        Reader(self.clone())
-    }
-
-    async fn finalize(&self, batches: Self::Merkleized) -> (Self::Snapshots, Barrier) {
-        let (snapshot, handle) = finalize_shared_or_panic::<E, T>(self, batches, None).await;
-        (
-            snapshot,
-            Barrier {
-                syncs: vec![(core::any::type_name::<T>(), None, handle)],
-            },
-        )
-    }
-
-    async fn snapshot(&self) -> Self::Snapshots {
-        snapshot_shared_or_panic::<E, T>(self, None).await
-    }
-
-    async fn prune(&self, target: &Self::SyncTargets) {
-        prune_shared_or_panic::<E, T>(self, target, None).await;
-    }
-
-    async fn committed_targets(&self) -> Self::SyncTargets {
-        let database = self.read().await;
-        T::sync_target(&database)
-    }
-
-    async fn rewind_to_targets(&self, target: Self::SyncTargets) {
-        rewind_shared_or_panic::<E, T>(self, target, None).await;
-    }
-}
-
-impl<E, T, R, D> StateSyncSet<E, R, D> for Shared<T>
+impl<E, T, S, D> StateSyncSet<E, S, D> for Single<T>
 where
     E: Send + Sync + Metrics,
-    T: StateSyncDb<E, R> + 'static,
-    R: Send + 'static,
+    T: StateSyncDb<E, S> + 'static,
+    S: Send + 'static,
     D: Digest,
 {
     type Error = T::SyncError;
@@ -842,7 +720,7 @@ where
     async fn sync(
         context: E,
         config: Self::Config,
-        source: R,
+        source: S,
         anchor: Anchor<D>,
         target: Self::SyncTargets,
         tip_updates: ring::Receiver<TipUpdate<D, Self::SyncTargets>>,
@@ -936,7 +814,7 @@ where
             T::sync_target(&database) == converged_target,
             "state sync database target does not match the coordinator target",
         );
-        Ok((Self::new("stateful.db", database), converged_anchor))
+        Ok((Self::from(database), converged_anchor))
     }
 }
 
@@ -990,24 +868,24 @@ where
     target_tx.send_lossy(new_target).await
 }
 
-/// Implement [`DatabaseSet`] for a tuple of individually-locked
-/// [`ManagedDb`] instances.
+/// Implement [`DatabaseSet`] for a tuple of gated one-database sets.
 macro_rules! impl_database_set {
     ($($T:ident : $idx:tt),+) => {
         impl<E: Send + Sync + Metrics, $($T: ManagedDb<E> + 'static),+> DatabaseSet<E>
-            for ($(Shared<$T>,)+)
+            for ($(Single<$T>,)+)
         {
             type Unmerkleized = ($($T::Unmerkleized,)+);
             type Merkleized = ($($T::Merkleized,)+);
-            type Readers = ($(Reader<$T>,)+);
-            type Snapshots = ($($T::Snapshot,)+);
             type Config = ($($T::Config,)+);
             type SyncTargets = ($($T::SyncTarget,)+);
+            type Snapshots = ($($T::Snapshot,)+);
+            type Handles = ($(Reader<$T>,)+);
 
             async fn init(context: E, config: Self::Config) -> Self {
-                let result = join!($(
+                join!($(
                     async {
-                        let db = $T::init(
+                        Single::from(
+                            $T::init(
                                 context.child(concat!("db_", stringify!($idx))),
                                 config.$idx,
                             )
@@ -1018,20 +896,25 @@ macro_rules! impl_database_set {
                                 ", type ",
                                 stringify!($T),
                                 ")",
-                            ));
-                        Shared::new(concat!("stateful.db.", stringify!($idx)), db)
+                            )),
+                        )
                     },
-                )+);
-                result
+                )+)
             }
 
             fn initial_sync_targets() -> Self::SyncTargets {
                 ($($T::initial_sync_target(),)+)
             }
 
-            async fn new_batches(&self) -> Self::Unmerkleized {
-                let databases = join!($(self.$idx.read_locked(),)+);
-                ($($T::new_batch(databases.$idx.batch_context()),)+)
+            fn handles(&self) -> Self::Handles {
+                ($(self.$idx.handle(),)+)
+            }
+
+            async fn new_batches(handles: &Self::Handles) -> Result<Self::Unmerkleized, Closed> {
+                let batches = join!($(
+                    $T::new_batch(handles.$idx.clone()),
+                )+);
+                Ok(($(batches.$idx?,)+))
             }
 
             fn fork_batches(parent: &Self::Merkleized) -> Self::Unmerkleized {
@@ -1042,70 +925,52 @@ macro_rules! impl_database_set {
                 $($T::matches_sync_target(&batches.$idx, &targets.$idx))&&+
             }
 
-            fn readers(&self) -> Self::Readers {
-                ($(Reader(self.$idx.clone()),)+)
+            async fn applied_targets(&self) -> Self::SyncTargets {
+                join!($(
+                    async { self.$idx.writer.read().await.sync_target() },
+                )+)
             }
 
-            async fn finalize(
-                &self,
-                batches: Self::Merkleized,
-            ) -> (Self::Snapshots, Barrier) {
-                // Each member completes its own write-lock lifecycle. Holding
-                // a partial tuple of writers can deadlock cross-database reads.
-                let results = join!($(finalize_shared_or_panic::<E, $T>(
-                    &self.$idx,
-                    batches.$idx,
-                    Some($idx),
-                ),)+);
-                let snapshots = ($(results.$idx.0,)+);
+            async fn finalize(self, batches: Self::Merkleized) -> (Self, Self::Snapshots, Barrier) {
+                // Every database captures at its own apply boundary inside this call, so the
+                // captured snapshots form one capture.
+                let results = join!($(
+                    finalize_or_panic(self.$idx, batches.$idx, Some($idx)),
+                )+);
                 let barrier = Barrier {
-                    syncs: vec![$((
-                        core::any::type_name::<$T>(),
-                        Some($idx),
-                        results.$idx.1,
-                    ),)+],
+                    syncs: vec![$(
+                        (core::any::type_name::<$T>(), Some($idx), results.$idx.2),
+                    )+],
                 };
-                (snapshots, barrier)
+                (
+                    ($(results.$idx.0,)+),
+                    ($(results.$idx.1,)+),
+                    barrier,
+                )
             }
 
-            async fn snapshot(&self) -> Self::Snapshots {
-                join!($(snapshot_shared_or_panic::<E, $T>(
-                    &self.$idx,
-                    Some($idx),
-                ),)+)
+            async fn snapshot(self) -> (Self, Self::Snapshots) {
+                let results = join!($(
+                    snapshot_or_panic(self.$idx, Some($idx)),
+                )+);
+                (($(results.$idx.0,)+), ($(results.$idx.1,)+))
             }
 
-            async fn prune(
-                &self,
-                targets: &Self::SyncTargets,
-            ) {
-                join!($(prune_shared_or_panic::<E, $T>(
-                    &self.$idx,
-                    &targets.$idx,
-                    Some($idx),
-                ),)+);
+            async fn prune(self, targets: &Self::SyncTargets) -> Self {
+                join!($(
+                    prune_or_panic(self.$idx, &targets.$idx, Some($idx)),
+                )+)
             }
 
-            async fn committed_targets(&self) -> Self::SyncTargets {
-                let databases = join!($(self.$idx.read(),)+);
-                ($($T::sync_target(&databases.$idx),)+)
-            }
-
-            async fn rewind_to_targets(
-                &self,
-                targets: Self::SyncTargets,
-            ) {
-                join!($(rewind_shared_or_panic::<E, $T>(
-                    &self.$idx,
-                    targets.$idx,
-                    Some($idx),
-                ),)+);
+            async fn rewind_to_targets(self, targets: Self::SyncTargets) -> Self {
+                join!($(
+                    rewind_or_panic(self.$idx, targets.$idx, Some($idx)),
+                )+)
             }
         }
     };
 }
 
-impl_database_set!(DB1: 0);
 impl_database_set!(DB1: 0, DB2: 1);
 impl_database_set!(DB1: 0, DB2: 1, DB3: 2);
 impl_database_set!(DB1: 0, DB2: 1, DB3: 2, DB4: 3);
@@ -1151,14 +1016,14 @@ struct CoordinatorSyncSenders<T> {
 }
 
 macro_rules! impl_state_sync_set {
-    ($($T:ident : $R:ident : $idx:tt),+) => {
-        impl<E, D, $($T, $R),+> StateSyncSet<E, ($($R,)+), D> for ($(Shared<$T>,)+)
+    ($($T:ident : $S:ident : $idx:tt),+) => {
+        impl<E, D, $($T, $S),+> StateSyncSet<E, ($($S,)+), D> for ($(Single<$T>,)+)
         where
             E: Send + Sync + Spawner + Metrics + 'static,
             D: Digest + 'static,
             $(
-                $T: StateSyncDb<E, $R> + 'static,
-                $R: Send + 'static,
+                $T: StateSyncDb<E, $S> + 'static,
+                $S: Send + 'static,
             )+
         {
             type Error = String;
@@ -1167,7 +1032,7 @@ macro_rules! impl_state_sync_set {
             async fn sync(
                 context: E,
                 config: Self::Config,
-                sources: ($($R,)+),
+                sources: ($($S,)+),
                 anchor: Anchor<D>,
                 targets: Self::SyncTargets,
                 tip_updates: ring::Receiver<TipUpdate<D, Self::SyncTargets>>,
@@ -1179,13 +1044,6 @@ macro_rules! impl_state_sync_set {
                     ),
                 )+);
                 let coordinator_senders = ($(
-                    CoordinatorSyncSenders {
-                        target_tx: db_channels.$idx.target_tx.clone(),
-                        finish_tx: db_channels.$idx.finish_tx.clone(),
-                        generation_tx: db_channels.$idx.generation_tx.clone(),
-                    },
-                )+);
-                let coordinator_owned_senders = ($(
                     CoordinatorSyncSenders {
                         target_tx: db_channels.$idx.target_tx,
                         finish_tx: db_channels.$idx.finish_tx,
@@ -1201,7 +1059,6 @@ macro_rules! impl_state_sync_set {
                     Arc::new(commonware_utils::sync::Mutex::new(None));
                 let coordinator_handle = context.child("coordinator").spawn({
                     move |_context| async move {
-                        let coordinator_owned_senders = coordinator_owned_senders;
                         let mut tip_updates = Some(tip_updates);
                         let mut state = CoordinatorState::new(db_count, anchor, coordinator_targets);
                         let mut last_dispatched_targets = initial_targets;
@@ -1282,7 +1139,6 @@ macro_rules! impl_state_sync_set {
                                     state.record_reached(idx, generation);
                                 },
                                 _ = completion_rx.recv() => {
-                                    drop(coordinator_owned_senders);
                                     return None;
                                 },
                                 update = update_future => {
@@ -1399,20 +1255,13 @@ macro_rules! impl_state_sync_set {
                                     }
                                 };
                                 let (sync_result, _) = join!(sync, forward_reached);
-                                let result = sync_result
-                                    .map(|database| {
-                                        Shared::new(
-                                            concat!("stateful.db.", stringify!($idx)),
-                                            database,
-                                        )
-                                    })
-                                    .map_err(|err| {
-                                        format!(
-                                            "state sync failed (index {}, db {}): {err:?}",
-                                            $idx,
-                                            core::any::type_name::<$T>(),
-                                        )
-                                    });
+                                let result = sync_result.map_err(|err| {
+                                    format!(
+                                        "state sync failed (index {}, db {}): {err:?}",
+                                        $idx,
+                                        core::any::type_name::<$T>(),
+                                    )
+                                });
                                 if let Err(err) = &result {
                                     let mut first = first_db_error.lock();
                                     if first.is_none() {
@@ -1443,13 +1292,11 @@ macro_rules! impl_state_sync_set {
                     return Err(err);
                 }
 
-                let synced = ($(synced.$idx?,)+);
+                let synced = ($(Single::from(synced.$idx?),)+);
                 let Some((converged_anchor, converged_targets)) = converged_anchor else {
                     return Err("state sync coordinator did not report a converged anchor".into());
                 };
-                let committed_targets =
-                    <Self as DatabaseSet<E>>::committed_targets(&synced).await;
-                if committed_targets != converged_targets {
+                if <Self as DatabaseSet<E>>::applied_targets(&synced).await != converged_targets {
                     return Err(
                         "state sync database targets do not match the coordinator target set"
                             .into(),
@@ -1462,29 +1309,29 @@ macro_rules! impl_state_sync_set {
     };
 }
 
-impl_state_sync_set!(DB1: R1: 0, DB2: R2: 1);
-impl_state_sync_set!(DB1: R1: 0, DB2: R2: 1, DB3: R3: 2);
-impl_state_sync_set!(DB1: R1: 0, DB2: R2: 1, DB3: R3: 2, DB4: R4: 3);
-impl_state_sync_set!(DB1: R1: 0, DB2: R2: 1, DB3: R3: 2, DB4: R4: 3, DB5: R5: 4);
-impl_state_sync_set!(DB1: R1: 0, DB2: R2: 1, DB3: R3: 2, DB4: R4: 3, DB5: R5: 4, DB6: R6: 5);
+impl_state_sync_set!(DB1: S1: 0, DB2: S2: 1);
+impl_state_sync_set!(DB1: S1: 0, DB2: S2: 1, DB3: S3: 2);
+impl_state_sync_set!(DB1: S1: 0, DB2: S2: 1, DB3: S3: 2, DB4: S4: 3);
+impl_state_sync_set!(DB1: S1: 0, DB2: S2: 1, DB3: S3: 2, DB4: S4: 3, DB5: S5: 4);
+impl_state_sync_set!(DB1: S1: 0, DB2: S2: 1, DB3: S3: 2, DB4: S4: 3, DB5: S5: 4, DB6: S6: 5);
 impl_state_sync_set!(
-    DB1: R1: 0,
-    DB2: R2: 1,
-    DB3: R3: 2,
-    DB4: R4: 3,
-    DB5: R5: 4,
-    DB6: R6: 5,
-    DB7: R7: 6
+    DB1: S1: 0,
+    DB2: S2: 1,
+    DB3: S3: 2,
+    DB4: S4: 3,
+    DB5: S5: 4,
+    DB6: S6: 5,
+    DB7: S7: 6
 );
 impl_state_sync_set!(
-    DB1: R1: 0,
-    DB2: R2: 1,
-    DB3: R3: 2,
-    DB4: R4: 3,
-    DB5: R5: 4,
-    DB6: R6: 5,
-    DB7: R7: 6,
-    DB8: R8: 7
+    DB1: S1: 0,
+    DB2: S2: 1,
+    DB3: S3: 2,
+    DB4: S4: 3,
+    DB5: S5: 4,
+    DB6: S6: 5,
+    DB7: S7: 6,
+    DB8: S8: 7
 );
 
 async fn drain_generation_updates<T>(
@@ -1839,127 +1686,118 @@ where
     result
 }
 
-#[tracing::instrument(name = "stateful.db.finalize_or_panic", level = "info", skip_all, fields(index = index))]
-async fn finalize_or_panic<E, T: ManagedDb<E>>(
-    database: T,
-    batch: T::Merkleized,
-    index: Option<usize>,
-) -> (T, T::Snapshot, Handle<()>) {
-    // Mutable finalize failures are fatal by design because the batch may already have been
-    // applied to other databases in the same set, leaving partially applied state.
-    match database.finalize(batch).await {
-        Ok(result) => result,
-        Err(err) => {
-            let index = index.map_or(String::new(), |i| format!("index {i}, "));
-            panic!(
-                "database finalize failed ({index}type {}): {err:?}",
-                core::any::type_name::<T>(),
-            );
-        }
-    }
-}
-
-async fn finalize_shared_or_panic<E, T: ManagedDb<E>>(
-    shared: &Shared<T>,
-    batch: T::Merkleized,
-    index: Option<usize>,
-) -> (T::Snapshot, Handle<()>) {
-    let (slot, database) = shared.write().await;
-    let (database, snapshot, handle) = finalize_or_panic(database, batch, index).await;
-    slot.put(database);
-    (snapshot, handle)
-}
-
 #[tracing::instrument(name = "stateful.db.snapshot_or_panic", level = "info", skip_all, fields(index = index))]
-async fn snapshot_shared_or_panic<E, T: ManagedDb<E>>(
-    shared: &Shared<T>,
+async fn snapshot_or_panic<E, T: ManagedDb<E>>(
+    member: Single<T>,
     index: Option<usize>,
-) -> T::Snapshot {
-    let (slot, database) = shared.write().await;
+) -> (Single<T>, T::Snapshot) {
     // Capture failures are fatal by design: a set that cannot snapshot its applied
     // state cannot publish, and other members may already have captured.
-    let (database, snapshot) = match database.snapshot().await {
-        Ok(result) => result,
-        Err(err) => {
-            let index = index.map_or(String::new(), |i| format!("index {i}, "));
-            panic!(
-                "database snapshot capture failed ({index}type {}): {err:?}",
-                core::any::type_name::<T>(),
-            );
-        }
-    };
-    slot.put(database);
-    snapshot
+    let Single { writer } = member;
+    let (writer, snapshot) = writer
+        .mutate(|database| async move {
+            match database.snapshot().await {
+                Ok(result) => result,
+                Err(err) => {
+                    let index = index.map_or(String::new(), |i| format!("index {i}, "));
+                    panic!(
+                        "database snapshot capture failed ({index}type {}): {err:?}",
+                        core::any::type_name::<T>(),
+                    );
+                }
+            }
+        })
+        .await;
+    (Single { writer }, snapshot)
 }
 
-async fn prune_shared_or_panic<E, T: ManagedDb<E>>(
-    shared: &Shared<T>,
-    target: &T::SyncTarget,
+#[tracing::instrument(name = "stateful.db.finalize_or_panic", level = "info", skip_all, fields(index = index))]
+async fn finalize_or_panic<E, T: ManagedDb<E>>(
+    member: Single<T>,
+    batch: T::Merkleized,
     index: Option<usize>,
-) {
-    let (slot, database) = shared.write().await;
-    slot.put(prune_or_panic(database, target, index).await);
-}
-
-async fn rewind_shared_or_panic<E, T: ManagedDb<E>>(
-    shared: &Shared<T>,
-    target: T::SyncTarget,
-    index: Option<usize>,
-) {
-    let (slot, database) = shared.write().await;
-    if T::sync_target(&database) == target {
-        slot.put(database);
-        return;
-    }
-    slot.put(rewind_or_panic(database, target, index).await);
+) -> (Single<T>, T::Snapshot, Handle<()>) {
+    // Mutable finalize failures are fatal by design because the batch may already have been
+    // applied to other databases in the same set, leaving partially applied state.
+    let Single { writer } = member;
+    let (writer, (snapshot, sync)) = writer
+        .mutate(|database| async move {
+            match database.finalize(batch).await {
+                Ok((database, snapshot, sync)) => (database, (snapshot, sync)),
+                Err(err) => {
+                    let index = index.map_or(String::new(), |i| format!("index {i}, "));
+                    panic!(
+                        "database finalize failed ({index}type {}): {err:?}",
+                        core::any::type_name::<T>(),
+                    );
+                }
+            }
+        })
+        .await;
+    (Single { writer }, snapshot, sync)
 }
 
 #[tracing::instrument(name = "stateful.db.rewind_or_panic", level = "info", skip_all, fields(index = index))]
 async fn rewind_or_panic<E, T: ManagedDb<E>>(
-    database: T,
+    member: Single<T>,
     target: T::SyncTarget,
     index: Option<usize>,
-) -> T {
+) -> Single<T> {
     // Mutable rewind failures are fatal by design because the database handle
     // may be internally diverged after a failed rewind.
-    match database.rewind_to_target(target).await {
-        Ok(database) => database,
-        Err(err) => {
-            let index = index.map_or(String::new(), |i| format!("index {i}, "));
-            panic!(
-                "database rewind failed ({index}type {}): {err:?}",
-                core::any::type_name::<T>(),
-            );
-        }
-    }
+    let Single { writer } = member;
+    let (writer, ()) = writer
+        .mutate(|database| async move {
+            if T::sync_target(&database) == target {
+                return (database, ());
+            }
+            match database.rewind_to_target(target).await {
+                Ok(database) => (database, ()),
+                Err(err) => {
+                    let index = index.map_or(String::new(), |i| format!("index {i}, "));
+                    panic!(
+                        "database rewind failed ({index}type {}): {err:?}",
+                        core::any::type_name::<T>(),
+                    );
+                }
+            }
+        })
+        .await;
+    Single { writer }
 }
 
 #[tracing::instrument(name = "stateful.db.prune_or_panic", level = "info", skip_all, fields(index = index))]
 async fn prune_or_panic<E, T: ManagedDb<E>>(
-    database: T,
+    member: Single<T>,
     target: &T::SyncTarget,
     index: Option<usize>,
-) -> T {
+) -> Single<T> {
     // Prune failures are fatal because pruning may already have discarded part
     // of the retained history before the error surfaced.
-    match database.prune(target).await {
-        Ok(database) => database,
-        Err(err) => {
-            let index = index.map_or(String::new(), |i| format!("index {i}, "));
-            panic!(
-                "database prune failed ({index}type {}): {err:?}",
-                core::any::type_name::<T>(),
-            );
-        }
-    }
+    let Single { writer } = member;
+    let (writer, ()) = writer
+        .mutate(|database| async move {
+            match database.prune(target).await {
+                Ok(database) => (database, ()),
+                Err(err) => {
+                    let index = index.map_or(String::new(), |i| format!("index {i}, "));
+                    panic!(
+                        "database prune failed ({index}type {}): {err:?}",
+                        core::any::type_name::<T>(),
+                    );
+                }
+            }
+        })
+        .await;
+    Single { writer }
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        Anchor, Barrier, BatchContext, CoordinatorAction, CoordinatorState, DatabaseSet,
-        MAX_CHANNEL_DRAIN_PER_TICK, ManagedDb, Shared, StateSyncDb, StateSyncSet, SyncEngineConfig,
-        TipUpdate, drain_single_tip_updates,
+        Anchor, Barrier, Closed, CoordinatorAction, CoordinatorState, DatabaseSet,
+        MAX_CHANNEL_DRAIN_PER_TICK, ManagedDb, Reader, Single, StateSyncDb, StateSyncSet,
+        SyncEngineConfig, TipUpdate, Writer, drain_single_tip_updates,
     };
     use crate::stateful::tests::mocks::{TestMerkleized, TestUnmerkleized, anchor as mock_anchor};
     use commonware_cryptography::sha256;
@@ -1984,12 +1822,12 @@ mod tests {
     };
 
     mod managed_db_lifecycle {
-        use super::{ManagedDb, Shared};
+        use super::{ManagedDb, Writer};
         use crate::stateful::db::Unmerkleized;
         use commonware_cryptography::{Sha256, sha256::Digest};
         use commonware_parallel::Sequential;
         use commonware_runtime::{
-            Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
+            Handle, Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
         };
         use commonware_storage::{
             journal::contiguous::{
@@ -2300,26 +2138,41 @@ mod tests {
             }
         }
 
+        /// Finalize `batch` through the writer, returning the snapshot and flush handle.
+        async fn finalize<T: ManagedDb<Context>>(
+            writer: Writer<T>,
+            batch: T::Merkleized,
+        ) -> (Writer<T>, T::Snapshot, Handle<()>) {
+            let (writer, (snapshot, sync)) = writer
+                .mutate(|db| async move {
+                    let (db, snapshot, sync) = T::finalize(db, batch).await.unwrap_or_else(|err| {
+                        panic!("finalize failed: {err:?}");
+                    });
+                    (db, (snapshot, sync))
+                })
+                .await;
+            (writer, snapshot, sync)
+        }
+
         async fn assert_initial_sync_target_and_finalize<T>(context: Context, config: T::Config)
         where
             T: ManagedDb<Context> + 'static,
-            T::Unmerkleized: Unmerkleized<Merkleized = T::Merkleized>,
             <T::Unmerkleized as Unmerkleized>::Error: Debug,
             T::SyncTarget: Debug,
         {
             let initial = T::initial_sync_target();
             let db = T::init(context, config).await.unwrap();
             assert_eq!(initial, db.sync_target());
-            let db = Shared::new("test", db);
-            let batch = db
-                .new_batch_for_test::<Context>()
+            let writer = Writer::new(db);
+            let handle = writer.reader();
+            let batch = T::new_batch(handle)
                 .await
+                .expect("writer is live")
                 .merkleize()
                 .await
                 .expect("empty batch must merkleize");
-            let (slot, database) = db.write().await;
-            let (database, _snapshot, sync) = T::finalize(database, batch).await.unwrap();
-            slot.put(database);
+            let (_writer, snapshot, sync) = finalize(writer, batch).await;
+            drop(snapshot);
             sync.await.expect("empty batch finalize flush failed");
         }
 
@@ -2370,13 +2223,116 @@ mod tests {
             #[case] config: fn(&Context, &str) -> T::Config,
         ) where
             T: ManagedDb<Context> + 'static,
-            T::Unmerkleized: Unmerkleized<Merkleized = T::Merkleized>,
             <T::Unmerkleized as Unmerkleized>::Error: Debug,
             T::SyncTarget: Debug,
         {
             deterministic::Runner::default().start(|context| async move {
                 let config = config(&context, "db");
                 assert_initial_sync_target_and_finalize::<T>(context.child("db"), config).await;
+            });
+        }
+
+        async fn assert_rewind_restores_finalized_target<T>(context: Context, config: T::Config)
+        where
+            T: ManagedDb<Context> + 'static,
+            <T::Unmerkleized as Unmerkleized>::Error: Debug,
+            T::SyncTarget: Debug,
+        {
+            let db = T::init(context, config).await.unwrap();
+            let writer = Writer::new(db);
+            let handle = writer.reader();
+            let batch = T::new_batch(handle.clone())
+                .await
+                .expect("writer is live")
+                .merkleize()
+                .await
+                .expect("first batch must merkleize");
+            let (writer, snapshot, sync) = finalize(writer, batch).await;
+            drop(snapshot);
+            sync.await.expect("first finalize flush failed");
+            let target = handle.read().await.expect("writer is live").sync_target();
+
+            let batch = T::new_batch(handle.clone())
+                .await
+                .expect("writer is live")
+                .merkleize()
+                .await
+                .expect("second batch must merkleize");
+            let (writer, snapshot, sync) = finalize(writer, batch).await;
+            drop(snapshot);
+            sync.await.expect("second finalize flush failed");
+
+            let (_writer, ()) = writer
+                .mutate(|db| {
+                    let target = target.clone();
+                    async move {
+                        let db = db
+                            .rewind_to_target(target)
+                            .await
+                            .unwrap_or_else(|_| panic!("rewind to finalized target failed"));
+                        (db, ())
+                    }
+                })
+                .await;
+            assert_eq!(
+                handle.read().await.expect("writer is live").sync_target(),
+                target
+            );
+        }
+
+        #[rstest]
+        #[case::any_fixed(PhantomData::<AnyFixed>, any_fixed_config)]
+        #[case::any_variable(PhantomData::<AnyVariable>, any_variable_config)]
+        #[case::current_unordered_fixed(
+            PhantomData::<CurrentUnorderedFixed>,
+            current_fixed_config
+        )]
+        #[case::current_ordered_fixed(
+            PhantomData::<CurrentOrderedFixed>,
+            current_fixed_config
+        )]
+        #[case::current_unordered_variable(
+            PhantomData::<CurrentUnorderedVariable>,
+            current_variable_config
+        )]
+        #[case::current_ordered_variable(
+            PhantomData::<CurrentOrderedVariable>,
+            current_variable_config
+        )]
+        #[case::immutable_fixed(PhantomData::<ImmutableFixed>, immutable_fixed_config)]
+        #[case::immutable_variable(
+            PhantomData::<ImmutableVariable>,
+            immutable_variable_config
+        )]
+        #[case::immutable_compact_fixed(
+            PhantomData::<ImmutableCompactFixed>,
+            immutable_compact_fixed_config
+        )]
+        #[case::immutable_compact_variable(
+            PhantomData::<ImmutableCompactVariable>,
+            immutable_compact_variable_config
+        )]
+        #[case::keyless_fixed(PhantomData::<KeylessFixed>, keyless_fixed_config)]
+        #[case::keyless_variable(PhantomData::<KeylessVariable>, keyless_variable_config)]
+        #[case::keyless_compact_fixed(
+            PhantomData::<KeylessCompactFixed>,
+            keyless_compact_fixed_config
+        )]
+        #[case::keyless_compact_variable(
+            PhantomData::<KeylessCompactVariable>,
+            keyless_compact_variable_config
+        )]
+        fn rewind_restores_earlier_finalized_sync_target<T>(
+            #[case] _db: PhantomData<T>,
+            #[case] config: fn(&Context, &str) -> T::Config,
+        ) where
+            T: ManagedDb<Context> + 'static,
+            <T::Unmerkleized as Unmerkleized>::Error: Debug,
+            T::SyncTarget: Debug,
+        {
+            deterministic::Runner::default().start(|context| async move {
+                let config = config(&context, "db");
+                assert_rewind_restores_finalized_target::<T>(context.child("db"), config).await;
             });
         }
     }
@@ -2422,8 +2378,8 @@ mod tests {
             Ok(Self)
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2459,8 +2415,8 @@ mod tests {
             unreachable!("CountingRewindDb is constructed directly in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2498,8 +2454,8 @@ mod tests {
             Ok(Self { prune_count })
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2608,8 +2564,8 @@ mod tests {
             Ok(Self)
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2630,37 +2586,78 @@ mod tests {
         }
     }
 
+    struct FailingSnapshotDb;
+
+    impl<E: Send> ManagedDb<E> for FailingSnapshotDb {
+        type Unmerkleized = TestUnmerkleized;
+        type Merkleized = TestMerkleized;
+        type Error = TestFinalizeError;
+        type Config = ();
+        type SyncTarget = ();
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Err(TestFinalizeError)
+        }
+
+        fn initial_sync_target() -> Self::SyncTarget {}
+
+        async fn init(_context: E, _config: Self::Config) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
+        }
+
+        fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
+            true
+        }
+
+        async fn finalize(
+            self,
+            _batch: Self::Merkleized,
+        ) -> Result<(Self, Self::Snapshot, Handle<()>), Self::Error> {
+            Ok((self, (), Handle::ready(Ok(()))))
+        }
+
+        fn sync_target(&self) -> Self::SyncTarget {}
+
+        async fn rewind_to_target(self, _target: Self::SyncTarget) -> Result<Self, Self::Error> {
+            Ok(self)
+        }
+    }
+
     #[test]
     fn tuple_rewind_to_targets_skips_already_aligned_databases() {
         deterministic::Runner::default().start(|_context| async move {
-            type DbSet = (Shared<CountingRewindDb>, Shared<CountingRewindDb>);
+            type RewindPair = (Single<CountingRewindDb>, Single<CountingRewindDb>);
 
-            let left = Shared::new(
-                "test",
-                CountingRewindDb {
-                    current_target: 2,
-                    rewind_count: 0,
-                },
+            let left = CountingRewindDb {
+                current_target: 2,
+                rewind_count: 0,
+            };
+            let right = CountingRewindDb {
+                current_target: 1,
+                rewind_count: 0,
+            };
+
+            let databases: RewindPair = (Single::from(left), Single::from(right));
+            let databases = <RewindPair as DatabaseSet<deterministic::Context>>::rewind_to_targets(
+                databases,
+                (1, 1),
+            )
+            .await;
+
+            let (left, right) = (databases.0.handle(), databases.1.handle());
+            assert_eq!(left.read().await.expect("writer is live").current_target, 1);
+            assert_eq!(left.read().await.expect("writer is live").rewind_count, 1);
+
+            assert_eq!(
+                right.read().await.expect("writer is live").current_target,
+                1
             );
-            let right = Shared::new(
-                "test",
-                CountingRewindDb {
-                    current_target: 1,
-                    rewind_count: 0,
-                },
-            );
-            let databases: DbSet = (left.clone(), right.clone());
-
-            <DbSet as DatabaseSet<deterministic::Context>>::rewind_to_targets(&databases, (1, 1))
-                .await;
-
-            let left = left.read().await;
-            assert_eq!(left.current_target, 1);
-            assert_eq!(left.rewind_count, 1);
-
-            let right = right.read().await;
-            assert_eq!(right.current_target, 1);
-            assert_eq!(right.rewind_count, 0);
+            assert_eq!(right.read().await.expect("writer is live").rewind_count, 0);
         });
     }
 
@@ -2668,15 +2665,11 @@ mod tests {
     fn database_set_prune_calls_managed_db_prune() {
         deterministic::Runner::default().start(|_context| async move {
             let prune_count = Arc::new(AtomicUsize::new(0));
-            let database = Shared::new(
-                "test",
-                PruneCountingDb {
-                    prune_count: prune_count.clone(),
-                },
-            );
+            let database = Single::from(PruneCountingDb {
+                prune_count: prune_count.clone(),
+            });
 
-            <Shared<PruneCountingDb> as DatabaseSet<deterministic::Context>>::prune(&database, &())
-                .await;
+            let _database = DatabaseSet::<deterministic::Context>::prune(database, &()).await;
 
             assert_eq!(prune_count.load(Ordering::SeqCst), 1);
         });
@@ -2700,8 +2693,8 @@ mod tests {
             unreachable!("BlockingFinalizeDb is constructed directly in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2748,8 +2741,8 @@ mod tests {
             unreachable!("SlowSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2791,8 +2784,8 @@ mod tests {
             )
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2830,8 +2823,8 @@ mod tests {
             unreachable!("FastSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2869,8 +2862,8 @@ mod tests {
             unreachable!("FailingStateSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2908,8 +2901,8 @@ mod tests {
             unreachable!("MismatchedTargetSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2947,8 +2940,8 @@ mod tests {
             unreachable!("ImmediateStateSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -2986,8 +2979,8 @@ mod tests {
             unreachable!("FinishClosedSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -3025,8 +3018,8 @@ mod tests {
             unreachable!("ObservedSlowSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -3064,8 +3057,8 @@ mod tests {
             unreachable!("ObservedFastSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -3107,8 +3100,8 @@ mod tests {
             )
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -3255,8 +3248,8 @@ mod tests {
             unreachable!("StaleReachedSyncDb is only constructed through state sync in tests")
         }
 
-        fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-            TestUnmerkleized
+        async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+            Ok(TestUnmerkleized)
         }
 
         fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -3695,85 +3688,6 @@ mod tests {
     }
 
     #[test]
-    fn tuple_new_batches_queues_reads_concurrently() {
-        deterministic::Runner::default().start(|_context| async move {
-            let db1 = Shared::new("test", TestDb);
-            let db2 = Shared::new("test", TestDb);
-            let databases = (db1.clone(), db2.clone());
-
-            let (slot1, taken1) = db1.write().await;
-            let (slot2, taken2) = db2.write().await;
-
-            let new_batches = <(Shared<TestDb>, Shared<TestDb>) as DatabaseSet<
-                deterministic::Context,
-            >>::new_batches(&databases);
-            pin_mut!(new_batches);
-            assert!(new_batches.as_mut().now_or_never().is_none());
-
-            slot2.put(taken2);
-            {
-                let writer2_again = db2.write();
-                pin_mut!(writer2_again);
-                assert!(
-                    writer2_again.as_mut().now_or_never().is_none(),
-                    "tuple new_batches should queue reads for all databases concurrently"
-                );
-            }
-
-            slot1.put(taken1);
-            let _ = new_batches.await;
-        });
-    }
-
-    #[test]
-    fn new_batches_releases_read_lock_before_returning() {
-        deterministic::Runner::default().start(|_context| async move {
-            let database = Shared::new("test", TestDb);
-            let _ = <Shared<TestDb> as DatabaseSet<deterministic::Context>>::new_batches(&database)
-                .await;
-
-            let writer = database.write();
-            pin_mut!(writer);
-            assert!(
-                writer.as_mut().now_or_never().is_some(),
-                "batch construction must release its read lock before returning",
-            );
-        });
-    }
-
-    #[test]
-    fn tuple_finalize_does_not_hold_ready_writer_while_waiting_for_reader() {
-        deterministic::Runner::default().start(|_context| async move {
-            type DbSet = (Shared<TestDb>, Shared<TestDb>);
-
-            let db1 = Shared::new("test", TestDb);
-            let db2 = Shared::new("test", TestDb);
-            let databases = (db1.clone(), db2.clone());
-            let reader1 = db1.read().await;
-
-            let finalize = async {
-                <DbSet as DatabaseSet<deterministic::Context>>::finalize(
-                    &databases,
-                    (TestMerkleized, TestMerkleized),
-                )
-                .await
-            };
-            pin_mut!(finalize);
-            assert!(finalize.as_mut().now_or_never().is_none());
-
-            let reader2 = db2.read();
-            pin_mut!(reader2);
-            assert!(
-                reader2.as_mut().now_or_never().is_some(),
-                "finalization must not hold one writer while waiting for another database's reader",
-            );
-
-            drop(reader1);
-            assert!(finalize.await.1.durable().await);
-        });
-    }
-
-    #[test]
     fn tuple_finalize_runs_databases_in_parallel() {
         deterministic::Runner::default().start(|_context| async move {
             let (started1_tx, started1_rx) = oneshot::channel();
@@ -3782,14 +3696,14 @@ mod tests {
             let (release2_tx, release2_rx) = oneshot::channel();
 
             let databases = (
-                Shared::new("test", BlockingFinalizeDb::new(started1_tx, release1_rx)),
-                Shared::new("test", BlockingFinalizeDb::new(started2_tx, release2_rx)),
+                Single::from(BlockingFinalizeDb::new(started1_tx, release1_rx)),
+                Single::from(BlockingFinalizeDb::new(started2_tx, release2_rx)),
             );
 
-            let finalize =
-                <(Shared<BlockingFinalizeDb>, Shared<BlockingFinalizeDb>) as DatabaseSet<
-                    deterministic::Context,
-                >>::finalize(&databases, (TestMerkleized, TestMerkleized));
+            let finalize = DatabaseSet::<deterministic::Context>::finalize(
+                databases,
+                (TestMerkleized, TestMerkleized),
+            );
             pin_mut!(finalize);
             assert!(finalize.as_mut().now_or_never().is_none());
 
@@ -3805,7 +3719,8 @@ mod tests {
 
             let _ = release1_tx.send(());
             let _ = release2_tx.send(());
-            assert!(finalize.await.1.durable().await);
+            let (_, _, barrier) = finalize.await;
+            assert!(barrier.durable().await);
         });
     }
 
@@ -3815,14 +3730,23 @@ mod tests {
     )]
     fn tuple_finalize_panic_identifies_failing_database() {
         deterministic::Runner::default().start(|_context| async move {
-            let databases = (
-                Shared::new("test", TestDb),
-                Shared::new("test", FailingFinalizeDb),
-            );
-            let _ = <(Shared<TestDb>, Shared<FailingFinalizeDb>) as DatabaseSet<
-                deterministic::Context,
-            >>::finalize(&databases, (TestMerkleized, TestMerkleized))
+            let databases = (Single::from(TestDb), Single::from(FailingFinalizeDb));
+            let _ = DatabaseSet::<deterministic::Context>::finalize(
+                databases,
+                (TestMerkleized, TestMerkleized),
+            )
             .await;
+        });
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "database snapshot capture failed (index 1, type commonware_glue::stateful::db::tests::FailingSnapshotDb)"
+    )]
+    fn tuple_snapshot_panic_identifies_failing_database() {
+        deterministic::Runner::default().start(|_context| async move {
+            let databases = (Single::from(TestDb), Single::from(FailingSnapshotDb));
+            let _ = DatabaseSet::<deterministic::Context>::snapshot(databases).await;
         });
     }
 
@@ -3961,7 +3885,7 @@ mod tests {
 
             let sync = context.child("single_state_sync_closed_tip_updates").spawn(
                 move |context| async move {
-                    <Shared<SlowSyncDb> as StateSyncSet<
+                    <Single<SlowSyncDb> as StateSyncSet<
                         deterministic::Context,
                         Arc<AtomicBool>,
                         sha256::Digest,
@@ -4000,7 +3924,7 @@ mod tests {
             let (mut tip_tx, tip_rx) = ring::channel(NonZeroUsize::new(1).unwrap());
             let _ = tip_tx.send(TipUpdate::new(anchor(1), 1u64)).await;
 
-            let result = <Shared<FailingStateSyncDb> as StateSyncSet<
+            let result = <Single<FailingStateSyncDb> as StateSyncSet<
                 deterministic::Context,
                 (),
                 sha256::Digest,
@@ -4037,7 +3961,7 @@ mod tests {
             let sync = context
                 .child("single_state_sync_ignores_backward_tip_updates")
                 .spawn(move |context| async move {
-                    <Shared<ObservedSlowSyncDb> as StateSyncSet<
+                    <Single<ObservedSlowSyncDb> as StateSyncSet<
                         deterministic::Context,
                         SlowSyncController,
                         sha256::Digest,
@@ -4065,7 +3989,12 @@ mod tests {
             drop(tip_tx);
 
             let (database, converged_anchor) = sync.await.expect("sync task should complete");
-            let final_target = database.read().await.final_target;
+            let final_target = database
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
             assert_eq!(
                 final_target, 2,
                 "single-db sync target must never move backward"
@@ -4087,7 +4016,7 @@ mod tests {
 
             let sync = context.child("single_state_sync_noop_target_update").spawn(
                 move |context| async move {
-                    <Shared<RejectDuplicateTargetSyncDb> as StateSyncSet<
+                    <Single<RejectDuplicateTargetSyncDb> as StateSyncSet<
                         deterministic::Context,
                         Arc<AtomicBool>,
                         sha256::Digest,
@@ -4123,7 +4052,15 @@ mod tests {
             drop(tip_tx);
 
             let (database, converged_anchor) = sync.await.expect("sync task should complete");
-            assert_eq!(database.read().await.final_target, 7);
+            assert_eq!(
+                database
+                    .handle()
+                    .read()
+                    .await
+                    .expect("writer is live")
+                    .final_target,
+                7
+            );
             assert_eq!(converged_anchor, anchor(9));
         });
     }
@@ -4137,7 +4074,7 @@ mod tests {
                 context
                     .child("single_state_sync_stale_reached")
                     .spawn(move |context| async move {
-                        <Shared<StaleReachedSyncDb> as StateSyncSet<
+                        <Single<StaleReachedSyncDb> as StateSyncSet<
                             deterministic::Context,
                             (),
                             sha256::Digest,
@@ -4163,7 +4100,12 @@ mod tests {
             let _ = tip_tx.send(TipUpdate::new(anchor(2), 2)).await;
 
             let (database, converged_anchor) = sync.await.expect("sync task should complete");
-            let final_target = database.read().await.final_target;
+            let final_target = database
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
             assert_eq!(
                 final_target, 2,
                 "single-db sync must not finish on a stale reached target",
@@ -4188,7 +4130,7 @@ mod tests {
             let sync = context
                 .child("tuple_state_sync")
                 .spawn(move |context| async move {
-                    <(Shared<SlowSyncDb>, Shared<FastSyncDb>) as StateSyncSet<
+                    <(Single<SlowSyncDb>, Single<FastSyncDb>) as StateSyncSet<
                         deterministic::Context,
                         (Arc<AtomicBool>, Arc<AtomicBool>),
                         sha256::Digest,
@@ -4220,8 +4162,20 @@ mod tests {
             drop(tip_tx);
 
             let (synced, converged_anchor) = sync.await.expect("sync task should complete");
-            let slow_target = synced.0.read().await.final_target;
-            let fast_target = synced.1.read().await.final_target;
+            let slow_target = synced
+                .0
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
+            let fast_target = synced
+                .1
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
 
             assert_eq!(
                 slow_target, fast_target,
@@ -4247,7 +4201,7 @@ mod tests {
             let sync = context
                 .child("tuple_state_sync_ignores_backward_tip_updates")
                 .spawn(move |context| async move {
-                    <(Shared<SlowSyncDb>, Shared<FastSyncDb>) as StateSyncSet<
+                    <(Single<SlowSyncDb>, Single<FastSyncDb>) as StateSyncSet<
                         deterministic::Context,
                         (Arc<AtomicBool>, Arc<AtomicBool>),
                         sha256::Digest,
@@ -4281,8 +4235,20 @@ mod tests {
             slow_release.store(true, Ordering::SeqCst);
 
             let (synced, converged_anchor) = sync.await.expect("sync task should complete");
-            let slow_target = synced.0.read().await.final_target;
-            let fast_target = synced.1.read().await.final_target;
+            let slow_target = synced
+                .0
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
+            let fast_target = synced
+                .1
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
             assert_eq!(
                 slow_target, 2,
                 "slow database target must never move backward"
@@ -4305,7 +4271,7 @@ mod tests {
             let (_tip_tx, tip_rx) = ring::channel(NonZeroUsize::new(1).unwrap());
             let fast_done = Arc::new(AtomicBool::new(false));
 
-            let result = <(Shared<MismatchedTargetSyncDb>, Shared<FastSyncDb>) as StateSyncSet<
+            let result = <(Single<MismatchedTargetSyncDb>, Single<FastSyncDb>) as StateSyncSet<
                 deterministic::Context,
                 ((), Arc<AtomicBool>),
                 sha256::Digest,
@@ -4343,7 +4309,7 @@ mod tests {
             let (_tip_tx, tip_rx) = ring::channel(NonZeroUsize::new(1).unwrap());
 
             let result =
-                <(Shared<ImmediateStateSyncDb>, Shared<FailingStateSyncDb>) as StateSyncSet<
+                <(Single<ImmediateStateSyncDb>, Single<FailingStateSyncDb>) as StateSyncSet<
                     deterministic::Context,
                     ((), ()),
                     sha256::Digest,
@@ -4385,7 +4351,7 @@ mod tests {
             let (_tip_tx, tip_rx) = ring::channel(NonZeroUsize::new(1).unwrap());
             let release = Arc::new(AtomicBool::new(true));
 
-            let result = <(Shared<SlowSyncDb>, Shared<FailingStateSyncDb>) as StateSyncSet<
+            let result = <(Single<SlowSyncDb>, Single<FailingStateSyncDb>) as StateSyncSet<
                 deterministic::Context,
                 (Arc<AtomicBool>, ()),
                 sha256::Digest,
@@ -4427,7 +4393,7 @@ mod tests {
             let (_tip_tx, tip_rx) = ring::channel(NonZeroUsize::new(1).unwrap());
 
             let result =
-                <(Shared<FinishClosedSyncDb>, Shared<FailingStateSyncDb>) as StateSyncSet<
+                <(Single<FinishClosedSyncDb>, Single<FailingStateSyncDb>) as StateSyncSet<
                     deterministic::Context,
                     ((), ()),
                     sha256::Digest,
@@ -4454,11 +4420,11 @@ mod tests {
             };
             assert!(
                 err.contains("state sync failed (index 1, db"),
-                "error should include failing database index, got: {err}",
+                "error should include failing database index: {err}"
             );
             assert!(
                 err.contains("FailingStateSyncDb"),
-                "error should include failing database type, got: {err}",
+                "error should include failing database type: {err}"
             );
         });
     }
@@ -4558,8 +4524,8 @@ mod tests {
             let sync = context.child("tuple_state_sync_algorithm").spawn(
                 move |context| async move {
                     <(
-                        Shared<ObservedSlowSyncDb>,
-                        Shared<ObservedFastSyncDb>,
+                        Single<ObservedSlowSyncDb>,
+                        Single<ObservedFastSyncDb>,
                     ) as StateSyncSet<
                         deterministic::Context,
                         (SlowSyncController, FastSyncObserver),
@@ -4594,8 +4560,8 @@ mod tests {
             drop(tip_tx);
 
             let (synced, converged_anchor) = sync.await.expect("sync task should complete");
-            let slow_target = synced.0.read().await.final_target;
-            let fast_target = synced.1.read().await.final_target;
+            let slow_target = synced.0.handle().read().await.expect("writer is live").final_target;
+            let fast_target = synced.1.handle().read().await.expect("writer is live").final_target;
 
             assert_eq!(
                 slow_target, fast_target,
@@ -4629,7 +4595,7 @@ mod tests {
                     update_count: fast_update_count.clone(),
                 };
                 move |context| async move {
-                    <(Shared<SlowSyncDb>, Shared<ObservedFastSyncDb>) as StateSyncSet<
+                    <(Single<SlowSyncDb>, Single<ObservedFastSyncDb>) as StateSyncSet<
                         deterministic::Context,
                         (Arc<AtomicBool>, FastSyncObserver),
                         sha256::Digest,
@@ -4661,8 +4627,20 @@ mod tests {
             slow_release.store(true, Ordering::SeqCst);
 
             let (synced, converged_anchor) = sync.await.expect("sync task should complete");
-            let slow_target = synced.0.read().await.final_target;
-            let fast_target = synced.1.read().await.final_target;
+            let slow_target = synced
+                .0
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
+            let fast_target = synced
+                .1
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
 
             assert_eq!(slow_target, target);
             assert_eq!(fast_target, target);
@@ -4692,7 +4670,7 @@ mod tests {
                         update_count: fast_update_count.clone(),
                     };
                     move |context| async move {
-                        <(Shared<SlowSyncDb>, Shared<DistinctObservedFastSyncDb>) as StateSyncSet<
+                        <(Single<SlowSyncDb>, Single<DistinctObservedFastSyncDb>) as StateSyncSet<
                             deterministic::Context,
                             (Arc<AtomicBool>, FastSyncObserver),
                             sha256::Digest,
@@ -4726,8 +4704,20 @@ mod tests {
             drop(tip_tx);
 
             let (synced, converged_anchor) = sync.await.expect("sync task should complete");
-            let slow_target = synced.0.read().await.final_target;
-            let fast_target = synced.1.read().await.final_target;
+            let slow_target = synced
+                .0
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
+            let fast_target = synced
+                .1
+                .handle()
+                .read()
+                .await
+                .expect("writer is live")
+                .final_target;
 
             assert_eq!(slow_target, 9);
             assert_eq!(fast_target, 7);

--- a/glue/src/stateful/db/snapshot.rs
+++ b/glue/src/stateful/db/snapshot.rs
@@ -110,7 +110,7 @@ impl<S> Publisher<S> {
 
     /// Hold `snapshots`, captured at `height`, until they and all
     /// earlier-captured snapshots have been durably flushed.
-    pub fn stage(&mut self, height: Height, snapshots: S) {
+    pub(crate) fn stage(&mut self, height: Height, snapshots: S) {
         let replaced = self.staged.insert(
             height,
             Staged {
@@ -124,7 +124,7 @@ impl<S> Publisher<S> {
     /// Record that `height`'s flush finished durably, publishing the newest
     /// snapshots that are now fully on disk and dropping any older ones still
     /// held.
-    pub fn complete(&mut self, height: Height) {
+    pub(crate) fn complete(&mut self, height: Height) {
         let staged = self
             .staged
             .get_mut(&height)
@@ -153,7 +153,7 @@ impl<S> Publisher<S> {
     ///
     /// Only for state that is already on disk, whether recovered at startup,
     /// synced at transition, or captured after every flush finished.
-    pub fn publish_now(&mut self, height: Height, snapshots: S) {
+    pub(crate) fn publish_now(&mut self, height: Height, snapshots: S) {
         assert!(
             self.staged.is_empty(),
             "immediate publication requires every staged flush to have drained",
@@ -191,7 +191,7 @@ impl<S> Publisher<S> {
     }
 
     /// Whether a flush at or below `barrier` is still running, blocking a prune.
-    pub fn blocks_prune(&self, barrier: Height) -> bool {
+    pub(crate) fn blocks_prune(&self, barrier: Height) -> bool {
         self.staged
             .iter()
             .find(|(_, staged)| !staged.flushed)
@@ -200,14 +200,14 @@ impl<S> Publisher<S> {
 
     /// Mark all snapshots captured so far, staged or served, as predating a
     /// prune. Check [`needs_refresh`](Self::needs_refresh) afterwards.
-    pub fn mark_stale(&mut self) {
+    pub(crate) fn mark_stale(&mut self) {
         self.stale_boundary = self.staged.keys().last().copied().or(self.last_published);
     }
 
     /// Whether the caller must capture fresh snapshots and
     /// [`publish_now`](Self::publish_now). True when the served snapshots are
     /// stale from a prune and nothing staged remains to replace them.
-    pub fn needs_refresh(&self) -> bool {
+    pub(crate) fn needs_refresh(&self) -> bool {
         self.stale_boundary.is_some() && self.staged.is_empty()
     }
 }

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -6,7 +6,7 @@
 //! bookkeeping:
 //!
 //! 1. Before each `propose` or `verify`, the actor forks unmerkleized batches
-//!    from the parent block's pending state (or from committed database state
+//!    from the parent block's pending state (or from applied database state
 //!    if the parent has been finalized).
 //! 2. The application executes against those batches and returns merkleized
 //!    results, which the actor stores as a new pending tip keyed by the
@@ -96,7 +96,7 @@
 use commonware_consensus::{CertifiableBlock, Epochable, Viewable, marshal::ancestry::Ancestry};
 use commonware_cryptography::certificate::Scheme;
 use commonware_runtime::{Clock, Metrics, Spawner};
-use db::DatabaseSet;
+use db::{DatabaseSet, HandlesOf, MerkleizedOf, UnmerkleizedOf};
 use rand_core::Rng;
 use std::future::Future;
 
@@ -141,14 +141,19 @@ pub struct Input<Upstream, Provider> {
 /// return [`DatabaseSet::Merkleized`] batches after execution. The surrounding
 /// wrapper handles persistence: storing merkleized batches as pending tips on
 /// the block tree and applying changesets to the underlying databases on
-/// finalization.
+/// finalization. Every execution method reads through `batches`, which is the
+/// only database access an implementor is given: a batch overlays speculative
+/// ancestor state and falls back to applied state for anything it does not
+/// cover, so it is always the complete view for its branch.
 ///
 /// [`Stateful`] may freely clone the application and invoke its methods
-/// concurrently. Implementors should treat `Application` as a stateless,
-/// deterministic state machine: given the same method inputs and database
-/// state, every clone must produce the same state-transition result. Mutable
-/// state that affects those results must live in the database batches provided
-/// to proposal, verification, and replay methods.
+/// concurrently. Any method may run on a fresh clone that is discarded
+/// afterward, so cloning must be cheap and state an implementor wants to keep
+/// must live behind shared handles. Implementors should treat `Application` as
+/// a stateless, deterministic state machine: given the same method inputs and
+/// database state, every clone must produce the same state-transition result.
+/// Mutable state that affects those results must live in the database batches
+/// provided to proposal, verification, and replay methods.
 pub trait Application<E>: Clone + Send + 'static
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -224,7 +229,7 @@ where
         &mut self,
         context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
+        batches: UnmerkleizedOf<Self::Databases, E>,
         input: Input<Self::Input, Self::Provider>,
     ) -> impl Future<Output = Option<Proposed<Self, E>>> + Send;
 
@@ -237,15 +242,14 @@ where
     /// stable verdict. Return [`None`] only when the block is permanently
     /// invalid for the supplied context, ancestry, and batches. If validity may
     /// still change as additional information becomes available, continue
-    /// waiting instead of returning [`None`].
+    /// waiting instead of returning [`None`]. In other words, to abstain from
+    /// voting, do not resolve this future yet. Abstaining is not represented by
+    /// a special return value.
     ///
-    /// Validity is relative to those inputs: finalizing a competing branch
-    /// later does not retroactively change a completed verdict.
-    ///
-    /// In other words, to abstain from voting, do not resolve this future yet.
-    /// Keep it pending until the implementation can either prove the block
-    /// valid, prove it invalid, or the consensus engine cancels the request.
-    /// Abstaining is not represented by a special return value.
+    /// Validity is relative to the supplied inputs. Finalizing a competing
+    /// branch later does not retroactively change a completed verdict. A
+    /// verdict reached after that finalization is reported as invalid instead,
+    /// because its branch is no longer reachable.
     ///
     /// Verification must reject any block whose execution result does not
     /// match the block's committed state (for example, a state root mismatch).
@@ -259,24 +263,21 @@ where
     /// merkleized batch root. The wrapper's sync-target check only verifies the
     /// ops root and operation range used by replay sync.
     ///
-    /// This future is scoped to its caller. Stateful may also cancel and retry
-    /// it before finalization or pruning. Cancellation and retry must not
-    /// violate invariants or lose durable progress.
+    /// This future is scoped to its caller. Dropping the response cancels only
+    /// this request. The wrapper never cancels it: a batch operation running
+    /// when a finalized block is applied waits for that apply and then
+    /// continues.
     ///
-    /// Verification may overlap finalization while its batches remain valid.
-    /// Stateful retries or rejects requests that cannot safely overlap it.
-    /// Read through the provided batches without holding the database set's
-    /// locks. Batches may be branch-scoped views rather than historical
-    /// snapshots: retained ancestor overlays preserve same-branch state, while
-    /// unresolved reads may fall through to the live applied database. Such
-    /// batches remain valid only while applied state advances along their branch
-    /// (see [`db::Shared::read`] for guard discipline).
+    /// `batches` is a branch-scoped view, not a historical snapshot. Retained
+    /// ancestor overlays preserve same-branch state, while unresolved reads fall
+    /// through to the batch's own database. A batch is therefore valid only
+    /// while applied state advances along its own branch.
     fn verify(
         &mut self,
         context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> impl Future<Output = Option<<Self::Databases as DatabaseSet<E>>::Merkleized>> + Send;
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> impl Future<Output = Option<MerkleizedOf<Self::Databases, E>>> + Send;
 
     /// Apply a previously certified block to reconstruct its merkleized state.
     ///
@@ -290,9 +291,9 @@ where
     /// replay result during finalization and cannot re-check block-specific
     /// commitments generically.
     ///
-    /// This future may be cancelled if its originating request is dropped, or
-    /// cancelled and retried before finalization or pruning. Cancellation and
-    /// retry must not violate invariants or lose durable progress.
+    /// This future may be cancelled if its originating request is dropped. The
+    /// wrapper itself never cancels it. Cancellation must not violate
+    /// invariants or lose durable progress.
     ///
     /// # Panics
     ///
@@ -302,8 +303,8 @@ where
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> impl Future<Output = <Self::Databases as DatabaseSet<E>>::Merkleized> + Send;
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> impl Future<Output = MerkleizedOf<Self::Databases, E>> + Send;
 
     /// Observe a finalized block after it is reflected in the database set.
     ///
@@ -320,10 +321,10 @@ where
     /// reported or applied during handoff. Applications must derive synchronized state from the
     /// database set rather than rely on receiving every peer-state-sync finalization here.
     ///
-    /// This hook receives read-only database handles and may overlap verification
-    /// of blocks built on the newly finalized block or one of its retained
-    /// descendants. Result-affecting mutations must be made through normal block
-    /// execution, not from this observer.
+    /// This hook receives read handles over the set. It runs after the block is
+    /// applied, and the block's marshal acknowledgement waits for it, so a slow
+    /// implementation stalls finalization. Result-affecting mutations must be
+    /// made through normal block execution, not from this observer.
     ///
     /// For blocks that are reported, this is an at-least-once notification inherited from
     /// marshal's reporter stream: a crash after this hook runs but before the block's flush and
@@ -336,7 +337,7 @@ where
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
-        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+        _handles: HandlesOf<Self::Databases, E>,
     ) -> impl Future<Output = ()> + Send {
         async {}
     }

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -1,6 +1,9 @@
 use crate::stateful::{
     Application, Input, Proposed,
-    db::{BatchContext, DatabaseSet, ManagedDb, Merkleized, Shared, Unmerkleized},
+    db::{
+        DatabaseSet, ManagedDb, Merkleized, MerkleizedOf, Unmerkleized, UnmerkleizedOf,
+        live::{Closed, Reader, Writer},
+    },
 };
 use commonware_codec::{EncodeSize, Error as CodecError, Read, ReadExt as _, Write};
 use commonware_consensus::{
@@ -12,11 +15,11 @@ use commonware_consensus::{
 use commonware_cryptography::{
     Digest as _, Digestible, Signer as _, ed25519, sha256::Digest as Sha256Digest,
 };
-use commonware_runtime::{Buf, BufMut, Error as RuntimeError, Handle};
+use commonware_runtime::{Buf, BufMut, Error as RuntimeError, Handle, deterministic};
 use commonware_utils::{channel::oneshot, sync::Mutex};
 use std::{convert::Infallible, sync::Arc};
 
-pub(crate) type TestDatabases = Shared<TestDb>;
+pub(crate) type TestDatabases = crate::stateful::db::Single<TestDb>;
 pub(crate) type TestScheme = scheme_mocks::Scheme<ed25519::PublicKey>;
 pub(crate) type TestVariant = Standard<TestBlock>;
 
@@ -66,26 +69,6 @@ pub(crate) struct FlushControl {
     prune_gate: Arc<Mutex<Option<PruneGate>>>,
 }
 
-impl FlushControl {
-    /// Gates the next prune. The receiver reports entry, and sending on the
-    /// returned sender lets pruning continue. Only one gate may be active.
-    pub(crate) fn gate_prune(&self) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
-        let (started, started_rx) = oneshot::channel();
-        let (release, release_rx) = oneshot::channel();
-        assert!(
-            self.prune_gate
-                .lock()
-                .replace(PruneGate {
-                    started,
-                    release: release_rx,
-                })
-                .is_none(),
-            "prune gate already installed",
-        );
-        (started_rx, release)
-    }
-}
-
 #[derive(Default)]
 pub(crate) struct TestDb {
     finalize: Mutex<Option<Handle<()>>>,
@@ -133,8 +116,8 @@ impl<E: Send> ManagedDb<E> for TestDb {
         Ok(Self::default())
     }
 
-    fn new_batch(_database: BatchContext<'_, Self>) -> Self::Unmerkleized {
-        TestUnmerkleized
+    async fn new_batch(_handle: Reader<Self>) -> Result<Self::Unmerkleized, Closed> {
+        Ok(TestUnmerkleized)
     }
 
     fn matches_sync_target(_batch: &Self::Merkleized, _target: &Self::SyncTarget) -> bool {
@@ -307,7 +290,7 @@ impl<
         &mut self,
         _context: (E, Self::Context),
         _ancestry: impl Ancestry<Self::Block>,
-        _batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
+        _batches: UnmerkleizedOf<Self::Databases, E>,
         _input: Input<Self::Input, Self::Provider>,
     ) -> Option<Proposed<Self, E>> {
         None
@@ -317,8 +300,8 @@ impl<
         &mut self,
         _context: (E, Self::Context),
         _ancestry: impl Ancestry<Self::Block>,
-        _batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        _batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> Option<MerkleizedOf<Self::Databases, E>> {
         None
     }
 
@@ -326,14 +309,33 @@ impl<
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
-        _batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
+        _batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> MerkleizedOf<Self::Databases, E> {
         TestMerkleized
     }
 }
 
 pub(crate) fn test_databases() -> TestDatabases {
-    Shared::new("test", TestDb::default())
+    TestDb::default().into()
+}
+
+/// Finalize `batch` through the writer, returning the snapshot and flush handle.
+///
+/// Tests that drive [`ManagedDb`] directly wrap their database in a writer and
+/// use this instead of the set layer.
+pub(crate) async fn finalize<D: ManagedDb<deterministic::Context>>(
+    writer: Writer<D>,
+    batch: D::Merkleized,
+) -> (Writer<D>, D::Snapshot, Handle<()>) {
+    let (writer, (snapshot, sync)) = writer
+        .mutate(|db| async move {
+            let (db, snapshot, sync) = D::finalize(db, batch)
+                .await
+                .unwrap_or_else(|err| panic!("finalize failed: {err:?}"));
+            (db, (snapshot, sync))
+        })
+        .await;
+    (writer, snapshot, sync)
 }
 
 pub(crate) fn anchor(height: u64, digest_byte: u8) -> crate::stateful::db::Anchor<Sha256Digest> {

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -18,9 +18,9 @@ use crate::{
         property::Property,
     },
     stateful::{
-        Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
-        Stateful as StatefulActor, SyncPlan,
-        db::{DatabaseSet, Merkleized as _, SyncEngineConfig, snapshot::Publisher},
+        Application, Config as StatefulConfig, Input, Proposed, Stateful as StatefulActor,
+        SyncPlan,
+        db::{DatabaseSet, HandlesOf, Merkleized as _, SyncEngineConfig, snapshot::Publisher},
     },
 };
 use commonware_actor::Feedback;
@@ -64,10 +64,11 @@ use properties::{
 };
 use std::{collections::VecDeque, convert::Infallible, future::Future, sync::Arc, time::Duration};
 
-mod common;
+pub(crate) mod common;
 pub(crate) mod fixtures;
 pub(crate) mod mocks;
 mod multi_db_app;
+mod ownership;
 mod properties;
 mod single_db_app;
 
@@ -1002,13 +1003,13 @@ impl Application<deterministic::Context> for GatedMultiApp {
         &mut self,
         context: (deterministic::Context, Self::Context),
         block: &Self::Block,
-        readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        handles: HandlesOf<Self::Databases, deterministic::Context>,
     ) {
         <MultiApp as Application<deterministic::Context>>::finalized(
             &mut self.inner,
             context,
             block,
-            readers,
+            handles,
         )
         .await;
         let gate = self.finalize_gate.lock().take();
@@ -1037,8 +1038,9 @@ async fn build_chain(context: &deterministic::Context, blocks: u64) -> (Block, V
     .await;
     let mut batches = <SingleDatabaseSet<deterministic::Context> as DatabaseSet<
         deterministic::Context,
-    >>::new_batches(&databases)
-    .await;
+    >>::new_batches(&databases.handles())
+    .await
+    .expect("writer is live");
     let mut parent = genesis.clone();
     let mut chain = Vec::with_capacity(blocks as usize);
 
@@ -1092,8 +1094,9 @@ async fn build_multi_chain(
     .await;
     let mut batches = <MultiDatabaseSet<deterministic::Context> as DatabaseSet<
         deterministic::Context,
-    >>::new_batches(&databases)
-    .await;
+    >>::new_batches(&databases.handles())
+    .await
+    .expect("writer is live");
     let mut parent = genesis.clone();
     let mut chain = Vec::with_capacity(blocks as usize);
     let mut speculative = Vec::with_capacity(blocks as usize);
@@ -1212,7 +1215,6 @@ fn out_of_order_certifications_complete_on_qmdb() {
             },
         );
         let stateful_actor = stateful.start();
-        let _databases = stateful_mailbox.subscribe_databases().await;
 
         for block in &blocks {
             assert!(marshal.verified(block.context.round, block.clone()).await);
@@ -1345,7 +1347,6 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             },
         );
         let stateful_actor = stateful.start();
-        let databases = stateful_mailbox.subscribe_databases().await;
 
         for block in &blocks {
             assert!(marshal.verified(block.context.round, block.clone()).await);
@@ -1420,9 +1421,11 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
         finalize_started
             .await
             .expect("first multi-QMDB finalization should reach the application gate");
+        // The descendant verifications are untouched by the apply: each is still
+        // waiting in the application, holding the gate it was given.
         assert!(
             verify_releases.iter().all(|release| !release.is_closed()),
-            "the first finalization should retain descendant verifications",
+            "an apply must not disturb a running verification",
         );
 
         // A queued finalization is not active until the current one completes.
@@ -1435,10 +1438,12 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             finalizations.push(waiter);
         }
         context.sleep(Duration::from_millis(10)).await;
-        assert!(
-            verify_releases.iter().all(|release| !release.is_closed()),
-            "queued finalization quiesced work before the current finalization completed",
-        );
+        for waiter in &mut finalizations {
+            assert!(
+                futures::poll!(waiter).is_pending(),
+                "a queued finalization must wait for the active one",
+            );
+        }
         finalize_release
             .send(())
             .expect("first multi-QMDB finalization should remain active");
@@ -1453,10 +1458,10 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
                 panic!("multi-QMDB finalizations did not become durable");
             },
         }
+        // Released, the verifications finish on the attempts they were already
+        // running when the finalizations landed.
         for release in verify_releases {
-            release
-                .send(())
-                .expect("compatible verification should remain active across finalization");
+            let _ = release.send(());
         }
         for (index, certification) in certifications {
             select! {
@@ -1489,288 +1494,12 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             },
         }
 
-        let committed = <MultiDatabaseSet<deterministic::Context> as DatabaseSet<
-            deterministic::Context,
-        >>::committed_targets(&databases)
-        .await;
-        let expected =
-            <GatedMultiApp as Application<deterministic::Context>>::sync_targets(&blocks[5]);
-        assert_eq!(committed.0, expected.0, "full QMDB target diverged");
-        assert_eq!(committed.1, expected.1, "compact QMDB target diverged");
-
-        stateful_actor.abort();
-        marshal_actor.abort();
-        let _ = stateful_actor.await;
-        let _ = marshal_actor.await;
-    });
-}
-
-#[test]
-fn pruning_quiesces_and_retries_verification_on_real_qmdbs() {
-    deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-        let (genesis, blocks) = build_multi_chain(&context, 5).await;
-        let page_cache = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
-        let mut signing_context = context.child("signing");
-        let fixture = scheme_mocks::fixture(
-            &mut signing_context,
-            b"_COMMONWARE_GLUE_MULTI_QMDB_PRUNE_OVERLAP",
-            1,
-        );
-        let provider = ConstantProvider::new(fixture.schemes[0].clone());
-        let finalizations_by_height = prunable::Archive::init(
-            context.child("finalizations_by_height"),
-            archive_config(
-                "prune-overlap-multi-qmdb-marshal",
-                "finalizations",
-                page_cache.clone(),
-                (),
-            ),
-        )
-        .await
-        .expect("failed to initialize finalizations archive");
-        let finalized_blocks = prunable::Archive::init(
-            context.child("finalized_blocks"),
-            archive_config(
-                "prune-overlap-multi-qmdb-marshal",
-                "blocks",
-                page_cache.clone(),
-                (),
-            ),
-        )
-        .await
-        .expect("failed to initialize blocks archive");
-        let (marshal_actor, marshal, floor) =
-            MarshalActor::<_, Standard<MultiBlock>, _, _, _, _, _>::init(
-                context.child("marshal"),
-                finalizations_by_height,
-                finalized_blocks,
-                marshal::Config {
-                    provider,
-                    epocher: FixedEpocher::new(EPOCH_LENGTH),
-                    start: marshal::Start::Genesis(genesis.clone()),
-                    partition_prefix: "prune-overlap-multi-qmdb-marshal".to_string(),
-                    mailbox_size: NZUsize!(8),
-                    view_retention: ViewDelta::new(10),
-                    prunable_items_per_section: NZU64!(10),
-                    page_cache: page_cache.clone(),
-                    replay_buffer: IO_BUFFER_SIZE,
-                    key_write_buffer: IO_BUFFER_SIZE,
-                    value_write_buffer: IO_BUFFER_SIZE,
-                    block_codec_config: (),
-                    max_repair: NZUsize!(10),
-                    max_pending_acks: NZUsize!(1),
-                    strategy: Sequential,
-                },
-            )
-            .await;
-        let (resolver_receiver, _resolver_handler) =
-            handler::init(context.child("marshal_resolver"), NZUsize!(8));
-        let marshal_actor = marshal_actor.start_unbuffered(
-            NoopMultiMarshalApplication,
-            (resolver_receiver, fixtures::IgnoreResolver),
-        );
-
-        let verify_gates = Arc::new(Mutex::new(VecDeque::new()));
-        let finalize_gate = Arc::new(Mutex::new(None));
-        let application = GatedMultiApp {
-            inner: MultiApp::new(genesis),
-            verify_gates: verify_gates.clone(),
-            finalize_gate: finalize_gate.clone(),
-        };
-        let plan = SyncPlan::init(&context, "prune-overlap-multi-qmdb-stateful".to_string()).await;
-        let publication_context = context.child("publication");
-        let (snapshot_publisher, _snapshot_reader) = Publisher::new(&publication_context);
-        let (stateful, stateful_mailbox) = StatefulActor::init(
-            context.child("stateful"),
-            StatefulConfig {
-                application,
-                db_config: multi_qmdb_config("prune-overlap-multi-qmdb-stateful", page_cache),
-                provider: (),
-                marshal: (marshal.clone(), floor),
-                mailbox_size: NZUsize!(1),
-                plan,
-                resolvers: (NoopQmdbResolver, NoopCompactQmdbResolver),
-                sync_config: SyncEngineConfig {
-                    fetch_batch_size: NZU64!(1),
-                    apply_batch_size: NZU64!(1),
-                    max_outstanding_requests: 1,
-                    update_channel_size: NZUsize!(1),
-                    max_retained_roots: 1,
-                },
-                // The first prune runs at block 4 and targets block 3's floor,
-                // which crosses the full QMDB's first journal blob.
-                prune_config: Some(PruneConfig {
-                    maintenance_interval: NZUsize!(1),
-                    retained_marshal_blocks: 2,
-                    retained_qmdb_blocks: 0,
-                }),
-                snapshot_publisher,
-            },
-        );
-        let stateful_actor = stateful.start();
-        let databases = stateful_mailbox.subscribe_databases().await;
-
-        for block in &blocks {
-            assert!(marshal.verified(block.context.round, block.clone()).await);
-        }
-
-        let mut deferred = Deferred::new(
-            context.child("deferred"),
-            stateful_mailbox,
-            marshal,
-            FixedEpocher::new(EPOCH_LENGTH),
-        );
-
-        // Keep the first four batches available so block 5 reaches application
-        // verification without owning ancestor replay.
-        for block in &blocks[..4] {
-            let certification = deferred.certify(block.context.round, block.digest()).await;
-            assert!(
-                certification
-                    .await
-                    .expect("priming certification result missing"),
-            );
-        }
-
-        let finalized_tip = &blocks[3];
-        let _ = deferred.report(marshal::Update::Tip(
-            finalized_tip.context.round,
-            finalized_tip.height,
-            finalized_tip.digest(),
-        ));
-        let mut reporter = deferred;
-        for block in &blocks[..3] {
-            let (acknowledgement, waiter) = Exact::handle();
-            let _ = reporter.report(marshal::Update::Block(
-                Arc::new(block.clone()),
-                acknowledgement,
-            ));
-            select! {
-                result = waiter => result.expect("priming finalization should be durable"),
-                _ = context.sleep(Duration::from_secs(2)) => {
-                    panic!("priming finalization did not become durable");
-                },
-            }
-        }
-
-        let expected_floor = *blocks[2].range_a.start();
+        // The set is owned by the actor, so assert through the published
+        // generation, which is what a peer can actually observe.
         assert!(
-            expected_floor > mmr::Location::new(0),
-            "the prune target must discard real QMDB history",
+            _snapshot_reader.latest().is_some(),
+            "serving generation must be published once blocks apply",
         );
-
-        let (first_gate, first_started, mut first_release) = application_gate();
-        let (retry_gate, mut retry_started, retry_release) = application_gate();
-        verify_gates.lock().extend([first_gate, retry_gate]);
-        let (gate, finalize_started, finalize_release) = application_gate();
-        assert!(
-            finalize_gate.lock().replace(gate).is_none(),
-            "finalization gate already installed",
-        );
-
-        let block = &blocks[4];
-        let mut certification = reporter.certify(block.context.round, block.digest()).await;
-        first_started
-            .await
-            .expect("verification should start before pruning");
-        assert!(
-            futures::poll!(&mut certification).is_pending(),
-            "verification completed before pruning",
-        );
-
-        let (acknowledgement, finalized) = Exact::handle();
-        let _ = reporter.report(marshal::Update::Block(
-            Arc::new(blocks[3].clone()),
-            acknowledgement,
-        ));
-        finalize_started
-            .await
-            .expect("block 4 finalization should reach the application gate");
-        assert!(
-            !first_release.is_closed(),
-            "same-branch finalization should retain verification",
-        );
-
-        // Hold the full QMDB reader after finalization applies block 4. Pruning
-        // can quiesce verification, but cannot delete history or requeue it
-        // until this guard is released.
-        let full_database = databases.0.read().await;
-        let before_prune = full_database.bounds();
-        assert_eq!(
-            before_prune.start,
-            mmr::Location::new(0),
-            "QMDB pruned before the configured retention window filled",
-        );
-        finalize_release
-            .send(())
-            .expect("block 4 finalization should remain active");
-
-        select! {
-            _ = first_release.closed() => {},
-            _ = context.sleep(Duration::from_secs(2)) => {
-                panic!("pruning did not quiesce the active verification");
-            },
-        }
-        assert_eq!(
-            full_database.bounds(),
-            before_prune,
-            "QMDB history changed while its reader was held",
-        );
-        assert!(
-            futures::poll!(&mut certification).is_pending(),
-            "quiesced verification completed before retry",
-        );
-        assert!(
-            futures::poll!(&mut retry_started).is_pending(),
-            "verification restarted before physical pruning completed",
-        );
-        drop(full_database);
-
-        select! {
-            result = &mut retry_started => {
-                result.expect("verification should restart after pruning");
-            },
-            _ = context.sleep(Duration::from_secs(2)) => {
-                panic!("verification did not restart after pruning");
-            },
-        }
-
-        let after_prune = databases.0.read().await.bounds();
-        assert!(
-            after_prune.start > before_prune.start,
-            "verification restarted before the full QMDB discarded history",
-        );
-        assert!(
-            after_prune.start <= expected_floor,
-            "full QMDB pruned past the requested floor",
-        );
-        assert_eq!(
-            after_prune.end, before_prune.end,
-            "pruning changed the full QMDB tip",
-        );
-        retry_release
-            .send(())
-            .expect("retried verification should remain active");
-        select! {
-            result = certification => {
-                assert!(result.expect("retried certification result missing"));
-            },
-            _ = context.sleep(Duration::from_secs(2)) => {
-                panic!("retried verification did not complete");
-            },
-        }
-        finalized
-            .await
-            .expect("block 4 finalization should become durable");
-
-        let committed = <MultiDatabaseSet<deterministic::Context> as DatabaseSet<
-            deterministic::Context,
-        >>::committed_targets(&databases)
-        .await;
-        let expected =
-            <GatedMultiApp as Application<deterministic::Context>>::sync_targets(&blocks[3]);
-        assert_eq!(committed.0, expected.0, "full QMDB target diverged");
-        assert_eq!(committed.1, expected.1, "compact QMDB target diverged");
 
         stateful_actor.abort();
         marshal_actor.abort();

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -8,8 +8,8 @@ use crate::{
         Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
         Stateful as StatefulActor, SyncPlan,
         db::{
-            DatabaseSet, Merkleized as _, Shared, SnapshotsOf, SyncEngineConfig, Unmerkleized as _,
-            p2p as qmdb_resolver,
+            DatabaseSet, Merkleized as _, MerkleizedOf, Single, SnapshotsOf, SyncEngineConfig,
+            Unmerkleized as _, UnmerkleizedOf, p2p as qmdb_resolver,
         },
         probe::{Config as ProbeConfig, Probe},
     },
@@ -74,12 +74,8 @@ type QmdbA<E> =
 pub(super) type QmdbB<E> =
     immutable::fixed::CompactDb<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, Sequential>;
 
-/// A single QMDB database behind a lock.
-type DbA<E> = Shared<QmdbA<E>>;
-type DbB<E> = Shared<QmdbB<E>>;
-
 /// A full and a compact QMDB as a tuple.
-pub(crate) type MultiDatabaseSet<E> = (DbA<E>, DbB<E>);
+pub(crate) type MultiDatabaseSet<E> = (Single<QmdbA<E>>, Single<QmdbB<E>>);
 
 /// Readers over the set's published snapshots.
 type MultiSnapshot<E> = SnapshotsOf<MultiDatabaseSet<E>, E>;
@@ -249,14 +245,8 @@ impl App {
     /// Execute a block against two databases.
     pub(super) async fn execute<E: Rng + Spawner + StorageContext>(
         height: Height,
-        batches: (
-            <DbA<E> as DatabaseSet<E>>::Unmerkleized,
-            <DbB<E> as DatabaseSet<E>>::Unmerkleized,
-        ),
-    ) -> (
-        <DbA<E> as DatabaseSet<E>>::Merkleized,
-        <DbB<E> as DatabaseSet<E>>::Merkleized,
-    ) {
+        batches: UnmerkleizedOf<MultiDatabaseSet<E>, E>,
+    ) -> MerkleizedOf<MultiDatabaseSet<E>, E> {
         let (mut batch_a, batch_b) = batches;
 
         // DB-A: increment counter and write a height marker, mirroring the single-db app's
@@ -301,7 +291,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         &mut self,
         context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
+        batches: UnmerkleizedOf<Self::Databases, E>,
         _input: Input<Self::Input, Self::Provider>,
     ) -> Option<Proposed<Self, E>> {
         let mut ancestry = Box::pin(ancestry);
@@ -329,8 +319,8 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         &mut self,
         _context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> Option<MerkleizedOf<Self::Databases, E>> {
         let mut ancestry = Box::pin(ancestry);
         let tip = ancestry.next().await?;
         let (merkleized_a, merkleized_b) = Self::execute(tip.height(), batches).await;
@@ -350,8 +340,8 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         &mut self,
         _context: (E, Self::Context),
         block: &Self::Block,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> MerkleizedOf<Self::Databases, E> {
         Self::execute(block.height(), batches).await
     }
 
@@ -679,7 +669,7 @@ impl EngineDefinition for MultiDbEngine {
         marshal_actor.start(marshal_reporters, buffer, resolver);
 
         // Attach the marshal to probe, entering service. A syncing node has
-        // already consumed its floor above; a source attaches without ever soliciting peers.
+        // already consumed its floor above, so serving needs no peer solicitation.
         probe_mailbox.attach(marshal_mailbox.clone());
 
         if should_state_sync {

--- a/glue/src/stateful/tests/ownership.rs
+++ b/glue/src/stateful/tests/ownership.rs
@@ -1,0 +1,138 @@
+//! Causal ownership tests for the by-value database set: readers and the writer
+//! share nothing that can block either side.
+//!
+//! - a staged capture is never visible before its flush proves durable, and
+//!   does not hold the writer back ([`staged_capture_stays_invisible`])
+//! - a serve holding a published snapshot across parked I/O cannot delay the
+//!   writer, and its snapshot stays frozen while publication moves on
+//!   ([`parked_serve_never_delays_the_writer`])
+//!
+//! The deterministic runtime advances time only at quiescence, so `blocked_on`
+//! resolving to its timeout proves the probed future could not progress at any
+//! scheduling point.
+
+use super::mocks::{FlushControl, TestDb, TestMerkleized};
+use crate::stateful::db::{Barrier, DatabaseSet, Single, snapshot::Publisher};
+use commonware_consensus::types::Height;
+use commonware_macros::test_traced;
+use commonware_runtime::{Clock, Runner as _, Spawner as _, Supervisor as _, deterministic};
+use commonware_utils::channel::oneshot;
+use std::time::Duration;
+
+/// How long `blocked_on` waits before declaring the probed future blocked.
+const BLOCKED: Duration = Duration::from_secs(1);
+
+/// A parked single-member set plus the flush controls driving it.
+fn parked_set() -> (Single<TestDb>, FlushControl) {
+    let control = FlushControl::default();
+    (Single::from(TestDb::gated(control.clone())), control)
+}
+
+/// Finalize an empty batch, pinning the set's environment to the
+/// deterministic runtime ([`TestDb`] works in any environment).
+async fn finalize(set: Single<TestDb>) -> (Single<TestDb>, u64, Barrier) {
+    DatabaseSet::<deterministic::Context>::finalize(set, TestMerkleized).await
+}
+
+/// Await `future` against a deterministic timeout, `Ok` if it completed and
+/// `Err(future)` if the runtime reached quiescence without it progressing.
+async fn blocked_on<F, T>(context: &deterministic::Context, future: F) -> Result<T, F>
+where
+    F: std::future::Future<Output = T> + Unpin,
+{
+    let mut future = future;
+    commonware_macros::select! {
+        result = &mut future => Ok(result),
+        _ = context.sleep(BLOCKED) => Err(future),
+    }
+}
+
+/// Release the oldest parked flush.
+fn release(control: &FlushControl) {
+    control.flushes.lock().remove(0).send(Ok(())).unwrap();
+}
+
+/// Staging alone publishes nothing: a staged capture stays invisible until
+/// its flush proves durable, and does not hold the writer back.
+#[test_traced]
+fn staged_capture_stays_invisible() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let (set, control) = parked_set();
+        let (mut publisher, reader) = Publisher::new(&context);
+
+        // The first capture applies but its flush is parked, so it stays
+        // staged and no reader can see it.
+        let (set, snapshot, first) = finalize(set).await;
+        publisher.stage(Height::new(1), snapshot);
+        assert!(
+            reader.latest().is_none(),
+            "an applied but non-durable capture must not be visible"
+        );
+
+        // The staged capture does not hold the writer back.
+        let next = context.child("finalize").spawn(move |_| finalize(set));
+        let (_, snapshot, second) = blocked_on(&context, next)
+            .await
+            .unwrap_or_else(|_| panic!("a staged capture delayed the writer"))
+            .unwrap();
+        publisher.stage(Height::new(2), snapshot);
+
+        // Durability publishes, in order.
+        release(&control);
+        assert!(first.durable().await);
+        publisher.complete(Height::new(1));
+        assert_eq!(reader.latest(), Some(1));
+        release(&control);
+        assert!(second.durable().await);
+        publisher.complete(Height::new(2));
+        assert_eq!(reader.latest(), Some(2));
+    });
+}
+
+/// A serve holding a published snapshot across parked I/O cannot delay the
+/// writer, and the held snapshot stays frozen while publication moves on.
+#[test_traced]
+fn parked_serve_never_delays_the_writer() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context| async move {
+        let (set, control) = parked_set();
+        let (mut publisher, reader) = Publisher::new(&context);
+        let (set, snapshot, barrier) = finalize(set).await;
+        publisher.stage(Height::new(1), snapshot);
+        release(&control);
+        assert!(barrier.durable().await);
+        publisher.complete(Height::new(1));
+
+        // A serve takes the published snapshot and parks mid-assembly.
+        let served = reader.latest().unwrap();
+        let (io_done, io_gate) = oneshot::channel();
+        let serve = context.child("serve").spawn(move |_| async move {
+            let _ = io_gate.await;
+            served
+        });
+
+        // The parked serve shares nothing with the writer, so the next
+        // finalize and publication proceed without delay.
+        let next = context.child("finalize").spawn(move |_| finalize(set));
+        let (_, snapshot, barrier) = blocked_on(&context, next)
+            .await
+            .unwrap_or_else(|_| panic!("a parked serve delayed the writer"))
+            .unwrap();
+        publisher.stage(Height::new(2), snapshot);
+        release(&control);
+        assert!(barrier.durable().await);
+        publisher.complete(Height::new(2));
+
+        // The serve completes against its captured snapshot while the reader
+        // already serves the newer capture.
+        io_done.send(()).unwrap();
+        let held = serve.await.unwrap();
+        assert_eq!(held, 1, "the held snapshot never moved");
+        assert_eq!(
+            reader.latest(),
+            Some(2),
+            "publication moved on while the serve was parked"
+        );
+    });
+}

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -8,8 +8,8 @@ use crate::{
         Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
         Stateful as StatefulActor, SyncPlan,
         db::{
-            DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
-            p2p as qmdb_resolver,
+            DatabaseSet, Merkleized as _, MerkleizedOf, SyncEngineConfig, Unmerkleized as _,
+            UnmerkleizedOf, p2p as qmdb_resolver,
         },
         probe::{Config as ProbeConfig, Probe},
     },
@@ -65,7 +65,7 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 pub(super) type Qmdb<E> =
     fixed::Db<mmr::Family, E, sha256::Digest, sha256::Digest, Sha256, TwoCap, Sequential>;
 
-pub(crate) type SingleDatabaseSet<E> = Shared<Qmdb<E>>;
+pub(crate) type SingleDatabaseSet<E> = crate::stateful::db::Single<Qmdb<E>>;
 
 /// Builds the QMDB configuration used by single-database tests.
 pub(super) fn qmdb_config(prefix: &str, page_cache: CacheRef) -> FixedConfig<TwoCap, Sequential> {
@@ -193,8 +193,8 @@ impl App {
     /// Execute a block: increment "counter" and write `height -> height_val`.
     pub(super) async fn execute<E: Rng + Spawner + StorageContext>(
         height: Height,
-        mut batches: <SingleDatabaseSet<E> as DatabaseSet<E>>::Unmerkleized,
-    ) -> <SingleDatabaseSet<E> as DatabaseSet<E>>::Merkleized {
+        mut batches: UnmerkleizedOf<SingleDatabaseSet<E>, E>,
+    ) -> MerkleizedOf<SingleDatabaseSet<E>, E> {
         let counter = Sha256::hash(&[b"counter"]);
         let current: u64 = batches
             .get(&counter)
@@ -226,7 +226,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         &mut self,
         context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
+        batches: UnmerkleizedOf<Self::Databases, E>,
         _input: Input<Self::Input, Self::Provider>,
     ) -> Option<Proposed<Self, E>> {
         let mut ancestry = Box::pin(ancestry);
@@ -248,8 +248,8 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         &mut self,
         _context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> Option<MerkleizedOf<Self::Databases, E>> {
         let mut ancestry = Box::pin(ancestry);
         let tip = ancestry.next().await?;
         let merkleized = Self::execute(tip.height(), batches).await;
@@ -266,8 +266,8 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         &mut self,
         _context: (E, Self::Context),
         block: &Self::Block,
-        batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
+        batches: UnmerkleizedOf<Self::Databases, E>,
+    ) -> MerkleizedOf<Self::Databases, E> {
         Self::execute(block.height(), batches).await
     }
 
@@ -553,7 +553,7 @@ impl EngineDefinition for SingleDbEngine {
         marshal_actor.start(marshal_reporters, buffer, resolver);
 
         // Attach the marshal to probe, entering service. A syncing node has
-        // already consumed its floor above; a source attaches without ever soliciting peers.
+        // already consumed its floor above, so serving needs no peer solicitation.
         probe_mailbox.attach(marshal_mailbox.clone());
 
         if should_state_sync {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -3695,6 +3695,259 @@ mod tests {
         });
     }
 
+    /// A compatible child batch must read and merkleize identically whether its
+    /// ancestor is still pending or already applied. This is the property that
+    /// lets a paused verification resume against post-apply state.
+    #[test]
+    fn merkleize_after_compatible_ancestor_apply_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("resume-after-apply", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            // Seed with churn so floor maintenance has real work at every
+            // later merkleize.
+            let hot = Sha256::hash(&[b"hot"]);
+            let cold = Sha256::hash(&[b"cold"]);
+            let doomed = Sha256::hash(&[b"doomed"]);
+            let mut db = db;
+            for round in 0u64..4 {
+                let batch = db
+                    .new_batch()
+                    .write(hot, Some(Sha256::hash(&[&round.to_be_bytes()])))
+                    .write(cold, Some(Sha256::hash(&[b"cold-value"])))
+                    .write(doomed, (round % 2 == 0).then_some(Sha256::hash(&[b"d"])))
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap();
+                (db, _) = db.apply_batch(batch).await.unwrap();
+            }
+
+            // The parent the child forks from, merkleized but not yet applied.
+            let parent_write = Sha256::hash(&[b"parent-write"]);
+            let parent = db
+                .new_batch()
+                .write(hot, Some(parent_write))
+                .write(doomed, None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Two identical children forked from the pending parent.
+            let child_write = Sha256::hash(&[b"child-write"]);
+            let build = |parent: &Arc<MerkleizedBatch<_, _, _, _>>| {
+                parent
+                    .new_batch::<Sha256>()
+                    .write(cold, Some(child_write))
+                    .write(hot, Some(child_write))
+            };
+
+            // Path A, today's order. The child merkleizes while its parent is
+            // pending. Capture its root and a fallback read of an untouched key.
+            let child_pre = build(&parent);
+            let read_pre = child_pre.get(&doomed, &db).await.unwrap();
+            let root_pre = child_pre.merkleize(&db, None).await.unwrap().root();
+
+            // Apply the parent.
+            let (db, _) = db.apply_batch(parent.clone()).await.unwrap();
+
+            // Path B, the resume order. An identical child reads and merkleizes
+            // against the post-apply database.
+            let child_post = build(&parent);
+            let read_post = child_post.get(&doomed, &db).await.unwrap();
+            assert_eq!(read_pre, read_post, "fallback reads must not change");
+            let child_post = child_post.merkleize(&db, None).await.unwrap();
+            assert_eq!(
+                root_pre,
+                child_post.root(),
+                "merkleize must be order-independent for compatible batches",
+            );
+
+            // The post-merkleized child applies cleanly and lands the same root.
+            let (db, _) = db.apply_batch(child_post).await.unwrap();
+            assert_eq!(db.root(), root_pre);
+            assert_eq!(db.get(&hot).await.unwrap(), Some(child_write));
+            assert_eq!(db.get(&cold).await.unwrap(), Some(child_write));
+            assert_eq!(db.get(&doomed).await.unwrap(), None);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Pruning happens while batches are live, so a batch must keep reading and
+    /// merkleizing across one. Pruning only discards operations below the
+    /// inactivity floor, which are superseded, and leaves the root untouched.
+    #[test]
+    fn batch_reads_and_merkleizes_across_a_prune() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("prune-under-batch", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            // Churn so the inactivity floor advances and history is prunable.
+            let hot = Sha256::hash(&[b"hot"]);
+            let cold = Sha256::hash(&[b"cold"]);
+            let mut db = db;
+            for round in 0u64..8 {
+                let batch = db
+                    .new_batch()
+                    .write(hot, Some(Sha256::hash(&[&round.to_be_bytes()])))
+                    .write(cold, Some(Sha256::hash(&[b"cold-value"])))
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap();
+                (db, _) = db.apply_batch(batch).await.unwrap();
+            }
+            let floor = db.inactivity_floor_loc();
+            assert!(*floor > 0, "the test needs prunable history");
+
+            // A batch built before the prune, plus the reference values it must
+            // still produce afterward.
+            let write = Sha256::hash(&[b"write"]);
+            let build = || db.new_batch().write(hot, Some(write));
+            let reference = build();
+            let read_before = reference.get(&cold, &db).await.unwrap();
+            let root_before = reference.merkleize(&db, None).await.unwrap().root();
+            let batch = build();
+
+            let db = db.prune(floor).await.unwrap();
+
+            assert_eq!(
+                batch.get(&cold, &db).await.unwrap(),
+                read_before,
+                "a fallback read must survive pruning",
+            );
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            assert_eq!(
+                merkleized.root(),
+                root_before,
+                "pruning must not change what a live batch merkleizes to",
+            );
+
+            // It still applies, because pruning is not a competing batch.
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            assert_eq!(db.get(&hot).await.unwrap(), Some(write));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A batch on a losing fork keeps being read and merkleized after a
+    /// competing batch is applied, which is outside the branch-validity
+    /// contract. This pins down what actually happens, because callers that do
+    /// not cancel such work depend on it: no panic, keys the fork covers keep
+    /// their own branch's values, and only fallback reads of keys the fork does
+    /// not cover see the competing state.
+    #[test]
+    fn stale_fork_batch_reads_and_merkleizes_without_panicking() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("stale-fork", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let hot = Sha256::hash(&[b"hot"]);
+            let cold = Sha256::hash(&[b"cold"]);
+            let winner_only = Sha256::hash(&[b"winner-only"]);
+            let mut db = db;
+            for round in 0u64..4 {
+                let batch = db
+                    .new_batch()
+                    .write(hot, Some(Sha256::hash(&[&round.to_be_bytes()])))
+                    .write(cold, Some(Sha256::hash(&[b"cold-value"])))
+                    .merkleize(&db, None)
+                    .await
+                    .unwrap();
+                (db, _) = db.apply_batch(batch).await.unwrap();
+            }
+
+            // Two competing batches off the same committed prefix. Only the
+            // winner touches `winner_only`.
+            let winner_write = Sha256::hash(&[b"winner"]);
+            let winner = db
+                .new_batch()
+                .write(hot, Some(winner_write))
+                .write(winner_only, Some(winner_write))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let loser_write = Sha256::hash(&[b"loser"]);
+            let loser = db
+                .new_batch()
+                .write(hot, Some(loser_write))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // The loser's child, forked before anything is applied.
+            let child_write = Sha256::hash(&[b"child"]);
+            let build = || loser.new_batch::<Sha256>().write(cold, Some(child_write));
+            let before = build();
+            let covered_before = before.get(&hot, &db).await.unwrap();
+            let uncovered_before = before.get(&winner_only, &db).await.unwrap();
+            let root_before = before.merkleize(&db, None).await.unwrap().root();
+            assert_eq!(covered_before, Some(loser_write));
+            assert_eq!(uncovered_before, None);
+
+            // The winner lands. The loser's chain is now stale.
+            let child = build();
+            let (db, _) = db.apply_batch(winner).await.unwrap();
+
+            // Reads still answer. Keys the fork covers keep the fork's value;
+            // keys it does not cover fall through to the applied winner.
+            assert_eq!(
+                child.get(&hot, &db).await.unwrap(),
+                Some(loser_write),
+                "a covered key must keep the fork's own value",
+            );
+            assert_eq!(
+                child.get(&winner_only, &db).await.unwrap(),
+                Some(winner_write),
+                "an uncovered key falls through to the applied state",
+            );
+
+            // Merkleizing does not panic and stays on the fork's own chain.
+            let stale = child.merkleize(&db, None).await.unwrap();
+            assert_eq!(
+                stale.root(),
+                root_before,
+                "a stale fork merkleizes over its own chain, not the winner's",
+            );
+
+            // Applying it is separately rejected (see `batch_chain`).
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// Instantiate the staged-vs-explicit bulk-update parity test for one `any` DB kind.
     ///
     /// The staged path (`stage` + `Staged::merkleize`) must produce a byte-identical root to an

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1520,6 +1520,77 @@ mod tests {
         db.commit().await.unwrap()
     }
 
+    /// A compatible child batch must read and merkleize to the same canonical
+    /// root whether its ancestor is still pending or already applied, including
+    /// the grafted and bitmap layers. This is the property that lets a paused
+    /// verification resume against post-apply state.
+    #[test_traced]
+    fn test_merkleize_after_compatible_ancestor_apply_matches() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let db = MmrDb::init(
+                ctx.child("storage"),
+                fixed_config::<OneCap>("resume-after-apply", &ctx),
+            )
+            .await
+            .unwrap();
+            // Churn so activity bits and the floor have real work to do.
+            let db = populate_fixed_db::<mmr::Family, _>(db, 0, 40).await;
+            let db = populate_fixed_db::<mmr::Family, _>(db, 0, 40).await;
+
+            let hot = Sha256::hash(&[&0u64.to_be_bytes()]);
+            let cold = Sha256::hash(&[&1u64.to_be_bytes()]);
+            let untouched = Sha256::hash(&[&2u64.to_be_bytes()]);
+
+            // The parent the child forks from, merkleized but not yet applied.
+            let parent_write = Sha256::hash(&[b"parent-write"]);
+            let parent = db
+                .new_batch()
+                .write(hot, Some(parent_write))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Two identical children forked from the pending parent.
+            let child_write = Sha256::hash(&[b"child-write"]);
+            let build =
+                |parent: &Arc<crate::qmdb::current::batch::MerkleizedBatch<_, _, _, 32, _>>| {
+                    parent
+                        .new_batch::<Sha256>()
+                        .write(cold, Some(child_write))
+                        .write(hot, Some(child_write))
+                };
+
+            // Path A, today's order: merkleize while the parent is pending.
+            let child_pre = build(&parent);
+            let read_pre = child_pre.get(&untouched, &db).await.unwrap();
+            let root_pre = child_pre.merkleize(&db, None).await.unwrap().root();
+
+            // Apply the parent.
+            let (db, _) = db.apply_batch(parent.clone()).await.unwrap();
+
+            // Path B, the resume order: an identical child reads and merkleizes
+            // against the post-apply database.
+            let child_post = build(&parent);
+            let read_post = child_post.get(&untouched, &db).await.unwrap();
+            assert_eq!(read_pre, read_post, "fallback reads must not change");
+            let child_post = child_post.merkleize(&db, None).await.unwrap();
+            assert_eq!(
+                root_pre,
+                child_post.root(),
+                "canonical root must be order-independent for compatible batches",
+            );
+
+            // The post-merkleized child applies cleanly and lands the same root.
+            let (db, _) = db.apply_batch(child_post).await.unwrap();
+            assert_eq!(db.root(), root_pre);
+            assert_eq!(db.get(&hot).await.unwrap(), Some(child_write));
+            assert_eq!(db.get(&cold).await.unwrap(), Some(child_write));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// A snapshot's ops proofs stay byte-stable and verifiable against the captured ops root
     /// while the live database updates keys (flipping activity bits and raising the floor),
     /// commits, and prunes past it.


### PR DESCRIPTION
## Summary

The stateful actor now owns its database set outright, and read access to a database is a separate value from the authority to mutate it. That separation is what lets this PR delete two things at once: `Shared<DB>` (the `Arc<RwLock<Option<DB>>>` writers and readers used to meet through, where a cancelled mutation left the cell permanently empty), and the entire verification-cancellation machinery.

Verification jobs are no longer cancelled when a block finalizes. A job pauses at its next storage read while the apply runs, then continues, and its verdict is still correct or is refused. Speculative work is no longer thrown away on every finalization.

## Design

**The writer.** `Writer::new(db)` owns the database: the unique, non-`Clone` `Writer` is the sole mutation authority, and it creates cloneable `Reader`s. The old `&databases` parameter bundled three things: read access, mutation authority, and proof the database exists. Unbundled, a job can hold read access indefinitely without blocking mutation, mutation authority stays unique with the set, and nothing needs to be cancelled at all. The compiler enforces the split once instead of the runtime enforcing it continuously.

**Batches carry their own reader.** Every batch type holds a `Reader` and locks the database internally for exactly one storage call per read, so `get`, `merkleize`, and friends are now one-argument calls, and pairing a batch with the wrong database is unrepresentable. Applications never see a handle or a lease, so no lease can span application code: a mutation waits at most one storage call and cannot be starved (the lock is fair and write-preferring). A read of a writer whose owner is gone returns `Closed` (rendered as `Error::Runtime(Closed)` by storage-facing calls). Verification and proposal jobs that hit it produce no verdict, exactly as if they had been cancelled.

**Jobs are `'static`.** `DatabaseSet::new_batches` takes read handles instead of `&self`, so the verification context (`Execution`) holds only handles, shared state, and metrics; it is `Clone + 'static` and each `Verifier` owns one. Jobs are plain pool futures that survive any number of applies. Everything cancellation needed dies with this: `quiesce`/`quiesce_where`, per-job invalidation channels, `VerificationProgress`/`VerificationPhase`, `FinalizationBoundary`/`Disposition`, and the two-phase `run_until_transition`/`apply_transition` loop with its `Quiescent`/`Transition` hand-off types. The loop is now one flat loop; `drive` pins a mutation once and keeps polling job completions alongside it, so an apply never starves verification and verification never delays an apply by more than one storage call.

**Ownership.** Mutating `DatabaseSet` operations consume and return the set, the same convention `ManagedDb` already uses, so mutation capability stays with the actor. `DatabaseSet` loses `Clone`, `Shared` and its guards are deleted, `Single<T>` is the one-database set, and the database-subscription mailbox path is removed. The syncer hands the synced set through the completion channel exactly once; displaced target updates report `UpdateOutcome` instead of carrying a set.

## Retention: why an uncancelled job is still correct

QMDB's branch-validity rule: a merkleized batch stays usable only while everything applied since is an ancestor of that batch. Three cases, each pinned by a storage test in this PR:

1. **The job's batch descends from the finalized block.** The apply is an ancestor, so reads and the root are unchanged. `merkleize_after_compatible_ancestor_apply_matches` (in `any` and `current`) forks two identical children, applies the parent between their merkleizations, and asserts identical roots and reads.
2. **The job's batch is a sibling of the finalized block.** It runs to completion and is refused at `cache_pending`, the last gate in `Verifier::verify`: a result whose branch is no longer reachable from the anchor answers false, the same verdict cancellation used to force, by a different mechanism. Reads and merkleization on such a stale fork are outside the branch-validity contract, so `stale_fork_batch_reads_and_merkleizes_without_panicking` measures them: no panic, covered keys keep the fork's values, uncovered keys fall through to the applied winner, the root stays on the fork's own chain, and applying it fails with `StaleBatch`. A stale fork can therefore never answer true and never crash the node.
3. **Pruning under a live batch.** QMDB prunes only below the inactivity floor and pruning does not change the root; `batch_reads_and_merkleizes_across_a_prune` asserts reads, root, and a later apply all survive.

## API changes

These APIs are ALPHA so breaking changes are OK.

- `Application::propose`, `verify`, and `apply` receive only batches; the batch is the complete view for its branch, including speculative ancestor state the raw databases do not reflect. `finalized`, the one hook that observes applied state, receives read handles (`HandlesOf`).
- The `Application` clone contract is explicit: any method may run on a fresh clone that is discarded afterward, so clones must be cheap and persistent state must live behind shared handles. In-tree applications already comply.
- Batch construction and reads drop their database parameters across all four QMDB wrapper families; `DatabaseSet::new_batches` is a static over `Handles` and reports `Closed` when the owning actor is gone.
- `DatabaseSet` is owned by value and loses `Clone`; `Single<T>` replaces `Shared<T>`. `Readers` is deleted; the reader is used as `live::Reader` and the snapshot reader as `snapshot::Reader`.
- Set mutations still panic on database errors; deferred flush failures still surface through `Barrier`. Nothing about capture or publication changes in this PR.