### PR TITLE
[consensus/simplex] Fix optimistic validation edge cases

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -125,6 +125,11 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// notarized, or only voted for locally, and before consensus enters
         /// the context's view. Build on the named parent regardless; if the
         /// parent is later abandoned, this proposal is abandoned with it.
+        /// Within a Simplex run, dropping the response is terminal for this
+        /// request and declines the view. For an optimistic future request,
+        /// the missing proposal is remembered and causes nullification once
+        /// Simplex enters that view. Keep the response pending when temporary
+        /// unavailability should not forfeit the view.
         fn propose(
             &mut self,
             context: Self::Context,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -151,10 +151,7 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// for temporary inability to decide.
         ///
         /// The future-context requirement on [`Self::propose`] applies here
-        /// too. Do not return `false` or close the channel only because the
-        /// context's dependencies are temporarily unavailable. Under the
-        /// single-shot contract, either outcome permanently rejects the
-        /// request.
+        /// too: the context's dependencies may not be resolvable locally yet.
         fn verify(
             &mut self,
             context: Self::Context,

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -120,16 +120,14 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// `propose` also commits the local proposer to certifying that same
         /// `(round, payload)` if it later becomes notarized.
         ///
-        /// A consensus engine that runs ahead optimistically (see [`simplex`])
-        /// may request a payload while the parent named in the context is only
-        /// notarized, or only voted for locally, and before consensus enters
-        /// the context's view. Build on the named parent regardless; if the
-        /// parent is later abandoned, this proposal is abandoned with it.
-        /// Within a Simplex run, dropping the response is terminal for this
-        /// request and declines the view. For an optimistic future request,
-        /// the missing proposal is remembered and causes nullification once
-        /// Simplex enters that view. Keep the response pending when temporary
-        /// unavailability should not forfeit the view.
+        /// Consensus may request a payload for a future context before earlier
+        /// contexts complete. Honor any dependencies supplied in the context
+        /// rather than rebuilding them from current local state. If consensus
+        /// later abandons a dependency, it also abandons the proposal.
+        ///
+        /// Closing the response declines this request, which consensus may
+        /// treat as final for the context. Keep the response pending when
+        /// temporary unavailability should not abandon the context.
         fn propose(
             &mut self,
             context: Self::Context,
@@ -152,12 +150,11 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         /// where verification cannot ever produce a verdict anymore (for example, shutdown), not
         /// for temporary inability to decide.
         ///
-        /// The parent caveat on [`Self::propose`] applies here too: an
-        /// optimistic request may arrive before consensus enters the context's
-        /// view. A `false` verdict (or a closed channel) for such a view is
-        /// remembered and nullifies the view once consensus enters it.
-        /// Rejecting a payload that cannot be validated *yet* therefore
-        /// forfeits the view.
+        /// The future-context requirement on [`Self::propose`] applies here
+        /// too. Do not return `false` or close the channel only because the
+        /// context's dependencies are temporarily unavailable. Under the
+        /// single-shot contract, either outcome permanently rejects the
+        /// request.
         fn verify(
             &mut self,
             context: Self::Context,

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -772,8 +772,7 @@ mod tests {
         actor
     }
 
-    #[test_async]
-    async fn self_targeted_fetch_does_not_restrict_existing_backfill() {
+    fn assert_targeted_fetch_does_not_restrict_existing_backfill(target_index: usize) {
         let runtime = deterministic::Runner::timed(Duration::from_secs(10));
         runtime.start(|mut context| async move {
             let Fixture {
@@ -806,7 +805,7 @@ mod tests {
             }
             let mut connections = connections.into_iter();
             let requester_connection = connections.next().unwrap();
-            let (_target_sender, mut target_receiver) = connections.next().unwrap();
+            let (_silent_sender, mut silent_receiver) = connections.next().unwrap();
             let responder_connection = connections.next().unwrap();
             let _unused_connection = connections.next().unwrap();
 
@@ -878,7 +877,7 @@ mod tests {
             context.sleep(Duration::from_millis(10)).await;
 
             // Advancing to view 2 creates an unrestricted background ask for
-            // view 1. The only connected peer is the silent target, so seeing
+            // view 1. The only connected peer is silent, so seeing
             // its request proves the background fetch is already in flight.
             requester_mailbox.updated(Certificate::Nullification(build_nullification(
                 &schemes,
@@ -887,25 +886,25 @@ mod tests {
                 View::new(2),
             )));
             let (requester_key, _) = select! {
-                request = target_receiver.recv() => request.expect("target channel closed"),
+                request = silent_receiver.recv() => request.expect("silent peer channel closed"),
                 _ = context.sleep(Duration::from_secs(2)) => {
-                    panic!("background request did not reach silent target");
+                    panic!("background request did not reach silent peer");
                 },
             };
             assert_eq!(requester_key, participants[0]);
 
-            // A stable leader can later ask for the same ancestry targeted at
-            // its own key. It must attach a subscriber without narrowing the
-            // in-flight unrestricted fetch; self is not an eligible peer.
+            // A later targeted ancestry request may name a remote peer or the
+            // requester itself. It must attach its subscriber without
+            // narrowing the in-flight unrestricted fetch.
             requester_mailbox.resolve(
                 View::new(3),
                 requested,
                 Kind::Nullification,
-                Some(participants[0].clone()),
+                Some(participants[target_index].clone()),
             );
             context.sleep(Duration::from_millis(10)).await;
 
-            // Remove the silent target and expose a different responder. If
+            // Remove the silent peer and expose a different responder. If
             // the targeted ask narrowed the fetch, recovery cannot finish.
             oracle
                 .remove_link(participants[0].clone(), participants[1].clone())
@@ -931,7 +930,7 @@ mod tests {
             let recovered = select! {
                 message = requester_voter_receiver.recv() => message.expect("voter mailbox closed"),
                 _ = context.sleep(Duration::from_secs(2)) => {
-                    panic!("unrestricted fetch was narrowed to the silent target");
+                    panic!("unrestricted fetch was narrowed by the targeted request");
                 },
             };
             assert!(matches!(
@@ -942,6 +941,16 @@ mod tests {
                 } if nullification == available
             ));
         });
+    }
+
+    #[test_async]
+    async fn targeted_fetch_does_not_restrict_existing_backfill() {
+        assert_targeted_fetch_does_not_restrict_existing_backfill(1);
+    }
+
+    #[test_async]
+    async fn self_targeted_fetch_does_not_restrict_existing_backfill() {
+        assert_targeted_fetch_does_not_restrict_existing_backfill(0);
     }
 
     /// A valid notarization that does not settle the ask does not prevent a

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -773,7 +773,7 @@ mod tests {
     }
 
     #[test_async]
-    async fn targeted_fetch_does_not_restrict_existing_backfill() {
+    async fn self_targeted_fetch_does_not_restrict_existing_backfill() {
         let runtime = deterministic::Runner::timed(Duration::from_secs(10));
         runtime.start(|mut context| async move {
             let Fixture {
@@ -894,14 +894,14 @@ mod tests {
             };
             assert_eq!(requester_key, participants[0]);
 
-            // Add a targeted ancestry ask for the same key and silent peer.
-            // It must attach a subscriber without narrowing the in-flight
-            // unrestricted fetch.
+            // A stable leader can later ask for the same ancestry targeted at
+            // its own key. It must attach a subscriber without narrowing the
+            // in-flight unrestricted fetch; self is not an eligible peer.
             requester_mailbox.resolve(
                 View::new(3),
                 requested,
                 Kind::Nullification,
-                Some(participants[1].clone()),
+                Some(participants[0].clone()),
             );
             context.sleep(Duration::from_millis(10)).await;
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -557,7 +557,8 @@ impl<
 
         // Tell the resolver this view is complete so it can stop requesting it.
         // For a certificate from the batcher, this update is enqueued before
-        // the next loop can emit any targeted ancestry repair it exposes. The
+        // the next loop iteration can emit any targeted ancestry repair it
+        // exposes. The
         // resolver's unrestricted backfill therefore cannot be narrowed by
         // that later target. Skip if the resolver just sent us this certificate
         // (avoid boomerang).

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -274,7 +274,10 @@ impl<
     /// Syncs the journal section written by this iteration, if any.
     ///
     /// Called after construction and before publication so every appended artifact
-    /// is durable by the end of the iteration. A single sync coalesces all appends.
+    /// is durable by the end of the iteration. The next iteration cannot dispatch
+    /// work made eligible here until this sync completes, so a durable child
+    /// certification also implies its parent anchor is durable. A single sync
+    /// coalesces all appends.
     async fn sync_journal(mut self) -> Self {
         let Some(view) = self.dirty_section else {
             return self;
@@ -553,7 +556,11 @@ impl<
         }
 
         // Tell the resolver this view is complete so it can stop requesting it.
-        // Skip if the resolver just sent us this certificate (avoid boomerang).
+        // For a certificate from the batcher, this update is enqueued before
+        // the next loop can emit any targeted ancestry repair it exposes. The
+        // resolver's unrestricted backfill therefore cannot be narrowed by
+        // that later target. Skip if the resolver just sent us this certificate
+        // (avoid boomerang).
         if resolved != Resolved::Notarization {
             resolver.updated(Certificate::Notarization(notarization.clone()));
         }
@@ -1096,8 +1103,10 @@ impl<
             self.context,
             on_start => {
                 // Drop any pending items if we have moved past their view (work
-                // for optimistic future views is kept). A view is exited only on
-                // successful certification, nullification, or finalization.
+                // for optimistic future views is kept). This runs before the
+                // waiters are rebuilt, so a verification completion cannot be
+                // polled after another branch exits its view. A view is exited
+                // only on successful certification, nullification, or finalization.
                 // Nullification does not cancel certification work for the
                 // exited view, so the automaton must tolerate a dropped verify
                 // receiver while certify still wants the result.
@@ -1126,7 +1135,9 @@ impl<
                 //
                 // Even our own proposals are certified through the automaton: that
                 // is the durability barrier that makes a block recoverable before
-                // we cast a finalize vote for it.
+                // we cast a finalize vote for it. Because the prior iteration's
+                // journal sync completed before this block runs, a child made
+                // eligible by its parent cannot become durable first.
                 let (candidates, fetches) = self.state.certify_candidates();
                 for CertificateFetch { proposal, view, kind, target } in fetches {
                     resolver.resolve(proposal, view, kind, target);

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -558,10 +558,9 @@ impl<
         // Tell the resolver this view is complete so it can stop requesting it.
         // For a certificate from the batcher, this update is enqueued before
         // the next loop iteration can emit any targeted ancestry repair it
-        // exposes. The
-        // resolver's unrestricted backfill therefore cannot be narrowed by
-        // that later target. Skip if the resolver just sent us this certificate
-        // (avoid boomerang).
+        // exposes. The resolver's unrestricted backfill therefore cannot be
+        // narrowed by that later target. Skip if the resolver just sent us
+        // this certificate (avoid boomerang).
         if resolved != Resolved::Notarization {
             resolver.updated(Certificate::Notarization(notarization.clone()));
         }

--- a/consensus/src/simplex/actors/voter/ingress.rs
+++ b/consensus/src/simplex/actors/voter/ingress.rs
@@ -141,6 +141,35 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
             return;
         }
 
+        // Preserve the leader-nullify fast path. An inactivity timeout can be
+        // ignored after a proposal is buffered, while a leader's explicit
+        // refusal remains sufficient to abandon the view.
+        if let Self::Timeout {
+            round: new_round,
+            reason: new_reason,
+            ..
+        } = &message
+            && let Some(index) = overflow.messages.iter().position(|old_message| {
+                matches!(
+                    old_message,
+                    Self::Timeout { round, .. } if round.view() == new_round.view()
+                )
+            })
+        {
+            if *new_reason == TimeoutReason::LeaderNullify
+                && matches!(
+                    &overflow.messages[index],
+                    Self::Timeout {
+                        reason: TimeoutReason::Inactivity,
+                        ..
+                    }
+                )
+            {
+                overflow.messages[index] = message;
+            }
+            return;
+        }
+
         // Ignore the message if it is a duplicate
         if overflow
             .messages
@@ -156,16 +185,6 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
                         ..
                     },
                 ) => new_proposal.view() == old_proposal.view(),
-                (
-                    Self::Timeout {
-                        round: new_round, ..
-                    },
-                    Self::Timeout {
-                        round: old_round, ..
-                    },
-                ) => {
-                    new_round.view() == old_round.view() // only retain the first queued timeout reason
-                }
                 (
                     Self::Verified {
                         certificate: new_certificate,
@@ -497,5 +516,48 @@ mod tests {
 
         let overflow = drain(overflow);
         assert_eq!(overflow.len(), 2);
+    }
+
+    #[test]
+    fn leader_nullify_replaces_inactivity_for_same_view() {
+        let mut overflow = Pending::<TestScheme, Sha256Digest>::default();
+        Message::handle(
+            &mut overflow,
+            timeout_msg(View::new(4), TimeoutReason::Inactivity),
+        );
+        Message::handle(
+            &mut overflow,
+            timeout_msg(View::new(4), TimeoutReason::LeaderNullify),
+        );
+
+        let mut overflow = drain(overflow);
+        assert!(matches!(
+            overflow.pop_front(),
+            Some(Message::Timeout {
+                round,
+                reason: TimeoutReason::LeaderNullify,
+                ..
+            }) if round.view() == View::new(4)
+        ));
+        assert!(overflow.is_empty());
+
+        let mut overflow = Pending::<TestScheme, Sha256Digest>::default();
+        Message::handle(
+            &mut overflow,
+            timeout_msg(View::new(4), TimeoutReason::LeaderNullify),
+        );
+        Message::handle(
+            &mut overflow,
+            timeout_msg(View::new(4), TimeoutReason::Inactivity),
+        );
+        let mut overflow = drain(overflow);
+        assert!(matches!(
+            overflow.pop_front(),
+            Some(Message::Timeout {
+                reason: TimeoutReason::LeaderNullify,
+                ..
+            })
+        ));
+        assert!(overflow.is_empty());
     }
 }

--- a/consensus/src/simplex/actors/voter/ingress.rs
+++ b/consensus/src/simplex/actors/voter/ingress.rs
@@ -141,9 +141,9 @@ impl<S: Scheme, D: Digest> Policy for Message<S, D> {
             return;
         }
 
-        // Preserve the leader-nullify fast path. An inactivity timeout can be
-        // ignored after a proposal is buffered, while a leader's explicit
-        // refusal remains sufficient to abandon the view.
+        // For the same view, LeaderNullify is stronger than Inactivity. A
+        // buffered proposal may suppress inactivity, but the leader's explicit
+        // refusal must still abandon the view.
         if let Self::Timeout {
             round: new_round,
             reason: new_reason,
@@ -520,6 +520,7 @@ mod tests {
 
     #[test]
     fn leader_nullify_replaces_inactivity_for_same_view() {
+        // A leader refusal upgrades an inactivity timeout already in the queue.
         let mut overflow = Pending::<TestScheme, Sha256Digest>::default();
         Message::handle(
             &mut overflow,
@@ -541,6 +542,7 @@ mod tests {
         ));
         assert!(overflow.is_empty());
 
+        // A later inactivity timeout cannot downgrade a queued leader refusal.
         let mut overflow = Pending::<TestScheme, Sha256Digest>::default();
         Message::handle(
             &mut overflow,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -4182,9 +4182,8 @@ mod tests {
             let elector = RoundRobin::<Sha256>::default();
             let built_elector: RoundRobinElector<ed25519::Scheme> =
                 elector.clone().build(schemes[0].participants());
-            let leader_index = usize::from(
-                built_elector.elect(Round::new(epoch, View::new(1)), None),
-            );
+            let leader_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
             let local_index = (leader_index + 1) % schemes.len();
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, _, relay, reporter) = setup_voter(

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -190,8 +190,12 @@ mod tests {
         local_index: usize,
         /// Mock application propose latency, in milliseconds.
         propose_latency_ms: f64,
+        /// Mock application verify latency, in milliseconds.
+        verify_latency_ms: f64,
         /// Mock application certify latency, in milliseconds.
         certify_latency_ms: f64,
+        /// Views whose verification requests reached the mock application.
+        verify_requests: Option<Arc<Mutex<Vec<View>>>>,
         certifier: mocks::application::Certifier<Sha256Digest>,
     }
 
@@ -205,7 +209,9 @@ mod tests {
                 timeout_retry: Duration::from_secs(1000),
                 local_index: 0,
                 propose_latency_ms: 1.0,
+                verify_latency_ms: 1.0,
                 certify_latency_ms: 1.0,
+                verify_requests: None,
                 certifier: mocks::application::Certifier::Always,
             }
         }
@@ -240,17 +246,23 @@ mod tests {
         let reporter = mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
         let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
         let elector = elector.build(signing.participants());
+        let verify_requests = options.verify_requests;
 
         let application_cfg = mocks::application::Config::<Sha256, _> {
             relay: relay.clone(),
             me: me.clone(),
             propose_latency: (options.propose_latency_ms, 0.0),
-            verify_latency: (1.0, 0.0),
+            verify_latency: (options.verify_latency_ms, 0.0),
             certify_latency: (options.certify_latency_ms, 0.0),
             should_certify: options.certifier,
         };
-        let (actor, application) =
+        let (mut actor, application) =
             mocks::application::Application::new(context.child("app"), application_cfg);
+        if let Some(verify_requests) = verify_requests {
+            actor.set_verify_observer(Box::new(move |context, _| {
+                verify_requests.lock().push(context.view());
+            }));
+        }
         actor.start();
 
         let voter_cfg = Config {
@@ -3324,20 +3336,38 @@ mod tests {
                     _ => continue,
                 }
             }
+            while resolver_receiver.recv().now_or_never().flatten().is_some() {}
 
             // Deliver notarization(3), skipping notarization(2): the voter
             // observed the certificate broadcast for view 3 but missed the one
             // for view 2. Certifying view 3 requires view 2's exact-view
-            // certificate, so the voter must fetch it.
+            // certificate, so the voter must fetch it. The certificate update
+            // must reach the resolver first: it opens unrestricted background
+            // repair that a later leader target cannot narrow.
             mailbox.recovered(Certificate::Notarization(notarization_3));
+            assert!(matches!(
+                resolver_receiver.recv().await.unwrap(),
+                MailboxMessage::Certificate {
+                    certificate: Certificate::Notarization(notarization),
+                    ..
+                } if notarization.view() == View::new(3)
+            ));
             loop {
                 select! {
                     message = resolver_receiver.recv() => {
-                        let MailboxMessage::Resolve { view, kind, .. } = message.unwrap() else {
+                        let MailboxMessage::Resolve {
+                            proposal,
+                            view,
+                            kind,
+                            target,
+                            ..
+                        } = message.unwrap() else {
                             continue;
                         };
+                        assert_eq!(proposal, View::new(3));
                         assert_eq!(view, View::new(2));
                         assert!(matches!(kind, crate::simplex::actors::Kind::Notarization));
+                        assert!(target.is_some(), "certification repair should retain leader affinity");
                         break;
                     },
                     _ = context.sleep(Duration::from_secs(20)) => {
@@ -4130,6 +4160,101 @@ mod tests {
         );
         dropped_verify_emits_nullify_immediately::<_, _, RoundRobin>(ed25519::fixture);
         dropped_verify_emits_nullify_immediately::<_, _, RoundRobin>(secp256r1::fixture);
+    }
+
+    /// A view-exiting certificate cancels an in-flight verification before
+    /// its completion can be processed into a vote for the exited view.
+    #[test_traced]
+    fn test_finalization_cancels_inflight_verification() {
+        let n = 4;
+        let quorum = quorum(n);
+        let epoch = Epoch::new(333);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, b"finalization_cancels_verify", n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+            let elector = RoundRobin::<Sha256>::default();
+            let built_elector: RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let leader_index = usize::from(
+                built_elector.elect(Round::new(epoch, View::new(1)), None),
+            );
+            let local_index = (leader_index + 1) % schemes.len();
+            let verify_requests = Arc::new(Mutex::new(Vec::new()));
+            let (mut mailbox, mut batcher_receiver, _, relay, reporter) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    leader_timeout: Duration::from_secs(5),
+                    certification_timeout: Duration::from_secs(5),
+                    local_index,
+                    verify_latency_ms: 1_000.0,
+                    verify_requests: Some(verify_requests.clone()),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            let (target_view, leader) = match batcher_receiver.recv().await.unwrap() {
+                batcher::Message::Update {
+                    current, leader, ..
+                } => (current, leader),
+                _ => panic!("expected initial update"),
+            };
+            assert_eq!(target_view, View::new(1));
+            assert_eq!(usize::from(leader), leader_index);
+            assert_ne!(usize::from(leader), local_index);
+
+            let proposal = Proposal::new(
+                Round::new(epoch, target_view),
+                target_view.previous().unwrap_or(View::zero()),
+                Sha256::hash(&[b"verification_overtaken_by_finalization"]),
+            );
+            let contents = (
+                proposal.round,
+                mocks::application::genesis::<Sha256>(epoch),
+                7u64,
+            )
+                .encode();
+            relay.broadcast(
+                &participants[leader_index],
+                Recipients::All,
+                (proposal.payload, contents),
+            );
+            mailbox.proposal(proposal.clone());
+
+            context.sleep(Duration::from_millis(10)).await;
+            assert!(
+                verify_requests.lock().contains(&target_view),
+                "verification must be in flight before finalization arrives"
+            );
+
+            let (_, finalization) = build_finalization(&schemes, &proposal, quorum);
+            mailbox.recovered(Certificate::Finalization(finalization));
+            loop {
+                match batcher_receiver.recv().await.unwrap() {
+                    batcher::Message::Update { current, .. } if current > target_view => break,
+                    _ => {}
+                }
+            }
+
+            // Let the application finish the now-canceled verification. The
+            // old view must not regain a path into vote construction.
+            context.sleep(Duration::from_secs(2)).await;
+            assert!(
+                !reporter.notarizes.lock().contains_key(&target_view),
+                "verification completed after finalization must not emit a notarize vote"
+            );
+        });
     }
 
     /// Tests that permanently invalid proposal ancestry fast-paths `nullify`

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -637,10 +637,10 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// rule can permanently lose a one-shot vote, while a looser rule can sign
     /// ancestry the local automaton rejected.
     ///
-    /// One abstention is tolerated: a parent at failed certification rejects
-    /// the child's one-shot vote. A later parent finalization restores the
-    /// ancestry but does not retry the vote, because vote construction runs
-    /// only for the view an event touches and the finalization touches the
+    /// One abstention is tolerated: a parent whose certification failed
+    /// rejects the child's one-shot vote. A later parent finalization
+    /// restores the ancestry but does not retry the vote: construction runs
+    /// only for the view an event touches, and the finalization touches the
     /// parent. Reaching this case requires the network to finalize a proposal
     /// our automaton rejected, and that finalization proves a quorum advanced
     /// without our vote.
@@ -1142,9 +1142,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         // Certification exempts term starts, so the candidate and its parent
         // sit mid-term and share the term's stable leader (see
         // [`Self::term_leader`]). Without a tracked leader the fetch asks any
-        // peer. A leader that is the local signer is also excluded: the fetch
-        // exists because we lack the certificate, and a fresh fetch targeted
-        // only at ourselves has no peer to serve it.
+        // peer. A leader that is the local signer is also excluded: a fresh
+        // fetch targeted only at ourselves has no peer to serve it.
         Some(CertificateFetch {
             proposal: *proposal_view,
             view: *parent_view,
@@ -3494,7 +3493,7 @@ mod tests {
     }
 
     /// Certification exempts term-start candidates from the parent precheck
-    /// (see [`State::certification_parent_ready`]): a term-start proposal
+    /// (see [`State::certification_parent_ready`]). A term-start proposal
     /// dispatches even when its cross-term parent is uncertified and the
     /// skipped views' nullifications are not held.
     #[test]
@@ -4040,7 +4039,7 @@ mod tests {
                 state.construct_notarize(View::new(2)).is_none(),
                 "failed-certified parent must not unlock optimistic child notarize"
             );
-            // Certification of the notarized child is blocked the same way.
+            // The notarized child must also remain ineligible for certification.
             let child_notarization = build_notarization(&verifier, &schemes, &child);
             assert!(state.add_notarization(child_notarization).0);
             assert!(state.certify_candidates().0.is_empty());
@@ -7127,8 +7126,8 @@ mod tests {
 
             // Construct a defensive state the actor cannot persist: live
             // child certification is dispatched only after its parent anchor's
-            // journal section has synced. This bypasses that ordering directly
-            // to keep the state-level finalize gate fail-closed.
+            // journal section has synced. The test bypasses that ordering to
+            // prove the state-level finalize gate stays closed.
             let proposal_v1 = Proposal::new(
                 Rnd::new(Epoch::new(1), View::new(1)),
                 GENESIS_VIEW,

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1270,8 +1270,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
         // Serve directly-certified ancestry from the stored certificate so it
         // is always payload the certificate actually supports, independent of
-        // the slot's proposal bookkeeping. The acceptance rule is shared with
-        // `optimistic_parent_ready`.
+        // the slot's proposal bookkeeping.
         if round.is_directly_notarized() {
             return round.certificate_ancestry_payload();
         }
@@ -3494,6 +3493,43 @@ mod tests {
         });
     }
 
+    /// Certification exempts term-start candidates from the parent precheck
+    /// (see [`State::certification_parent_ready`]): a term-start proposal
+    /// dispatches even when its cross-term parent is uncertified and the
+    /// skipped views' nullifications are not held.
+    #[test]
+    fn certify_candidates_exempts_term_start_from_parent_precheck() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                20,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            // Term 2 starts at view 6. Its parent (view 1) is not certified
+            // and no nullification for views 2..=5 is tracked.
+            let term_start = fetch_proposal(6, 1, 61);
+            assert!(
+                state
+                    .add_notarization(build_notarization(&verifier, &schemes, &term_start))
+                    .0
+            );
+            let (ready, fetches) = state.certify_candidates();
+            assert_eq!(ready, vec![term_start]);
+            assert!(fetches.is_empty());
+        });
+    }
+
     /// A certificate is adversarial input: a notarization whose proposal is
     /// structurally invalid must be dropped by certification, with no fetch
     /// and no requeue.
@@ -4004,6 +4040,7 @@ mod tests {
                 state.construct_notarize(View::new(2)).is_none(),
                 "failed-certified parent must not unlock optimistic child notarize"
             );
+            // Certification of the notarized child is blocked the same way.
             let child_notarization = build_notarization(&verifier, &schemes, &child);
             assert!(state.add_notarization(child_notarization).0);
             assert!(state.certify_candidates().0.is_empty());

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -5125,8 +5125,7 @@ mod tests {
             );
             // Use a non-leader so its local vote is the event that opens the
             // optimistic child.
-            let leader_idx =
-                usize::from(elector.elect(Rnd::new(epoch, View::new(1)), None));
+            let leader_idx = usize::from(elector.elect(Rnd::new(epoch, View::new(1)), None));
             let local_idx = (leader_idx + 1) % schemes.len();
 
             let config = |scheme, elector| Config {

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -625,7 +625,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let result = self.create_round(view).add_finalization(finalization);
         if result.0 {
             self.slide_optimistic_frontier(view);
-            self.requeue_child_certification(view);
         }
         result
     }
@@ -1071,11 +1070,9 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.insert(view);
     }
 
-    /// Takes all newly eligible certification candidates and returns proposals
-    /// ready for certification, plus fetches for candidates blocked on a
-    /// certificate we do not hold (see [`Self::certification_fetch`]). A
-    /// parent-blocked candidate remains dormant until the parent certifies or
-    /// finalizes, rather than being polled on every actor wakeup.
+    /// Takes all certification candidates and returns proposals ready for
+    /// certification, plus fetches for candidates blocked on a certificate we
+    /// do not hold (see [`Self::certification_fetch`]).
     pub fn certify_candidates(
         &mut self,
     ) -> (Vec<Proposal<D>>, Vec<CertificateFetch<S::PublicKey>>) {
@@ -1100,13 +1097,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                     warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
                 } else {
                     fetches.extend(self.certification_fetch(&err));
-                    // The resolver owns parent-certificate retries, and the
-                    // child is woken when that parent becomes usable. A
-                    // missing-nullification dependency has no such keyed
-                    // wakeup, so keep it active.
-                    if matches!(err, ParentPayloadError::MissingNullification { .. }) {
-                        self.certification_candidates.insert(view);
-                    }
+                    self.certification_candidates.insert(view);
                 }
                 continue;
             }
@@ -1120,23 +1111,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             }
         }
         (ready, fetches)
-    }
-
-    /// Requeues certification for the immediate in-term child after `parent`
-    /// becomes explicit ancestry.
-    ///
-    /// No other candidate can depend on this transition. The gate applies only
-    /// within a term, where structural validation requires each proposal to
-    /// name the previous view. Term-start candidates bypass the gate.
-    fn requeue_child_certification(&mut self, parent: View) {
-        let child = parent.next();
-        if child <= self.last_finalized
-            || child.is_term_start(self.term_length())
-            || self.notarization(child).is_none()
-        {
-            return;
-        }
-        self.certification_candidates.insert(child);
     }
 
     /// Returns the fetch a blocked certification justifies, if any.
@@ -1200,8 +1174,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.remove(&view);
 
         if is_success {
-            self.requeue_child_certification(view);
-
             // Keep the stall deadline armed after certification so the
             // term-level timeout can still abandon a term that certifies but
             // never finalizes.
@@ -3375,12 +3347,7 @@ mod tests {
             assert!(state.is_me(leader.idx));
             assert!(fetches[0].target.is_none());
 
-            // The resolver owns retries after the first fetch. Leave the
-            // blocked candidate dormant until its parent's state changes so
-            // unrelated actor wakeups do not rescan the whole blocked set.
-            assert!(state.certification_candidates.is_empty());
-
-            // Unrelated certification passes do not duplicate the fetch.
+            // The round deduplicates the fetch while it is outstanding.
             let (ready, fetches) = state.certify_candidates();
             assert!(ready.is_empty());
             assert!(fetches.is_empty());
@@ -4040,7 +4007,6 @@ mod tests {
             let child_notarization = build_notarization(&verifier, &schemes, &child);
             assert!(state.add_notarization(child_notarization).0);
             assert!(state.certify_candidates().0.is_empty());
-            assert!(state.certification_candidates.is_empty());
 
             // A finalization certificate for the parent overrides the local
             // rejection and restores it as usable ancestry.

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -625,33 +625,24 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let result = self.create_round(view).add_finalization(finalization);
         if result.0 {
             self.slide_optimistic_frontier(view);
+            self.wake_certification_child(view);
         }
         result
     }
 
-    /// Returns true when an optimistic in-term `view` has local evidence for
-    /// its immediate parent: our own broadcast notarize vote, an observed
-    /// notarization or finalization certificate, or (when `view` is already
-    /// current) the parent's explicit certification. Only meaningful inside
+    /// Returns true when an optimistic in-term `view` has locally usable
+    /// ancestry for its immediate parent. Only meaningful inside
     /// [`Self::in_issuance_window`].
     ///
-    /// This throttles notarize issuance; signing still resolves and checks
-    /// full ancestry. It must never be *stricter* than
-    /// [`Self::optimistic_ancestry_payload`]: votes are constructed once per
-    /// event, so a gate that rejects at the child's verified event loses the
-    /// vote permanently.
+    /// This must use the same ancestry rule as proposal construction. A stricter
+    /// rule can permanently lose a one-shot vote, while a looser rule can sign
+    /// ancestry the local automaton rejected.
     fn optimistic_parent_ready(&self, view: View) -> bool {
         let Some(parent) = self.previous_in_term(view) else {
             return true;
         };
 
-        let parent_completed =
-            view == self.view && self.explicit_ancestry_payload(parent).is_some();
-        parent_completed
-            || self.views.get(&parent).is_some_and(|round| {
-                // A parent certificate is stronger evidence than our own vote.
-                round.broadcast_notarize() || round.certificate_ancestry_payload().is_some()
-            })
+        self.optimistic_ancestry_payload(parent).is_some()
     }
 
     /// Construct a notarize vote for this view when we're ready to sign.
@@ -776,7 +767,9 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     ///
     /// Restores round-level broadcast flags (via [`Round::replay`]) and
     /// tracking sets (`nullify_views`, `nullification_views`) so that
-    /// term-safety checks work correctly after a restart. Unlike
+    /// term-safety checks work correctly after a restart. Replaying a local
+    /// notarize vote also restores the optimistic successor prepared by live
+    /// vote construction. Unlike
     /// [`Self::add_nullification`] (which the actor's replay loop also calls,
     /// making the `nullification_views` insert idempotent on that path), this
     /// never advances the view.
@@ -788,6 +781,9 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             self.nullification_views.insert(n.view());
         }
         self.create_round(artifact.view()).replay(artifact);
+        if matches!(artifact, Artifact::Notarize(_)) {
+            self.prepare_optimistic_successor(artifact.view());
+        }
     }
 
     /// Returns the leader index for `view` if we already entered it.
@@ -1067,9 +1063,11 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.insert(view);
     }
 
-    /// Takes all certification candidates and returns proposals ready for
-    /// certification, plus fetches for candidates blocked on a certificate we
-    /// do not hold (see [`Self::certification_fetch`]).
+    /// Takes all newly eligible certification candidates and returns proposals
+    /// ready for certification, plus fetches for candidates blocked on a
+    /// certificate we do not hold (see [`Self::certification_fetch`]). A
+    /// parent-blocked candidate remains dormant until the parent certifies or
+    /// finalizes, rather than being polled on every actor wakeup.
     pub fn certify_candidates(
         &mut self,
     ) -> (Vec<Proposal<D>>, Vec<CertificateFetch<S::PublicKey>>) {
@@ -1094,7 +1092,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                     warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
                 } else {
                     fetches.extend(self.certification_fetch(&err));
-                    self.certification_candidates.insert(view);
+                    // The resolver owns parent-certificate retries, and the
+                    // child is woken when that parent becomes usable. A
+                    // missing-nullification dependency has no such keyed
+                    // wakeup, so keep it active.
+                    if matches!(err, ParentPayloadError::MissingNullification { .. }) {
+                        self.certification_candidates.insert(view);
+                    }
                 }
                 continue;
             }
@@ -1108,6 +1112,19 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             }
         }
         (ready, fetches)
+    }
+
+    /// Reconsiders the immediate in-term child whose certification was blocked
+    /// on `parent`. The child's round retains the notarization while dormant.
+    fn wake_certification_child(&mut self, parent: View) {
+        let child = parent.next();
+        if child <= self.last_finalized
+            || child.is_term_start(self.term_length())
+            || self.notarization(child).is_none()
+        {
+            return;
+        }
+        self.certification_candidates.insert(child);
     }
 
     /// Returns the fetch a blocked certification justifies, if any.
@@ -1166,6 +1183,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.remove(&view);
 
         if is_success {
+            self.wake_certification_child(view);
             // Keep the stall deadline armed after certification so the
             // term-level timeout can still abandon a term that certifies but
             // never finalizes.
@@ -3302,13 +3320,16 @@ mod tests {
         runtime.start(|mut context| async move {
             let (
                 Fixture {
-                    schemes, verifier, ..
+                    participants,
+                    schemes,
+                    verifier,
+                    ..
                 },
                 mut state,
             ) = setup_state_with(
                 &mut context,
                 4,
-                1,
+                2,
                 9,
                 10,
                 TermLength::new(NZU32!(5)),
@@ -3331,8 +3352,18 @@ mod tests {
             assert_eq!(fetches[0].proposal, View::new(3));
             assert_eq!(fetches[0].view, View::new(2));
             assert!(matches!(fetches[0].kind, Kind::Notarization));
+            assert_eq!(
+                fetches[0].target.as_ref(),
+                Some(&participants[2]),
+                "the stable leader may target itself after unrestricted backfill is already queued"
+            );
 
-            // The round deduplicates the fetch while it is outstanding.
+            // The resolver owns retries after the first fetch. Leave the
+            // blocked candidate dormant until its parent's state changes so
+            // unrelated actor wakeups do not rescan the whole blocked set.
+            assert!(state.certification_candidates.is_empty());
+
+            // Unrelated certification passes do not duplicate the fetch.
             let (ready, fetches) = state.certify_candidates();
             assert!(ready.is_empty());
             assert!(fetches.is_empty());
@@ -3973,7 +4004,7 @@ mod tests {
                 View::new(1),
                 Sha256Digest::from([117u8; 32]),
             );
-            assert!(state.set_proposal(View::new(2), child));
+            assert!(state.set_proposal(View::new(2), child.clone()));
             assert!(matches!(state.try_verify(), Verify::Ready(..)));
             assert!(state.verified(View::new(2)));
 
@@ -3989,12 +4020,65 @@ mod tests {
                 state.construct_notarize(View::new(2)).is_none(),
                 "failed-certified parent must not unlock optimistic child notarize"
             );
+            let child_notarization = build_notarization(&verifier, &schemes, &child);
+            assert!(state.add_notarization(child_notarization).0);
+            assert!(state.certify_candidates().0.is_empty());
+            assert!(state.certification_candidates.is_empty());
 
             // A finalization certificate for the parent overrides the local
             // rejection and restores it as usable ancestry.
             let finalization = build_finalization(&verifier, &schemes, &parent);
             assert!(state.add_finalization(finalization).0);
             assert!(state.construct_notarize(View::new(2)).is_some());
+            assert_eq!(state.certify_candidates().0, vec![child]);
+        });
+    }
+
+    #[test]
+    fn failed_certification_blocks_locally_proposed_optimistic_child_notarize() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                2,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(1),
+            );
+
+            let parent = propose_and_notarize_view1(&mut state, 118);
+            let child_context = state
+                .try_propose()
+                .expect("optimistic child proposal should start");
+            assert_eq!(child_context.view(), View::new(2));
+            assert_eq!(child_context.parent, (View::new(1), parent.payload));
+
+            let notarization = build_notarization(&verifier, &schemes, &parent);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(1), false).is_some());
+            assert!(
+                state
+                    .construct_nullify(View::new(1), TimeoutReason::FailedCertification)
+                    .is_some()
+            );
+
+            let child = Proposal::new(
+                child_context.round,
+                child_context.parent.0,
+                Sha256Digest::from([119u8; 32]),
+            );
+            assert!(state.proposed(child));
+            assert!(
+                state.construct_notarize(View::new(2)).is_none(),
+                "failed-certified parent must block a locally proposed optimistic child"
+            );
         });
     }
 
@@ -5016,6 +5100,75 @@ mod tests {
             let candidates = state.certify_candidates().0;
             assert_eq!(candidates.len(), 1);
             assert_eq!(candidates[0].round.view(), view);
+        });
+    }
+
+    #[test]
+    fn replayed_local_notarize_restores_optimistic_child_verification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let namespace = b"ns".to_vec();
+            let Fixture {
+                schemes, verifier, ..
+            } = ed25519::fixture(&mut context, &namespace, 4);
+            let epoch = Epoch::new(12);
+            let elector = round_robin_with_term(
+                &verifier,
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(4),
+                ViewDelta::new(2),
+            );
+            let leader_idx =
+                usize::from(elector.elect(Rnd::new(epoch, View::new(1)), None));
+            let local_idx = (leader_idx + 1) % schemes.len();
+            let config = |scheme, elector| Config {
+                scheme,
+                elector,
+                epoch,
+                view_retention: ViewDelta::new(10),
+                leader_timeout: Duration::from_secs(1),
+                certification_timeout: Duration::from_secs(2),
+                timeout_retry: Duration::from_secs(3),
+            };
+
+            let mut live = State::new(
+                context.child("live"),
+                config(schemes[local_idx].clone(), elector.clone()),
+            );
+            live.set_genesis(test_genesis());
+
+            let parent = Proposal::new(
+                Rnd::new(epoch, View::new(1)),
+                GENESIS_VIEW,
+                Sha256Digest::from([123u8; 32]),
+            );
+            assert!(live.set_proposal(View::new(1), parent));
+            assert!(matches!(live.try_verify(), Verify::Ready(..)));
+            assert!(live.verified(View::new(1)));
+            let local_vote = live
+                .construct_notarize(View::new(1))
+                .expect("local notarize vote");
+
+            let child = Proposal::new(
+                Rnd::new(epoch, View::new(2)),
+                View::new(1),
+                Sha256Digest::from([124u8; 32]),
+            );
+            assert!(live.set_proposal(View::new(2), child.clone()));
+            assert!(matches!(live.try_verify(), Verify::Ready(..)));
+
+            let mut restarted = State::new(
+                context.child("restarted"),
+                config(schemes[local_idx].clone(), elector),
+            );
+            restarted.set_genesis(test_genesis());
+            restarted.replay(&Artifact::Notarize(local_vote));
+            assert!(restarted.set_proposal(View::new(2), child));
+
+            assert!(
+                matches!(restarted.try_verify(), Verify::Ready(..)),
+                "replayed local notarize should preserve optimistic child verification"
+            );
         });
     }
 
@@ -6926,7 +7079,7 @@ mod tests {
     }
 
     #[test]
-    fn replayed_certification_withholds_finalize_until_parent_anchor() {
+    fn certified_child_without_parent_anchor_cannot_finalize() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let (
@@ -6944,9 +7097,10 @@ mod tests {
                 ViewDelta::new(0),
             );
 
-            // View 1 notarizes, but its certification artifact did not
-            // survive the crash (per-view journal sections sync
-            // independently).
+            // Construct a defensive state the actor cannot persist: live
+            // child certification is dispatched only after its parent anchor's
+            // journal section has synced. This bypasses that ordering directly
+            // to keep the state-level finalize gate fail-closed.
             let proposal_v1 = Proposal::new(
                 Rnd::new(Epoch::new(1), View::new(1)),
                 GENESIS_VIEW,
@@ -6955,9 +7109,8 @@ mod tests {
             let notarization_v1 = build_notarization(&verifier, &schemes, &proposal_v1);
             assert!(state.add_notarization(notarization_v1).0);
 
-            // View 2 notarizes and its certification replays, restoring the
-            // certified round without re-running the certification parent
-            // precheck.
+            // Replay the child's certification directly, without the parent
+            // precheck that guards the production dispatch path.
             let proposal_v2 = Proposal::new(
                 Rnd::new(Epoch::new(1), View::new(2)),
                 View::new(1),
@@ -6976,8 +7129,7 @@ mod tests {
                 "finalize must wait for the parent's explicit certification anchor"
             );
 
-            // Re-certifying the parent (as the actor does after replay while
-            // its notarization is still present) restores the anchor.
+            // Supplying the missing parent anchor restores the valid state.
             assert!(state.certified(View::new(1), true).is_some());
             assert!(
                 state.construct_finalize(View::new(2)).is_some(),

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -625,7 +625,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let result = self.create_round(view).add_finalization(finalization);
         if result.0 {
             self.slide_optimistic_frontier(view);
-            self.wake_certification_child(view);
+            self.requeue_child_certification(view);
         }
         result
     }
@@ -1114,9 +1114,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         (ready, fetches)
     }
 
-    /// Reconsiders the immediate in-term child whose certification was blocked
-    /// on `parent`. The child's round retains the notarization while dormant.
-    fn wake_certification_child(&mut self, parent: View) {
+    /// Requeues certification for the immediate in-term child after `parent`
+    /// becomes explicit ancestry.
+    ///
+    /// No other candidate can depend on this transition. The gate applies only
+    /// within a term, where structural validation requires each proposal to
+    /// name the previous view. Term-start candidates bypass the gate.
+    fn requeue_child_certification(&mut self, parent: View) {
         let child = parent.next();
         if child <= self.last_finalized
             || child.is_term_start(self.term_length())
@@ -1183,7 +1187,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.remove(&view);
 
         if is_success {
-            self.wake_certification_child(view);
+            self.requeue_child_certification(view);
+
             // Keep the stall deadline armed after certification so the
             // term-level timeout can still abandon a term that certifies but
             // never finalizes.
@@ -5118,9 +5123,12 @@ mod tests {
                 Duration::from_secs(4),
                 ViewDelta::new(2),
             );
+            // Use a non-leader so its local vote is the event that opens the
+            // optimistic child.
             let leader_idx =
                 usize::from(elector.elect(Rnd::new(epoch, View::new(1)), None));
             let local_idx = (leader_idx + 1) % schemes.len();
+
             let config = |scheme, elector| Config {
                 scheme,
                 elector,
@@ -5131,6 +5139,8 @@ mod tests {
                 timeout_retry: Duration::from_secs(3),
             };
 
+            // Follow the live path through a local view-1 notarize vote and an
+            // optimistic verification request for view 2.
             let mut live = State::new(
                 context.child("live"),
                 config(schemes[local_idx].clone(), elector.clone()),
@@ -5157,6 +5167,8 @@ mod tests {
             assert!(live.set_proposal(View::new(2), child.clone()));
             assert!(matches!(live.try_verify(), Verify::Ready(..)));
 
+            // Rebuild from the durable vote and redeliver the child proposal,
+            // matching the inputs available after restart.
             let mut restarted = State::new(
                 context.child("restarted"),
                 config(schemes[local_idx].clone(), elector),
@@ -5165,6 +5177,8 @@ mod tests {
             restarted.replay(&Artifact::Notarize(local_vote));
             assert!(restarted.set_proposal(View::new(2), child));
 
+            // Replay must restore the ancestry gate that admitted the child on
+            // the live path.
             assert!(
                 matches!(restarted.try_verify(), Verify::Ready(..)),
                 "replayed local notarize should preserve optimistic child verification"

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -637,6 +637,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// This must use the same ancestry rule as proposal construction. A stricter
     /// rule can permanently lose a one-shot vote, while a looser rule can sign
     /// ancestry the local automaton rejected.
+    ///
+    /// One abstention is tolerated: a parent at failed certification rejects
+    /// the child's one-shot vote. A later parent finalization restores the
+    /// ancestry but does not retry the vote, because vote construction runs
+    /// only for the view an event touches and the finalization touches the
+    /// parent. Reaching this case requires the network to finalize a proposal
+    /// our automaton rejected, and that finalization proves a quorum advanced
+    /// without our vote.
     fn optimistic_parent_ready(&self, view: View) -> bool {
         let Some(parent) = self.previous_in_term(view) else {
             return true;
@@ -1234,8 +1242,9 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     //
     // The `*_parent_ready` predicates answer whether a view's immediate parent
     // is settled enough to act on. Certification and finalization require
-    // `explicit_parent_ready`. Notarize issuance uses the weaker
-    // `optimistic_parent_ready`.
+    // `explicit_parent_ready`. Notarize issuance uses `optimistic_parent_ready`,
+    // which delegates to `optimistic_ancestry_payload` so issuance and proposal
+    // construction share one ancestry rule.
 
     /// Returns the payload of `view`'s explicitly certified (or finalized)
     /// proposal, the strongest form of ancestry.

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1160,12 +1160,17 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         // Certification exempts term starts, so the candidate and its parent
         // sit mid-term and share the term's stable leader (see
         // [`Self::term_leader`]). Without a tracked leader the fetch asks any
-        // peer.
+        // peer. A leader that is the local signer is also excluded: the fetch
+        // exists because we lack the certificate, and a fresh fetch targeted
+        // only at ourselves has no peer to serve it.
         Some(CertificateFetch {
             proposal: *proposal_view,
             view: *parent_view,
             kind: Kind::Notarization,
-            target: self.term_leader(*proposal_view).map(|leader| leader.key),
+            target: self
+                .term_leader(*proposal_view)
+                .filter(|leader| !self.is_me(leader.idx))
+                .map(|leader| leader.key),
         })
     }
 
@@ -3325,10 +3330,7 @@ mod tests {
         runtime.start(|mut context| async move {
             let (
                 Fixture {
-                    participants,
-                    schemes,
-                    verifier,
-                    ..
+                    schemes, verifier, ..
                 },
                 mut state,
             ) = setup_state_with(
@@ -3357,11 +3359,12 @@ mod tests {
             assert_eq!(fetches[0].proposal, View::new(3));
             assert_eq!(fetches[0].view, View::new(2));
             assert!(matches!(fetches[0].kind, Kind::Notarization));
-            assert_eq!(
-                fetches[0].target.as_ref(),
-                Some(&participants[2]),
-                "the stable leader may target itself after unrestricted backfill is already queued"
-            );
+            // The local signer is the term's stable leader, so the fetch is
+            // untargeted: a fresh fetch targeted only at ourselves has no
+            // peer to serve it.
+            let leader = state.term_leader(View::new(3)).expect("term leader");
+            assert!(state.is_me(leader.idx));
+            assert!(fetches[0].target.is_none());
 
             // The resolver owns retries after the first fetch. Leave the
             // blocked candidate dormant until its parent's state changes so


### PR DESCRIPTION
## Summary

- Use one recursive optimistic-ancestry rule for proposal construction and notarize issuance. This prevents a child vote after local certification rejects its parent.
- Restore the optimistic successor when replaying a local notarize vote, so restart preserves the live verification path.
- Preserve `LeaderNullify` over a queued `Inactivity` timeout when the voter mailbox overflows.
- Avoid targeting the local signer when certification repair needs a certificate missing locally.
- Clarify the Automaton future-context and single-shot response contracts.

## Scheduling and recovery

Certification candidates retain the existing polling behavior. The round request flag deduplicates resolver fetches, while polling avoids requiring every parent-state transition to wake its child.

The added tests cover resolver targeting and ordering, failed-parent ancestry, replayed optimistic votes, journal durability ordering, timeout overflow, and finalization overtaking an in-flight verification.

## Validation

- `just test -p commonware-consensus`
- `just clippy -p commonware-consensus`
