### PR TITLE
[consensus/simplex] Pin wake invariant and drop a dead prune

### DIFF
--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -158,8 +158,8 @@ pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D:
     nullification_views: BTreeSet<View>,
 
     /// Views with a local certification rejection not covered by finalization.
-    /// A rejected view blocks same-term descendant certificates as ancestry.
-    /// Every entry sits above the retention floor, so [`Self::prune`] skips
+    /// A rejected view cannot support same-term descendant ancestry.
+    /// Every entry remains above the retention floor, so [`Self::prune`] skips
     /// this set.
     failed_certifications: BTreeSet<View>,
 
@@ -1087,11 +1087,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.insert(view);
     }
 
-    /// Queues the same-term child that `parent`'s certification or
-    /// finalization unblocked.
-    ///
-    /// Certification follows an immediate-parent chain inside a term, so a
-    /// blocked descendant stays dormant until its own parent certifies or
+    /// Queues a blocked immediate same-term child when `parent` certifies or
     /// finalizes.
     fn wake_certification_child(&mut self, parent: View) {
         let child = parent.next();
@@ -1133,10 +1129,10 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                 if err.invalid_proposal() {
                     warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
                 } else {
-                    // An uncertified parent is the only blocking error (see
-                    // [`Self::certification_parent_ready`]), so every dropped
-                    // candidate has a wake through
-                    // [`Self::wake_certification_child`].
+                    // Dormant candidates wake only through
+                    // [`Self::wake_certification_child`]. Therefore,
+                    // [`Self::certification_parent_ready`] may block only on an
+                    // uncertified parent.
                     assert!(
                         matches!(err, ParentPayloadError::ParentNotCertified { .. }),
                         "blocked candidate has no wake: {err:?}"

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -158,7 +158,9 @@ pub struct State<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D:
     nullification_views: BTreeSet<View>,
 
     /// Views with a local certification rejection not covered by finalization.
-    /// Direct descendant certificates remain subject to these ancestry verdicts.
+    /// A rejected view blocks same-term descendant certificates as ancestry.
+    /// Every entry sits above the retention floor, so [`Self::prune`] skips
+    /// this set.
     failed_certifications: BTreeSet<View>,
 
     certification_candidates: BTreeSet<View>,
@@ -612,8 +614,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         if view > self.last_finalized {
             self.last_finalized = view;
 
-            // Finalization makes local certification verdicts at or below its
-            // view irrelevant to descendant ancestry.
+            // Finalization overrides local certification rejections at or
+            // below its view.
             self.failed_certifications = self.failed_certifications.split_off(&view.next());
 
             // Prune certification candidates at or below finalized view.
@@ -1085,11 +1087,12 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.outstanding_certifications.insert(view);
     }
 
-    /// Queues the one same-term child whose certification dependency was satisfied.
+    /// Queues the same-term child that `parent`'s certification or
+    /// finalization unblocked.
     ///
-    /// Certification follows an immediate-parent chain inside a term, so
-    /// blocked descendants remain dormant until this transition advances the
-    /// ready frontier.
+    /// Certification follows an immediate-parent chain inside a term, so a
+    /// blocked descendant stays dormant until its own parent certifies or
+    /// finalizes.
     fn wake_certification_child(&mut self, parent: View) {
         let child = parent.next();
         if self.previous_in_term(child) != Some(parent)
@@ -1130,6 +1133,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                 if err.invalid_proposal() {
                     warn!(round = ?proposal.round, ?err, "proposal failed certification precheck");
                 } else {
+                    // An uncertified parent is the only blocking error (see
+                    // [`Self::certification_parent_ready`]), so every dropped
+                    // candidate has a wake through
+                    // [`Self::wake_certification_child`].
+                    assert!(
+                        matches!(err, ParentPayloadError::ParentNotCertified { .. }),
+                        "blocked candidate has no wake: {err:?}"
+                    );
                     fetches.extend(self.certification_fetch(&err));
                 }
                 continue;
@@ -1235,7 +1246,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         let removed = replace(&mut self.views, kept).into_keys().collect();
         self.nullification_views = self.nullification_views.split_off(&min);
         self.nullify_views = self.nullify_views.split_off(&min);
-        self.failed_certifications = self.failed_certifications.split_off(&min);
 
         // Update metrics
         let _ = self.tracked_views.try_set(self.views.len());
@@ -3395,7 +3405,7 @@ mod tests {
             assert!(state.is_me(leader.idx));
             assert!(fetches[0].target.is_none());
 
-            // The round deduplicates the fetch while it is outstanding.
+            // The blocked candidate is dormant, so another pass emits nothing.
             let (ready, fetches) = state.certify_candidates();
             assert!(ready.is_empty());
             assert!(fetches.is_empty());


### PR DESCRIPTION
Review fixes stacked on #4438.

- Assert that `ParentNotCertified` is the only error allowed to make a certification candidate dormant. Parent certification or finalization then wakes every dormant candidate.
- Remove the ineffective `failed_certifications` prune. Finalization removes every entry that the retention floor could cover.
- Correct and simplify the related comments.

Validation:
- Full voter and resolver test suites pass.
- Clippy, rustfmt, and docs are clean.