### PR TITLE
[consensus/simplex] Fix stale proposal verification and ancestry repair

### DIFF
--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -205,6 +205,13 @@ impl<
         }
     }
 
+    /// Returns the highest finalized view, or zero if none is known.
+    fn last_finalized(&self) -> View {
+        self.state
+            .finalization()
+            .map_or(View::zero(), |certificate| certificate.view())
+    }
+
     /// Records a certificate and applies its resolver lifecycle effects.
     fn updated<R: Resolver<Key = U64, Subscriber = Ask>>(
         &mut self,
@@ -212,10 +219,7 @@ impl<
         certificate: Certificate<S, D>,
     ) {
         let term_length = self.state.term_length();
-        let last_finalized = self
-            .state
-            .finalization()
-            .map_or(View::zero(), |certificate| certificate.view());
+        let last_finalized = self.last_finalized();
 
         // Retain encoded certificates for as long as a peer can still ask for them.
         // [State] prunes at the floor, which rises sooner than finalization and
@@ -274,10 +278,7 @@ impl<
     ) {
         // Every verdict clears the pending payload. Only successful
         // notarizations above finalization become servable.
-        let last_finalized = self
-            .state
-            .finalization()
-            .map_or(View::zero(), |certificate| certificate.view());
+        let last_finalized = self.last_finalized();
         if let Some(notarization) = self.pending_notarizations.remove(&view)
             && success
             && view > last_finalized
@@ -425,11 +426,7 @@ impl<
         // Finalization rules out any further need for the view. This is also
         // what settles an ask answered by a finalization, since resolver state
         // retains the highest one independently of its construction floor.
-        let last_finalized = self
-            .state
-            .finalization()
-            .map_or(View::zero(), |certificate| certificate.view());
-        if view <= last_finalized {
+        if view <= self.last_finalized() {
             return true;
         }
         match kind {
@@ -464,12 +461,8 @@ impl<
     /// the current floor is served. Pending notarizations and notarizations
     /// that fail certification are never served.
     fn produce_certificate(&self, view: View) -> Option<Bytes> {
-        // Resolver state retains the full highest finalization independently
-        // of its movable construction floor. A higher notarization can advance
-        // that floor without settling a request for older ancestry, so the
-        // retained finalization must remain available here. It also subsumes
-        // every lower finalization because it settles all requests at or below
-        // its view.
+        // Prefer the retained finalization because a higher notarization does
+        // not settle an older ancestry request.
         if let Some(certificate @ Certificate::Finalization(_)) = self.state.get(view) {
             return Some(certificate.encode());
         }

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -58,10 +58,6 @@ pub struct Actor<
     /// applies to the resolver (see [Self::apply_effects]).
     state: State<S, D>,
 
-    /// Highest finalized view observed. Targeted ancestry at or below this
-    /// view can no longer be required by a valid proposal.
-    last_finalized: View,
-
     /// Encoded nullifications retained while they cover an unfinalized view.
     /// This cache survives floor raises so asks below the floor remain servable.
     nullifications: BTreeMap<View, Bytes>,
@@ -106,7 +102,6 @@ impl<
                 fetch_timeout: cfg.fetch_timeout,
 
                 state: State::new(cfg.term_length),
-                last_finalized: View::zero(),
                 nullifications: BTreeMap::new(),
                 pending_notarizations: BTreeMap::new(),
                 certified_notarizations: BTreeMap::new(),
@@ -217,6 +212,10 @@ impl<
         certificate: Certificate<S, D>,
     ) {
         let term_length = self.state.term_length();
+        let last_finalized = self
+            .state
+            .finalization()
+            .map_or(View::zero(), |certificate| certificate.view());
 
         // Retain encoded certificates for as long as a peer can still ask for them.
         // [State] prunes at the floor, which rises sooner than finalization and
@@ -224,7 +223,7 @@ impl<
         match &certificate {
             Certificate::Nullification(nullification) => {
                 let view = nullification.view();
-                if view.term_end(term_length) > self.last_finalized {
+                if view.term_end(term_length) > last_finalized {
                     self.nullifications.insert(view, certificate.encode());
                     let covered = view..=view.term_end(term_length);
                     Self::retire(resolver, move |view, ask| {
@@ -234,7 +233,7 @@ impl<
             }
             Certificate::Notarization(notarization) => {
                 let view = notarization.view();
-                if view > self.last_finalized && !self.uncertifiable_notarizations.contains(&view) {
+                if view > last_finalized && !self.uncertifiable_notarizations.contains(&view) {
                     if !self.certified_notarizations.contains_key(&view) {
                         self.pending_notarizations
                             .insert(view, certificate.encode());
@@ -248,8 +247,7 @@ impl<
                 // Finalization is the global retirement boundary: a valid proposal
                 // can no longer name ancestry at or below it, so nothing here can
                 // still be asked for.
-                self.last_finalized = self.last_finalized.max(finalization.view());
-                let finalized = self.last_finalized;
+                let finalized = last_finalized.max(finalization.view());
                 self.nullifications
                     .retain(|view, _| view.term_end(term_length) > finalized);
                 self.pending_notarizations
@@ -276,9 +274,13 @@ impl<
     ) {
         // Every verdict clears the pending payload. Only successful
         // notarizations above finalization become servable.
+        let last_finalized = self
+            .state
+            .finalization()
+            .map_or(View::zero(), |certificate| certificate.view());
         if let Some(notarization) = self.pending_notarizations.remove(&view)
             && success
-            && view > self.last_finalized
+            && view > last_finalized
         {
             self.certified_notarizations.insert(view, notarization);
         }
@@ -287,7 +289,7 @@ impl<
         // is not an answer to an exact-parent request.
         if !success {
             self.certified_notarizations.remove(&view);
-            if view > self.last_finalized {
+            if view > last_finalized {
                 self.uncertifiable_notarizations.insert(view);
             }
             Self::retire(resolver, move |asked, ask| {
@@ -421,9 +423,13 @@ impl<
     /// evidence the actor records, but not what was asked for.
     fn settled(&self, view: View, kind: Kind) -> bool {
         // Finalization rules out any further need for the view. This is also
-        // what settles an ask answered by a finalization, since recording one
-        // raises [Self::last_finalized].
-        if view <= self.last_finalized {
+        // what settles an ask answered by a finalization, since resolver state
+        // retains the highest one independently of its construction floor.
+        let last_finalized = self
+            .state
+            .finalization()
+            .map_or(View::zero(), |certificate| certificate.view());
+        if view <= last_finalized {
             return true;
         }
         match kind {
@@ -452,14 +458,18 @@ impl<
 
     /// Selects the best certificate to serve for `view`.
     ///
-    /// An active finalization floor settles every ask at or below it. Otherwise
+    /// The highest finalization settles every ask at or below it. Otherwise
     /// an exact certified notarization is preferred to a covering
     /// nullification, matching proposal construction. If neither is retained,
     /// the current floor is served. Pending notarizations and notarizations
     /// that fail certification are never served.
     fn produce_certificate(&self, view: View) -> Option<Bytes> {
-        // A current finalization floor settles either kind, so retained
-        // ancestry cannot improve the answer.
+        // Resolver state retains the full highest finalization independently
+        // of its movable construction floor. A higher notarization can advance
+        // that floor without settling a request for older ancestry, so the
+        // retained finalization must remain available here. It also subsumes
+        // every lower finalization because it settles all requests at or below
+        // its view.
         if let Some(certificate @ Certificate::Finalization(_)) = self.state.get(view) {
             return Some(certificate.encode());
         }
@@ -473,8 +483,8 @@ impl<
             return Some(nullification.clone());
         }
 
-        // The floor advances by view, so this can serve a higher certified
-        // notarization after it supersedes an older finalization.
+        // Above retained finalization, the movable floor may still serve a
+        // higher certified notarization.
         self.state.get(view).map(|certificate| certificate.encode())
     }
 
@@ -1452,36 +1462,52 @@ mod tests {
     }
 
     #[test_async]
-    async fn higher_certified_floor_is_served_over_older_finalization() {
+    async fn higher_certified_floor_does_not_hide_older_finalization() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let Fixture {
                 schemes, verifier, ..
             } = ed25519::fixture(&mut context, NAMESPACE, 4);
-            let mut actor = build_actor(context, verifier.clone(), TERM_LENGTH);
-            let mut resolver = RecordingResolver::default();
+            let mut responder =
+                build_actor(context.child("responder"), verifier.clone(), TERM_LENGTH);
+            let mut responder_resolver = RecordingResolver::default();
 
             let requested = View::new(3);
             let finalization = Certificate::Finalization(build_finalization(
                 &schemes, &verifier, EPOCH, requested,
             ));
-            let expected_finalization = finalization.encode();
-            actor.updated(&mut resolver, finalization);
-            assert_eq!(
-                actor.produce_certificate(requested),
-                Some(expected_finalization)
-            );
+            responder.updated(&mut responder_resolver, finalization);
 
             let floor = View::new(6);
             let notarization =
                 Certificate::Notarization(build_notarization(&schemes, &verifier, EPOCH, floor));
-            let expected = notarization.encode();
-            actor.updated(&mut resolver, notarization);
-            actor.certified(&mut resolver, floor, true);
+            responder.updated(&mut responder_resolver, notarization);
+            responder.certified(&mut responder_resolver, floor, true);
 
-            // The floor advances by view, so the higher certified
-            // notarization supersedes the older finalization.
-            assert_eq!(actor.produce_certificate(requested), Some(expected));
+            // The notarization is now the construction floor, but returning it
+            // for view 3 would leave the targeted ask ambiguous. The retained
+            // finalization settles that ask instead.
+            let data = responder
+                .produce_certificate(requested)
+                .expect("responder should retain settling finalization");
+
+            let (voter_tx, _voter_rx) = mailbox::new(context.child("requester_voter"), NZUsize!(8));
+            let mut voter = voter::Mailbox::new(voter_tx);
+            let mut requester = build_actor(context.child("requester"), verifier, TERM_LENGTH);
+            let mut requester_resolver = RecordingResolver::default();
+            let (response, receiver) = oneshot::channel();
+            requester.handle_resolver(
+                HandlerMessage::Deliver {
+                    span: tracing::Span::none(),
+                    view: requested,
+                    data,
+                    asks: non_empty_vec![Ask::ancestry(Kind::Notarization)],
+                    response,
+                },
+                &mut voter,
+                &mut requester_resolver,
+            );
+            assert_eq!(receiver.await.unwrap(), Outcome::Complete);
         });
     }
 

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -33,12 +33,12 @@
 //! certification verdict retires that request, whereas a certified-floor raise retires only
 //! background work.
 //!
-//! The wire key names only the view. An active finalization floor settles every ask at or below it.
+//! The wire key names only the view. A retained finalization settles every ask at or below it.
 //! Otherwise serving prefers an exact certified notarization to a covering nullification, matching
-//! proposal construction. If neither is retained, the responder serves its current floor. Floors
-//! advance by view, so a higher certified notarization supersedes an older finalization, while a
-//! finalization upgrades a certified notarization at the same view. The requester treats a valid
-//! response that does not settle its ask as ambiguous and retries without faulting the peer.
+//! proposal construction. If neither is retained, the responder serves its current floor. The
+//! highest finalization remains servable even when a newer certified notarization advances the
+//! construction floor. The requester treats a valid response that does not settle its ask as
+//! ambiguous and retries without faulting the peer.
 //!
 //! A notarization is served only after local certification succeeds. Possession still settles the
 //! holder's own ask, because certification judges evidence already in hand. A failed verdict also

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -39,13 +39,23 @@ pub(crate) enum Effect {
     RetainAbove(View),
 }
 
-/// Tracks all known certificates from the last
-/// certified notarization or finalized view to the current view.
+/// Tracks the construction floor, retained finalization, and certificates
+/// needed to repair views through the current view.
+///
+/// The construction floor and retained finalization have different lifetimes.
+/// A higher certified notarization advances the floor, but it does not replace
+/// the finalization as a settling response for requests at or below the
+/// finalized view. The full finalization certificate is therefore retained
+/// independently so it remains servable after the floor advances. Only the
+/// highest finalization is needed because it settles every request that a
+/// lower finalization would settle.
 pub struct State<S: Scheme, D: Digest> {
     /// Highest seen view.
     current_view: View,
-    /// Most recent certified notarization or finalization.
+    /// Highest certificate used as the construction floor.
     floor: Option<Certificate<S, D>>,
+    /// Full highest finalization, retained independently of the movable floor.
+    finalization: Option<Certificate<S, D>>,
     /// Notarizations pending certification (possible floors).
     notarizations: BTreeMap<View, Notarization<S, D>>,
     /// Nullifications that cover any view greater than the floor.
@@ -66,6 +76,7 @@ impl<S: Scheme, D: Digest> State<S, D> {
         Self {
             current_view: View::zero(),
             floor: None,
+            finalization: None,
             notarizations: BTreeMap::new(),
             nullifications: BTreeMap::new(),
             fetch_floor: View::zero(),
@@ -99,8 +110,18 @@ impl<S: Scheme, D: Digest> State<S, D> {
             }
             Certificate::Finalization(finalization) => {
                 let view = finalization.view();
+                let certificate = Certificate::Finalization(finalization);
+                // Retain the proof, not just its view: it may need to be served
+                // after a higher certified notarization advances the floor.
+                if self
+                    .finalization
+                    .as_ref()
+                    .is_none_or(|known| view > known.view())
+                {
+                    self.finalization = Some(certificate.clone());
+                }
                 if view > self.floor_view() || self.can_upgrade_floor(view) {
-                    self.floor = Some(Certificate::Finalization(finalization));
+                    self.floor = Some(certificate);
                     effects.push(self.prune());
                 }
             }
@@ -146,10 +167,18 @@ impl<S: Scheme, D: Digest> State<S, D> {
         effects
     }
 
-    /// Get the best certificate for a given view (or the floor
-    /// if the view is below the floor).
+    /// Get the best certificate for a given view.
+    ///
+    /// The retained finalization is preferred at or below its view because it
+    /// settles those requests. A higher notarization may be the current floor
+    /// without settling a targeted request for older ancestry.
     pub fn get(&self, view: View) -> Option<&Certificate<S, D>> {
-        // If view is <= floor, return the floor
+        if let Some(finalization) = &self.finalization
+            && view <= finalization.view()
+        {
+            return Some(finalization);
+        }
+
         if let Some(floor) = &self.floor
             && view <= floor.view()
         {
@@ -158,6 +187,14 @@ impl<S: Scheme, D: Digest> State<S, D> {
 
         // Otherwise, return the nullification covering the view if it exists.
         self.covering_nullification(view)
+    }
+
+    /// Returns the full highest finalization retained for serving requests.
+    ///
+    /// Its view alone is insufficient because the resolver may need to return
+    /// the certificate after the construction floor advances beyond it.
+    pub const fn finalization(&self) -> Option<&Certificate<S, D>> {
+        self.finalization.as_ref()
     }
 
     /// Returns the stored nullification covering `view`, if any.

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -189,10 +189,8 @@ impl<S: Scheme, D: Digest> State<S, D> {
         self.covering_nullification(view)
     }
 
-    /// Returns the full highest finalization retained for serving requests.
-    ///
-    /// Its view alone is insufficient because the resolver may need to return
-    /// the certificate after the construction floor advances beyond it.
+    /// Returns the highest finalization certificate retained independently of
+    /// the construction floor.
     pub const fn finalization(&self) -> Option<&Certificate<S, D>> {
         self.finalization.as_ref()
     }

--- a/consensus/src/simplex/actors/resolver/state.rs
+++ b/consensus/src/simplex/actors/resolver/state.rs
@@ -109,10 +109,10 @@ impl<S: Scheme, D: Digest> State<S, D> {
                 }
             }
             Certificate::Finalization(finalization) => {
-                let view = finalization.view();
-                let certificate = Certificate::Finalization(finalization);
                 // Retain the proof, not just its view: it may need to be served
                 // after a higher certified notarization advances the floor.
+                let view = finalization.view();
+                let certificate = Certificate::Finalization(finalization);
                 if self
                     .finalization
                     .as_ref()

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -196,6 +196,8 @@ mod tests {
         certify_latency_ms: f64,
         /// Views whose verification requests reached the mock application.
         verify_requests: Option<Arc<Mutex<Vec<View>>>>,
+        /// Whether every mock application verification should fail.
+        fail_verification: bool,
         certifier: mocks::application::Certifier<Sha256Digest>,
     }
 
@@ -212,6 +214,7 @@ mod tests {
                 verify_latency_ms: 1.0,
                 certify_latency_ms: 1.0,
                 verify_requests: None,
+                fail_verification: false,
                 certifier: mocks::application::Certifier::Always,
             }
         }
@@ -258,6 +261,7 @@ mod tests {
         };
         let (mut actor, application) =
             mocks::application::Application::new(context.child("app"), application_cfg);
+        actor.set_fail_verification(options.fail_verification);
         if let Some(verify_requests) = verify_requests {
             actor.set_verify_observer(Box::new(move |context, _| {
                 verify_requests.lock().push(context.view());
@@ -6730,6 +6734,100 @@ mod tests {
         );
         certification_cancelled_on_finalization::<_, _, RoundRobin>(ed25519::fixture);
         certification_cancelled_on_finalization::<_, _, RoundRobin>(secp256r1::fixture);
+    }
+
+    #[test_traced]
+    fn test_stale_same_parent_verification_failure_does_not_nullify_replacement() {
+        let n = 5;
+        let quorum = quorum(n);
+        let executor = deterministic::Runner::timed(Duration::from_secs(10));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, b"stale-same-parent-verification", n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+            let verify_requests = Arc::new(Mutex::new(Vec::new()));
+            let (mut mailbox, mut batcher_receiver, mut resolver_receiver, relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                RoundRobin::<Sha256>::default(),
+                VoterOptions {
+                    leader_timeout: Duration::from_secs(5),
+                    certification_timeout: Duration::from_secs(5),
+                    timeout_retry: Duration::from_mins(60),
+                    verify_latency_ms: 100.0,
+                    certify_latency_ms: 500.0,
+                    verify_requests: Some(verify_requests.clone()),
+                    fail_verification: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            if let batcher::Message::Update { .. } = batcher_receiver.recv().await.unwrap() {}
+            let view = View::new(5);
+            let parent_payload =
+                advance_to_view(&mut mailbox, &mut batcher_receiver, &schemes, quorum, view).await;
+
+            let proposal_a = Proposal::new(
+                Round::new(Epoch::new(333), view),
+                view.previous().unwrap(),
+                Sha256::hash(&[b"proposal-a"]),
+            );
+            relay.broadcast(
+                &participants[1],
+                Recipients::All,
+                (
+                    proposal_a.payload,
+                    (proposal_a.round, parent_payload, 1u64).encode(),
+                ),
+            );
+            mailbox.proposal(proposal_a);
+            context.sleep(Duration::from_millis(10)).await;
+            assert_eq!(*verify_requests.lock(), vec![view]);
+
+            let proposal_b = Proposal::new(
+                Round::new(Epoch::new(333), view),
+                view.previous().unwrap(),
+                Sha256::hash(&[b"proposal-b"]),
+            );
+            let (_, notarization) = build_notarization(&schemes, &proposal_b, quorum);
+            mailbox.recovered(Certificate::Notarization(notarization));
+
+            loop {
+                select! {
+                    message = batcher_receiver.recv() => match message.unwrap() {
+                        batcher::Message::Constructed(Vote::Nullify(nullify))
+                            if nullify.view() == view =>
+                        {
+                            panic!("stale verification failure nullified the replacement proposal");
+                        }
+                        batcher::Message::Update { .. }
+                        | batcher::Message::Constructed(_) => {}
+                    },
+                    message = resolver_receiver.recv() => match message.unwrap() {
+                        MailboxMessage::Certified { view: certified, success, .. }
+                            if certified == view =>
+                        {
+                            assert!(success);
+                            break;
+                        }
+                        MailboxMessage::Certificate { .. }
+                        | MailboxMessage::Certified { .. }
+                        | MailboxMessage::Resolve { .. } => {}
+                    },
+                    _ = context.sleep(Duration::from_secs(3)) => {
+                        panic!("replacement proposal did not finish certification");
+                    },
+                }
+            }
+        });
     }
 
     /// Test that in-flight certification is still reported to resolver after nullification.

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -78,10 +78,9 @@ pub struct Round<S: Scheme, D: Digest> {
     certify: CertifyState,
     last_ancestry_request: Option<View>,
 
-    // Parent selected when peer proposal verification was started. Used to
-    // detect the parent being displaced by a conflicting certificate before
-    // we sign (see `State::verified_parent_matches`).
-    verifying_parent: Option<(View, D)>,
+    // Proposal and resolved parent payload selected when peer verification
+    // started. A certificate may replace either while the request is in flight.
+    verifying: Option<(Proposal<D>, D)>,
 }
 
 impl<S: Scheme, D: Digest> Round<S, D> {
@@ -110,7 +109,7 @@ impl<S: Scheme, D: Digest> Round<S, D> {
             broadcast_finalization: false,
             certify: CertifyState::Ready,
             last_ancestry_request: None,
-            verifying_parent: None,
+            verifying: None,
         }
     }
 
@@ -171,19 +170,19 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         true
     }
 
-    /// Records the parent selected when peer proposal verification started.
-    pub const fn set_verifying_parent(&mut self, parent: View, payload: D) {
-        self.verifying_parent = Some((parent, payload));
+    /// Records the proposal and parent payload selected when verification started.
+    pub const fn set_verifying(&mut self, proposal: Proposal<D>, parent_payload: D) {
+        self.verifying = Some((proposal, parent_payload));
     }
 
-    /// Returns the parent recorded when verification started, if any.
-    pub const fn verifying_parent(&self) -> Option<&(View, D)> {
-        self.verifying_parent.as_ref()
+    /// Returns the proposal binding recorded when verification started, if any.
+    pub const fn verifying(&self) -> Option<&(Proposal<D>, D)> {
+        self.verifying.as_ref()
     }
 
-    /// Clears the recorded verification parent.
-    pub const fn clear_verifying_parent(&mut self) {
-        self.verifying_parent = None;
+    /// Clears the recorded verification binding.
+    pub const fn clear_verifying(&mut self) {
+        self.verifying = None;
     }
 
     /// Attempt to certify this round's proposal.

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -667,7 +667,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         if self.in_issuance_window(view) && !self.optimistic_parent_ready(view) {
             return None;
         }
-        if !self.verified_parent_matches(view) {
+        if !self.verification_matches(view) {
             return None;
         }
         let candidate = self
@@ -996,7 +996,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             if !round.request_verify() {
                 continue;
             }
-            round.set_verifying_parent(proposal.parent, parent_payload);
+            round.set_verifying(proposal.clone(), parent_payload);
             return Verify::Ready(
                 Context {
                     round: proposal.round,
@@ -1009,13 +1009,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         Verify::Wait
     }
 
-    /// Returns true when a verification completion describes a parent we have
-    /// since replaced, discarding the stale binding.
+    /// Returns true when a verification completion describes a proposal or
+    /// parent we have since replaced, discarding the stale binding.
     ///
-    /// An optimistic child is verified before its parent is certified, so a
-    /// conflicting parent certificate can land while the request is in flight.
-    /// The completion then reports on ancestry we no longer hold and says
-    /// nothing about the proposal under the parent we now accept.
+    /// A same-view certificate can replace the proposal while the request is in
+    /// flight without advancing the voter. An optimistic child's parent can
+    /// likewise be displaced before it certifies. In either case, the
+    /// completion says nothing about the proposal and ancestry we now hold.
     ///
     /// The proposal is not re-queued for verification under the
     /// replacement parent: displacement implies the leader equivocated, and
@@ -1029,11 +1029,11 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// whom the voter blocks. A Byzantine leader therefore pays this delay at
     /// most once: later views skip at the leader timeout.
     fn verification_is_stale(&mut self, view: View) -> bool {
-        if self.verified_parent_matches(view) {
+        if self.verification_matches(view) {
             return false;
         }
         if let Some(round) = self.views.get_mut(&view) {
-            round.clear_verifying_parent();
+            round.clear_verifying();
         }
         true
     }
@@ -1322,20 +1322,19 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         }
     }
 
-    fn verified_parent_matches(&self, view: View) -> bool {
-        // Parents are recorded only for peer proposals (in try_verify). A locally
-        // built proposal's parent can only be displaced by conflicting certificates
-        // for the parent view, which requires more than f faults.
+    fn verification_matches(&self, view: View) -> bool {
+        // Bindings are recorded only for peer proposals (in try_verify). A locally
+        // built proposal is never completed through this verification path.
         let Some(round) = self.views.get(&view) else {
             return true;
         };
-        let Some((parent_view, parent_payload)) = round.verifying_parent() else {
+        let Some((verifying, parent_payload)) = round.verifying() else {
             return true;
         };
         let Some(proposal) = round.proposal() else {
             return false;
         };
-        if proposal.parent != *parent_view {
+        if proposal != verifying {
             return false;
         }
         self.parent_payload(proposal)

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1017,17 +1017,18 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// likewise be displaced before it certifies. In either case, the
     /// completion says nothing about the proposal and ancestry we now hold.
     ///
-    /// The proposal is not re-queued for verification under the
-    /// replacement parent: displacement implies the leader equivocated, and
-    /// the proposal commits to the parent it was built on. The view instead
-    /// resolves through a peer's notarization of the proposal or the normal
-    /// timeout/nullification path.
+    /// A replacement proposal is certificate-backed and proceeds through
+    /// certification. A proposal with a displaced parent still commits to its
+    /// original parent, so it cannot be reverified under the replacement parent.
+    /// The proposal's view resolves through a peer's notarization of that proposal
+    /// or the timeout/nullification path.
     ///
-    /// The discard trades latency, not safety. A discarded rejection leaves
-    /// the view to the certification timeout instead of an immediate nullify.
-    /// The displacing certificate also identifies the equivocating leader,
-    /// whom the voter blocks. A Byzantine leader therefore pays this delay at
-    /// most once: later views skip at the leader timeout.
+    /// Discarding a stale rejection trades latency, not safety. Only parent
+    /// displacement can delay the view until the certification timeout instead
+    /// of an immediate nullify. The displacing certificate identifies the
+    /// equivocating leader, whom the voter blocks. Each Byzantine leader can
+    /// cause this delay at most once. Later views skip that leader at the leader
+    /// timeout.
     fn verification_is_stale(&mut self, view: View) -> bool {
         if self.verification_matches(view) {
             return false;
@@ -1051,9 +1052,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
     /// Latches `reason` after the automaton rejected or dropped a proposal.
     ///
-    /// A stale completion is discarded rather than latched: nullifying on a
-    /// verdict about a parent we have already replaced would forfeit the view
-    /// over ancestry that no longer applies.
+    /// Discards a stale verdict so it cannot forfeit the view after its
+    /// proposal or resolved parent has been replaced.
     pub fn verification_failed(&mut self, view: View, reason: TimeoutReason) {
         if self.verification_is_stale(view) {
             return;


### PR DESCRIPTION
Related: #3416

## Summary

Follow-up to #4426 for two production-reachable edge cases found during review:

- Bind in-flight application verification to the exact proposal and resolved parent payload, preventing a stale result for a displaced same-parent proposal from nullifying its certificate-backed replacement.
- Retain the highest full finalization separately from the movable resolver construction floor, keeping a settling proof servable for older targeted ancestry requests after a higher notarization becomes the floor.
- Add deterministic actor-loop regressions for both paths.

The resolver wire key and peer-visible encoding remain unchanged.