### PR TITLE
[consensus/simplex] Overlap batcher crypto via dispatch pool instead of inline awaits

### DIFF
--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -29,7 +29,7 @@ use commonware_runtime::{
 use commonware_utils::{N3f1, futures::Pool, ordered::Quorum};
 use rand_core::CryptoRng;
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::{Duration, SystemTime},
 };
@@ -45,6 +45,20 @@ struct Current {
     view: View,
     leader: Option<Participant>,
     leader_nullify_hinted: bool,
+}
+
+/// Moves each dirty view into one dispatch pass, prioritizing the current view.
+fn prepare_dispatch(
+    dirty_views: &mut BTreeSet<View>,
+    current: View,
+    dispatch_views: &mut Vec<View>,
+) {
+    dispatch_views.clear();
+    if dirty_views.remove(&current) {
+        dispatch_views.push(current);
+    }
+    dispatch_views.extend(dirty_views.iter().copied());
+    dirty_views.clear();
 }
 
 /// A completed crypto job from the actor's dispatch pool.
@@ -345,15 +359,23 @@ where
     /// Results arrive through the pool's completion branch, which reintegrates
     /// them and marks the view dirty so this dispatch runs again (e.g. to
     /// recover a certificate from a quorum a batch just completed).
-    fn dispatch_view(
+    ///
+    /// Returns true when the strategy's execution capacity is full. The caller
+    /// must retain the view for a later pass because more work may be ready.
+    pub(super) fn dispatch_view(
         &mut self,
         pool: &mut Pool<Done<S, D>>,
         view: View,
         round: &mut Round<S, B, D, Re>,
-    ) {
+    ) -> bool {
+        let capacity = self.strategy.manual().parallelism();
+
         // Begin a verification batch for every vote kind with work worth
         // verifying.
-        while let Some((batch, job)) = round.begin_verify(self.context.as_mut(), &self.strategy) {
+        while pool.len() < capacity
+            && let Some((batch, job)) =
+                round.begin_verify(self.context.as_mut(), &self.strategy)
+        {
             let timer = self.verify_latency.timer(self.context.as_ref());
             pool.push(async move {
                 let (votes, invalid) = job.await;
@@ -368,7 +390,9 @@ where
         }
 
         // Begin recovery of every certificate with a verified quorum.
-        while let Some(job) = round.begin_construct_certificate(&self.strategy) {
+        while pool.len() < capacity
+            && let Some(job) = round.begin_construct_certificate(&self.strategy)
+        {
             let timer = self.recover_latency.timer(self.context.as_ref());
             pool.push(async move {
                 Done::Recovered {
@@ -378,6 +402,8 @@ where
                 }
             });
         }
+
+        pool.len() == capacity
     }
 
     /// Reintegrates a completed crypto job from the dispatch pool.
@@ -482,9 +508,10 @@ where
         let mut finalized = self.floor;
         let mut work: BTreeMap<View, Round<S, B, D, Re>> = BTreeMap::new();
 
-        // Views whose rounds may have become actionable. Capacity is reused
-        // across select-loop iterations.
-        let mut dirty_views: Vec<View> = Vec::new();
+        // Views whose rounds may have become actionable. Views that cannot be
+        // dispatched at capacity remain queued for a later completion.
+        let mut dirty_views: BTreeSet<View> = BTreeSet::new();
+        let mut dispatch_views: Vec<View> = Vec::new();
         // In-flight crypto (verification batches and certificate recoveries).
         // Dispatching instead of awaiting keeps the event loop free to ingest
         // votes while the strategy's workers verify, so multiple batches (and
@@ -492,9 +519,6 @@ where
         let mut crypto_pool: Pool<Done<S, D>> = Pool::default();
         select_loop! {
             self.context,
-            on_start => {
-                dirty_views.clear();
-            },
             on_stopped => {
                 debug!("context shutdown, stopping batcher");
             },
@@ -539,7 +563,7 @@ where
                         // span so all of its work shares one trace
                         let round = self.round_for_view(&current, &mut work, current.view);
                         round.set_span(span);
-                        dirty_views.push(current.view);
+                        dirty_views.insert(current.view);
 
                         // Revisit rounds in the admission window now that the
                         // current view advanced: rounds already visited are
@@ -548,7 +572,7 @@ where
                         if current.view < limit {
                             for (&view, round) in work.range_mut(current.view.next()..=limit) {
                                 self.stamp_leader(&current, view, round);
-                                dirty_views.push(view);
+                                dirty_views.insert(view);
                             }
                         }
 
@@ -611,7 +635,7 @@ where
                         let _guard = process.entered();
                         round.accept_vote(message, true);
                         self.added.inc();
-                        dirty_views.push(view);
+                        dirty_views.insert(view);
                     }
                 }
             },
@@ -619,7 +643,7 @@ where
             // certificate recoveries)
             done = crypto_pool.next_completed() => {
                 if let Some(view) = self.handle_done(&mut voter, &mut work, done) {
-                    dirty_views.push(view);
+                    dirty_views.insert(view);
                 }
             },
             // Handle certificates from the network
@@ -683,7 +707,7 @@ where
                 // certificate may have unlocked already-buffered votes.
                 let round = self.round_for_view(&current, &mut work, view);
                 if round.record_certificate(&message) {
-                    dirty_views.push(view);
+                    dirty_views.insert(view);
                 }
                 voter.recovered(message);
             },
@@ -743,7 +767,7 @@ where
                             .entered();
                         voter.timeout(round, TimeoutReason::LeaderNullify);
                     }
-                    dirty_views.push(view);
+                    dirty_views.insert(view);
                 }
             },
             on_end => {
@@ -753,7 +777,10 @@ where
 
                 let me = self.scheme.me();
 
-                for view in dirty_views.drain(..) {
+                // Process each currently dirty view once. Saturated views are
+                // reinserted for a later pass.
+                prepare_dispatch(&mut dirty_views, current.view, &mut dispatch_views);
+                for view in dispatch_views.drain(..) {
                     // Skip verification and construction for views at or below
                     // finalized. We still admit votes there (see
                     // [Viewport::retains]) to notify the reporter of all votes
@@ -784,7 +811,9 @@ where
                     }
 
                     let span = round.span();
-                    span.in_scope(|| self.dispatch_view(&mut crypto_pool, view, round));
+                    if span.in_scope(|| self.dispatch_view(&mut crypto_pool, view, round)) {
+                        dirty_views.insert(view);
+                    }
                 }
 
                 // Drop any rounds that are no longer retained
@@ -797,5 +826,22 @@ where
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BTreeSet, View, prepare_dispatch};
+
+    #[test]
+    fn dispatch_pass_prioritizes_current_without_reprocessing() {
+        let current = View::new(3);
+        let mut dirty = BTreeSet::from([View::new(1), current, View::new(4)]);
+        let mut dispatch = vec![View::new(9)];
+
+        prepare_dispatch(&mut dirty, current, &mut dispatch);
+
+        assert_eq!(dispatch, [current, View::new(1), View::new(4)]);
+        assert!(dirty.is_empty());
     }
 }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -48,7 +48,7 @@ struct Current {
 }
 
 /// A completed crypto job from the actor's dispatch pool.
-enum Done<S: Scheme<D>, D: Digest> {
+pub(super) enum Done<S: Scheme<D>, D: Digest> {
     /// A verification batch completed: its verified votes must be
     /// reintegrated into the view's round (see [Round::finish_verify]) and
     /// invalid signers blocked.
@@ -375,6 +375,77 @@ where
         }
     }
 
+    /// Reintegrates a completed crypto job from the dispatch pool.
+    ///
+    /// A verification batch's votes return to the view's round and mark it
+    /// dirty: the batch may have completed a quorum, or more votes may have
+    /// buffered while it was in flight. A recovered certificate is recorded
+    /// on the round and forwarded to the voter. A view pruned while its job
+    /// was in flight drops the votes but still forwards the certificate: the
+    /// voter prunes independently.
+    pub(super) fn handle_done(
+        &mut self,
+        voter: &mut voter::Mailbox<S, D>,
+        work: &mut BTreeMap<View, Round<S, B, D, Re>>,
+        dirty_views: &mut Vec<View>,
+        done: Done<S, D>,
+    ) {
+        match done {
+            Done::Verified {
+                view,
+                batch,
+                timer,
+                votes,
+                invalid,
+            } => {
+                timer.observe(self.context.as_ref());
+                self.verified.inc_by(batch as u64);
+                self.batch_size.observe(batch as f64);
+
+                for signer in invalid {
+                    if let Some(signer) = self.scheme.participants().key(signer) {
+                        commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
+                    }
+                }
+
+                // The round may have been pruned while the batch was in
+                // flight; its votes are no longer needed.
+                let Some(round) = work.get_mut(&view) else {
+                    return;
+                };
+                let _guard = round.span().entered();
+                trace!(%view, batch, "batch verified votes");
+                round.finish_verify(votes);
+
+                // Revisit the view: the batch may have completed a
+                // quorum (certificate recovery) or more votes may have
+                // buffered while it was in flight (another batch).
+                dirty_views.push(view);
+            }
+            Done::Recovered {
+                view,
+                timer,
+                certificate,
+            } => {
+                timer.observe(self.context.as_ref());
+                let kind = certificate.kind();
+
+                // Record the certificate on its round (completing the
+                // certified phase and applying the retention policy)
+                // unless the round was pruned while recovery was in
+                // flight. Recording may unlock already-buffered votes.
+                if let Some(round) = work.get_mut(&view) {
+                    let _guard = round.span().entered();
+                    debug!(%view, %kind, "constructed certificate, forwarding to voter");
+                    if round.record_certificate(&certificate) {
+                        dirty_views.push(view);
+                    }
+                }
+                voter.recovered(certificate);
+            }
+        }
+    }
+
     pub fn start(
         mut self,
         voter: voter::Mailbox<S, D>,
@@ -544,50 +615,7 @@ where
             // Handle completed crypto work (verification batches and
             // certificate recoveries)
             done = crypto_pool.next_completed() => {
-                match done {
-                    Done::Verified { view, batch, timer, votes, invalid } => {
-                        timer.observe(self.context.as_ref());
-                        self.verified.inc_by(batch as u64);
-                        self.batch_size.observe(batch as f64);
-
-                        for signer in invalid {
-                            if let Some(signer) = self.scheme.participants().key(signer) {
-                                commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
-                            }
-                        }
-
-                        // The round may have been pruned while the batch was in
-                        // flight; its votes are no longer needed.
-                        let Some(round) = work.get_mut(&view) else {
-                            continue;
-                        };
-                        let _guard = round.span().entered();
-                        trace!(%view, batch, "batch verified votes");
-                        round.finish_verify(votes);
-
-                        // Revisit the view: the batch may have completed a
-                        // quorum (certificate recovery) or more votes may have
-                        // buffered while it was in flight (another batch).
-                        dirty_views.push(view);
-                    }
-                    Done::Recovered { view, timer, certificate } => {
-                        timer.observe(self.context.as_ref());
-                        let kind = certificate.kind();
-
-                        // Record the certificate on its round (completing the
-                        // certified phase and applying the retention policy)
-                        // unless the round was pruned while recovery was in
-                        // flight. Recording may unlock already-buffered votes.
-                        if let Some(round) = work.get_mut(&view) {
-                            let _guard = round.span().entered();
-                            debug!(%view, %kind, "constructed certificate, forwarding to voter");
-                            if round.record_certificate(&certificate) {
-                                dirty_views.push(view);
-                            }
-                        }
-                        voter.recovered(certificate);
-                    }
-                }
+                self.handle_done(&mut voter, &mut work, &mut dirty_views, done);
             },
             // Handle certificates from the network
             Ok((sender, message)) = certificate_receiver.recv() else break => {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -382,15 +382,14 @@ where
 
     /// Reintegrates a completed crypto job from the dispatch pool.
     ///
-    /// A verification batch's votes return to the view's round: the batch may
-    /// have completed a quorum, or more votes may have buffered while it was
-    /// in flight. A recovered certificate is recorded on the round and
-    /// forwarded to the voter. A view pruned while its job was in flight
-    /// drops the votes but still forwards the certificate: the voter prunes
-    /// independently.
+    /// A verification batch's votes return to the view's round. A recovered
+    /// certificate is recorded on the round and forwarded to the voter. A
+    /// view pruned while its job was in flight drops the votes but still
+    /// forwards the certificate: the voter prunes independently.
     ///
     /// Returns the view to revisit when the completion may have made new
-    /// work ready.
+    /// work ready: a batch may have completed a quorum, or more votes may
+    /// have buffered while it was in flight.
     pub(super) fn handle_done(
         &mut self,
         voter: &mut voter::Mailbox<S, D>,

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -373,8 +373,7 @@ where
         // Begin a verification batch for every vote kind with work worth
         // verifying.
         while pool.len() < capacity
-            && let Some((batch, job)) =
-                round.begin_verify(self.context.as_mut(), &self.strategy)
+            && let Some((batch, job)) = round.begin_verify(self.context.as_mut(), &self.strategy)
         {
             let timer = self.verify_latency.timer(self.context.as_ref());
             pool.push(async move {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -382,19 +382,21 @@ where
 
     /// Reintegrates a completed crypto job from the dispatch pool.
     ///
-    /// A verification batch's votes return to the view's round and mark it
-    /// dirty: the batch may have completed a quorum, or more votes may have
-    /// buffered while it was in flight. A recovered certificate is recorded
-    /// on the round and forwarded to the voter. A view pruned while its job
-    /// was in flight drops the votes but still forwards the certificate: the
-    /// voter prunes independently.
+    /// A verification batch's votes return to the view's round: the batch may
+    /// have completed a quorum, or more votes may have buffered while it was
+    /// in flight. A recovered certificate is recorded on the round and
+    /// forwarded to the voter. A view pruned while its job was in flight
+    /// drops the votes but still forwards the certificate: the voter prunes
+    /// independently.
+    ///
+    /// Returns the view to revisit when the completion may have made new
+    /// work ready.
     pub(super) fn handle_done(
         &mut self,
         voter: &mut voter::Mailbox<S, D>,
         work: &mut BTreeMap<View, Round<S, B, D, Re>>,
-        dirty_views: &mut Vec<View>,
         done: Done<S, D>,
-    ) {
+    ) -> Option<View> {
         match done {
             Done::Verified {
                 view,
@@ -415,9 +417,7 @@ where
 
                 // The round may have been pruned while the batch was in
                 // flight; its votes are no longer needed.
-                let Some(round) = work.get_mut(&view) else {
-                    return;
-                };
+                let round = work.get_mut(&view)?;
                 let _guard = round.span().entered();
                 trace!(%view, batch, "batch verified votes");
                 round.finish_verify(votes);
@@ -425,7 +425,7 @@ where
                 // Revisit the view: the batch may have completed a
                 // quorum (certificate recovery) or more votes may have
                 // buffered while it was in flight (another batch).
-                dirty_views.push(view);
+                Some(view)
             }
             Done::Recovered {
                 view,
@@ -439,14 +439,16 @@ where
                 // certified phase and applying the retention policy)
                 // unless the round was pruned while recovery was in
                 // flight. Recording may unlock already-buffered votes.
+                let mut dirty = None;
                 if let Some(round) = work.get_mut(&view) {
                     let _guard = round.span().entered();
                     debug!(%view, %kind, "constructed certificate, forwarding to voter");
                     if round.record_certificate(&certificate) {
-                        dirty_views.push(view);
+                        dirty = Some(view);
                     }
                 }
                 voter.recovered(certificate);
+                dirty
             }
         }
     }
@@ -620,7 +622,9 @@ where
             // Handle completed crypto work (verification batches and
             // certificate recoveries)
             done = crypto_pool.next_completed() => {
-                self.handle_done(&mut voter, &mut work, &mut dirty_views, done);
+                if let Some(view) = self.handle_done(&mut voter, &mut work, done) {
+                    dirty_views.push(view);
+                }
             },
             // Handle certificates from the network
             Ok((sender, message)) = certificate_receiver.recv() else break => {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -345,7 +345,12 @@ where
     /// Results arrive through the pool's completion branch, which reintegrates
     /// them and marks the view dirty so this dispatch runs again (e.g. to
     /// recover a certificate from a quorum a batch just completed).
-    fn dispatch_view(&mut self, pool: &mut Pool<Done<S, D>>, view: View, round: &mut Round<S, B, D, Re>) {
+    fn dispatch_view(
+        &mut self,
+        pool: &mut Pool<Done<S, D>>,
+        view: View,
+        round: &mut Round<S, B, D, Re>,
+    ) {
         // Begin a verification batch for every vote kind with work worth
         // verifying.
         while let Some((batch, job)) = round.begin_verify(self.context.as_mut(), &self.strategy) {

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -1,4 +1,4 @@
-use super::{Config, Mailbox, Message, Round};
+use super::{Config, Mailbox, Message, Round, VerifiedVotes};
 use crate::{
     Epochable, Relay, Reporter, Viewable,
     simplex::{
@@ -26,14 +26,14 @@ use commonware_runtime::{
         traces::TracedExt as _,
     },
 };
-use commonware_utils::{N3f1, ordered::Quorum};
+use commonware_utils::{N3f1, futures::Pool, ordered::Quorum};
 use rand_core::CryptoRng;
 use std::{
     collections::BTreeMap,
     sync::Arc,
     time::{Duration, SystemTime},
 };
-use tracing::{Instrument as _, Span, debug, info_span, trace};
+use tracing::{Span, debug, info_span, trace};
 
 /// Tracks the current view, its leader, and whether the voter has already been
 /// sent the leader-nullify hint for it.
@@ -45,6 +45,28 @@ struct Current {
     view: View,
     leader: Option<Participant>,
     leader_nullify_hinted: bool,
+}
+
+/// A completed crypto job from the actor's dispatch pool.
+enum Done<S: Scheme<D>, D: Digest> {
+    /// A verification batch completed: its verified votes must be
+    /// reintegrated into the view's round (see [Round::finish_verify]) and
+    /// invalid signers blocked.
+    Verified {
+        view: View,
+        batch: usize,
+        timer: histogram::Timer,
+        votes: VerifiedVotes<S, D>,
+        invalid: Vec<Participant>,
+    },
+    /// A certificate was recovered from a verified quorum and must be
+    /// recorded on the view's round (see [Round::record_certificate]) and
+    /// forwarded to the voter.
+    Recovered {
+        view: View,
+        timer: histogram::Timer,
+        certificate: Certificate<S, D>,
+    },
 }
 
 pub struct Actor<E, S, B, D, Re, Rl, T>
@@ -315,49 +337,41 @@ where
         }
     }
 
-    /// Batch-verifies any ready votes for `view` and forwards newly
-    /// constructible certificates to the voter.
-    async fn process_view(
-        &mut self,
-        voter: &mut voter::Mailbox<S, D>,
-        view: View,
-        round: &mut Round<S, B, D, Re>,
-    ) {
-        loop {
+    /// Dispatches any ready crypto work for `view` into `pool` without
+    /// blocking the event loop: one verification batch per vote kind (each
+    /// kind independently tracks an in-flight batch) plus recovery of every
+    /// certificate with a verified quorum.
+    ///
+    /// Results arrive through the pool's completion branch, which reintegrates
+    /// them and marks the view dirty so this dispatch runs again (e.g. to
+    /// recover a certificate from a quorum a batch just completed).
+    fn dispatch_view(&mut self, pool: &mut Pool<Done<S, D>>, view: View, round: &mut Round<S, B, D, Re>) {
+        // Begin a verification batch for every vote kind with work worth
+        // verifying.
+        while let Some((batch, job)) = round.begin_verify(self.context.as_mut(), &self.strategy) {
             let timer = self.verify_latency.timer(self.context.as_ref());
-            let Some((batch, failed)) = round
-                .try_verify(self.context.as_mut(), &self.strategy)
-                .await
-            else {
-                trace!(%view, "no verifier ready");
-                break;
-            };
-
-            timer.observe(self.context.as_ref());
-
-            trace!(%view, batch, "batch verified votes");
-            self.verified.inc_by(batch as u64);
-            self.batch_size.observe(batch as f64);
-
-            for invalid in failed {
-                if let Some(signer) = self.scheme.participants().key(invalid) {
-                    commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
+            pool.push(async move {
+                let (votes, invalid) = job.await;
+                Done::Verified {
+                    view,
+                    batch,
+                    timer,
+                    votes,
+                    invalid,
                 }
-            }
+            });
         }
 
-        // Construct and forward every certificate with a verified quorum
-        while let Some(certificate) = self
-            .recover_latency
-            .time_some(
-                self.context.as_ref(),
-                round.try_construct_certificate(&self.strategy),
-            )
-            .await
-        {
-            let kind = certificate.kind();
-            debug!(%view, %kind, "constructed certificate, forwarding to voter");
-            voter.recovered(certificate);
+        // Begin recovery of every certificate with a verified quorum.
+        while let Some(job) = round.begin_construct_certificate(&self.strategy) {
+            let timer = self.recover_latency.timer(self.context.as_ref());
+            pool.push(async move {
+                Done::Recovered {
+                    view,
+                    timer,
+                    certificate: job.await,
+                }
+            });
         }
     }
 
@@ -397,6 +411,11 @@ where
         // Views whose rounds may have become actionable. Capacity is reused
         // across select-loop iterations.
         let mut dirty_views: Vec<View> = Vec::new();
+        // In-flight crypto (verification batches and certificate recoveries).
+        // Dispatching instead of awaiting keeps the event loop free to ingest
+        // votes while the strategy's workers verify, so multiple batches (and
+        // views) make progress concurrently.
+        let mut crypto_pool: Pool<Done<S, D>> = Pool::default();
         select_loop! {
             self.context,
             on_start => {
@@ -519,6 +538,54 @@ where
                         round.accept_vote(message, true);
                         self.added.inc();
                         dirty_views.push(view);
+                    }
+                }
+            },
+            // Handle completed crypto work (verification batches and
+            // certificate recoveries)
+            done = crypto_pool.next_completed() => {
+                match done {
+                    Done::Verified { view, batch, timer, votes, invalid } => {
+                        timer.observe(self.context.as_ref());
+                        self.verified.inc_by(batch as u64);
+                        self.batch_size.observe(batch as f64);
+
+                        for signer in invalid {
+                            if let Some(signer) = self.scheme.participants().key(signer) {
+                                commonware_p2p::block!(self.blocker, signer.clone(), "invalid signature");
+                            }
+                        }
+
+                        // The round may have been pruned while the batch was in
+                        // flight; its votes are no longer needed.
+                        let Some(round) = work.get_mut(&view) else {
+                            continue;
+                        };
+                        let _guard = round.span().entered();
+                        trace!(%view, batch, "batch verified votes");
+                        round.finish_verify(votes);
+
+                        // Revisit the view: the batch may have completed a
+                        // quorum (certificate recovery) or more votes may have
+                        // buffered while it was in flight (another batch).
+                        dirty_views.push(view);
+                    }
+                    Done::Recovered { view, timer, certificate } => {
+                        timer.observe(self.context.as_ref());
+                        let kind = certificate.kind();
+
+                        // Record the certificate on its round (completing the
+                        // certified phase and applying the retention policy)
+                        // unless the round was pruned while recovery was in
+                        // flight. Recording may unlock already-buffered votes.
+                        if let Some(round) = work.get_mut(&view) {
+                            let _guard = round.span().entered();
+                            debug!(%view, %kind, "constructed certificate, forwarding to voter");
+                            if round.record_certificate(&certificate) {
+                                dirty_views.push(view);
+                            }
+                        }
+                        voter.recovered(certificate);
                     }
                 }
             },
@@ -684,9 +751,7 @@ where
                     }
 
                     let span = round.span();
-                    self.process_view(&mut voter, view, round)
-                        .instrument(span)
-                        .await;
+                    span.in_scope(|| self.dispatch_view(&mut crypto_pool, view, round));
                 }
 
                 // Drop any rounds that are no longer retained

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -439,16 +439,13 @@ where
                 // certified phase and applying the retention policy)
                 // unless the round was pruned while recovery was in
                 // flight. Recording may unlock already-buffered votes.
-                let mut dirty = None;
-                if let Some(round) = work.get_mut(&view) {
+                let recorded = work.get_mut(&view).is_some_and(|round| {
                     let _guard = round.span().entered();
                     debug!(%view, %kind, "constructed certificate, forwarding to voter");
-                    if round.record_certificate(&certificate) {
-                        dirty = Some(view);
-                    }
-                }
+                    round.record_certificate(&certificate)
+                });
                 voter.recovered(certificate);
-                dirty
+                recorded.then_some(view)
             }
         }
     }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -439,8 +439,9 @@ where
                     }
                 }
 
-                // The round may have been pruned while the batch was in
-                // flight; its votes are no longer needed.
+                // The round may have been pruned while the batch was in flight.
+                // The monotonic retention floor also gates vote admission, so a
+                // pruned view cannot be recreated and its votes are no longer needed.
                 let round = work.get_mut(&view)?;
                 let _guard = round.span().entered();
                 trace!(%view, batch, "batch verified votes");

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -44,7 +44,7 @@ pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{actor::Done, *};
     use crate::{
         Viewable,
         simplex::{
@@ -85,11 +85,19 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{
         Clock, Metrics as _, Quota, Runner, Strategizer as _, Supervisor as _, deterministic,
-        telemetry::traces::{TracedExt as _, collector::TraceStorage},
+        telemetry::{
+            metrics::{
+                MetricsExt as _,
+                histogram::{Buckets, Timed},
+            },
+            traces::{TracedExt as _, collector::TraceStorage},
+        },
         tokio,
     };
     use commonware_utils::{NZUsize, TestRng, ordered::Set, sync::Mutex, test_rng};
-    use std::{marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration};
+    use std::{
+        collections::BTreeMap, marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration,
+    };
     use tracing::{Level, Span};
 
     type Broadcasts = Arc<Mutex<Vec<(Sha256Digest, Round, Vec<PublicKey>)>>>;
@@ -507,6 +515,176 @@ mod tests {
             round.try_construct_certificate(&Sequential).await,
             Some(Certificate::Notarization(_))
         ));
+    }
+
+    /// [Actor::handle_done] routes batch results to the view that dispatched
+    /// them, in any completion order across views.
+    #[test_traced]
+    fn test_handle_done_routes_by_view() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let Fixture { schemes, .. } = ed25519::fixture(&mut context, b"batcher_test", 5);
+            let quorum = quorum(5) as usize;
+            let epoch = Epoch::new(0);
+            let cfg = test_config(
+                schemes[0].clone(),
+                NoopBlocker,
+                NoopReporter(PhantomData),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (mut actor, _mailbox) = Actor::new(context.child("actor"), cfg);
+            let (voter_sender, _voter_receiver) = mailbox::new::<voter::Message<_, Sha256Digest>>(
+                context.child("voter_mailbox"),
+                NZUsize!(8),
+            );
+            let mut voter = voter::Mailbox::new(voter_sender);
+            let timed = Timed::new(context.histogram(
+                "test_latency",
+                "test latency",
+                Buckets::CRYPTOGRAPHY,
+            ));
+
+            // Track two rounds with distinct proposals.
+            let mut work = BTreeMap::new();
+            let mut proposals = Vec::new();
+            for view in [1u64, 2] {
+                let round_id = Round::new(epoch, View::new(view));
+                work.insert(
+                    View::new(view),
+                    super::Round::new(
+                        round_id,
+                        Arc::new(schemes[0].clone()),
+                        NoopBlocker,
+                        NoopReporter(PhantomData),
+                        false,
+                    ),
+                );
+                proposals.push(Proposal::new(
+                    round_id,
+                    View::new(view - 1),
+                    Sha256::hash(&[(view as u8).to_be_bytes().as_slice()]),
+                ));
+            }
+
+            // Reintegrate the higher view's batch first.
+            let mut dirty_views = Vec::new();
+            for (view, proposal) in [(2u64, &proposals[1]), (1u64, &proposals[0])] {
+                let votes = schemes
+                    .iter()
+                    .take(quorum)
+                    .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
+                    .collect();
+                actor.handle_done(
+                    &mut voter,
+                    &mut work,
+                    &mut dirty_views,
+                    Done::Verified {
+                        view: View::new(view),
+                        batch: quorum,
+                        timer: timed.timer(&context),
+                        votes: VerifiedVotes::Notarizes(votes),
+                        invalid: vec![],
+                    },
+                );
+            }
+            assert_eq!(dirty_views, vec![View::new(2), View::new(1)]);
+
+            // Each round holds exactly its own quorum: recovery yields the
+            // matching proposal.
+            for (view, proposal) in [(1u64, &proposals[0]), (2u64, &proposals[1])] {
+                let round = work.get_mut(&View::new(view)).unwrap();
+                let Some(Certificate::Notarization(notarization)) =
+                    round.try_construct_certificate(&Sequential).await
+                else {
+                    panic!("view {view} must recover a notarization");
+                };
+                assert_eq!(&notarization.proposal, proposal);
+            }
+        });
+    }
+
+    /// A completion for a view pruned mid-flight drops the votes but still
+    /// forwards a recovered certificate: the voter prunes independently.
+    #[test_traced]
+    fn test_handle_done_tolerates_pruned_view() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let Fixture { schemes, .. } = ed25519::fixture(&mut context, b"batcher_test", 5);
+            let quorum = quorum(5) as usize;
+            let epoch = Epoch::new(0);
+            let cfg = test_config(
+                schemes[0].clone(),
+                NoopBlocker,
+                NoopReporter(PhantomData),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (mut actor, _mailbox) = Actor::new(context.child("actor"), cfg);
+            let (voter_sender, mut voter_receiver) =
+                mailbox::new::<voter::Message<_, Sha256Digest>>(
+                    context.child("voter_mailbox"),
+                    NZUsize!(8),
+                );
+            let mut voter = voter::Mailbox::new(voter_sender);
+            let timed = Timed::new(context.histogram(
+                "test_latency",
+                "test latency",
+                Buckets::CRYPTOGRAPHY,
+            ));
+
+            let view = View::new(9);
+            let proposal =
+                Proposal::new(Round::new(epoch, view), View::new(8), Sha256::hash(&[b"pruned"]));
+            let votes: Vec<_> = schemes
+                .iter()
+                .take(quorum)
+                .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
+                .collect();
+
+            // No round tracks the view.
+            let mut work = BTreeMap::new();
+            let mut dirty_views = Vec::new();
+            actor.handle_done(
+                &mut voter,
+                &mut work,
+                &mut dirty_views,
+                Done::Verified {
+                    view,
+                    batch: quorum,
+                    timer: timed.timer(&context),
+                    votes: VerifiedVotes::Notarizes(votes.clone()),
+                    invalid: vec![],
+                },
+            );
+            assert!(dirty_views.is_empty());
+
+            // A recovered certificate still reaches the voter.
+            let notarization =
+                Notarization::from_owned_notarizes(&schemes[0], votes, &Sequential)
+                    .expect("quorum must assemble");
+            actor.handle_done(
+                &mut voter,
+                &mut work,
+                &mut dirty_views,
+                Done::Recovered {
+                    view,
+                    timer: timed.timer(&context),
+                    certificate: Certificate::Notarization(notarization.clone()),
+                },
+            );
+            assert!(dirty_views.is_empty());
+            let voter::Message::Verified {
+                certificate: Certificate::Notarization(received),
+                ..
+            } = voter_receiver.recv().await.unwrap()
+            else {
+                panic!("voter must receive the recovered notarization");
+            };
+            assert_eq!(received.proposal, notarization.proposal);
+        });
     }
 
     /// Deterministic-runtime tests drive `Strategy::spawn` inline: the deterministic runtime's

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -544,27 +544,32 @@ mod tests {
             let mut proposals = Vec::new();
             for view in [1u64, 2] {
                 let round_id = Round::new(epoch, View::new(view));
-                work.insert(
-                    View::new(view),
-                    super::Round::new(
-                        round_id,
-                        Arc::new(schemes[0].clone()),
-                        NoopBlocker,
-                        NoopReporter(PhantomData),
-                        false,
-                    ),
-                );
-                proposals.push(Proposal::new(
+                let proposal = Proposal::new(
                     round_id,
                     View::new(view - 1),
                     Sha256::hash(&[(view as u8).to_be_bytes().as_slice()]),
-                ));
+                );
+                let mut round = super::Round::new(
+                    round_id,
+                    Arc::new(schemes[0].clone()),
+                    NoopBlocker,
+                    NoopReporter(PhantomData),
+                    false,
+                );
+                round.set_leader(Participant::new(0));
+                round.accept_vote(
+                    Vote::Notarize(Notarize::sign(&schemes[0], proposal.clone()).unwrap()),
+                    false,
+                );
+                work.insert(View::new(view), round);
+                proposals.push(proposal);
             }
 
             // Reintegrate the higher view's batch first.
             for (view, proposal) in [(2u64, &proposals[1]), (1u64, &proposals[0])] {
                 let votes = schemes
                     .iter()
+                    .skip(1)
                     .take(quorum)
                     .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
                     .collect();

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -91,7 +91,7 @@ mod tests {
         },
         tokio,
     };
-    use commonware_utils::{NZUsize, TestRng, ordered::Set, sync::Mutex, test_rng};
+    use commonware_utils::{NZUsize, TestRng, futures::Pool, ordered::Set, sync::Mutex, test_rng};
     use std::{
         collections::BTreeMap, marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration,
     };
@@ -598,6 +598,83 @@ mod tests {
                 };
                 assert_eq!(&notarization.proposal, proposal);
             }
+        });
+    }
+
+    /// Crypto dispatch never submits more jobs than the strategy can execute
+    /// concurrently. A view skipped at capacity remains ready for a later pass.
+    #[test_traced]
+    fn test_dispatch_view_respects_strategy_parallelism() {
+        let executor = deterministic::Runner::default();
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, b"batcher_test", 5);
+            let epoch = Epoch::new(0);
+            let cfg = test_config(
+                schemes[0].clone(),
+                NoopBlocker,
+                NoopReporter(PhantomData),
+                MockRelay::new(),
+                epoch,
+                BatcherOptions::default(),
+            );
+            let (mut actor, _mailbox) = Actor::new(context.child("actor"), cfg);
+            let mut rounds = BTreeMap::new();
+
+            for view in [View::new(1), View::new(2)] {
+                let round_id = Round::new(epoch, view);
+                let proposal = Proposal::new(
+                    round_id,
+                    view.previous().unwrap_or(View::zero()),
+                    Sha256::hash(&[&view.get().to_be_bytes()]),
+                );
+                let mut round = super::Round::new(
+                    round_id,
+                    Arc::new(schemes[0].clone()),
+                    NoopBlocker,
+                    NoopReporter(PhantomData),
+                    false,
+                );
+                round.set_leader(Participant::new(0));
+                for (participant, scheme) in participants.iter().zip(&schemes) {
+                    let vote = Notarize::sign(scheme, proposal.clone()).unwrap();
+                    assert!(round.add_network(participant.clone(), Vote::Notarize(vote)));
+                }
+                rounds.insert(view, round);
+            }
+
+            let mut pool = Pool::default();
+            actor.dispatch_view(
+                &mut pool,
+                View::new(1),
+                rounds.get_mut(&View::new(1)).unwrap(),
+            );
+            assert_eq!(pool.len(), 1);
+
+            actor.dispatch_view(
+                &mut pool,
+                View::new(2),
+                rounds.get_mut(&View::new(2)).unwrap(),
+            );
+            assert_eq!(pool.len(), 1);
+
+            let Done::Verified { view, .. } = pool.next_completed().await else {
+                panic!("expected a verification completion");
+            };
+            assert_eq!(view, View::new(1));
+
+            actor.dispatch_view(
+                &mut pool,
+                View::new(2),
+                rounds.get_mut(&View::new(2)).unwrap(),
+            );
+            let Done::Verified { view, .. } = pool.next_completed().await else {
+                panic!("expected a verification completion");
+            };
+            assert_eq!(view, View::new(2));
         });
     }
 

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -86,10 +86,7 @@ mod tests {
     use commonware_runtime::{
         Clock, Metrics as _, Quota, Runner, Strategizer as _, Supervisor as _, deterministic,
         telemetry::{
-            metrics::{
-                MetricsExt as _,
-                histogram::{Buckets, Timed},
-            },
+            metrics::histogram::Timed,
             traces::{TracedExt as _, collector::TraceStorage},
         },
         tokio,
@@ -540,11 +537,7 @@ mod tests {
                 NZUsize!(8),
             );
             let mut voter = voter::Mailbox::new(voter_sender);
-            let timed = Timed::new(context.histogram(
-                "test_latency",
-                "test latency",
-                Buckets::CRYPTOGRAPHY,
-            ));
+            let timed = Timed::register(&context, "test_latency", "test latency");
 
             // Track two rounds with distinct proposals.
             let mut work = BTreeMap::new();
@@ -569,17 +562,15 @@ mod tests {
             }
 
             // Reintegrate the higher view's batch first.
-            let mut dirty_views = Vec::new();
             for (view, proposal) in [(2u64, &proposals[1]), (1u64, &proposals[0])] {
                 let votes = schemes
                     .iter()
                     .take(quorum)
                     .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
                     .collect();
-                actor.handle_done(
+                let dirty = actor.handle_done(
                     &mut voter,
                     &mut work,
-                    &mut dirty_views,
                     Done::Verified {
                         view: View::new(view),
                         batch: quorum,
@@ -588,8 +579,8 @@ mod tests {
                         invalid: vec![],
                     },
                 );
+                assert_eq!(dirty, Some(View::new(view)));
             }
-            assert_eq!(dirty_views, vec![View::new(2), View::new(1)]);
 
             // Each round holds exactly its own quorum: recovery yields the
             // matching proposal.
@@ -629,11 +620,7 @@ mod tests {
                     NZUsize!(8),
                 );
             let mut voter = voter::Mailbox::new(voter_sender);
-            let timed = Timed::new(context.histogram(
-                "test_latency",
-                "test latency",
-                Buckets::CRYPTOGRAPHY,
-            ));
+            let timed = Timed::register(&context, "test_latency", "test latency");
 
             let view = View::new(9);
             let proposal =
@@ -643,39 +630,34 @@ mod tests {
                 .take(quorum)
                 .map(|scheme| Notarize::sign(scheme, proposal.clone()).unwrap())
                 .collect();
+            let notarization = build_notarization(&schemes, &proposal, quorum);
 
             // No round tracks the view.
             let mut work = BTreeMap::new();
-            let mut dirty_views = Vec::new();
-            actor.handle_done(
+            let dirty = actor.handle_done(
                 &mut voter,
                 &mut work,
-                &mut dirty_views,
                 Done::Verified {
                     view,
                     batch: quorum,
                     timer: timed.timer(&context),
-                    votes: VerifiedVotes::Notarizes(votes.clone()),
+                    votes: VerifiedVotes::Notarizes(votes),
                     invalid: vec![],
                 },
             );
-            assert!(dirty_views.is_empty());
+            assert!(dirty.is_none());
 
             // A recovered certificate still reaches the voter.
-            let notarization =
-                Notarization::from_owned_notarizes(&schemes[0], votes, &Sequential)
-                    .expect("quorum must assemble");
-            actor.handle_done(
+            let dirty = actor.handle_done(
                 &mut voter,
                 &mut work,
-                &mut dirty_views,
                 Done::Recovered {
                     view,
                     timer: timed.timer(&context),
                     certificate: Certificate::Notarization(notarization.clone()),
                 },
             );
-            assert!(dirty_views.is_empty());
+            assert!(dirty.is_none());
             let voter::Message::Verified {
                 certificate: Certificate::Notarization(received),
                 ..

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -15,7 +15,7 @@ use commonware_parallel::Strategy;
 pub use ingress::{Mailbox, Message};
 pub use round::Round;
 use std::{num::NonZeroUsize, time::Duration};
-pub use verifier::Verifier;
+pub use verifier::{VerifiedVotes, Verifier};
 
 pub struct Config<S: Scheme, B: Blocker, Re: Reporter, Rl: Relay, T: Strategy> {
     pub scheme: S,

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -376,10 +376,8 @@ impl<
         rng: &mut E,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        let (batch, job) = self.begin_verify(rng, strategy)?;
-        let (votes, invalid) = job.await;
-        self.finish_verify(votes);
-        Some((batch, invalid))
+        let begun = self.begin_verify(rng, strategy);
+        self.verifier.drive(begun).await
     }
 
     /// Begins a batch verification of the first kind of vote worth verifying
@@ -458,16 +456,12 @@ impl<
         Some(certificate)
     }
 
-    /// Begins recovery of a certificate from verified votes: the first kind
-    /// (notarization, then nullification, then finalization) with an
-    /// unconsumed verified quorum. Call repeatedly to drain every
-    /// constructible kind.
+    /// Begins recovery of a certificate from verified votes (see
+    /// [Verifier::begin_construct_certificate]).
     ///
-    /// Returns an owned future that resolves to the certificate. Recovery
-    /// consumes the verified votes when it begins; do not drop the future
-    /// unless the round will also be discarded. The caller must pass the
-    /// resolved certificate to [Self::record_certificate] so the round
-    /// completes the certified phase and applies its retention policy.
+    /// The caller must pass the resolved certificate to
+    /// [Self::record_certificate] so the round completes the certified phase
+    /// and applies its retention policy.
     pub fn begin_construct_certificate(
         &mut self,
         strategy: &impl Strategy,

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -376,8 +376,10 @@ impl<
         rng: &mut E,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        let begun = self.begin_verify(rng, strategy);
-        self.verifier.drive(begun).await
+        let (batch, job) = self.begin_verify(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
     }
 
     /// Begins a batch verification of the first kind of vote worth verifying
@@ -439,13 +441,8 @@ impl<
             .collect()
     }
 
-    /// Attempts to construct a certificate from verified votes: the first kind
-    /// (notarization, then nullification, then finalization) with an unconsumed
-    /// verified quorum. Call repeatedly to drain every constructible kind.
-    /// Test-only shim over [Self::begin_construct_certificate].
-    ///
-    /// Once recovery starts, it consumes the verified votes. Do not cancel unless the round will
-    /// also be discarded.
+    /// Test-only shim over [Self::begin_construct_certificate] and
+    /// [Self::record_certificate].
     #[cfg(test)]
     pub async fn try_construct_certificate(
         &mut self,

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -1,4 +1,7 @@
-use super::{Verifier, verifier::ProposalState};
+use super::{
+    Verifier,
+    verifier::{ProposalState, VerifiedVotes, VerifyJob},
+};
 use crate::{
     Reporter,
     simplex::{
@@ -16,7 +19,7 @@ use commonware_p2p::Blocker;
 use commonware_parallel::Strategy;
 use commonware_utils::{N3f1, ordered::Quorum};
 use rand_core::CryptoRng;
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 use tracing::Span;
 
 /// Per-view state for vote accumulation and certificate tracking.
@@ -363,21 +366,49 @@ impl<
 
     /// Batch verifies the first kind of vote worth verifying (notarizes, then
     /// nullifies, then finalizes), or `None` if no kind is worthwhile.
+    /// Test-only shim over [Self::begin_verify] and [Self::finish_verify].
     ///
     /// Returns the number of votes processed and the signers that failed
     /// verification.
+    #[cfg(test)]
     pub async fn try_verify<E: CryptoRng>(
         &mut self,
         rng: &mut E,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        if let Some(result) = self.verifier.try_verify_notarizes(rng, strategy).await {
-            return Some(result);
+        let (batch, job) = self.begin_verify(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Begins a batch verification of the first kind of vote worth verifying
+    /// (notarizes, then nullifies, then finalizes), or `None` if no kind is
+    /// worthwhile. Each kind independently tracks an in-flight batch, so call
+    /// repeatedly to start every worthwhile kind.
+    ///
+    /// Returns the batch size and an owned future that resolves to the
+    /// verified votes and the signers that failed verification. The caller
+    /// must feed the future's votes back through [Self::finish_verify]; until
+    /// then, no further batch of that kind begins.
+    pub fn begin_verify<E: CryptoRng>(
+        &mut self,
+        rng: &mut E,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
+        if let Some(begun) = self.verifier.begin_verify_notarizes(rng, strategy) {
+            return Some(begun);
         }
-        if let Some(result) = self.verifier.try_verify_nullifies(rng, strategy).await {
-            return Some(result);
+        if let Some(begun) = self.verifier.begin_verify_nullifies(rng, strategy) {
+            return Some(begun);
         }
-        self.verifier.try_verify_finalizes(rng, strategy).await
+        self.verifier.begin_verify_finalizes(rng, strategy)
+    }
+
+    /// Reintegrates the result of a completed verification batch. See
+    /// [Verifier::finish_verify].
+    pub fn finish_verify(&mut self, votes: VerifiedVotes<S, D>) {
+        self.verifier.finish_verify(votes);
     }
 
     /// Returns whether `signer` has a nullify vote.
@@ -413,15 +444,34 @@ impl<
     /// Attempts to construct a certificate from verified votes: the first kind
     /// (notarization, then nullification, then finalization) with an unconsumed
     /// verified quorum. Call repeatedly to drain every constructible kind.
+    /// Test-only shim over [Self::begin_construct_certificate].
     ///
     /// Once recovery starts, it consumes the verified votes. Do not cancel unless the round will
     /// also be discarded.
+    #[cfg(test)]
     pub async fn try_construct_certificate(
         &mut self,
         strategy: &impl Strategy,
     ) -> Option<Certificate<S, D>> {
-        let certificate = self.verifier.try_construct_certificate(strategy).await?;
+        let certificate = self.begin_construct_certificate(strategy)?.await;
         self.record_certificate(&certificate);
         Some(certificate)
+    }
+
+    /// Begins recovery of a certificate from verified votes: the first kind
+    /// (notarization, then nullification, then finalization) with an
+    /// unconsumed verified quorum. Call repeatedly to drain every
+    /// constructible kind.
+    ///
+    /// Returns an owned future that resolves to the certificate. Recovery
+    /// consumes the verified votes when it begins; do not drop the future
+    /// unless the round will also be discarded. The caller must pass the
+    /// resolved certificate to [Self::record_certificate] so the round
+    /// completes the certified phase and applies its retention policy.
+    pub fn begin_construct_certificate(
+        &mut self,
+        strategy: &impl Strategy,
+    ) -> Option<impl Future<Output = Certificate<S, D>> + Send + 'static> {
+        self.verifier.begin_construct_certificate(strategy)
     }
 }

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -1250,8 +1250,8 @@ mod tests {
         assert_eq!(verifier.notarize.verified().len(), 3);
         assert_eq!(verifier.notarize.pending().len(), 1);
 
-        // The cleared gate lets the buffered vote form the next batch, which
-        // completes the quorum.
+        // Reintegration clears the in-flight mark, so the buffered vote forms
+        // the next batch and completes the quorum.
         let (batch, job) = verifier
             .begin_verify_notarizes(&mut rng, &Sequential)
             .expect("buffered vote must batch");

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -12,9 +12,10 @@ use commonware_cryptography::{Digest, certificate::Verification};
 use commonware_parallel::Strategy;
 use commonware_runtime::telemetry::traces::TracedExt as _;
 use commonware_utils::ordered::Set;
+use futures::{FutureExt as _, future::BoxFuture};
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
-use std::{future::Future, mem, pin::Pin, sync::Arc};
+use std::{future::Future, mem, sync::Arc};
 use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
@@ -216,8 +217,7 @@ pub enum VerifiedVotes<S: Scheme<D>, D: Digest> {
 /// An owned, in-flight verification batch: resolves to the verified votes and
 /// the signers that failed verification. Feed the votes back through
 /// [Verifier::finish_verify].
-pub type VerifyJob<S, D> =
-    Pin<Box<dyn Future<Output = (VerifiedVotes<S, D>, Vec<Participant>)> + Send>>;
+pub type VerifyJob<S, D> = BoxFuture<'static, (VerifiedVotes<S, D>, Vec<Participant>)>;
 
 /// How the selected proposal changed after an update.
 pub(super) struct ProposalUpdate {
@@ -352,13 +352,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         self.proposal.proposal()
     }
 
-    /// Attempts to construct a certificate from verified votes: the first kind
-    /// (notarization, then nullification, then finalization) with an unconsumed
-    /// verified quorum. Call repeatedly to drain every constructible kind.
     /// Test-only shim over [Self::begin_construct_certificate].
-    ///
-    /// Once recovery starts, it consumes the verified votes. Do not cancel unless
-    /// the verifier will also be discarded.
     #[cfg(test)]
     pub async fn try_construct_certificate(
         &mut self,
@@ -539,7 +533,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// result. Test-only shim over the `begin_verify_*` methods and
     /// [Self::finish_verify].
     #[cfg(test)]
-    pub(super) async fn drive(
+    async fn drive(
         &mut self,
         begun: Option<(usize, VerifyJob<S, D>)>,
     ) -> Option<(usize, Vec<Participant>)> {
@@ -610,7 +604,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             ));
             (VerifiedVotes::Notarizes(verified_notarizes), invalid)
         });
-        Some((batch, Box::pin(job) as VerifyJob<S, D>))
+        Some((batch, job.boxed()))
     }
 
     /// Test-only shim over [Self::begin_verify_nullifies] and
@@ -661,7 +655,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             );
             (VerifiedVotes::Nullifies(verified_nullifies), invalid)
         });
-        Some((batch, Box::pin(job) as VerifyJob<S, D>))
+        Some((batch, job.boxed()))
     }
 
     /// Test-only shim over [Self::begin_verify_finalizes] and
@@ -725,7 +719,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
             ));
             (VerifiedVotes::Finalizes(verified_finalizes), invalid)
         });
-        Some((batch, Box::pin(job) as VerifyJob<S, D>))
+        Some((batch, job.boxed()))
     }
 
     /// Reintegrates the result of a completed verification batch into the

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -724,11 +724,21 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
 
     /// Reintegrates the result of a completed verification batch into the
     /// [Certification] of its kind (see [Certification::finish_verify]).
+    /// Proposal-bearing votes are filtered against the current proposal,
+    /// which may have changed while the batch was in flight.
     pub fn finish_verify(&mut self, votes: VerifiedVotes<S, D>) {
         match votes {
-            VerifiedVotes::Notarizes(notarizes) => self.notarize.finish_verify(notarizes),
+            VerifiedVotes::Notarizes(mut notarizes) => {
+                let proposal = self.proposal();
+                notarizes.retain(|notarize| Some(&notarize.proposal) == proposal);
+                self.notarize.finish_verify(notarizes);
+            }
             VerifiedVotes::Nullifies(nullifies) => self.nullify.finish_verify(nullifies),
-            VerifiedVotes::Finalizes(finalizes) => self.finalize.finish_verify(finalizes),
+            VerifiedVotes::Finalizes(mut finalizes) => {
+                let proposal = self.proposal();
+                finalizes.retain(|finalize| Some(&finalize.proposal) == proposal);
+                self.finalize.finish_verify(finalizes);
+            }
         }
     }
 }
@@ -1239,6 +1249,58 @@ mod tests {
         buffer_votes_while_batch_in_flight(bls12381_multisig::fixture::<MinPk, _>).await;
         buffer_votes_while_batch_in_flight(ed25519::fixture).await;
         buffer_votes_while_batch_in_flight(secp256r1::fixture).await;
+    }
+
+    #[test_async]
+    async fn test_proposal_displacement_filters_in_flight_batches() {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
+        let quorum = N3f1::quorum(schemes.len());
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let mut verifier =
+            Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone(), quorum);
+        let proposal_a = Proposal::new(round, View::zero(), sample_digest(1));
+        let proposal_b = Proposal::new(round, View::zero(), sample_digest(2));
+
+        verifier.set_leader(Participant::new(0), None);
+        for scheme in schemes.iter().take(quorum as usize) {
+            verifier.add(
+                Vote::Notarize(Notarize::sign(scheme, proposal_a.clone()).unwrap()),
+                false,
+            );
+            verifier.add(
+                Vote::Finalize(Finalize::sign(scheme, proposal_a.clone()).unwrap()),
+                false,
+            );
+        }
+
+        let (_, notarizes) = verifier
+            .begin_verify_notarizes(&mut rng, &Sequential)
+            .expect("notarize batch must begin");
+        let (_, finalizes) = verifier
+            .begin_verify_finalizes(&mut rng, &Sequential)
+            .expect("finalize batch must begin");
+        assert!(
+            verifier
+                .set_proposal(ProposalState::Certificate(proposal_b))
+                .changed
+        );
+
+        let (notarizes, invalid) = notarizes.await;
+        assert!(invalid.is_empty());
+        verifier.finish_verify(notarizes);
+        let (finalizes, invalid) = finalizes.await;
+        assert!(invalid.is_empty());
+        verifier.finish_verify(finalizes);
+
+        assert!(verifier.notarize.verified().is_empty());
+        assert!(verifier.finalize.verified().is_empty());
+        assert!(
+            verifier
+                .try_construct_certificate(&Sequential)
+                .await
+                .is_none()
+        );
     }
 
     fn add_nullify<S, F>(mut fixture: F)

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -529,9 +529,9 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         }
     }
 
-    /// Drives a begun verification batch to completion and reintegrates its
-    /// result. Test-only shim over the `begin_verify_*` methods and
-    /// [Self::finish_verify].
+    /// Awaits a begun verification batch and reintegrates its result through
+    /// [Self::finish_verify]. Shared body of the test-only `try_verify_*`
+    /// shims.
     #[cfg(test)]
     async fn drive(
         &mut self,

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -1190,6 +1190,96 @@ mod tests {
         ready_and_verify_notarizes(secp256r1::fixture).await;
     }
 
+    async fn buffer_votes_while_batch_in_flight<S, F>(mut fixture: F)
+    where
+        S: Scheme<Sha256, PublicKey = PublicKey>,
+        F: FnMut(&mut TestRng, &[u8], u32) -> Fixture<S>,
+    {
+        let mut rng = test_rng();
+        let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
+        let quorum = N3f1::quorum(schemes.len());
+        let mut verifier = Verifier::<S, Sha256>::new(
+            Round::new(Epoch::new(0), View::new(1)),
+            schemes[0].clone(),
+            quorum,
+        );
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let notarizes: Vec<_> = schemes
+            .iter()
+            .map(|scheme| create_notarize(scheme, round, View::new(0), 1))
+            .collect();
+
+        verifier.set_leader(notarizes[0].signer(), None);
+        for notarize in &notarizes[..4] {
+            verifier.add(Vote::Notarize(notarize.clone()), false);
+        }
+
+        // The batch takes every pending vote and marks the kind in flight:
+        // no second batch may begin until the first reintegrates.
+        let (batch, job) = verifier
+            .begin_verify_notarizes(&mut rng, &Sequential)
+            .expect("batch must begin");
+        assert_eq!(batch, 4);
+        assert!(verifier.notarize.pending().is_empty());
+        assert!(
+            verifier
+                .begin_verify_notarizes(&mut rng, &Sequential)
+                .is_none()
+        );
+
+        // A vote arriving while the batch is in flight buffers as pending
+        // without opening a second batch.
+        verifier.add(Vote::Notarize(notarizes[4].clone()), false);
+        assert_eq!(verifier.notarize.pending().len(), 1);
+        assert!(
+            verifier
+                .begin_verify_notarizes(&mut rng, &Sequential)
+                .is_none()
+        );
+
+        // Reintegrate the batch one vote short of a quorum, as if one vote
+        // had failed verification.
+        let (votes, invalid) = job.await;
+        assert!(invalid.is_empty());
+        let VerifiedVotes::Notarizes(mut verified) = votes else {
+            panic!("expected notarizes");
+        };
+        assert_eq!(verified.len(), 4);
+        verified.truncate(3);
+        verifier.finish_verify(VerifiedVotes::Notarizes(verified));
+        assert_eq!(verifier.notarize.verified().len(), 3);
+        assert_eq!(verifier.notarize.pending().len(), 1);
+
+        // The cleared gate lets the buffered vote form the next batch, which
+        // completes the quorum.
+        let (batch, job) = verifier
+            .begin_verify_notarizes(&mut rng, &Sequential)
+            .expect("buffered vote must batch");
+        assert_eq!(batch, 1);
+        let (votes, invalid) = job.await;
+        assert!(invalid.is_empty());
+        verifier.finish_verify(votes);
+        assert_eq!(verifier.notarize.verified().len(), quorum as usize);
+
+        let certificate = verifier
+            .try_construct_certificate(&Sequential)
+            .await
+            .expect("quorum must recover a certificate");
+        assert!(matches!(certificate, Certificate::Notarization(_)));
+    }
+
+    #[test_async]
+    async fn test_buffer_votes_while_batch_in_flight() {
+        buffer_votes_while_batch_in_flight(bls12381_threshold_vrf::fixture::<MinSig, _>).await;
+        buffer_votes_while_batch_in_flight(bls12381_threshold_vrf::fixture::<MinPk, _>).await;
+        buffer_votes_while_batch_in_flight(bls12381_threshold_std::fixture::<MinSig, _>).await;
+        buffer_votes_while_batch_in_flight(bls12381_threshold_std::fixture::<MinPk, _>).await;
+        buffer_votes_while_batch_in_flight(bls12381_multisig::fixture::<MinSig, _>).await;
+        buffer_votes_while_batch_in_flight(bls12381_multisig::fixture::<MinPk, _>).await;
+        buffer_votes_while_batch_in_flight(ed25519::fixture).await;
+        buffer_votes_while_batch_in_flight(secp256r1::fixture).await;
+    }
+
     fn add_nullify<S, F>(mut fixture: F)
     where
         S: Scheme<Sha256, PublicKey = PublicKey>,

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -14,12 +14,14 @@ use commonware_runtime::telemetry::traces::TracedExt as _;
 use commonware_utils::ordered::Set;
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
-use std::{future::Future, mem, sync::Arc};
+use std::{future::Future, mem, pin::Pin, sync::Arc};
 use tracing::{Instrument as _, Span, info_span};
 
 /// Runs a CPU-bound job through [Strategy::spawn], entering `span` on the worker thread and
-/// instrumenting the awaited future so the offloaded work stays attributed to the caller's trace.
-async fn offload<P, F, T>(span: Span, strategy: &P, job: F) -> T
+/// instrumenting the returned future so the offloaded work stays attributed to the caller's trace.
+///
+/// The job is submitted eagerly: it starts without the returned future being polled.
+fn offload<P, F, T>(span: Span, strategy: &P, job: F) -> impl Future<Output = T> + Send + 'static
 where
     P: Strategy,
     F: FnOnce(P) -> T + Send + 'static,
@@ -29,7 +31,6 @@ where
     strategy
         .spawn(move |strategy| worker_span.in_scope(|| job(strategy)))
         .instrument(span)
-        .await
 }
 
 /// Certification progress for one kind of vote.
@@ -41,6 +42,9 @@ struct Certification<V> {
     quorum: usize,
     /// Whether the scheme benefits from batching signature verification.
     batchable: bool,
+    /// Whether a verification batch is currently in flight. At most one batch
+    /// per kind runs at a time; votes arriving meanwhile buffer as pending.
+    in_flight: bool,
     /// Progress toward a certificate.
     state: State<V>,
 }
@@ -64,6 +68,7 @@ impl<V> Certification<V> {
         Self {
             quorum,
             batchable,
+            in_flight: false,
             state: State::Incomplete {
                 pending: Vec::new(),
                 verified: Vec::new(),
@@ -95,10 +100,13 @@ impl<V> Certification<V> {
         votes.push(vote);
     }
 
-    /// Returns true if a batch verification should run: pending votes exist,
-    /// the quorum is unmet, and (for batchable schemes) the buffers together
-    /// could reach it.
+    /// Returns true if a batch verification should run: no batch is already in
+    /// flight, pending votes exist, the quorum is unmet, and (for batchable
+    /// schemes) the buffers together could reach it.
     const fn should_verify(&self) -> bool {
+        if self.in_flight {
+            return false;
+        }
         match &self.state {
             State::Incomplete { pending, verified } => {
                 !pending.is_empty()
@@ -109,18 +117,30 @@ impl<V> Certification<V> {
         }
     }
 
-    /// Runs `f` over the buffered votes and stores the verified set it
+    /// Runs `f` over the buffered votes and reintegrates the verified set it
     /// returns, or `None` if a batch is not worth verifying (see
-    /// [Self::should_verify]).
-    ///
-    /// `f` receives the pending and previously verified votes and returns the
-    /// new verified set plus the signers that failed verification. Returns
-    /// the number of votes processed alongside those signers.
+    /// [Self::should_verify]). Test-only shim over [Self::begin_verify] and
+    /// [Self::finish_verify].
+    #[cfg(test)]
     async fn try_verify<F, Fut>(&mut self, f: F) -> Option<(usize, Vec<Participant>)>
     where
         F: FnOnce(Vec<V>, Vec<V>) -> Fut,
         Fut: Future<Output = (Vec<V>, Vec<Participant>)>,
     {
+        let (batch, pending, prior) = self.begin_verify()?;
+        let (votes, invalid) = f(pending, prior).await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Surrenders the buffered votes for a verification batch, or `None` if a
+    /// batch is not worth verifying (see [Self::should_verify]).
+    ///
+    /// Returns the number of pending votes alongside the pending and
+    /// previously verified votes. Marks the certification in flight until
+    /// [Self::finish_verify] reintegrates the batch's result; votes arriving
+    /// meanwhile buffer as pending for a later batch.
+    fn begin_verify(&mut self) -> Option<(usize, Vec<V>, Vec<V>)> {
         if !self.should_verify() {
             return None;
         }
@@ -129,12 +149,27 @@ impl<V> Certification<V> {
         };
         let batch = pending.len();
         let (pending, prior) = (mem::take(pending), mem::take(verified));
-        let (votes, invalid) = f(pending, prior).await;
+        self.in_flight = true;
+        Some((batch, pending, prior))
+    }
+
+    /// Reintegrates the verified votes of a completed batch, merging them with
+    /// any votes verified while the batch was in flight. Signer uniqueness is
+    /// owned by the caller ([Verifier::add]), so the merge cannot double-count
+    /// a signer.
+    ///
+    /// Dropped without effect if a certificate completed while the batch was
+    /// in flight.
+    fn finish_verify(&mut self, votes: Vec<V>) {
+        self.in_flight = false;
         let State::Incomplete { verified, .. } = &mut self.state else {
-            unreachable!("certification completed mid-verification");
+            return;
         };
-        *verified = votes;
-        Some((batch, invalid))
+        if verified.is_empty() {
+            *verified = votes;
+        } else {
+            verified.extend(votes);
+        }
     }
 
     /// Completes with a verified quorum, surrendering it for certificate
@@ -169,6 +204,20 @@ impl<V> Certification<V> {
         }
     }
 }
+
+/// The verified votes of one completed batch, tagged by kind so a pooled
+/// verification's result can be routed back to the right [Certification].
+pub enum VerifiedVotes<S: Scheme<D>, D: Digest> {
+    Notarizes(Vec<Notarize<S, D>>),
+    Nullifies(Vec<Nullify<S>>),
+    Finalizes(Vec<Finalize<S, D>>),
+}
+
+/// An owned, in-flight verification batch: resolves to the verified votes and
+/// the signers that failed verification. Feed the votes back through
+/// [Verifier::finish_verify].
+pub type VerifyJob<S, D> =
+    Pin<Box<dyn Future<Output = (VerifiedVotes<S, D>, Vec<Participant>)> + Send>>;
 
 /// How the selected proposal changed after an update.
 pub(super) struct ProposalUpdate {
@@ -306,59 +355,61 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     /// Attempts to construct a certificate from verified votes: the first kind
     /// (notarization, then nullification, then finalization) with an unconsumed
     /// verified quorum. Call repeatedly to drain every constructible kind.
+    /// Test-only shim over [Self::begin_construct_certificate].
     ///
     /// Once recovery starts, it consumes the verified votes. Do not cancel unless
     /// the verifier will also be discarded.
+    #[cfg(test)]
     pub async fn try_construct_certificate(
         &mut self,
         strategy: &impl Strategy,
     ) -> Option<Certificate<S, D>> {
-        if let Some(notarizes) = self.notarize.try_complete() {
-            let span = info_span!(
-                "simplex.batcher.try_construct_notarization",
-                epoch = self.round.epoch().traced(),
-                view = self.round.view().traced()
-            );
-            let scheme = Arc::clone(&self.scheme);
-            let notarization = offload(span, strategy, move |strategy| {
+        Some(self.begin_construct_certificate(strategy)?.await)
+    }
+
+    /// Begins recovery of a certificate from verified votes: the first kind
+    /// (notarization, then nullification, then finalization) with an
+    /// unconsumed verified quorum. Call repeatedly to drain every
+    /// constructible kind.
+    ///
+    /// Returns an owned future that resolves to the certificate. Recovery
+    /// consumes the verified votes when it begins; do not drop the future
+    /// unless the verifier will also be discarded.
+    pub fn begin_construct_certificate(
+        &mut self,
+        strategy: &impl Strategy,
+    ) -> Option<impl Future<Output = Certificate<S, D>> + Send + 'static> {
+        let (quorum, name) = if let Some(notarizes) = self.notarize.try_complete() {
+            (VerifiedVotes::Notarizes(notarizes), "notarization")
+        } else if let Some(nullifies) = self.nullify.try_complete() {
+            (VerifiedVotes::Nullifies(nullifies), "nullification")
+        } else {
+            (
+                VerifiedVotes::Finalizes(self.finalize.try_complete()?),
+                "finalization",
+            )
+        };
+        let span = info_span!(
+            "simplex.batcher.construct_certificate",
+            kind = name,
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let scheme = Arc::clone(&self.scheme);
+        Some(offload(span, strategy, move |strategy| match quorum {
+            VerifiedVotes::Notarizes(notarizes) => Certificate::Notarization(
                 Notarization::from_owned_notarizes(scheme.as_ref(), notarizes, &strategy)
-                    .expect("verified notarize quorum must assemble")
-            })
-            .await;
-            return Some(Certificate::Notarization(notarization));
-        }
-
-        if let Some(nullifies) = self.nullify.try_complete() {
-            let span = info_span!(
-                "simplex.batcher.try_construct_nullification",
-                epoch = self.round.epoch().traced(),
-                view = self.round.view().traced()
-            );
-            let scheme = Arc::clone(&self.scheme);
-            let nullification = offload(span, strategy, move |strategy| {
+                    .expect("verified notarize quorum must assemble"),
+            ),
+            VerifiedVotes::Nullifies(nullifies) => Certificate::Nullification(
                 Nullification::from_owned_nullifies(scheme.as_ref(), nullifies, &strategy)
-                    .expect("verified nullify quorum must assemble")
-            })
-            .await;
-            return Some(Certificate::Nullification(nullification));
-        }
-
-        if let Some(finalizes) = self.finalize.try_complete() {
-            let span = info_span!(
-                "simplex.batcher.try_construct_finalization",
-                epoch = self.round.epoch().traced(),
-                view = self.round.view().traced()
-            );
-            let scheme = Arc::clone(&self.scheme);
-            let finalization = offload(span, strategy, move |strategy| {
+                    .expect("verified nullify quorum must assemble"),
+            ),
+            VerifiedVotes::Finalizes(finalizes) => Certificate::Finalization(
                 Finalization::from_owned_finalizes(scheme.as_ref(), finalizes, &strategy)
-                    .expect("verified finalize quorum must assemble")
-            })
-            .await;
-            return Some(Certificate::Finalization(finalization));
-        }
-
-        None
+                    .expect("verified finalize quorum must assemble"),
+            ),
+        }))
     }
 
     /// Returns true if a certificate of `kind` exists.
@@ -500,51 +551,68 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// The number of votes processed and the signer indices for whom verification
     /// failed, or `None` if verification was not worthwhile.
+    #[cfg(test)]
     pub async fn try_verify_notarizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
+        let (batch, job) = self.begin_verify_notarizes(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Begins a batch verification of pending [Vote::Notarize] messages, if
+    /// worthwhile (see [Certification::should_verify]), returning the batch
+    /// size and an owned future that resolves to the verified votes and the
+    /// signers that failed verification.
+    ///
+    /// The caller must feed the future's votes back through
+    /// [Self::finish_verify]; until then, no further notarize batch begins.
+    pub fn begin_verify_notarizes<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
         // Until the proposal is known, notarizes may reference many different
         // proposals.
         if matches!(self.proposal, ProposalState::Unknown) {
             return None;
         }
-        self.notarize
-            .try_verify(|notarizes, mut verified_notarizes| {
-                let span = info_span!(
-                    "simplex.batcher.verify_notarizes",
-                    epoch = self.round.epoch().traced(),
-                    view = self.round.view().traced()
-                );
-                let scheme = Arc::clone(&self.scheme);
-                let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
-                    let (proposals, attestations): (Vec<_>, Vec<_>) = notarizes
-                        .into_iter()
-                        .map(|n| (n.proposal, n.attestation))
-                        .unzip();
-                    // All proposals here are equal: pending votes are filtered to the
-                    // selected proposal before verification becomes ready.
-                    let proposal = &proposals[0];
+        let (batch, notarizes, mut verified_notarizes) = self.notarize.begin_verify()?;
+        let span = info_span!(
+            "simplex.batcher.verify_notarizes",
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let scheme = Arc::clone(&self.scheme);
+        let mut rng = StdRng::from_rng(rng);
+        let job = offload(span, strategy, move |strategy| {
+            let (proposals, attestations): (Vec<_>, Vec<_>) = notarizes
+                .into_iter()
+                .map(|n| (n.proposal, n.attestation))
+                .unzip();
+            // All proposals here are equal: pending votes are filtered to the
+            // selected proposal before verification becomes ready.
+            let proposal = &proposals[0];
 
-                    let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
-                        &mut rng,
-                        Subject::Notarize { proposal },
-                        attestations,
-                        &strategy,
-                    );
+            let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
+                &mut rng,
+                Subject::Notarize { proposal },
+                attestations,
+                &strategy,
+            );
 
-                    verified_notarizes.extend(verified.into_iter().zip(proposals).map(
-                        |(attestation, proposal)| Notarize {
-                            proposal,
-                            attestation,
-                        },
-                    ));
-                    (verified_notarizes, invalid)
-                })
-            })
-            .await
+            verified_notarizes.extend(verified.into_iter().zip(proposals).map(
+                |(attestation, proposal)| Notarize {
+                    proposal,
+                    attestation,
+                },
+            ));
+            (VerifiedVotes::Notarizes(verified_notarizes), invalid)
+        });
+        Some((batch, Box::pin(job) as VerifyJob<S, D>))
     }
 
     /// Batch verifies pending [Vote::Nullify] messages, if worthwhile (see
@@ -562,38 +630,55 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// The number of votes processed and the signer indices for whom verification
     /// failed, or `None` if verification was not worthwhile.
+    #[cfg(test)]
     pub async fn try_verify_nullifies<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        self.nullify
-            .try_verify(|nullifies, mut verified_nullifies| {
-                let span = info_span!(
-                    "simplex.batcher.verify_nullifies",
-                    epoch = self.round.epoch().traced(),
-                    view = self.round.view().traced()
-                );
-                let round = nullifies[0].round;
-                let scheme = Arc::clone(&self.scheme);
-                let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
-                    let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
-                        &mut rng,
-                        Subject::Nullify { round },
-                        nullifies.into_iter().map(|nullify| nullify.attestation),
-                        &strategy,
-                    );
+        let (batch, job) = self.begin_verify_nullifies(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
 
-                    verified_nullifies.extend(
-                        verified
-                            .into_iter()
-                            .map(|attestation| Nullify { round, attestation }),
-                    );
-                    (verified_nullifies, invalid)
-                })
-            })
-            .await
+    /// Begins a batch verification of pending [Vote::Nullify] messages, if
+    /// worthwhile (see [Certification::should_verify]), returning the batch
+    /// size and an owned future that resolves to the verified votes and the
+    /// signers that failed verification.
+    ///
+    /// The caller must feed the future's votes back through
+    /// [Self::finish_verify]; until then, no further nullify batch begins.
+    pub fn begin_verify_nullifies<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
+        let (batch, nullifies, mut verified_nullifies) = self.nullify.begin_verify()?;
+        let span = info_span!(
+            "simplex.batcher.verify_nullifies",
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let round = nullifies[0].round;
+        let scheme = Arc::clone(&self.scheme);
+        let mut rng = StdRng::from_rng(rng);
+        let job = offload(span, strategy, move |strategy| {
+            let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
+                &mut rng,
+                Subject::Nullify { round },
+                nullifies.into_iter().map(|nullify| nullify.attestation),
+                &strategy,
+            );
+
+            verified_nullifies.extend(
+                verified
+                    .into_iter()
+                    .map(|attestation| Nullify { round, attestation }),
+            );
+            (VerifiedVotes::Nullifies(verified_nullifies), invalid)
+        });
+        Some((batch, Box::pin(job) as VerifyJob<S, D>))
     }
 
     /// Batch verifies pending [Vote::Finalize] messages, if worthwhile: the
@@ -612,11 +697,30 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// The number of votes processed and the signer indices for whom verification
     /// failed, or `None` if verification was not worthwhile.
+    #[cfg(test)]
     pub async fn try_verify_finalizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
+        let (batch, job) = self.begin_verify_finalizes(rng, strategy)?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Begins a batch verification of pending [Vote::Finalize] messages, if
+    /// worthwhile (see [Certification::should_verify]), returning the batch
+    /// size and an owned future that resolves to the verified votes and the
+    /// signers that failed verification.
+    ///
+    /// The caller must feed the future's votes back through
+    /// [Self::finish_verify]; until then, no further finalize batch begins.
+    pub fn begin_verify_finalizes<R: CryptoRng>(
+        &mut self,
+        rng: &mut R,
+        strategy: &impl Strategy,
+    ) -> Option<(usize, VerifyJob<S, D>)> {
         // Until the proposal is known (from the leader's vote or a verified
         // certificate, which suffices even when the leader is unknown, e.g. a
         // round only learned about through certificates), finalizes may
@@ -624,39 +728,47 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         if matches!(self.proposal, ProposalState::Unknown) {
             return None;
         }
-        self.finalize
-            .try_verify(|finalizes, mut verified_finalizes| {
-                let span = info_span!(
-                    "simplex.batcher.verify_finalizes",
-                    epoch = self.round.epoch().traced(),
-                    view = self.round.view().traced()
-                );
-                let scheme = Arc::clone(&self.scheme);
-                let mut rng = StdRng::from_rng(rng);
-                offload(span, strategy, move |strategy| {
-                    let (proposals, attestations): (Vec<_>, Vec<_>) = finalizes
-                        .into_iter()
-                        .map(|n| (n.proposal, n.attestation))
-                        .unzip();
-                    let proposal = &proposals[0];
+        let (batch, finalizes, mut verified_finalizes) = self.finalize.begin_verify()?;
+        let span = info_span!(
+            "simplex.batcher.verify_finalizes",
+            epoch = self.round.epoch().traced(),
+            view = self.round.view().traced()
+        );
+        let scheme = Arc::clone(&self.scheme);
+        let mut rng = StdRng::from_rng(rng);
+        let job = offload(span, strategy, move |strategy| {
+            let (proposals, attestations): (Vec<_>, Vec<_>) = finalizes
+                .into_iter()
+                .map(|n| (n.proposal, n.attestation))
+                .unzip();
+            let proposal = &proposals[0];
 
-                    let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
-                        &mut rng,
-                        Subject::Finalize { proposal },
-                        attestations,
-                        &strategy,
-                    );
+            let Verification { verified, invalid } = scheme.verify_attestations::<_, D, _>(
+                &mut rng,
+                Subject::Finalize { proposal },
+                attestations,
+                &strategy,
+            );
 
-                    verified_finalizes.extend(verified.into_iter().zip(proposals).map(
-                        |(attestation, proposal)| Finalize {
-                            proposal,
-                            attestation,
-                        },
-                    ));
-                    (verified_finalizes, invalid)
-                })
-            })
-            .await
+            verified_finalizes.extend(verified.into_iter().zip(proposals).map(
+                |(attestation, proposal)| Finalize {
+                    proposal,
+                    attestation,
+                },
+            ));
+            (VerifiedVotes::Finalizes(verified_finalizes), invalid)
+        });
+        Some((batch, Box::pin(job) as VerifyJob<S, D>))
+    }
+
+    /// Reintegrates the result of a completed verification batch into the
+    /// [Certification] of its kind (see [Certification::finish_verify]).
+    pub fn finish_verify(&mut self, votes: VerifiedVotes<S, D>) {
+        match votes {
+            VerifiedVotes::Notarizes(notarizes) => self.notarize.finish_verify(notarizes),
+            VerifiedVotes::Nullifies(nullifies) => self.nullify.finish_verify(nullifies),
+            VerifiedVotes::Finalizes(finalizes) => self.finalize.finish_verify(finalizes),
+        }
     }
 }
 

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -535,32 +535,30 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         }
     }
 
-    /// Batch verifies pending [Vote::Notarize] messages, if worthwhile: the
-    /// proposal is known (notarizes reference one proposal) and the buffers
-    /// warrant a batch (see [Certification::should_verify]).
-    ///
-    /// It uses `S::verify_attestations` for efficient batch verification, run as one CPU-bound job
-    /// submitted through [Strategy::spawn] so a parallel strategy hosts it on its own pool
-    /// instead of occupying the calling task.
-    ///
-    /// # Arguments
-    ///
-    /// * `rng` - Randomness source used by schemes that require batching randomness.
-    ///
-    /// # Returns
-    ///
-    /// The number of votes processed and the signer indices for whom verification
-    /// failed, or `None` if verification was not worthwhile.
+    /// Drives a begun verification batch to completion and reintegrates its
+    /// result. Test-only shim over the `begin_verify_*` methods and
+    /// [Self::finish_verify].
+    #[cfg(test)]
+    pub(super) async fn drive(
+        &mut self,
+        begun: Option<(usize, VerifyJob<S, D>)>,
+    ) -> Option<(usize, Vec<Participant>)> {
+        let (batch, job) = begun?;
+        let (votes, invalid) = job.await;
+        self.finish_verify(votes);
+        Some((batch, invalid))
+    }
+
+    /// Test-only shim over [Self::begin_verify_notarizes] and
+    /// [Self::finish_verify].
     #[cfg(test)]
     pub async fn try_verify_notarizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        let (batch, job) = self.begin_verify_notarizes(rng, strategy)?;
-        let (votes, invalid) = job.await;
-        self.finish_verify(votes);
-        Some((batch, invalid))
+        let begun = self.begin_verify_notarizes(rng, strategy);
+        self.drive(begun).await
     }
 
     /// Begins a batch verification of pending [Vote::Notarize] messages, if
@@ -615,31 +613,16 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         Some((batch, Box::pin(job) as VerifyJob<S, D>))
     }
 
-    /// Batch verifies pending [Vote::Nullify] messages, if worthwhile (see
-    /// [Certification::should_verify]).
-    ///
-    /// It uses `S::verify_attestations` for efficient batch verification, run as one CPU-bound job
-    /// submitted through [Strategy::spawn] so a parallel strategy hosts it on its own pool
-    /// instead of occupying the calling task.
-    ///
-    /// # Arguments
-    ///
-    /// * `rng` - Randomness source used by schemes that require batching randomness.
-    ///
-    /// # Returns
-    ///
-    /// The number of votes processed and the signer indices for whom verification
-    /// failed, or `None` if verification was not worthwhile.
+    /// Test-only shim over [Self::begin_verify_nullifies] and
+    /// [Self::finish_verify].
     #[cfg(test)]
     pub async fn try_verify_nullifies<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        let (batch, job) = self.begin_verify_nullifies(rng, strategy)?;
-        let (votes, invalid) = job.await;
-        self.finish_verify(votes);
-        Some((batch, invalid))
+        let begun = self.begin_verify_nullifies(rng, strategy);
+        self.drive(begun).await
     }
 
     /// Begins a batch verification of pending [Vote::Nullify] messages, if
@@ -681,32 +664,16 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
         Some((batch, Box::pin(job) as VerifyJob<S, D>))
     }
 
-    /// Batch verifies pending [Vote::Finalize] messages, if worthwhile: the
-    /// proposal is known (finalizes reference one proposal) and the buffers
-    /// warrant a batch (see [Certification::should_verify]).
-    ///
-    /// It uses `S::verify_attestations` for efficient batch verification, run as one CPU-bound job
-    /// submitted through [Strategy::spawn] so a parallel strategy hosts it on its own pool
-    /// instead of occupying the calling task.
-    ///
-    /// # Arguments
-    ///
-    /// * `rng` - Randomness source used by schemes that require batching randomness.
-    ///
-    /// # Returns
-    ///
-    /// The number of votes processed and the signer indices for whom verification
-    /// failed, or `None` if verification was not worthwhile.
+    /// Test-only shim over [Self::begin_verify_finalizes] and
+    /// [Self::finish_verify].
     #[cfg(test)]
     pub async fn try_verify_finalizes<R: CryptoRng>(
         &mut self,
         rng: &mut R,
         strategy: &impl Strategy,
     ) -> Option<(usize, Vec<Participant>)> {
-        let (batch, job) = self.begin_verify_finalizes(rng, strategy)?;
-        let (votes, invalid) = job.await;
-        self.finish_verify(votes);
-        Some((batch, invalid))
+        let begun = self.begin_verify_finalizes(rng, strategy);
+        self.drive(begun).await
     }
 
     /// Begins a batch verification of pending [Vote::Finalize] messages, if


### PR DESCRIPTION
Closes #4353.

## Problem

The batcher awaits signature verification and certificate recovery inside its event loop. Measurements from #4356 showed about 2.2 ms per batch verification, 0.55 ms per recovery, and 92% actor occupancy at 335 batches per second.

While crypto runs, the batcher cannot ingest votes, process another vote kind, or construct a ready certificate. This limits certification throughput and delays block production after the optimistic issuance window fills.

## Design

`Certification::begin_verify` transfers pending and verified votes into an owned job. `finish_verify` reintegrates the result. Each vote kind permits one verification batch at a time. Votes that arrive during a batch remain pending until it completes.

The actor submits verification and certificate-recovery jobs to a `commonware_utils::futures::Pool`. The pool allows crypto to overlap message processing and work for other views. The actor limits submitted jobs to `Strategy::manual().parallelism()` and only dispatches rounds in the admission window.

The actor dispatches the current view first. It then dispatches other dirty views in ascending order. A view remains dirty when capacity is full, so a later completion retries it.

The completion path handles concurrent state changes:

- `finish_verify` filters proposal-bearing votes against the current proposal.
- If the round still exists, the actor records a recovered certificate before forwarding it.
- A pruned round discards completed verification results. The actor still forwards a recovered certificate because the voter applies its own pruning policy.

Tests cover votes arriving during verification, proposal replacement, duplicate certificate arrival, out-of-order completion, pruning, and capacity retry.

## Evidence

An equivalent implementation in #4356 improved throughput from 175.5 to 192.4 blocks per second. Exact 5 ms intervals increased from 88.8% to 99.46%. These measurements predate the post-#4443 verifier used here.

## Validation

- `just test -p commonware-consensus`
- `just clippy -p commonware-consensus`
- `just check-fmt`
