### PR TITLE
[marshal] Handle Dropped Acknowledgements During Shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1606,7 +1606,6 @@ dependencies = [
  "commonware-p2p",
  "commonware-runtime",
  "commonware-utils",
- "futures",
  "rand 0.10.2",
  "serde",
  "serde_yaml",

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -482,9 +482,21 @@ where
             },
             // Handle application acknowledgements (drain all ready acks, sync once)
             result = self.pending_acks.current() => {
-                self = self
+                let next = match self
                     .handle_ack(result, &mut application, &mut buffer, &mut resolver)
-                    .await;
+                    .await
+                {
+                    Ok(next) => next,
+                    Err((height, e)) => {
+                        debug!(
+                            ?e,
+                            %height,
+                            "application acknowledgement dropped, stopping marshal"
+                        );
+                        return;
+                    }
+                };
+                self = next;
             },
             // Handle consensus inputs before backfill or resolver traffic
             Some(message) = self.mailbox.recv() else {
@@ -535,7 +547,7 @@ where
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         buffer: &mut Buf,
         resolver: &mut R,
-    ) -> Box<Self>
+    ) -> Result<Box<Self>, (Height, A::Error)>
     where
         Buf: Buffer<V>,
         R: Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
@@ -552,10 +564,7 @@ where
                     self.update_processed_height(height, resolver);
                     self = self.update_processed_round(height, resolver).await;
                 }
-                Err(e) => {
-                    // Ack failures are fatal for marshal/application coordination.
-                    panic!("application did not acknowledge block at height {height}: {e:?}");
-                }
+                Err(e) => return Err((height, e)),
             }
             processed_commitments.push(commitment);
 
@@ -582,7 +591,7 @@ where
         });
 
         // Refill the application dispatch pipeline.
-        self.try_dispatch_blocks(application).await
+        Ok(self.try_dispatch_blocks(application).await)
     }
 
     /// Handles a single mailbox message from local consensus/application callers.

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -106,7 +106,7 @@ mod tests {
     use commonware_utils::{
         Acknowledgement as _, NZU16, NZU64, NZUsize,
         acknowledgement::Exact,
-        channel::{fallible::OneshotExt, oneshot, oneshot::error::TryRecvError},
+        channel::{fallible::OneshotExt, mpsc, oneshot, oneshot::error::TryRecvError},
         ordered::{Quorum as _, Set},
         sequence::U64,
         sync::Mutex,
@@ -4101,6 +4101,23 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct ApplicationReporter {
+        updates: mpsc::UnboundedSender<Update<B>>,
+    }
+
+    impl Reporter for ApplicationReporter {
+        type Activity = Update<B>;
+
+        fn report(&mut self, activity: Self::Activity) -> Feedback {
+            if self.updates.send(activity).is_ok() {
+                Feedback::Ok
+            } else {
+                Feedback::Closed
+            }
+        }
+    }
+
     async fn start_standard_actor<R, Buf, P>(
         context: deterministic::Context,
         partition_prefix: &str,
@@ -4208,6 +4225,78 @@ mod tests {
             actor.start_unbuffered(application, (resolver_rx, resolver.clone()))
         };
         (mailbox, buffer, resolver, actor_handle)
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_application_shutdown_with_pending_ack_stops_cleanly() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+
+            // Model an application that handles genesis normally, then owns the first
+            // non-genesis acknowledgement while its work remains in flight.
+            let (updates, mut application_mailbox) = mpsc::unbounded_channel::<Update<B>>();
+            let (delivered, delivery) = oneshot::channel();
+            let application_handle = context.child("application").spawn(move |_| async move {
+                let mut delivered = Some(delivered);
+                while let Some(update) = application_mailbox.recv().await {
+                    let Update::Block(block, acknowledgement) = update else {
+                        continue;
+                    };
+                    if block.height() == Height::zero() {
+                        acknowledgement.acknowledge();
+                        continue;
+                    }
+
+                    delivered
+                        .take()
+                        .expect("normal block should only be delivered once")
+                        .send_lossy(block.height());
+
+                    // Keep the acknowledgement in the suspended future so aborting this task
+                    // exercises application-owned cancellation during shutdown.
+                    std::future::pending::<()>().await;
+                    acknowledgement.acknowledge();
+                }
+            });
+
+            // Retain marshal's mailbox, buffer, and resolver until the final assertion so no
+            // other input closing can account for the actor's exit.
+            let (mut mailbox, _buffer, _resolver, marshal_handle) = start_standard_actor(
+                context.child("validator"),
+                "application-shutdown-with-pending-ack",
+                ConstantProvider::new(schemes[0].clone()),
+                ApplicationReporter { updates },
+                Some(RecordingBuffer::default()),
+                Start::Genesis(genesis.clone()),
+            )
+            .await;
+
+            // Deliver a normal finalized block and wait until the application owns its
+            // acknowledgement before beginning shutdown.
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            assert!(mailbox.verified(round, block).await);
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            assert_eq!(
+                delivery.await.expect("normal block should be delivered"),
+                Height::new(1)
+            );
+
+            // Drop the application first; the pending acknowledgement must stop marshal cleanly.
+            application_handle.abort();
+            let _ = application_handle.await;
+            marshal_handle
+                .await
+                .expect("application shutdown should stop marshal cleanly");
+        });
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -4228,11 +4228,13 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_standard_application_shutdown_with_pending_ack_stops_cleanly() {
+    fn test_standard_application_shutdown_redelivers_pending_ack_after_restart() {
+        const PARTITION_PREFIX: &str = "application-shutdown-with-pending-ack";
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
-        runner.start(|mut context| async move {
+        let first_run = |mut context: deterministic::Context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let provider = ConstantProvider::new(schemes[0].clone());
             let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
 
             // Model an application that handles genesis normally, then owns the first
@@ -4262,12 +4264,12 @@ mod tests {
                 }
             });
 
-            // Retain marshal's mailbox, buffer, and resolver until the final assertion so no
-            // other input closing can account for the actor's exit.
+            // Retain marshal's mailbox, buffer, and resolver until the exit assertion so no other
+            // input closing can account for the actor's exit.
             let (mut mailbox, _buffer, _resolver, marshal_handle) = start_standard_actor(
                 context.child("validator"),
-                "application-shutdown-with-pending-ack",
-                ConstantProvider::new(schemes[0].clone()),
+                PARTITION_PREFIX,
+                provider.clone(),
                 ApplicationReporter { updates },
                 Some(RecordingBuffer::default()),
                 Start::Genesis(genesis.clone()),
@@ -4278,6 +4280,7 @@ mod tests {
             // acknowledgement before beginning shutdown.
             let round = Round::new(Epoch::zero(), View::new(1));
             let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            let block_digest = block.digest();
             let finalization = StandardHarness::make_finalization(
                 Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
                 &schemes,
@@ -4296,6 +4299,41 @@ mod tests {
             marshal_handle
                 .await
                 .expect("application shutdown should stop marshal cleanly");
+
+            (provider, genesis, block_digest)
+        };
+
+        // Shut down with a pending acknowledgement, then recover the runtime.
+        let ((provider, genesis, block_digest), checkpoint) = runner.start_and_recover(first_run);
+        deterministic::Runner::from(checkpoint).start(move |context| async move {
+            // The canceled acknowledgement must leave the processed floor behind the block so the
+            // recovered application receives the same finalized block again.
+            let restart_application = Application::<B>::manual_ack();
+            let (_mailbox, _buffer, _resolver, _marshal_handle) = start_standard_actor(
+                context.child("validator").with_attribute("restart", 0),
+                PARTITION_PREFIX,
+                provider,
+                restart_application.clone(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(genesis),
+            )
+            .await;
+            select! {
+                height = restart_application.acknowledged() => {
+                    assert_eq!(height, Height::new(1));
+                    assert_eq!(
+                        restart_application
+                            .blocks()
+                            .get(&height)
+                            .expect("redelivered block must be recorded")
+                            .digest(),
+                        block_digest,
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("unacknowledged block was not redelivered after restart");
+                },
+            }
         });
     }
 

--- a/examples/flood/Cargo.toml
+++ b/examples/flood/Cargo.toml
@@ -23,7 +23,6 @@ commonware-math.workspace = true
 commonware-p2p.workspace = true
 commonware-runtime.workspace = true
 commonware-utils.workspace = true
-futures.workspace = true
 rand = { workspace = true, features = ["alloc"] }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml.workspace = true

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -9,12 +9,11 @@ use commonware_flood::Config;
 use commonware_formatting::from_hex;
 use commonware_p2p::{Manager as _, Receiver, Recipients, Sender, authenticated::discovery};
 use commonware_runtime::{
-    Buf, Quota, Runner, Spawner, Supervisor as _,
+    Buf, Handle, Quota, Runner, Spawner, Supervisor as _,
     telemetry::metrics::{HistogramExt as _, MetricsExt as _},
     tokio,
 };
 use commonware_utils::{NZU32, TryCollect, ordered::Set, union};
-use futures::future::try_join_all;
 use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::{
     collections::HashMap,
@@ -196,8 +195,8 @@ fn main() {
                 }
             });
 
-        // Wait for any task to error
-        if let Err(e) = try_join_all(vec![p2p, flood_sender, flood_receiver]).await {
+        // Stop the process when any long-lived task exits.
+        if let Err(e) = Handle::select([p2p, flood_sender, flood_receiver]).await {
             error!(?e, "task failed");
         }
     });

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -37,10 +37,9 @@ use commonware_glue::{
 use commonware_macros::boxed;
 use commonware_p2p::authenticated::{self, discovery};
 use commonware_parallel::Sequential;
-use commonware_runtime::{Supervisor as _, buffer::paged::CacheRef, tokio};
+use commonware_runtime::{Handle, Supervisor as _, buffer::paged::CacheRef, tokio};
 use commonware_storage::{archive::prunable, translator::TwoCap};
 use commonware_utils::{NZDuration, NZU64, NZUsize};
-use futures::future::try_join_all;
 use std::{marker::PhantomData, path::PathBuf, time::Duration};
 use tracing::error;
 
@@ -56,7 +55,7 @@ pub struct Validator {
     pub state_sync: bool,
 }
 
-/// Start every validator actor and run until one fails.
+/// Start every validator actor and run until one stops.
 #[boxed]
 pub async fn run(context: tokio::Context, args: Validator) {
     let node = NodeConfig::load(&args.node_dir).expect("failed to load node config");
@@ -371,7 +370,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
     probe_mailbox.attach(marshal.clone());
     let stateful_handle = stateful_actor.start();
 
-    if let Err(err) = try_join_all(vec![
+    if let Err(err) = Handle::select([
         p2p_handle,
         broadcast_handle,
         probe_handle,
@@ -404,5 +403,55 @@ fn archive_config<C>(
         key_write_buffer: IO_BUFFER_SIZE,
         value_write_buffer: IO_BUFFER_SIZE,
         replay_buffer: IO_BUFFER_SIZE,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{FutureExt as _, future::pending};
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    struct CountDrop(Arc<AtomicUsize>);
+
+    impl Drop for CountDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn pending_handle(dropped: Arc<AtomicUsize>) -> Handle<()> {
+        let count_drop = CountDrop(dropped);
+        Handle::from_future(async move {
+            let _count_drop = count_drop;
+            pending().await
+        })
+    }
+
+    #[test]
+    fn successful_actor_completion_stops_validator() {
+        let dropped = Arc::new(AtomicUsize::new(0));
+
+        // Model a clean actor exit alongside siblings that would otherwise run forever.
+        let actors = [
+            Handle::ready(Ok(())),
+            pending_handle(dropped.clone()),
+            pending_handle(dropped.clone()),
+            pending_handle(dropped.clone()),
+            pending_handle(dropped.clone()),
+            pending_handle(dropped.clone()),
+            pending_handle(dropped.clone()),
+            pending_handle(dropped.clone()),
+        ];
+
+        // Supervision must complete and abort every pending sibling.
+        assert!(matches!(
+            Handle::select(actors).now_or_never(),
+            Some(Ok(()))
+        ));
+        assert_eq!(dropped.load(Ordering::Relaxed), 7);
     }
 }

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -36,7 +36,6 @@ use commonware_cryptography::{
     ed25519,
     sha256::{self, Digest as Sha256Digest},
 };
-use commonware_macros::select;
 use commonware_p2p::{Blocker, Manager, Receiver, Sender};
 use commonware_parallel::Strategy;
 use commonware_runtime::{
@@ -513,41 +512,14 @@ where
         );
         let simplex_handle = simplex.start(votes, certificates, resolver_network);
 
-        BootstrapActors {
+        Handle::select([
             buffer_handle,
             reshare_handle,
             marshal_handle,
             simplex_handle,
-        }
-        .supervise()
-        .await;
-    }
-}
-
-struct BootstrapActors {
-    buffer_handle: Handle<()>,
-    reshare_handle: Handle<()>,
-    marshal_handle: Handle<()>,
-    simplex_handle: Handle<()>,
-}
-
-impl BootstrapActors {
-    async fn supervise(mut self) {
-        select! {
-            result = &mut self.buffer_handle => result.expect("failed dkg"),
-            result = &mut self.reshare_handle => result.expect("failed dkg"),
-            result = &mut self.marshal_handle => result.expect("failed dkg"),
-            result = &mut self.simplex_handle => result.expect("failed dkg"),
-        }
-    }
-}
-
-impl Drop for BootstrapActors {
-    fn drop(&mut self) {
-        self.buffer_handle.abort();
-        self.reshare_handle.abort();
-        self.marshal_handle.abort();
-        self.simplex_handle.abort();
+        ])
+        .await
+        .expect("failed dkg");
     }
 }
 

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -450,41 +450,7 @@ pub(super) struct ReshareEngine {
 
 pub(super) struct ValidatorEngine {
     context: DeterministicContext,
-    handles: ValidatorHandles,
-}
-
-struct ValidatorHandles {
-    probe: Handle<()>,
-    qmdb: Handle<()>,
-    reshare: Handle<()>,
-    orchestrator: Handle<()>,
-    marshal: Handle<()>,
-    stateful: Handle<()>,
-}
-
-impl ValidatorHandles {
-    async fn join(mut self) {
-        futures::try_join!(
-            &mut self.probe,
-            &mut self.qmdb,
-            &mut self.reshare,
-            &mut self.orchestrator,
-            &mut self.marshal,
-            &mut self.stateful,
-        )
-        .expect("validator actor failed");
-    }
-}
-
-impl Drop for ValidatorHandles {
-    fn drop(&mut self) {
-        self.probe.abort();
-        self.qmdb.abort();
-        self.reshare.abort();
-        self.orchestrator.abort();
-        self.marshal.abort();
-        self.stateful.abort();
-    }
+    handles: [Handle<()>; 6],
 }
 
 #[derive(Clone)]
@@ -1076,14 +1042,14 @@ impl EngineDefinition for ReshareEngine {
         (
             ValidatorEngine {
                 context,
-                handles: ValidatorHandles {
-                    probe: probe_handle,
-                    qmdb: qmdb_handle,
-                    reshare: reshare_handle,
-                    orchestrator: orchestrator_handle,
-                    marshal: marshal_handle,
-                    stateful: stateful_handle,
-                },
+                handles: [
+                    probe_handle,
+                    qmdb_handle,
+                    reshare_handle,
+                    orchestrator_handle,
+                    marshal_handle,
+                    stateful_handle,
+                ],
             },
             ValidatorState {
                 marshal,
@@ -1097,7 +1063,11 @@ impl EngineDefinition for ReshareEngine {
 
     fn start(engine: Self::Engine) -> Handle<()> {
         let ValidatorEngine { context, handles } = engine;
-        context.spawn(move |_| handles.join())
+        context.spawn(move |_| async move {
+            Handle::select(handles)
+                .await
+                .expect("validator actor failed");
+        })
     }
 }
 

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -1,6 +1,6 @@
 //! Mailbox for the [`super::Stateful`] actor.
 
-use crate::stateful::{Application, actor::core::Deferred};
+use crate::stateful::Application;
 use commonware_actor::{
     Feedback,
     mailbox::{Overflow, Policy, Sender},
@@ -14,7 +14,10 @@ use commonware_consensus::{
 };
 use commonware_cryptography::Digestible;
 use commonware_runtime::{Clock, Metrics, Spawner, telemetry::traces::TracedExt as _};
-use commonware_utils::channel::{fallible::OneshotExt, oneshot};
+use commonware_utils::{
+    acknowledgement::Exact,
+    channel::{fallible::OneshotExt, oneshot},
+};
 use rand_core::Rng;
 use std::{collections::VecDeque, sync::Arc};
 use tracing::{Span, info_span};
@@ -67,7 +70,7 @@ where
     Finalized {
         span: Span,
         block: Arc<A::Block>,
-        acknowledgement: Deferred,
+        acknowledgement: Exact,
         retry_mailbox: RetryMailbox<E, A>,
     },
 
@@ -302,7 +305,7 @@ where
                 Message::Finalized {
                     span,
                     block,
-                    acknowledgement: acknowledgement.into(),
+                    acknowledgement,
                     retry_mailbox: self.retry_mailbox.clone(),
                 }
             }

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -25,7 +25,7 @@ use commonware_consensus::{
 use commonware_cryptography::{Digestible, certificate::Scheme};
 use commonware_runtime::{ContextCell, Handle, Spawner, spawn_cell, telemetry::metrics::GaugeExt};
 use commonware_storage::Context;
-use commonware_utils::{Acknowledgement as _, acknowledgement::Exact, channel::oneshot};
+use commonware_utils::channel::oneshot;
 use futures::join;
 use rand_core::Rng;
 use std::num::NonZeroUsize;
@@ -39,32 +39,6 @@ mod syncing;
 mod verifications;
 
 type BlockDigest<A, E> = <<A as Application<E>>::Block as Digestible>::Digest;
-
-/// Defers marshal's acknowledgement until finalized work completes.
-pub(crate) struct Deferred(Option<Exact>);
-
-impl Deferred {
-    fn acknowledge(mut self) {
-        self.0
-            .take()
-            .expect("pending acknowledgement must exist")
-            .acknowledge();
-    }
-}
-
-impl From<Exact> for Deferred {
-    fn from(acknowledgement: Exact) -> Self {
-        Self(Some(acknowledgement))
-    }
-}
-
-impl Drop for Deferred {
-    fn drop(&mut self) {
-        if let Some(acknowledgement) = self.0.take() {
-            acknowledgement.abandon();
-        }
-    }
-}
 
 /// Periodic pruning configuration.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -319,7 +293,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Config, Deferred, Stateful};
+    use super::{Config, Stateful};
     use crate::stateful::{
         actor::syncer::SyncPlan,
         db::{AttachableResolver, Shared, StateSyncDb, SyncEngineConfig},
@@ -335,10 +309,7 @@ mod tests {
     use commonware_cryptography::sha256::Digest as Sha256Digest;
     use commonware_macros::select;
     use commonware_runtime::{Clock as _, Runner as _, Supervisor as _, deterministic};
-    use commonware_utils::{
-        Acknowledgement as _, NZU64, NZUsize, acknowledgement::Exact, channel::mpsc,
-    };
-    use futures::FutureExt as _;
+    use commonware_utils::{NZU64, NZUsize, channel::mpsc};
     use std::{convert::Infallible, time::Duration};
 
     #[derive(Clone)]
@@ -363,13 +334,6 @@ mod tests {
         ) -> Result<Self, Self::SyncError> {
             Ok(Self::default())
         }
-    }
-
-    #[test]
-    fn dropped_deferred_keeps_waiter_pending() {
-        let (acknowledgement, waiter) = Exact::handle();
-        drop(Deferred::from(acknowledgement));
-        assert!(waiter.now_or_never().is_none());
     }
 
     #[test]

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -20,7 +20,7 @@ use commonware_consensus::{
 use commonware_cryptography::certificate::Scheme;
 use commonware_macros::{select, select_loop};
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
-use commonware_utils::{channel::fallible::OneshotExt, futures::Pool};
+use commonware_utils::{Acknowledgement as _, channel::fallible::OneshotExt, futures::Pool};
 use futures::{
     FutureExt as _,
     future::{Either, ready},
@@ -2370,12 +2370,12 @@ mod tests {
             )
             .await;
 
-            let (acknowledgement, mut waiter1) = Exact::handle();
+            let (acknowledgement, waiter1) = Exact::handle();
             let _ = mailbox.report(Update::Block(
                 Arc::new(TestBlock::new(1, 1)),
                 acknowledgement,
             ));
-            let (acknowledgement, mut waiter2) = Exact::handle();
+            let (acknowledgement, waiter2) = Exact::handle();
             let _ = mailbox.report(Update::Block(
                 Arc::new(TestBlock::new(2, 2)),
                 acknowledgement,
@@ -2387,8 +2387,12 @@ mod tests {
             drop(control.flushes.lock().remove(0));
             actor.await.expect("processing actor should stop");
             assert!(
-                poll!(&mut waiter1).is_pending() && poll!(&mut waiter2).is_pending(),
-                "aborted target flush must leave acknowledgements pending",
+                waiter1.await.is_err(),
+                "aborted target flush must cancel the first acknowledgement",
+            );
+            assert!(
+                waiter2.await.is_err(),
+                "aborted target flush must cancel the second acknowledgement",
             );
             assert!(
                 control.pruned.lock().is_empty(),
@@ -2398,8 +2402,8 @@ mod tests {
     }
 
     /// While the loop is idle, a completed flush must release its acknowledgement without
-    /// displacing a simultaneously reported block, while an incomplete flush must leave its block
-    /// unacknowledged.
+    /// displacing a simultaneously reported block, while an incomplete flush must cancel its
+    /// acknowledgement when processing stops.
     #[test]
     fn idle_acks_follow_flush_outcome() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
@@ -2423,7 +2427,7 @@ mod tests {
             // without displacing the new message.
             let release = control.flushes.lock().remove(0);
             let _ = release.send(Ok(()));
-            let (acknowledgement, mut waiter2) = Exact::handle();
+            let (acknowledgement, waiter2) = Exact::handle();
             let _ = mailbox.report(Update::Block(
                 Arc::new(TestBlock::new(2, 2)),
                 acknowledgement,
@@ -2435,13 +2439,13 @@ mod tests {
             context.sleep(Duration::from_millis(50)).await;
 
             // Dropping block 2's release resolves its flush as shutdown. The
-            // acknowledgement must be withheld so marshal's floor cannot pass
-            // unflushed state.
+            // acknowledgement is canceled so marshal stops without advancing
+            // its floor past unflushed state.
             drop(control.flushes.lock().remove(0));
             actor.await.expect("processing actor should stop");
             assert!(
-                poll!(&mut waiter2).is_pending(),
-                "unflushed block acknowledgement must remain pending",
+                waiter2.await.is_err(),
+                "unflushed block acknowledgement must be canceled",
             );
         });
     }
@@ -2452,7 +2456,7 @@ mod tests {
             let (mut mailbox, control, _marshal, actor) =
                 spawn_processing(&context, "gated-ready-abort", None).await;
 
-            let (acknowledgement, mut waiter1) = Exact::handle();
+            let (acknowledgement, waiter1) = Exact::handle();
             let _ = mailbox.report(Update::Block(
                 Arc::new(TestBlock::new(1, 1)),
                 acknowledgement,
@@ -2461,7 +2465,7 @@ mod tests {
                 context.sleep(Duration::from_millis(10)).await;
             }
 
-            let (acknowledgement, mut waiter2) = Exact::handle();
+            let (acknowledgement, waiter2) = Exact::handle();
             let _ = mailbox.report(Update::Block(
                 Arc::new(TestBlock::new(2, 2)),
                 acknowledgement,
@@ -2471,20 +2475,24 @@ mod tests {
             actor.await.expect("processing actor should stop");
             assert_eq!(control.flushes.lock().len(), 1);
             assert!(
-                poll!(&mut waiter1).is_pending() && poll!(&mut waiter2).is_pending(),
-                "unflushed acknowledgements must remain pending",
+                waiter1.await.is_err(),
+                "the active unflushed acknowledgement must be canceled",
+            );
+            assert!(
+                waiter2.await.is_err(),
+                "the queued unflushed acknowledgement must be canceled",
             );
         });
     }
 
-    /// Stopping processing with a flush in flight must not cancel marshal's acknowledgement.
+    /// Stopping processing with a flush in flight must cancel marshal's acknowledgement.
     #[test]
-    fn shutdown_keeps_pending_flush_ack_pending() {
+    fn shutdown_cancels_pending_flush_ack() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
             let (mut mailbox, control, _marshal, actor) =
                 spawn_processing(&context, "gated-shutdown", None).await;
 
-            let (acknowledgement, mut waiter) = Exact::handle();
+            let (acknowledgement, waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(
                 Arc::new(TestBlock::new(1, 1)),
                 acknowledgement,
@@ -2496,8 +2504,8 @@ mod tests {
             drop(mailbox);
             actor.await.expect("processing actor should stop");
             assert!(
-                poll!(&mut waiter).is_pending(),
-                "shutdown must leave in-flight acknowledgements pending",
+                waiter.await.is_err(),
+                "shutdown must cancel in-flight acknowledgements",
             );
         });
     }

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -2,8 +2,7 @@ use crate::stateful::{
     Application,
     actor::{
         core::{
-            Deferred, mailbox::Message, processing::Processing,
-            verifications::Request as VerificationRequest,
+            mailbox::Message, processing::Processing, verifications::Request as VerificationRequest,
         },
         metrics::Metrics as StatefulMetrics,
         processor::{Applied, PendingSyncTargets, Processor, Pruning},
@@ -23,16 +22,20 @@ use commonware_cryptography::{Digestible, certificate::Scheme};
 use commonware_macros::{select, select_loop};
 use commonware_runtime::{ContextCell, Spawner, telemetry::metrics::GaugeExt};
 use commonware_storage::Context;
-use commonware_utils::channel::{fallible::OneshotExt, oneshot};
+use commonware_utils::{
+    Acknowledgement as _,
+    acknowledgement::Exact,
+    channel::{fallible::OneshotExt, oneshot},
+};
 use rand_core::Rng;
 use std::{collections::VecDeque, sync::Arc};
 use tracing::{Instrument as _, debug, error, info_span};
 
 /// Finalized work needed to transition from syncing to processing.
 enum FinalizedHandoff<B> {
-    Covered(B, Deferred),
-    Reflected(B, Deferred),
-    Apply(B, Deferred),
+    Covered(B, Exact),
+    Reflected(B, Exact),
+    Apply(B, Exact),
 }
 
 /// A finalized block retained with its marshal acknowledgement while state sync is active.
@@ -41,7 +44,7 @@ enum FinalizedHandoff<B> {
 /// is recorded or the block is durably handed off after state sync completes.
 pub(super) struct PendingFinalization<B> {
     block: B,
-    acknowledgement: Deferred,
+    acknowledgement: Exact,
 }
 
 /// Serves application requests while coordinating state sync and its handoff.
@@ -200,7 +203,7 @@ where
     async fn process_finalized(
         mut self,
         block: Arc<A::Block>,
-        acknowledgement: Deferred,
+        acknowledgement: Exact,
     ) -> (Self, Option<VecDeque<FinalizedHandoff<Arc<A::Block>>>>) {
         assert!(
             self.artifact.is_none(),
@@ -432,7 +435,7 @@ mod tests {
         let (acknowledgement, _waiter) = Exact::handle();
         PendingFinalization {
             block: Arc::new(block),
-            acknowledgement: acknowledgement.into(),
+            acknowledgement,
         }
     }
 
@@ -480,10 +483,11 @@ mod tests {
             let mut waiters = Vec::new();
             for (height, digest) in [(8, 10), (9, 11)] {
                 let (acknowledgement, mut waiter) = Exact::handle();
-                let mut process = Box::pin(self.syncing.process_finalized(
-                    Arc::new(TestBlock::new(height, digest)),
-                    acknowledgement.into(),
-                ));
+                let mut process =
+                    Box::pin(self.syncing.process_finalized(
+                        Arc::new(TestBlock::new(height, digest)),
+                        acknowledgement,
+                    ));
                 let std::task::Poll::Ready((syncing, handoff)) = poll!(process.as_mut()) else {
                     panic!("a partial acknowledgement window must not retarget");
                 };
@@ -497,7 +501,7 @@ mod tests {
             let (acknowledgement, mut newest_waiter) = Exact::handle();
             let process = context.child("full_window").spawn(move |_| {
                 self.syncing
-                    .process_finalized(Arc::new(TestBlock::new(10, 12)), acknowledgement.into())
+                    .process_finalized(Arc::new(TestBlock::new(10, 12)), acknowledgement)
             });
             let Some(syncer::mailbox::Message::UpdateTargets { update, response }) =
                 syncer_receiver.recv().await
@@ -739,15 +743,12 @@ mod tests {
                 harness.syncing.transition([
                     FinalizedHandoff::Reflected(
                         Arc::new(TestBlock::new(7, 9)),
-                        reflected_acknowledgement.into(),
+                        reflected_acknowledgement,
                     ),
-                    FinalizedHandoff::Apply(
-                        Arc::new(TestBlock::new(8, 10)),
-                        first_acknowledgement.into(),
-                    ),
+                    FinalizedHandoff::Apply(Arc::new(TestBlock::new(8, 10)), first_acknowledgement),
                     FinalizedHandoff::Apply(
                         Arc::new(TestBlock::new(9, 11)),
-                        second_acknowledgement.into(),
+                        second_acknowledgement,
                     ),
                 ])
             });
@@ -799,7 +800,7 @@ mod tests {
     }
 
     #[test]
-    fn aborted_handoff_flush_keeps_ack_pending_and_sync_incomplete() {
+    fn aborted_handoff_flush_cancels_ack_and_keeps_sync_incomplete() {
         deterministic::Runner::default().start(|context| async move {
             let mut harness = TestHarness::new(context.child("harness"), anchor(7, 9)).await;
             let databases = Shared::new(
@@ -813,18 +814,18 @@ mod tests {
                 .expect("harness must contain a sync artifact")
                 .databases = databases;
 
-            let (acknowledgement, mut waiter) = Exact::handle();
+            let (acknowledgement, waiter) = Exact::handle();
             harness
                 .syncing
                 .transition(Some(FinalizedHandoff::Apply(
                     Arc::new(TestBlock::new(8, 10)),
-                    acknowledgement.into(),
+                    acknowledgement,
                 )))
                 .await;
 
             assert!(
-                poll!(&mut waiter).is_pending(),
-                "an aborted handoff must leave marshal's acknowledgement pending",
+                waiter.await.is_err(),
+                "an aborted handoff must cancel marshal's acknowledgement",
             );
             let reopened =
                 StateSyncMetadata::<_, TestScheme, Sha256Digest>::init(&context, "syncing-test")
@@ -859,7 +860,7 @@ mod tests {
             let process = context.child("process_finalized").spawn(move |_| {
                 harness
                     .syncing
-                    .process_finalized(Arc::new(block), acknowledgement.into())
+                    .process_finalized(Arc::new(block), acknowledgement)
             });
             let Some(syncer::mailbox::Message::UpdateTargets { update, response }) =
                 syncer_receiver.recv().await
@@ -1171,7 +1172,7 @@ mod tests {
     }
 
     #[test]
-    fn target_observation_shutdown_keeps_floor_and_ack_pending() {
+    fn target_observation_shutdown_keeps_floor_and_cancels_ack() {
         deterministic::Runner::default().start(|mut context| async move {
             let fixture = scheme_mocks::fixture(&mut context, b"syncing-harness", 1);
             let initial = fixtures::finalization(&fixture, 7, Sha256::fill(9));
@@ -1202,7 +1203,7 @@ mod tests {
             let process = context.child("process_finalized").spawn(move |_| {
                 harness
                     .syncing
-                    .process_finalized(Arc::new(block), acknowledgement.into())
+                    .process_finalized(Arc::new(block), acknowledgement)
             });
             let Some(syncer::mailbox::Message::UpdateTargets { update, response }) =
                 syncer_receiver.recv().await
@@ -1230,8 +1231,8 @@ mod tests {
             drop(syncing);
             drop(pending_update);
             assert!(
-                poll!(&mut waiter).is_pending(),
-                "shutdown must leave the retained acknowledgement pending",
+                waiter.await.is_err(),
+                "shutdown must cancel the retained acknowledgement",
             );
             stop.await.expect("stop task should finish");
         });

--- a/glue/src/stateful/tests/fixtures.rs
+++ b/glue/src/stateful/tests/fixtures.rs
@@ -26,13 +26,17 @@ use commonware_storage::{
     translator::TwoCap,
 };
 use commonware_utils::{
-    NZU16, NZU64, NZUsize, acknowledgement::Acknowledgement as _, vec::NonEmptyVec,
+    NZU16, NZU64, NZUsize,
+    acknowledgement::{Acknowledgement as _, Exact},
+    sync::Mutex,
+    vec::NonEmptyVec,
 };
-use std::num::NonZeroUsize;
+use std::{num::NonZeroUsize, sync::Arc};
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct FixtureReporter {
     acknowledge: bool,
+    pending: Arc<Mutex<Vec<Exact>>>,
 }
 
 impl Reporter for FixtureReporter {
@@ -43,7 +47,7 @@ impl Reporter for FixtureReporter {
             if self.acknowledge {
                 ack.acknowledge();
             } else {
-                ack.abandon();
+                self.pending.lock().push(ack);
             }
         }
         Feedback::Ok
@@ -54,7 +58,7 @@ impl Reporter for FixtureReporter {
 enum Dispatch {
     Stopped,
     Acknowledge,
-    Freeze,
+    Hold,
 }
 
 struct Options<'a> {
@@ -275,7 +279,7 @@ pub(crate) async fn marshal_fixture_with_floor(
             block: Some(block),
             floor: Some(finalization),
             max_pending_acks,
-            dispatch: Dispatch::Freeze,
+            dispatch: Dispatch::Hold,
         },
     )
     .await
@@ -283,7 +287,7 @@ pub(crate) async fn marshal_fixture_with_floor(
 
 /// Initializes a started marshal actor over prunable finalized archives.
 ///
-/// When provided, `block` is pre-seeded. Dispatched blocks are abandoned unless
+/// When provided, `block` is pre-seeded. Dispatched blocks are held open unless
 /// `acknowledge` is set.
 pub(crate) async fn prunable_marshal_fixture(
     context: deterministic::Context,
@@ -302,7 +306,7 @@ pub(crate) async fn prunable_marshal_fixture(
         dispatch: if acknowledge {
             Dispatch::Acknowledge
         } else {
-            Dispatch::Freeze
+            Dispatch::Hold
         },
     };
     let page_cache = CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(8));
@@ -446,6 +450,7 @@ where
         handler::init(context.child("resolver_handler"), NZUsize!(8));
     let reporter = FixtureReporter {
         acknowledge: matches!(options.dispatch, Dispatch::Acknowledge),
+        pending: Arc::new(Mutex::new(Vec::new())),
     };
     let handle = actor.start_unbuffered(reporter, (resolver_receiver, IgnoreResolver));
     MarshalFixture {

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -9,7 +9,7 @@ use commonware_utils::{
 };
 use futures::{
     FutureExt as _,
-    future::{Either, select},
+    future::{Either, poll_fn, select},
     pin_mut,
     stream::{AbortHandle, Abortable, Aborted},
 };
@@ -49,6 +49,22 @@ where
         future: Abortable<Completion<T>>,
         abort_handle: AbortHandle,
     },
+}
+
+/// Aborts every owned handle when a group is no longer supervised.
+struct HandleGroup<T>(Vec<Handle<T>>)
+where
+    T: Send + 'static;
+
+impl<T> Drop for HandleGroup<T>
+where
+    T: Send + 'static,
+{
+    fn drop(&mut self) {
+        for handle in &self.0 {
+            handle.abort();
+        }
+    }
 }
 
 /// Normalizes receiver-backed and future-backed completions behind one abortable future.
@@ -168,6 +184,56 @@ where
         let (sender, receiver) = oneshot::channel();
         let _ = sender.send(result);
         Self::from_receiver(receiver)
+    }
+
+    /// Waits for the first handle to complete and aborts all handles before returning.
+    ///
+    /// Dropping the returned future also aborts every handle. Selection is biased toward handles
+    /// that appear earlier in the iterator.
+    ///
+    /// Runtime supervision already aborts a task's descendants when that task exits. This method
+    /// is intended for an owned group whose teardown boundary is the first handle completion,
+    /// independent of whether the caller exits immediately afterward.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # futures::executor::block_on(async {
+    /// use commonware_runtime::Handle;
+    ///
+    /// let handles = [
+    ///     Handle::ready(Ok(7)),
+    ///     Handle::from_future(futures::future::pending()),
+    /// ];
+    /// assert_eq!(Handle::select(handles).await.unwrap(), 7);
+    /// # });
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::Closed`] if `handles` is empty.
+    pub fn select(
+        handles: impl IntoIterator<Item = Self>,
+    ) -> impl Future<Output = Result<T, Error>> + Send + 'static {
+        // Construct the guard before returning so dropping the future without polling still aborts
+        // every handle.
+        let mut handles = HandleGroup(handles.into_iter().collect::<Vec<_>>());
+
+        async move {
+            if handles.0.is_empty() {
+                return Err(Error::Closed);
+            }
+
+            poll_fn(move |cx| {
+                for handle in &mut handles.0 {
+                    if let Poll::Ready(result) = Pin::new(handle).poll(cx) {
+                        return Poll::Ready(result);
+                    }
+                }
+                Poll::Pending
+            })
+            .await
+        }
     }
 
     /// Returns a handle that resolves to [`Error::Closed`] without spawning work.
@@ -470,6 +536,58 @@ mod tests {
                 Some(0),
                 "expected tasks_running gauge to return to 0 after abort: {metrics}",
             );
+        });
+    }
+
+    #[test]
+    fn select_aborts_remaining_tasks() {
+        const LABEL: &str = "tasks_running_select_remaining";
+
+        deterministic::Runner::default().start(|context| async move {
+            let completed = context.child("select_completed").spawn(|_| async {});
+            let pending = context.child(LABEL).spawn(|_| future::pending());
+
+            Handle::select([completed, pending])
+                .await
+                .expect("task failed");
+
+            let metrics = context.encode();
+            assert_eq!(
+                running_tasks_for_label(&metrics, LABEL),
+                Some(0),
+                "select should abort remaining tasks: {metrics}",
+            );
+        });
+    }
+
+    #[test]
+    fn select_empty_returns_closed() {
+        deterministic::Runner::default().start(|_| async move {
+            assert!(matches!(
+                Handle::<()>::select([]).await,
+                Err(Error::Closed)
+            ));
+        });
+    }
+
+    #[test]
+    fn dropping_select_aborts_tasks_before_polling() {
+        const FIRST_LABEL: &str = "tasks_running_select_drop_first";
+        const SECOND_LABEL: &str = "tasks_running_select_drop_second";
+
+        deterministic::Runner::default().start(|context| async move {
+            let first = context
+                .child(FIRST_LABEL)
+                .spawn(|_| future::pending::<()>());
+            let second = context
+                .child(SECOND_LABEL)
+                .spawn(|_| future::pending::<()>());
+
+            drop(Handle::select([first, second]));
+
+            let metrics = context.encode();
+            assert_eq!(running_tasks_for_label(&metrics, FIRST_LABEL), Some(0));
+            assert_eq!(running_tasks_for_label(&metrics, SECOND_LABEL), Some(0));
         });
     }
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -563,10 +563,7 @@ mod tests {
     #[test]
     fn select_empty_returns_closed() {
         deterministic::Runner::default().start(|_| async move {
-            assert!(matches!(
-                Handle::<()>::select([]).await,
-                Err(Error::Closed)
-            ));
+            assert!(matches!(Handle::<()>::select([]).await, Err(Error::Closed)));
         });
     }
 

--- a/utils/src/acknowledgement.rs
+++ b/utils/src/acknowledgement.rs
@@ -37,7 +37,7 @@ pub trait Acknowledgement: Clone + Send + Sync + Debug + 'static {
 
 /// [Acknowledgement] that returns after all instances are acknowledged.
 ///
-/// Dropping an acknowledgement cancels the waiter unless [`Exact::abandon`] is used.
+/// Dropping an acknowledgement cancels the waiter.
 pub struct Exact {
     state: Arc<ExactState>,
     acknowledged: bool,
@@ -48,15 +48,6 @@ impl Debug for Exact {
         f.debug_struct("Exact")
             .field("acknowledged", &self.acknowledged)
             .finish()
-    }
-}
-
-impl Exact {
-    /// Consume this handle without resolving or canceling its waiter.
-    ///
-    /// The waiter remains pending so incomplete work can be redelivered after restart.
-    pub fn abandon(mut self) {
-        self.acknowledged = true;
     }
 }
 
@@ -198,13 +189,6 @@ mod tests {
         let (ack, waiter) = Exact::handle();
         drop(ack);
         assert!(waiter.now_or_never().unwrap().is_err());
-    }
-
-    #[test]
-    fn abandon_neither_acknowledges_nor_cancels() {
-        let (ack, waiter) = Exact::handle();
-        ack.abandon();
-        assert!(waiter.now_or_never().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Applications commonly handle `Update::Block` in an async task. During shutdown, that task can be canceled while an acknowledgement is still owned by the task future or buffered in a channel. Dropping the task drops the `Exact`, which cancels the marshal acknowledgement waiter. Since [`b009b24`](https://github.com/commonwarexyz/monorepo/pull/3847/commits/b009b24a40564226e09f45f60f60b4000941d3ae) treated that cancellation as fatal, an otherwise normal application-before-marshal shutdown could panic marshal instead of terminating cleanly.

This restores the documented `Update::Block` contract: a dropped acknowledgement stops marshal cleanly without advancing its processed floor, allowing the block to be redelivered after restart. Genuine storage failures remain fatal.

A clean marshal exit must also stop the actor group that owns it. The reshare validator previously used `try_join_all`, which returned early for an error but kept waiting after an actor returned `Ok(())`. Once acknowledgement cancellation became a normal marshal exit, that could leave the remaining validator actors running without marshal. `Handle::select` now defines the correct teardown boundary for these owned groups: the first handle completion, successful or erroneous, returns from supervision and aborts every remaining handle. Dropping the supervising future does the same, and an empty group returns `Error::Closed`. Reshare, DKG bootstrap, the DKG reshare harness, and flood now use this shared behavior.

Related history: the panic change landed in [#3847](https://github.com/commonwarexyz/monorepo/pull/3847), which was merged into the broader [#3828](https://github.com/commonwarexyz/monorepo/pull/3828) state-sync change. The later Stateful [`start_sync` integration in #4384](https://github.com/commonwarexyz/monorepo/pull/4384) retained acknowledgements across asynchronous durability work, making this shutdown ordering easier to hit, and introduced `Exact::abandon` to suppress cancellation.

The `abandon` workaround is not a safe shutdown contract: it leaves the waiter unresolved and requires every asynchronous owner to remember special handling. This removes `Exact::abandon` and the Stateful `Deferred` wrapper. Stateful now retains the raw acknowledgement until durable work completes, while normal task teardown drops it naturally.

Regression coverage exercises a normal post-genesis acknowledgement held by an application task that is canceled before marshal, successful actor completion tearing down pending siblings, supervisor cancellation before its first poll, and empty handle selection.
