### PR TITLE
[storage] Apply the journal and index concurrently in Db::apply_batch

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2863,7 +2863,9 @@ where
 
         // The journal append and the in-memory index application touch disjoint state (the log vs
         // the snapshot and bitmap), so run them concurrently. The index application is spawned as a
-        // job on the strategy while the journal append proceeds on this task.
+        // job on the strategy while the journal append proceeds on this task. A journal failure
+        // leaves the instance unusable either way (mutable storage failures are fatal and consume
+        // the database), so the index job's effects on error do not need to be rolled back.
         let strategy = self.strategy().clone();
         let log = self.log;
         let snapshot = self.snapshot;

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2879,7 +2879,6 @@ where
             // `extend_to`.
             bitmap.set_bit(*last_commit_loc, false);
             bitmap.set_bit(*batch.bounds.tip.size - 1, true);
-            drop(bitmap);
             snapshot
         });
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2802,7 +2802,14 @@ where
         let index_batch = Arc::clone(&batch);
         let index_bitmap = Arc::clone(&self.bitmap);
         let last_commit_loc = self.last_commit_loc;
-        let index_job = strategy.spawn(batch.diff.len(), move |_| {
+        // The job merges or scans every ancestor diff in addition to the tip diff, so
+        // size the spawn from all of them.
+        let work_hint = batch
+            .ancestor_diffs
+            .iter()
+            .map(|diff| diff.len())
+            .fold(batch.diff.len(), usize::saturating_add);
+        let index_job = strategy.spawn(work_hint, move |_| {
             let batch = index_batch;
             let mut snapshot = snapshot;
             let mut bitmap = index_bitmap.write();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -665,6 +665,75 @@ impl<'a, K: Ord, F: Family, V> Iterator for DiffMerge<'a, K, F, V> {
     }
 }
 
+/// Publish `batch`'s key-level changes to the in-memory snapshot index and activity bitmap.
+///
+/// `snapshot` and `bitmap` must hold the state committed through `last_commit_loc`, the location of
+/// the commit operation they currently end at. On return they reflect `batch.bounds.tip`.
+fn apply_batch_to_index<F, D, I, U, S, const N: usize>(
+    snapshot: &mut I,
+    bitmap: &mut bitmap::Prunable<N>,
+    batch: &MerkleizedBatch<F, D, U, S>,
+    last_commit_loc: Location<F>,
+) where
+    F: Family,
+    D: Digest,
+    I: UnorderedIndex<Value = Location<F>>,
+    U: update::Update,
+    S: Strategy,
+    Operation<F, U>: Send + Sync,
+{
+    let db_size = *last_commit_loc + 1;
+    let tip = *batch.bounds.tip.size;
+    bitmap.extend_to(tip);
+
+    if batch.ancestor_diffs.is_empty() {
+        // Fast path: no ancestors to merge, no fixups to look up.
+        for (key, entry) in batch.diff.iter() {
+            apply_diff(snapshot, bitmap, key, entry, entry.base_old_loc());
+        }
+    } else {
+        // Partition ancestor diffs into already-applied (provide `base_old_loc` fixups) and pending
+        // (still to be applied; merged with the child).
+        let mut applied = Vec::with_capacity(batch.ancestor_diffs.len());
+        let mut pending = Vec::with_capacity(batch.ancestor_diffs.len());
+        for (ancestor, diff) in batch.bounds.ancestors.iter().zip(&batch.ancestor_diffs) {
+            if ancestor.state.size <= db_size {
+                applied.push(diff.as_slice());
+            } else {
+                pending.push(diff.as_slice());
+            }
+        }
+        let mut resolver = DiffCursors::new(applied);
+        let mut base_locs = batch.ancestor_base_locs.iter().peekable();
+        let merge =
+            DiffMerge::new(iter::once(batch.diff.as_slice()).chain(pending.iter().copied()));
+        for (key, entry) in merge {
+            // Merged keys ascend, so the boundary cursor only moves forward.
+            while base_locs
+                .peek()
+                .is_some_and(|(candidate, _)| candidate < key)
+            {
+                base_locs.next();
+            }
+
+            // The key's location before this batch: from an already-applied ancestor, else the
+            // location recorded at the retained chain's boundary, else the batch's own record.
+            let old = if let Some(ancestor_entry) = resolver.resolve(key) {
+                ancestor_entry.loc()
+            } else if let Some((_, loc)) = base_locs.next_if(|(candidate, _)| candidate == key) {
+                *loc
+            } else {
+                entry.base_old_loc()
+            };
+            apply_diff(snapshot, bitmap, key, entry, old);
+        }
+    }
+
+    // Maintain the invariant that only the most recent CommitFloor operation can be active.
+    bitmap.set_bit(*last_commit_loc, false);
+    bitmap.set_bit(tip - 1, true);
+}
+
 /// Fill `out` with up to `limit` floor-raise candidates in `[floor, tip)` under a single bitmap
 /// read guard, returning the next `floor`.
 fn fill_candidates<F: Family, const N: usize>(
@@ -2791,94 +2860,30 @@ where
         let db_size = *self.last_commit_loc + 1;
         let start_loc = Location::new(db_size);
 
-        // The journal append and the in-memory index application touch disjoint state
-        // (the log vs the snapshot and bitmap), so run them concurrently: the index
-        // application is one job on the strategy while the journal append proceeds on
-        // this task. A storage failure leaves the instance unusable either way, so the
-        // index job's effects on error do not need to be rolled back.
+        // The journal append and the in-memory index application touch disjoint state (the log vs
+        // the snapshot and bitmap), so run them concurrently. The index application is spawned as a
+        // job on the strategy while the journal append proceeds on this task.
         let strategy = self.strategy().clone();
         let log = self.log;
         let snapshot = self.snapshot;
         let index_batch = Arc::clone(&batch);
         let index_bitmap = Arc::clone(&self.bitmap);
         let last_commit_loc = self.last_commit_loc;
-        // The job merges or scans every ancestor diff in addition to the tip diff, so
-        // size the spawn from all of them.
+
+        // The job merges or scans the tip and its uncommitted ancestor diffs.
         let work_hint = batch
             .ancestor_diffs
             .iter()
             .map(|diff| diff.len())
             .fold(batch.diff.len(), usize::saturating_add);
         let index_job = strategy.spawn(work_hint, move |_| {
-            let batch = index_batch;
             let mut snapshot = snapshot;
-            let mut bitmap = index_bitmap.write();
-            bitmap.extend_to(*batch.bounds.tip.size);
-
-            if batch.ancestor_diffs.is_empty() {
-                // Fast path: no ancestors to merge, no fixups to look up.
-                for (key, entry) in batch.diff.iter() {
-                    apply_diff(&mut snapshot, &mut bitmap, key, entry, entry.base_old_loc());
-                }
-            } else {
-                // Partition ancestor diffs into already-applied (provide `base_old_loc` fixups)
-                // and pending (still to be applied; merged with the child).
-                let mut applied = Vec::with_capacity(batch.ancestor_diffs.len());
-                let mut pending = Vec::with_capacity(batch.ancestor_diffs.len());
-                for (i, ancestor_diff) in batch.ancestor_diffs.iter().enumerate() {
-                    if batch.bounds.ancestors[i].state.size <= db_size {
-                        applied.push(ancestor_diff.as_slice());
-                    } else {
-                        pending.push(ancestor_diff.as_slice());
-                    }
-                }
-                let mut resolver = DiffCursors::new(applied);
-                if batch.ancestor_base_locs.is_empty() {
-                    let merge = DiffMerge::new(
-                        iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
-                    );
-                    for (key, entry) in merge {
-                        let old = resolver
-                            .resolve(key)
-                            .map(DiffEntry::loc)
-                            .unwrap_or_else(|| entry.base_old_loc());
-                        apply_diff(&mut snapshot, &mut bitmap, key, entry, old);
-                    }
-                } else {
-                    let mut ancestor_base_locs = batch.ancestor_base_locs.iter().peekable();
-                    let merge = DiffMerge::new(
-                        iter::once(batch.diff.as_slice()).chain(pending.iter().copied()),
-                    );
-                    for (key, entry) in merge {
-                        let old = resolver.resolve(key).map_or_else(
-                            || {
-                                while ancestor_base_locs
-                                    .peek()
-                                    .is_some_and(|(candidate, _)| candidate < key)
-                                {
-                                    ancestor_base_locs.next();
-                                }
-                                if ancestor_base_locs
-                                    .peek()
-                                    .is_some_and(|(candidate, _)| candidate == key)
-                                {
-                                    ancestor_base_locs.next().expect("peeked entry exists").1
-                                } else {
-                                    entry.base_old_loc()
-                                }
-                            },
-                            DiffEntry::loc,
-                        );
-                        apply_diff(&mut snapshot, &mut bitmap, key, entry, old);
-                    }
-                }
-            }
-
-            // CommitFloor: bit = 1 only on the current last commit. Demote the previous and
-            // set the new; earlier ancestor commits between them are already 0 from
-            // `extend_to`.
-            bitmap.set_bit(*last_commit_loc, false);
-            bitmap.set_bit(*batch.bounds.tip.size - 1, true);
+            apply_batch_to_index(
+                &mut snapshot,
+                &mut index_bitmap.write(),
+                &index_batch,
+                last_commit_loc,
+            );
             snapshot
         });
 

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -667,8 +667,8 @@ impl<'a, K: Ord, F: Family, V> Iterator for DiffMerge<'a, K, F, V> {
 
 /// Publish `batch`'s key-level changes to the in-memory snapshot index and activity bitmap.
 ///
-/// `snapshot` and `bitmap` must hold the state committed through `last_commit_loc`, the location of
-/// the commit operation they currently end at. On return they reflect `batch.bounds.tip`.
+/// `snapshot` and `bitmap` must hold the state already applied through `last_commit_loc`, the
+/// location of the commit operation they currently end at. On return they reflect `batch.bounds.tip`.
 fn apply_batch_to_index<F, D, I, U, S, const N: usize>(
     snapshot: &mut I,
     bitmap: &mut bitmap::Prunable<N>,
@@ -718,13 +718,14 @@ fn apply_batch_to_index<F, D, I, U, S, const N: usize>(
 
             // The key's location before this batch: from an already-applied ancestor, else the
             // location recorded at the retained chain's boundary, else the batch's own record.
-            let old = if let Some(ancestor_entry) = resolver.resolve(key) {
-                ancestor_entry.loc()
-            } else if let Some((_, loc)) = base_locs.next_if(|(candidate, _)| candidate == key) {
-                *loc
-            } else {
-                entry.base_old_loc()
-            };
+            let old = resolver.resolve(key).map_or_else(
+                || {
+                    base_locs
+                        .next_if(|(candidate, _)| candidate == key)
+                        .map_or_else(|| entry.base_old_loc(), |(_, loc)| *loc)
+                },
+                |ancestor_entry| ancestor_entry.loc(),
+            );
             apply_diff(snapshot, bitmap, key, entry, old);
         }
     }
@@ -2870,7 +2871,7 @@ where
         let index_bitmap = Arc::clone(&self.bitmap);
         let last_commit_loc = self.last_commit_loc;
 
-        // The job merges or scans the tip and its uncommitted ancestor diffs.
+        // The job merges or scans the tip and its pending ancestor diffs.
         let work_hint = batch
             .ancestor_diffs
             .iter()

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2740,7 +2740,7 @@ where
     F: Family,
     E: Context,
     C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
+    I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     U: update::Update,
     S: Strategy,
@@ -2791,24 +2791,27 @@ where
         let db_size = *self.last_commit_loc + 1;
         let start_loc = Location::new(db_size);
 
-        // Apply journal (handles its own partial ancestor skipping).
-        self.log = self.log.apply_batch(&batch.journal_batch).await?;
-
-        // Scoped so the bitmap guard drops before later `.await`s (guard is `!Send`).
-        {
-            let mut bitmap = self.bitmap.write();
+        // The journal append and the in-memory index application touch disjoint state
+        // (the log vs the snapshot and bitmap), so run them concurrently: the index
+        // application is one job on the strategy while the journal append proceeds on
+        // this task. A storage failure leaves the instance unusable either way, so the
+        // index job's effects on error do not need to be rolled back.
+        let strategy = self.strategy().clone();
+        let log = self.log;
+        let snapshot = self.snapshot;
+        let index_batch = Arc::clone(&batch);
+        let index_bitmap = Arc::clone(&self.bitmap);
+        let last_commit_loc = self.last_commit_loc;
+        let index_job = strategy.spawn(batch.diff.len(), move |_| {
+            let batch = index_batch;
+            let mut snapshot = snapshot;
+            let mut bitmap = index_bitmap.write();
             bitmap.extend_to(*batch.bounds.tip.size);
 
             if batch.ancestor_diffs.is_empty() {
                 // Fast path: no ancestors to merge, no fixups to look up.
                 for (key, entry) in batch.diff.iter() {
-                    apply_diff(
-                        &mut self.snapshot,
-                        &mut bitmap,
-                        key,
-                        entry,
-                        entry.base_old_loc(),
-                    );
+                    apply_diff(&mut snapshot, &mut bitmap, key, entry, entry.base_old_loc());
                 }
             } else {
                 // Partition ancestor diffs into already-applied (provide `base_old_loc` fixups)
@@ -2832,7 +2835,7 @@ where
                             .resolve(key)
                             .map(DiffEntry::loc)
                             .unwrap_or_else(|| entry.base_old_loc());
-                        apply_diff(&mut self.snapshot, &mut bitmap, key, entry, old);
+                        apply_diff(&mut snapshot, &mut bitmap, key, entry, old);
                     }
                 } else {
                     let mut ancestor_base_locs = batch.ancestor_base_locs.iter().peekable();
@@ -2859,7 +2862,7 @@ where
                             },
                             DiffEntry::loc,
                         );
-                        apply_diff(&mut self.snapshot, &mut bitmap, key, entry, old);
+                        apply_diff(&mut snapshot, &mut bitmap, key, entry, old);
                     }
                 }
             }
@@ -2867,9 +2870,16 @@ where
             // CommitFloor: bit = 1 only on the current last commit. Demote the previous and
             // set the new; earlier ancestor commits between them are already 0 from
             // `extend_to`.
-            bitmap.set_bit(*self.last_commit_loc, false);
+            bitmap.set_bit(*last_commit_loc, false);
             bitmap.set_bit(*batch.bounds.tip.size - 1, true);
-        }
+            drop(bitmap);
+            snapshot
+        });
+
+        // Apply journal (handles its own partial ancestor skipping) while the index job runs.
+        let (log, snapshot) = futures::join!(log.apply_batch(&batch.journal_batch), index_job);
+        self.log = log?;
+        self.snapshot = snapshot;
 
         // Update DB metadata.
         self.active_keys = batch.total_active_keys;
@@ -3028,7 +3038,7 @@ mod trait_impls {
         K: Key,
         V: ValueEncoding + 'static,
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
-        I: UnorderedIndex<Value = Location<F>>,
+        I: UnorderedIndex<Value = Location<F>> + 'static,
         H: Hasher,
         S: Strategy,
         Operation<F, update::Unordered<K, V>>: Codec,
@@ -3059,7 +3069,7 @@ mod trait_impls {
         K: Key,
         V: ValueEncoding + 'static,
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
-        I: OrderedIndex<Value = Location<F>>,
+        I: OrderedIndex<Value = Location<F>> + 'static,
         H: Hasher,
         S: Strategy,
         Operation<F, update::Ordered<K, V>>: Codec,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -401,7 +401,7 @@ where
     F: merkle::Graftable,
     E: Context,
     C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
+    I: UnorderedIndex<Value = Location<F>> + 'static,
     H: Hasher,
     U: Update,
     S: Strategy,


### PR DESCRIPTION
## Summary

`Db::apply_batch` previously ran its three phases serially: ops-journal append, in-memory merkle apply, then the index and bitmap application. The journal append and the index application touch disjoint state (the log vs the snapshot and bitmap), so this change runs the index and bitmap application as one job on the strategy while the journal append proceeds on the calling task, joining before the metadata update.

The size-aware `Strategy::spawn` (#4423) gates the offload adaptively, so batches too small to amortize the hand-off degrade to the previous sequential behavior. Because the policy measures caller-marginal cost, the overlap makes offloading look nearly free, which it now is.

The `I: 'static` bound ripples to the impl blocks whose methods move the index into the job. `Send` needs no mention: `Unordered` gained it as a supertrait in #4452.

The index application phase has been extracted into its own function with simplified control flow for improved comprehensibility.

## Benchmarks

All runs produce byte-identical databases (and bit-exact roots where the bench prints them). Linux, x86_64, AMD EPYC 9354P, mimalloc in the bench binary, paired same-session runs.

| workload | before | after | delta |
|---|---|---|---|
| eth_replay (100k blocks from a 5M-block seed, follower, 32 GiB cache) | 219.27s / 221.94s wall | 213.03s / 213.70s | **-3.3% wall, apply phase -20%, +4.2% writes/s** |
| qmdb generator (50M keyspace, 25M updates, 10k-update commits, p3 ordered) | 109.96s / 110.06s | 104.90s / 103.93s | **-5.1%** |
| apply_batch micro (16,384 updates, ordered p256) | 6.24ms | 4.86ms | **-22%** (non-overlapping CIs) |
| Constantinople seed+churn (1M-update seed + 4x32k churn applies) | 1.598s | 1.514s | **-5.3%** (Mac arm64: -5.0%; roots bit-exact across states and platforms) |

Constantinople's timed section (load + merkleize, which never applies) is unchanged, as expected.

## Pool size, and what the gains consist of

Everything above was measured with an 8-thread strategy pool on both arms, and the pool size itself turns out to be a significant variable. Idle pool workers are not free: rayon workers with nothing to do spin-yield around the serial thread, and on a workload with long serial stretches between parallel bursts that interference is expensive. Re-running this PR against its base at both 1-thread and 8-thread pools (same host, 20k-block eth-replay windows) shows the idle pool costs the base +78% on the apply phase and +14% on wall:

| | wall | apply |
|---|---|---|
| base, 8 threads | 50.80s | 8.03s |
| this PR, 8 threads | 48.81s | 6.02s |
| base, 1 thread | 44.45s | 4.52s |
| this PR, 1 thread | 43.86s | 4.38s |

Two things follow. First, the -25% apply / -3.9% wall reported above reproduces, but most of it is the overlap sheltering the critical path from that idle-pool interference -- and putting one otherwise-idle worker to work -- rather than raw concurrency: with a 1-thread pool the spawn inlines, the overlap is off, and the diff measures about -3% apply / -1.3% wall. Second, the benchmark tables in this description are accurate for the 8-thread environment they were measured in; they are not pool-independent.

The idle-pool cost tracks the workload's parallel duty cycle rather than being universal. On the same host at 1 vs. 8 threads (plain main): the merkleize microbenchmarks are a wash (within 1.5% either way), eth-replay runs 7% faster with the minimal pool, while the 50M-key generator runs 9% faster and the Constantinople shape 26% faster with the full pool. Pool size is therefore a per-workload deployment choice: sparse block-replay shapes run fastest with a minimal pool, dense batch workloads with a full one.

## Validation

-  qmdb tests, `just check-stability` clean.
- `db_bytes` identical across every A/B pair above; Constantinople speculative roots bit-exact per iteration.
- no impact on apply batch microbenchmarks.



