### PR TITLE
[consensus/simplex] Apply review fixes to stale verification and resolver

### DIFF
--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -205,6 +205,13 @@ impl<
         }
     }
 
+    /// Returns the highest finalized view, or zero if none is known.
+    fn last_finalized(&self) -> View {
+        self.state
+            .finalization()
+            .map_or(View::zero(), |certificate| certificate.view())
+    }
+
     /// Records a certificate and applies its resolver lifecycle effects.
     fn updated<R: Resolver<Key = U64, Subscriber = Ask>>(
         &mut self,
@@ -212,10 +219,7 @@ impl<
         certificate: Certificate<S, D>,
     ) {
         let term_length = self.state.term_length();
-        let last_finalized = self
-            .state
-            .finalization()
-            .map_or(View::zero(), |certificate| certificate.view());
+        let last_finalized = self.last_finalized();
 
         // Retain encoded certificates for as long as a peer can still ask for them.
         // [State] prunes at the floor, which rises sooner than finalization and
@@ -274,10 +278,7 @@ impl<
     ) {
         // Every verdict clears the pending payload. Only successful
         // notarizations above finalization become servable.
-        let last_finalized = self
-            .state
-            .finalization()
-            .map_or(View::zero(), |certificate| certificate.view());
+        let last_finalized = self.last_finalized();
         if let Some(notarization) = self.pending_notarizations.remove(&view)
             && success
             && view > last_finalized
@@ -425,11 +426,7 @@ impl<
         // Finalization rules out any further need for the view. This is also
         // what settles an ask answered by a finalization, since resolver state
         // retains the highest one independently of its construction floor.
-        let last_finalized = self
-            .state
-            .finalization()
-            .map_or(View::zero(), |certificate| certificate.view());
-        if view <= last_finalized {
+        if view <= self.last_finalized() {
             return true;
         }
         match kind {
@@ -464,12 +461,8 @@ impl<
     /// the current floor is served. Pending notarizations and notarizations
     /// that fail certification are never served.
     fn produce_certificate(&self, view: View) -> Option<Bytes> {
-        // Resolver state retains the full highest finalization independently
-        // of its movable construction floor. A higher notarization can advance
-        // that floor without settling a request for older ancestry, so the
-        // retained finalization must remain available here. It also subsumes
-        // every lower finalization because it settles all requests at or below
-        // its view.
+        // Prefer the retained finalization because a higher notarization does
+        // not settle an older ancestry request.
         if let Some(certificate @ Certificate::Finalization(_)) = self.state.get(view) {
             return Some(certificate.encode());
         }

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1017,17 +1017,18 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// likewise be displaced before it certifies. In either case, the
     /// completion says nothing about the proposal and ancestry we now hold.
     ///
-    /// The proposal is not re-queued for verification under the
-    /// replacement parent: displacement implies the leader equivocated, and
-    /// the proposal commits to the parent it was built on. The view instead
-    /// resolves through a peer's notarization of the proposal or the normal
-    /// timeout/nullification path.
+    /// A replacement proposal is certificate-backed and proceeds through
+    /// certification. A proposal with a displaced parent still commits to its
+    /// original parent, so it cannot be reverified under the replacement parent.
+    /// The proposal's view resolves through a peer's notarization of that proposal
+    /// or the timeout/nullification path.
     ///
-    /// The discard trades latency, not safety. A discarded rejection leaves
-    /// the view to the certification timeout instead of an immediate nullify.
-    /// The displacing certificate also identifies the equivocating leader,
-    /// whom the voter blocks. A Byzantine leader therefore pays this delay at
-    /// most once: later views skip at the leader timeout.
+    /// Discarding a stale rejection trades latency, not safety. Only parent
+    /// displacement can delay the view until the certification timeout instead
+    /// of an immediate nullify. The displacing certificate identifies the
+    /// equivocating leader, whom the voter blocks. Each Byzantine leader can
+    /// cause this delay at most once. Later views skip that leader at the leader
+    /// timeout.
     fn verification_is_stale(&mut self, view: View) -> bool {
         if self.verification_matches(view) {
             return false;
@@ -1051,9 +1052,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
     /// Latches `reason` after the automaton rejected or dropped a proposal.
     ///
-    /// A stale completion is discarded rather than latched: nullifying on a
-    /// verdict about a parent we have already replaced would forfeit the view
-    /// over ancestry that no longer applies.
+    /// Discards a stale verdict so it cannot forfeit the view after its
+    /// proposal or resolved parent has been replaced.
     pub fn verification_failed(&mut self, view: View, reason: TimeoutReason) {
         if self.verification_is_stale(view) {
             return;


### PR DESCRIPTION
Review fixes stacked on #4436.

- Cover both replacement cases in the stale-verification rationale: the opening paragraph named same-parent proposal replacement, but the supporting paragraphs still reasoned only about a displaced parent. Only the displaced-parent case pays the certification timeout; a replacement proposal arrives inside a certificate and completes through certification without a local verification verdict. `verification_failed`'s note now says "proposal or parent".
- Deduplicate the retained-finalization view lookup (three copies of the same `map_or`) behind a private `Actor::last_finalized` helper.
- Trim the `produce_certificate` sentence that restated the `State` doc's highest-only argument.

Skipped from review: replacing the test's empty `if let` on the first batcher message with an assertion. That form has seven other identical instances in the module, so changing one diverges from the local idiom; a follow-up could sweep all eight.
