### PR TITLE
[consensus/simplex] Fix certification wakeups and failed-ancestry tracking

### DIFF
--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3094,6 +3094,8 @@ mod tests {
         let term_length = TermLength::new(NZU32!(5));
         let executor = deterministic::Runner::timed(Duration::from_secs(20));
         executor.start(|mut context| async move {
+            // Build a stable-leader network with a follower whose application
+            // rejects certification for view 1.
             let Fixture {
                 participants,
                 schemes,
@@ -3141,6 +3143,8 @@ mod tests {
                 batcher::Message::Update { .. }
             ));
 
+            // Locally notarize view 1 so its child enters the optimistic
+            // issuance window.
             let genesis = mocks::application::genesis::<Sha256>(epoch);
             let proposal_1 = Proposal::new(
                 Round::new(epoch, View::new(1)),
@@ -3166,6 +3170,8 @@ mod tests {
                 }
             }
 
+            // Extend the chain optimistically before view 1's certificate
+            // arrives.
             let proposal_2 = Proposal::new(
                 Round::new(epoch, View::new(2)),
                 View::new(1),
@@ -3190,6 +3196,9 @@ mod tests {
                 }
             }
 
+            // Prepare both certificates, but deliver only view 1. Its
+            // certification rejection must emit a nullify before view 2
+            // becomes directly notarized.
             let (_, notarization_1) = build_notarization(&schemes, &proposal_1, quorum);
             let (_, notarization_2) = build_notarization(&schemes, &proposal_2, quorum);
             mailbox.resolved(Certificate::Notarization(notarization_1));
@@ -3209,6 +3218,9 @@ mod tests {
                 }
             }
 
+            // Deliver view 2's certificate and extend the direct chain. The
+            // unresolved view-1 rejection must block view 3 before application
+            // verification.
             mailbox.resolved(Certificate::Notarization(notarization_2));
             let proposal_3 = Proposal::new(
                 Round::new(epoch, View::new(3)),
@@ -3236,6 +3248,8 @@ mod tests {
                 "rejected ancestry must not reach application verification"
             );
 
+            // Nullify the failed ancestor to abandon the term and confirm the
+            // voter can advance.
             let (_, nullification) =
                 build_nullification(&schemes, Round::new(epoch, View::new(1)), quorum);
             mailbox.resolved(Certificate::Nullification(nullification));

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3083,6 +3083,179 @@ mod tests {
         });
     }
 
+    /// A directly notarized descendant must not hide a local certification
+    /// failure in its same-term ancestry.
+    #[test_traced]
+    fn test_failed_certification_blocks_direct_descendant_verify() {
+        let n = 5;
+        let quorum = quorum(n);
+        let namespace = b"failed_certification_blocks_direct_descendant_verify".to_vec();
+        let epoch = Epoch::new(333);
+        let term_length = TermLength::new(NZU32!(5));
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+
+            let elector = RoundRobin::<Sha256>::default().with_term(
+                term_length,
+                Duration::from_secs(30),
+                ViewDelta::new(2),
+            );
+            let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let leader_idx = built_elector.elect(Round::new(epoch, View::new(1)), None);
+            let local_index = (usize::from(leader_idx) + 1) % participants.len();
+            let leader = participants[usize::from(leader_idx)].clone();
+            let verify_requests = Arc::new(Mutex::new(Vec::new()));
+
+            let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    leader_timeout: Duration::from_secs(10),
+                    certification_timeout: Duration::from_secs(10),
+                    timeout_retry: Duration::from_secs(30),
+                    local_index,
+                    verify_requests: Some(verify_requests.clone()),
+                    certifier: mocks::application::Certifier::Custom(Box::new(|round, _| {
+                        round.view() != View::new(1)
+                    })),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            assert!(matches!(
+                batcher_receiver.recv().await.unwrap(),
+                batcher::Message::Update { .. }
+            ));
+
+            let genesis = mocks::application::genesis::<Sha256>(epoch);
+            let proposal_1 = Proposal::new(
+                Round::new(epoch, View::new(1)),
+                View::zero(),
+                Sha256::hash(&[b"failed_ancestor_view_1"]),
+            );
+            let contents_1 = (proposal_1.round, genesis, 0u64).encode();
+            relay.broadcast(&leader, Recipients::All, (proposal_1.payload, contents_1));
+            mailbox.proposal(proposal_1.clone());
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                            && notarize.view() == View::new(1)
+                        {
+                            break;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected notarize for view 1");
+                    }
+                }
+            }
+
+            let proposal_2 = Proposal::new(
+                Round::new(epoch, View::new(2)),
+                View::new(1),
+                Sha256::hash(&[b"failed_ancestor_view_2"]),
+            );
+            let contents_2 = (proposal_2.round, proposal_1.payload, 1u64).encode();
+            relay.broadcast(&leader, Recipients::All, (proposal_2.payload, contents_2));
+            mailbox.proposal(proposal_2.clone());
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                            && notarize.view() == View::new(2)
+                        {
+                            break;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected optimistic notarize for view 2");
+                    }
+                }
+            }
+
+            let (_, notarization_1) = build_notarization(&schemes, &proposal_1, quorum);
+            let (_, notarization_2) = build_notarization(&schemes, &proposal_2, quorum);
+            mailbox.resolved(Certificate::Notarization(notarization_1));
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Nullify(nullify)) = msg.unwrap()
+                            && nullify.view() == View::new(1)
+                        {
+                            break;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected failed certification to nullify view 1");
+                    }
+                }
+            }
+
+            mailbox.resolved(Certificate::Notarization(notarization_2));
+            let proposal_3 = Proposal::new(
+                Round::new(epoch, View::new(3)),
+                View::new(2),
+                Sha256::hash(&[b"failed_ancestor_view_3"]),
+            );
+            let contents_3 = (proposal_3.round, proposal_2.payload, 2u64).encode();
+            relay.broadcast(&leader, Recipients::All, (proposal_3.payload, contents_3));
+            mailbox.proposal(proposal_3);
+
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                            && notarize.view() == View::new(3)
+                        {
+                            panic!("rejected ancestry must not produce a view 3 notarize");
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(1)) => break,
+                }
+            }
+            assert!(
+                !verify_requests.lock().contains(&View::new(3)),
+                "rejected ancestry must not reach application verification"
+            );
+
+            let (_, nullification) =
+                build_nullification(&schemes, Round::new(epoch, View::new(1)), quorum);
+            mailbox.resolved(Certificate::Nullification(nullification));
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Update { current, .. } = msg.unwrap()
+                            && current == View::new(6)
+                        {
+                            break;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected nullification to advance to the next term");
+                    }
+                }
+            }
+        });
+    }
+
     fn finalization_from_resolver<S, F, L>(mut fixture: F)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -4122,12 +4122,16 @@ mod tests {
                 ViewDelta::new(2),
             );
 
+            // Directly notarize two consecutive views in the same term.
             let ancestor = fetch_proposal(1, 0, 116);
             let descendant = fetch_proposal(2, 1, 117);
             for proposal in [&ancestor, &descendant] {
                 let notarization = build_notarization(&verifier, &schemes, proposal);
                 assert!(state.add_notarization(notarization).0);
             }
+
+            // Restore a rejected certification for the ancestor. It must veto
+            // the descendant's otherwise certificate-backed ancestry.
             state.replay(&Artifact::Certification(ancestor.round, false));
             assert!(
                 state
@@ -4135,6 +4139,8 @@ mod tests {
                     .is_none()
             );
 
+            // A descendant finalization covers the rejection and makes that
+            // certificate usable again.
             let finalization = build_finalization(&verifier, &schemes, &descendant);
             assert!(state.add_finalization(finalization).0);
             assert_eq!(
@@ -4302,8 +4308,11 @@ mod tests {
                 ViewDelta::new(3),
             );
 
+            // Certify view 1 so only view 2 is initially ready.
             certify_first_view(&mut state, &verifier, &schemes);
 
+            // Deliver the remaining chain in reverse, leaving each descendant
+            // blocked on its immediate parent.
             let proposals = [
                 fetch_proposal(2, 1, 102),
                 fetch_proposal(3, 2, 103),
@@ -4314,6 +4323,8 @@ mod tests {
                 assert!(state.add_notarization(notarization).0);
             }
 
+            // Each successful certification wakes only its immediate child.
+            // More distant descendants remain dormant.
             for proposal in proposals {
                 let (ready, fetches) = state.certify_candidates();
                 assert_eq!(ready, vec![proposal.clone()]);

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -158,7 +158,9 @@ pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D:
     nullification_views: BTreeSet<View>,
 
     /// Views with a local certification rejection not covered by finalization.
-    /// Direct descendant certificates remain subject to these ancestry verdicts.
+    /// A rejected view cannot support same-term descendant ancestry.
+    /// Every entry remains above the retention floor, so [`Self::prune`] skips
+    /// this set.
     failed_certifications: BTreeSet<View>,
 
     certification_candidates: BTreeSet<View>,
@@ -612,8 +614,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         if view > self.last_finalized {
             self.last_finalized = view;
 
-            // Finalization makes local certification verdicts at or below its
-            // view irrelevant to descendant ancestry.
+            // Finalization overrides local certification rejections at or
+            // below its view.
             self.failed_certifications = self.failed_certifications.split_off(&view.next());
 
             // Prune certification candidates at or below finalized view.
@@ -1085,11 +1087,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.insert(view);
     }
 
-    /// Queues the one same-term child whose certification dependency was satisfied.
-    ///
-    /// Certification follows an immediate-parent chain inside a term, so
-    /// blocked descendants remain dormant until this transition advances the
-    /// ready frontier.
+    /// Queues a blocked immediate same-term child when `parent` certifies or
+    /// finalizes.
     fn wake_certification_child(&mut self, parent: View) {
         let child = parent.next();
         if self.previous_in_term(child) != Some(parent)
@@ -1130,6 +1129,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                 if err.invalid_proposal() {
                     warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
                 } else {
+                    // Dormant candidates wake only through
+                    // [`Self::wake_certification_child`]. Therefore,
+                    // [`Self::certification_parent_ready`] may block only on an
+                    // uncertified parent.
+                    assert!(
+                        matches!(err, ParentPayloadError::ParentNotCertified { .. }),
+                        "blocked candidate has no wake: {err:?}"
+                    );
                     fetches.extend(self.certification_fetch(&err));
                 }
                 continue;
@@ -1235,7 +1242,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let removed = replace(&mut self.views, kept).into_keys().collect();
         self.nullification_views = self.nullification_views.split_off(&min);
         self.nullify_views = self.nullify_views.split_off(&min);
-        self.failed_certifications = self.failed_certifications.split_off(&min);
 
         // Update metrics
         let _ = self.tracked_views.try_set(self.views.len());
@@ -3395,7 +3401,7 @@ mod tests {
             assert!(state.is_me(leader.idx));
             assert!(fetches[0].target.is_none());
 
-            // The round deduplicates the fetch while it is outstanding.
+            // The blocked candidate is dormant, so another pass emits nothing.
             let (ready, fetches) = state.certify_candidates();
             assert!(ready.is_empty());
             assert!(fetches.is_empty());

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -157,6 +157,10 @@ pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D:
     /// without scanning all tracked rounds.
     nullification_views: BTreeSet<View>,
 
+    /// Views with a local certification rejection not covered by finalization.
+    /// Direct descendant certificates remain subject to these ancestry verdicts.
+    failed_certifications: BTreeSet<View>,
+
     certification_candidates: BTreeSet<View>,
     outstanding_certifications: BTreeSet<View>,
 
@@ -221,6 +225,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             stall_anchor: GENESIS_VIEW,
             nullify_views: BTreeSet::new(),
             nullification_views: BTreeSet::new(),
+            failed_certifications: BTreeSet::new(),
             certification_candidates: BTreeSet::new(),
             outstanding_certifications: BTreeSet::new(),
             current_view,
@@ -607,6 +612,10 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         if view > self.last_finalized {
             self.last_finalized = view;
 
+            // Finalization makes local certification verdicts at or below its
+            // view irrelevant to descendant ancestry.
+            self.failed_certifications = self.failed_certifications.split_off(&view.next());
+
             // Prune certification candidates at or below finalized view.
             // Finalization is definitive, so these certifications are no longer relevant.
             self.certification_candidates.retain(|v| *v > view);
@@ -624,6 +633,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.set_leader(view.next(), Some(&finalization.certificate));
         let result = self.create_round(view).add_finalization(finalization);
         if result.0 {
+            self.wake_certification_child(view);
             self.slide_optimistic_frontier(view);
         }
         result
@@ -773,10 +783,10 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// Replays a journaled artifact into the appropriate round during recovery.
     ///
     /// Restores round-level broadcast flags (via [`Round::replay`]) and
-    /// tracking sets (`nullify_views`, `nullification_views`) so that
-    /// term-safety checks work correctly after a restart. Replaying a local
-    /// notarize vote also restores the optimistic successor prepared by live
-    /// vote construction. Unlike
+    /// tracking sets (`nullify_views`, `nullification_views`, and
+    /// `failed_certifications`) so that term-safety and ancestry checks work
+    /// correctly after a restart. Replaying a local notarize vote also restores
+    /// the optimistic successor prepared by live vote construction. Unlike
     /// [`Self::add_nullification`] (which the actor's replay loop also calls,
     /// making the `nullification_views` insert idempotent on that path), this
     /// never advances the view.
@@ -786,6 +796,11 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         }
         if let Artifact::Nullification(n) = artifact {
             self.nullification_views.insert(n.view());
+        }
+        if matches!(artifact, Artifact::Certification(_, false))
+            && artifact.view() > self.last_finalized
+        {
+            self.failed_certifications.insert(artifact.view());
         }
         self.create_round(artifact.view()).replay(artifact);
         if matches!(artifact, Artifact::Notarize(_)) {
@@ -1070,9 +1085,28 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.insert(view);
     }
 
-    /// Takes all certification candidates and returns proposals ready for
-    /// certification, plus fetches for candidates blocked on a certificate we
-    /// do not hold (see [`Self::certification_fetch`]).
+    /// Queues the one same-term child whose certification dependency was satisfied.
+    ///
+    /// Certification follows an immediate-parent chain inside a term, so
+    /// blocked descendants remain dormant until this transition advances the
+    /// ready frontier.
+    fn wake_certification_child(&mut self, parent: View) {
+        let child = parent.next();
+        if self.previous_in_term(child) != Some(parent)
+            || child <= self.last_finalized
+            || !self
+                .views
+                .get(&child)
+                .is_some_and(|round| round.notarization().is_some())
+        {
+            return;
+        }
+        self.certification_candidates.insert(child);
+    }
+
+    /// Takes newly notarized or unblocked certification candidates and returns
+    /// proposals ready for certification, plus fetches for missing parent
+    /// certificates (see [`Self::certification_fetch`]).
     pub fn certify_candidates(
         &mut self,
     ) -> (Vec<Proposal<D>>, Vec<CertificateFetch<S::PublicKey>>) {
@@ -1097,7 +1131,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                     warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
                 } else {
                     fetches.extend(self.certification_fetch(&err));
-                    self.certification_candidates.insert(view);
                 }
                 continue;
             }
@@ -1171,12 +1204,16 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
         // Remove from outstanding since certification is complete
         self.outstanding_certifications.remove(&view);
+        if !is_success && view > self.last_finalized {
+            self.failed_certifications.insert(view);
+        }
 
         if is_success {
             // Keep the stall deadline armed after certification so the
             // term-level timeout can still abandon a term that certifies but
             // never finalizes.
             self.enter_view(view.next());
+            self.wake_certification_child(view);
         } else {
             self.trigger_timeout(view, TimeoutReason::FailedCertification);
         }
@@ -1198,6 +1235,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let removed = replace(&mut self.views, kept).into_keys().collect();
         self.nullification_views = self.nullification_views.split_off(&min);
         self.nullify_views = self.nullify_views.split_off(&min);
+        self.failed_certifications = self.failed_certifications.split_off(&min);
 
         // Update metrics
         let _ = self.tracked_views.try_set(self.views.len());
@@ -1256,6 +1294,16 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.explicit_ancestry_payload(parent)
     }
 
+    /// Returns true when `view` or a same-term predecessor has an unresolved
+    /// local certification rejection. Intra-term proposals link every
+    /// intermediate view; term starts instead require explicit ancestry.
+    fn has_failed_optimistic_ancestry(&self, view: View) -> bool {
+        self.failed_certifications
+            .range(view.term_start(self.term_length())..=view)
+            .next()
+            .is_some()
+    }
+
     /// Returns the payload of a parent usable as *optimistic* ancestry: a
     /// certificate-backed payload when one exists, otherwise our own verified,
     /// unequivocated, notarize-broadcast proposal; recursively, so the whole
@@ -1271,6 +1319,9 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         // is always payload the certificate actually supports, independent of
         // the slot's proposal bookkeeping.
         if round.is_directly_notarized() {
+            if self.has_failed_optimistic_ancestry(view) {
+                return None;
+            }
             return round.certificate_ancestry_payload();
         }
 
@@ -4053,6 +4104,49 @@ mod tests {
     }
 
     #[test]
+    fn replayed_failed_ancestor_blocks_direct_descendant_until_finalization() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            let ancestor = fetch_proposal(1, 0, 116);
+            let descendant = fetch_proposal(2, 1, 117);
+            for proposal in [&ancestor, &descendant] {
+                let notarization = build_notarization(&verifier, &schemes, proposal);
+                assert!(state.add_notarization(notarization).0);
+            }
+            state.replay(&Artifact::Certification(ancestor.round, false));
+            assert!(
+                state
+                    .optimistic_ancestry_payload(descendant.view())
+                    .is_none()
+            );
+
+            let finalization = build_finalization(&verifier, &schemes, &descendant);
+            assert!(state.add_finalization(finalization).0);
+            assert_eq!(
+                state
+                    .optimistic_ancestry_payload(descendant.view())
+                    .copied(),
+                Some(descendant.payload)
+            );
+        });
+    }
+
+    #[test]
     fn failed_certification_blocks_locally_proposed_optimistic_child_notarize() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
@@ -4186,6 +4280,92 @@ mod tests {
             let candidates = state.certify_candidates().0;
             assert_eq!(candidates.len(), 1);
             assert_eq!(candidates[0].round.view(), View::new(2));
+        });
+    }
+
+    #[test]
+    fn blocked_certification_candidates_wake_parent_first() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(10)),
+                ViewDelta::new(3),
+            );
+
+            certify_first_view(&mut state, &verifier, &schemes);
+
+            let proposals = [
+                fetch_proposal(2, 1, 102),
+                fetch_proposal(3, 2, 103),
+                fetch_proposal(4, 3, 104),
+            ];
+            for proposal in proposals.iter().rev() {
+                let notarization = build_notarization(&verifier, &schemes, proposal);
+                assert!(state.add_notarization(notarization).0);
+            }
+
+            for proposal in proposals {
+                let (ready, fetches) = state.certify_candidates();
+                assert_eq!(ready, vec![proposal.clone()]);
+                assert!(fetches.is_empty());
+                assert!(
+                    state.certification_candidates.is_empty(),
+                    "parent-blocked descendants must remain dormant"
+                );
+                assert!(state.certified(proposal.view(), true).is_some());
+            }
+        });
+    }
+
+    #[test]
+    fn finalization_wakes_child_after_failed_parent_certification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with(
+                &mut context,
+                4,
+                1,
+                9,
+                10,
+                TermLength::new(NZU32!(5)),
+                ViewDelta::new(2),
+            );
+
+            certify_first_view(&mut state, &verifier, &schemes);
+
+            let parent = fetch_proposal(2, 1, 102);
+            let child = fetch_proposal(3, 2, 103);
+            for proposal in [&parent, &child] {
+                let notarization = build_notarization(&verifier, &schemes, proposal);
+                assert!(state.add_notarization(notarization).0);
+            }
+
+            let (ready, fetches) = state.certify_candidates();
+            assert_eq!(ready, vec![parent.clone()]);
+            assert!(fetches.is_empty());
+            assert!(state.certification_candidates.is_empty());
+
+            assert!(state.certified(parent.view(), false).is_some());
+            assert!(state.certify_candidates().0.is_empty());
+
+            let finalization = build_finalization(&verifier, &schemes, &parent);
+            assert!(state.add_finalization(finalization).0);
+            assert_eq!(state.certify_candidates().0, vec![child]);
         });
     }
 


### PR DESCRIPTION
Related: #3416

## Summary

Fix two production-reachable optimistic-validation edge cases:

- Keep certification candidates dormant while their immediate parent is uncertified. Parent certification or finalization wakes only the same-term child. Missing-parent repair still fetches the exact parent certificate.
- Track local certification failures as unresolved ancestry. A failed same-term ancestor blocks descendant verification and notarize votes. Replay restores failures. Finalization clears covered failures.
- Add deterministic state and actor-loop tests for parent-first wakeups, finalization recovery, restart replay, and descendant vote suppression.

No public API, wire-format, or storage-format changes.

## Testing

- `just test -p commonware-consensus` (1,013 passed)
- `just clippy -p commonware-consensus`
- `just check-fmt`