### PR TITLE
[storage] Simplify trait bounds

### DIFF
--- a/storage/src/archive/immutable/storage.rs
+++ b/storage/src/archive/immutable/storage.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use commonware_codec::{CodecShared, EncodeSize, FixedSize, Read, ReadExt, Write};
 use commonware_runtime::{
-    Buf, BufMut, BufferPooler,
+    Buf, BufMut,
     telemetry::metrics::{Counter, MetricsExt as _},
 };
 use commonware_utils::{Array, bitmap::BitMap, sequence::prefixed_u64::U64};
@@ -86,7 +86,7 @@ impl EncodeSize for Record {
 }
 
 /// The archive's state, boxed so the public [Archive] handle stays pointer-sized.
-struct Inner<E: BufferPooler + Context, K: Array, V: CodecShared> {
+struct Inner<E: Context, K: Array, V: CodecShared> {
     /// Number of items per section.
     items_per_section: u64,
 
@@ -105,7 +105,7 @@ struct Inner<E: BufferPooler + Context, K: Array, V: CodecShared> {
     syncs: Counter,
 }
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> Inner<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
     /// See [Archive::init].
     async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         // Initialize metadata
@@ -232,7 +232,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Inner<E, K, V> {
     }
 }
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> Inner<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
     /// See [crate::archive::Archive::put].
     async fn put(mut self: Box<Self>, index: u64, key: K, data: V) -> Result<Box<Self>, Error> {
         // Ignore duplicates
@@ -361,9 +361,9 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Inner<E, K, V> {
 ///
 /// Mutating functions consume the archive and return it only on success: an error (or a
 /// dropped future) destroys the handle.
-pub struct Archive<E: BufferPooler + Context, K: Array, V: CodecShared>(Box<Inner<E, K, V>>);
+pub struct Archive<E: Context, K: Array, V: CodecShared>(Box<Inner<E, K, V>>);
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> std::fmt::Debug for Archive<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> std::fmt::Debug for Archive<E, K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Archive")
             .field("first_index", &self.0.first_index())
@@ -372,16 +372,14 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> std::fmt::Debug for Ar
     }
 }
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> Archive<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> Archive<E, K, V> {
     /// Initialize a new [Archive] with the given [Config].
     pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         Ok(Self(Box::new(Inner::init(context, cfg).await?)))
     }
 }
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> crate::archive::Archive
-    for Archive<E, K, V>
-{
+impl<E: Context, K: Array, V: CodecShared> crate::archive::Archive for Archive<E, K, V> {
     type Key = K;
     type Value = V;
 

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -1,5 +1,6 @@
 use super::{Config, Translator};
 use crate::{
+    Context,
     archive::{Error, Identifier},
     index::{Unordered, unordered::Index},
     journal::segmented::oversized::{
@@ -9,7 +10,7 @@ use crate::{
 };
 use commonware_codec::{CodecShared, FixedSize, Read, ReadExt, Write};
 use commonware_runtime::{
-    Buf, BufMut, BufferPooler, Handle, Metrics, Storage,
+    Buf, BufMut, Handle,
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
 };
 use commonware_utils::Array;
@@ -100,7 +101,7 @@ where
 }
 
 /// The archive's state, boxed so the public [Archive] handle stays pointer-sized.
-struct Inner<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared> {
+struct Inner<T: Translator, E: Context, K: Array, V: CodecShared> {
     items_per_section: u64,
 
     /// Combined index + value storage with crash recovery.
@@ -147,9 +148,7 @@ struct Inner<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: Co
     syncs: Counter,
 }
 
-impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared>
-    Inner<T, E, K, V>
-{
+impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
     /// Calculate the section for a given index.
     const fn section(&self, index: u64) -> u64 {
         (index / self.items_per_section) * self.items_per_section
@@ -585,13 +584,9 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
 /// Mutating functions consume the archive and return it only on success: an error (or a
 /// dropped future) destroys the handle. Puts below the prune floor are satisfied without
 /// storing (see [crate::archive::Archive]).
-pub struct Archive<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared>(
-    Box<Inner<T, E, K, V>>,
-);
+pub struct Archive<T: Translator, E: Context, K: Array, V: CodecShared>(Box<Inner<T, E, K, V>>);
 
-impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared> std::fmt::Debug
-    for Archive<T, E, K, V>
-{
+impl<T: Translator, E: Context, K: Array, V: CodecShared> std::fmt::Debug for Archive<T, E, K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Archive")
             .field("first_index", &self.0.first_index())
@@ -600,9 +595,7 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
     }
 }
 
-impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared>
-    Archive<T, E, K, V>
-{
+impl<T: Translator, E: Context, K: Array, V: CodecShared> Archive<T, E, K, V> {
     /// Initialize a new `Archive` instance.
     ///
     /// The in-memory index for `Archive` is populated during this call
@@ -622,8 +615,8 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
     }
 }
 
-impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared>
-    crate::archive::Archive for Archive<T, E, K, V>
+impl<T: Translator, E: Context, K: Array, V: CodecShared> crate::archive::Archive
+    for Archive<T, E, K, V>
 {
     type Key = K;
     type Value = V;
@@ -706,8 +699,8 @@ impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShare
     }
 }
 
-impl<T: Translator, E: BufferPooler + Storage + Metrics, K: Array, V: CodecShared>
-    crate::archive::MultiArchive for Archive<T, E, K, V>
+impl<T: Translator, E: Context, K: Array, V: CodecShared> crate::archive::MultiArchive
+    for Archive<T, E, K, V>
 {
     async fn get_all(&self, index: u64) -> Result<Option<Vec<V>>, Error> {
         self.0.get_all(index).await

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -395,7 +395,7 @@ where
 }
 
 /// The freezer's state, boxed so the public [Freezer] handle stays pointer-sized.
-struct Inner<E: BufferPooler + Context, K: Array, V: CodecShared> {
+struct Inner<E: Context, K: Array, V: CodecShared> {
     // Context for storage operations
     context: E,
 
@@ -433,7 +433,7 @@ struct Inner<E: BufferPooler + Context, K: Array, V: CodecShared> {
     resizes: Counter,
 }
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> Inner<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
     /// Calculate the byte offset for a table index.
     #[inline]
     const fn table_offset(table_index: u32) -> u64 {
@@ -1137,9 +1137,9 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> Inner<E, K, V> {
 ///
 /// Mutating functions consume the freezer and return it only on success: an error (or a dropped
 /// future) destroys the handle.
-pub struct Freezer<E: BufferPooler + Context, K: Array, V: CodecShared>(Box<Inner<E, K, V>>);
+pub struct Freezer<E: Context, K: Array, V: CodecShared>(Box<Inner<E, K, V>>);
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> std::fmt::Debug for Freezer<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> std::fmt::Debug for Freezer<E, K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Freezer")
             .field("current_section", &self.0.current_section)
@@ -1148,7 +1148,7 @@ impl<E: BufferPooler + Context, K: Array, V: CodecShared> std::fmt::Debug for Fr
     }
 }
 
-impl<E: BufferPooler + Context, K: Array, V: CodecShared> Freezer<E, K, V> {
+impl<E: Context, K: Array, V: CodecShared> Freezer<E, K, V> {
     /// Initialize a [Freezer] instance, aligning existing data to a [Checkpoint] when provided.
     ///
     /// Passing `None` or an empty [Checkpoint] deletes any existing freezer data and starts empty.

--- a/storage/src/index/mod.rs
+++ b/storage/src/index/mod.rs
@@ -205,7 +205,7 @@ pub trait Factory<T: Translator>: Unordered + Sized {
 
 /// A trait defining the additional operations provided by a memory-efficient index that allows
 /// ordered traversal of the indexed keys.
-pub trait Ordered: Unordered + Send + Sync {
+pub trait Ordered: Unordered {
     // Returns an iterator over all values associated with a translated key that lexicographically
     // precedes the result of translating `key`. The implementation will cycle around to the last
     // translated key if `key` is less than or equal to the first translated key. The returned
@@ -1550,7 +1550,7 @@ mod tests {
 
     fn run_index_cursor_across_threads<I>(index: Arc<Mutex<I>>)
     where
-        I: Unordered<Value = u64> + Send + 'static,
+        I: Unordered<Value = u64> + 'static,
     {
         // Insert some initial data
         {

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -177,9 +177,7 @@ pub trait Contiguous: Send + Sync {
     fn read_many(
         &self,
         positions: &[u64],
-    ) -> impl Future<Output = Result<Vec<Self::Item>, Error>> + Send
-    where
-        Self::Item: Send;
+    ) -> impl Future<Output = Result<Vec<Self::Item>, Error>> + Send;
 
     /// Read an item if it can be done synchronously (e.g. without I/O), returning `None`
     /// otherwise. Decode failures surface as `None` and the async read path reports the error.

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -27,10 +27,10 @@
 //! 5. Decode value
 
 use super::manager::{Config as ManagerConfig, Manager, WriteFactory};
-use crate::journal::Error;
+use crate::{Context, journal::Error};
 use commonware_codec::{Codec, CodecShared, FixedSize};
 use commonware_cryptography::{Crc32, crc32};
-use commonware_runtime::{BufMut, BufferPooler, Error as RError, Handle, Metrics, Storage};
+use commonware_runtime::{BufMut, Error as RError, Handle};
 use std::{io::Cursor, num::NonZeroUsize};
 use zstd::{bulk::compress, decode_all};
 
@@ -51,7 +51,7 @@ pub struct Config<C> {
 }
 
 /// The glob's state, boxed so the public [Glob] handle stays pointer-sized.
-struct Inner<E: BufferPooler + Storage + Metrics, V: Codec> {
+struct Inner<E: Context, V: Codec> {
     manager: Manager<E, WriteFactory>,
 
     /// Compression level (if enabled).
@@ -61,7 +61,7 @@ struct Inner<E: BufferPooler + Storage + Metrics, V: Codec> {
     codec_config: V::Cfg,
 }
 
-impl<E: BufferPooler + Storage + Metrics, V: CodecShared> Inner<E, V> {
+impl<E: Context, V: CodecShared> Inner<E, V> {
     /// See [Glob::init].
     async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         let manager_cfg = ManagerConfig {
@@ -258,9 +258,9 @@ impl<E: BufferPooler + Storage + Metrics, V: CodecShared> Inner<E, V> {
 /// future) destroys the handle. Mutations on pruned sections fail with
 /// [Error::AlreadyPrunedToSection] without mutating. Check [Glob::pruned] first to keep the
 /// handle.
-pub struct Glob<E: BufferPooler + Storage + Metrics, V: Codec>(Box<Inner<E, V>>);
+pub struct Glob<E: Context, V: Codec>(Box<Inner<E, V>>);
 
-impl<E: BufferPooler + Storage + Metrics, V: CodecShared> std::fmt::Debug for Glob<E, V> {
+impl<E: Context, V: CodecShared> std::fmt::Debug for Glob<E, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Glob")
             .field("oldest_section", &self.oldest_section())
@@ -269,7 +269,7 @@ impl<E: BufferPooler + Storage + Metrics, V: CodecShared> std::fmt::Debug for Gl
     }
 }
 
-impl<E: BufferPooler + Storage + Metrics, V: CodecShared> Glob<E, V> {
+impl<E: Context, V: CodecShared> Glob<E, V> {
     /// Initialize blob storage, opening existing section blobs.
     pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
         Ok(Self(Box::new(Inner::init(context, cfg).await?)))

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -56,9 +56,9 @@ use super::{
     fixed::{Config as FixedConfig, Journal as FixedJournal, Replay as FixedReplay},
     glob::{Config as GlobConfig, Glob},
 };
-use crate::journal::Error;
+use crate::{Context, journal::Error};
 use commonware_codec::{Codec, CodecFixed, CodecShared};
-use commonware_runtime::{BufferPooler, Error as RError, Handle, Metrics, Storage};
+use commonware_runtime::{Error as RError, Handle};
 use futures::future::try_join;
 use std::{collections::HashSet, num::NonZeroUsize};
 use tracing::{debug, warn};
@@ -112,14 +112,12 @@ pub struct Config<C> {
 /// reader, which returns it via [Replay::finish] once exhausted. Mutations on pruned sections
 /// fail with [Error::AlreadyPrunedToSection]. Check [Oversized::pruned] first to keep the
 /// handle.
-pub struct Oversized<E: BufferPooler + Storage + Metrics, I: Record, V: Codec> {
+pub struct Oversized<E: Context, I: Record, V: Codec> {
     index: FixedJournal<E, I>,
     values: Glob<E, V>,
 }
 
-impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShared> std::fmt::Debug
-    for Oversized<E, I, V>
-{
+impl<E: Context, I: Record + Send + Sync, V: CodecShared> std::fmt::Debug for Oversized<E, I, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Oversized")
             .field("oldest_section", &self.oldest_section())
@@ -128,9 +126,7 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
     }
 }
 
-impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShared>
-    Oversized<E, I, V>
-{
+impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Initialize with crash recovery.
     ///
     /// `checkpoint` is the durable state recovery restores, as `(section, index size)`.
@@ -670,12 +666,12 @@ impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShare
 /// Yields `(section, position, entry)` in order. Dropping the reader before it is exhausted
 /// destroys the journal: recovery is re-initialization. Call [Replay::finish] on an exhausted
 /// reader to get the journal back.
-pub struct Replay<E: BufferPooler + Storage + Metrics, I: Record, V: Codec> {
+pub struct Replay<E: Context, I: Record, V: Codec> {
     index: FixedReplay<E, I>,
     values: Glob<E, V>,
 }
 
-impl<E: BufferPooler + Storage + Metrics, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
+impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
     /// Returns the next `(section, position, entry)`, or `None` once every section is
     /// exhausted.
     ///
@@ -704,7 +700,7 @@ mod tests {
     use commonware_cryptography::Crc32;
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        Blob as _, Buf, BufMut, BufferPooler, Runner, Supervisor as _, WriteOptions,
+        Blob as _, Buf, BufMut, BufferPooler, Runner, Storage as _, Supervisor as _, WriteOptions,
         buffer::paged::CacheRef, deterministic, mocks::SyncFaultContext,
     };
     use commonware_utils::{NZU16, NZUsize};

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -4,7 +4,7 @@ use commonware_codec::{CodecFixed, FixedSize, Read, ReadExt, Write as CodecWrite
 use commonware_cryptography::{Crc32, crc32};
 use commonware_formatting::hex;
 use commonware_runtime::{
-    Blob, Buf, BufMut, BufferPooler, Error as RError, WriteOptions,
+    Blob, Buf, BufMut, Error as RError, WriteOptions,
     buffer::{Read as ReadBuffer, Write},
     telemetry::metrics::{Counter, MetricsExt as _},
 };
@@ -80,7 +80,7 @@ where
 }
 
 /// The store's state, boxed so the public [Ordinal] handle stays pointer-sized.
-struct Inner<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> {
+struct Inner<E: Context, V: CodecFixed<Cfg = ()>> {
     // Configuration and context
     context: E,
     config: Config,
@@ -104,7 +104,7 @@ struct Inner<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> {
     _phantom: PhantomData<V>,
 }
 
-impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
+impl<E: Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
     /// See [Ordinal::init].
     async fn init(
         context: E,
@@ -459,9 +459,9 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
 ///
 /// Mutating functions consume the store and return it only on success: an error (or a dropped
 /// future) destroys the handle.
-pub struct Ordinal<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>>(Box<Inner<E, V>>);
+pub struct Ordinal<E: Context, V: CodecFixed<Cfg = ()>>(Box<Inner<E, V>>);
 
-impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> std::fmt::Debug for Ordinal<E, V> {
+impl<E: Context, V: CodecFixed<Cfg = ()>> std::fmt::Debug for Ordinal<E, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Ordinal")
             .field("first_index", &self.0.intervals.first_index())
@@ -470,7 +470,7 @@ impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> std::fmt::Debug for Ord
     }
 }
 
-impl<E: BufferPooler + Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
+impl<E: Context, V: CodecFixed<Cfg = ()>> Ordinal<E, V> {
     /// Initialize a new [Ordinal] instance with a collection of [BitMap]s (indicating which
     /// records should be considered available).
     ///

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2683,10 +2683,10 @@ impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: update::Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -2718,10 +2718,10 @@ impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: update::Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: update::Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -2867,13 +2867,14 @@ where
     }
 }
 
-impl<F: Family, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
+impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
+    F: Family,
     E: Context,
-    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: update::Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -23,7 +23,7 @@ use crate::{
     },
 };
 use ahash::{AHashMap, AHashSet};
-use commonware_codec::{Codec, CodecShared};
+use commonware_codec::Codec;
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_utils::bitmap;
@@ -49,7 +49,7 @@ type CandidateChunk<'a, F, U> = (&'a [Location<F>], &'a [Operation<F, U>]);
 /// floor and that source, so a staged merkleize reads it before its serial bookkeeping
 /// runs. `finish` drains this buffer, then resumes the live scan at `next_scan`, producing
 /// exactly the sequence the live scan alone would have.
-pub(crate) struct PrefetchedCandidates<F: Family, U: update::Update + Send + Sync>
+pub(crate) struct PrefetchedCandidates<F: Family, U: update::Update>
 where
     Operation<F, U>: Codec,
 {
@@ -199,10 +199,7 @@ fn merge_sorted_diffs<K: Ord, F: Family, V>(
 }
 
 /// Where this batch's inherited state comes from.
-enum Base<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy>
-where
-    Operation<F, U>: Send + Sync,
-{
+enum Base<F: Family, D: Digest, U: update::Update, S: Strategy> {
     /// Created from the DB via `db.new_batch()`.
     Db {
         state: Commitment<F, D>,
@@ -213,10 +210,7 @@ where
     Child(Arc<MerkleizedBatch<F, D, U, S>>),
 }
 
-impl<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy> Base<F, D, U, S>
-where
-    Operation<F, U>: Send + Sync,
-{
+impl<F: Family, D: Digest, U: update::Update, S: Strategy> Base<F, D, U, S> {
     /// The [Commitment] for the state off which this batch was created.
     fn base_state(&self) -> Commitment<F, D> {
         match self {
@@ -268,7 +262,7 @@ where
 /// parameter, so the batch is lifetime-free and can be stored independently of the DB.
 pub struct UnmerkleizedBatch<F: Family, H, U, S: Strategy>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -301,7 +295,7 @@ type StagedResolution<F, U> = Option<(StagedLoc<F>, <U as update::Update>::Cache
 /// different batch.
 pub struct Staged<F: Family, H, U, S: Strategy>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -341,10 +335,7 @@ where
 /// with [`crate::qmdb::Error::StaleBatch`] (see [`crate::qmdb::batch_chain`] for more details).
 #[allow(clippy::type_complexity)]
 #[derive(Clone)]
-pub struct MerkleizedBatch<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy>
-where
-    Operation<F, U>: Send + Sync,
-{
+pub struct MerkleizedBatch<F: Family, D: Digest, U: update::Update, S: Strategy> {
     /// Merkleized authenticated journal batch (provides the speculative Merkle root).
     pub(crate) journal_batch: Arc<authenticated::MerkleizedBatch<F, D, Operation<F, U>, S>>,
 
@@ -383,7 +374,7 @@ type AncestorBatch<F, D, U, S> = Arc<MerkleizedBatch<F, D, U, S>>;
 /// threading.
 struct Merkleizer<F: Family, H, U, S: Strategy>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -396,13 +387,10 @@ where
 }
 
 /// Look up a key in the ancestor chain (immediate parent first).
-fn resolve_in_ancestors<'a, F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy>(
+fn resolve_in_ancestors<'a, F: Family, D: Digest, U: update::Update, S: Strategy>(
     ancestors: &'a [Arc<MerkleizedBatch<F, D, U, S>>],
     key: &U::Key,
-) -> Option<&'a DiffEntry<F, U::Value>>
-where
-    Operation<F, U>: Send + Sync,
-{
+) -> Option<&'a DiffEntry<F, U::Value>> {
     for batch in ancestors {
         if let Some(entry) = lookup_sorted(batch.diff.as_slice(), key) {
             return Some(entry);
@@ -697,14 +685,11 @@ fn fill_candidates<F: Family, const N: usize>(
 /// Panics if `loc` cannot be located in the chain: either it falls outside the region (including
 /// when `ancestors` is empty), or the ancestor spans are non-contiguous (a bookkeeping invariant
 /// violation).
-fn read_op_from_ancestors<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy>(
+fn read_op_from_ancestors<F: Family, D: Digest, U: update::Update, S: Strategy>(
     ancestors: &[Arc<MerkleizedBatch<F, D, U, S>>],
     loc: u64,
     db_size: u64,
-) -> &Operation<F, U>
-where
-    Operation<F, U>: Send + Sync,
-{
+) -> &Operation<F, U> {
     // ancestors is ordered parent-first: [parent, grandparent, ...].
     // Each batch's items span [next_batch.size(), this_batch.size()).
     // The last ancestor's base is db_size (committed DB boundary).
@@ -744,7 +729,7 @@ where
 /// In-memory locations are resolved synchronously; only disk locations await the `reader`.
 impl<F: Family, H, U, S: Strategy> Merkleizer<F, H, U, S>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -856,7 +841,7 @@ where
     where
         E: Context,
         C: Contiguous<Item = Operation<F, U>>,
-        Operation<F, U>: CodecShared,
+        Operation<F, U>: Codec,
     {
         if self.all_committed_ascending(locations) {
             let positions: Vec<u64> = locations.iter().map(|loc| **loc).collect();
@@ -1311,7 +1296,7 @@ where
 
 impl<F: Family, H, U, S: Strategy> UnmerkleizedBatch<F, H, U, S>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -1349,7 +1334,7 @@ where
 
 impl<F: Family, H, U, S: Strategy> Staged<F, H, U, S>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -1709,7 +1694,7 @@ where
 // Generic get() for both ordered and unordered UnmerkleizedBatch.
 impl<F: Family, H, U, S: Strategy> UnmerkleizedBatch<F, H, U, S>
 where
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -2573,10 +2558,7 @@ where
     }
 }
 
-impl<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy> MerkleizedBatch<F, D, U, S>
-where
-    Operation<F, U>: Send + Sync,
-{
+impl<F: Family, D: Digest, U: update::Update, S: Strategy> MerkleizedBatch<F, D, U, S> {
     /// Return the speculative root.
     pub const fn root(&self) -> D {
         self.bounds.tip.root
@@ -2599,7 +2581,7 @@ where
     }
 }
 
-impl<F: Family, D: Digest, U: update::Update + Send + Sync, S: Strategy> MerkleizedBatch<F, D, U, S>
+impl<F: Family, D: Digest, U: update::Update, S: Strategy> MerkleizedBatch<F, D, U, S>
 where
     Operation<F, U>: Codec,
 {
@@ -2701,7 +2683,7 @@ impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
@@ -2736,7 +2718,7 @@ impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: update::Update + Send + Sync + 'static,
+    U: update::Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
@@ -2888,7 +2870,7 @@ where
 impl<F: Family, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     E: Context,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
@@ -3004,8 +2986,8 @@ mod trait_impls {
         }
     }
 
-    impl<F: Family, D: Digest, U: update::Update + Send + Sync + 'static, S: Strategy>
-        MerkleizedBatchTrait for Arc<MerkleizedBatch<F, D, U, S>>
+    impl<F: Family, D: Digest, U: update::Update, S: Strategy> MerkleizedBatchTrait
+        for Arc<MerkleizedBatch<F, D, U, S>>
     where
         Operation<F, U>: Codec,
     {
@@ -3876,7 +3858,7 @@ mod tests {
     );
 
     /// Build a [`Staged`] handle with the keys and resolutions `stage`/`expand` would produce.
-    fn staged_with<F: Family, H: Hasher, U: update::Update + Send + Sync, S: Strategy>(
+    fn staged_with<F: Family, H: Hasher, U: update::Update, S: Strategy>(
         batch: UnmerkleizedBatch<F, H, U, S>,
         keys: Vec<U::Key>,
         resolutions: Vec<StagedResolution<F, U>>,

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -119,14 +119,14 @@ pub struct Db<
     pub(crate) _update: core::marker::PhantomData<U>,
 }
 
-impl<F, E, U, C, I, H, const N: usize, S> std::fmt::Debug for Db<F, E, C, I, H, U, N, S>
+impl<F, E, C, I, H, U, const N: usize, S> std::fmt::Debug for Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -139,14 +139,14 @@ where
 }
 
 // Shared read-only functionality.
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
+impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -405,15 +405,15 @@ where
     }
 }
 
-// Functionality requiring Mutable journal.
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
+// Functionality requiring a mutable journal.
+impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -704,20 +704,7 @@ where
 
         Ok(self)
     }
-}
 
-// Functionality requiring a mutable journal.
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
-where
-    F: Family,
-    E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
     /// Returns a [Db] initialized from `log`. `shared_bitmap = None` allocates a fresh bitmap;
     /// `Some(b)` adopts a pre-allocated bitmap (used by `current::Db`, which sizes pruned chunks
     /// from grafted metadata). `init_concurrency` is the index's snapshot-build concurrency

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -81,7 +81,7 @@ use crate::{
     },
     translator::Translator,
 };
-use commonware_codec::{CodecShared, Encode};
+use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
@@ -110,7 +110,7 @@ where
     F: Family,
     H: Hasher,
     U: Update,
-    Operation<F, U>: Encode,
+    Operation<F, U>: Codec,
 {
     single_operation_root::<F, H>(&Operation::<F, U>::CommitFloor(None, Location::new(0)))
 }
@@ -157,13 +157,13 @@ pub async fn init<F, E, U, H, T, I, J, S>(
 where
     F: Family,
     E: Context + Spawner,
-    U: Update + Send + Sync,
+    U: Update,
     H: Hasher,
     T: Translator,
     I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
     J: authenticated::Backing<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
-    Operation<F, U>: Committable + CodecShared,
+    Operation<F, U>: Codec,
 {
     init_with_bitmap::<F, E, U, H, T, I, J, S, BITMAP_CHUNK_BYTES>(context, cfg, None).await
 }
@@ -179,13 +179,13 @@ pub(crate) async fn init_with_bitmap<F, E, U, H, T, I, J, S, const N: usize>(
 where
     F: Family,
     E: Context + Spawner,
-    U: Update + Send + Sync,
+    U: Update,
     H: Hasher,
     T: Translator,
     I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
     J: authenticated::Backing<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
-    Operation<F, U>: Committable + CodecShared,
+    Operation<F, U>: Codec,
 {
     let mut log = authenticated::Journal::<F, E, J, H, S>::new(
         context.child("log"),

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -378,15 +378,15 @@ pub(crate) mod test {
         -> impl Future<Output = Result<Self, Error>> + Send;
     }
 
-    impl<E, U, C, I, H, const N: usize, S> RewindableDb for AnyDb<mmr::Family, E, C, I, H, U, N, S>
+    impl<E, C, I, H, U, const N: usize, S> RewindableDb for AnyDb<mmr::Family, E, C, I, H, U, N, S>
     where
         E: crate::Context,
-        U: UpdateTrait,
         C: Mutable<Item = AnyOperation<mmr::Family, U>>,
         I: UnorderedIndex<Value = Location>,
         H: Hasher,
-        AnyOperation<mmr::Family, U>: Codec,
+        U: UpdateTrait,
         S: Strategy,
+        AnyOperation<mmr::Family, U>: Codec,
     {
         async fn rewind_to_size(self, size: Location) -> Result<Self, Error> {
             self.rewind(size).await

--- a/storage/src/qmdb/any/sync/mod.rs
+++ b/storage/src/qmdb/any/sync/mod.rs
@@ -39,7 +39,7 @@ use crate::{
             },
         },
         metrics::Metrics,
-        operation::{Committable, Key},
+        operation::Key,
     },
     translator::Translator,
 };
@@ -70,13 +70,13 @@ async fn build_db<F, E, U, I, H, C, T, S>(
 where
     F: merkle::Family,
     E: Context + Spawner,
-    U: Update + Send + Sync + 'static,
+    U: Update,
     I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
     H: Hasher,
     T: Translator,
     C: Mutable<Item = Operation<F, U>> + 'static,
     S: Strategy,
-    Operation<F, U>: Codec + Committable + CodecShared,
+    Operation<F, U>: Codec,
 {
     let hasher = qmdb::hasher::<H>();
 

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -749,10 +749,10 @@ async fn compute_current_layer<F, E, U, C, I, H, const N: usize, S>(
 where
     F: Graftable,
     E: Context,
-    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: update::Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -1101,10 +1101,10 @@ impl<F, E, C, I, H, U, const N: usize, S> super::db::Db<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
     E: Context,
-    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: update::Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -244,7 +244,7 @@ impl<F: Graftable, D: Digest, S: Strategy> Readable for BatchOverMem<'_, F, D, S
 pub struct UnmerkleizedBatch<F, H, U, const N: usize, S: Strategy>
 where
     F: Graftable,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -262,7 +262,7 @@ where
 pub struct Staged<F, H, U, const N: usize, S: Strategy>
 where
     F: Graftable,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -305,14 +305,7 @@ where
 ///   are consistent.
 /// - Extending a batch after a different branch has been applied is not safe. Do not call `get`,
 ///   `new_batch`, or `apply_batch` on that branch again.
-pub struct MerkleizedBatch<
-    F: Graftable,
-    D: Digest,
-    U: update::Update + Send + Sync,
-    const N: usize,
-    S: Strategy,
-> where
-    Operation<F, U>: Send + Sync,
+pub struct MerkleizedBatch<F: Graftable, D: Digest, U: update::Update, const N: usize, S: Strategy>
 {
     /// Inner any-layer batch (ops MMR, diff, floor, commit loc, sizes).
     pub(crate) inner: Arc<any::batch::MerkleizedBatch<F, D, U, S>>,
@@ -330,7 +323,7 @@ pub struct MerkleizedBatch<
 impl<F, H, U, const N: usize, S: Strategy> UnmerkleizedBatch<F, H, U, N, S>
 where
     F: Graftable,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -424,7 +417,7 @@ where
 impl<F, H, U, const N: usize, S: Strategy> Staged<F, H, U, N, S>
 where
     F: Graftable,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     H: Hasher,
     Operation<F, U>: Codec,
 {
@@ -756,7 +749,7 @@ async fn compute_current_layer<F, E, U, C, I, H, const N: usize, S>(
 where
     F: Graftable,
     E: Context,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
@@ -1011,10 +1004,8 @@ impl<const N: usize> bitmap::Readable<N> for BitmapBatch<N> {
     }
 }
 
-impl<F: Graftable, D: Digest, U: update::Update + Send + Sync, const N: usize, S: Strategy>
+impl<F: Graftable, D: Digest, U: update::Update, const N: usize, S: Strategy>
     MerkleizedBatch<F, D, U, N, S>
-where
-    Operation<F, U>: Send + Sync,
 {
     /// Return the canonical root.
     pub const fn root(&self) -> D {
@@ -1045,7 +1036,7 @@ where
     }
 }
 
-impl<F: Graftable, D: Digest, U: update::Update + Send + Sync, const N: usize, S: Strategy>
+impl<F: Graftable, D: Digest, U: update::Update, const N: usize, S: Strategy>
     MerkleizedBatch<F, D, U, N, S>
 where
     Operation<F, U>: Codec,
@@ -1110,7 +1101,7 @@ impl<F, E, C, I, H, U, const N: usize, S> super::db::Db<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
     E: Context,
-    U: update::Update + Send + Sync,
+    U: update::Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
@@ -1214,13 +1205,8 @@ mod trait_impls {
         }
     }
 
-    impl<
-        F: Graftable,
-        D: Digest,
-        U: update::Update + Send + Sync + 'static,
-        const N: usize,
-        S: Strategy,
-    > MerkleizedBatchTrait for Arc<MerkleizedBatch<F, D, U, N, S>>
+    impl<F: Graftable, D: Digest, U: update::Update, const N: usize, S: Strategy>
+        MerkleizedBatchTrait for Arc<MerkleizedBatch<F, D, U, N, S>>
     where
         Operation<F, U>: Codec,
     {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -854,7 +854,7 @@ impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: merkle::Graftable,
     E: Context,
-    U: Update + 'static,
+    U: Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -173,10 +173,10 @@ impl<F, E, C, I, H, U, const N: usize, S> std::fmt::Debug for Db<F, E, C, I, H, 
 where
     F: merkle::Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -193,10 +193,10 @@ impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: merkle::Graftable,
     E: Context,
-    U: Update,
     C: Contiguous<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -248,20 +248,7 @@ where
     ) -> bool {
         proof.verify::<H, _, N>(start_loc, ops, chunks, root)
     }
-}
 
-// Functionality requiring non-mutable journal.
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
-where
-    F: merkle::Graftable,
-    E: Context,
-    U: Update,
-    C: Contiguous<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
     /// Returns a virtual [`crate::merkle::storage::Storage`] view over the grafted tree and ops
     /// tree.
     ///
@@ -409,15 +396,15 @@ where
     }
 }
 
-// Functionality requiring mutable journal.
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
+// Functionality requiring a mutable journal.
+impl<F, E, C, I, H, U, const N: usize, S> Db<F, E, C, I, H, U, N, S>
 where
     F: merkle::Graftable,
     E: Context,
-    U: Update,
     C: Mutable<Item = Operation<F, U>>,
     I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {
@@ -732,6 +719,93 @@ where
 
         Ok(self)
     }
+
+    /// Begin durably persisting the journal state published by prior [`Db::apply_batch`] calls.
+    ///
+    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
+    /// plus a best-effort attempt to bound the recovery needed on startup.
+    /// Bitmap metadata is not persisted by this call or by [Self::commit]. A new sync waits for
+    /// the prior sync before starting. Failures surface as described on
+    /// [`any::Db::start_sync`](crate::qmdb::any::db::Db::start_sync).
+    #[tracing::instrument(name = "qmdb.current.db.start_sync", level = "info", skip_all)]
+    #[boxed]
+    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
+        let (any, handle) = self.any.start_sync().await?;
+        self.any = any;
+        Ok((self, handle))
+    }
+
+    /// Durably commit the journal state published by prior [`Db::apply_batch`]
+    /// calls.
+    #[tracing::instrument(name = "qmdb.current.db.commit", level = "info", skip_all)]
+    #[boxed]
+    pub async fn commit(mut self) -> Result<Self, Error<F>> {
+        self.any = self.any.commit().await?;
+        Ok(self)
+    }
+
+    /// Sync all database state to disk.
+    #[tracing::instrument(name = "qmdb.current.db.sync", level = "info", skip_all)]
+    #[boxed]
+    pub async fn sync(mut self) -> Result<Self, Error<F>> {
+        let _timer = self.metrics.sync_timer();
+        self.metrics.sync_calls.inc();
+        self.any = self.any.sync().await?;
+
+        // Write the bitmap pruning boundary to disk so that next startup doesn't have to
+        // re-Merkleize the inactive portion up to the inactivity floor.
+        self = self.sync_metadata().await?;
+        self.update_metrics();
+        Ok(self)
+    }
+
+    /// Destroy the db, removing all data from disk.
+    #[boxed]
+    pub async fn destroy(self) -> Result<(), Error<F>> {
+        // Destructure before the await boundary to avoid stack growth from
+        // retaining the entire `self` in the future.
+        let Self { any, metadata, .. } = self;
+        metadata.destroy().await?;
+        any.destroy().await
+    }
+
+    /// Check that `batch` can be applied to the database in its current state, without
+    /// applying it.
+    ///
+    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
+    /// fails; callers that want to reject a bad batch and keep the handle can check first.
+    pub fn validate_batch(
+        &self,
+        batch: &super::batch::MerkleizedBatch<F, H::Digest, U, N, S>,
+    ) -> Result<(), Error<F>> {
+        self.any.validate_batch(&batch.inner)
+    }
+
+    /// Apply a batch to the database, returning the range of written operations.
+    ///
+    /// A batch is valid only if every batch applied to the database since this batch's
+    /// ancestor chain was created is an ancestor of this batch. Applying a batch from a
+    /// different fork returns [`Error::StaleBatch`] (see [`crate::qmdb::batch_chain`] for
+    /// more details).
+    ///
+    /// This publishes the batch to the in-memory Current view and appends it to the journal, but
+    /// does not durably persist it. Call [`Db::commit`] or [`Db::sync`], or await the handle
+    /// returned by [`Db::start_sync`], to guarantee durability.
+    #[tracing::instrument(name = "qmdb.current.db.apply_batch", level = "info", skip_all)]
+    #[boxed]
+    pub async fn apply_batch(
+        mut self,
+        batch: Arc<super::batch::MerkleizedBatch<F, H::Digest, U, N, S>>,
+    ) -> Result<(Self, Range<Location<F>>), Error<F>> {
+        let _timer = self.metrics.apply_batch_timer();
+        self.metrics.apply_batch_calls.inc();
+        let range;
+        (self.any, range) = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
+        Arc::make_mut(&mut self.grafted_tree).apply_batch(&batch.grafted)?;
+        self.root = batch.canonical_root;
+        self.update_metrics();
+        Ok((self, range))
+    }
 }
 
 /// Compute the safe sync boundary from the chunk-aligned inactivity floor and the current
@@ -786,118 +860,6 @@ fn pair_absorption_threshold<F: Graftable, const N: usize>(chunk_count: u64) -> 
     let pair_start = pair_chunk << grafting_height;
     let pair_pos = F::subtree_root_position(Location::<F>::new(pair_start), grafting_height + 1);
     Some(F::peak_birth_size(pair_pos, grafting_height + 1))
-}
-
-// Functionality requiring mutable + persistable journal.
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
-where
-    F: merkle::Graftable,
-    E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    /// Begin durably persisting the journal state published by prior [`Db::apply_batch`] calls.
-    ///
-    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
-    /// plus a best-effort attempt to bound the recovery needed on startup.
-    /// Bitmap metadata is not persisted by this call or by [Self::commit]. A new sync waits for
-    /// the prior sync before starting. Failures surface as described on
-    /// [`any::Db::start_sync`](crate::qmdb::any::db::Db::start_sync).
-    #[tracing::instrument(name = "qmdb.current.db.start_sync", level = "info", skip_all)]
-    #[boxed]
-    pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
-        let (any, handle) = self.any.start_sync().await?;
-        self.any = any;
-        Ok((self, handle))
-    }
-
-    /// Durably commit the journal state published by prior [`Db::apply_batch`]
-    /// calls.
-    #[tracing::instrument(name = "qmdb.current.db.commit", level = "info", skip_all)]
-    #[boxed]
-    pub async fn commit(mut self) -> Result<Self, Error<F>> {
-        self.any = self.any.commit().await?;
-        Ok(self)
-    }
-
-    /// Sync all database state to disk.
-    #[tracing::instrument(name = "qmdb.current.db.sync", level = "info", skip_all)]
-    #[boxed]
-    pub async fn sync(mut self) -> Result<Self, Error<F>> {
-        let _timer = self.metrics.sync_timer();
-        self.metrics.sync_calls.inc();
-        self.any = self.any.sync().await?;
-
-        // Write the bitmap pruning boundary to disk so that next startup doesn't have to
-        // re-Merkleize the inactive portion up to the inactivity floor.
-        self = self.sync_metadata().await?;
-        self.update_metrics();
-        Ok(self)
-    }
-
-    /// Destroy the db, removing all data from disk.
-    #[boxed]
-    pub async fn destroy(self) -> Result<(), Error<F>> {
-        // Destructure before the await boundary to avoid stack growth from
-        // retaining the entire `self` in the future.
-        let Self { any, metadata, .. } = self;
-        metadata.destroy().await?;
-        any.destroy().await
-    }
-}
-
-impl<F, E, U, C, I, H, const N: usize, S> Db<F, E, C, I, H, U, N, S>
-where
-    F: merkle::Graftable,
-    E: Context,
-    U: Update,
-    C: Mutable<Item = Operation<F, U>>,
-    I: UnorderedIndex<Value = Location<F>>,
-    H: Hasher,
-    S: Strategy,
-    Operation<F, U>: Codec,
-{
-    /// Check that `batch` can be applied to the database in its current state, without
-    /// applying it.
-    ///
-    /// [`Self::apply_batch`] runs the same validation but consumes the database when it
-    /// fails; callers that want to reject a bad batch and keep the handle can check first.
-    pub fn validate_batch(
-        &self,
-        batch: &super::batch::MerkleizedBatch<F, H::Digest, U, N, S>,
-    ) -> Result<(), Error<F>> {
-        self.any.validate_batch(&batch.inner)
-    }
-
-    /// Apply a batch to the database, returning the range of written operations.
-    ///
-    /// A batch is valid only if every batch applied to the database since this batch's
-    /// ancestor chain was created is an ancestor of this batch. Applying a batch from a
-    /// different fork returns [`Error::StaleBatch`] (see [`crate::qmdb::batch_chain`] for
-    /// more details).
-    ///
-    /// This publishes the batch to the in-memory Current view and appends it to the journal, but
-    /// does not durably persist it. Call [`Db::commit`] or [`Db::sync`], or await the handle
-    /// returned by [`Db::start_sync`], to guarantee durability.
-    #[tracing::instrument(name = "qmdb.current.db.apply_batch", level = "info", skip_all)]
-    #[boxed]
-    pub async fn apply_batch(
-        mut self,
-        batch: Arc<super::batch::MerkleizedBatch<F, H::Digest, U, N, S>>,
-    ) -> Result<(Self, Range<Location<F>>), Error<F>> {
-        let _timer = self.metrics.apply_batch_timer();
-        self.metrics.apply_batch_calls.inc();
-        let range;
-        (self.any, range) = self.any.apply_batch(Arc::clone(&batch.inner)).await?;
-        Arc::make_mut(&mut self.grafted_tree).apply_batch(&batch.grafted)?;
-        self.root = batch.canonical_root;
-        self.update_metrics();
-        Ok((self, range))
-    }
 }
 
 /// The bitmap's incomplete trailing chunk and the number of bits in it, or `None` if the bitmap

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -338,11 +338,10 @@ use crate::{
             operation::{Operation, Update},
         },
         bitmap::Shared,
-        operation::Committable,
     },
     translator::Translator,
 };
-use commonware_codec::{CodecShared, FixedSize};
+use commonware_codec::{Codec, FixedSize};
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
@@ -419,13 +418,13 @@ pub(super) async fn init<F, E, U, H, T, I, J, const N: usize, S>(
 where
     F: merkle::Graftable,
     E: Context + Spawner,
-    U: Update + Send + Sync,
+    U: Update,
     H: Hasher,
     T: Translator,
     I: IndexFactory<T, Value = Location<F>> + crate::qmdb::SnapshotBuild<F>,
     J: authenticated::Backing<E, Item = Operation<F, U>> + 'static,
     S: Strategy,
-    Operation<F, U>: Committable + CodecShared,
+    Operation<F, U>: Codec,
 {
     // TODO: Re-evaluate assertion placement after `generic_const_exprs` is stable.
     const {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -27,7 +27,7 @@
 
 use crate::{
     Context,
-    index::Factory as IndexFactory,
+    index::{Factory as IndexFactory, Unordered as UnorderedIndex},
     journal::{
         authenticated,
         contiguous::{Contiguous, Mutable, fixed, variable},
@@ -353,15 +353,15 @@ impl_current_sync_database!(
 
 /// A `current` database serves proofs from the `any` database it wraps. The sync engine
 /// operates on the ops root, which is `any`'s root.
-impl<F, E, U, C, I, H, const N: usize, S> crate::qmdb::sync::Source
+impl<F, E, C, I, H, U, const N: usize, S> crate::qmdb::sync::Source
     for db::Db<F, E, C, I, H, U, N, S>
 where
     F: Graftable,
     E: Context,
-    U: Update,
     C: Mutable<Item = Operation<F, U>>,
-    I: crate::index::Unordered<Value = Location<F>>,
+    I: UnorderedIndex<Value = Location<F>>,
     H: Hasher,
+    U: Update,
     S: Strategy,
     Operation<F, U>: Codec,
 {

--- a/storage/src/qmdb/current/sync/mod.rs
+++ b/storage/src/qmdb/current/sync/mod.rs
@@ -62,7 +62,7 @@ use crate::{
             },
         },
         metrics::Metrics as AnyMetrics,
-        operation::{Committable, Key},
+        operation::Key,
         sync::{Database, DatabaseConfig as Config, FeedbackTx, Request, Response},
     },
     translator::Translator,
@@ -111,13 +111,13 @@ async fn build_db<F, E, U, I, H, J, T, const N: usize, S>(
 where
     F: Graftable,
     E: Context + Spawner,
-    U: Update + Send + Sync + 'static,
+    U: Update,
     I: IndexFactory<T> + crate::qmdb::SnapshotBuild<F>,
     H: Hasher,
     T: Translator,
     J: Mutable<Item = Operation<F, U>> + 'static,
     S: Strategy,
-    Operation<F, U>: Codec + Committable + CodecShared,
+    Operation<F, U>: Codec,
 {
     // Build authenticated log.
     let merkle = Merkle::<F, _, _, S>::init_sync(
@@ -358,12 +358,12 @@ impl<F, E, U, C, I, H, const N: usize, S> crate::qmdb::sync::Source
 where
     F: Graftable,
     E: Context,
-    U: Update + Send + Sync + 'static,
-    C: Mutable<Item = Operation<F, U>> + Send + Sync,
-    I: crate::index::Unordered<Value = Location<F>> + Send + Sync,
+    U: Update,
+    C: Mutable<Item = Operation<F, U>>,
+    I: crate::index::Unordered<Value = Location<F>>,
     H: Hasher,
     S: Strategy,
-    Operation<F, U>: Codec + Send,
+    Operation<F, U>: Codec,
 {
     type Family = F;
     type Digest = H::Digest;

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -815,8 +815,7 @@ where
     C: Mutable<Item = Operation<F, K, V>>,
     C::Item: EncodeShared,
     H: Hasher,
-    T: Translator + Send + Sync,
-    T::Key: Send + Sync,
+    T: Translator,
     S: Strategy,
 {
     type Family = F;

--- a/storage/src/qmdb/store/mod.rs
+++ b/storage/src/qmdb/store/mod.rs
@@ -9,7 +9,7 @@ pub(crate) mod tests {
     use commonware_utils::Array;
     use core::fmt::Debug;
 
-    pub trait TestKey: Array + Copy + Send + Sync {
+    pub trait TestKey: Array + Copy {
         fn from_seed(seed: u64) -> Self;
     }
 

--- a/storage/src/qmdb/sync/source.rs
+++ b/storage/src/qmdb/sync/source.rs
@@ -542,15 +542,15 @@ where
     }
 }
 
-impl<F, E, U, C, I, H, const N: usize, S> Source
+impl<F, E, C, I, H, U, const N: usize, S> Source
     for crate::qmdb::any::db::Db<F, E, C, I, H, U, N, S>
 where
     F: Family,
     E: Context,
-    U: crate::qmdb::any::operation::update::Update,
     C: crate::journal::contiguous::Mutable<Item = crate::qmdb::any::operation::Operation<F, U>>,
     I: crate::index::Unordered<Value = Location<F>>,
     H: Hasher,
+    U: crate::qmdb::any::operation::update::Update,
     S: Strategy,
     crate::qmdb::any::operation::Operation<F, U>: commonware_codec::Codec,
 {

--- a/storage/src/qmdb/sync/source.rs
+++ b/storage/src/qmdb/sync/source.rs
@@ -549,7 +549,7 @@ where
     E: Context,
     U: crate::qmdb::any::operation::update::Update,
     C: crate::journal::contiguous::Mutable<Item = crate::qmdb::any::operation::Operation<F, U>>,
-    I: crate::index::Unordered<Value = Location<F>> + Send + Sync,
+    I: crate::index::Unordered<Value = Location<F>>,
     H: Hasher,
     S: Strategy,
     crate::qmdb::any::operation::Operation<F, U>: commonware_codec::Codec,


### PR DESCRIPTION
Deletes bound fragments already implied by supertraits:

- `U: Update + Send + Sync (+ 'static)` -> `U: Update` (x37). `Update` already declares `Clone + Send + Sync + 'static` as supertraits.
- `Operation<F, U>: Send + Sync` where-lines (x8). The enum is structurally `Send + Sync` given `U: Update` (`Key` and `Value` are `CodecShared`, `Family` is `Send + Sync`).
- `C: Mutable<..> + Send + Sync`, `I: Unordered<..> + Send + Sync`, and `T: Translator + Send + Sync` / `T::Key: Send + Sync`. All spelled in the traits' own definitions (`Mutable: Contiguous: Send + Sync`, `Unordered: Send + Sync`, `Translator` and its `Key` likewise).
- `Ordered: Unordered + Send + Sync` -> `Ordered: Unordered`.
- `where Self::Item: Send` on `Contiguous::read_many`. The associated type already declares `Send`.

Canonicalizes the codec bound to a single pattern, `Operation<F, U>: Codec`, replacing `Encode`, `CodecShared`, `Codec + Send`, and `Codec + Committable + CodecShared`. `Committable` is implemented unconditionally, and `CodecShared` follows from `Codec` via its blanket impl. The `Codec` bound itself is irreducible (the blanket `Write`/`Read` impls hang off `OperationCodec`, not a supertrait).

Also collapses the storage context bound to one pattern. `storage::Context` is an alias for `BufferPooler + Storage + Clock + Metrics`, yet the crate spelled that requirement three ways:

- `E: BufferPooler + Context` (ordinal, freezer, archive/immutable) becomes `E: Context`. The `BufferPooler` was redundant.
- `E: BufferPooler + Storage + Metrics` (segmented glob, segmented oversized, archive/prunable) becomes `E: Context`. Note this one technically widens the bounds by `Clock`.

Also tidies the `Db` impl surface now that the bounds are uniform:

- Merges impl blocks whose where-clauses became identical (`any/db.rs`, `current/db.rs`).
- Canonicalizes impl generic parameter order to the struct's declaration order (`F, E, C, I, H, U, N, S`) and orders where-clauses to match.

No behavior change.