### PR TITLE
Make `Strategy::spawn` size-aware (adaptive inline vs offload)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1588,6 +1588,7 @@ dependencies = [
  "clap",
  "commonware-cryptography",
  "commonware-macros",
+ "commonware-utils",
  "futures",
  "reqwest",
  "serde",

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -19,7 +19,7 @@ use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
 /// instrumenting the awaited future so the offloaded work stays attributed to the caller's trace.
-async fn offload<P, F, T>(span: Span, strategy: &P, job: F) -> T
+async fn offload<P, F, T>(len: usize, span: Span, strategy: &P, job: F) -> T
 where
     P: Strategy,
     F: FnOnce(P) -> T + Send + 'static,
@@ -27,7 +27,7 @@ where
 {
     let worker_span = span.clone();
     strategy
-        .spawn(move |strategy| worker_span.in_scope(|| job(strategy)))
+        .spawn(len, move |strategy| worker_span.in_scope(|| job(strategy)))
         .instrument(span)
         .await
 }
@@ -320,7 +320,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 view = self.round.view().traced()
             );
             let scheme = Arc::clone(&self.scheme);
-            let notarization = offload(span, strategy, move |strategy| {
+            let notarization = offload(notarizes.len(), span, strategy, move |strategy| {
                 Notarization::from_owned_notarizes(scheme.as_ref(), notarizes, &strategy)
                     .expect("verified notarize quorum must assemble")
             })
@@ -335,7 +335,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 view = self.round.view().traced()
             );
             let scheme = Arc::clone(&self.scheme);
-            let nullification = offload(span, strategy, move |strategy| {
+            let nullification = offload(nullifies.len(), span, strategy, move |strategy| {
                 Nullification::from_owned_nullifies(scheme.as_ref(), nullifies, &strategy)
                     .expect("verified nullify quorum must assemble")
             })
@@ -350,7 +350,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 view = self.round.view().traced()
             );
             let scheme = Arc::clone(&self.scheme);
-            let finalization = offload(span, strategy, move |strategy| {
+            let finalization = offload(finalizes.len(), span, strategy, move |strategy| {
                 Finalization::from_owned_finalizes(scheme.as_ref(), finalizes, &strategy)
                     .expect("verified finalize quorum must assemble")
             })
@@ -519,7 +519,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 );
                 let scheme = Arc::clone(&self.scheme);
                 let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
+                offload(notarizes.len(), span, strategy, move |strategy| {
                     let (proposals, attestations): (Vec<_>, Vec<_>) = notarizes
                         .into_iter()
                         .map(|n| (n.proposal, n.attestation))
@@ -577,7 +577,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 let round = nullifies[0].round;
                 let scheme = Arc::clone(&self.scheme);
                 let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
+                offload(nullifies.len(), span, strategy, move |strategy| {
                     let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
                         &mut rng,
                         Subject::Nullify { round },
@@ -633,7 +633,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 );
                 let scheme = Arc::clone(&self.scheme);
                 let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
+                offload(finalizes.len(), span, strategy, move |strategy| {
                     let (proposals, attestations): (Vec<_>, Vec<_>) = finalizes
                         .into_iter()
                         .map(|n| (n.proposal, n.attestation))

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -19,10 +19,6 @@ use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
 /// instrumenting the returned future so the offloaded work stays attributed to the caller's trace.
-///
-/// `#[track_caller]` forwards each call site's location into [Strategy::spawn], so the adaptive
-/// policy keys its decisions per call site instead of sharing one entry across all of them.
-#[track_caller]
 fn offload<P, F, T>(len: usize, span: Span, strategy: &P, job: F) -> impl Future<Output = T> + Send
 where
     P: Strategy,

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -19,7 +19,7 @@ use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
 /// instrumenting the awaited future so the offloaded work stays attributed to the caller's trace.
-async fn offload<P, F, T>(span: Span, strategy: &P, job: F) -> T
+async fn offload<P, F, T>(len: usize, span: Span, strategy: &P, job: F) -> T
 where
     P: Strategy,
     F: FnOnce(P) -> T + Send + 'static,
@@ -27,7 +27,7 @@ where
 {
     let worker_span = span.clone();
     strategy
-        .spawn(move |strategy| worker_span.in_scope(|| job(strategy)))
+        .spawn(len, move |strategy| worker_span.in_scope(|| job(strategy)))
         .instrument(span)
         .await
 }
@@ -320,7 +320,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 view = self.round.view().traced()
             );
             let scheme = Arc::clone(&self.scheme);
-            let notarization = offload(span, strategy, move |strategy| {
+            let notarization = offload(notarizes.len(), span, strategy, move |strategy| {
                 Notarization::from_owned_notarizes(
                     scheme.as_ref(),
                     non_empty![@notarizes],
@@ -339,7 +339,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 view = self.round.view().traced()
             );
             let scheme = Arc::clone(&self.scheme);
-            let nullification = offload(span, strategy, move |strategy| {
+            let nullification = offload(nullifies.len(), span, strategy, move |strategy| {
                 Nullification::from_owned_nullifies(
                     scheme.as_ref(),
                     non_empty![@nullifies],
@@ -358,7 +358,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 view = self.round.view().traced()
             );
             let scheme = Arc::clone(&self.scheme);
-            let finalization = offload(span, strategy, move |strategy| {
+            let finalization = offload(finalizes.len(), span, strategy, move |strategy| {
                 Finalization::from_owned_finalizes(
                     scheme.as_ref(),
                     non_empty![@finalizes],
@@ -531,7 +531,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 );
                 let scheme = Arc::clone(&self.scheme);
                 let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
+                offload(notarizes.len(), span, strategy, move |strategy| {
                     let (proposals, attestations): (Vec<_>, Vec<_>) = notarizes
                         .into_iter()
                         .map(|n| (n.proposal, n.attestation))
@@ -589,7 +589,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 let round = nullifies[0].round;
                 let scheme = Arc::clone(&self.scheme);
                 let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
+                offload(nullifies.len(), span, strategy, move |strategy| {
                     let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
                         &mut rng,
                         Subject::Nullify { round },
@@ -645,7 +645,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 );
                 let scheme = Arc::clone(&self.scheme);
                 let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
+                offload(finalizes.len(), span, strategy, move |strategy| {
                     let (proposals, attestations): (Vec<_>, Vec<_>) = finalizes
                         .into_iter()
                         .map(|n| (n.proposal, n.attestation))

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -18,8 +18,12 @@ use std::{future::Future, mem, sync::Arc};
 use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
-/// instrumenting the awaited future so the offloaded work stays attributed to the caller's trace.
-async fn offload<P, F, T>(len: usize, span: Span, strategy: &P, job: F) -> T
+/// instrumenting the returned future so the offloaded work stays attributed to the caller's trace.
+///
+/// `#[track_caller]` forwards each call site's location into [Strategy::spawn], so the adaptive
+/// policy keys its decisions per call site instead of sharing one entry across all of them.
+#[track_caller]
+fn offload<P, F, T>(len: usize, span: Span, strategy: &P, job: F) -> impl Future<Output = T> + Send
 where
     P: Strategy,
     F: FnOnce(P) -> T + Send + 'static,
@@ -29,7 +33,6 @@ where
     strategy
         .spawn(len, move |strategy| worker_span.in_scope(|| job(strategy)))
         .instrument(span)
-        .await
 }
 
 /// Certification progress for one kind of vote.

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -23,6 +23,7 @@ aws = [
 	"clap",
 	"commonware-cryptography",
 	"commonware-macros/std",
+	"commonware-utils",
 	"futures",
 	"reqwest",
 	"serde_yaml",
@@ -42,6 +43,7 @@ chrono = { workspace = true, optional = true }
 clap = { workspace = true, optional = true }
 commonware-cryptography = { workspace = true, optional = true }
 commonware-macros.workspace = true
+commonware-utils = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 serde = { workspace = true, features = ["derive"] }

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -12,6 +12,7 @@ use crate::aws::{
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_macros::boxed;
+use commonware_utils::iter::zip_eq;
 use futures::{
     future::try_join_all,
     stream::{self, StreamExt, TryStreamExt},
@@ -848,9 +849,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
                             count = chunk.len(),
                             "instances running in region"
                         );
-                        let deployments: Vec<Deployment> = chunk
-                            .into_iter()
-                            .zip(ips)
+                        let deployments: Vec<Deployment> = zip_eq(chunk, ips)
                             .map(|((instance_id, instance_config), ip)| Deployment {
                                 instance: instance_config,
                                 id: instance_id,

--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -38,6 +38,7 @@ tracing.workspace = true
 [dev-dependencies]
 commonware-conformance.workspace = true
 commonware-math.workspace = true
+commonware-parallel = { workspace = true, features = ["test-utils"] }
 commonware-runtime = { workspace = true, features = ["test-utils"] }
 tracing-subscriber.workspace = true
 

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -259,7 +259,8 @@ where
                 continue;
             } => {
                 let config = self.codec_config.clone();
-                let handle = self.strategy.spawn(move |_| {
+                let decode_len = bytes.len();
+                let handle = self.strategy.spawn(decode_len, move |_| {
                     let result = V::decode_cfg(bytes.as_ref(), &config);
                     (peer, result)
                 });
@@ -428,7 +429,11 @@ mod tests {
             Manual::new(self.clone(), self.parallelism)
         }
 
-        fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
+        fn spawn<F, T>(
+            &self,
+            _len: usize,
+            f: F,
+        ) -> impl core::future::Future<Output = T> + Send + 'static
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -259,8 +259,7 @@ where
                 continue;
             } => {
                 let config = self.codec_config.clone();
-                let decode_len = bytes.len();
-                let handle = self.strategy.spawn(decode_len, move |_| {
+                let handle = self.strategy.spawn(bytes.len(), move |_| {
                     let result = V::decode_cfg(bytes.as_ref(), &config);
                     (peer, result)
                 });

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -299,12 +299,12 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
     };
     use commonware_macros::test_traced;
-    use commonware_parallel::{Manual, Sequential, Strategy};
+    use commonware_parallel::{Sequential, mocks};
     use commonware_runtime::{Clock as _, IoBuf, Quota, Runner, Supervisor as _, deterministic};
     use commonware_utils::{NZUsize, channel::mpsc, ordered::Set, probability};
     use std::{
         io,
-        num::{NonZeroU32, NonZeroUsize},
+        num::NonZeroU32,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -398,128 +398,6 @@ mod tests {
 
         fn block(&mut self, _peer: Self::PublicKey) -> Feedback {
             Feedback::Ok
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    struct TestStrategy {
-        parallelism: NonZeroUsize,
-        pending: bool,
-    }
-
-    impl TestStrategy {
-        const fn complete(parallelism: NonZeroUsize) -> Self {
-            Self {
-                parallelism,
-                pending: false,
-            }
-        }
-
-        const fn pending(parallelism: NonZeroUsize) -> Self {
-            Self {
-                parallelism,
-                pending: true,
-            }
-        }
-    }
-
-    impl Strategy for TestStrategy {
-        fn manual(&self) -> Manual<Self> {
-            Manual::new(self.clone(), self.parallelism)
-        }
-
-        fn spawn<F, T>(
-            &self,
-            _len: usize,
-            f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
-        where
-            F: FnOnce(Self) -> T + Send + 'static,
-            T: Send + 'static,
-        {
-            let pending = self.pending;
-            let s = self.clone();
-            async move {
-                if pending {
-                    futures::future::pending::<()>().await;
-                }
-                f(s)
-            }
-        }
-
-        fn fold_init<I, INIT, T, R, ID, F, RD>(
-            &self,
-            iter: I,
-            init: INIT,
-            identity: ID,
-            fold_op: F,
-            reduce_op: RD,
-        ) -> R
-        where
-            I: IntoIterator<IntoIter: Send, Item: Send> + Send,
-            INIT: Fn() -> T + Send + Sync,
-            T: Send,
-            R: Send,
-            ID: Fn() -> R + Send + Sync,
-            F: Fn(R, &mut T, I::Item) -> R + Send + Sync,
-            RD: Fn(R, R) -> R + Send + Sync,
-        {
-            Sequential.fold_init(iter, init, identity, fold_op, reduce_op)
-        }
-
-        fn try_fold<I, R, E, ID, F, RD>(
-            &self,
-            iter: I,
-            identity: ID,
-            fold_op: F,
-            reduce_op: RD,
-        ) -> Result<R, E>
-        where
-            I: IntoIterator<IntoIter: Send, Item: Send> + Send,
-            R: Send,
-            E: Send,
-            ID: Fn() -> R + Send + Sync,
-            F: Fn(R, I::Item) -> Result<R, E> + Send + Sync,
-            RD: Fn(R, R) -> R + Send + Sync,
-        {
-            Sequential.try_fold(iter, identity, fold_op, reduce_op)
-        }
-
-        fn run<R, SEQ, PAR>(&self, len: usize, serial: SEQ, parallel: PAR) -> R
-        where
-            R: Send,
-            SEQ: FnOnce() -> R + Send,
-            PAR: FnOnce() -> R + Send,
-        {
-            Sequential.run(len, serial, parallel)
-        }
-
-        fn try_run<R, E, SEQ, PAR>(&self, len: usize, serial: SEQ, parallel: PAR) -> Result<R, E>
-        where
-            R: Send,
-            E: Send,
-            SEQ: FnOnce() -> Result<R, E> + Send,
-            PAR: FnOnce() -> Result<R, E> + Send,
-        {
-            Sequential.try_run(len, serial, parallel)
-        }
-
-        fn join<A, B, RA, RB>(&self, a: A, b: B) -> (RA, RB)
-        where
-            A: FnOnce() -> RA + Send,
-            B: FnOnce() -> RB + Send,
-            RA: Send,
-            RB: Send,
-        {
-            Sequential.join(a, b)
-        }
-
-        fn sort_by<T, C>(&self, items: &mut [T], compare: C)
-        where
-            T: Send,
-            C: Fn(&T, &T) -> std::cmp::Ordering + Send + Sync,
-        {
-            Sequential.sort_by(items, compare);
         }
     }
 
@@ -682,7 +560,7 @@ mod tests {
                 (),
                 control2.clone(),
                 NZUsize!(50),
-                TestStrategy::complete(NZUsize!(4)),
+                mocks::inline(NZUsize!(4)),
             );
             let _handle = bg.start();
 
@@ -816,7 +694,7 @@ mod tests {
                 (),
                 NoopBlocker,
                 NZUsize!(16),
-                TestStrategy::pending(NZUsize!(2)),
+                mocks::pending(NZUsize!(2)),
             );
             let handle = bg.start();
 

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -28,3 +28,4 @@ rayon.workspace = true
 [features]
 default = [ "std" ]
 std = [ "commonware-macros/std", "dep:dashmap", "dep:futures", "dep:rayon" ]
+test-utils = [ "std" ]

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1610,6 +1610,21 @@ mod test {
         assert_eq!(policy_len(&strategy), 2);
     }
 
+    /// `manual()` forces the hand-off on a multi-worker pool: the job runs on the pool no matter
+    /// what the adaptive policy would have decided for this call site.
+    #[test]
+    fn manual_spawn_always_hands_off() {
+        let strategy = parallel_strategy();
+        let manual = strategy.manual();
+
+        for _ in 0..10 {
+            let on_pool = futures::executor::block_on(
+                manual.spawn(1, |_| rayon::current_thread_index().is_some()),
+            );
+            assert!(on_pool, "manual spawn ran on the calling task");
+        }
+    }
+
     #[test]
     fn manual_strategy_does_not_use_adaptive_policy() {
         let strategy = parallel_strategy();
@@ -1679,6 +1694,8 @@ mod test {
         }));
 
         assert_eq!(result, 7);
+
+        // Spawn trains only the spawn-side policy: no run entries are created.
         assert_eq!(policy_len(&strategy), 0);
     }
 

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1115,18 +1115,22 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                             .unwrap_or_else(|_| panic!("strategy job dropped before completion"));
                     }
                 };
-                if let Some((Some(policy), caller, len, threads, setup)) = recorder {
-                    policy.record_spawn(
-                        caller,
-                        len,
-                        threads,
-                        policy::SpawnExecution::Offload,
-                        setup.saturating_add(poll_start.elapsed()),
-                        job_wall,
-                    );
-                }
                 match result {
-                    Ok(value) => value,
+                    Ok(value) => {
+                        // Record successful runs only, matching the inline arm: a panicked
+                        // job's wall time says nothing about the job size.
+                        if let Some((Some(policy), caller, len, threads, setup)) = recorder {
+                            policy.record_spawn(
+                                caller,
+                                len,
+                                threads,
+                                policy::SpawnExecution::Offload,
+                                setup.saturating_add(poll_start.elapsed()),
+                                job_wall,
+                            );
+                        }
+                        value
+                    }
                     Err(payload) => panic::resume_unwind(payload),
                 }
             })
@@ -1343,6 +1347,53 @@ mod test {
 
     fn parallel_strategy() -> Rayon {
         Rayon::new(NonZeroUsize::new(4).unwrap()).unwrap()
+    }
+
+    /// Call `spawn` with this helper so the policy entry is keyed by the helper's call
+    /// site (both `track_caller` locations resolve to the same line).
+    #[track_caller]
+    fn spawn_flagged(
+        strategy: &Rayon,
+        panics: bool,
+    ) -> (
+        &'static std::panic::Location<'static>,
+        impl core::future::Future<Output = usize> + Send + 'static,
+    ) {
+        (
+            std::panic::Location::caller(),
+            strategy.spawn(64, move |_| {
+                if panics {
+                    panic!("job panic");
+                }
+                7
+            }),
+        )
+    }
+
+    fn spawn_recorded(strategy: &Rayon, loc: &'static std::panic::Location<'static>) -> bool {
+        let parallelism = strategy.manual().parallelism();
+        strategy
+            .policy
+            .as_ref()
+            .is_some_and(|policy| policy.spawn_recorded(loc, 64, parallelism))
+    }
+
+    /// A panicking offloaded job must not update the spawn policy: its wall time says
+    /// nothing about the job size and would train the policy toward inlining.
+    #[test]
+    fn spawn_panic_records_nothing() {
+        let strategy = parallel_strategy();
+
+        let (loc, job) = spawn_flagged(&strategy, true);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            futures::executor::block_on(job)
+        }));
+        assert!(result.is_err());
+        assert!(!spawn_recorded(&strategy, loc));
+
+        let (loc, job) = spawn_flagged(&strategy, false);
+        assert_eq!(futures::executor::block_on(job), 7);
+        assert!(spawn_recorded(&strategy, loc));
     }
 
     fn policy_len(strategy: &Rayon) -> usize {

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -619,6 +619,7 @@ commonware_macros::stability_scope!(BETA {
             }
         }
 
+        #[track_caller]
         fn spawn<F, T>(
             &self,
             len: usize,

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -85,6 +85,7 @@ commonware_macros::stability_scope!(BETA {
             use std::{
                 panic::{self, AssertUnwindSafe, Location},
                 sync::Arc,
+                time::{Duration, Instant},
             };
 
             mod policy;
@@ -130,16 +131,26 @@ commonware_macros::stability_scope!(BETA {
         where
             Self: Sized;
 
-        /// Submit one CPU-bound job to this strategy.
+        /// Submit one CPU-bound job to this strategy, running it inline on the calling task or
+        /// offloading it to the pool based on the measured cost of each path.
         ///
-        /// The returned future resolves when the submitted job completes, but blocking on external
+        /// `len` is a size hint used only to group similar calls. It has no ordering or
+        /// correctness meaning. Jobs too small to amortize the pool hand-off run inline. To force
+        /// an unconditional hand-off, submit through [`manual`](Self::manual).
+        ///
+        /// The returned future resolves when the job completes. Blocking on external
         /// synchronization or I/O inside the job can occupy execution capacity until it returns.
         /// When the polling thread itself belongs to the strategy's execution resources (e.g. a
         /// runtime whose executor thread is registered as a pool worker), the job (and other
         /// pending work) may be executed inline on that thread rather than waited on.
         ///
         /// If the job panics, the panic is propagated to the caller; it never aborts the process.
-        fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
+        #[track_caller]
+        fn spawn<F, T>(
+            &self,
+            len: usize,
+            f: F,
+        ) -> impl core::future::Future<Output = T> + Send + 'static
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static;
@@ -614,13 +625,17 @@ commonware_macros::stability_scope!(BETA {
             }
         }
 
-        fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
+        fn spawn<F, T>(
+            &self,
+            len: usize,
+            f: F,
+        ) -> impl core::future::Future<Output = T> + Send + 'static
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
         {
             let s = self.clone();
-            self.strategy.spawn(|_| f(s))
+            self.strategy.spawn(len, |_| f(s))
         }
 
         #[track_caller]
@@ -797,7 +812,11 @@ commonware_macros::stability_scope!(BETA {
             Manual::new(Self, NonZeroUsize::new(1).unwrap())
         }
 
-        fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
+        fn spawn<F, T>(
+            &self,
+            _len: usize,
+            f: F,
+        ) -> impl core::future::Future<Output = T> + Send + 'static
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
@@ -1016,45 +1035,99 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             }
         }
 
-        fn spawn<F, T>(&self, f: F) -> impl core::future::Future<Output = T> + Send + 'static
+        #[track_caller]
+        fn spawn<F, T>(
+            &self,
+            len: usize,
+            f: F,
+        ) -> impl core::future::Future<Output = T> + Send + 'static
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
         {
-            if self.thread_pool.current_num_threads() <= 1 {
-                return Either::Left(future::ready(f(self.clone())));
+            let threads = self.thread_pool.current_num_threads();
+            let caller = Location::caller();
+
+            // One worker cannot overlap (always inline); a manual strategy has no policy (keep
+            // spawn's unconditional offload). Otherwise let the policy decide.
+            let (offload_it, measure) = if threads <= 1 {
+                (false, false)
+            } else {
+                self.policy.as_ref().map_or((true, false), |policy| {
+                    match policy.choose_spawn(caller, len, threads) {
+                        (policy::SpawnExecution::Inline, measure) => (false, measure),
+                        (policy::SpawnExecution::Offload, measure) => (true, measure),
+                    }
+                })
+            };
+
+            if !offload_it {
+                // Inline: run on the calling task and hand back a ready future.
+                let start = measure.then(Instant::now);
+                let result = f(self.clone());
+                if let (Some(start), Some(policy)) = (start, self.policy.as_ref()) {
+                    policy.record_spawn(
+                        caller,
+                        len,
+                        threads,
+                        policy::SpawnExecution::Inline,
+                        start.elapsed(),
+                        None,
+                    );
+                }
+                return Either::Left(future::ready(result));
             }
 
+            // Offload: hand the job to the pool. The worker times the job's own wall so we can
+            // estimate the inline cost; the returned future times the residual wait once joined.
+            let setup_start = measure.then(Instant::now);
             let (tx, mut rx) = oneshot::channel();
             let s = self.clone();
             let pool = self.thread_pool.clone();
             self.thread_pool.spawn(move || {
-                // Catch the panic so a panicking job propagates to the awaiting task rather than
-                // aborting the process (rayon aborts on an uncaught panic in a spawned job).
+                let job_start = measure.then(Instant::now);
                 let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
-                let _ = tx.send(result);
+                let job_wall = job_start.map(|start| start.elapsed());
+                let _ = tx.send((result, job_wall));
+            });
+            let recorder = measure.then(|| {
+                (
+                    self.policy.clone(),
+                    caller,
+                    len,
+                    threads,
+                    setup_start.map_or(Duration::ZERO, |start| start.elapsed()),
+                )
             });
             Either::Right(async move {
-                // When the polling thread is itself a member of the pool, waiting on the channel
-                // could park the only worker able to run the job. Execute pending pool work inline
-                // until the job completes or another worker takes over. `yield_now` returns `None`
-                // when this thread is not a pool member, so external callers fall through to the
-                // channel immediately.
-                loop {
-                    if let Ok(Some(result)) = rx.try_recv() {
-                        return match result {
-                            Ok(value) => value,
-                            Err(payload) => panic::resume_unwind(payload),
-                        };
+                // Time from the caller's first poll (when it joins) to the result: the part of the
+                // job not hidden behind the caller's interleaved work.
+                let poll_start = Instant::now();
+                let (result, job_wall) = loop {
+                    if let Ok(Some(payload)) = rx.try_recv() {
+                        break payload;
                     }
+
+                    // If the polling thread is a pool member, run pending pool work inline rather
+                    // than parking the only worker able to finish the job.
                     if !matches!(pool.yield_now(), Some(Yield::Executed)) {
-                        break;
+                        break rx.await
+                            .unwrap_or_else(|_| panic!("strategy job dropped before completion"));
                     }
+                };
+                if let Some((Some(policy), caller, len, threads, setup)) = recorder {
+                    policy.record_spawn(
+                        caller,
+                        len,
+                        threads,
+                        policy::SpawnExecution::Offload,
+                        setup.saturating_add(poll_start.elapsed()),
+                        job_wall,
+                    );
                 }
-                match rx.await {
-                    Ok(Ok(value)) => value,
-                    Ok(Err(payload)) => panic::resume_unwind(payload),
-                    Err(_) => panic!("strategy job dropped before completion"),
+                match result {
+                    Ok(value) => value,
+                    Err(payload) => panic::resume_unwind(payload),
                 }
             })
         }
@@ -1325,7 +1398,7 @@ mod test {
         let strategy = Rayon::with_pool(Arc::new(pool));
 
         let result = strategy
-            .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+            .spawn(2, |strategy| strategy.map_collect_vec(0..2, |i| i + 1))
             .now_or_never()
             .expect("spawn should complete on first poll via the yield loop");
         assert_eq!(result, vec![1, 2]);
@@ -1489,7 +1562,7 @@ mod test {
 
     #[test]
     fn sequential_spawn_runs_job() {
-        let result = futures::executor::block_on(Sequential.spawn(|_| 7));
+        let result = futures::executor::block_on(Sequential.spawn(1, |_| 7));
 
         assert_eq!(result, 7);
     }
@@ -1498,7 +1571,7 @@ mod test {
     fn rayon_spawn_runs_job_on_pool() {
         let strategy = parallel_strategy();
 
-        let result = futures::executor::block_on(strategy.spawn(|_| {
+        let result = futures::executor::block_on(strategy.spawn(1, |_| {
             assert!(rayon::current_thread_index().is_some());
             7
         }));
@@ -1519,7 +1592,7 @@ mod test {
 
         assert_eq!(strategy.manual().parallelism(), 4);
 
-        let result = strategy.spawn(|_| 7).now_or_never();
+        let result = strategy.spawn(1, |_| 7).now_or_never();
 
         assert_eq!(result, Some(7));
         assert_eq!(policy_len(&strategy), 0);
@@ -1531,13 +1604,13 @@ mod test {
         // A panic on a pool worker must surface at the await point, not abort the process.
         let strategy = parallel_strategy();
 
-        let _: () = futures::executor::block_on(strategy.spawn(|_| panic!("boom")));
+        let _: () = futures::executor::block_on(strategy.spawn(1, |_| panic!("boom")));
     }
 
     #[test]
     #[should_panic(expected = "boom")]
     fn sequential_spawn_propagates_job_panic() {
-        let _: () = futures::executor::block_on(Sequential.spawn(|_| panic!("boom")));
+        let _: () = futures::executor::block_on(Sequential.spawn(1, |_| panic!("boom")));
     }
 
     proptest! {

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -68,11 +68,11 @@
 
 commonware_macros::stability_scope!(BETA {
     use cfg_if::cfg_if;
-    use core::{cmp::Ordering, fmt, num::NonZeroUsize};
+    use core::{cmp::Ordering, fmt};
 
     cfg_if! {
         if #[cfg(any(feature = "std", test))] {
-            use core::convert::Infallible;
+            use core::{convert::Infallible, num::NonZeroUsize};
             use futures::{
                 channel::oneshot,
                 future::{self, Either},
@@ -85,7 +85,7 @@ commonware_macros::stability_scope!(BETA {
             use std::{
                 panic::{self, AssertUnwindSafe, Location},
                 sync::Arc,
-                time::{Duration, Instant},
+                time::Instant,
             };
 
             mod policy;
@@ -97,8 +97,9 @@ commonware_macros::stability_scope!(BETA {
 
     /// A strategy wrapper for manually partitioned work.
     ///
-    /// This disables adaptive serial-vs-parallel policy decisions for operations that callers have
-    /// already split into partitions.
+    /// Built via [`Strategy::manual`], this disables adaptive policy decisions (including spawn
+    /// placement) for operations that callers have already split into partitions, and carries
+    /// the parallelism used to plan those partitions.
     #[derive(Clone, Debug)]
     pub struct Manual<S> {
         strategy: S,
@@ -106,14 +107,6 @@ commonware_macros::stability_scope!(BETA {
     }
 
     impl<S> Manual<S> {
-        /// Creates a strategy wrapper for manually partitioned work.
-        pub const fn new(strategy: S, parallelism: NonZeroUsize) -> Self {
-            Self {
-                strategy,
-                parallelism: parallelism.get(),
-            }
-        }
-
         /// Returns the parallelism to use for manually partitioned work.
         pub const fn parallelism(&self) -> usize {
             self.parallelism
@@ -131,12 +124,13 @@ commonware_macros::stability_scope!(BETA {
         where
             Self: Sized;
 
-        /// Submit one CPU-bound job to this strategy, running it inline on the calling task or
-        /// offloading it to the pool based on the measured cost of each path.
+        /// Submit one CPU-bound job to this strategy, running it inline on the calling task when
+        /// it is measured cheaper than the round trip of offloading it to the pool.
         ///
-        /// `len` is a size hint used only to group similar calls. It has no ordering or
-        /// correctness meaning. Jobs too small to amortize the pool hand-off run inline. To force
-        /// an unconditional hand-off, submit through [`manual`](Self::manual).
+        /// `len` groups calls at a call site into size classes for those measurements, so similar
+        /// `len` must mean comparable cost. An inline job runs to completion before `spawn`
+        /// returns, and jobs whose measured cost exceeds a small time budget offload. To force a
+        /// hand-off on a multi-worker pool, submit through [`manual`](Self::manual).
         ///
         /// The returned future resolves when the job completes. Blocking on external
         /// synchronization or I/O inside the job can occupy execution capacity until it returns.
@@ -809,7 +803,10 @@ commonware_macros::stability_scope!(BETA {
 
     impl Strategy for Sequential {
         fn manual(&self) -> Manual<Self> {
-            Manual::new(Self, NonZeroUsize::new(1).unwrap())
+            Manual {
+                strategy: Self,
+                parallelism: 1,
+            }
         }
 
         fn spawn<F, T>(
@@ -992,7 +989,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             &self,
             len: usize,
             multiplier: usize,
-            run: impl FnOnce(policy::Execution) -> R,
+            run: impl FnOnce(policy::RunExecution) -> R,
         ) -> R {
             match self.try_execute(len, multiplier, |execution| {
                 Ok::<_, Infallible>(run(execution))
@@ -1007,13 +1004,13 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             &self,
             len: usize,
             multiplier: usize,
-            run: impl FnOnce(policy::Execution) -> Result<R, E>,
+            run: impl FnOnce(policy::RunExecution) -> Result<R, E>,
         ) -> Result<R, E> {
             let Some(policy) = &self.policy else {
                 let execution = if self.parallelism <= 1 {
-                    policy::Execution::Serial
+                    policy::RunExecution::Serial
                 } else {
-                    policy::Execution::Parallel
+                    policy::RunExecution::Parallel
                 };
                 return run(execution);
             };
@@ -1048,92 +1045,107 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             let threads = self.thread_pool.current_num_threads();
             let caller = Location::caller();
 
-            // One worker cannot overlap (always inline); a manual strategy has no policy (keep
-            // spawn's unconditional offload). Otherwise let the policy decide.
-            let (offload_it, measure) = if threads <= 1 {
-                (false, false)
+            // A single-worker pool cannot overlap a hand-off, so the job always runs inline,
+            // untimed. A manual strategy has no policy and keeps spawn's unconditional
+            // hand-off. Otherwise the policy weighs the measured job cost against the offload
+            // round trip.
+            let ((execution, measure), policy) = if threads <= 1 {
+                ((policy::SpawnExecution::Inline, false), None)
             } else {
-                self.policy.as_ref().map_or((true, false), |policy| {
-                    match policy.choose_spawn(caller, len, threads) {
-                        (policy::SpawnExecution::Inline, measure) => (false, measure),
-                        (policy::SpawnExecution::Offload, measure) => (true, measure),
-                    }
-                })
+                self.policy.as_ref().map_or(
+                    ((policy::SpawnExecution::Offload, false), None),
+                    |policy| (policy.choose_spawn(caller, len, threads), Some(policy)),
+                )
             };
 
-            if !offload_it {
-                // Inline: run on the calling task and hand back a ready future.
-                let start = measure.then(Instant::now);
-                let result = f(self.clone());
-                if let (Some(start), Some(policy)) = (start, self.policy.as_ref()) {
-                    policy.record_spawn(
-                        caller,
-                        len,
-                        threads,
-                        policy::SpawnExecution::Inline,
-                        start.elapsed(),
-                        None,
-                    );
+            match execution {
+                policy::SpawnExecution::Inline => {
+                    // Inline: run on the calling task and hand back a ready future.
+                    let start = measure.then(Instant::now);
+                    let result = f(self.clone());
+                    if let (Some(start), Some(policy)) = (start, policy) {
+                        policy.record_spawn_inline(caller, len, threads, start.elapsed());
+                    }
+                    Either::Left(future::ready(result))
                 }
-                return Either::Left(future::ready(result));
-            }
+                policy::SpawnExecution::Offload => {
+                    // Offload: hand the job to the pool. The worker records the job wall (so
+                    // job estimates survive a dropped future), and the awaiting future records
+                    // the round-trip overhead when it observes the result.
+                    let spawn_start = measure.then(Instant::now);
+                    let (tx, mut rx) = oneshot::channel();
+                    let s = self.clone();
+                    let pool = self.thread_pool.clone();
+                    let recorder = if measure {
+                        policy.cloned().map(|policy| (policy, caller, len, threads))
+                    } else {
+                        None
+                    };
+                    let worker_recorder = recorder.clone();
+                    self.thread_pool.spawn(move || {
+                        let job_start = worker_recorder.is_some().then(Instant::now);
 
-            // Offload: hand the job to the pool. The worker times the job's own wall so we can
-            // estimate the inline cost; the returned future times the residual wait once joined.
-            let setup_start = measure.then(Instant::now);
-            let (tx, mut rx) = oneshot::channel();
-            let s = self.clone();
-            let pool = self.thread_pool.clone();
-            self.thread_pool.spawn(move || {
-                let job_start = measure.then(Instant::now);
-                let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
-                let job_wall = job_start.map(|start| start.elapsed());
-                let _ = tx.send((result, job_wall));
-            });
-            let recorder = measure.then(|| {
-                (
-                    self.policy.clone(),
-                    caller,
-                    len,
-                    threads,
-                    setup_start.map_or(Duration::ZERO, |start| start.elapsed()),
-                )
-            });
-            Either::Right(async move {
-                // Time from the caller's first poll (when it joins) to the result: the part of the
-                // job not hidden behind the caller's interleaved work.
-                let poll_start = Instant::now();
-                let (result, job_wall) = loop {
-                    if let Ok(Some(payload)) = rx.try_recv() {
-                        break payload;
-                    }
+                        // Catch the panic so a panicking job propagates to the awaiting task
+                        // rather than aborting the process (rayon aborts on an uncaught panic in
+                        // a spawned job).
+                        let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
+                        let job = job_start.map(|start| start.elapsed());
+                        let ok = result.is_ok();
+                        let _ = tx.send((result, job));
 
-                    // If the polling thread is a pool member, run pending pool work inline rather
-                    // than parking the only worker able to finish the job.
-                    if !matches!(pool.yield_now(), Some(Yield::Executed)) {
-                        break rx.await
-                            .unwrap_or_else(|_| panic!("strategy job dropped before completion"));
-                    }
-                };
-                match result {
-                    Ok(value) => {
-                        // Record successful runs only, matching the inline arm: a panicked
-                        // job's wall time says nothing about the job size.
-                        if let Some((Some(policy), caller, len, threads, setup)) = recorder {
-                            policy.record_spawn(
-                                caller,
-                                len,
-                                threads,
-                                policy::SpawnExecution::Offload,
-                                setup.saturating_add(poll_start.elapsed()),
-                                job_wall,
-                            );
+                        // Record successful runs only, matching the inline arm: a panicked job's
+                        // wall time says nothing about the job size. Recording after the send
+                        // keeps the bookkeeping off the caller's wake path.
+                        if ok
+                            && let (Some((policy, caller, len, threads)), Some(job)) =
+                                (worker_recorder, job)
+                        {
+                            policy.record_spawn_job(caller, len, threads, job);
                         }
-                        value
-                    }
-                    Err(payload) => panic::resume_unwind(payload),
+                    });
+                    Either::Right(async move {
+                        // When the polling thread is itself a member of the pool, waiting on the
+                        // channel could park the only worker able to run the job. Execute pending
+                        // pool work inline until the job completes or another worker takes over.
+                        // `yield_now` returns `None` when this thread is not a pool member, so
+                        // external callers fall through to the channel immediately.
+                        let (result, job) = loop {
+                            if let Ok(Some(payload)) = rx.try_recv() {
+                                break payload;
+                            }
+                            if !matches!(pool.yield_now(), Some(Yield::Executed)) {
+                                break rx.await.unwrap_or_else(|_| {
+                                    panic!("strategy job dropped before completion")
+                                });
+                            }
+                        };
+                        match result {
+                            Ok(value) => {
+                                // The round trip is everything around the job itself: hand-off
+                                // setup, queueing, worker wake, result send, task wake, and this
+                                // poll. A late poll inflates the sample with overlap slack, which
+                                // only ever biases toward inline, and the policy's budget caps
+                                // what that bias can buy.
+                                if let (
+                                    Some((policy, caller, len, threads)),
+                                    Some(job),
+                                    Some(start),
+                                ) = (recorder, job, spawn_start)
+                                {
+                                    policy.record_spawn_overhead(
+                                        caller,
+                                        len,
+                                        threads,
+                                        start.elapsed().saturating_sub(job),
+                                    );
+                                }
+                                value
+                            }
+                            Err(payload) => panic::resume_unwind(payload),
+                        }
+                    })
                 }
-            })
+            }
         }
 
         #[track_caller]
@@ -1144,8 +1156,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             PAR: FnOnce() -> R + Send,
         {
             self.execute(len, 1, |execution| match execution {
-                policy::Execution::Serial => serial(),
-                policy::Execution::Parallel => parallel(),
+                policy::RunExecution::Serial => serial(),
+                policy::RunExecution::Parallel => parallel(),
             })
         }
 
@@ -1158,8 +1170,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             PAR: FnOnce() -> Result<R, E> + Send,
         {
             self.try_execute(len, 1, |execution| match execution {
-                policy::Execution::Serial => serial(),
-                policy::Execution::Parallel => parallel(),
+                policy::RunExecution::Serial => serial(),
+                policy::RunExecution::Parallel => parallel(),
             })
         }
 
@@ -1183,10 +1195,10 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => {
+                policy::RunExecution::Serial => {
                     Sequential.fold_init(items, init, identity, fold_op, reduce_op)
                 }
-                policy::Execution::Parallel => self.thread_pool.install(|| {
+                policy::RunExecution::Parallel => self.thread_pool.install(|| {
                     items
                         .into_par_iter()
                         .fold(
@@ -1211,8 +1223,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.map_collect_vec(items, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.map_collect_vec(items, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map(map_op).collect()),
             })
@@ -1228,8 +1240,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.try_execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.try_map_collect_vec(items, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.try_map_collect_vec(items, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map(map_op).collect()),
             })
@@ -1246,8 +1258,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map_init(init, map_op).collect()),
             })
@@ -1270,8 +1282,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), multiplier, |execution| match execution {
-                policy::Execution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map_init(init, map_op).collect()),
             })
@@ -1295,10 +1307,10 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.try_execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => {
+                policy::RunExecution::Serial => {
                     Sequential.try_fold(items, identity, fold_op, reduce_op)
                 }
-                policy::Execution::Parallel => self.thread_pool.install(|| {
+                policy::RunExecution::Parallel => self.thread_pool.install(|| {
                     items
                         .into_par_iter()
                         .try_fold(&identity, &fold_op)
@@ -1324,13 +1336,16 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             C: Fn(&T, &T) -> Ordering + Send + Sync,
         {
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.sort_by(items, compare),
-                policy::Execution::Parallel => {
+                policy::RunExecution::Serial => Sequential.sort_by(items, compare),
+                policy::RunExecution::Parallel => {
                     self.thread_pool.install(|| items.par_sort_by(compare))
                 }
             });
         }
     }
+});
+commonware_macros::stability_scope!(ALPHA, cfg(any(feature = "test-utils", test)) {
+    pub mod mocks;
 });
 
 #[cfg(test)]
@@ -1394,6 +1409,41 @@ mod test {
         let (loc, job) = spawn_flagged(&strategy, false);
         assert_eq!(futures::executor::block_on(job), 7);
         assert!(spawn_recorded(&strategy, loc));
+    }
+
+    /// Once the seed and boundary runs measure a trivial job cheaper than the pool hand-off,
+    /// spawn places it inline on the calling (non-pool) thread.
+    #[test]
+    fn spawn_converges_inline_for_tiny_jobs() {
+        let strategy = parallel_strategy();
+
+        for _ in 0..100 {
+            let on_pool = futures::executor::block_on(
+                strategy.spawn(64, |_| rayon::current_thread_index().is_some()),
+            );
+            if !on_pool {
+                return;
+            }
+        }
+        panic!("a trivial job never converged to inline placement");
+    }
+
+    /// A job measured over the inline budget keeps offloading: the calling task is never blocked
+    /// on a big job even when the hand-off looks expensive.
+    #[test]
+    fn spawn_keeps_offloading_big_jobs() {
+        let strategy = parallel_strategy();
+
+        for _ in 0..20 {
+            let on_pool = futures::executor::block_on(strategy.spawn(64, |_| {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+                rayon::current_thread_index().is_some()
+            }));
+            assert!(
+                on_pool,
+                "a job over the inline budget ran on the calling task"
+            );
+        }
     }
 
     fn policy_len(strategy: &Rayon) -> usize {

--- a/parallel/src/mocks.rs
+++ b/parallel/src/mocks.rs
@@ -57,4 +57,10 @@ mod tests {
 
         assert!(strategy.spawn(1, |_| 7).now_or_never().is_none());
     }
+
+    #[test]
+    #[should_panic(expected = "pending requires a multi-worker pool")]
+    fn pending_rejects_single_worker() {
+        pending(NonZeroUsize::MIN);
+    }
 }

--- a/parallel/src/mocks.rs
+++ b/parallel/src/mocks.rs
@@ -1,0 +1,51 @@
+//! Mock strategy configurations for testing.
+
+use crate::{Rayon, ThreadPool};
+use core::num::NonZeroUsize;
+use rayon::ThreadPoolBuilder;
+use std::sync::Arc;
+
+/// Returns a strategy whose spawned jobs run inline at submission: a single-worker pool with the
+/// manual parallelism overridden to `parallelism`.
+pub fn inline(parallelism: NonZeroUsize) -> Rayon {
+    Rayon::new(NonZeroUsize::MIN)
+        .unwrap()
+        .with_parallelism(parallelism)
+}
+
+/// Returns a strategy whose spawned jobs never run: `workers` workers are registered but never
+/// started, so offloaded jobs queue forever.
+pub fn pending(workers: NonZeroUsize) -> Rayon {
+    let pool: ThreadPool = Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(workers.get())
+            .spawn_handler(|_| Ok(()))
+            .build()
+            .unwrap(),
+    );
+    Rayon::with_pool(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Strategy;
+    use futures::FutureExt;
+
+    #[test]
+    fn inline_runs_spawned_jobs_at_submission() {
+        let strategy = inline(NonZeroUsize::new(4).unwrap());
+
+        assert_eq!(strategy.manual().parallelism(), 4);
+        assert_eq!(strategy.spawn(1, |_| 7).now_or_never(), Some(7));
+    }
+
+    /// Construction must return (rayon's `build` does not wait for workers to prime) and the
+    /// spawned job must stay queued forever.
+    #[test]
+    fn pending_never_completes_spawned_jobs() {
+        let strategy = pending(NonZeroUsize::new(2).unwrap());
+
+        assert!(strategy.spawn(1, |_| 7).now_or_never().is_none());
+    }
+}

--- a/parallel/src/mocks.rs
+++ b/parallel/src/mocks.rs
@@ -15,7 +15,16 @@ pub fn inline(parallelism: NonZeroUsize) -> Rayon {
 
 /// Returns a strategy whose spawned jobs never run: `workers` workers are registered but never
 /// started, so offloaded jobs queue forever.
+///
+/// # Panics
+///
+/// Panics if `workers` is 1: `spawn` runs jobs inline at submission on a single-worker pool,
+/// which would violate this mock's contract.
 pub fn pending(workers: NonZeroUsize) -> Rayon {
+    assert!(
+        workers.get() >= 2,
+        "pending requires a multi-worker pool: spawn inlines jobs on a single-worker pool"
+    );
     let pool: ThreadPool = Arc::new(
         ThreadPoolBuilder::new()
             .num_threads(workers.get())

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -335,14 +335,8 @@ struct SpawnEntry {
 }
 
 impl SpawnEntry {
-    // Returns the path to run and whether the caller should time it. Offload is seeded first: it is
-    // the only path that also measures the job's own wall time, which estimates the inline cost.
-    // Once both estimates exist, the cheaper caller-visible cost wins (ties -> inline, which frees a
-    // worker). Inlining is gated on the latest raw inline sample (or the pool wall before we have
-    // one) against `budget`, so a single over-budget inline run switches to offloading at once and
-    // a long job never blocks the calling task. The loser is probed on an interval that doubles
-    // with how badly it lost, so a close race is re-checked often while a blowout is re-checked
-    // rarely.
+    // Decides whether this call runs inline or offloads, and whether the caller should time the run.
+    // `budget` bounds how long an inline run may occupy the calling task.
     fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
         let Some(offload_ns) = self.offload_ns else {
             self.since_probe = u32::MAX;
@@ -391,6 +385,8 @@ impl SpawnEntry {
         )
     }
 
+    // Folds one timing sample into this entry: `caller_ns` is the caller-visible wait for
+    // `execution`, and `job_wall_ns` is the job's own pool wall (present only for offload runs).
     fn record(&mut self, execution: SpawnExecution, caller_ns: u64, job_wall_ns: Option<u64>) {
         match execution {
             SpawnExecution::Inline => {

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -198,12 +198,17 @@ impl Policy {
         }
         let key = Key::new(caller, len, len, parallelism);
         let mut entry = self.spawn_entries.entry(key).or_default();
-        estimate(&mut entry).record(nanos(sample));
+        estimate(&mut entry).record(u64::try_from(sample.as_nanos()).unwrap_or(u64::MAX));
     }
 
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
         self.run_entries.len()
+    }
+
+    #[cfg(test)]
+    pub(super) fn spawn_len(&self) -> usize {
+        self.spawn_entries.len()
     }
 
     /// Whether the spawn entry for this call site has recorded at least one sample
@@ -417,7 +422,7 @@ impl RunEntry {
     }
 
     fn record(&mut self, execution: RunExecution, elapsed: Duration) {
-        let elapsed_ns = nanos(elapsed);
+        let elapsed_ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
         match execution {
             RunExecution::Serial => self.serial_ns.record(elapsed_ns),
             RunExecution::Parallel => self.parallel_ns.record(elapsed_ns),
@@ -488,11 +493,6 @@ impl SpawnEntry {
         self.cadence
             .arbitrate(preferred, loser, winner_ns, loser_ns, probe_allowed)
     }
-}
-
-// Saturating nanosecond conversion for timing samples.
-fn nanos(duration: Duration) -> u64 {
-    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 fn update_ewma(current: u64, next: u64) -> u64 {
@@ -1133,6 +1133,18 @@ mod tests {
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, _)
         ));
+    }
+
+    #[test]
+    fn spawn_entries_bucket_by_len() {
+        let policy = Policy::default();
+        let location = Location::caller();
+
+        let _ = policy.choose_spawn(location, 1, PARALLELISM);
+        let _ = policy.choose_spawn(location, 2, PARALLELISM);
+        let _ = policy.choose_spawn(location, 3, PARALLELISM);
+
+        assert_eq!(policy.spawn_len(), 2);
     }
 
     #[test]

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -65,6 +65,7 @@ const EWMA_NEXT_WEIGHT: u64 = 1;
 const EWMA_WEIGHT: u64 = EWMA_PREVIOUS_WEIGHT + EWMA_NEXT_WEIGHT;
 
 type Entries = DashMap<Key, Entry>;
+type SpawnEntries = DashMap<Key, SpawnEntry>;
 
 /// The path the policy chose for a call: the strategy runs the matching serial or parallel body.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -73,10 +74,19 @@ pub(super) enum Execution {
     Parallel,
 }
 
+/// The path the spawn policy chose: run the job inline on the calling task, or offload it to the
+/// pool, which overlaps it with the caller's other work at the cost of a hand-off.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum SpawnExecution {
+    Inline,
+    Offload,
+}
+
 /// Adaptive serial-vs-parallel decisions, shared cheaply across [`super::Rayon`] clones.
 #[derive(Clone, Debug, Default)]
 pub(super) struct Policy {
     entries: Arc<Entries>,
+    spawn_entries: Arc<SpawnEntries>,
 }
 
 impl Policy {
@@ -110,6 +120,52 @@ impl Policy {
             entry.record(execution, start.elapsed());
         }
         result
+    }
+
+    /// Chooses whether to run a spawned job inline on the calling task or offload it to the pool,
+    /// and whether the caller should time this run and feed the result back via
+    /// [`record_spawn`](Self::record_spawn).
+    pub(super) fn choose_spawn(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+    ) -> (SpawnExecution, bool) {
+        // A single worker cannot overlap a hand-off, so always inline.
+        if parallelism <= 1 {
+            return (SpawnExecution::Inline, false);
+        }
+        let key = Key::new(caller, len, len, parallelism);
+        self.spawn_entries
+            .entry(key)
+            .or_default()
+            .choose(SERIAL_SAMPLE_BUDGET_NS)
+    }
+
+    /// Records the caller-visible cost of a spawned job. `caller_ns` is the marginal latency the
+    /// chosen path added to the caller. For inline it is the job's wall time. For offload it is
+    /// the hand-off setup plus the residual wait once the caller joined. `job_wall_ns` is the
+    /// job's measured wall time on the pool (offload only). It estimates the inline cost and
+    /// bounds inlining so a long job never blocks the calling task.
+    pub(super) fn record_spawn(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        execution: SpawnExecution,
+        caller_ns: Duration,
+        job_wall_ns: Option<Duration>,
+    ) {
+        if parallelism <= 1 {
+            return;
+        }
+        let key = Key::new(caller, len, len, parallelism);
+        let caller_ns = u64::try_from(caller_ns.as_nanos()).unwrap_or(u64::MAX);
+        let job_wall_ns = job_wall_ns.map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX));
+        self.spawn_entries
+            .entry(key)
+            .or_default()
+            .record(execution, caller_ns, job_wall_ns);
     }
 
     #[cfg(test)]
@@ -259,6 +315,103 @@ impl Entry {
     }
 }
 
+/// Timing state for one spawn [`Key`]: the caller-visible cost of inlining vs offloading, the job's
+/// measured wall time on the pool, and the latest raw inline sample used by the safety gate.
+#[derive(Clone, Copy, Debug, Default)]
+struct SpawnEntry {
+    inline_ns: Option<u64>,
+    offload_ns: Option<u64>,
+    job_wall_ns: Option<u64>,
+    // The most recent inline measurement, kept raw (not blended into `inline_ns`) so the
+    // executor-block gate reacts to a single over-budget run instead of waiting for the EWMA.
+    last_inline_ns: Option<u64>,
+    since_probe: u32,
+}
+
+impl SpawnEntry {
+    // Returns the path to run and whether the caller should time it. Offload is seeded first: it is
+    // the only path that also measures the job's own wall time, which estimates the inline cost.
+    // Once both estimates exist, the cheaper caller-visible cost wins (ties -> inline, which frees a
+    // worker). Inlining is gated on the latest raw inline sample (or the pool wall before we have
+    // one) against `budget`, so a single over-budget inline run switches to offloading at once and
+    // a long job never blocks the calling task. The loser is probed on an interval that doubles
+    // with how badly it lost, so a close race is re-checked often while a blowout is re-checked
+    // rarely.
+    fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
+        let Some(offload_ns) = self.offload_ns else {
+            self.since_probe = u32::MAX;
+            return (SpawnExecution::Offload, true);
+        };
+        let job_wall = self.job_wall_ns.unwrap_or(offload_ns);
+        // `inline_est` (an EWMA) drives the cheaper-path preference. The safety gate instead uses
+        // the latest raw inline sample, so a single over-budget run offloads immediately rather
+        // than after the EWMA slowly crosses `budget`. Before any inline sample both fall back to
+        // the offload-measured pool wall, which is also stale once the policy converges to inline.
+        let inline_est = self.inline_ns.unwrap_or(job_wall);
+        let inline_gate = self.last_inline_ns.unwrap_or(job_wall);
+        let inline_safe = inline_gate < budget;
+        let preferred = if inline_safe && inline_est <= offload_ns {
+            SpawnExecution::Inline
+        } else {
+            SpawnExecution::Offload
+        };
+        let (winner_ns, loser_ns) = match preferred {
+            SpawnExecution::Inline => (inline_est, offload_ns),
+            SpawnExecution::Offload => (offload_ns, inline_est),
+        };
+        let slowdown = loser_ns / winner_ns.max(1);
+        let shift = slowdown
+            .saturating_sub(1)
+            .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
+        let interval = RESAMPLE_INTERVAL << shift;
+
+        self.since_probe = self.since_probe.saturating_add(1);
+        if self.since_probe >= interval {
+            self.since_probe = 0;
+            let probe = match preferred {
+                SpawnExecution::Inline => SpawnExecution::Offload,
+                // Probe inline whenever fresh offload evidence (`job_wall`, refreshed by the
+                // offloads we are running) says the job is small enough to try safely, even if the
+                // last inline sample was over budget. This lets a transient slow run recover once
+                // the job shrinks again instead of offloading forever.
+                SpawnExecution::Offload if job_wall < budget => SpawnExecution::Inline,
+                SpawnExecution::Offload => SpawnExecution::Offload,
+            };
+            return (probe, true);
+        }
+        (
+            preferred,
+            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
+        )
+    }
+
+    fn record(&mut self, execution: SpawnExecution, caller_ns: u64, job_wall_ns: Option<u64>) {
+        match execution {
+            SpawnExecution::Inline => {
+                self.inline_ns = Some(
+                    self.inline_ns
+                        .map_or(caller_ns, |current| update_ewma(current, caller_ns)),
+                );
+                // Keep the raw sample for the safety gate, unblended, so an over-budget run is
+                // seen immediately rather than smoothed away by the EWMA above.
+                self.last_inline_ns = Some(caller_ns);
+            }
+            SpawnExecution::Offload => {
+                self.offload_ns = Some(
+                    self.offload_ns
+                        .map_or(caller_ns, |current| update_ewma(current, caller_ns)),
+                );
+                if let Some(job_wall_ns) = job_wall_ns {
+                    self.job_wall_ns = Some(
+                        self.job_wall_ns
+                            .map_or(job_wall_ns, |current| update_ewma(current, job_wall_ns)),
+                    );
+                }
+            }
+        }
+    }
+}
+
 fn update_ewma(current: u64, next: u64) -> u64 {
     let weighted = u128::from(current) * u128::from(EWMA_PREVIOUS_WEIGHT)
         + u128::from(next) * u128::from(EWMA_NEXT_WEIGHT);
@@ -281,6 +434,7 @@ const fn len_bucket(len: usize) -> u8 {
 mod tests {
     use super::{
         Entry, Execution, MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL,
+        SERIAL_SAMPLE_BUDGET_NS, SpawnEntry, SpawnExecution,
     };
     use std::{panic::Location, time::Duration};
 
@@ -749,5 +903,134 @@ mod tests {
         }
         let (_, parallel_ns) = policy.get_entry(location, len, work, PARALLELISM).unwrap();
         assert_eq!(parallel_ns, parallel_estimate);
+    }
+
+    #[test]
+    fn spawn_seeds_offload_then_inlines_a_tiny_poorly_overlapped_job() {
+        let mut entry = SpawnEntry::default();
+
+        // The first call seeds the offload estimate (and the job's own wall time).
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
+        // A 2us job whose caller-visible cost was 50us: the overlap did not hide it.
+        entry.record(SpawnExecution::Offload, 50_000, Some(2_000));
+
+        // The seed leaves the entry due for an immediate boundary, which re-probes offload.
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
+        entry.record(SpawnExecution::Offload, 50_000, Some(2_000));
+
+        // The job (2us) fits the budget and beats its 50us offload cost, so inline wins.
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Inline, false)
+        );
+    }
+
+    #[test]
+    fn spawn_keeps_offloading_a_well_overlapped_job() {
+        let mut entry = SpawnEntry::default();
+
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
+        // A 50us job whose caller-visible cost was only 3us: the overlap hid almost all of it.
+        entry.record(SpawnExecution::Offload, 3_000, Some(50_000));
+
+        // Offload is preferred (3us beats a 50us inline), so the boundary probes the inline loser.
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Inline, true)
+        );
+        entry.record(SpawnExecution::Inline, 50_000, None);
+
+        // With both estimates known, offload still wins because the overlap makes it cheaper.
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
+            SpawnExecution::Offload
+        );
+    }
+
+    #[test]
+    fn spawn_never_inlines_a_job_over_the_executor_block_budget() {
+        let mut entry = SpawnEntry::default();
+
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
+        // A job whose measured wall exceeds the budget must never run inline (it would stall the
+        // async executor), no matter how the caller-visible cost compares.
+        let over_budget = SERIAL_SAMPLE_BUDGET_NS * 2;
+        entry.record(SpawnExecution::Offload, over_budget, Some(over_budget));
+
+        for _ in 0..(2 * RESAMPLE_INTERVAL) {
+            assert_eq!(
+                entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
+                SpawnExecution::Offload
+            );
+            entry.record(SpawnExecution::Offload, over_budget, Some(over_budget));
+        }
+    }
+
+    #[test]
+    fn spawn_single_worker_always_inlines() {
+        // With one worker a hand-off cannot overlap, so the policy inlines without measuring.
+        let policy = Policy::default();
+        let location = Location::caller();
+        assert_eq!(
+            policy.choose_spawn(location, 64, 1),
+            (SpawnExecution::Inline, false)
+        );
+    }
+
+    #[test]
+    fn spawn_offloads_after_a_single_over_budget_inline_sample() {
+        // Start from a cheap, converged inline estimate: offload is expensive, inline is cheap, and
+        // both sit well under the budget.
+        let mut entry = SpawnEntry {
+            offload_ns: Some(30_000_000), // offloading measured at 30ms
+            inline_ns: Some(2_000),       // established cheap inline EWMA (2us)
+            last_inline_ns: Some(2_000),
+            job_wall_ns: Some(2_000),
+            ..Default::default()
+        };
+        // One inline run now measures 15ms, over the 10ms budget. The blended `inline_ns` stays
+        // ~3ms (still "safe" on its own), but the raw safety gate must offload on this single
+        // sample rather than wait for the EWMA to cross the budget.
+        entry.record(SpawnExecution::Inline, 15_000_000, None);
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
+            SpawnExecution::Offload
+        );
+    }
+
+    #[test]
+    fn spawn_probes_inline_to_recover_after_a_transient_slow_run() {
+        // A transient slow inline left `last_inline_ns` over budget, so the gate is unsafe and the
+        // entry is offloading. Fresh offloads now show the job is small again (`job_wall` under
+        // budget), and the entry is due for a boundary.
+        let mut entry = SpawnEntry {
+            offload_ns: Some(5_000),          // 5us
+            job_wall_ns: Some(2_000),         // 2us: fresh offload evidence, the job is small
+            inline_ns: Some(3_000_000),       // stale 3ms EWMA from the slow run
+            last_inline_ns: Some(15_000_000), // 15ms: over budget, currently locks out inline
+            since_probe: u32::MAX,
+        };
+        // Rather than offload forever, the boundary schedules a controlled inline probe because the
+        // offload evidence is under budget.
+        assert_eq!(
+            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            (SpawnExecution::Inline, true)
+        );
+        // The probe measures the now-tiny job, clearing the raw over-budget gate so the entry can
+        // inline again.
+        entry.record(SpawnExecution::Inline, 2_000, None);
+        assert!(entry.last_inline_ns.unwrap() < SERIAL_SAMPLE_BUDGET_NS);
     }
 }

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -173,6 +173,21 @@ impl Policy {
         self.entries.len()
     }
 
+    /// Whether the spawn entry for this call site has recorded at least one sample
+    /// (a choose-created but never-recorded entry has no estimates).
+    #[cfg(test)]
+    pub(super) fn spawn_recorded(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+    ) -> bool {
+        let key = Key::new(caller, len, len, parallelism);
+        self.spawn_entries
+            .get(&key)
+            .is_some_and(|entry| entry.offload_ns.is_some() || entry.inline_ns.is_some())
+    }
+
     #[cfg(test)]
     pub(super) fn get_entry(
         &self,

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -1,4 +1,4 @@
-//! Adaptive execution policy for collection operations.
+//! Adaptive execution policies for collection operations and spawned jobs.
 //!
 //! Entries are keyed by callsite, input-size bucket, work-size bucket, and planning parallelism
 //! so a decision learned for one workload does not leak into another. The policy compares recent
@@ -59,33 +59,36 @@ const MAX_RESAMPLE_SHIFT: u32 = 5;
 // The tuner only arbitrates cases where a serial run is provably cheap: serial is seeded,
 // probed, or preferred only when its projected and measured costs fit this budget.
 const SERIAL_SAMPLE_BUDGET_NS: u64 = 10_000_000;
+// Only jobs measured below this executor-friendly budget are eligible to run inline.
+const SPAWN_INLINE_BUDGET_NS: u64 = 1_000_000;
 // Track a short EWMA so recent measurements outweigh old startup noise.
 const EWMA_PREVIOUS_WEIGHT: u64 = 4;
 const EWMA_NEXT_WEIGHT: u64 = 1;
 const EWMA_WEIGHT: u64 = EWMA_PREVIOUS_WEIGHT + EWMA_NEXT_WEIGHT;
 
-type Entries = DashMap<Key, Entry>;
+type RunEntries = DashMap<Key, RunEntry>;
 type SpawnEntries = DashMap<Key, SpawnEntry>;
 
 /// The path the policy chose for a call: the strategy runs the matching serial or parallel body.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum Execution {
+pub(super) enum RunExecution {
     Serial,
     Parallel,
 }
 
-/// The path the spawn policy chose: run the job inline on the calling task, or offload it to the
-/// pool, which overlaps it with the caller's other work at the cost of a hand-off.
+/// The placement the spawn policy chose: run the job inline on the calling task, or hand it off
+/// to the pool.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(super) enum SpawnExecution {
     Inline,
     Offload,
 }
 
-/// Adaptive serial-vs-parallel decisions, shared cheaply across [`super::Rayon`] clones.
+/// Adaptive execution decisions (serial vs parallel for collection operations, inline vs
+/// offload for spawned jobs), shared cheaply across [`super::Rayon`] clones.
 #[derive(Clone, Debug, Default)]
 pub(super) struct Policy {
-    entries: Arc<Entries>,
+    run_entries: Arc<RunEntries>,
     spawn_entries: Arc<SpawnEntries>,
 }
 
@@ -103,35 +106,38 @@ impl Policy {
         len: usize,
         work: usize,
         parallelism: usize,
-        run: impl FnOnce(Execution) -> Result<R, E>,
+        run: impl FnOnce(RunExecution) -> Result<R, E>,
     ) -> Result<R, E> {
         // A strategy configured for serial execution cannot benefit from rayon scheduling, so
         // always run serial and never spend a measurement on it.
         if parallelism <= 1 {
-            return run(Execution::Serial);
+            return run(RunExecution::Serial);
         }
 
         let key = Key::new(caller, len, work, parallelism);
-        let (execution, measure) = self.entries.entry(key).or_default().choose(parallelism);
+        let (execution, measure) = self.run_entries.entry(key).or_default().choose(parallelism);
         let start = measure.then(Instant::now);
         let result = run(execution);
         if let (Some(start), Ok(_)) = (start, &result) {
-            let mut entry = self.entries.entry(key).or_default();
+            let mut entry = self.run_entries.entry(key).or_default();
             entry.record(execution, start.elapsed());
         }
         result
     }
 
-    /// Chooses whether to run a spawned job inline on the calling task or offload it to the pool,
-    /// and whether the caller should time this run and feed the result back via
-    /// [`record_spawn`](Self::record_spawn).
+    /// Chooses where to run a spawned job (inline on the calling task when the job is measured
+    /// cheaper than the round trip of offloading it, offloaded to the pool otherwise) and whether
+    /// the caller should time the run and feed the samples back via
+    /// [`record_spawn_inline`](Self::record_spawn_inline),
+    /// [`record_spawn_job`](Self::record_spawn_job), and
+    /// [`record_spawn_overhead`](Self::record_spawn_overhead).
     pub(super) fn choose_spawn(
         &self,
         caller: &'static Location<'static>,
         len: usize,
         parallelism: usize,
     ) -> (SpawnExecution, bool) {
-        // A single worker cannot overlap a hand-off, so always inline.
+        // A single worker cannot overlap a hand-off, so always inline (nothing to measure).
         if parallelism <= 1 {
             return (SpawnExecution::Inline, false);
         }
@@ -139,38 +145,65 @@ impl Policy {
         self.spawn_entries
             .entry(key)
             .or_default()
-            .choose(SERIAL_SAMPLE_BUDGET_NS)
+            .choose(SPAWN_INLINE_BUDGET_NS)
     }
 
-    /// Records the caller-visible cost of a spawned job. `caller_ns` is the marginal latency the
-    /// chosen path added to the caller. For inline it is the job's wall time. For offload it is
-    /// the hand-off setup plus the residual wait once the caller joined. `job_wall_ns` is the
-    /// job's measured wall time on the pool (offload only). It estimates the inline cost and
-    /// bounds inlining so a long job never blocks the calling task.
-    pub(super) fn record_spawn(
+    /// Records the wall time of a spawned job that ran inline on the calling task.
+    pub(super) fn record_spawn_inline(
         &self,
         caller: &'static Location<'static>,
         len: usize,
         parallelism: usize,
-        execution: SpawnExecution,
-        caller_ns: Duration,
-        job_wall_ns: Option<Duration>,
+        job: Duration,
+    ) {
+        self.record_spawn(caller, len, parallelism, job, |entry| &mut entry.inline_ns);
+    }
+
+    /// Records the wall time of a spawned job that ran on a pool worker.
+    pub(super) fn record_spawn_job(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        job: Duration,
+    ) {
+        self.record_spawn(caller, len, parallelism, job, |entry| &mut entry.job_ns);
+    }
+
+    /// Records one offloaded spawn's round-trip overhead: the elapsed time from spawn entry to
+    /// the result being observed by the awaiting future, minus the job's own wall time.
+    pub(super) fn record_spawn_overhead(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        overhead: Duration,
+    ) {
+        self.record_spawn(caller, len, parallelism, overhead, |entry| {
+            &mut entry.overhead_ns
+        });
+    }
+
+    /// Folds one spawn timing sample into the selected estimate.
+    fn record_spawn(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        sample: Duration,
+        estimate: impl FnOnce(&mut SpawnEntry) -> &mut Estimate,
     ) {
         if parallelism <= 1 {
             return;
         }
         let key = Key::new(caller, len, len, parallelism);
-        let caller_ns = u64::try_from(caller_ns.as_nanos()).unwrap_or(u64::MAX);
-        let job_wall_ns = job_wall_ns.map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX));
-        self.spawn_entries
-            .entry(key)
-            .or_default()
-            .record(execution, caller_ns, job_wall_ns);
+        let mut entry = self.spawn_entries.entry(key).or_default();
+        estimate(&mut entry).record(nanos(sample));
     }
 
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
-        self.entries.len()
+        self.run_entries.len()
     }
 
     /// Whether the spawn entry for this call site has recorded at least one sample
@@ -185,7 +218,7 @@ impl Policy {
         let key = Key::new(caller, len, len, parallelism);
         self.spawn_entries
             .get(&key)
-            .is_some_and(|entry| entry.offload_ns.is_some() || entry.inline_ns.is_some())
+            .is_some_and(|entry| entry.overhead_ns.get().is_some() || entry.job_ns.get().is_some())
     }
 
     #[cfg(test)]
@@ -197,7 +230,9 @@ impl Policy {
         parallelism: usize,
     ) -> Option<(Option<u64>, Option<u64>)> {
         let key = Key::new(caller, len, work, parallelism);
-        self.entries.get(&key).map(|e| (e.serial_ns, e.parallel_ns))
+        self.run_entries
+            .get(&key)
+            .map(|e| (e.serial_ns.get(), e.parallel_ns.get()))
     }
 }
 
@@ -230,15 +265,86 @@ impl Key {
     }
 }
 
-/// Timing state for one [`Key`].
+/// An EWMA-smoothed wall-clock estimate in nanoseconds.
+///
+/// The first sample initializes the estimate, and every later sample blends into the EWMA, so a
+/// single outlier (a contended pool) moves an established estimate by at most a fifth of the gap.
 #[derive(Clone, Copy, Debug, Default)]
-struct Entry {
-    serial_ns: Option<u64>,
-    parallel_ns: Option<u64>,
+struct Estimate(Option<u64>);
+
+impl Estimate {
+    const fn get(&self) -> Option<u64> {
+        self.0
+    }
+
+    fn record(&mut self, sample_ns: u64) {
+        self.0 = Some(
+            self.0
+                .map_or(sample_ns, |current| update_ewma(current, sample_ns)),
+        );
+    }
+}
+
+/// Paces measurement and probing for one policy entry.
+///
+/// Between boundaries the preferred path is measured every [`PREFERRED_SAMPLE_INTERVAL`] calls so
+/// its estimate stays live. The boundary recurs every `RESAMPLE_INTERVAL << shift` calls, where
+/// the shift grows with how badly the losing path lost (one doubling per multiple of the winner's
+/// wall time, capped at [`MAX_RESAMPLE_SHIFT`]), so a close race is re-checked often while a
+/// blowout is re-checked rarely yet remains discoverable.
+#[derive(Clone, Copy, Debug, Default)]
+struct Cadence {
     since_probe: u32,
 }
 
-impl Entry {
+impl Cadence {
+    // Saturate the counter so the next call lands on a boundary (used at seed time so a freshly
+    // seeded entry is re-examined immediately instead of waiting a full interval that a
+    // low-frequency callsite may never reach).
+    const fn saturate(&mut self) {
+        self.since_probe = u32::MAX;
+    }
+
+    // Arbitrates one call between a `preferred` and a `loser` path, returning the path to run
+    // and whether the caller should time it. The loser runs at an allowed probe boundary, and a
+    // disallowed boundary still measures the preferred path and resets the counter.
+    fn arbitrate<P: Copy>(
+        &mut self,
+        preferred: P,
+        loser: P,
+        winner_ns: u64,
+        loser_ns: u64,
+        probe_allowed: bool,
+    ) -> (P, bool) {
+        let slowdown = loser_ns / winner_ns.max(1);
+        let shift = slowdown
+            .saturating_sub(1)
+            .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
+        let interval = RESAMPLE_INTERVAL << shift;
+        self.since_probe = self.since_probe.saturating_add(1);
+        if self.since_probe >= interval {
+            self.since_probe = 0;
+            if probe_allowed {
+                return (loser, true);
+            }
+            return (preferred, true);
+        }
+        (
+            preferred,
+            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
+        )
+    }
+}
+
+/// Timing state for one [`Key`].
+#[derive(Clone, Copy, Debug, Default)]
+struct RunEntry {
+    serial_ns: Estimate,
+    parallel_ns: Estimate,
+    cadence: Cadence,
+}
+
+impl RunEntry {
     // A serial pass of work that parallel finishes in `parallel_ns` can take up to
     // `parallel_ns * parallelism`.
     fn projected_serial(parallel_ns: u64, parallelism: usize) -> u64 {
@@ -248,27 +354,26 @@ impl Entry {
     // Returns the path to prefer: the faster estimate, provided both the projected and
     // measured serial cost fit under the budget (the tuner only arbitrates small cases).
     // Ties go to serial (equal wall time for fewer busy workers).
-    fn preferred(serial_ns: u64, parallel_ns: u64, parallelism: usize) -> Execution {
+    fn preferred(serial_ns: u64, parallel_ns: u64, parallelism: usize) -> RunExecution {
         if Self::projected_serial(parallel_ns, parallelism) >= SERIAL_SAMPLE_BUDGET_NS
             || serial_ns >= SERIAL_SAMPLE_BUDGET_NS
             || parallel_ns < serial_ns
         {
-            Execution::Parallel
+            RunExecution::Parallel
         } else {
-            Execution::Serial
+            RunExecution::Serial
         }
     }
 
     // Returns the path to run and whether the caller should time it and feed the elapsed duration
     // back to [`record`](Self::record).
-    fn choose(&mut self, parallelism: usize) -> (Execution, bool) {
-        // Seed the parallel estimate with the first call. Saturating the probe counter keeps
-        // the entry due for an immediate boundary, so the serial seed is offered as soon as
-        // the parallel estimate lands (when the projection allows) instead of waiting a full
-        // interval that a low-frequency callsite may never reach.
-        let Some(parallel_ns) = self.parallel_ns else {
-            self.since_probe = u32::MAX;
-            return (Execution::Parallel, true);
+    fn choose(&mut self, parallelism: usize) -> (RunExecution, bool) {
+        // Seed the parallel estimate with the first call. Saturating the cadence keeps the
+        // entry due for an immediate boundary, so the serial seed is offered as soon as the
+        // parallel estimate lands (when the projection allows).
+        let Some(parallel_ns) = self.parallel_ns.get() else {
+            self.cadence.saturate();
+            return (RunExecution::Parallel, true);
         };
 
         // The projection gates serial in both sampling and preference: a case whose projection
@@ -277,156 +382,117 @@ impl Entry {
         let can_sample_serial =
             Self::projected_serial(parallel_ns, parallelism) < SERIAL_SAMPLE_BUDGET_NS;
 
-        // Until serial is sampled, parallel is preferred by default and the boundary doubles
-        // as the seed slot. Once both estimates exist, the boundary probes the losing path on
-        // an interval that doubles for each multiple of the winner's wall time it is behind,
-        // so a close race is re-checked often while a blowout is re-checked rarely.
-        let (preferred, interval) =
-            self.serial_ns
-                .map_or((Execution::Parallel, RESAMPLE_INTERVAL), |serial_ns| {
-                    let preferred = Self::preferred(serial_ns, parallel_ns, parallelism);
-                    let (winner_ns, loser_ns) = match preferred {
-                        Execution::Serial => (serial_ns, parallel_ns),
-                        Execution::Parallel => (parallel_ns, serial_ns),
-                    };
-                    let slowdown = loser_ns / winner_ns.max(1);
-                    let shift = slowdown
-                        .saturating_sub(1)
-                        .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
-                    (preferred, RESAMPLE_INTERVAL << shift)
-                });
+        // Until serial is sampled, parallel is preferred by default (winner and loser tie, so
+        // the cadence runs at its base interval) and the boundary doubles as the seed slot.
+        let (preferred, loser, winner_ns, loser_ns) = self.serial_ns.get().map_or(
+            (
+                RunExecution::Parallel,
+                RunExecution::Serial,
+                parallel_ns,
+                parallel_ns,
+            ),
+            |serial_ns| match Self::preferred(serial_ns, parallel_ns, parallelism) {
+                RunExecution::Serial => (
+                    RunExecution::Serial,
+                    RunExecution::Parallel,
+                    serial_ns,
+                    parallel_ns,
+                ),
+                RunExecution::Parallel => (
+                    RunExecution::Parallel,
+                    RunExecution::Serial,
+                    parallel_ns,
+                    serial_ns,
+                ),
+            },
+        );
 
         // Exactly one caller crosses the boundary, and a serial seed whose sample never lands
         // is simply offered again at the next boundary. A serial seed or probe must fit the
         // live projection. A parallel probe is always allowed: it pays the true parallel wall
         // (including any pool queueing), which the capped interval amortizes.
-        self.since_probe = self.since_probe.saturating_add(1);
-        if self.since_probe >= interval {
-            self.since_probe = 0;
-            let probe = match preferred {
-                Execution::Serial => Execution::Parallel,
-                Execution::Parallel if can_sample_serial => Execution::Serial,
-                Execution::Parallel => Execution::Parallel,
-            };
-            return (probe, true);
-        }
-
-        (
-            preferred,
-            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
-        )
+        let probe_allowed = preferred == RunExecution::Serial || can_sample_serial;
+        self.cadence
+            .arbitrate(preferred, loser, winner_ns, loser_ns, probe_allowed)
     }
 
-    // The first sample of each path initializes its estimate, and every later sample blends
-    // into the EWMA, so a single outlier (a contended pool) moves an established estimate by
-    // at most a fifth of the gap.
-    fn record(&mut self, execution: Execution, elapsed: Duration) {
-        let elapsed_ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
-        let estimate = match execution {
-            Execution::Serial => &mut self.serial_ns,
-            Execution::Parallel => &mut self.parallel_ns,
-        };
-        *estimate = Some(estimate.map_or(elapsed_ns, |current| update_ewma(current, elapsed_ns)));
+    fn record(&mut self, execution: RunExecution, elapsed: Duration) {
+        let elapsed_ns = nanos(elapsed);
+        match execution {
+            RunExecution::Serial => self.serial_ns.record(elapsed_ns),
+            RunExecution::Parallel => self.parallel_ns.record(elapsed_ns),
+        }
     }
 }
 
 /// Timing state for one spawn [`Key`].
 ///
-/// Offloading never makes the job itself run faster. What it buys is overlap: the calling task can
-/// do other work while the job runs on the pool, so the caller waits only for whatever is left when
-/// it finally awaits the result. `choose` therefore compares the caller's *wait*, not the job's
-/// runtime: the whole job if inlined, versus the hand-off plus that leftover if offloaded (measured
-/// in [`crate::Strategy::spawn`]). Offloading wins when the caller has enough of its own work to
-/// overlap the job behind.
+/// Since caller overlap cannot be observed, the policy inlines only when the job wall is no
+/// greater than both the offload round-trip overhead EWMA and [`SPAWN_INLINE_BUDGET_NS`]. The
+/// overhead is everything an offloaded run costs around the job itself (hand-off setup, queueing,
+/// worker wake, result send, task wake, and the observing poll), so a caller that waits on the
+/// result inlines whenever that is measured cheaper. A caller that polls late inflates its
+/// overhead samples with overlap slack, which biases toward inline, and the budget bounds what
+/// that bias can place on the calling task.
+///
+/// The job wall is tracked per placement: the worker-measured wall carries the penalty of
+/// migrating the job to another core, so the decision prefers the inline-measured wall once one
+/// exists, and the offload-state boundary probes inline (when the live worker wall fits the
+/// budget) so that estimate is observable from an entry seeded into offload.
 #[derive(Clone, Copy, Debug, Default)]
 struct SpawnEntry {
-    inline_ns: Option<u64>,
-    offload_ns: Option<u64>,
-    job_wall_ns: Option<u64>,
-    // The most recent inline measurement, kept raw (not blended into `inline_ns`) so the
-    // executor-block gate reacts to a single over-budget run instead of waiting for the EWMA.
-    last_inline_ns: Option<u64>,
-    since_probe: u32,
+    // Spawn entry to result observed, minus the job's own wall time, from offloaded runs.
+    overhead_ns: Estimate,
+    // The job's own wall time on a pool worker.
+    job_ns: Estimate,
+    // The job's own wall time inline on the calling task.
+    inline_ns: Estimate,
+    cadence: Cadence,
 }
 
 impl SpawnEntry {
-    // Decides whether this call runs inline or offloads, and whether the caller should time the run.
-    // `budget` bounds how long an inline run may occupy the calling task.
+    // Decides where this call runs and whether the caller should time it. `budget` caps the job
+    // wall eligible for inlining.
     fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
-        let Some(offload_ns) = self.offload_ns else {
-            self.since_probe = u32::MAX;
+        // Seed both offload estimates before ever inlining.
+        let (Some(overhead_ns), Some(job_ns)) = (self.overhead_ns.get(), self.job_ns.get()) else {
+            self.cadence.saturate();
             return (SpawnExecution::Offload, true);
         };
-        let job_wall = self.job_wall_ns.unwrap_or(offload_ns);
-        // `inline_est` (an EWMA) drives the cheaper-path preference. The safety gate instead uses
-        // the latest raw inline sample, so a single over-budget run offloads immediately rather
-        // than after the EWMA slowly crosses `budget`. Before any inline sample both fall back to
-        // the offload-measured pool wall, which is also stale once the policy converges to inline.
-        let inline_est = self.inline_ns.unwrap_or(job_wall);
-        let inline_gate = self.last_inline_ns.unwrap_or(job_wall);
-        let inline_safe = inline_gate < budget;
-        let preferred = if inline_safe && inline_est <= offload_ns {
-            SpawnExecution::Inline
+
+        // Ties go to inline: equal cost for one fewer pool wake. An inline probe is gated on
+        // the live worker wall fitting the budget: the inline wall is only observable by
+        // inlining, so without the probe an entry seeded into offload could never learn it,
+        // and gating on the live worker wall (not the stale inline estimate) lets a poisoned
+        // inline estimate recover. An offload probe is always allowed, since it keeps the
+        // offload estimates tracking the live pool.
+        let bound = self.inline_ns.get().unwrap_or(job_ns);
+        let threshold = overhead_ns.min(budget);
+        let (preferred, loser, winner_ns, loser_ns, probe_allowed) = if bound > threshold {
+            (
+                SpawnExecution::Offload,
+                SpawnExecution::Inline,
+                threshold,
+                bound,
+                job_ns < budget,
+            )
         } else {
-            SpawnExecution::Offload
+            (
+                SpawnExecution::Inline,
+                SpawnExecution::Offload,
+                bound,
+                threshold,
+                true,
+            )
         };
-        let (winner_ns, loser_ns) = match preferred {
-            SpawnExecution::Inline => (inline_est, offload_ns),
-            SpawnExecution::Offload => (offload_ns, inline_est),
-        };
-        let slowdown = loser_ns / winner_ns.max(1);
-        let shift = slowdown
-            .saturating_sub(1)
-            .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
-        let interval = RESAMPLE_INTERVAL << shift;
-
-        self.since_probe = self.since_probe.saturating_add(1);
-        if self.since_probe >= interval {
-            self.since_probe = 0;
-            let probe = match preferred {
-                SpawnExecution::Inline => SpawnExecution::Offload,
-                // Probe inline whenever fresh offload evidence (`job_wall`, refreshed by the
-                // offloads we are running) says the job is small enough to try safely, even if the
-                // last inline sample was over budget. This lets a transient slow run recover once
-                // the job shrinks again instead of offloading forever.
-                SpawnExecution::Offload if job_wall < budget => SpawnExecution::Inline,
-                SpawnExecution::Offload => SpawnExecution::Offload,
-            };
-            return (probe, true);
-        }
-        (
-            preferred,
-            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
-        )
+        self.cadence
+            .arbitrate(preferred, loser, winner_ns, loser_ns, probe_allowed)
     }
+}
 
-    // Folds one timing sample into this entry: `caller_ns` is the caller-visible wait for
-    // `execution`, and `job_wall_ns` is the job's own pool wall (present only for offload runs).
-    fn record(&mut self, execution: SpawnExecution, caller_ns: u64, job_wall_ns: Option<u64>) {
-        match execution {
-            SpawnExecution::Inline => {
-                self.inline_ns = Some(
-                    self.inline_ns
-                        .map_or(caller_ns, |current| update_ewma(current, caller_ns)),
-                );
-                // Keep the raw sample for the safety gate, unblended, so an over-budget run is
-                // seen immediately rather than smoothed away by the EWMA above.
-                self.last_inline_ns = Some(caller_ns);
-            }
-            SpawnExecution::Offload => {
-                self.offload_ns = Some(
-                    self.offload_ns
-                        .map_or(caller_ns, |current| update_ewma(current, caller_ns)),
-                );
-                if let Some(job_wall_ns) = job_wall_ns {
-                    self.job_wall_ns = Some(
-                        self.job_wall_ns
-                            .map_or(job_wall_ns, |current| update_ewma(current, job_wall_ns)),
-                    );
-                }
-            }
-        }
-    }
+// Saturating nanosecond conversion for timing samples.
+fn nanos(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 fn update_ewma(current: u64, next: u64) -> u64 {
@@ -450,54 +516,54 @@ const fn len_bucket(len: usize) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::{
-        Entry, Execution, MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL,
-        SERIAL_SAMPLE_BUDGET_NS, SpawnEntry, SpawnExecution,
+        MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL, RunEntry,
+        RunExecution, SPAWN_INLINE_BUDGET_NS, SpawnEntry, SpawnExecution,
     };
     use std::{panic::Location, time::Duration};
 
     const PARALLELISM: usize = 4;
 
-    fn choose(entry: &mut Entry) -> (Execution, bool) {
+    fn choose(entry: &mut RunEntry) -> (RunExecution, bool) {
         entry.choose(PARALLELISM)
     }
 
     #[test]
     fn starts_parallel_then_seeds_serial_immediately() {
-        let mut entry = Entry::default();
+        let mut entry = RunEntry::default();
 
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
-        entry.record(Execution::Parallel, Duration::from_micros(100));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
 
         // The projection fits the budget, so the serial seed is offered on the very next
         // call rather than after a full interval.
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
-        entry.record(Execution::Serial, Duration::from_micros(95));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
+        entry.record(RunExecution::Serial, Duration::from_micros(95));
 
         // With both estimates seeded, the boundary resumes its normal cadence.
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
     fn defers_serial_seed_when_projection_exceeds_budget() {
-        let mut entry = Entry::default();
+        let mut entry = RunEntry::default();
 
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
-        entry.record(Execution::Parallel, Duration::from_millis(10));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
 
         // The projection (10ms x 4) is over budget, so the immediate boundary refreshes
         // parallel instead of seeding serial and the cadence resets to a full interval.
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
-        assert!(entry.serial_ns.is_none());
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
+        assert!(entry.serial_ns.get().is_none());
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
     }
@@ -506,34 +572,34 @@ mod tests {
     fn never_seeds_serial_when_projection_exceeds_budget() {
         // A serial pass could cost up to parallel * parallelism. When that projection exceeds
         // the budget, the tuner biases to parallel without ever paying a serial sample.
-        let mut entry = Entry::default();
+        let mut entry = RunEntry::default();
 
-        entry.record(Execution::Parallel, Duration::from_millis(10));
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
 
         for i in 1..=(2 * RESAMPLE_INTERVAL) {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert!(entry.serial_ns.is_none());
+        assert!(entry.serial_ns.get().is_none());
     }
 
     #[test]
     fn never_runs_serial_on_big_work() {
         // The production profile of a large signature batch: parallel wall of 25ms on a
         // 12-thread pool. Serial must never run, no matter how many calls arrive.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(25));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(25));
 
         for _ in 0..10_000 {
             let (execution, measure) = entry.choose(12);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
             if measure {
-                entry.record(Execution::Parallel, Duration::from_millis(25));
+                entry.record(RunExecution::Parallel, Duration::from_millis(25));
             }
         }
-        assert!(entry.serial_ns.is_none());
+        assert!(entry.serial_ns.get().is_none());
     }
 
     #[test]
@@ -541,13 +607,13 @@ mod tests {
         // Both estimates exceed the budget and serial nominally wins the comparison, but the
         // tuner only arbitrates small cases: big work runs parallel outright, and the serial
         // probe stays suppressed because the projection is over budget too.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(30));
-        entry.record(Execution::Serial, Duration::from_millis(12));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(30));
+        entry.record(RunExecution::Serial, Duration::from_millis(12));
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             let (execution, _) = choose(&mut entry);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
         }
     }
 
@@ -556,44 +622,44 @@ mod tests {
         // A workload grew within its bucket: parallel is now 25ms on a 12-thread pool
         // (projection 300ms, well over budget), but a stale serial estimate from a smaller
         // input claims 8ms. The live projection must keep serial from running.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(25));
-        entry.record(Execution::Serial, Duration::from_millis(8));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(25));
+        entry.record(RunExecution::Serial, Duration::from_millis(8));
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             let (execution, _) = entry.choose(12);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
         }
     }
 
     #[test]
     fn prefers_serial_when_faster() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(95));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(95));
 
-        assert_eq!(choose(&mut entry), (Execution::Serial, false));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, false));
     }
 
     #[test]
     fn prefers_parallel_when_it_wins_wall_time() {
         // Serial is only 2x slower in wall time (cheaper in worker time on a 4-thread pool),
         // but the policy optimizes latency: parallel wins.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(200));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(200));
 
-        assert_eq!(choose(&mut entry), (Execution::Parallel, false));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, false));
     }
 
     #[test]
     fn prefers_serial_on_tie() {
         // Equal wall time: serial occupies one worker instead of the whole pool.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(100));
 
-        assert_eq!(choose(&mut entry), (Execution::Serial, false));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, false));
     }
 
     #[test]
@@ -601,55 +667,55 @@ mod tests {
         // Before serial is seeded there is no loser: parallel samples smooth into the EWMA,
         // so a single outlier (a contended call) cannot swing the projection that gates
         // serial sampling.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(10));
-        entry.record(Execution::Parallel, Duration::from_millis(20));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
+        entry.record(RunExecution::Parallel, Duration::from_millis(20));
 
-        assert_eq!(entry.parallel_ns, Some(12_000_000));
+        assert_eq!(entry.parallel_ns.get(), Some(12_000_000));
     }
 
     #[test]
     fn blends_preferred_samples_with_integer_math() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_nanos(1000));
-        entry.record(Execution::Serial, Duration::from_nanos(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_nanos(1000));
+        entry.record(RunExecution::Serial, Duration::from_nanos(100));
 
         // Serial is preferred, so further serial samples blend 4:1.
-        entry.record(Execution::Serial, Duration::from_nanos(200));
+        entry.record(RunExecution::Serial, Duration::from_nanos(200));
 
-        assert_eq!(entry.serial_ns, Some(120));
+        assert_eq!(entry.serial_ns.get(), Some(120));
     }
 
     #[test]
     fn blends_preferred_parallel_samples() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_nanos(100));
-        entry.record(Execution::Serial, Duration::from_nanos(1000));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_nanos(100));
+        entry.record(RunExecution::Serial, Duration::from_nanos(1000));
 
         // Parallel is preferred, so further parallel samples blend 4:1.
-        entry.record(Execution::Parallel, Duration::from_nanos(200));
+        entry.record(RunExecution::Parallel, Duration::from_nanos(200));
 
-        assert_eq!(entry.parallel_ns, Some(120));
+        assert_eq!(entry.parallel_ns.get(), Some(120));
     }
 
     #[test]
     fn probes_blend_into_stale_estimates() {
         // A probe's sample blends like any other, so one probe moves a stale estimate by a
         // fifth of the gap rather than trusting a single measurement outright.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(25));
-        entry.record(Execution::Serial, Duration::from_millis(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(25));
+        entry.record(RunExecution::Serial, Duration::from_millis(100));
 
-        entry.record(Execution::Serial, Duration::from_millis(5));
+        entry.record(RunExecution::Serial, Duration::from_millis(5));
 
-        assert_eq!(entry.serial_ns, Some(81_000_000));
+        assert_eq!(entry.serial_ns.get(), Some(81_000_000));
         assert_eq!(
-            Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+            RunEntry::preferred(
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
     }
 
@@ -657,80 +723,80 @@ mod tests {
     fn seeds_serial_once_projection_shrinks_into_budget() {
         // The projection is live: a key that starts over budget seeds serial at the first
         // boundary after refreshes shrink the parallel estimate into the budget.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(10));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
 
         for _ in 1..RESAMPLE_INTERVAL {
             let (execution, measure) = choose(&mut entry);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
             if measure {
-                entry.record(Execution::Parallel, Duration::from_micros(100));
+                entry.record(RunExecution::Parallel, Duration::from_micros(100));
             }
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
     }
 
     #[test]
     fn resamples_other_execution() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(80));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(80));
 
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
     fn resamples_serial_when_parallel_wins() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(150));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(150));
 
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
     }
 
     #[test]
     fn resample_interval_doubles_per_slowdown_multiple() {
         // Parallel lost by 2x-3x, so the probe interval doubles once.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(250));
-        entry.record(Execution::Serial, Duration::from_micros(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(250));
+        entry.record(RunExecution::Serial, Duration::from_micros(100));
 
         for i in 1..(2 * RESAMPLE_INTERVAL) {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
     fn resample_interval_is_capped() {
         // Serial lost by 9x, so the interval shift is capped and the probe still happens.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(900));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(900));
 
         let interval = RESAMPLE_INTERVAL << MAX_RESAMPLE_SHIFT;
         for i in 1..interval {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
     }
 
     #[test]
@@ -739,40 +805,40 @@ mod tests {
         // is preferred. The projection is still under budget (2ms x 4 = 8ms). The true
         // parallel cost is 0.5ms: probes blend the estimate down geometrically until the
         // preference flips.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(2));
-        entry.record(Execution::Serial, Duration::from_millis(1));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(2));
+        entry.record(RunExecution::Serial, Duration::from_millis(1));
         assert_eq!(
-            Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+            RunEntry::preferred(
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Serial
+            RunExecution::Serial
         );
 
         let mut probes = 0;
         let mut flipped_at = None;
         for i in 1..=1_000 {
-            if Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+            if RunEntry::preferred(
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM,
-            ) == Execution::Parallel
+            ) == RunExecution::Parallel
             {
                 flipped_at = Some(i - 1);
                 break;
             }
             let (execution, measure) = choose(&mut entry);
             match execution {
-                Execution::Parallel => {
+                RunExecution::Parallel => {
                     assert!(measure);
                     probes += 1;
-                    entry.record(Execution::Parallel, Duration::from_micros(500));
+                    entry.record(RunExecution::Parallel, Duration::from_micros(500));
                 }
-                Execution::Serial => {
+                RunExecution::Serial => {
                     if measure {
-                        entry.record(Execution::Serial, Duration::from_millis(1));
+                        entry.record(RunExecution::Serial, Duration::from_millis(1));
                     }
                 }
             }
@@ -790,22 +856,22 @@ mod tests {
         // Exactly one caller crosses the probe boundary and receives the serial seed, so
         // concurrent callers cannot herd onto serial. A seed whose sample never lands (the
         // call panicked) is offered again one interval later instead of wedging the key.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(250));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(250));
 
         for round in 0..2 {
             for i in 1..RESAMPLE_INTERVAL {
                 assert_eq!(
                     choose(&mut entry),
-                    (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0),
+                    (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0),
                     "round {round}"
                 );
             }
-            assert_eq!(choose(&mut entry), (Execution::Serial, true));
+            assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
         }
 
-        entry.record(Execution::Serial, Duration::from_millis(1));
-        assert_eq!(choose(&mut entry).0, Execution::Parallel);
+        entry.record(RunExecution::Serial, Duration::from_millis(1));
+        assert_eq!(choose(&mut entry).0, RunExecution::Parallel);
     }
 
     #[test]
@@ -813,16 +879,16 @@ mod tests {
         // A serial estimate poisoned over the budget (e.g. one contended stall) must not
         // lock serial out forever: the probe gate reads the live projection, not the stale
         // estimate.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(500));
-        entry.record(Execution::Serial, Duration::from_millis(15));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(500));
+        entry.record(RunExecution::Serial, Duration::from_millis(15));
         assert_eq!(
-            Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+            RunEntry::preferred(
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
 
         // Slowdown 15ms / 500us = 30 caps the shift, so the probe fires at 100 << 5 calls.
@@ -830,57 +896,57 @@ mod tests {
         for i in 1..interval {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
 
-        entry.record(Execution::Serial, Duration::from_micros(300));
-        assert_eq!(entry.serial_ns, Some(12_060_000));
+        entry.record(RunExecution::Serial, Duration::from_micros(300));
+        assert_eq!(entry.serial_ns.get(), Some(12_060_000));
     }
 
     #[test]
     fn poisoned_probe_cannot_flip_preference() {
         // A spuriously fast serial sample (e.g. from a contended probe) blends into the EWMA
         // and cannot flip the preference on its own.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(800));
-        entry.record(Execution::Serial, Duration::from_millis(3));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(800));
+        entry.record(RunExecution::Serial, Duration::from_millis(3));
         assert_eq!(
-            Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+            RunEntry::preferred(
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
 
-        entry.record(Execution::Serial, Duration::from_micros(20));
+        entry.record(RunExecution::Serial, Duration::from_micros(20));
 
-        assert_eq!(entry.serial_ns, Some(2_404_000));
+        assert_eq!(entry.serial_ns.get(), Some(2_404_000));
         assert_eq!(
-            Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+            RunEntry::preferred(
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
     }
 
     #[test]
     fn refreshes_preferred_parallel_sample() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(410));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(410));
 
         for i in 1..PREFERRED_SAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
@@ -913,8 +979,8 @@ mod tests {
                     work,
                     PARALLELISM,
                     |execution| match execution {
-                        Execution::Parallel => Err(()),
-                        Execution::Serial => Ok(()),
+                        RunExecution::Parallel => Err(()),
+                        RunExecution::Serial => Ok(()),
                     },
                 );
         }
@@ -923,75 +989,115 @@ mod tests {
     }
 
     #[test]
-    fn spawn_seeds_offload_then_inlines_a_tiny_poorly_overlapped_job() {
+    fn spawn_seeds_offload_then_inlines_a_sub_overhead_job() {
         let mut entry = SpawnEntry::default();
 
-        // The first call seeds the offload estimate (and the job's own wall time).
+        // The first call seeds both estimates from an offloaded run.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        // A 2us job whose caller-visible cost was 50us: the overlap did not hide it.
-        entry.record(SpawnExecution::Offload, 50_000, Some(2_000));
+        // A 2us job behind a 50us round-trip overhead.
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
 
-        // The seed leaves the entry due for an immediate boundary, which re-probes offload.
+        // The seed leaves the entry due for an immediate boundary, which re-measures offload.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        entry.record(SpawnExecution::Offload, 50_000, Some(2_000));
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
 
-        // The job (2us) fits the budget and beats its 50us offload cost, so inline wins.
+        // The job costs less than the overhead and fits the budget, so it runs inline.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Inline, false)
         );
     }
 
     #[test]
-    fn spawn_keeps_offloading_a_well_overlapped_job() {
+    fn spawn_keeps_offloading_a_job_bigger_than_the_overhead() {
+        // A 50us job behind a 5us round-trip overhead: offloading is cheaper under any polling.
         let mut entry = SpawnEntry::default();
-
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        // A 50us job whose caller-visible cost was only 3us: the overlap hid almost all of it.
-        entry.record(SpawnExecution::Offload, 3_000, Some(50_000));
+        entry.job_ns.record(50_000);
+        entry.overhead_ns.record(5_000);
 
-        // Offload is preferred (3us beats a 50us inline), so the boundary probes the inline loser.
+        // The seed leaves the entry due for a boundary, which probes inline (the worker wall
+        // fits the budget) to observe the inline wall.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Inline, true)
         );
-        entry.record(SpawnExecution::Inline, 50_000, None);
+        entry.inline_ns.record(50_000);
 
-        // With both estimates known, offload still wins because the overlap makes it cheaper.
+        // The inline wall confirms the job is bigger than the overhead, so offload holds until
+        // the next (backed-off) boundary.
+        for _ in 0..(2 * RESAMPLE_INTERVAL) {
+            match entry.choose(SPAWN_INLINE_BUDGET_NS) {
+                (SpawnExecution::Offload, measure) => {
+                    if measure {
+                        entry.job_ns.record(50_000);
+                        entry.overhead_ns.record(5_000);
+                    }
+                }
+                (execution, _) => panic!("expected offload, got {execution:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn spawn_probe_learns_the_inline_wall() {
+        // The worker-measured wall (25us, migrated to another core) exceeds the 10us overhead,
+        // so the entry seeds into offload. The boundary probe runs the job inline, the inline
+        // wall (8us) comes in under the overhead, and the entry flips: without the probe this
+        // state is unlearnable.
+        let mut entry = SpawnEntry::default();
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
-            SpawnExecution::Offload
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
+        entry.job_ns.record(25_000);
+        entry.overhead_ns.record(10_000);
+
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, true)
+        );
+        entry.inline_ns.record(8_000);
+
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, false)
         );
     }
 
     #[test]
-    fn spawn_never_inlines_a_job_over_the_executor_block_budget() {
+    fn spawn_budget_caps_inline_when_the_overhead_is_inflated() {
+        // A contended pool measured the round-trip overhead at 50ms. The 2ms job is cheaper, but its
+        // EWMA exceeds the inline budget, so it remains offloaded.
         let mut entry = SpawnEntry::default();
-
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        // A job whose measured wall exceeds the budget must never run inline (it would stall the
-        // async executor), no matter how the caller-visible cost compares.
-        let over_budget = SERIAL_SAMPLE_BUDGET_NS * 2;
-        entry.record(SpawnExecution::Offload, over_budget, Some(over_budget));
+        entry.job_ns.record(2_000_000);
+        entry.overhead_ns.record(50_000_000);
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
-            assert_eq!(
-                entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
-                SpawnExecution::Offload
-            );
-            entry.record(SpawnExecution::Offload, over_budget, Some(over_budget));
+            match entry.choose(SPAWN_INLINE_BUDGET_NS) {
+                (SpawnExecution::Offload, measure) => {
+                    if measure {
+                        entry.job_ns.record(2_000_000);
+                        entry.overhead_ns.record(50_000_000);
+                    }
+                }
+                (execution, _) => panic!("expected offload, got {execution:?}"),
+            }
         }
     }
 
@@ -1007,47 +1113,154 @@ mod tests {
     }
 
     #[test]
-    fn spawn_offloads_after_a_single_over_budget_inline_sample() {
-        // Start from a cheap, converged inline estimate: offload is expensive, inline is cheap, and
-        // both sit well under the budget.
-        let mut entry = SpawnEntry {
-            offload_ns: Some(30_000_000), // offloading measured at 30ms
-            inline_ns: Some(2_000),       // established cheap inline EWMA (2us)
-            last_inline_ns: Some(2_000),
-            job_wall_ns: Some(2_000),
-            ..Default::default()
-        };
-        // One inline run now measures 15ms, over the 10ms budget. The blended `inline_ns` stays
-        // ~3ms (still "safe" on its own), but the raw safety gate must offload on this single
-        // sample rather than wait for the EWMA to cross the budget.
-        entry.record(SpawnExecution::Inline, 15_000_000, None);
+    fn spawn_inline_ewma_crossing_the_overhead_revokes_inline() {
+        // A converged-inline entry whose inline wall grows: the flip must come from the inline
+        // EWMA while the worker wall stays low, pinning that the decision prefers the inline
+        // wall once one exists.
+        let mut entry = SpawnEntry::default();
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
+        entry.inline_ns.record(2_000);
+        assert!(matches!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, _)
+        ));
+
+        // One grown sample blends the inline EWMA over the 50us overhead.
+        entry.inline_ns.record(500_000);
+        assert_eq!(entry.inline_ns.get(), Some(101_600));
+        assert!(matches!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Offload, _)
+        ));
+    }
+
+    #[test]
+    fn spawn_records_feed_choose() {
+        // Policy-level wiring for the three spawn record paths: the worker and future samples
+        // seed the entry, and the probe's inline sample drives the flip.
+        let policy = Policy::default();
+        let location = Location::caller();
+
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
-            SpawnExecution::Offload
+            policy.choose_spawn(location, 64, PARALLELISM),
+            (SpawnExecution::Offload, true)
+        );
+        policy.record_spawn_job(location, 64, PARALLELISM, Duration::from_micros(25));
+        policy.record_spawn_overhead(location, 64, PARALLELISM, Duration::from_micros(10));
+
+        // The boundary probes inline (the worker wall fits the budget).
+        assert_eq!(
+            policy.choose_spawn(location, 64, PARALLELISM),
+            (SpawnExecution::Inline, true)
+        );
+
+        // The probe's inline wall beats the overhead, so the entry flips inline: recording it
+        // anywhere but the inline estimate would leave the entry offloaded.
+        policy.record_spawn_inline(location, 64, PARALLELISM, Duration::from_micros(8));
+        assert_eq!(
+            policy.choose_spawn(location, 64, PARALLELISM),
+            (SpawnExecution::Inline, false)
         );
     }
 
     #[test]
-    fn spawn_probes_inline_to_recover_after_a_transient_slow_run() {
-        // A transient slow inline left `last_inline_ns` over budget, so the gate is unsafe and the
-        // entry is offloading. Fresh offloads now show the job is small again (`job_wall` under
-        // budget), and the entry is due for a boundary.
-        let mut entry = SpawnEntry {
-            offload_ns: Some(5_000),          // 5us
-            job_wall_ns: Some(2_000),         // 2us: fresh offload evidence, the job is small
-            inline_ns: Some(3_000_000),       // stale 3ms EWMA from the slow run
-            last_inline_ns: Some(15_000_000), // 15ms: over budget, currently locks out inline
-            since_probe: u32::MAX,
-        };
-        // Rather than offload forever, the boundary schedules a controlled inline probe because the
-        // offload evidence is under budget.
+    fn spawn_uses_job_ewma() {
+        // A converged-inline entry: cheap job, expensive round trip.
+        let mut entry = SpawnEntry::default();
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
+        entry.inline_ns.record(2_000);
+
+        // The latest inline sample exceeds the overhead, but the EWMA remains below it.
+        entry.inline_ns.record(100_000);
+        assert_eq!(entry.inline_ns.get(), Some(21_600));
+        assert!(matches!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, _)
+        ));
+    }
+
+    #[test]
+    fn spawn_recovers_after_a_transient_slow_run() {
+        // A spike poisoned the inline estimate. Boundary probes are gated on the live worker
+        // wall rather than the stale inline estimate, so probe samples blend the estimate back
+        // down and inline placement returns.
+        let mut entry = SpawnEntry::default();
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
+        entry.inline_ns.record(15_000_000);
+
+        let mut calls: u32 = 0;
+        loop {
+            match entry.choose(SPAWN_INLINE_BUDGET_NS) {
+                (SpawnExecution::Inline, measure) => {
+                    if measure {
+                        entry.inline_ns.record(2_000);
+                    }
+                    if entry.inline_ns.get().unwrap() <= 50_000 {
+                        break;
+                    }
+                }
+                (SpawnExecution::Offload, measure) => {
+                    if measure {
+                        entry.job_ns.record(2_000);
+                        entry.overhead_ns.record(50_000);
+                    }
+                }
+            }
+            calls += 1;
+            assert!(calls <= 100_000, "inline placement never recovered");
+        }
+    }
+
+    #[test]
+    fn spawn_inline_records_on_cadence_and_probes_offload() {
+        // The overhead is within 2x of the job, so the shared cadence probes at its base
+        // interval.
+        let mut entry = SpawnEntry::default();
+        entry.job_ns.record(30_000);
+        entry.overhead_ns.record(50_000);
+
+        for i in 1..RESAMPLE_INTERVAL {
+            assert_eq!(
+                entry.choose(SPAWN_INLINE_BUDGET_NS),
+                (
+                    SpawnExecution::Inline,
+                    i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
+                ),
+                "call {i}"
+            );
+        }
+        // The boundary hands one call back to the pool so the overhead estimate stays live.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Inline, true)
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
         );
-        // The probe measures the now-tiny job, clearing the raw over-budget gate so the entry can
-        // inline again.
-        entry.record(SpawnExecution::Inline, 2_000, None);
-        assert!(entry.last_inline_ns.unwrap() < SERIAL_SAMPLE_BUDGET_NS);
+    }
+
+    #[test]
+    fn spawn_probe_interval_is_capped() {
+        // Inline wins by 25x, so the offload probe backs off to the capped interval while the
+        // measure cadence continues, matching the serial-vs-parallel entries.
+        let mut entry = SpawnEntry::default();
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
+
+        let interval = RESAMPLE_INTERVAL << MAX_RESAMPLE_SHIFT;
+        for i in 1..interval {
+            assert_eq!(
+                entry.choose(SPAWN_INLINE_BUDGET_NS),
+                (
+                    SpawnExecution::Inline,
+                    i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
+                ),
+                "call {i}"
+            );
+        }
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
     }
 }

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -315,8 +315,14 @@ impl Entry {
     }
 }
 
-/// Timing state for one spawn [`Key`]: the caller-visible cost of inlining vs offloading, the job's
-/// measured wall time on the pool, and the latest raw inline sample used by the safety gate.
+/// Timing state for one spawn [`Key`].
+///
+/// Offloading never makes the job itself run faster. What it buys is overlap: the calling task can
+/// do other work while the job runs on the pool, so the caller waits only for whatever is left when
+/// it finally awaits the result. `choose` therefore compares the caller's *wait*, not the job's
+/// runtime: the whole job if inlined, versus the hand-off plus that leftover if offloaded (measured
+/// in [`crate::Strategy::spawn`]). Offloading wins when the caller has enough of its own work to
+/// overlap the job behind.
 #[derive(Clone, Copy, Debug, Default)]
 struct SpawnEntry {
     inline_ns: Option<u64>,

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -2567,7 +2567,7 @@ mod tests {
             assert_eq!(strategy.parallelism(), 2);
 
             let output = strategy
-                .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+                .spawn(2, |strategy| strategy.map_collect_vec(0..2, |i| i + 1))
                 .await;
 
             assert_eq!(output, vec![1, 2]);
@@ -2585,7 +2585,7 @@ mod tests {
             assert_eq!(first.parallelism(), 1);
             assert_eq!(first.run(2, || "serial", || "parallel"), "serial");
             let output = first
-                .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+                .spawn(2, |strategy| strategy.map_collect_vec(0..2, |i| i + 1))
                 .now_or_never()
                 .expect("single-threaded pool should run spawned work inline");
             assert_eq!(output, vec![1, 2]);
@@ -2594,7 +2594,7 @@ mod tests {
             assert_eq!(second.parallelism(), 3);
             assert_eq!(second.run(2, || "serial", || "parallel"), "parallel");
             let output = second
-                .spawn(|strategy| strategy.map_collect_vec(0..3, |i| i + 1))
+                .spawn(3, |strategy| strategy.map_collect_vec(0..3, |i| i + 1))
                 .now_or_never()
                 .expect("single-threaded pool should run spawned work inline");
             assert_eq!(output, vec![1, 2, 3]);
@@ -2606,7 +2606,7 @@ mod tests {
             assert_eq!(third.parallelism(), 4);
             assert_eq!(third.run(2, || "serial", || "parallel"), "parallel");
             let output = third
-                .spawn(|strategy| strategy.map_collect_vec(0..4, |i| i + 1))
+                .spawn(4, |strategy| strategy.map_collect_vec(0..4, |i| i + 1))
                 .now_or_never()
                 .expect("single-threaded pool should run spawned work inline");
             assert_eq!(output, vec![1, 2, 3, 4]);
@@ -2624,7 +2624,7 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
 
             let output = strategy
-                .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+                .spawn(2, |strategy| strategy.map_collect_vec(0..2, |i| i + 1))
                 .await;
             assert_eq!(output, vec![1, 2]);
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -3320,7 +3320,7 @@ mod tests {
             let strategy = context.child("pool").strategy(NZUsize!(1)).manual();
 
             let output = strategy
-                .spawn(|strategy| strategy.map_collect_vec(0..2, |i| i + 1))
+                .spawn(2, |strategy| strategy.map_collect_vec(0..2, |i| i + 1))
                 .await;
 
             assert_eq!(output, vec![1, 2]);

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -1036,7 +1036,7 @@ mod tests {
         let runner = std::thread::spawn(move || {
             let strategy = Runner::new(cfg).start(move |context| async move {
                 let strategy = context.strategy(NZUsize!(2));
-                strategy.spawn(|_| ()).await;
+                strategy.spawn(1, |_| ()).await;
                 retain.then_some(strategy)
             });
             strategy_tx.send(strategy).unwrap();
@@ -1155,7 +1155,7 @@ mod tests {
         assert!(run_with_returned_strategy(false).is_none());
 
         let strategy = run_with_returned_strategy(true).unwrap();
-        assert_eq!(futures::executor::block_on(strategy.spawn(|_| 42)), 42);
+        assert_eq!(futures::executor::block_on(strategy.spawn(1, |_| 42)), 42);
     }
 
     #[test]
@@ -1168,7 +1168,7 @@ mod tests {
                 std::panic::catch_unwind(AssertUnwindSafe(|| {
                     Runner::new(cfg).start(move |context| async move {
                         let strategy = context.strategy(NZUsize!(2));
-                        strategy.spawn(|_| ()).await;
+                        strategy.spawn(1, |_| ()).await;
                         std::panic::panic_any(strategy);
                     });
                 }));
@@ -1184,7 +1184,7 @@ mod tests {
             .expect("Runner::start did not resume the strategy panic payload");
         runner.join().unwrap();
         let _ = std::fs::remove_dir_all(storage_directory);
-        assert_eq!(futures::executor::block_on(strategy.spawn(|_| 42)), 42);
+        assert_eq!(futures::executor::block_on(strategy.spawn(1, |_| 42)), 42);
     }
 
     #[test]

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -329,8 +329,7 @@ where
     /// The job hashes against an immutable snapshot of the committed Merkle state, so a parallel
     /// strategy can host the batch's dominant CPU phase on its own pool instead of occupying the
     /// calling task. If the job's caller is cancelled, the job still runs to completion
-    /// against its snapshot and the result is discarded (a panic inside the job is caught by
-    /// [`Strategy::spawn`] and only propagates to a caller that awaits it).
+    /// against its snapshot and the result is discarded.
     pub(crate) async fn merkleize(
         &self,
         batch: UnmerkleizedBatch<F, H, C::Item, S>,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -323,13 +323,12 @@ where
         }
     }
 
-    /// Add `items` to `batch`, merkleize, and compute the post-apply root, all as one CPU-bound
-    /// job submitted through [`Strategy::spawn`].
+    /// Add `items` to `batch`, merkleize, and compute the post-apply root, all as one CPU-bound job
+    /// submitted through [`Strategy::spawn`].
     ///
     /// The job hashes against an immutable snapshot of the committed Merkle state, so a parallel
     /// strategy can host the batch's dominant CPU phase on its own pool instead of occupying the
-    /// calling task -- or run it inline when the batch is small enough that the pool hand-off would
-    /// not pay. If an offloaded job's caller is cancelled mid-job, the job still runs to completion
+    /// calling task. If the job's caller is cancelled, the job still runs to completion
     /// against its snapshot and the result is discarded (a panic inside the job is caught by
     /// [`Strategy::spawn`] and only propagates to a caller that awaits it).
     pub(crate) async fn merkleize(
@@ -345,9 +344,8 @@ where
         let mem = self.merkle.snapshot();
         let hasher = self.hasher.clone();
         let strategy = self.strategy().clone();
-        let items_len = items.len();
         strategy
-            .spawn(items_len, move |_| {
+            .spawn(items.len(), move |_| {
                 let merkleized = batch.add_many(items).merkleize(&mem);
                 let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
                 drop(ancestors);

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -326,11 +326,12 @@ where
     /// Add `items` to `batch`, merkleize, and compute the post-apply root, all as one CPU-bound
     /// job submitted through [`Strategy::spawn`].
     ///
-    /// The job hashes against an immutable snapshot of the committed Merkle state, so a
-    /// parallel strategy hosts the batch's dominant CPU phase on its own pool instead of
-    /// occupying the calling task. If the caller is cancelled mid-job, the job still runs to
-    /// completion against its snapshot and the result is discarded (a panic inside the job is
-    /// caught by [`Strategy::spawn`] and only propagates to a caller that awaits it).
+    /// The job hashes against an immutable snapshot of the committed Merkle state, so a parallel
+    /// strategy can host the batch's dominant CPU phase on its own pool instead of occupying the
+    /// calling task -- or run it inline when the batch is small enough that the pool hand-off would
+    /// not pay. If an offloaded job's caller is cancelled mid-job, the job still runs to completion
+    /// against its snapshot and the result is discarded (a panic inside the job is caught by
+    /// [`Strategy::spawn`] and only propagates to a caller that awaits it).
     pub(crate) async fn merkleize(
         &self,
         batch: UnmerkleizedBatch<F, H, C::Item, S>,
@@ -344,8 +345,9 @@ where
         let mem = self.merkle.snapshot();
         let hasher = self.hasher.clone();
         let strategy = self.strategy().clone();
+        let items_len = items.len();
         strategy
-            .spawn(move |_| {
+            .spawn(items_len, move |_| {
                 let merkleized = batch.add_many(items).merkleize(&mem);
                 let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
                 drop(ancestors);

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -26,7 +26,7 @@ use ahash::{AHashMap, AHashSet};
 use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
-use commonware_utils::bitmap;
+use commonware_utils::{bitmap, iter::zip_eq};
 use core::{cmp::Ordering, ops::Range};
 use std::{
     collections::{BTreeMap, hash_map},
@@ -1118,17 +1118,9 @@ where
                         }
                     };
 
-                    // One resolved operation per read candidate: the zip below would silently
-                    // drop a surplus.
-                    assert_eq!(
-                        read_candidates.len(),
-                        resolved.iter().map(Vec::len).sum::<usize>()
-                    );
-
-                    // Classify each candidate against the pre-raise state, in candidate
-                    // order.
+                    // Classify each candidate against the pre-raise state, in candidate order.
                     let outcomes: Vec<FloorOutcome<F>> = strategy.map_collect_vec(
-                        read_candidates.iter().zip(resolved.iter().flatten()),
+                        zip_eq(read_candidates.iter(), resolved.iter().flatten()),
                         |(loc, op)| classify(*loc, op),
                     );
                     (resolved, outcomes)

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -41,9 +41,6 @@ type DiffSlice<K, F, V> = [(K, DiffEntry<F, V>)];
 /// Sorted locations at the retained batch chain's committed boundary.
 type AncestorBaseLocs<K, F> = Vec<(K, Option<Location<F>>)>;
 
-/// One contiguous chunk of floor-raise candidates paired with their resolved operations.
-type CandidateChunk<'a, F, U> = (&'a [Location<F>], &'a [Operation<F, U>]);
-
 /// Floor-raise candidates prefetched from the committed prefix of the raise's candidate
 /// source, with their resolved operations. The candidate sequence depends only on the base
 /// floor and that source, so a staged merkleize reads it before its serial bookkeeping
@@ -1059,119 +1056,81 @@ where
                         read_candidates.push(*candidate);
                     }
                 }
-                let (resolved, outcomes): (_, Vec<Vec<FloorOutcome<F>>>) =
-                    if read_candidates.is_empty() {
-                        (Vec::new(), Vec::new())
-                    } else {
-                        // Batch-read candidates: page-cache hits are served by one batched read,
-                        // disk misses are fetched concurrently. Prefetched shards enter as the
-                        // reader probed them, ahead of the live suffix's read.
-                        let live = &read_candidates[pf_count..];
-                        let mut resolved = pf_shards;
-                        if !live.is_empty() {
-                            resolved.extend(self.read_ops_sharded(live, &ops, &db.log).await?);
-                        }
+                let (resolved, outcomes): (_, Vec<FloorOutcome<F>>) = if read_candidates.is_empty()
+                {
+                    (Vec::new(), Vec::new())
+                } else {
+                    // Batch-read candidates: page-cache hits are served by one batched read,
+                    // disk misses are fetched concurrently. Prefetched shards enter as the
+                    // reader probed them, ahead of the live suffix's read.
+                    let live = &read_candidates[pf_count..];
+                    let mut resolved = pf_shards;
+                    if !live.is_empty() {
+                        resolved.extend(self.read_ops_sharded(live, &ops, &db.log).await?);
+                    }
 
-                        // Classification is the first consumer of the sorted diff. By now the
-                        // sort has overlapped the fill and read above.
-                        if let Some(job) = diff_sort.take() {
-                            diff = job.await;
-                        }
+                    // Classification is the first consumer of the sorted diff. By now the
+                    // sort has overlapped the fill and read above.
+                    if let Some(job) = diff_sort.take() {
+                        diff = job.await;
+                    }
 
-                        // Classify read candidates against the pre-raise state (see
-                        // [`FloorOutcome`]). Revalidation is required even for candidates whose
-                        // committed bitmap bit is set: an uncommitted ancestor diff may supersede
-                        // the committed location, and that is not reflected in the bitmap.
-                        let classify = |candidate: Location<F>, op: &Operation<F, U>| {
-                            let Some(key) = op.key() else {
-                                return FloorOutcome::Inactive; // CommitFloor and other non-keyed ops
-                            };
-                            match diff.binary_search_by(|(k, _)| k.cmp(key)) {
-                                Ok(idx) => {
-                                    let entry = &diff[idx].1;
+                    // Classify read candidates against the pre-raise state (see
+                    // [`FloorOutcome`]). Revalidation is required even for candidates whose
+                    // committed bitmap bit is set: an uncommitted ancestor diff may supersede
+                    // the committed location, and that is not reflected in the bitmap.
+                    let classify = |candidate: Location<F>, op: &Operation<F, U>| {
+                        let Some(key) = op.key() else {
+                            return FloorOutcome::Inactive; // CommitFloor and other non-keyed ops
+                        };
+                        match diff.binary_search_by(|(k, _)| k.cmp(key)) {
+                            Ok(idx) => {
+                                let entry = &diff[idx].1;
+                                if entry.loc() == Some(candidate) {
+                                    FloorOutcome::MoveExisting {
+                                        idx,
+                                        base_old_loc: entry.base_old_loc(),
+                                    }
+                                } else {
+                                    FloorOutcome::Inactive
+                                }
+                            }
+                            Err(_) => resolve_in_ancestors(&self.ancestors, key).map_or_else(
+                                || {
+                                    if db.snapshot.get(key).any(|&l| l == candidate) {
+                                        FloorOutcome::MoveNew {
+                                            base_old_loc: Some(candidate),
+                                        }
+                                    } else {
+                                        FloorOutcome::Inactive
+                                    }
+                                },
+                                |entry| {
                                     if entry.loc() == Some(candidate) {
-                                        FloorOutcome::MoveExisting {
-                                            idx,
+                                        FloorOutcome::MoveNew {
                                             base_old_loc: entry.base_old_loc(),
                                         }
                                     } else {
                                         FloorOutcome::Inactive
                                     }
-                                }
-                                Err(_) => resolve_in_ancestors(&self.ancestors, key).map_or_else(
-                                    || {
-                                        if db.snapshot.get(key).any(|&l| l == candidate) {
-                                            FloorOutcome::MoveNew {
-                                                base_old_loc: Some(candidate),
-                                            }
-                                        } else {
-                                            FloorOutcome::Inactive
-                                        }
-                                    },
-                                    |entry| {
-                                        if entry.loc() == Some(candidate) {
-                                            FloorOutcome::MoveNew {
-                                                base_old_loc: entry.base_old_loc(),
-                                            }
-                                        } else {
-                                            FloorOutcome::Inactive
-                                        }
-                                    },
-                                ),
-                            }
-                        };
-
-                        // Classify each candidate against the pre-raise state. Both branches yield
-                        // outcomes in candidate order (the caller flattens them).
-                        let outcomes: Vec<Vec<FloorOutcome<F>>> = strategy.run(
-                            read_candidates.len(),
-                            || {
-                                let mut outcomes = Vec::with_capacity(resolved.len());
-                                let mut offset = 0;
-                                for chunk in &resolved {
-                                    let locs = &read_candidates[offset..offset + chunk.len()];
-                                    offset += chunk.len();
-                                    outcomes.push(
-                                        locs.iter()
-                                            .zip(chunk)
-                                            .map(|(loc, op)| classify(*loc, op))
-                                            .collect(),
-                                    );
-                                }
-                                outcomes
-                            },
-                            || {
-                                // Chunk finer (by 4x) than the pool parallelism since snapshot
-                                // probes have varying latency. `manual` runs this fixed partition
-                                // without the policy re-chunking.
-                                let manual = strategy.manual();
-                                let target = read_candidates
-                                    .len()
-                                    .div_ceil(manual.parallelism() * 4)
-                                    .max(1);
-                                let mut chunks: Vec<CandidateChunk<'_, F, U>> = Vec::new();
-                                let mut offset = 0;
-                                for chunk in &resolved {
-                                    let locs = &read_candidates[offset..offset + chunk.len()];
-                                    offset += chunk.len();
-                                    chunks.extend(locs.chunks(target).zip(chunk.chunks(target)));
-                                }
-                                manual.map_collect_vec(chunks, |(chunk_locs, chunk_ops)| {
-                                    chunk_locs
-                                        .iter()
-                                        .zip(chunk_ops)
-                                        .map(|(loc, op)| classify(*loc, op))
-                                        .collect()
-                                })
-                            },
-                        );
-                        (resolved, outcomes)
+                                },
+                            ),
+                        }
                     };
+
+                    // Classify each candidate against the pre-raise state, in candidate
+                    // order.
+                    let outcomes: Vec<FloorOutcome<F>> = strategy.map_collect_vec(
+                        read_candidates.iter().zip(resolved.iter().flatten()),
+                        |(loc, op)| classify(*loc, op),
+                    );
+                    (resolved, outcomes)
+                };
 
                 // Apply in candidate order, moving active ops to the tip. `read_candidates`
                 // preserves candidate order, so a candidate that does not match the next
                 // pending read was superseded and only advances the floor.
-                let mut outcomes = outcomes.into_iter().flatten();
+                let mut outcomes = outcomes.into_iter();
                 let mut reads = resolved.into_iter().flatten();
                 let mut pending = read_candidates.iter().peekable();
                 for candidate in candidates {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1118,6 +1118,13 @@ where
                         }
                     };
 
+                    // One resolved operation per read candidate: the zip below would silently
+                    // drop a surplus.
+                    assert_eq!(
+                        read_candidates.len(),
+                        resolved.iter().map(Vec::len).sum::<usize>()
+                    );
+
                     // Classify each candidate against the pre-raise state, in candidate
                     // order.
                     let outcomes: Vec<FloorOutcome<F>> = strategy.map_collect_vec(
@@ -1216,8 +1223,8 @@ where
         let leaves = self.base_state.size + ops.len() as u64;
         let inactive_peaks = db.inactive_peaks(leaves, floor);
 
-        // Leaf and node hashing dominate merkleization, so run them as one job on the
-        // strategy instead of occupying the calling task (see `Journal::merkleize`).
+        // Leaf and node hashing dominate merkleization, so run them as one job through the
+        // strategy (see `Journal::merkleize`).
         let (journal, root) = db
             .log
             .merkleize(self.journal_batch, ops, inactive_peaks)

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -974,8 +974,7 @@ where
         let mut diff_sort = None;
         if !diff.is_empty() {
             let unsorted = mem::take(&mut diff);
-            let unsorted_len = unsorted.len();
-            diff_sort = Some(db.strategy().spawn(unsorted_len, move |strategy| {
+            diff_sort = Some(db.strategy().spawn(unsorted.len(), move |strategy| {
                 let mut diff = unsorted;
                 strategy.sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
                 diff
@@ -1122,14 +1121,8 @@ where
                             }
                         };
 
-                        // Classify against the pre-raise state. The candidate count drives an
-                        // adaptive serial-vs-parallel choice: a small per-block candidate set is
-                        // classified inline (a pool hand-off would not pay), while a large set
-                        // fans out. When parallel, the work is subdivided past the pool
-                        // parallelism because the snapshot probes that dominate classification
-                        // have variable latency, so finer chunks balance the tail. Both paths keep
-                        // each location aligned with the operation resolved for the same filtered
-                        // candidate and yield outcomes in candidate order (the caller flattens).
+                        // Classify each candidate against the pre-raise state. Both branches yield
+                        // outcomes in candidate order (the caller flattens them).
                         let outcomes: Vec<Vec<FloorOutcome<F>>> = strategy.run(
                             read_candidates.len(),
                             || {
@@ -1148,6 +1141,9 @@ where
                                 outcomes
                             },
                             || {
+                                // Chunk finer (by 4x) than the pool parallelism since snapshot
+                                // probes have varying latency. `manual` runs this fixed partition
+                                // without the policy re-chunking.
                                 let manual = strategy.manual();
                                 let target = read_candidates
                                     .len()

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -974,7 +974,8 @@ where
         let mut diff_sort = None;
         if !diff.is_empty() {
             let unsorted = mem::take(&mut diff);
-            diff_sort = Some(db.strategy().spawn(move |strategy| {
+            let unsorted_len = unsorted.len();
+            diff_sort = Some(db.strategy().spawn(unsorted_len, move |strategy| {
                 let mut diff = unsorted;
                 strategy.sort_by(&mut diff, |a, b| a.0.cmp(&b.0));
                 diff
@@ -1121,31 +1122,53 @@ where
                             }
                         };
 
-                        // Classification is already partitioned by candidate chunk, so use
-                        // manual strategy execution and keep each location aligned with the
-                        // operation resolved for the same filtered candidate. Chunks are
-                        // subdivided past the pool parallelism because the snapshot probes
-                        // that dominate classification have variable latency, so finer
-                        // chunks balance the tail.
-                        let manual = strategy.manual();
-                        let target = read_candidates
-                            .len()
-                            .div_ceil(manual.parallelism() * 4)
-                            .max(1);
-                        let mut chunks: Vec<CandidateChunk<'_, F, U>> = Vec::new();
-                        let mut offset = 0;
-                        for chunk in &resolved {
-                            let locs = &read_candidates[offset..offset + chunk.len()];
-                            offset += chunk.len();
-                            chunks.extend(locs.chunks(target).zip(chunk.chunks(target)));
-                        }
-                        let outcomes = manual.map_collect_vec(chunks, |(chunk_locs, chunk_ops)| {
-                            chunk_locs
-                                .iter()
-                                .zip(chunk_ops)
-                                .map(|(loc, op)| classify(*loc, op))
-                                .collect()
-                        });
+                        // Classify against the pre-raise state. The candidate count drives an
+                        // adaptive serial-vs-parallel choice: a small per-block candidate set is
+                        // classified inline (a pool hand-off would not pay), while a large set
+                        // fans out. When parallel, the work is subdivided past the pool
+                        // parallelism because the snapshot probes that dominate classification
+                        // have variable latency, so finer chunks balance the tail. Both paths keep
+                        // each location aligned with the operation resolved for the same filtered
+                        // candidate and yield outcomes in candidate order (the caller flattens).
+                        let outcomes: Vec<Vec<FloorOutcome<F>>> = strategy.run(
+                            read_candidates.len(),
+                            || {
+                                let mut outcomes = Vec::with_capacity(resolved.len());
+                                let mut offset = 0;
+                                for chunk in &resolved {
+                                    let locs = &read_candidates[offset..offset + chunk.len()];
+                                    offset += chunk.len();
+                                    outcomes.push(
+                                        locs.iter()
+                                            .zip(chunk)
+                                            .map(|(loc, op)| classify(*loc, op))
+                                            .collect(),
+                                    );
+                                }
+                                outcomes
+                            },
+                            || {
+                                let manual = strategy.manual();
+                                let target = read_candidates
+                                    .len()
+                                    .div_ceil(manual.parallelism() * 4)
+                                    .max(1);
+                                let mut chunks: Vec<CandidateChunk<'_, F, U>> = Vec::new();
+                                let mut offset = 0;
+                                for chunk in &resolved {
+                                    let locs = &read_candidates[offset..offset + chunk.len()];
+                                    offset += chunk.len();
+                                    chunks.extend(locs.chunks(target).zip(chunk.chunks(target)));
+                                }
+                                manual.map_collect_vec(chunks, |(chunk_locs, chunk_ops)| {
+                                    chunk_locs
+                                        .iter()
+                                        .zip(chunk_ops)
+                                        .map(|(loc, op)| classify(*loc, op))
+                                        .collect()
+                                })
+                            },
+                        );
                         (resolved, outcomes)
                     };
 
@@ -1215,7 +1238,8 @@ where
         // never revisits it), so the merge inputs are disjoint.
         let mut diff_merge = None;
         if !floor_diff.is_empty() {
-            diff_merge = Some(db.strategy().spawn(move |strategy| {
+            let merge_len = floor_diff.len() + diff.len();
+            diff_merge = Some(db.strategy().spawn(merge_len, move |strategy| {
                 let mut floor_diff = floor_diff;
                 strategy.sort_by(&mut floor_diff, |a, b| a.0.cmp(&b.0));
                 let diff = merge_sorted_diffs(diff, floor_diff);
@@ -1621,9 +1645,10 @@ where
         // source, and the step bound, none of which depend on the resolution. The batch
         // moves into the job, so its floor is captured first.
         let scan_from = self.batch.base.inactivity_floor_loc();
-        let resolve = db
-            .strategy()
-            .spawn(move |strategy| self.resolve_updates(updates, upserts, &strategy));
+        let resolve_len = updates.len() + upserts.len();
+        let resolve = db.strategy().spawn(resolve_len, move |strategy| {
+            self.resolve_updates(updates, upserts, &strategy)
+        });
 
         // Gather the committed-prefix candidates and read their operations, sharded, while
         // the resolution job runs.

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -9,14 +9,13 @@ use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use std::sync::Arc;
 
-/// Encode operations, append them to a compact Merkle batch, merkleize, and compute the
-/// post-apply root, all as one CPU-bound job submitted through [`Strategy::spawn`].
+/// Encode operations, append them to a compact Merkle batch, merkleize, and compute the post-apply
+/// root, all as one CPU-bound job submitted through [`Strategy::spawn`].
 ///
 /// The job hashes against an immutable snapshot of the committed Merkle state, so a parallel
-/// strategy can host the batch's dominant CPU phase on its own pool instead of occupying the
-/// calling task -- or run it inline when the batch is small enough that the pool hand-off would
-/// not pay. If an offloaded job's caller is cancelled mid-job, the job still runs to completion
-/// against its snapshot and the result is discarded.
+/// strategy can offload the dominant CPU phase onto its own pool instead of occupying the calling
+/// task. If the caller is cancelled mid-job, the job still runs to completion against its snapshot
+/// and the result is discarded.
 #[allow(clippy::type_complexity)]
 pub(crate) async fn merkleize_ops<F, H, S, Op>(
     merkle: &compact::Merkle<F, H::Digest, S>,
@@ -34,9 +33,8 @@ where
     let ancestors = batch.retain_ancestors();
     let mem = merkle.snapshot();
     let strategy = merkle.strategy().clone();
-    let ops_len = ops.len();
     strategy
-        .spawn(ops_len, move |strategy| {
+        .spawn(ops.len(), move |strategy| {
             let hasher = qmdb::hasher::<H>();
             let leaf_digests =
                 strategy.map_init_collect_vec(ops.iter().enumerate(), Vec::new, |buf, (i, op)| {

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -13,9 +13,10 @@ use std::sync::Arc;
 /// post-apply root, all as one CPU-bound job submitted through [`Strategy::spawn`].
 ///
 /// The job hashes against an immutable snapshot of the committed Merkle state, so a parallel
-/// strategy hosts the batch's dominant CPU phase on its own pool instead of occupying the
-/// calling task. If the caller is cancelled mid-job, the job still runs to completion against
-/// its snapshot and the result is discarded.
+/// strategy can host the batch's dominant CPU phase on its own pool instead of occupying the
+/// calling task -- or run it inline when the batch is small enough that the pool hand-off would
+/// not pay. If an offloaded job's caller is cancelled mid-job, the job still runs to completion
+/// against its snapshot and the result is discarded.
 #[allow(clippy::type_complexity)]
 pub(crate) async fn merkleize_ops<F, H, S, Op>(
     merkle: &compact::Merkle<F, H::Digest, S>,
@@ -33,8 +34,9 @@ where
     let ancestors = batch.retain_ancestors();
     let mem = merkle.snapshot();
     let strategy = merkle.strategy().clone();
+    let ops_len = ops.len();
     strategy
-        .spawn(move |strategy| {
+        .spawn(ops_len, move |strategy| {
             let hasher = qmdb::hasher::<H>();
             let leaf_digests =
                 strategy.map_init_collect_vec(ops.iter().enumerate(), Vec::new, |buf, (i, op)| {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -872,9 +872,9 @@ where
     });
 
     // Prefetch each chunk's covering ops-tree node, then run graft hashing and the grafted
-    // MMR build/merkleize as one job on the strategy (against a snapshot of the committed
-    // grafted tree) instead of occupying the calling task. An empty graft set hashes
-    // nothing, so it merkleizes inline rather than paying for a job handoff.
+    // MMR build/merkleize as one job through the strategy (against a snapshot of the
+    // committed grafted tree). An empty graft set hashes nothing, so it merkleizes without
+    // submitting a job.
     let graft_inputs = read_graft_inputs::<F, _, N>(&ops_tree_adapter, chunks_to_update).await?;
     let grafted_batch = if graft_inputs.is_empty() {
         let grafted_hasher = grafting::hasher::<F, H>(grafting_height);

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1327,7 +1327,7 @@ mod tests {
     use crate::{mmb, mmr, utils::detached::block_strategy};
     use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
-    use commonware_parallel::Rayon;
+    use commonware_parallel::{Manual, Rayon};
     use commonware_utils::{NZUsize, bitmap::Prunable as BitMap};
     use std::{
         future::Future as _,
@@ -1338,7 +1338,8 @@ mod tests {
     // N=4 -> CHUNK_SIZE_BITS = 32
     const N: usize = 4;
     type Bm = BitMap<N>;
-    type GraftedBatch = Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>;
+    type GraftedBatch =
+        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Manual<Rayon>>>;
     type Location = mmr::Location;
 
     fn make_bitmap(bits: &[bool]) -> Bm {
@@ -1350,7 +1351,7 @@ mod tests {
     }
 
     fn grafted_chain(
-        strategy: &Rayon,
+        strategy: &Manual<Rayon>,
         mem: &Arc<Mem<mmb::Family, <Sha256 as Hasher>::Digest>>,
     ) -> (GraftedBatch, GraftedBatch) {
         let hasher = grafting::hasher::<mmb::Family, Sha256>(grafting::height::<1>());
@@ -1370,6 +1371,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_merkleize_retains_ancestors_after_cancellation() {
         let strategy = Rayon::new(NZUsize!(2)).unwrap();
+        let manual = strategy.manual();
         let mem = Arc::new(Mem::<mmb::Family, <Sha256 as Hasher>::Digest>::new());
         let grafting_height = grafting::height::<1>();
         let graft_inputs = || vec![(0, Sha256::hash(&[b"replacement"]), [1u8; 1])];
@@ -1377,11 +1379,11 @@ mod tests {
         let mut context = TaskContext::from_waker(&waker);
 
         // Observe the worker result so a missing grandparent fails the test directly.
-        let (a, b) = grafted_chain(&strategy, &mem);
+        let (a, b) = grafted_chain(&manual, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
-            &strategy,
+            &manual,
             Arc::clone(&b),
             &mem,
             graft_inputs(),
@@ -1395,11 +1397,11 @@ mod tests {
         assert!(ancestor.upgrade().is_none());
 
         // Drop the waiter while the worker is queued to prove the guard moved with it.
-        let (a, b) = grafted_chain(&strategy, &mem);
+        let (a, b) = grafted_chain(&manual, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
-            &strategy,
+            &manual,
             Arc::clone(&b),
             &mem,
             graft_inputs(),

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -768,9 +768,10 @@ where
     let mut grafted_batch = grafted_parent.new_batch();
     let ancestors = grafted_batch.retain_ancestors();
     let grafted_tree = Arc::clone(grafted_tree);
+    let graft_len = graft_inputs.len();
     strategy
         .clone()
-        .spawn(move |strategy| {
+        .spawn(graft_len, move |strategy| {
             let new_leaves = grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
             for (chunk_idx, digest) in new_leaves {
                 if chunk_idx < old_grafted_leaves {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -768,10 +768,9 @@ where
     let mut grafted_batch = grafted_parent.new_batch();
     let ancestors = grafted_batch.retain_ancestors();
     let grafted_tree = Arc::clone(grafted_tree);
-    let graft_len = graft_inputs.len();
     strategy
         .clone()
-        .spawn(graft_len, move |strategy| {
+        .spawn(graft_inputs.len(), move |strategy| {
             let new_leaves = grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
             for (chunk_idx, digest) in new_leaves {
                 if chunk_idx < old_grafted_leaves {

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -272,8 +272,8 @@ where
         let total_size = base + ops.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
 
-        // Leaf and node hashing dominate merkleization, so run them as one job on the
-        // strategy instead of occupying the calling task (see `Journal::merkleize`).
+        // Leaf and node hashing dominate merkleization, so run them as one job through the
+        // strategy (see `Journal::merkleize`).
         let (journal, root) = db
             .journal
             .merkleize(self.journal_batch, ops, inactive_peaks)

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -17,6 +17,7 @@ use crate::{
 use commonware_codec::EncodeShared;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
+use commonware_utils::iter::zip_eq;
 use std::{
     collections::BTreeMap,
     sync::{Arc, Weak},
@@ -220,7 +221,7 @@ where
 
         if !db_keys.is_empty() {
             let db_results = db.get_many(&db_keys).await?;
-            for (slot, value) in db_indices.into_iter().zip(db_results) {
+            for (slot, value) in zip_eq(db_indices, db_results) {
                 results[slot] = value;
             }
         }
@@ -407,7 +408,7 @@ where
 
         if !db_keys.is_empty() {
             let db_results = db.get_many(&db_keys).await?;
-            for (slot, value) in db_indices.into_iter().zip(db_results) {
+            for (slot, value) in zip_eq(db_indices, db_results) {
                 results[slot] = value;
             }
         }

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -285,8 +285,8 @@ where
         let total_size = self.base.size + ops.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
 
-        // Leaf and node hashing dominate merkleization, so run them as one job on the
-        // strategy instead of occupying the calling task (see `Journal::merkleize`).
+        // Leaf and node hashing dominate merkleization, so run them as one job through the
+        // strategy (see `Journal::merkleize`).
         let (journal, root) = db
             .journal
             .merkleize(self.journal_batch, ops, inactive_peaks)

--- a/storage/src/utils/detached.rs
+++ b/storage/src/utils/detached.rs
@@ -18,7 +18,9 @@ pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<(
     for _ in 0..workers {
         let started_tx = started_tx.clone();
         let release_rx = Arc::clone(&release_rx);
-        drop(strategy.spawn(move |_| {
+        // The job blocks until released, so it must never run inline on the calling
+        // task: submit through `manual()` for an unconditional hand-off.
+        drop(strategy.manual().spawn(1, move |_| {
             started_tx.send(()).unwrap();
             let _ = release_rx.lock().recv();
         }));

--- a/storage/src/utils/detached.rs
+++ b/storage/src/utils/detached.rs
@@ -12,15 +12,19 @@ use std::{
 
 /// Occupy `workers` Rayon workers until the returned sender is dropped.
 pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<()> {
+    // The jobs block until released, so they must never run inline on the calling task.
+    let manual = strategy.manual();
+    assert!(
+        manual.parallelism() >= 2,
+        "block_strategy requires a multi-worker pool"
+    );
     let (started_tx, started_rx) = mpsc::channel();
     let (release_tx, release_rx) = mpsc::channel();
     let release_rx = Arc::new(Mutex::new(release_rx));
     for _ in 0..workers {
         let started_tx = started_tx.clone();
         let release_rx = Arc::clone(&release_rx);
-        // The job blocks until released, so it must never run inline on the calling
-        // task: submit through `manual()` for an unconditional hand-off.
-        drop(strategy.manual().spawn(1, move |_| {
+        drop(manual.spawn(1, move |_| {
             started_tx.send(()).unwrap();
             let _ = release_rx.lock().recv();
         }));

--- a/utils/src/iter.rs
+++ b/utils/src/iter.rs
@@ -88,9 +88,63 @@ macro_rules! non_empty {
     };
 }
 
+/// Zips two iterators, panicking if one is exhausted before the other.
+///
+/// Use this over [`Iterator::zip`] when equal lengths are an invariant: `zip` silently truncates
+/// to the shorter side, hiding the mismatch.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_utils::iter::zip_eq;
+///
+/// let pairs: Vec<_> = zip_eq([1, 2], ["a", "b"]).collect();
+/// assert_eq!(pairs, vec![(1, "a"), (2, "b")]);
+/// ```
+pub fn zip_eq<A: IntoIterator, B: IntoIterator>(a: A, b: B) -> ZipEq<A::IntoIter, B::IntoIter> {
+    ZipEq {
+        a: a.into_iter(),
+        b: b.into_iter(),
+    }
+}
+
+/// See [`zip_eq`].
+#[derive(Clone, Debug)]
+pub struct ZipEq<A, B> {
+    a: A,
+    b: B,
+}
+
+impl<A: Iterator, B: Iterator> Iterator for ZipEq<A, B> {
+    type Item = (A::Item, B::Item);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.a.next(), self.b.next()) {
+            (Some(a), Some(b)) => Some((a, b)),
+            (None, None) => None,
+            (Some(_), None) => panic!("zip_eq: right iterator exhausted first"),
+            (None, Some(_)) => panic!("zip_eq: left iterator exhausted first"),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (a_low, a_high) = self.a.size_hint();
+        let (b_low, b_high) = self.b.size_hint();
+        let high = match (a_high, b_high) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        (a_low.min(b_low), high)
+    }
+}
+
+impl<A: ExactSizeIterator, B: ExactSizeIterator> ExactSizeIterator for ZipEq<A, B> {}
+
 #[cfg(test)]
 mod tests {
-    use super::NonEmpty;
+    use super::{NonEmpty, zip_eq};
 
     #[test]
     fn try_new_rejects_empty() {
@@ -123,6 +177,25 @@ mod tests {
             non_empty![@1..4].into_iter().collect::<Vec<_>>(),
             vec![1, 2, 3]
         );
+    }
+
+    #[test]
+    fn zip_eq_pairs_equal_lengths() {
+        let pairs: Vec<_> = zip_eq([1, 2, 3], ["a", "b", "c"]).collect();
+
+        assert_eq!(pairs, vec![(1, "a"), (2, "b"), (3, "c")]);
+    }
+
+    #[test]
+    #[should_panic(expected = "right iterator exhausted first")]
+    fn zip_eq_panics_when_right_is_shorter() {
+        zip_eq([1, 2], [1]).count();
+    }
+
+    #[test]
+    #[should_panic(expected = "left iterator exhausted first")]
+    fn zip_eq_panics_when_left_is_shorter() {
+        zip_eq([1], [1, 2]).count();
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The merkle strategy's parallelism scaled *negatively* with thread count on
per-block workloads. On an EVM-state replay benchmark (QMDB follower write path,
32-core EPYC, state fully cached), `merkleize` at 8 threads was ~3.3x **slower**
than at 1 thread, and adding threads made it monotonically worse.

The cause was not hashing or a buffer-pool lock. `Strategy::spawn` was the one
strategy op that ignored input size: it unconditionally handed a job to the pool
whenever parallelism > 1, so the merkleize path's tiny per-block jobs each paid a
pool hand-off (oneshot channel + worker wake + work-steal) that dwarfed the work.
`run`/`sort_by`/`map` already adapt serial-vs-parallel by size; `spawn` did not.

## Fix

**`spawn` becomes size-aware.** It takes a `len` and, on a strategy with an adaptive
policy, decides per call site (and per size class) whether to run the job inline on
the calling task or offload it to the pool.

The decision rule (after #4603, which replaced the original caller-residual signal):
a job runs inline iff its measured wall time is no greater than both the measured
**offload round-trip overhead** and a 1ms executor-block budget. The overhead is
everything an offloaded run costs around the job itself: hand-off setup, queueing,
worker wake, result send, task wake, and the observing poll, measured as the spawn
to result-observed elapsed time minus the job's own wall (recorded on the worker, so
job estimates are independent of how or whether the caller polls). A caller that
waits on the result therefore inlines whenever that is measured cheaper; a caller
that polls late inflates its overhead samples with overlap slack, which only ever
biases small jobs toward inline, bounded by the budget. Estimates are per
(call site, size bucket) EWMAs with a shared measurement cadence; entries seed by
offloading, and boundary probes keep both paths' estimates live. To force an
unconditional hand-off, submit through `manual()`; a single-worker pool always runs
jobs inline.

**Callers pass the job size.** The QMDB/journal merkleize path is the motivating
win: journal `merkleize`, `diff_sort`/`diff_merge`, `graft_hash`,
`resolve_updates_prefetched`, compact `merkleize_ops`, plus the floor-raise
classification (routed through `strategy.run(read_candidates.len(), ..)`). The
simplex batcher (vote-batch counts), p2p decode (message byte length), and the
runtime/test strategies pass their natural sizes too.

## Result

QMDB follower write path, 500k blocks, 32 GiB cache, measured during development
against the pre-PR spawn:

| threads | before (wall / writes-per-s) | after |
|---|---|---|
| 1 | 13.3s / 132.6k | 13.7s / 128.6k |
| 8 | 44.5s / 35.3k | 15.1s / 114.8k |

- **Negative scaling eliminated**: 8 threads is now ~1.1x the 1-thread wall (was 3.3x).
- **+225% write throughput at 8 threads**; merkleize 36.2s to 10.0s.
- Holds at 2M blocks and on the builder path.
- **Byte-identical output**: the on-disk DB is bit-for-bit identical across thread
  counts, so the change affects only dispatch, not computation.

Re-verified at the exact merge candidate (rebased head `662ac6ac9` vs current main
`b269a647`, same protocol, arms interleaved twice): main still reproduces the original
pathology (t8 wall 43.7s to 44.7s, 35.3k to 36.2k writes/s), while this branch runs t8
at 13.5s to 15.0s and 114k to 128k writes/s, a wash at t1, byte-identical databases. A
heavy window (50k blocks at height 5M+, ~340 writes per block) was also measured; see
the known gap below.

The benchmarks use an 8-thread strategy pool on both arms. Beyond gating individual
call sites, adaptive inlining reduces how often the pool is woken at all, which
matters because idle pool workers are not free on low-parallel-duty-cycle workloads
(quantified in #4432); the policy adapts by measurement, so its decisions recalibrate
under any future change to pool idle costs.

## Known performance gap

The merged policy cannot observe caller overlap, only round-trip overhead. Deferred-join
call sites whose jobs genuinely overlap the caller's other work (the qmdb
`diff_sort`/`diff_merge` sites at heavy block sizes) measure inflated overhead and get
pulled inline, moving that formerly hidden work onto the critical path. Measured against
the pre-#4603 caller-residual variant of this branch: light-window t8 merkleize +2% to
+5%; heavy-window t8 merkleize +13% to +15% and writes/s -9% to -10% (t1 a wash in both
windows, heavy t1 slightly favoring the merged policy). This is an accepted trade for
measurement that is robust to caller polling style (the caller-residual signal
mismeasured pipeline-shaped callers such as the p2p decoder); the gap is reclaimable
later via a per-site placement declaration for overlapping-by-design sites. Details and
tables in the #4603 review thread.

## Tests

`SpawnEntry` decision unit tests cover seeding via offload, convergence to inline for
sub-overhead jobs, offload for jobs above the overhead or budget, budget capping under
an inflated overhead estimate, measurement cadence, and probe pacing; `Rayon::spawn`
integration tests pin tiny-job inlining and over-budget jobs never leaving the pool.
`just test -p commonware-parallel` green; qmdb/journal/compact, consensus batcher, p2p
codec, and runtime strategy suites pass at the rebased head.
