### PR TITLE
[runtime] Page-align the storage buffer pool

### DIFF
--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -208,8 +208,9 @@ impl BufferPoolConfig {
             pool_min_size: 0,
             class_limits: BTreeMap::new(),
             prefill: false,
-            // TODO (#2960): this needs to be page/block aligned for O_DIRECT
-            alignment: NZUsize!(1),
+            // Page-align storage buffers (equal to the smallest size class) so reads and
+            // writes are ready for direct I/O and DMA.
+            alignment: NZUsize!(page_size()),
             parallelism: NZUsize!(1),
             thread_cache_config: BufferPoolThreadCacheConfig::Enabled(None),
         }
@@ -2707,7 +2708,7 @@ mod tests {
             BufferPoolThreadCacheConfig::Enabled(None)
         );
         assert!(!config.prefill);
-        assert_eq!(config.alignment.get(), 1);
+        assert_eq!(config.alignment.get(), page_size());
     }
 
     #[test]
@@ -2744,7 +2745,7 @@ mod tests {
             BufferPoolThreadCacheConfig::Enabled(Some(NZUsize!(8)))
         );
         assert!(config.prefill);
-        assert_eq!(config.alignment.get(), 1);
+        assert_eq!(config.alignment.get(), page_size());
 
         // Alignment can be tuned explicitly as long as the smallest class is
         // also adjusted.


### PR DESCRIPTION
## Summary

`BufferPoolConfig::for_storage()` hardcoded `alignment: 1` as a placeholder (the `#2960` TODO), so the shared storage buffer pool (used by every storage component: journal, MMR, metadata, freezer, ADB) handed out buffers that were not page/block aligned.

This aligns storage buffers to the system page size. That value equals the smallest storage size class, so the pool's `min_size >= alignment` validation holds by construction, and it adapts per platform (4096 on x86-64).

## Scope

This is a prerequisite/correctness change, not a behavior change:

- It page-aligns the *in-memory* buffers only. The I/O path stays buffered (`pread`/`pwrite`), which is alignment-agnostic, so on-disk contents are byte-identical and existing V0 (non-page-aligned) blobs read and write exactly as before.
- It does not enable direct I/O on its own. A true `O_DIRECT` open path (with V1-only gating, since a V0 blob's on-disk data offset is not block aligned) remains a separate follow-up. This change just removes the alignment blocker.

## Testing

- `just test -p commonware-runtime iobuf` (197 passed) and `utils::buffer::paged` (146 passed)
- `just test -p commonware-storage journal::contiguous` (220 passed)
- Updated the two `for_storage` alignment assertions in the `pool.rs` tests to `page_size()` (left `for_network` at 1).

A storage replay A/B (100k blocks) showed no throughput change (within run-to-run noise) and a byte-identical resulting database, confirming the change is transparent on the buffered path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
