### PR TITLE
[storage/qmdb] Drop the eager staged key index

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -3882,7 +3882,7 @@ mod tests {
         2
     );
 
-    /// Build a [`Staged`] handle with the slot key-id map `stage`/`expand` would have built.
+    /// Build a [`Staged`] handle with the keys and resolutions `stage`/`expand` would produce.
     fn staged_with<F: Family, H: Hasher, U: update::Update + Send + Sync, S: Strategy>(
         batch: UnmerkleizedBatch<F, H, U, S>,
         keys: Vec<U::Key>,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1453,10 +1453,12 @@ where
 
         // Resolve last-write-wins per distinct key: a forward walk keyed on the staged key leaves
         // each key's final write, the same winner as a newest-first scan. Later writes overwrite
-        // their key's entry in place, so `winners` holds one entry per distinct key written and
-        // every structure here is sized by the updates submitted, not by the staged read set.
-        let mut winner_of: AHashMap<&U::Key, usize> = AHashMap::with_capacity(updates.len());
-        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = Vec::with_capacity(updates.len());
+        // their key's entry in place, so `winners` holds one entry per distinct key written. A
+        // distinct key needs a staged slot, so the staged read set caps the reservation that a
+        // duplicate-heavy update list would otherwise inflate.
+        let capacity = updates.len().min(keys.len());
+        let mut winner_of: AHashMap<&U::Key, usize> = AHashMap::with_capacity(capacity);
+        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = Vec::with_capacity(capacity);
         for (slot, value) in updates {
             assert!(slot < keys.len(), "update index out of staged read range");
             match winner_of.entry(&keys[slot]) {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -29,7 +29,7 @@ use commonware_parallel::Strategy;
 use commonware_utils::bitmap;
 use core::{cmp::Ordering, ops::Range};
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, hash_map},
     iter, mem,
     sync::{Arc, Weak},
 };
@@ -306,68 +306,8 @@ where
     Operation<F, U>: Codec,
 {
     batch: UnmerkleizedBatch<F, H, U, S>,
-    keys: StagedKeys<U::Key>,
+    keys: Vec<U::Key>,
     resolutions: Vec<StagedResolution<F, U>>,
-}
-
-/// The staged read slots: each staged key paired with its distinct-key id, assigned by
-/// first occurrence across [`stage`](UnmerkleizedBatch::stage) and
-/// [`expand`](Staged::expand). Ids are assigned while staging so
-/// [`resolve_updates`](Staged::resolve_updates) deduplicates updates by direct indexing
-/// instead of hashing every key on the merkleize path.
-struct StagedKeys<K> {
-    /// Staged keys, one per slot.
-    keys: Vec<K>,
-    /// Slot -> distinct-key id (1:1 with `keys`).
-    slots: Vec<usize>,
-    /// Key -> distinct-key id backing `slots`, retained so a later
-    /// [`expand`](Staged::expand) chunk assigns consistent ids to keys staged again. Only
-    /// probed, never iterated.
-    ids: AHashMap<K, usize>,
-}
-
-impl<K: Clone + Eq + core::hash::Hash> StagedKeys<K> {
-    /// Wrap the initial staged chunk, assigning each key its distinct-key id.
-    fn new(keys: Vec<K>) -> Self {
-        let mut staged = Self {
-            keys: Vec::new(),
-            slots: Vec::new(),
-            ids: AHashMap::with_capacity(keys.len()),
-        };
-        staged.append(keys);
-        staged
-    }
-
-    /// Append a staged chunk, assigning each key its distinct-key id (by first occurrence).
-    fn append(&mut self, mut keys: Vec<K>) {
-        self.slots.reserve(keys.len());
-        for key in &keys {
-            let next = self.ids.len();
-            let id = *self.ids.entry(key.clone()).or_insert(next);
-            self.slots.push(id);
-        }
-        self.keys.append(&mut keys);
-    }
-
-    /// Number of staged slots.
-    const fn len(&self) -> usize {
-        self.keys.len()
-    }
-
-    /// The key staged at `slot`.
-    fn key(&self, slot: usize) -> &K {
-        &self.keys[slot]
-    }
-
-    /// The distinct-key id assigned to `slot`.
-    fn id(&self, slot: usize) -> usize {
-        self.slots[slot]
-    }
-
-    /// Number of distinct staged keys, bounding the id space.
-    fn distinct(&self) -> usize {
-        self.ids.len()
-    }
 }
 
 /// A speculative batch of operations whose root digest has been computed,
@@ -1458,7 +1398,7 @@ where
             .checked_add(keys.len())
             .expect("staged read index overflow");
         let (values, keys, mut resolutions) = self.batch.stage_reads(keys, db).await?;
-        self.keys.append(keys);
+        self.keys.extend(keys);
         self.resolutions.append(&mut resolutions);
         Ok((start..end, values, self))
     }
@@ -1511,48 +1451,53 @@ where
             return (Self::apply_upserts(batch, upserts), staged_updates);
         }
 
-        // Resolve last-write-wins per distinct key without hashing on the merkleize path:
-        // each staged slot carries its distinct-key id, so a forward walk leaves each id's
-        // final write (the same winner as a newest-first scan). Overlapping updates for upsert
-        // keys are dropped (upserts are applied last and win). Detecting the overlap is the
-        // one remaining hash probe, skipped entirely for the common upsert-free call.
-        // `touched` records each id on first write so the walks below stay proportional to
-        // the updates actually submitted, not the full staged read set.
-        let upsert_keys: AHashSet<&U::Key> = upserts.iter().map(|(key, _)| key).collect();
-        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = vec![None; keys.distinct()];
-        let mut touched: Vec<usize> = Vec::with_capacity(updates.len());
+        // Resolve last-write-wins per distinct key: a forward walk keyed on the staged key leaves
+        // each key's final write, the same winner as a newest-first scan. Later writes overwrite
+        // their key's entry in place, so `winners` holds one entry per distinct key written and
+        // every structure here is sized by the updates submitted, not by the staged read set.
+        let mut winner_of: AHashMap<&U::Key, usize> = AHashMap::with_capacity(updates.len());
+        let mut winners: Vec<Option<(usize, Option<U::Value>)>> = Vec::with_capacity(updates.len());
         for (slot, value) in updates {
             assert!(slot < keys.len(), "update index out of staged read range");
-            if !upsert_keys.is_empty() && upsert_keys.contains(keys.key(slot)) {
-                continue;
+            match winner_of.entry(&keys[slot]) {
+                hash_map::Entry::Vacant(vacant) => {
+                    vacant.insert(winners.len());
+                    winners.push(Some((slot, value)));
+                }
+                hash_map::Entry::Occupied(occupied) => {
+                    winners[*occupied.get()] = Some((slot, value))
+                }
             }
-            let id = keys.id(slot);
-            if winners[id].is_none() {
-                touched.push(id);
-            }
-            winners[id] = Some((slot, value));
         }
+
+        // Upserts are applied last and win over overlapping staged updates. Only updated keys can
+        // overlap, so this probes the winner index rather than the whole staged read set.
+        for (key, _) in &upserts {
+            if let Some(&entry) = winner_of.get(key) {
+                winners[entry] = None;
+            }
+        }
+        drop(winner_of);
 
         // Split the winners: updates whose slot resolved to a location become staged
         // updates, the rest fall back to batch mutations. A surviving staged write must not
         // also emit an older batch mutation for the same key, so it is removed here. The
         // probe is skipped when the batch had no mutations before this call: each distinct
-        // key is visited at most once (winners are per key id), so a staged winner can never
+        // key is visited at most once (winners are per key), so a staged winner can never
         // chase a fallback inserted by this same loop.
         let had_mutations = !batch.mutations.is_empty();
-        let mut order: Vec<(Location<F>, usize)> = Vec::with_capacity(touched.len());
-        for &id in &touched {
-            let winner = &mut winners[id];
+        let mut order: Vec<(Location<F>, usize)> = Vec::with_capacity(winners.len());
+        for (entry, winner) in winners.iter_mut().enumerate() {
             let Some((slot, value)) = winner else {
-                unreachable!("touched ids hold a winner");
+                continue;
             };
-            let key = keys.key(*slot);
+            let key = &keys[*slot];
             match &resolutions[*slot] {
                 Some((sloc, _)) if value.is_some() || U::STAGES_DELETES => {
                     if had_mutations {
                         batch.mutations.remove(key);
                     }
-                    order.push((sloc.loc(), *slot));
+                    order.push((sloc.loc(), entry));
                 }
                 _ => {
                     let (_, value) = winner.take().expect("winner checked above");
@@ -1563,18 +1508,18 @@ where
 
         // Locations are unique after last-write-wins dedup (each key resolves to exactly one
         // location, committed or ancestor), so the parallel sort is deterministic. Sorting
-        // compact `(location, slot)` pairs instead of the staged tuples keeps its memory
+        // compact `(location, winner)` pairs instead of the staged tuples keeps its memory
         // traffic low. The tuples are then drained in sorted order, moving each winner's
         // payload and value instead of cloning them.
         strategy.sort_by(&mut order, |a, b| a.0.cmp(&b.0));
         staged_updates = order
             .iter()
-            .map(|&(_, slot)| {
-                let (_, value) = winners[keys.id(slot)]
+            .map(|&(_, entry)| {
+                let (slot, value) = winners[entry]
                     .take()
                     .expect("winner recorded for staged slot");
                 let (sloc, payload) = resolutions[slot].take().expect("resolution checked above");
-                (keys.key(slot).clone(), sloc, payload, value)
+                (keys[slot].clone(), sloc, payload, value)
             })
             .collect();
         (Self::apply_upserts(batch, upserts), staged_updates)
@@ -1684,7 +1629,7 @@ where
             .iter()
             .filter(|(slot, _)| self.resolutions.get(*slot).is_some_and(Option::is_some))
             .count()
-            .min(self.keys.distinct());
+            .min(self.keys.len());
         let existing_writes = upserts
             .iter()
             .map(|(key, _)| key)
@@ -1920,7 +1865,7 @@ where
             results,
             Staged {
                 batch: self,
-                keys: StagedKeys::new(keys),
+                keys,
                 resolutions,
             },
         ))
@@ -3946,7 +3891,7 @@ mod tests {
     {
         Staged {
             batch,
-            keys: StagedKeys::new(keys),
+            keys,
             resolutions,
         }
     }


### PR DESCRIPTION
## Summary

- drop the eager distinct-key index that staging built over every staged read, and resolve last-write-wins at merkleize by hashing the submitted updates instead
- `StagedKeys` (its `ids` map, its `slots` vector, and the winner directory sized by that id space) is gone; `Staged` now holds a plain `Vec<Key>`
- `expand` no longer has to assign ids consistent with earlier chunks, removing the one cross-chunk invariant in the staging path
- net 93 deletions against 38 insertions in a single file

Supersedes #4418, which made the eager index cheaper rather than removing it. Nothing from that PR survives here.

## Why

Staging assigned every staged slot a distinct-key id so that `resolve_updates` could deduplicate by direct indexing without hashing. Making the merkleize path hash-free cost a hash, a key clone, and a probe per staged slot on the load path. At one million staged reads the `ids` map alone is `AHashMap::with_capacity(1_000_000)`, i.e. 2^21 buckets of 40 bytes, roughly 80 MiB, probed a million times in hash order. That is about 27 ms of a 50 ms staged load, spent to save about 0.1 ms at merkleize.

## Performance

`constantinople`, `any::unordered::fixed::mmb`, 1M seeded keys, depth 0, 8 threads. Medians of 27 timed iterations per point (3 runs of iterations 1-9, discarding each run's warmup iteration). Baseline is `991ff08a`.

| config | phase | main | this branch | delta |
| --- | --- | --- | --- | --- |
| 1M reads / 4k updates | load | 48.89 ms | 22.92 ms | -53.1% |
| | merkleize | 1.69 ms | 1.19 ms | -29.6% |
| | **total** | **50.58 ms** | **24.16 ms** | **-52.2%** |
| 32k reads / 32k updates | total | 5.31 ms | 4.85 ms | -8.7% (within noise) |
| 262k reads / 262k updates | load | 10.06 ms | 5.07 ms | -49.6% |
| | merkleize | 32.85 ms | 35.15 ms | **+7.0%** |
| | **total** | **43.00 ms** | **40.32 ms** | **-6.2%** |

### The tradeoff, stated plainly

Hashing moves from the load phase onto the merkleize path, so **merkleize regresses at high update counts**: +7.0% at 262k updates, which is statistically resolved rather than noise. It is covered by a larger load-phase saving, so total improves in every configuration measured, but it is a real cost.

The two effects are cleanly separable and scale with different quantities:

- removed from load: about 19-26 ns per staged **slot** (hash, key clone, and insert into the large table)
- added to merkleize: about 8.8 ns per submitted **update** (+2.30 ms across 262k updates)

Break-even is therefore around `updates ~= 2.5 * staged slots`. Callers submit at most one update per staged slot in normal use, so this is a win across the realistic range; it would only lose if a batch rewrote the same staged keys several times over.

Reproduce with:

```
cargo bench -p commonware-storage --bench constantinople --features test-traits -- \
  any::unordered::fixed::mmb 0 10 1000000 1000000 1 4096 8
```

## Behavior change

One, called out because it is the only place the diff changes behavior rather than representation. `StagedKeys::distinct()` was the sole consumer of the id map outside deduplication: it clamped the floor-raise step bound to the distinct staged key count. That clamp is now `keys.len()`, the staged slot count, which is still a valid upper bound but a looser one. The bound is documented as approximate in both directions, and an over-estimate only prefetches surplus candidates, which the raise already drops once it has moved enough ops.

## Testing

- `just test -p commonware-storage qmdb::` (1639 passed)
- `cargo fmt --all -- --check` (via the pre-commit hook)
- Speculative root parity against `991ff08a`: 20 of 20 roots byte-identical across four configurations, covering `depth=2` (an uncommitted ancestor chain), `read_chunks=3` (multi-chunk `expand`, where the removed cross-chunk id consistency previously mattered), the read-heavy and update-heavy ratios, and `any::ordered::fixed::mmb` (which exercises the other `STAGES_DELETES` and `STAGES_ANCESTORS` paths).
