### PR TITLE
[storage/qmdb] Document sparse staged reads

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1795,9 +1795,11 @@ where
     /// Batch read multiple keys (mutations -> ancestor diffs -> committed DB).
     ///
     /// Returns results in the same order as the input keys, with `None` for absent or deleted
-    /// keys. Resolved locations are not retained: a batch that writes keys it read pays an
-    /// index re-probe and journal re-read at merkleize. Use [`stage`](Self::stage) to fuse
-    /// reads into merkleize instead.
+    /// keys. Resolved locations are not retained, so writing a key read only through `get_many`
+    /// requires an index re-probe and journal re-read during merkleize. Use
+    /// [`stage`](Self::stage) for keys that may be written. When the writable subset is known and
+    /// much smaller than the full read set, call `get_many` for the read-only keys first, then
+    /// [`stage`](Self::stage) only the writable keys.
     pub async fn get_many<E, C, I, const N: usize>(
         &self,
         keys: &[&U::Key],

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -371,7 +371,11 @@ where
 
     /// Batch read multiple keys.
     ///
-    /// Returns results in the same order as the input keys.
+    /// Returns results in the same order as the input keys. Resolved locations are not retained,
+    /// so writing a key read only through `get_many` requires an index re-probe and journal re-read
+    /// during merkleize. Use [`stage`](Self::stage) for keys that may be written. When the writable
+    /// subset is known and much smaller than the full read set, call `get_many` for the read-only
+    /// keys first, then [`stage`](Self::stage) only the writable keys.
     pub async fn get_many<E, C, I>(
         &self,
         keys: &[&U::Key],


### PR DESCRIPTION
## Summary

- clarify that `get_many` does not retain resolved locations for later writes
- document composing `get_many` for read-only keys with `stage` for a much smaller writable subset
- keep the guidance consistent across the `any` and `current` batch APIs

## Motivation

The previous wording broadly directed callers from `get_many` to `stage`. For read-heavy workloads with a known sparse write set, the existing APIs already compose efficiently: `get_many` borrows the batch, then `stage` consumes it and retains metadata only for writable keys.

## Validation

- `just check-fmt`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p commonware-storage --no-deps`