### PR TITLE
[consensus/simplex] Dispatch proposal and verification before voter persistence

### DIFF
--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1262,10 +1262,10 @@ impl<
                     staged.nullify = nullify;
                     staged.certification = certification;
 
-                    // Constructing the notarize advances the optimistic frontier,
-                    // making child requests eligible. Start them before journal
-                    // sync and publication. Their responses join the next
-                    // iteration's waiters.
+                    // A constructed notarize advances the optimistic frontier and
+                    // can make child requests eligible. Start those requests before
+                    // journal sync and publication. The next iteration polls their
+                    // responses.
                     self.reconcile_application_requests(
                         &mut resolver,
                         &mut pending_propose,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -412,6 +412,40 @@ impl<
         Some(Request(context, span, receiver))
     }
 
+    /// Starts eligible proposal and verification requests.
+    async fn dispatch_application_requests(
+        &mut self,
+        resolver: &mut resolver::Mailbox<S, D>,
+        pending_propose: &mut Option<Request<Context<D, S::PublicKey>, D>>,
+        pending_verify: &mut Option<Request<Context<D, S::PublicKey>, bool>>,
+    ) {
+        // Keep requests for optimistic future views and clear requests for
+        // exited views. Certification for an exited view can continue after
+        // its verification receiver is dropped.
+        let current_view = self.state.current_view();
+        if pending_propose
+            .as_ref()
+            .is_some_and(|request| request.view() < current_view)
+        {
+            *pending_propose = None;
+        }
+        if pending_verify
+            .as_ref()
+            .is_some_and(|request| request.view() < current_view)
+        {
+            *pending_verify = None;
+        }
+
+        // State and Round prevent duplicate requests when both checkpoints
+        // observe the same view.
+        if pending_propose.is_none() {
+            *pending_propose = self.try_propose().await;
+        }
+        if pending_verify.is_none() {
+            *pending_verify = self.try_verify(resolver).await;
+        }
+    }
+
     /// Persists our nullify vote to the journal for crash recovery.
     async fn handle_nullify(self, nullify: Nullify<S>) -> Self {
         self.append_journal(nullify.view(), Artifact::Nullify(nullify))
@@ -1082,34 +1116,13 @@ impl<
         select_loop! {
             self.context,
             on_start => {
-                // Drop any pending items if we have moved past their view (work
-                // for optimistic future views is kept). This runs before the
-                // waiters are rebuilt, so a verification completion cannot be
-                // polled after another branch exits its view. A view is exited
-                // only on successful certification, nullification, or finalization.
-                // Nullification does not cancel certification work for the
-                // exited view, so the automaton must tolerate a dropped verify
-                // receiver while certify still wants the result.
-                if let Some(ref pp) = pending_propose
-                    && pp.view() < self.state.current_view()
-                {
-                    pending_propose = None;
-                }
-                if let Some(ref pv) = pending_verify
-                    && pv.view() < self.state.current_view()
-                {
-                    pending_verify = None;
-                }
-
-                // If needed, propose a container
-                if pending_propose.is_none() {
-                    pending_propose = self.try_propose().await;
-                }
-
-                // If needed, verify current view
-                if pending_verify.is_none() {
-                    pending_verify = self.try_verify(&mut resolver).await;
-                }
+                // Reconcile application requests before building this iteration's
+                // response waiters.
+                self.dispatch_application_requests(
+                    &mut resolver,
+                    &mut pending_propose,
+                    &mut pending_verify,
+                ).await;
 
                 // Attempt to certify any views that we have notarizations for.
                 //
@@ -1248,14 +1261,13 @@ impl<
                     staged.nullify = nullify;
                     staged.certification = certification;
 
-                    // Construction may have made the next proposal eligible:
-                    // signing a notarize advances the optimistic frontier.
-                    // Dispatch the request before the journal sync and
-                    // broadcast below so the automaton builds during that
-                    // work. The result is consumed on a later iteration.
-                    if pending_propose.is_none() {
-                        pending_propose = self.try_propose().await;
-                    }
+                    // Start optimistic child requests before journal sync and
+                    // publication. Their responses join the next iteration's waiters.
+                    self.dispatch_application_requests(
+                        &mut resolver,
+                        &mut pending_propose,
+                        &mut pending_verify,
+                    ).await;
 
                     // Sync everything appended this iteration (during message
                     // processing and construction) in a single coalesced sync.

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1226,14 +1226,6 @@ impl<
                 resolved = processed_resolved;
             },
             on_end => {
-                // This iteration may make the next proposal eligible. Dispatch it
-                // before signing and journal sync so application pacing overlaps
-                // with that work. Its result is not consumed until the next
-                // iteration.
-                if pending_propose.is_none() {
-                    pending_propose = self.try_propose().await;
-                }
-
                 // Attempt to send any new view messages
                 //
                 // The batcher may drop votes we construct here if it has not yet been updated to the
@@ -1255,6 +1247,15 @@ impl<
                         .await;
                     staged.nullify = nullify;
                     staged.certification = certification;
+
+                    // Construction may have made the next proposal eligible:
+                    // signing a notarize advances the optimistic frontier.
+                    // Dispatch the request before the journal sync and
+                    // broadcast below so the automaton builds during that
+                    // work. The result is consumed on a later iteration.
+                    if pending_propose.is_none() {
+                        pending_propose = self.try_propose().await;
+                    }
 
                     // Sync everything appended this iteration (during message
                     // processing and construction) in a single coalesced sync.

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -412,8 +412,9 @@ impl<
         Some(Request(context, span, receiver))
     }
 
-    /// Starts eligible proposal and verification requests.
-    async fn dispatch_application_requests(
+    /// Reconciles pending application requests with the current view: drops
+    /// requests for exited views and dispatches eligible ones.
+    async fn reconcile_application_requests(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,
         pending_propose: &mut Option<Request<Context<D, S::PublicKey>, D>>,
@@ -1118,7 +1119,7 @@ impl<
             on_start => {
                 // Reconcile application requests before building this iteration's
                 // response waiters.
-                self.dispatch_application_requests(
+                self.reconcile_application_requests(
                     &mut resolver,
                     &mut pending_propose,
                     &mut pending_verify,
@@ -1263,7 +1264,7 @@ impl<
 
                     // Start optimistic child requests before journal sync and
                     // publication. Their responses join the next iteration's waiters.
-                    self.dispatch_application_requests(
+                    self.reconcile_application_requests(
                         &mut resolver,
                         &mut pending_propose,
                         &mut pending_verify,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -412,8 +412,8 @@ impl<
         Some(Request(context, span, receiver))
     }
 
-    /// Reconciles pending application requests with the current view: drops
-    /// requests for exited views and dispatches eligible ones.
+    /// Drops pending application requests for exited views and dispatches
+    /// eligible new ones.
     async fn reconcile_application_requests(
         &mut self,
         resolver: &mut resolver::Mailbox<S, D>,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1262,8 +1262,10 @@ impl<
                     staged.nullify = nullify;
                     staged.certification = certification;
 
-                    // Start optimistic child requests before journal sync and
-                    // publication. Their responses join the next iteration's waiters.
+                    // Constructing the notarize advances the optimistic frontier,
+                    // making child requests eligible. Start them before journal
+                    // sync and publication. Their responses join the next
+                    // iteration's waiters.
                     self.reconcile_application_requests(
                         &mut resolver,
                         &mut pending_propose,

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1226,6 +1226,14 @@ impl<
                 resolved = processed_resolved;
             },
             on_end => {
+                // This iteration may make the next proposal eligible. Dispatch it
+                // before signing and journal sync so application pacing overlaps
+                // with that work. Its result is not consumed until the next
+                // iteration.
+                if pending_propose.is_none() {
+                    pending_propose = self.try_propose().await;
+                }
+
                 // Attempt to send any new view messages
                 //
                 // The batcher may drop votes we construct here if it has not yet been updated to the

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -231,37 +231,7 @@ mod tests {
     }
 
     /// Helper to set up a voter actor for tests.
-    async fn setup_voter<S, L>(
-        context: &mut deterministic::Context,
-        oracle: &commonware_p2p::simulated::Oracle<S::PublicKey, deterministic::Context>,
-        participants: &[S::PublicKey],
-        schemes: &[S],
-        elector: L,
-        options: VoterOptions,
-    ) -> (
-        Mailbox<S, Sha256Digest>,
-        mailbox::Receiver<batcher::Message<S, Sha256Digest>>,
-        mailbox::Receiver<resolver::MailboxMessage<S, Sha256Digest>>,
-        Arc<mocks::relay::Relay<Sha256Digest, S::PublicKey>>,
-        mocks::reporter::Reporter<deterministic::Context, S, L, Sha256Digest>,
-    )
-    where
-        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
-        L: elector::Config<S>,
-    {
-        setup_voter_with_context(
-            context,
-            context.child("actor"),
-            oracle,
-            participants,
-            schemes,
-            elector,
-            options,
-        )
-        .await
-    }
-
-    async fn setup_voter_with_context<E, S, L>(
+    async fn setup_voter<E, S, L>(
         context: &deterministic::Context,
         voter_context: E,
         oracle: &commonware_p2p::simulated::Oracle<S::PublicKey, deterministic::Context>,
@@ -1434,7 +1404,8 @@ mod tests {
             let elector = L::default();
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
-                    &mut context,
+                    &context,
+                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -1552,7 +1523,8 @@ mod tests {
             let elector = L::default();
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
-                    &mut context,
+                    &context,
+                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -1683,7 +1655,8 @@ mod tests {
             let elector = L::default();
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
-                    &mut context,
+                    &context,
+                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -2610,7 +2583,8 @@ mod tests {
                 .unwrap();
 
             let (mut mailbox, mut batcher, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -2737,7 +2711,8 @@ mod tests {
             let leader_idx = built_elector.elect(first_round, None);
             let leader = participants[usize::from(leader_idx)].clone();
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -2842,7 +2817,8 @@ mod tests {
             let elector =
                 RoundRobin::<Sha256>::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(20), ViewDelta::new(0));
             let (mut mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -2985,7 +2961,8 @@ mod tests {
                 usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
 
             let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3086,7 +3063,7 @@ mod tests {
                 pending: pending_syncs.clone(),
             };
             let propose_requests = Arc::new(Mutex::new(Vec::new()));
-            let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter_with_context(
+            let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
                 &context,
                 voter_context,
                 &oracle,
@@ -3102,9 +3079,13 @@ mod tests {
             )
             .await;
 
+            // Once the view 1 propose request is in flight, gate the journal so
+            // the sync covering the view 1 notarize blocks until released.
             wait_for_request(&context, &propose_requests, View::new(1)).await;
             pending_syncs.arm();
 
+            // The voter appends the view 1 notarize and blocks on the gated
+            // sync. The view 2 propose request must still reach the application.
             let deferred = next_pending_sync(&pending_syncs);
             deferred
                 .blocked
@@ -3112,6 +3093,8 @@ mod tests {
                 .expect("view 1 journal sync was dropped");
             wait_for_request(&context, &propose_requests, View::new(2)).await;
 
+            // Nothing constructed for view 1 may reach the batcher while its
+            // sync is blocked.
             while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
                 assert!(
                     !matches!(
@@ -3128,6 +3111,7 @@ mod tests {
                 "expected one journal sync after the gate was armed"
             );
 
+            // Release the sync. The view 1 notarize must now be published.
             deferred.release.send(Ok(())).unwrap();
             pending_syncs.unblock();
 
@@ -3171,7 +3155,8 @@ mod tests {
             );
             let propose_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3191,8 +3176,11 @@ mod tests {
                 batcher_receiver.recv().await.unwrap(),
                 batcher::Message::Update { .. }
             ));
+            // The view 1 propose request stalls forever, occupying the pending
+            // request slot.
             wait_for_request(&context, &propose_requests, View::new(1)).await;
 
+            // The leader timeout fires while the request is still outstanding.
             let nullify = loop {
                 select! {
                     msg = batcher_receiver.recv() => {
@@ -3210,9 +3198,15 @@ mod tests {
             let nullification = Nullification::from_nullifies(&schemes[0], &[nullify], &Sequential)
                 .expect("one signer forms quorum");
 
+            // The nullification exits view 1. A mid-term view requires its
+            // immediate parent, so view 2 can never propose. The voter skips to
+            // view 3, the term start, which builds on genesis. The stalled
+            // view 1 request must not suppress the view 3 request.
             mailbox.resolved(Certificate::Nullification(nullification));
             wait_for_request(&context, &propose_requests, View::new(3)).await;
 
+            // The replacement must dispatch at the same-iteration checkpoint,
+            // before the nullification broadcast.
             let events = traces.get_by_level(Level::DEBUG);
             let replacement = trace_position(
                 &events,
@@ -3267,7 +3261,8 @@ mod tests {
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
 
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3334,6 +3329,8 @@ mod tests {
                 }
             }
 
+            // Verification for view 2 must dispatch at the same-iteration
+            // checkpoint, before the view 1 notarize broadcast.
             let events = traces.get_by_level(Level::DEBUG);
             let verify_next = trace_position(
                 &events,
@@ -3391,7 +3388,8 @@ mod tests {
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
 
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3570,7 +3568,8 @@ mod tests {
             // Setup application mock and voter
             let elector = L::default();
             let (mut mailbox, mut batcher_receiver, _, _, reporter) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3665,7 +3664,8 @@ mod tests {
             let elector = L::default();
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
-                    &mut context,
+                    &context,
+                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -3773,7 +3773,8 @@ mod tests {
             );
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, _reporter) =
                 setup_voter(
-                    &mut context,
+                    &context,
+                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -4654,7 +4655,8 @@ mod tests {
             let local_index = (leader_index + 1) % schemes.len();
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, _, relay, reporter) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -4749,7 +4751,8 @@ mod tests {
                     .await;
 
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7215,7 +7218,8 @@ mod tests {
                     .await;
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7490,7 +7494,8 @@ mod tests {
                 start_test_network_with_peers(context.child("network"), participants.clone(), true)
                     .await;
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7604,7 +7609,8 @@ mod tests {
                 .clone()
                 .build(&participants.clone().try_into().unwrap());
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7723,7 +7729,8 @@ mod tests {
                 .clone()
                 .build(&participants.clone().try_into().unwrap());
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7875,7 +7882,8 @@ mod tests {
                 .clone()
                 .build(&participants.clone().try_into().unwrap());
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8018,7 +8026,8 @@ mod tests {
 
             // Set up voter with Certifier::Cancel
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8154,7 +8163,8 @@ mod tests {
 
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8568,7 +8578,8 @@ mod tests {
             // Setup voter with Certifier::Cancel to simulate missing verification context.
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8768,7 +8779,8 @@ mod tests {
             // Set up voter with Certifier::Custom that always returns false
             // This simulates coding marshal's deferred_verify finding context mismatch
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8906,7 +8918,8 @@ mod tests {
 
             // Set up voter with Certifier::Pending (certify hangs indefinitely).
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9058,7 +9071,8 @@ mod tests {
 
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9203,7 +9217,8 @@ mod tests {
 
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9335,7 +9350,8 @@ mod tests {
             .await;
 
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9487,7 +9503,8 @@ mod tests {
             let leader = participants[usize::from(leader_idx)].clone();
 
             let (mut mailbox, mut batcher_receiver, _, relay, reporter) = setup_voter(
-                &mut context,
+                &context,
+                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -88,14 +88,16 @@ mod tests {
     };
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        Clock, Metrics as _, Quota, Runner, Supervisor as _, deterministic,
+        BufferPooler, Clock, Metrics, Quota, Runner, Spawner, Storage, Supervisor as _,
+        deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, next_pending_sync},
         reschedule,
-        telemetry::traces::collector::TraceStorage,
+        telemetry::traces::collector::{RecordedEvents, TraceStorage},
     };
     use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
     use commonware_utils::{NZU16, NZU32, NZUsize, sync::Mutex};
     use futures::FutureExt;
+    use rand_core::CryptoRng;
     use std::{
         num::{NonZeroU16, NonZeroU32},
         sync::Arc,
@@ -192,6 +194,10 @@ mod tests {
         local_index: usize,
         /// Mock application propose latency, in milliseconds.
         propose_latency_ms: f64,
+        /// Views whose proposal requests reached the mock application.
+        propose_requests: Option<Arc<Mutex<Vec<View>>>>,
+        /// Whether proposal responses should remain pending indefinitely.
+        stall_proposals: bool,
         /// Mock application verify latency, in milliseconds.
         verify_latency_ms: f64,
         /// Mock application certify latency, in milliseconds.
@@ -213,6 +219,8 @@ mod tests {
                 timeout_retry: Duration::from_secs(1000),
                 local_index: 0,
                 propose_latency_ms: 1.0,
+                propose_requests: None,
+                stall_proposals: false,
                 verify_latency_ms: 1.0,
                 certify_latency_ms: 1.0,
                 verify_requests: None,
@@ -241,6 +249,38 @@ mod tests {
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
         L: elector::Config<S>,
     {
+        setup_voter_with_context(
+            context,
+            context.child("actor"),
+            oracle,
+            participants,
+            schemes,
+            elector,
+            options,
+        )
+        .await
+    }
+
+    async fn setup_voter_with_context<E, S, L>(
+        context: &deterministic::Context,
+        voter_context: E,
+        oracle: &commonware_p2p::simulated::Oracle<S::PublicKey, deterministic::Context>,
+        participants: &[S::PublicKey],
+        schemes: &[S],
+        elector: L,
+        options: VoterOptions,
+    ) -> (
+        Mailbox<S, Sha256Digest>,
+        mailbox::Receiver<batcher::Message<S, Sha256Digest>>,
+        mailbox::Receiver<resolver::MailboxMessage<S, Sha256Digest>>,
+        Arc<mocks::relay::Relay<Sha256Digest, S::PublicKey>>,
+        mocks::reporter::Reporter<deterministic::Context, S, L, Sha256Digest>,
+    )
+    where
+        E: BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics,
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        L: elector::Config<S>,
+    {
         let signing = schemes[options.local_index].clone();
         let me = participants[options.local_index].clone();
         let reporter_cfg = mocks::reporter::Config {
@@ -251,6 +291,7 @@ mod tests {
         let reporter = mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
         let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
         let elector = elector.build(signing.participants());
+        let propose_requests = options.propose_requests;
         let verify_requests = options.verify_requests;
 
         let application_cfg = mocks::application::Config::<Sha256, _> {
@@ -263,7 +304,13 @@ mod tests {
         };
         let (mut actor, application) =
             mocks::application::Application::new(context.child("app"), application_cfg);
+        actor.set_stall_proposals(options.stall_proposals);
         actor.set_fail_verification(options.fail_verification);
+        if let Some(propose_requests) = propose_requests {
+            actor.set_propose_observer(Box::new(move |context| {
+                propose_requests.lock().push(context.view());
+            }));
+        }
         if let Some(verify_requests) = verify_requests {
             actor.set_verify_observer(Box::new(move |context, _| {
                 verify_requests.lock().push(context.view());
@@ -288,9 +335,9 @@ mod tests {
             view_retention: ViewDelta::new(10),
             replay_buffer: NZUsize!(10240),
             write_buffer: NZUsize!(10240),
-            page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            page_cache: CacheRef::from_pooler(&voter_context, PAGE_SIZE, PAGE_CACHE_SIZE),
         };
-        let (voter, mailbox) = Actor::new(context.child("actor"), voter_cfg);
+        let (voter, mailbox) = Actor::new(voter_context, voter_cfg);
 
         let (resolver_sender, resolver_receiver) =
             mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
@@ -322,6 +369,41 @@ mod tests {
             relay,
             reporter,
         )
+    }
+
+    async fn wait_for_request(
+        context: &deterministic::Context,
+        requests: &Arc<Mutex<Vec<View>>>,
+        view: View,
+    ) {
+        let deadline = context.current() + Duration::from_secs(1);
+        while !requests.lock().contains(&view) {
+            if context.current() >= deadline {
+                panic!("application did not receive request for {view}");
+            }
+            context.sleep(Duration::from_millis(1)).await;
+        }
+    }
+
+    fn trace_position(
+        events: &RecordedEvents,
+        content: &str,
+        span_name: &str,
+        view: View,
+    ) -> usize {
+        let view = view.to_string();
+        events
+            .iter()
+            .position(|event| {
+                event.metadata.content == content
+                    && event
+                        .expect_span_at_index(0, |span| {
+                            span.expect_content_exact(span_name)?;
+                            span.expect_field_exact("view", &view)
+                        })
+                        .is_ok()
+            })
+            .unwrap_or_else(|| panic!("missing {content} trace for view {view}"))
     }
 
     async fn seed_voter_journal<S>(
@@ -2965,15 +3047,12 @@ mod tests {
         });
     }
 
-    /// Regression: the next view's proposal request dispatches before the
-    /// current iteration's journal sync and vote broadcast, so the automaton
-    /// builds the next block during that work. Constructing the notarize for
-    /// view 1 advances the optimistic frontier, so the view 2 request must
-    /// dispatch before the view 1 notarize is broadcast.
-    #[test_collect_traces]
-    fn test_next_propose_dispatches_before_broadcast(traces: TraceStorage) {
+    /// The next view's proposal request reaches the application while the
+    /// current view's notarize is waiting for journal sync.
+    #[test_traced]
+    fn test_next_propose_dispatches_before_sync() {
         let n = 5;
-        let namespace = b"next_propose_dispatches_before_broadcast".to_vec();
+        let namespace = b"next_propose_dispatches_before_sync".to_vec();
         let epoch = Epoch::new(333);
         let term_length = TermLength::new(NZU32!(5));
         let executor = deterministic::Runner::timed(Duration::from_secs(20));
@@ -3001,75 +3080,164 @@ mod tests {
             let local_index =
                 usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
 
-            let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
-                &mut context,
+            let pending_syncs = PendingSyncs::default();
+            let voter_context = DelayedSyncContext {
+                inner: context.child("actor"),
+                pending: pending_syncs.clone(),
+            };
+            let propose_requests = Arc::new(Mutex::new(Vec::new()));
+            let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter_with_context(
+                &context,
+                voter_context,
                 &oracle,
                 &participants,
                 &schemes,
                 elector,
                 VoterOptions {
                     local_index,
+                    propose_latency_ms: 200.0,
+                    propose_requests: Some(propose_requests.clone()),
                     ..Default::default()
                 },
             )
             .await;
 
-            // Wait for the optimistic view-2 notarize: by then the voter has
-            // requested the view-2 proposal and broadcast the view-1 notarize.
+            wait_for_request(&context, &propose_requests, View::new(1)).await;
+            pending_syncs.arm();
+
+            let deferred = next_pending_sync(&pending_syncs);
+            deferred
+                .blocked
+                .await
+                .expect("view 1 journal sync was dropped");
+            wait_for_request(&context, &propose_requests, View::new(2)).await;
+
+            while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
+                assert!(
+                    !matches!(
+                        msg,
+                        batcher::Message::Constructed(Vote::Notarize(ref notarize))
+                            if notarize.view() == View::new(1)
+                    ),
+                    "view 1 notarize reached the batcher before journal sync"
+                );
+            }
+            assert_eq!(
+                pending_syncs.calls(),
+                1,
+                "expected one journal sync after the gate was armed"
+            );
+
+            deferred.release.send(Ok(())).unwrap();
+            pending_syncs.unblock();
+
             loop {
                 select! {
                     msg = batcher_receiver.recv() => {
                         if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
-                            && notarize.view() == View::new(2)
+                            && notarize.view() == View::new(1)
                         {
                             break;
                         }
                     },
-                    _ = context.sleep(Duration::from_secs(8)) => {
-                        panic!("expected optimistic notarize for view 2");
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected notarize for view 1 after journal sync");
                     }
                 }
             }
+        });
+    }
 
-            // Both events log at DEBUG from the voter task, so their order in
-            // the trace is the voter's execution order.
+    /// An exited view's pending proposal must not suppress replacement work.
+    #[test_collect_traces]
+    fn test_stale_propose_does_not_block_replacement_dispatch(traces: TraceStorage) {
+        let n = 1;
+        let namespace = b"stale_propose_does_not_block_replacement_dispatch".to_vec();
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+            let elector = RoundRobin::<Sha256>::default().with_term(
+                TermLength::new(NZU32!(2)),
+                Duration::from_secs(30),
+                ViewDelta::new(2),
+            );
+            let propose_requests = Arc::new(Mutex::new(Vec::new()));
+            let (mut mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    leader_timeout: Duration::from_millis(10),
+                    certification_timeout: Duration::from_secs(10),
+                    timeout_retry: Duration::from_secs(30),
+                    propose_requests: Some(propose_requests.clone()),
+                    stall_proposals: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            assert!(matches!(
+                batcher_receiver.recv().await.unwrap(),
+                batcher::Message::Update { .. }
+            ));
+            wait_for_request(&context, &propose_requests, View::new(1)).await;
+
+            let nullify = loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Nullify(nullify)) = msg.unwrap()
+                            && nullify.view() == View::new(1)
+                        {
+                            break nullify;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("expected nullify for view 1");
+                    }
+                }
+            };
+            let nullification = Nullification::from_nullifies(&schemes[0], &[nullify], &Sequential)
+                .expect("one signer forms quorum");
+
+            mailbox.resolved(Certificate::Nullification(nullification));
+            wait_for_request(&context, &propose_requests, View::new(3)).await;
+
             let events = traces.get_by_level(Level::DEBUG);
-            let propose_next = events
-                .iter()
-                .position(|event| {
-                    event.metadata.content == "requested proposal from automaton"
-                        && event
-                            .expect_span_at_index(0, |span| {
-                                span.expect_content_exact("simplex.voter.propose")?;
-                                span.expect_field_exact("view", "2")
-                            })
-                            .is_ok()
-                })
-                .expect("view 2 proposal must be requested");
-            let broadcast = events
-                .iter()
-                .position(|event| {
-                    event.metadata.content == "broadcasting notarize"
-                        && event
-                            .expect_span_at_index(0, |span| {
-                                span.expect_content_exact("simplex.voter.notify")?;
-                                span.expect_field_exact("view", "1")
-                            })
-                            .is_ok()
-                })
-                .expect("view 1 notarize must be broadcast");
+            let replacement = trace_position(
+                &events,
+                "requested proposal from automaton",
+                "simplex.voter.propose",
+                View::new(3),
+            );
+            let broadcast = trace_position(
+                &events,
+                "broadcasting nullification",
+                "simplex.voter.notify",
+                View::new(1),
+            );
             assert!(
-                propose_next < broadcast,
-                "view 2 propose request must dispatch before the view 1 notarize broadcast \
-                 (propose at {propose_next}, broadcast at {broadcast})"
+                replacement < broadcast,
+                "replacement proposal must dispatch before the view 1 nullification broadcast \
+                 (replacement at {replacement}, broadcast at {broadcast})"
             );
         });
     }
 
-    /// Regression: same-term optimistic future verification may run after a
-    /// local parent notarize, without waiting for parent certification.
-    #[test_traced]
-    fn test_optimistic_future_verify_uses_local_parent_notarize() {
+    /// A buffered optimistic child starts verification as soon as the local
+    /// parent notarize makes its ancestry available.
+    #[test_collect_traces]
+    fn test_optimistic_future_verify_uses_local_parent_notarize(traces: TraceStorage) {
         let n = 5;
         let namespace = b"optimistic_future_verify_uses_local_parent_notarize".to_vec();
         let epoch = Epoch::new(333);
@@ -3096,6 +3264,7 @@ mod tests {
             let leader_idx = built_elector.elect(Round::new(epoch, View::new(1)), None);
             let local_index = (usize::from(leader_idx) + 1) % participants.len();
             let leader = participants[usize::from(leader_idx)].clone();
+            let verify_requests = Arc::new(Mutex::new(Vec::new()));
 
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &mut context,
@@ -3111,7 +3280,8 @@ mod tests {
                     certification_timeout: Duration::from_secs(10),
                     timeout_retry: Duration::from_secs(30),
                     local_index,
-                    propose_latency_ms: 10.0,
+                    verify_latency_ms: 200.0,
+                    verify_requests: Some(verify_requests.clone()),
                     ..Default::default()
                 },
             )
@@ -3132,25 +3302,7 @@ mod tests {
             let contents_1 = (proposal_1.round, genesis, 0u64).encode();
             relay.broadcast(&leader, Recipients::All, (proposal_1.payload, contents_1));
             mailbox.proposal(proposal_1.clone());
-
-            loop {
-                select! {
-                    msg = batcher_receiver.recv() => {
-                        match msg.unwrap() {
-                            batcher::Message::Update { .. } => {}
-                            batcher::Message::Constructed(Vote::Notarize(notarize))
-                                if notarize.view() == View::new(1) =>
-                            {
-                                break;
-                            }
-                            _ => {}
-                        }
-                    },
-                    _ = context.sleep(Duration::from_secs(5)) => {
-                        panic!("expected local notarize for view 1 before testing optimistic future verify");
-                    }
-                }
-            }
+            wait_for_request(&context, &verify_requests, View::new(1)).await;
 
             let proposal_2 = Proposal::new(
                 Round::new(epoch, View::new(2)),
@@ -3181,6 +3333,25 @@ mod tests {
                     }
                 }
             }
+
+            let events = traces.get_by_level(Level::DEBUG);
+            let verify_next = trace_position(
+                &events,
+                "requested proposal verification",
+                "simplex.voter.verify",
+                View::new(2),
+            );
+            let broadcast = trace_position(
+                &events,
+                "broadcasting notarize",
+                "simplex.voter.notify",
+                View::new(1),
+            );
+            assert!(
+                verify_next < broadcast,
+                "view 2 verification must dispatch before the view 1 notarize broadcast \
+                 (verify at {verify_next}, broadcast at {broadcast})"
+            );
         });
     }
 

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -2968,8 +2968,8 @@ mod tests {
     /// Regression: the next view's proposal request dispatches before the
     /// current iteration's journal sync and vote broadcast, so the automaton
     /// builds the next block during that work. Constructing the notarize for
-    /// view 1 advances the optimistic frontier, so the view 2 request must go
-    /// out before the view 1 notarize is broadcast.
+    /// view 1 advances the optimistic frontier, so the view 2 request must
+    /// dispatch before the view 1 notarize is broadcast.
     #[test_collect_traces]
     fn test_next_propose_dispatches_before_broadcast(traces: TraceStorage) {
         let n = 5;

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -232,8 +232,7 @@ mod tests {
 
     /// Helper to set up a voter actor for tests.
     async fn setup_voter<E, S, L>(
-        context: &deterministic::Context,
-        voter_context: E,
+        context: &E,
         oracle: &commonware_p2p::simulated::Oracle<S::PublicKey, deterministic::Context>,
         participants: &[S::PublicKey],
         schemes: &[S],
@@ -244,7 +243,7 @@ mod tests {
         mailbox::Receiver<batcher::Message<S, Sha256Digest>>,
         mailbox::Receiver<resolver::MailboxMessage<S, Sha256Digest>>,
         Arc<mocks::relay::Relay<Sha256Digest, S::PublicKey>>,
-        mocks::reporter::Reporter<deterministic::Context, S, L, Sha256Digest>,
+        mocks::reporter::Reporter<E, S, L, Sha256Digest>,
     )
     where
         E: BufferPooler + Clock + CryptoRng + Spawner + Storage + Metrics,
@@ -305,9 +304,9 @@ mod tests {
             view_retention: ViewDelta::new(10),
             replay_buffer: NZUsize!(10240),
             write_buffer: NZUsize!(10240),
-            page_cache: CacheRef::from_pooler(&voter_context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
         };
-        let (voter, mailbox) = Actor::new(voter_context, voter_cfg);
+        let (voter, mailbox) = Actor::new(context.child("actor"), voter_cfg);
 
         let (resolver_sender, resolver_receiver) =
             mailbox::new(context.child("resolver_mailbox"), NZUsize!(8));
@@ -1405,7 +1404,6 @@ mod tests {
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
                     &context,
-                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -1524,7 +1522,6 @@ mod tests {
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
                     &context,
-                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -1656,7 +1653,6 @@ mod tests {
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
                     &context,
-                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -2584,7 +2580,6 @@ mod tests {
 
             let (mut mailbox, mut batcher, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -2712,7 +2707,6 @@ mod tests {
             let leader = participants[usize::from(leader_idx)].clone();
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -2818,7 +2812,6 @@ mod tests {
                 RoundRobin::<Sha256>::default().with_term(TermLength::new(NZU32!(3)), Duration::from_secs(20), ViewDelta::new(0));
             let (mut mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -2962,7 +2955,6 @@ mod tests {
 
             let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3059,13 +3051,12 @@ mod tests {
 
             let pending_syncs = PendingSyncs::default();
             let voter_context = DelayedSyncContext {
-                inner: context.child("actor"),
+                inner: context.child("voter"),
                 pending: pending_syncs.clone(),
             };
             let propose_requests = Arc::new(Mutex::new(Vec::new()));
             let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
-                &context,
-                voter_context,
+                &voter_context,
                 &oracle,
                 &participants,
                 &schemes,
@@ -3156,7 +3147,6 @@ mod tests {
             let propose_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3262,7 +3252,6 @@ mod tests {
 
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3389,7 +3378,6 @@ mod tests {
 
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3569,7 +3557,6 @@ mod tests {
             let elector = L::default();
             let (mut mailbox, mut batcher_receiver, _, _, reporter) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -3665,7 +3652,6 @@ mod tests {
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, reporter) =
                 setup_voter(
                     &context,
-                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -3774,7 +3760,6 @@ mod tests {
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, _reporter) =
                 setup_voter(
                     &context,
-                    context.child("actor"),
                     &oracle,
                     &participants,
                     &schemes,
@@ -4656,7 +4641,6 @@ mod tests {
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, _, relay, reporter) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -4752,7 +4736,6 @@ mod tests {
 
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7219,7 +7202,6 @@ mod tests {
             let verify_requests = Arc::new(Mutex::new(Vec::new()));
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7495,7 +7477,6 @@ mod tests {
                     .await;
             let (mut mailbox, mut batcher_receiver, mut resolver_receiver, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7610,7 +7591,6 @@ mod tests {
                 .build(&participants.clone().try_into().unwrap());
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7730,7 +7710,6 @@ mod tests {
                 .build(&participants.clone().try_into().unwrap());
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -7883,7 +7862,6 @@ mod tests {
                 .build(&participants.clone().try_into().unwrap());
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8027,7 +8005,6 @@ mod tests {
             // Set up voter with Certifier::Cancel
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8164,7 +8141,6 @@ mod tests {
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8579,7 +8555,6 @@ mod tests {
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8780,7 +8755,6 @@ mod tests {
             // This simulates coding marshal's deferred_verify finding context mismatch
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -8919,7 +8893,6 @@ mod tests {
             // Set up voter with Certifier::Pending (certify hangs indefinitely).
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9072,7 +9045,6 @@ mod tests {
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9218,7 +9190,6 @@ mod tests {
             let elector = RoundRobin::<Sha256>::default();
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9351,7 +9322,6 @@ mod tests {
 
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,
@@ -9504,7 +9474,6 @@ mod tests {
 
             let (mut mailbox, mut batcher_receiver, _, relay, reporter) = setup_voter(
                 &context,
-                context.child("actor"),
                 &oracle,
                 &participants,
                 &schemes,

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -2965,6 +2965,107 @@ mod tests {
         });
     }
 
+    /// Regression: the next view's proposal request dispatches before the
+    /// current iteration's journal sync and vote broadcast, so the automaton
+    /// builds the next block during that work. Constructing the notarize for
+    /// view 1 advances the optimistic frontier, so the view 2 request must go
+    /// out before the view 1 notarize is broadcast.
+    #[test_collect_traces]
+    fn test_next_propose_dispatches_before_broadcast(traces: TraceStorage) {
+        let n = 5;
+        let namespace = b"next_propose_dispatches_before_broadcast".to_vec();
+        let epoch = Epoch::new(333);
+        let term_length = TermLength::new(NZU32!(5));
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+
+            let oracle = start_test_network_with_peers(
+                context.child("network"),
+                participants.clone(),
+                true,
+            )
+            .await;
+
+            let elector = RoundRobin::<Sha256>::default().with_term(
+                term_length,
+                Duration::from_secs(30),
+                ViewDelta::new(2),
+            );
+            let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let local_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
+
+            let (_mailbox, mut batcher_receiver, _, _relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    local_index,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            // Wait for the optimistic view-2 notarize: by then the voter has
+            // requested the view-2 proposal and broadcast the view-1 notarize.
+            loop {
+                select! {
+                    msg = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                            && notarize.view() == View::new(2)
+                        {
+                            break;
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(8)) => {
+                        panic!("expected optimistic notarize for view 2");
+                    }
+                }
+            }
+
+            // Both events log at DEBUG from the voter task, so their order in
+            // the trace is the voter's execution order.
+            let events = traces.get_by_level(Level::DEBUG);
+            let propose_next = events
+                .iter()
+                .position(|event| {
+                    event.metadata.content == "requested proposal from automaton"
+                        && event
+                            .expect_span_at_index(0, |span| {
+                                span.expect_content_exact("simplex.voter.propose")?;
+                                span.expect_field_exact("view", "2")
+                            })
+                            .is_ok()
+                })
+                .expect("view 2 proposal must be requested");
+            let broadcast = events
+                .iter()
+                .position(|event| {
+                    event.metadata.content == "broadcasting notarize"
+                        && event
+                            .expect_span_at_index(0, |span| {
+                                span.expect_content_exact("simplex.voter.notify")?;
+                                span.expect_field_exact("view", "1")
+                            })
+                            .is_ok()
+                })
+                .expect("view 1 notarize must be broadcast");
+            assert!(
+                propose_next < broadcast,
+                "view 2 propose request must dispatch before the view 1 notarize broadcast \
+                 (propose at {propose_next}, broadcast at {broadcast})"
+            );
+        });
+    }
+
     /// Regression: same-term optimistic future verification may run after a
     /// local parent notarize, without waiting for parent certification.
     #[test_traced]


### PR DESCRIPTION
Closes #4352.

Port of #4354 (closed) to the voter loop that landed with #3416.

The dispatch sits between construction and the journal sync in `on_end`. Constructing the notarize advances the optimistic frontier, which makes the next view eligible, so an earlier dispatch point never fires on the stable-leader pipeline. The dispatch covers both application requests. While the voter syncs its journal and broadcasts, the next leader builds its block and every other validator verifies a buffered optimistic child.

Safety follows from existing guards. `pending_propose` and `pending_verify` block a second request while one is in flight. State one-shots construction per view. The `on_start` staleness drop uses `view < current`, so an optimistic future-view request survives. The result is only consumed on a later iteration.

Trace-based regression tests pin the order: the view 2 propose and verify requests must precede the view 1 notarize broadcast. The prior version of this change (#4354) was silently reverted by a loop rewrite; the tests fail if the dispatch is dropped.

Measurements are in #4354: ~2.7ms median proposal slack (from ~1.6ms consumed before dispatch) and past-deadline proposals ~15-19% -> ~10% at `TARGET_BLOCK_INTERVAL_MS = 5`.

## Testing

- `just test -p commonware-consensus` (1,353 passed)
- `just clippy -p commonware-consensus`
- `just check-fmt`
