### PR TITLE
[storage, parallel] Pipeline frozen-chunk graft work under the journal merkleize

### DIFF
--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -432,7 +432,7 @@ mod tests {
             &self,
             _len: usize,
             f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
+        ) -> impl core::future::Future<Output = T> + Send + 'static + use<F, T>
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -151,7 +151,7 @@ commonware_macros::stability_scope!(BETA {
             &self,
             len: usize,
             f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
+        ) -> impl core::future::Future<Output = T> + Send + 'static + use<Self, F, T>
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static;
@@ -630,7 +630,7 @@ commonware_macros::stability_scope!(BETA {
             &self,
             len: usize,
             f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
+        ) -> impl core::future::Future<Output = T> + Send + 'static + use<S, F, T>
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
@@ -817,7 +817,7 @@ commonware_macros::stability_scope!(BETA {
             &self,
             _len: usize,
             f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
+        ) -> impl core::future::Future<Output = T> + Send + 'static + use<F, T>
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,
@@ -1041,7 +1041,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             &self,
             len: usize,
             f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
+        ) -> impl core::future::Future<Output = T> + Send + 'static + use<F, T>
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -1908,7 +1908,7 @@ mod tests {
             &self,
             _len: usize,
             f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
+        ) -> impl core::future::Future<Output = T> + Send + 'static + use<F, T>
         where
             F: FnOnce(Self) -> T + Send + 'static,
             T: Send + 'static,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -68,11 +68,15 @@ pub struct UnmerkleizedBatch<F: Family, H: Hasher, Item: Send + Sync, S: Strateg
 
 type MerkleizedBatchArc<F, H, Item, S> = Arc<MerkleizedBatch<F, <H as Hasher>::Digest, Item, S>>;
 
+/// Result of a merkleize job: the merkleized batch and its root digest.
+type MerkleizeResult<F, H, Item, S> =
+    Result<(MerkleizedBatchArc<F, H, Item, S>, <H as Hasher>::Digest), merkle::Error<F>>;
+
 impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
     UnmerkleizedBatch<F, H, Item, S>
 {
     /// The batch's parent, if it has one (the committed journal otherwise).
-    pub(crate) fn parent(&self) -> Option<&MerkleizedParent<F, H, Item, S>> {
+    pub(crate) const fn parent(&self) -> Option<&MerkleizedParent<F, H, Item, S>> {
         self.parent.as_ref()
     }
 
@@ -356,12 +360,7 @@ where
         batch: UnmerkleizedBatch<F, H, C::Item, S>,
         items: Vec<C::Item>,
         inactive_peaks: usize,
-    ) -> impl Future<
-        Output = Result<(MerkleizedBatchArc<F, H, C::Item, S>, H::Digest), merkle::Error<F>>,
-    >
-    + Send
-    + 'static
-    + use<F, E, C, H, S>
+    ) -> impl Future<Output = MerkleizeResult<F, H, C::Item, S>> + Send + 'static + use<F, E, C, H, S>
     where
         C::Item: 'static,
     {

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -71,6 +71,11 @@ type MerkleizedBatchArc<F, H, Item, S> = Arc<MerkleizedBatch<F, <H as Hasher>::D
 impl<F: Family, H: Hasher, Item: Encode + Send + Sync, S: Strategy>
     UnmerkleizedBatch<F, H, Item, S>
 {
+    /// The batch's parent, if it has one (the committed journal otherwise).
+    pub(crate) fn parent(&self) -> Option<&MerkleizedParent<F, H, Item, S>> {
+        self.parent.as_ref()
+    }
+
     /// Add an item to the batch.
     #[allow(clippy::should_implement_trait)]
     pub fn add(mut self, item: Item) -> Self {
@@ -340,18 +345,36 @@ where
     where
         C::Item: 'static,
     {
+        self.merkleize_start(batch, items, inactive_peaks).await
+    }
+
+    /// Submit the merkleize job (see [Self::merkleize]) and return its un-awaited result
+    /// future, so a caller can run independent work on its own task while the job's leaf
+    /// and node hashing proceeds on the strategy.
+    pub(crate) fn merkleize_start(
+        &self,
+        batch: UnmerkleizedBatch<F, H, C::Item, S>,
+        items: Vec<C::Item>,
+        inactive_peaks: usize,
+    ) -> impl Future<
+        Output = Result<(MerkleizedBatchArc<F, H, C::Item, S>, H::Digest), merkle::Error<F>>,
+    >
+    + Send
+    + 'static
+    + use<F, E, C, H, S>
+    where
+        C::Item: 'static,
+    {
         let ancestors = batch.inner.retain_ancestors();
         let mem = self.merkle.snapshot();
         let hasher = self.hasher.clone();
         let strategy = self.strategy().clone();
-        strategy
-            .spawn(items.len(), move |_| {
-                let merkleized = batch.add_many(items).merkleize(&mem);
-                let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
-                drop(ancestors);
-                Ok((merkleized, root))
-            })
-            .await
+        strategy.spawn(items.len(), move |_| {
+            let merkleized = batch.add_many(items).merkleize(&mem);
+            let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
+            drop(ancestors);
+            Ok((merkleized, root))
+        })
     }
 
     /// Create an owned [`MerkleizedBatch`] representing the current committed state.

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -366,6 +366,74 @@ pub struct MerkleizedBatch<F: Family, D: Digest, U: update::Update, S: Strategy>
 /// Strong ref to an ancestor [`MerkleizedBatch`] collected during merkleize.
 type AncestorBatch<F, D, U, S> = Arc<MerkleizedBatch<F, D, U, S>>;
 
+/// The output of [`Merkleizer::finish_pending`]: the journal merkleize job already in
+/// flight on the strategy, plus everything else `finish` computes. Lets a caller overlap
+/// independent work with the job before sealing the batch via [`PendingMerkleize::seal`].
+#[allow(clippy::type_complexity)]
+pub(crate) struct PendingMerkleize<F: Family, H: Hasher, U: update::Update, S: Strategy>
+where
+    Operation<F, U>: Send + Sync,
+{
+    /// The in-flight journal merkleize job.
+    job: core::pin::Pin<
+        Box<
+            dyn Future<
+                    Output = Result<
+                        (
+                            Arc<authenticated::MerkleizedBatch<F, H::Digest, Operation<F, U>, S>>,
+                            H::Digest,
+                        ),
+                        crate::merkle::Error<F>,
+                    >,
+                > + Send,
+        >,
+    >,
+    /// The unmerkleized journal batch's parent, for reading pre-batch tree nodes while
+    /// the job runs.
+    pub(crate) journal_parent:
+        Option<Arc<authenticated::MerkleizedBatch<F, H::Digest, Operation<F, U>, S>>>,
+    pub(crate) diff: Arc<DiffVec<U::Key, F, U::Value>>,
+    parent: Option<Weak<MerkleizedBatch<F, H::Digest, U, S>>>,
+    total_active_keys: usize,
+    pub(crate) ancestor_diffs: Vec<Arc<DiffVec<U::Key, F, U::Value>>>,
+    ancestor_base_locs: AncestorBaseLocs<U::Key, F>,
+    ancestors: Vec<batch_chain::AncestorBounds<F, H::Digest>>,
+    base_state: Commitment<F, H::Digest>,
+    db_state: Commitment<F, H::Digest>,
+    /// Location of this batch's CommitFloor operation (the tip is one past it).
+    pub(crate) commit_loc: Location<F>,
+    pub(crate) floor: Location<F>,
+    /// Operations this batch appends, including the CommitFloor.
+    pub(crate) batch_len: usize,
+}
+
+impl<F: Family, H: Hasher, U: update::Update, S: Strategy> PendingMerkleize<F, H, U, S>
+where
+    Operation<F, U>: Send + Sync,
+{
+    /// Await the journal merkleize job and assemble the sealed batch.
+    pub(crate) async fn seal(
+        self,
+    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>> {
+        let (journal, root) = self.job.await?;
+        Ok(Arc::new(MerkleizedBatch {
+            journal_batch: journal,
+            diff: self.diff,
+            parent: self.parent,
+            total_active_keys: self.total_active_keys,
+            ancestor_diffs: self.ancestor_diffs,
+            ancestor_base_locs: self.ancestor_base_locs,
+            bounds: batch_chain::Bounds {
+                base: self.base_state,
+                db: self.db_state,
+                tip: Commitment::new(self.commit_loc + 1, root),
+                ancestors: self.ancestors,
+                inactivity_floor: self.floor,
+            },
+        }))
+    }
+}
+
 /// Batch-infrastructure state used during merkleization.
 ///
 /// Created by [`UnmerkleizedBatch::into_parts()`], which separates the pending mutations
@@ -1052,6 +1120,42 @@ where
     #[allow(clippy::too_many_arguments)]
     async fn finish<E, C, I, const N: usize>(
         self,
+        ops: Vec<Operation<F, U>>,
+        diff: DiffVec<U::Key, F, U::Value>,
+        superseded_locs: Vec<Location<F>>,
+        active_keys_delta: isize,
+        user_steps: u64,
+        metadata: Option<U::Value>,
+        prefetched: Option<PrefetchedCandidates<F, U>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
+        db: &Db<F, E, C, I, H, U, N, S>,
+    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>>,
+    {
+        self.finish_pending(
+            ops,
+            diff,
+            superseded_locs,
+            active_keys_delta,
+            user_steps,
+            metadata,
+            prefetched,
+            fill_candidates,
+            db,
+        )
+        .await?
+        .seal()
+        .await
+    }
+
+    /// [`Self::finish`], stopping after the journal merkleize job is submitted: the
+    /// returned [`PendingMerkleize`] carries the in-flight job so the caller can overlap
+    /// independent work with it before sealing.
+    async fn finish_pending<E, C, I, const N: usize>(
+        self,
         mut ops: Vec<Operation<F, U>>,
         mut diff: DiffVec<U::Key, F, U::Value>,
         mut superseded_locs: Vec<Location<F>>,
@@ -1061,7 +1165,7 @@ where
         mut prefetched: Option<PrefetchedCandidates<F, U>>,
         mut fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
         db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>>
+    ) -> Result<PendingMerkleize<F, H, U, S>, crate::qmdb::Error<F>>
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
@@ -1364,12 +1468,14 @@ where
         let leaves = self.base_state.size + ops.len() as u64;
         let inactive_peaks = db.inactive_peaks(leaves, floor);
 
-        // Leaf and node hashing dominate merkleization, so run them as one job on the
-        // strategy instead of occupying the calling task (see `Journal::merkleize`).
-        let (journal, root) = db
-            .log
-            .merkleize(self.journal_batch, ops, inactive_peaks)
-            .await?;
+        // Leaf and node hashing dominate merkleization, so submit them as one job on the
+        // strategy instead of occupying the calling task (see `Journal::merkleize_start`).
+        let batch_len = ops.len();
+        let journal_parent = self.journal_batch.parent().cloned();
+        let job = Box::pin(
+            db.log
+                .merkleize_start(self.journal_batch, ops, inactive_peaks),
+        );
         if let Some(job) = diff_merge.take() {
             diff = job.await;
         }
@@ -1403,21 +1509,21 @@ where
             .collect();
 
         assert!(total_active_keys >= 0, "active_keys underflow");
-        Ok(Arc::new(MerkleizedBatch {
-            journal_batch: journal,
+        Ok(PendingMerkleize {
+            job,
+            journal_parent,
             diff: Arc::new(diff),
             parent: self.ancestors.first().map(Arc::downgrade),
             total_active_keys: total_active_keys as usize,
             ancestor_diffs,
             ancestor_base_locs,
-            bounds: batch_chain::Bounds {
-                base: self.base_state,
-                db: self.db_state,
-                tip: Commitment::new(commit_loc + 1, root),
-                ancestors,
-                inactivity_floor: floor,
-            },
-        }))
+            ancestors,
+            base_state: self.base_state,
+            db_state: self.db_state,
+            commit_loc,
+            floor,
+            batch_len,
+        })
     }
 }
 
@@ -2320,6 +2426,26 @@ where
         C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
         I: OrderedIndex<Value = Location<F>>,
     {
+        self.merkleize_with_floor_scan_pending(db, metadata, staged_updates, fill_candidates)
+            .await?
+            .seal()
+            .await
+    }
+
+    /// [`Self::merkleize_with_floor_scan`], stopping with the journal merkleize job in
+    /// flight (see [`PendingMerkleize`]).
+    pub(crate) async fn merkleize_with_floor_scan_pending<E, C, I, const N: usize>(
+        self,
+        db: &Db<F, E, C, I, H, update::Ordered<K, V>, N, S>,
+        metadata: Option<V::Value>,
+        staged_updates: StagedUpdates<F, update::Ordered<K, V>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
+    ) -> Result<PendingMerkleize<F, H, update::Ordered<K, V>, S>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Ordered<K, V>>>,
+        I: OrderedIndex<Value = Location<F>>,
+    {
         let (mut mutations, m) = self.into_parts();
 
         // Resolve existing keys.
@@ -2671,7 +2797,7 @@ where
             .collect();
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(
+        m.finish_pending(
             ops,
             diff,
             superseded_locs,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1118,41 +1118,8 @@ where
     /// skips re-reading them. `prefetched` optionally holds committed-prefix candidates the
     /// caller gathered and read ahead of time, consumed by the raise before scanning live.
     #[allow(clippy::too_many_arguments)]
-    async fn finish<E, C, I, const N: usize>(
-        self,
-        ops: Vec<Operation<F, U>>,
-        diff: DiffVec<U::Key, F, U::Value>,
-        superseded_locs: Vec<Location<F>>,
-        active_keys_delta: isize,
-        user_steps: u64,
-        metadata: Option<U::Value>,
-        prefetched: Option<PrefetchedCandidates<F, U>>,
-        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
-        db: &Db<F, E, C, I, H, U, N, S>,
-    ) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, S>>, crate::qmdb::Error<F>>
-    where
-        E: Context,
-        C: Contiguous<Item = Operation<F, U>>,
-        I: UnorderedIndex<Value = Location<F>>,
-    {
-        self.finish_pending(
-            ops,
-            diff,
-            superseded_locs,
-            active_keys_delta,
-            user_steps,
-            metadata,
-            prefetched,
-            fill_candidates,
-            db,
-        )
-        .await?
-        .seal()
-        .await
-    }
-
-    /// [`Self::finish`], stopping after the journal merkleize job is submitted: the
-    /// returned [`PendingMerkleize`] carries the in-flight job so the caller can overlap
+    /// Complete merkleization through the journal job's submission: the returned
+    /// [`PendingMerkleize`] carries the in-flight job so the caller can overlap
     /// independent work with it before sealing.
     async fn finish_pending<E, C, I, const N: usize>(
         self,
@@ -2211,6 +2178,33 @@ where
         C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
         I: UnorderedIndex<Value = Location<F>>,
     {
+        self.merkleize_with_floor_scan_pending(
+            db,
+            metadata,
+            staged_updates,
+            prefetched,
+            fill_candidates,
+        )
+        .await?
+        .seal()
+        .await
+    }
+
+    /// [`Self::merkleize_with_floor_scan`], stopping with the journal merkleize job in
+    /// flight (see [`PendingMerkleize`]).
+    pub(crate) async fn merkleize_with_floor_scan_pending<E, C, I, const N: usize>(
+        self,
+        db: &Db<F, E, C, I, H, update::Unordered<K, V>, N, S>,
+        metadata: Option<V::Value>,
+        staged_updates: StagedUpdates<F, update::Unordered<K, V>>,
+        prefetched: Option<PrefetchedCandidates<F, update::Unordered<K, V>>>,
+        fill_candidates: impl FnMut(Location<F>, u64, usize, &mut Vec<Location<F>>) -> Location<F>,
+    ) -> Result<PendingMerkleize<F, H, update::Unordered<K, V>, S>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, update::Unordered<K, V>>>,
+        I: UnorderedIndex<Value = Location<F>>,
+    {
         let (mut mutations, m) = self.into_parts();
 
         // Resolve existing keys.
@@ -2353,7 +2347,7 @@ where
         }
 
         // Remaining phases: floor raise, CommitFloor, journal, diff merge.
-        m.finish(
+        m.finish_pending(
             ops,
             diff,
             superseded_locs,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -584,15 +584,15 @@ where
             bitmap_parent,
         } = self;
         let (inner, staged_updates) = inner.resolve_updates(updates, upserts, db.any.strategy());
-        let inner = inner
-            .merkleize_with_floor_scan(
+        let pending = inner
+            .merkleize_with_floor_scan_pending(
                 &db.any,
                 metadata,
                 staged_updates,
                 |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
             )
             .await?;
-        compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
+        compute_current_layer_pipelined(pending, db, &grafted_parent, &bitmap_parent).await
     }
 }
 
@@ -673,15 +673,15 @@ where
             bitmap_parent,
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
-        let inner = inner
-            .merkleize_with_floor_scan(
+        let pending = inner
+            .merkleize_with_floor_scan_pending(
                 &db.any,
                 metadata,
                 StagedUpdates::<F, update::Ordered<K, V>>::new(),
                 |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
             )
             .await?;
-        compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
+        compute_current_layer_pipelined(pending, db, &grafted_parent, &bitmap_parent).await
     }
 }
 
@@ -787,6 +787,136 @@ where
             merkleized
         })
         .await
+}
+
+/// [`compute_current_layer`] over a [`any::batch::PendingMerkleize`]: the frozen-chunk
+/// graft work (chunks below the pre-batch grafting boundary, whose covering ops-tree
+/// nodes this batch cannot change) runs on the calling task while the journal merkleize
+/// job hashes on the strategy; only the tip chunks wait for the sealed batch.
+async fn compute_current_layer_pipelined<F, E, U, C, I, H, const N: usize, S>(
+    pending: any::batch::PendingMerkleize<F, H, U, S>,
+    current_db: &super::db::Db<F, E, C, I, H, U, N, S>,
+    grafted_parent: &Arc<merkle::batch::MerkleizedBatch<F, H::Digest, S>>,
+    bitmap_parent: &BitmapBatch<N>,
+) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, N, S>>, Error<F>>
+where
+    F: Graftable,
+    E: Context,
+    U: update::Update,
+    C: Contiguous<Item = Operation<F, U>>,
+    I: UnorderedIndex<Value = Location<F>>,
+    H: Hasher,
+    S: Strategy,
+    Operation<F, U>: Codec,
+{
+    // Phase A: everything here depends only on the diff and pre-batch state.
+    let batch_len = pending.batch_len;
+    let batch_base = *pending.commit_loc + 1 - batch_len as u64;
+    let overlay = build_chunk_overlay::<F, U, _, N>(
+        bitmap_parent,
+        batch_len,
+        batch_base,
+        &pending.diff,
+        &pending.ancestor_diffs,
+    );
+
+    let grafting_height = grafting::height::<N>();
+    let overlay_ops_leaves = pending.commit_loc + 1;
+    let new_complete_chunks = overlay.complete_chunks();
+    let graftable_overlay = grafting::graftable_chunks::<F>(*overlay_ops_leaves, grafting_height)
+        .min(new_complete_chunks as u64) as usize;
+    let graftable_parent = *grafted_parent.leaves() as usize;
+    let pruned_chunks = bitmap_parent.pruned_chunks();
+    assert!(
+        pruned_chunks <= graftable_parent
+            && graftable_parent <= graftable_overlay
+            && graftable_overlay <= new_complete_chunks,
+        "invariant violated: pruned={pruned_chunks} graftable_parent={graftable_parent} graftable_overlay={graftable_overlay} new_complete={new_complete_chunks}"
+    );
+
+    // Frozen chunks: dirty below the pre-batch grafting boundary. Their covering ops-tree
+    // nodes predate this batch, so they resolve through the journal batch's parent (or the
+    // committed tree) while the job runs. Tip chunks ([graftable_parent, graftable_overlay))
+    // cover both dirty-at-tip and pending-to-graftable transitions, exactly the remainder
+    // of the set `compute_current_layer` builds.
+    let mut frozen: Vec<usize> = overlay
+        .chunks
+        .iter()
+        .filter(|&(&idx, _)| idx < graftable_parent && idx >= pruned_chunks)
+        .map(|(&idx, _)| idx)
+        .collect();
+    frozen.sort_unstable();
+    frozen.dedup();
+    let chunk_of = |idx: usize| {
+        overlay
+            .get(idx)
+            .copied()
+            .unwrap_or_else(|| bitmap_parent.get_chunk(idx))
+    };
+    let frozen_chunks = frozen.iter().map(|&idx| (idx, chunk_of(idx)));
+    let frozen_inputs = match &pending.journal_parent {
+        Some(parent) => {
+            let adapter = BatchStorageAdapter::new(parent, &current_db.any.log.merkle);
+            read_graft_inputs::<F, _, N>(&adapter, frozen_chunks).await?
+        }
+        None => read_graft_inputs::<F, _, N>(&current_db.any.log.merkle, frozen_chunks).await?,
+    };
+    let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
+    let mut grafted_batch = grafted_parent.new_batch();
+    if !frozen_inputs.is_empty() {
+        let frozen_leaves =
+            grafting::graft_chunk_digests::<H, _, N>(&current_db.strategy, frozen_inputs);
+        for (chunk_idx, digest) in frozen_leaves {
+            grafted_batch = grafted_batch
+                .update_leaf_digest(Location::<F>::new(chunk_idx as u64), digest)
+                .expect("update_leaf_digest failed");
+        }
+    }
+
+    // Phase B: seal (awaiting the job), then the tip chunks that need the fresh tree.
+    let inner = pending.seal().await?;
+    let ops_tree_adapter =
+        BatchStorageAdapter::new(&inner.journal_batch, &current_db.any.log.merkle);
+    let tip_chunks = (graftable_parent..graftable_overlay).map(|idx| (idx, chunk_of(idx)));
+    let tip_inputs = read_graft_inputs::<F, _, N>(&ops_tree_adapter, tip_chunks).await?;
+    if !tip_inputs.is_empty() {
+        let tip_leaves = grafting::graft_chunk_digests::<H, _, N>(&current_db.strategy, tip_inputs);
+        for (_, digest) in tip_leaves {
+            grafted_batch = grafted_batch.add_leaf_digest(digest);
+        }
+    }
+    let grafted_batch = grafted_batch.merkleize(&current_db.grafted_tree, &grafted_hasher);
+
+    // Remainder identical to `compute_current_layer`.
+    let bitmap_batch = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
+        parent: bitmap_parent.clone(),
+        overlay: Arc::new(overlay),
+        shared: Arc::clone(bitmap_parent.shared()),
+    }));
+    let ops_root = inner.root();
+    let layered = BatchOverMem {
+        batch: &grafted_batch,
+        mem: &current_db.grafted_tree,
+    };
+    let grafted_storage =
+        grafting::Storage::<F, H, _, _>::new(&layered, grafting_height, &ops_tree_adapter);
+    let partial = partial_chunk::<_, N>(&bitmap_batch);
+    let canonical_root = compute_db_root::<F, H, _, _, N>(
+        &bitmap_batch,
+        &grafted_storage,
+        overlay_ops_leaves,
+        partial,
+        inner.bounds.inactivity_floor,
+        &ops_root,
+    )
+    .await?;
+
+    Ok(Arc::new(MerkleizedBatch {
+        inner,
+        grafted: grafted_batch,
+        bitmap: bitmap_batch,
+        canonical_root,
+    }))
 }
 
 /// Compute the current layer (bitmap + grafted MMR + canonical root) on top of a merkleized any

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -526,8 +526,8 @@ where
                 fill_candidates(&bitmap_parent, floor, tip, limit, out)
             })
             .await?;
-        let inner = inner
-            .merkleize_with_floor_scan(
+        let pending = inner
+            .merkleize_with_floor_scan_pending(
                 &db.any,
                 metadata,
                 staged_updates,
@@ -535,7 +535,7 @@ where
                 |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
             )
             .await?;
-        compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
+        compute_current_layer_pipelined(pending, db, &grafted_parent, &bitmap_parent).await
     }
 }
 
@@ -628,8 +628,8 @@ where
             bitmap_parent,
         } = self;
         // Use the speculative parent bitmap rather than the committed `any` bitmap.
-        let inner = inner
-            .merkleize_with_floor_scan(
+        let pending = inner
+            .merkleize_with_floor_scan_pending(
                 &db.any,
                 metadata,
                 StagedUpdates::<F, update::Unordered<K, V>>::new(),
@@ -637,7 +637,7 @@ where
                 |floor, tip, limit, out| fill_candidates(&bitmap_parent, floor, tip, limit, out),
             )
             .await?;
-        compute_current_layer(inner, db, &grafted_parent, &bitmap_parent).await
+        compute_current_layer_pipelined(pending, db, &grafted_parent, &bitmap_parent).await
     }
 }
 
@@ -751,45 +751,8 @@ where
     overlay
 }
 
-/// Merkleize grafted chunk digests while retaining the live ancestor chain.
-async fn merkleize_grafted_batch<F, H, S, const N: usize>(
-    strategy: &S,
-    grafted_parent: Arc<GenericMerkleizedBatch<F, H::Digest, S>>,
-    grafted_tree: &Arc<Mem<F, H::Digest>>,
-    graft_inputs: Vec<(usize, H::Digest, [u8; N])>,
-    grafting_height: u32,
-) -> Arc<GenericMerkleizedBatch<F, H::Digest, S>>
-where
-    F: Graftable,
-    H: Hasher,
-    S: Strategy,
-{
-    let old_grafted_leaves = *grafted_parent.leaves() as usize;
-    let mut grafted_batch = grafted_parent.new_batch();
-    let ancestors = grafted_batch.retain_ancestors();
-    let grafted_tree = Arc::clone(grafted_tree);
-    strategy
-        .clone()
-        .spawn(graft_inputs.len(), move |strategy| {
-            let new_leaves = grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
-            for (chunk_idx, digest) in new_leaves {
-                if chunk_idx < old_grafted_leaves {
-                    grafted_batch = grafted_batch
-                        .update_leaf_digest(Location::<F>::new(chunk_idx as u64), digest)
-                        .expect("update_leaf_digest failed");
-                } else {
-                    grafted_batch = grafted_batch.add_leaf_digest(digest);
-                }
-            }
-            let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
-            let merkleized = grafted_batch.merkleize(&grafted_tree, &grafted_hasher);
-            drop(ancestors);
-            merkleized
-        })
-        .await
-}
-
-/// [`compute_current_layer`] over a [`any::batch::PendingMerkleize`]: the frozen-chunk
+/// Compute the current layer (bitmap + grafted MMR + canonical root), pipelined over a
+/// [`any::batch::PendingMerkleize`]: the frozen-chunk
 /// graft work (chunks below the pre-batch grafting boundary, whose covering ops-tree
 /// nodes this batch cannot change) runs on the calling task while the journal merkleize
 /// job hashes on the strategy; only the tip chunks wait for the sealed batch.
@@ -900,151 +863,6 @@ where
     };
     let grafted_storage =
         grafting::Storage::<F, H, _, _>::new(&layered, grafting_height, &ops_tree_adapter);
-    let partial = partial_chunk::<_, N>(&bitmap_batch);
-    let canonical_root = compute_db_root::<F, H, _, _, N>(
-        &bitmap_batch,
-        &grafted_storage,
-        overlay_ops_leaves,
-        partial,
-        inner.bounds.inactivity_floor,
-        &ops_root,
-    )
-    .await?;
-
-    Ok(Arc::new(MerkleizedBatch {
-        inner,
-        grafted: grafted_batch,
-        bitmap: bitmap_batch,
-        canonical_root,
-    }))
-}
-
-/// Compute the current layer (bitmap + grafted MMR + canonical root) on top of a merkleized any
-/// batch.
-///
-/// Builds a chunk overlay from the diff, computes grafted MMR leaves from dirty chunks, and
-/// produces the `Arc<MerkleizedBatch>` directly.
-async fn compute_current_layer<F, E, U, C, I, H, const N: usize, S>(
-    inner: Arc<any::batch::MerkleizedBatch<F, H::Digest, U, S>>,
-    current_db: &super::db::Db<F, E, C, I, H, U, N, S>,
-    grafted_parent: &Arc<merkle::batch::MerkleizedBatch<F, H::Digest, S>>,
-    bitmap_parent: &BitmapBatch<N>,
-) -> Result<Arc<MerkleizedBatch<F, H::Digest, U, N, S>>, Error<F>>
-where
-    F: Graftable,
-    E: Context,
-    C: Contiguous<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    U: update::Update,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    let batch_len = inner.journal_batch.items().len();
-    let batch_base = *inner.bounds.tip.size - batch_len as u64;
-
-    // Build chunk overlay: materialized bytes for every dirty chunk.
-    let overlay = build_chunk_overlay::<F, U, _, N>(
-        bitmap_parent,
-        batch_len,
-        batch_base,
-        &inner.diff,
-        &inner.ancestor_diffs,
-    );
-
-    let grafting_height = grafting::height::<N>();
-    let ops_tree_adapter =
-        BatchStorageAdapter::new(&inner.journal_batch, &current_db.any.log.merkle);
-
-    // Snapshot ops_leaves for the post-batch state (the canonical root we're about to compute
-    // sees this many ops). Thread it through `graftable_chunks` derivation and root computation.
-    let overlay_ops_leaves = inner.bounds.tip.size;
-
-    // Distinguish three counters:
-    //   - new_complete_chunks: chunks with all bits filled in the post-batch bitmap
-    //   - graftable_overlay:      chunks committed by the grafted tree (have a single h=G ancestor)
-    //   - graftable_parent:       grafted-tree leaf count from the parent (structural source of truth)
-    //
-    // The pending chunk (if any) sits at index `graftable_overlay` and is excluded from the
-    // grafted tree; its digest is hashed directly into the canonical root.
-    let new_complete_chunks = overlay.complete_chunks();
-    let graftable_overlay = grafting::graftable_chunks::<F>(*overlay_ops_leaves, grafting_height)
-        .min(new_complete_chunks as u64) as usize;
-    let graftable_parent = *grafted_parent.leaves() as usize;
-    let pruned_chunks = bitmap_parent.pruned_chunks();
-    assert!(
-        pruned_chunks <= graftable_parent
-            && graftable_parent <= graftable_overlay
-            && graftable_overlay <= new_complete_chunks,
-        "invariant violated: pruned={pruned_chunks} graftable_parent={graftable_parent} graftable_overlay={graftable_overlay} new_complete={new_complete_chunks}"
-    );
-
-    // Build the set of chunk indices whose grafted-leaf needs (re)computing:
-    //   1) Dirty chunks (bits changed in this batch) within the graftable range.
-    //   2) Pending -> graftable transitions: chunks newly graftable because the ops tree built
-    //      their h=G ancestor in this batch. Their bitmap bytes may not be dirty (the chunk
-    //      became graftable via ops growth alone) but they need a grafted-leaf entry now.
-    let mut chunk_indices_to_update: Vec<usize> = overlay
-        .chunks
-        .iter()
-        .filter(|&(&idx, _)| idx < graftable_overlay && idx >= pruned_chunks)
-        .map(|(&idx, _)| idx)
-        .collect();
-    chunk_indices_to_update.extend(graftable_parent..graftable_overlay);
-    chunk_indices_to_update.sort_unstable();
-    chunk_indices_to_update.dedup();
-    let chunks_to_update = chunk_indices_to_update.into_iter().map(|idx| {
-        let chunk = overlay
-            .get(idx)
-            .copied()
-            .unwrap_or_else(|| bitmap_parent.get_chunk(idx));
-        (idx, chunk)
-    });
-
-    // Prefetch each chunk's covering ops-tree node, then run graft hashing and the grafted
-    // MMR build/merkleize as one job on the strategy (against a snapshot of the committed
-    // grafted tree) instead of occupying the calling task. An empty graft set hashes
-    // nothing, so it merkleizes inline rather than paying for a job handoff.
-    let graft_inputs = read_graft_inputs::<F, _, N>(&ops_tree_adapter, chunks_to_update).await?;
-    let grafted_batch = if graft_inputs.is_empty() {
-        let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
-        grafted_parent
-            .new_batch()
-            .merkleize(&current_db.grafted_tree, &grafted_hasher)
-    } else {
-        merkleize_grafted_batch::<F, H, S, N>(
-            &current_db.strategy,
-            Arc::clone(grafted_parent),
-            &current_db.grafted_tree,
-            graft_inputs,
-            grafting_height,
-        )
-        .await
-    };
-
-    // Build the layered bitmap (parent + overlay) before computing the canonical root, so that
-    // compute_db_root sees newly completed chunks. Using bitmap_parent alone would miss chunks
-    // that transitioned from partial to complete in this batch.
-    let bitmap_batch = BitmapBatch::Layer(Arc::new(BitmapBatchLayer {
-        parent: bitmap_parent.clone(),
-        overlay: Arc::new(overlay),
-        shared: Arc::clone(bitmap_parent.shared()),
-    }));
-
-    // Compute canonical root. The grafted batch alone cannot resolve committed nodes,
-    // so layer it over the committed grafted MMR.
-    let ops_root = inner.root();
-    let layered = BatchOverMem {
-        batch: &grafted_batch,
-        mem: &current_db.grafted_tree,
-    };
-    let grafted_storage =
-        grafting::Storage::<F, H, _, _>::new(&layered, grafting_height, &ops_tree_adapter);
-    // Compute partial chunk (last incomplete chunk, if any). The partial chunk lives at
-    // index `new_complete_chunks` (the chunk currently being filled with bits) -- distinct
-    // from `graftable_overlay` (the grafted-tree boundary). At gh >= 3, partial and pending can
-    // coexist; this branch only handles partial. The pending chunk (when present) is read
-    // from the bitmap inside `compute_db_root` via `pending_chunk()`.
     let partial = partial_chunk::<_, N>(&bitmap_batch);
     let canonical_root = compute_db_root::<F, H, _, _, N>(
         &bitmap_batch,
@@ -1454,21 +1272,12 @@ mod trait_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{mmb, mmr, utils::detached::block_strategy};
-    use commonware_cryptography::Sha256;
-    use commonware_macros::test_traced;
-    use commonware_parallel::Rayon;
-    use commonware_utils::{NZUsize, bitmap::Prunable as BitMap};
-    use std::{
-        future::Future as _,
-        task::Context as TaskContext,
-        time::{Duration, Instant},
-    };
+    use crate::mmr;
+    use commonware_utils::bitmap::Prunable as BitMap;
 
     // N=4 -> CHUNK_SIZE_BITS = 32
     const N: usize = 4;
     type Bm = BitMap<N>;
-    type GraftedBatch = Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>;
     type Location = mmr::Location;
 
     fn make_bitmap(bits: &[bool]) -> Bm {
@@ -1477,79 +1286,6 @@ mod tests {
             bm.push(b);
         }
         bm
-    }
-
-    fn grafted_chain(
-        strategy: &Rayon,
-        mem: &Arc<Mem<mmb::Family, <Sha256 as Hasher>::Digest>>,
-    ) -> (GraftedBatch, GraftedBatch) {
-        let hasher = grafting::hasher::<mmb::Family, Sha256>(grafting::height::<1>());
-        let a = mem
-            .new_batch_with_strategy(strategy.clone())
-            .add_leaf_digest(Sha256::hash(&[b"a-0"]))
-            .add_leaf_digest(Sha256::hash(&[b"a-1"]))
-            .merkleize(mem, &hasher);
-        let b = a
-            .new_batch()
-            .add_leaf_digest(Sha256::hash(&[b"b-0"]))
-            .merkleize(mem, &hasher);
-        (a, b)
-    }
-
-    /// A detached grafted-tree merkleization owns the full ancestor chain after cancellation.
-    #[test_traced]
-    fn test_grafted_merkleize_retains_ancestors_after_cancellation() {
-        let strategy = Rayon::new(NZUsize!(2)).unwrap();
-        let mem = Arc::new(Mem::<mmb::Family, <Sha256 as Hasher>::Digest>::new());
-        let grafting_height = grafting::height::<1>();
-        let graft_inputs = || vec![(0, Sha256::hash(&[b"replacement"]), [1u8; 1])];
-        let waker = futures::task::noop_waker();
-        let mut context = TaskContext::from_waker(&waker);
-
-        // Observe the worker result so a missing grandparent fails the test directly.
-        let (a, b) = grafted_chain(&strategy, &mem);
-        let ancestor = Arc::downgrade(&a);
-        let release = block_strategy(&strategy, 2);
-        let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
-            &strategy,
-            Arc::clone(&b),
-            &mem,
-            graft_inputs(),
-            grafting_height,
-        ));
-        assert!(merkleize.as_mut().poll(&mut context).is_pending());
-        drop(b);
-        drop(a);
-        drop(release);
-        let _ = futures::executor::block_on(merkleize);
-        assert!(ancestor.upgrade().is_none());
-
-        // Drop the waiter while the worker is queued to prove the guard moved with it.
-        let (a, b) = grafted_chain(&strategy, &mem);
-        let ancestor = Arc::downgrade(&a);
-        let release = block_strategy(&strategy, 2);
-        let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
-            &strategy,
-            Arc::clone(&b),
-            &mem,
-            graft_inputs(),
-            grafting_height,
-        ));
-        assert!(merkleize.as_mut().poll(&mut context).is_pending());
-        drop(merkleize);
-        drop(b);
-        drop(a);
-        assert!(ancestor.upgrade().is_some());
-
-        drop(release);
-        let deadline = Instant::now() + Duration::from_secs(10);
-        while ancestor.upgrade().is_some() {
-            assert!(
-                Instant::now() < deadline,
-                "detached grafted merkleization did not release its ancestors"
-            );
-            std::thread::yield_now();
-        }
     }
 
     // ---- build_chunk_overlay tests ----


### PR DESCRIPTION
## Summary

In a `current` DB, the grafted layer (chunk overlay, graft-input reads, grafted-leaf hashing, grafted-tree merkleize, canonical root) ran serially after the journal merkleize job, yet most of that work does not depend on the job's output. A touched bitmap chunk below the pre-batch grafting boundary grafts onto an ops-tree subtree this batch cannot change (the tree is append-only), so its graft-input read and leaf hash need only the diff and pre-batch state. Since superseded locations scatter across history while new ops concentrate at the tip, most touched chunks per block are these "frozen" chunks.

Three seams implement the overlap:

- `Journal::merkleize_start` submits the leaf/node hashing job and returns it un-awaited (`merkleize` is now a thin wrapper).
- `Merkleizer::finish_pending` stops after job submission, returning a `PendingMerkleize` that carries the in-flight job plus everything else `finish` computes; `finish` seals it immediately, so all other paths are behavior-identical.
- `compute_current_layer_pipelined` runs the chunk overlay build, chunk classification, frozen-chunk graft-input reads (through the journal batch's parent, or the committed tree), and frozen-leaf hashing on the calling task while the job hashes on the strategy, sealing only for the tip chunks, the grafted merkleize, and the root. Wired for all four `current` entries (ordered and unordered, staged and plain); the previous sequential layer is removed.

`Strategy::spawn` returns adopt precise capturing (`use<..>`) so the job future no longer captures the strategy borrow and can cross function boundaries; the hidden types (a receiver, a ready value) were always `'static`. An impl's capture list has to match the trait's, so this also updates every `Strategy` impl: the three in `parallel`, plus the `TestStrategy` helper in `p2p`'s codec tests, which is why a p2p file appears here. That one captures `use<F, T>` rather than the trait's `use<Self, F, T>`, since `Self` is an alias inside an impl and cannot appear in a capture list.

## Benchmarks

Measured against this PR's base (EPYC 9354P, mimalloc, paired A/B, identical `db_bytes` in every pair, 8-thread strategy pool on both arms). The base already batches the graft-input node reads (#4465), which removes most of the serialized read latency this overlap also used to cover -- so the overlap's remaining value is running the graft hashing and the residual read work under the journal merkleize job:

| workload | base | this PR |
|---|---|---|
| Constantinople (32k reads + 32k updates, 1M keys, `current::ordered::fixed::mmb`, p50) | 28.03ms | 26.51ms (**-5.4%**) |
| eth_replay (20k-block windows from a 5M-block seed, follower, 32G cache) | wall 47.94s / merkleize 27.90s | 47.73s (-0.4%, within noise) / 27.32s (-2.1%) |

The dense Constantinople shape is where the overlap pays: its per-commit graft work is large relative to the journal job it hides behind. On the sparse eth-replay shape the graft phase is small once its reads are batched, and the win is mostly gone at this scale. `any`-only DBs have no grafted layer and are unaffected.

## Pool size

The overlap rides `Strategy::spawn`, so it engages only when a pool is present (see #4432 for the general duty-cycle analysis). With a 1-thread pool the spawn inlines and the split `PendingMerkleize` runs without buying any overlap, costing about 1-2% (eth wall +1.4%, Constantinople p50 +1.9%). Pool size is a per-workload deployment choice; the dense workloads this PR targets run with a full pool, where the overlap pays.

## Validation## Validation

- The qmdb, journal, and parallel suites are green, plus the `p2p` codec tests that exercise the updated `TestStrategy`.
- Constantinople speculative roots bit-exact across states and across platforms (arm64/x86_64).
- `db_bytes` identical in every A/B pair.
- Removed with the serial path: `merkleize_grafted_batch` and its `test_grafted_merkleize_retains_ancestors_after_cancellation`. That test pinned ancestor retention for the *detached* grafted-merkleize job, which this PR eliminates -- grafting now runs inline on the calling task, where ancestor lifetime is scoped to the future itself. The same retention contract on the one remaining detached job (the ops-tree merkleize) keeps its own regression test in `journal/authenticated.rs`, now exercised through `merkleize_start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG6CDm2eHLMgiVupMECBiU



