### PR TITLE
[storage/qmdb] Reduce staged update resolution overhead

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1561,6 +1561,7 @@ where
             }
         }
         drop(winner_of);
+        drop(slots);
 
         // Locations are unique after last-write-wins dedup (each key resolves to exactly one
         // location, committed or ancestor), so the parallel sort is deterministic. Sorting

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1504,26 +1504,32 @@ where
 
         // Resolve last-write-wins per distinct key without hashing each update: every staged slot
         // carries its distinct-key id, so a forward walk leaves each id's final write (the same
-        // winner as a newest-first scan). `touched` records each id on first write so the walks
-        // below stay proportional to the updates actually submitted, not the full staged read set.
+        // winner as a newest-first scan). `winner_of` is a directory over the staged read set
+        // holding one index per id, biased so zero means unwritten. `winners` stores the values,
+        // one per distinct key written, so it and the walks below scale with the writes.
         let StagedKeys { keys, slots, ids } = keys;
-        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = vec![None; ids.len()];
-        let mut touched: Vec<usize> = Vec::with_capacity(updates.len());
+        let mut winner_of: Vec<usize> = vec![0; ids.len()];
+        let mut winners: Vec<(usize, Option<U::Value>)> =
+            Vec::with_capacity(updates.len().min(ids.len()));
         for (slot, value) in updates {
             assert!(slot < keys.len(), "update index out of staged read range");
             let id = slots[slot];
-            if winners[id].is_none() {
-                touched.push(id);
+            match winner_of[id] {
+                0 => {
+                    winner_of[id] = winners.len() + 1;
+                    winners.push((slot, value));
+                }
+                entry => winners[entry - 1] = (slot, value),
             }
-            winners[id] = Some((slot, value));
         }
 
         // Upserts are applied last and win over overlapping staged updates. Reuse the staged key
         // index for overlap detection instead of building a second hash table, then release it
-        // before allocating the remaining merkleization bookkeeping.
+        // before allocating the remaining merkleization bookkeeping. Clearing the directory entry
+        // orphans that key's winner, which the split loop skips.
         for (key, _) in &upserts {
             if let Some(&id) = ids.get(key) {
-                winners[id] = None;
+                winner_of[id] = 0;
             }
         }
         drop(ids);
@@ -1533,42 +1539,39 @@ where
         // also emit an older batch mutation for the same key, so it is removed here. The
         // probe is skipped when the batch had no mutations before this call: each distinct
         // key is visited at most once (winners are per key id), so a staged winner can never
-        // chase a fallback inserted by this same loop. `touched` may also contain ids whose
-        // winners were cleared because an upsert supersedes them; those ids are skipped.
+        // chase a fallback inserted by this same loop. An entry the directory no longer points
+        // at was superseded by an upsert and is skipped.
         let had_mutations = !batch.mutations.is_empty();
-        let mut order: Vec<(Location<F>, usize)> = Vec::with_capacity(touched.len());
-        for &id in &touched {
-            let winner = &mut winners[id];
-            let Some((slot, value)) = winner else {
+        let mut order: Vec<(Location<F>, usize)> = Vec::with_capacity(winners.len());
+        for (entry, (slot, value)) in winners.iter_mut().enumerate() {
+            if winner_of[slots[*slot]] != entry + 1 {
                 continue;
-            };
+            }
             let key = &keys[*slot];
             match &resolutions[*slot] {
                 Some((sloc, _)) if value.is_some() || U::STAGES_DELETES => {
                     if had_mutations {
                         batch.mutations.remove(key);
                     }
-                    order.push((sloc.loc(), *slot));
+                    order.push((sloc.loc(), entry));
                 }
                 _ => {
-                    let (_, value) = winner.take().expect("winner checked above");
-                    batch.mutations.insert(key.clone(), value);
+                    batch.mutations.insert(key.clone(), value.take());
                 }
             }
         }
+        drop(winner_of);
 
         // Locations are unique after last-write-wins dedup (each key resolves to exactly one
         // location, committed or ancestor), so the parallel sort is deterministic. Sorting
-        // compact `(location, slot)` pairs instead of the staged tuples keeps its memory
-        // traffic low. The tuples are then drained in sorted order, moving each winner's
-        // payload and value instead of cloning them.
+        // compact `(location, winner)` pairs instead of the staged tuples keeps its memory
+        // traffic low. Each index appears once, so the tuples are drained in sorted order,
+        // moving each winner's payload and value instead of cloning them.
         strategy.sort_by(&mut order, |a, b| a.0.cmp(&b.0));
         staged_updates = order
             .iter()
-            .map(|&(_, slot)| {
-                let (_, value) = winners[slots[slot]]
-                    .take()
-                    .expect("winner recorded for staged slot");
+            .map(|&(_, entry)| {
+                let (slot, value) = mem::take(&mut winners[entry]);
                 let (sloc, payload) = resolutions[slot].take().expect("resolution checked above");
                 (keys[slot].clone(), sloc, payload, value)
             })

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -321,8 +321,9 @@ struct StagedKeys<K> {
     /// Slot -> distinct-key id (1:1 with `keys`).
     slots: Vec<usize>,
     /// Key -> distinct-key id backing `slots`, retained so a later
-    /// [`expand`](Staged::expand) chunk assigns consistent ids to keys staged again. Only
-    /// probed, never iterated.
+    /// [`expand`](Staged::expand) chunk assigns consistent ids to keys staged again and so
+    /// [`resolve_updates`](Staged::resolve_updates) can detect overlapping upserts. Only probed,
+    /// never iterated.
     ids: AHashMap<K, usize>,
 }
 
@@ -352,16 +353,6 @@ impl<K: Clone + Eq + core::hash::Hash> StagedKeys<K> {
     /// Number of staged slots.
     const fn len(&self) -> usize {
         self.keys.len()
-    }
-
-    /// The key staged at `slot`.
-    fn key(&self, slot: usize) -> &K {
-        &self.keys[slot]
-    }
-
-    /// The distinct-key id assigned to `slot`.
-    fn id(&self, slot: usize) -> usize {
-        self.slots[slot]
     }
 
     /// Number of distinct staged keys, bounding the id space.
@@ -1511,42 +1502,47 @@ where
             return (Self::apply_upserts(batch, upserts), staged_updates);
         }
 
-        // Resolve last-write-wins per distinct key without hashing on the merkleize path:
-        // each staged slot carries its distinct-key id, so a forward walk leaves each id's
-        // final write (the same winner as a newest-first scan). Overlapping updates for upsert
-        // keys are dropped (upserts are applied last and win). Detecting the overlap is the
-        // one remaining hash probe, skipped entirely for the common upsert-free call.
-        // `touched` records each id on first write so the walks below stay proportional to
-        // the updates actually submitted, not the full staged read set.
-        let upsert_keys: AHashSet<&U::Key> = upserts.iter().map(|(key, _)| key).collect();
-        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = vec![None; keys.distinct()];
+        // Resolve last-write-wins per distinct key without hashing each update: every staged slot
+        // carries its distinct-key id, so a forward walk leaves each id's final write (the same
+        // winner as a newest-first scan). `touched` records each id on first write so the walks
+        // below stay proportional to the updates actually submitted, not the full staged read set.
+        let StagedKeys { keys, slots, ids } = keys;
+        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = vec![None; ids.len()];
         let mut touched: Vec<usize> = Vec::with_capacity(updates.len());
         for (slot, value) in updates {
             assert!(slot < keys.len(), "update index out of staged read range");
-            if !upsert_keys.is_empty() && upsert_keys.contains(keys.key(slot)) {
-                continue;
-            }
-            let id = keys.id(slot);
+            let id = slots[slot];
             if winners[id].is_none() {
                 touched.push(id);
             }
             winners[id] = Some((slot, value));
         }
 
+        // Upserts are applied last and win over overlapping staged updates. Reuse the staged key
+        // index for overlap detection instead of building a second hash table, then release it
+        // before allocating the remaining merkleization bookkeeping.
+        for (key, _) in &upserts {
+            if let Some(&id) = ids.get(key) {
+                winners[id] = None;
+            }
+        }
+        drop(ids);
+
         // Split the winners: updates whose slot resolved to a location become staged
         // updates, the rest fall back to batch mutations. A surviving staged write must not
         // also emit an older batch mutation for the same key, so it is removed here. The
         // probe is skipped when the batch had no mutations before this call: each distinct
         // key is visited at most once (winners are per key id), so a staged winner can never
-        // chase a fallback inserted by this same loop.
+        // chase a fallback inserted by this same loop. `touched` may also contain ids whose
+        // winners were cleared because an upsert supersedes them; those ids are skipped.
         let had_mutations = !batch.mutations.is_empty();
         let mut order: Vec<(Location<F>, usize)> = Vec::with_capacity(touched.len());
         for &id in &touched {
             let winner = &mut winners[id];
             let Some((slot, value)) = winner else {
-                unreachable!("touched ids hold a winner");
+                continue;
             };
-            let key = keys.key(*slot);
+            let key = &keys[*slot];
             match &resolutions[*slot] {
                 Some((sloc, _)) if value.is_some() || U::STAGES_DELETES => {
                     if had_mutations {
@@ -1570,11 +1566,11 @@ where
         staged_updates = order
             .iter()
             .map(|&(_, slot)| {
-                let (_, value) = winners[keys.id(slot)]
+                let (_, value) = winners[slots[slot]]
                     .take()
                     .expect("winner recorded for staged slot");
                 let (sloc, payload) = resolutions[slot].take().expect("resolution checked above");
-                (keys.key(slot).clone(), sloc, payload, value)
+                (keys[slot].clone(), sloc, payload, value)
             })
             .collect();
         (Self::apply_upserts(batch, upserts), staged_updates)


### PR DESCRIPTION
## Summary

- reuse the staged key-to-id index to detect overlap with keyed upserts, avoiding a temporary upsert-key set and per-update hashing
- replace the fat winner array sized by the full staged read set with a zero-biased index directory and a compact winner-payload vector
- preserve last-write-wins behavior, upsert precedence, and deterministic location ordering
- release the staged key index and winner directory before allocating or sorting later merkleization bookkeeping

## Performance

Let `R` be the number of distinct staged reads, `M` the number of submitted staged updates, `W` the number of distinct updated keys, and `U` the number of keyed upserts.

Previously, mixed batches built an `O(U)` hash set and performed an overlap lookup for every staged update. Winner tracking also allocated and initialized `R` fat `Option<(usize, Option<Value>)>` entries, plus a touched list with capacity for `M` entries.

The new overlap path performs one lookup per upsert in the existing staged-key index and allocates no second hash table. Winner tracking uses `R` zeroed directory entries and `W` initialized payload entries, with payload capacity bounded by `min(M, R)`; subsequent winner walks scale with `W`.

This primarily helps read-heavy batches with sparse read-modify-write updates, especially when they also contain a small number of blind keyed mutations. Batches without upserts retain their hash-free staged-update walk.

Measured with the `constantinople` harness on `any::unordered::fixed::mmb` (1M seeded keys, depth 0, 8 threads), comparing this branch against its base at `991ff08a`. Figures are the median of 27 timed iterations per point (3 runs of iterations 1-9, discarding each run's warmup iteration).

| config | merkleize before | merkleize after | delta |
| --- | --- | --- | --- |
| 1M reads / 4k updates | 1.46 ms | 1.12 ms | -23% |
| 262k reads / 8k updates | 1.71 ms | 1.58 ms | -7.6% |

Total per-batch latency is unchanged in both configurations, because this harness is dominated by the staged load phase (roughly 48 ms of a 50 ms batch at 1M reads). Median p50 totals were 49.9 ms before versus 50.3 ms after at 1M reads, and 11.65 ms versus 11.90 ms at 262k reads, i.e. noise in both directions. The change reduces merkleize-phase work and transient allocation (roughly 48 MB down to 8 MB of winner bookkeeping at 1M staged reads), not end-to-end batch latency.

Reproduce with:

```
cargo bench -p commonware-storage --bench constantinople --features test-traits -- \
  any::unordered::fixed::mmb 0 10 1000000 1000000 1 4096 8
```

## Testing

- `cargo fmt --all -- --check`
- `just test -p commonware-storage staged` (14 passed)
- `cargo clippy -p commonware-storage --lib --no-deps -- -D warnings -A clippy::chunks-exact-to-as-chunks`
