### PR TITLE
[storage/archive, marshal] Serve finalized backfill off the marshal actor loop

### DIFF
--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -6,6 +6,7 @@ use super::{
     durability::{DispatchGate, Durable as _},
     floor::{Floor, State as FloorState},
     mailbox::{CommitmentFallback, Mailbox, Message},
+    serving,
     stream::Stream,
     subscriptions::{Key as SubscriptionKey, KeyFor as SubscriptionKeyFor, Subscriptions},
     variant::NoBuffer,
@@ -37,7 +38,7 @@ use commonware_resolver::{Delivery, Resolver, TargetedResolver};
 use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage, spawn_cell,
     telemetry::{
-        metrics::{Gauge, GaugeExt, MetricsExt as _},
+        metrics::{Gauge, GaugeExt, Histogram, HistogramExt as _, MetricsExt as _, histogram},
         traces::TracedExt as _,
     },
 };
@@ -157,6 +158,8 @@ where
     finalized_height: Gauge,
     // Latest processed height
     processed_height: Gauge,
+    // Time the actor loop spends answering produce requests inline
+    produce_serving: Histogram,
 }
 
 impl<E, V, P, FC, FB, ES, T, A> Actor<E, V, P, FC, FB, ES, T, A>
@@ -230,6 +233,11 @@ where
         // Create metrics
         let finalized_height = context.gauge("finalized_height", "Finalized height of application");
         let processed_height = context.gauge("processed_height", "Processed height of application");
+        let produce_serving = context.histogram(
+            "produce_serving_duration",
+            "Time the actor loop spends answering produce requests inline",
+            histogram::Buckets::LOCAL,
+        );
         if let Some(last_processed_height) = last_processed_height {
             let _ = processed_height.try_set(last_processed_height.get());
         }
@@ -269,6 +277,7 @@ where
                 finalized_blocks,
                 finalized_height,
                 processed_height,
+                produce_serving,
             },
             Mailbox::new(sender, config.max_pending_acks),
             floor,
@@ -379,6 +388,21 @@ where
     {
         // Create a local pool for waiter futures.
         let mut waiters = AbortablePool::<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>::default();
+
+        // Serve finalized backfill off the actor loop when both stores expose readers. Stores
+        // without readers, such as immutable archives, keep the inline path.
+        let serving = match (
+            self.finalizations_by_height.reader(),
+            self.finalized_blocks.reader(),
+        ) {
+            (Some(finalizations), Some(blocks)) => Some(serving::spawn::<_, V, _>(
+                self.context.child("serving"),
+                finalizations,
+                blocks,
+                self.max_repair,
+            )),
+            _ => None,
+        };
 
         // Observe durable syncs that no consensus caller awaits (the
         // notarization and finalization paths). A flush failure inside
@@ -533,6 +557,7 @@ where
                         &mut syncs,
                         &mut buffer,
                         &mut application,
+                        serving.as_ref(),
                     )
                     .await;
             },
@@ -937,6 +962,7 @@ where
 
     /// Handles a batch of resolver messages, starting one pooled
     /// finalized-archive sync if any accepted delivery buffered a write.
+    #[allow(clippy::too_many_arguments)]
     async fn handle_resolver_message<Buf, R>(
         mut self: Box<Self>,
         message: handler::Message<V::Commitment>,
@@ -945,6 +971,7 @@ where
         syncs: &mut Pool<PooledSync>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
+        serving: Option<&serving::Mailbox>,
     ) -> Box<Self>
     where
         Buf: Buffer<V, PublicKey = <P::Scheme as Verifier>::PublicKey>,
@@ -952,6 +979,7 @@ where
     {
         let mut handled = false;
         let mut produces = Vec::new();
+        let mut finalized = Vec::new();
         let mut delivers = Vec::new();
 
         // Drain up to max_repair resolver messages. Block deliveries are handled
@@ -967,9 +995,17 @@ where
             handled = true;
 
             match msg {
-                handler::Message::Produce { key, response } => {
-                    produces.push((key, response));
-                }
+                handler::Message::Produce { key, response } => match (key, serving.is_some()) {
+                    // Finalized keys read only the finalized stores, so the serving task answers
+                    // them off this loop. Held until the batch tail, like the inline produces, so
+                    // a height this batch finalized is published before the request reads.
+                    (Key::Finalized { height }, true) => {
+                        finalized.push((height, response));
+                    }
+                    (key, _) => {
+                        produces.push((key, response));
+                    }
+                },
                 handler::Message::Deliver {
                     delivery,
                     value,
@@ -1020,14 +1056,28 @@ where
         let round = self.floor.round();
         self = self.start_finalized_sync(round, syncs).await;
 
+        // Hand the finalized requests off now that this batch's writes are published.
+        if let Some(serving) = serving {
+            for (height, response) in finalized {
+                if !response.is_closed() {
+                    serving.forward(height, response);
+                }
+            }
+        }
+
         // Handle produce requests in parallel.
-        join_all(
-            produces
-                .into_iter()
-                .filter(|(_, response)| !response.is_closed())
-                .map(|(key, response)| self.handle_produce(key, response, buffer)),
-        )
-        .await;
+        if !produces.is_empty() {
+            let start = self.context.current();
+            join_all(
+                produces
+                    .into_iter()
+                    .filter(|(_, response)| !response.is_closed())
+                    .map(|(key, response)| self.handle_produce(key, response, buffer)),
+            )
+            .await;
+            self.produce_serving
+                .observe_between(start, self.context.current());
+        }
 
         self
     }
@@ -1057,7 +1107,7 @@ where
                     debug!(%height, "finalized block missing on request");
                     return;
                 };
-                response.send_lossy((finalization, V::into_inner(block)).encode());
+                response.send_lossy(serving::finalized_response::<V, _>(finalization, block));
             }
             Key::Notarized { round } => {
                 let Some(notarization) = self.cache.get_notarization(round).await else {

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod cache;
 mod delivery;
 pub(crate) mod durability;
 mod floor;
+mod serving;
 pub use floor::Floor;
 mod stream;
 

--- a/consensus/src/marshal/core/serving.rs
+++ b/consensus/src/marshal/core/serving.rs
@@ -1,0 +1,292 @@
+//! Serving finalized backfill requests off the marshal actor's critical path.
+//!
+//! When both finalized stores expose readers (see
+//! [Certificates::reader](crate::marshal::store::Certificates::reader)), the actor forwards
+//! `Key::Finalized` produce requests to a dedicated task, so serving disk reads never block
+//! consensus processing. They still share the executor and the disk with everything else.
+//!
+//! A request this task cannot answer is dropped, not answered: the channel closes, the peer sees a
+//! resolver error, and it retries. That covers a height either store has not published, a request
+//! arriving while the task is saturated, and a failed store read.
+//!
+//! Publishing follows the flush, not the fsync, so a height still awaiting its fsync is already
+//! readable and never misses. Retrying helps a height that is merely not published yet. A pruned
+//! height, or one gap repair stored without its own certificate, is gone for good and the peer must
+//! ask elsewhere -- as with the inline path.
+//!
+//! Publishing before the fsync means a served block is one a crash could lose. That is fine here:
+//! the block is finalized and the peer verifies its certificate, so the peer's copy stays valid
+//! whatever happens to our disk.
+
+use super::Variant;
+use crate::{marshal::store::Reader, simplex::types::Finalization, types::Height};
+use bytes::Bytes;
+use commonware_codec::Encode;
+use commonware_cryptography::certificate::Scheme;
+use commonware_macros::select;
+use commonware_runtime::{
+    Metrics, Spawner,
+    telemetry::{
+        metrics::{Counter, MetricsExt as _},
+        traces::TracedExt as _,
+    },
+};
+use commonware_utils::{
+    channel::{fallible::OneshotExt as _, mpsc, oneshot},
+    futures::Pool,
+};
+use std::{
+    num::NonZeroUsize,
+    sync::atomic::{AtomicBool, Ordering},
+};
+use tracing::{debug, warn};
+
+#[derive(Clone)]
+struct ServeMetrics {
+    /// Produce requests answered.
+    served: Counter,
+    /// Produce requests for a height either store lacks.
+    missing: Counter,
+    /// Produce requests dropped by a failed store read.
+    failed: Counter,
+}
+
+/// Encode a `Key::Finalized` response.
+pub(super) fn finalized_response<V: Variant, S: Scheme>(
+    finalization: Finalization<S, V::Commitment>,
+    block: V::Block,
+) -> Bytes {
+    (finalization, V::into_inner(block)).encode()
+}
+
+/// Forwards produce requests to the serving task.
+pub(super) struct Mailbox {
+    sender: mpsc::Sender<(Height, oneshot::Sender<Bytes>)>,
+    /// Requests forwarded to the serving task.
+    forwarded: Counter,
+    /// Requests dropped because the serving task was saturated (the peer retries).
+    dropped: Counter,
+    /// Set once the missing task has been logged, so a permanent failure warns once per node
+    /// rather than once per request.
+    warned_gone: AtomicBool,
+}
+
+impl Mailbox {
+    /// Forward a `Key::Finalized` produce request, dropping it when the serving task cannot take
+    /// it.
+    pub fn forward(&self, height: Height, response: oneshot::Sender<Bytes>) {
+        match self.sender.try_send((height, response)) {
+            Ok(()) => {
+                self.forwarded.inc();
+            }
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.dropped.inc();
+            }
+            // A closed channel means the task is gone.
+            // Warn on the first one: the rest add nothing, and `dropped` keeps counting.
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.dropped.inc();
+                if !self.warned_gone.swap(true, Ordering::Relaxed) {
+                    warn!("serving task is gone, dropping all finalized backfill");
+                }
+            }
+        }
+    }
+}
+
+/// Spawn a serving task over the given readers. At most `concurrency` requests are
+/// served at once and at most `concurrency` more may queue.
+///
+/// The task exits when the returned [Mailbox] is dropped.
+pub(super) fn spawn<E, V, S>(
+    context: E,
+    finalizations: Reader<Finalization<S, V::Commitment>>,
+    blocks: Reader<V::StoredBlock>,
+    concurrency: NonZeroUsize,
+) -> Mailbox
+where
+    E: Spawner + Metrics,
+    V: Variant,
+    S: Scheme,
+{
+    let (sender, receiver) = mpsc::channel(concurrency.get());
+    let mailbox = Mailbox {
+        sender,
+        forwarded: context.counter(
+            "forwarded",
+            "Produce requests forwarded to the serving task",
+        ),
+        dropped: context.counter(
+            "dropped",
+            "Produce requests the serving task could not accept",
+        ),
+        warned_gone: AtomicBool::new(false),
+    };
+    let metrics = ServeMetrics {
+        served: context.counter("served", "Produce requests answered"),
+        missing: context.counter(
+            "missing",
+            "Produce requests for a height either store lacks",
+        ),
+        failed: context.counter("failed", "Produce requests dropped by a failed store read"),
+    };
+    context.spawn(move |_| run::<V, S>(receiver, finalizations, blocks, concurrency, metrics));
+    mailbox
+}
+
+/// Serve forwarded requests until the mailbox closes, at most `concurrency` at a time.
+async fn run<V, S>(
+    mut receiver: mpsc::Receiver<(Height, oneshot::Sender<Bytes>)>,
+    finalizations: Reader<Finalization<S, V::Commitment>>,
+    blocks: Reader<V::StoredBlock>,
+    concurrency: NonZeroUsize,
+    metrics: ServeMetrics,
+) where
+    V: Variant,
+    S: Scheme,
+{
+    let mut inflight = Pool::default();
+    loop {
+        // Wait for capacity before taking the next request.
+        while inflight.len() >= concurrency.get() {
+            inflight.next_completed().await;
+        }
+        select! {
+            request = receiver.recv() => {
+                let Some((height, response)) = request else {
+                    break;
+                };
+                inflight.push(serve::<V, S>(
+                    finalizations.clone(),
+                    blocks.clone(),
+                    height,
+                    response,
+                    metrics.clone(),
+                ));
+            },
+            _ = inflight.next_completed() => {},
+        }
+    }
+    while !inflight.is_empty() {
+        inflight.next_completed().await;
+    }
+}
+
+/// Answer one `Key::Finalized` request. Any miss or failure drops the response, which the
+/// requester sees as a retryable error.
+///
+/// Unlike the actor's inline path, a store read failure is survivable here, so it is logged and
+/// counted. That keeps persistent corruption visible as `failed` instead of hiding in `missing`.
+#[tracing::instrument(name = "marshal.serving.finalized", level = "debug", skip_all, fields(height = height.traced()))]
+async fn serve<V, S>(
+    finalizations: Reader<Finalization<S, V::Commitment>>,
+    blocks: Reader<V::StoredBlock>,
+    height: Height,
+    response: oneshot::Sender<Bytes>,
+    metrics: ServeMetrics,
+) where
+    V: Variant,
+    S: Scheme,
+{
+    // The requester may have moved on while this request queued.
+    if response.is_closed() {
+        return;
+    }
+    let finalization = match finalizations.get(height).await {
+        Ok(Some(finalization)) => finalization,
+        Ok(None) => {
+            metrics.missing.inc();
+            debug!(%height, "finalization missing on serve");
+            return;
+        }
+        Err(err) => {
+            metrics.failed.inc();
+            warn!(%height, ?err, "failed to read finalization");
+            return;
+        }
+    };
+    // The requester may have disconnected during the certificate read.
+    if response.is_closed() {
+        return;
+    }
+    let block = match blocks.get(height).await {
+        Ok(Some(stored)) => stored.into(),
+        Ok(None) => {
+            metrics.missing.inc();
+            debug!(%height, "finalized block missing on serve");
+            return;
+        }
+        Err(err) => {
+            metrics.failed.inc();
+            warn!(%height, ?err, "failed to read block");
+            return;
+        }
+    };
+    if response.send_lossy(finalized_response::<V, _>(finalization, block)) {
+        metrics.served.inc();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_macros::test_traced;
+    use commonware_runtime::{Runner, deterministic, telemetry::metrics::has_metric_value};
+    use commonware_utils::NZUsize;
+
+    /// A mailbox over a channel of `capacity`, with its receiver so the test controls closure.
+    #[allow(clippy::type_complexity)]
+    fn mailbox(
+        context: &deterministic::Context,
+        capacity: usize,
+    ) -> (Mailbox, mpsc::Receiver<(Height, oneshot::Sender<Bytes>)>) {
+        let (sender, receiver) = mpsc::channel(capacity);
+        let mailbox = Mailbox {
+            sender,
+            forwarded: context.counter("forwarded", "forwarded"),
+            dropped: context.counter("dropped", "dropped"),
+            warned_gone: AtomicBool::new(false),
+        };
+        (mailbox, receiver)
+    }
+
+    #[test_traced("ERROR")]
+    fn test_forward_drops_when_saturated() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (mailbox, _receiver) = mailbox(&context, NZUsize!(1).get());
+
+            // The first request fits the channel; the second has nowhere to go, and the peer sees
+            // a closed response rather than a hang.
+            let (accepted, accepted_rx) = oneshot::channel();
+            mailbox.forward(Height::new(1), accepted);
+            let (refused, refused_rx) = oneshot::channel();
+            mailbox.forward(Height::new(2), refused);
+            assert!(refused_rx.await.is_err());
+            drop(accepted_rx);
+
+            let encoded = context.encode();
+            assert!(has_metric_value(&encoded, "forwarded_total", 1));
+            assert!(has_metric_value(&encoded, "dropped_total", 1));
+        });
+    }
+
+    #[test_traced("ERROR")]
+    fn test_forward_drops_when_the_serving_task_is_gone() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (mailbox, receiver) = mailbox(&context, NZUsize!(1).get());
+
+            // Losing the receiver stands in for the task exiting. Every later request is dropped,
+            // which must be counted rather than passing silently.
+            drop(receiver);
+            let (response, response_rx) = oneshot::channel();
+            mailbox.forward(Height::new(1), response);
+            assert!(response_rx.await.is_err());
+
+            let encoded = context.encode();
+            assert!(has_metric_value(&encoded, "forwarded_total", 0));
+            assert!(has_metric_value(&encoded, "dropped_total", 1));
+        });
+    }
+}

--- a/consensus/src/marshal/mod.rs
+++ b/consensus/src/marshal/mod.rs
@@ -40,6 +40,14 @@
 //! knowledge of finalized blocks, it will request the missing blocks from its peers. This ensures
 //! that the actor can catch up to the rest of the network if it falls behind.
 //!
+//! Serving a peer's request for a finalized block runs off the actor loop when both finalized
+//! stores expose a reader (see [`store::Certificates::reader`]), so those disk reads no longer
+//! block consensus processing, though they still share the executor and the disk. A reader serves
+//! what the store last published, and a batch publishes before its finalized requests are
+//! forwarded, so a height finalized in the same batch is served rather than missed. A height whose
+//! store has not published yet misses and the peer retries. Stores without a reader, such as
+//! immutable archives, answer inline as before.
+//!
 //! ## Storage
 //!
 //! The actor uses a combination of internal and external ([`store::Certificates`], [`store::Blocks`]) storage

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -93,7 +93,7 @@ mod tests {
     use commonware_resolver::{Consumer, Delivery, Fetch, Resolver, TargetedResolver};
     use commonware_runtime::{
         Clock, Metrics, Quota, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef,
-        deterministic,
+        deterministic, telemetry::metrics::has_metric_value,
     };
     use commonware_storage::{
         archive::{Archive as _, immutable, prunable},
@@ -4525,6 +4525,100 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_standard_finalized_produce_served_off_the_actor_loop() {
+        const PACE: Duration = Duration::from_millis(100);
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let config = Config {
+                provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                mailbox_size: NZUsize!(100),
+                view_retention: ViewDelta::new(10),
+                max_repair: NZUsize!(10),
+                max_pending_acks: NZUsize!(1),
+                block_codec_config: (),
+                partition_prefix: "finalized-produce-server".to_string(),
+                prunable_items_per_section: NZU64!(10),
+                replay_buffer: NZUsize!(1024),
+                key_write_buffer: NZUsize!(1024),
+                value_write_buffer: NZUsize!(1024),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                strategy: Sequential,
+            };
+
+            // Prunable stores expose readers, so the actor spawns the serving task. Their syncs
+            // are paced, which is what separates "stored" from "readable" below.
+            let (finalizations_by_height, finalized_blocks) =
+                paced_finalized_stores(&context, "finalized-produce-server", PACE).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                config,
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::default();
+            let _actor_handle =
+                actor.start_unbuffered(application.clone(), (resolver_rx, resolver.clone()));
+            wait_until(
+                &context,
+                Duration::from_secs(1),
+                "genesis dispatched",
+                || application.blocks().contains_key(&Height::zero()),
+            )
+            .await;
+
+            // A produce for a height that was never stored is dropped, and the peer retries.
+            let (response, missing_rx) = oneshot::channel();
+            resolver.enqueue(handler::Message::Produce {
+                key: handler::Key::Finalized {
+                    height: Height::new(9),
+                },
+                response,
+            });
+            assert!(missing_rx.await.is_err());
+
+            // Finalize a block, then ask for it. Publishing happens inside `start_sync`, so the
+            // height is readable before the paced handle resolves and the block reaches the
+            // application.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            assert!(mailbox.verified(round, block.clone()).await);
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization.clone()).await;
+            let (response, response_rx) = oneshot::channel();
+            resolver.enqueue(handler::Message::Produce {
+                key: handler::Key::Finalized {
+                    height: Height::new(1),
+                },
+                response,
+            });
+            let served = response_rx.await.expect("finalized height must be served");
+            assert_eq!(served, (finalization, block).encode());
+            assert!(
+                !application.blocks().contains_key(&Height::new(1)),
+                "served before the paced sync completed, so publishing did not wait for durability"
+            );
+
+            // Only the serving task keeps these counters, so they distinguish it from the actor
+            // answering inline.
+            let encoded = context.encode();
+            assert!(has_metric_value(&encoded, "forwarded_total", 2));
+            assert!(has_metric_value(&encoded, "served_total", 1));
+            assert!(has_metric_value(&encoded, "missing_total", 1));
+        });
+    }
+
+    #[test_traced("WARN")]
     fn test_standard_start_floor_applies_local_anchor_without_fetch() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
@@ -7103,6 +7197,10 @@ mod tests {
         fn last_index(&self) -> Option<Height> {
             self.inner.last_index()
         }
+
+        fn reader(&self) -> Option<crate::marshal::store::Reader<Self::Block>> {
+            self.inner.reader()
+        }
     }
 
     impl<T: crate::marshal::store::Certificates> crate::marshal::store::Certificates for PacedStore<T> {
@@ -7164,6 +7262,13 @@ mod tests {
 
         fn ranges_from(&self, from: Height) -> impl Iterator<Item = (Height, Height)> {
             self.inner.ranges_from(from)
+        }
+
+        fn reader(
+            &self,
+        ) -> Option<crate::marshal::store::Reader<Finalization<Self::Scheme, Self::Commitment>>>
+        {
+            self.inner.reader()
         }
     }
 

--- a/consensus/src/marshal/store.rs
+++ b/consensus/src/marshal/store.rs
@@ -1,13 +1,30 @@
 //! Interfaces for stores of finalized certificates and blocks.
 
 use crate::{Block, simplex::types::Finalization, types::Height};
+use commonware_codec::CodecShared;
 use commonware_cryptography::{Digest, Digestible, certificate::Scheme};
-use commonware_runtime::{BufferPooler, Clock, Handle, Metrics, Storage};
+use commonware_runtime::{Blob, BufferPooler, Clock, Handle, Metrics, Storage};
 use commonware_storage::{
     archive::{self, Archive, Identifier, immutable, prunable},
     translator::Translator,
 };
-use std::{error::Error, future::Future};
+use commonware_utils::BoxedError;
+use std::{error::Error, future::Future, pin::Pin, sync::Arc};
+
+/// A store's read half, shared by everything reading from it (see [HeightReader]).
+pub type Reader<T> = Arc<dyn HeightReader<Item = T>>;
+
+/// Future returned by [HeightReader::get].
+pub type Get<'a, T> = Pin<Box<dyn Future<Output = Result<Option<T>, BoxedError>> + Send + 'a>>;
+
+/// Reader of a [Certificates] or [Blocks] store.
+pub trait HeightReader: Send + Sync + 'static {
+    /// The type of item that is stored.
+    type Item;
+
+    /// Retrieve the item stored at `height` (see [Certificates::get] and [Blocks::get]).
+    fn get(&self, height: Height) -> Get<'_, Self::Item>;
+}
 
 /// Durable store for [Finalizations](Finalization) keyed by height and block digest.
 ///
@@ -109,6 +126,16 @@ pub trait Certificates: Send + Sync + Sized + 'static {
 
     /// Retrieve an iterator over ranges that overlap or follow `from`.
     fn ranges_from(&self, from: Height) -> impl Iterator<Item = (Height, Height)>;
+
+    /// A reader over the latest published state, or `None` when the implementation cannot serve
+    /// reads off the store's owner.
+    ///
+    /// Callers obtain a reader once and keep it while the store itself is consumed and replaced by
+    /// every mutation, so a reader must track its store's successors rather than snapshot the state
+    /// it was built from. It must observe later publishes and later prunes.
+    fn reader(&self) -> Option<Reader<Finalization<Self::Scheme, Self::Commitment>>> {
+        None
+    }
 }
 
 /// Durable store for finalized [Blocks](Block) keyed by height and block digest.
@@ -225,6 +252,16 @@ pub trait Blocks: Send + Sync + Sized + 'static {
     /// # Returns
     /// `Some(height)` if there are any stored blocks, or `None` if the store is empty.
     fn last_index(&self) -> Option<Height>;
+
+    /// A reader over the latest published state, or `None` when the implementation cannot serve
+    /// reads off the store's owner.
+    ///
+    /// Callers obtain a reader once and keep it while the store itself is consumed and replaced by
+    /// every mutation, so a reader must track its store's successors rather than snapshot the state
+    /// it was built from. It must observe later publishes and later prunes.
+    fn reader(&self) -> Option<Reader<Self::Block>> {
+        None
+    }
 }
 
 impl<E, B, C, S> Certificates for immutable::Archive<E, B, Finalization<S, C>>
@@ -331,6 +368,22 @@ where
     }
 }
 
+impl<B, V> HeightReader for prunable::Reader<B, V>
+where
+    B: Blob,
+    V: CodecShared + 'static,
+{
+    type Item = V;
+
+    fn get(&self, height: Height) -> Get<'_, Self::Item> {
+        Box::pin(async move {
+            Self::get(self, height.get())
+                .await
+                .map_err(BoxedError::from)
+        })
+    }
+}
+
 impl<T, E, B, C, S> Certificates for prunable::Archive<T, E, B, Finalization<S, C>>
 where
     T: Translator,
@@ -384,6 +437,10 @@ where
         <Self as Archive>::ranges_from(self, from.get())
             .map(|(s, e)| (Height::new(s), Height::new(e)))
     }
+
+    fn reader(&self) -> Option<Reader<Finalization<Self::Scheme, Self::Commitment>>> {
+        Some(Arc::new(Self::reader(self)))
+    }
 }
 
 impl<T, E, B> Blocks for prunable::Archive<T, E, B::Digest, B>
@@ -432,5 +489,9 @@ where
 
     fn last_index(&self) -> Option<Height> {
         <Self as Archive>::last_index(self).map(Height::new)
+    }
+
+    fn reader(&self) -> Option<Reader<Self::Block>> {
+        Some(Arc::new(Self::reader(self)))
     }
 }

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -909,6 +909,34 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_write_flush_puts_bytes_on_the_blob_but_leaves_them_undurable() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (blob, size) = context.open("partition", b"write_flush").await.unwrap();
+            let mut writer = Write::from_pooler(&context, blob.clone(), size, NZUsize!(8));
+            writer.write_at(0, b"hello").await.unwrap();
+
+            // A flush hands the bytes to the blob, so a handle on it sees them without a sync.
+            writer.flush().await.unwrap();
+            assert_eq!(writer.size(), 5);
+            let read = blob.read_at(0, 5).await.unwrap().freeze().coalesce();
+            assert_eq!(read.as_ref(), b"hello");
+
+            // They are not durable yet, so a fresh open of the same name still sees nothing.
+            let (_, size) = context.open("partition", b"write_flush").await.unwrap();
+            assert_eq!(size, 0);
+
+            // The writer stays dirty, so the sync it still owes is what makes them durable.
+            writer.sync().await.unwrap();
+            let (blob, size) = context.open("partition", b"write_flush").await.unwrap();
+            assert_eq!(size, 5);
+            let mut reader = Read::from_pooler(&context, blob, size, NZUsize!(8));
+            let read = reader.read(5).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), b"hello");
+        });
+    }
+
+    #[test_traced]
     fn test_write_multiple_flushes() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -95,6 +95,24 @@ impl<B: Blob> Write<B> {
         self.buffer.size()
     }
 
+    /// The underlying blob of this writer.
+    ///
+    /// Reading it skips the write buffer, so call [Self::flush] first to see all writes.
+    /// Mutating it while this [Write] exists causes undefined behavior.
+    pub const fn blob(&self) -> &B {
+        &self.blob
+    }
+
+    /// Write buffered bytes to the blob without syncing.
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        if let Some((buf, offset)) = self.buffer.take() {
+            self.sync_state
+                .write_at(&self.blob, offset, buf, WriteOptions::default())
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Read exactly `len` immutable bytes starting at `offset`.
     pub async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufs, Error> {
         // Ensure the read doesn't overflow.
@@ -240,12 +258,7 @@ impl<B: Blob> Write<B> {
     /// for the state flushed by this call. Later calls to [`Self::sync`] and writer methods that
     /// mutate the blob wait before issuing blob operations.
     pub async fn start_sync(&mut self) -> Handle<()> {
-        if let Some((buf, offset)) = self.buffer.take()
-            && let Err(err) = self
-                .sync_state
-                .write_at(&self.blob, offset, buf, WriteOptions::default())
-                .await
-        {
+        if let Err(err) = self.flush().await {
             return Handle::ready(Err(err));
         }
 

--- a/storage/fuzz/fuzz_targets/archive_operations.rs
+++ b/storage/fuzz/fuzz_targets/archive_operations.rs
@@ -30,9 +30,11 @@ enum ArchiveOperation {
     HasByKey(RawKey),
     Prune(u64),
     Sync,
+    StartSync,
     NextGap {
         start: u64,
     },
+    ReaderGet(u64),
 }
 
 #[derive(Arbitrary, Debug)]
@@ -65,6 +67,7 @@ fn fuzz(data: FuzzInput) {
         };
 
         let mut archive = Archive::<_, _, Key, Value>::init(context.child("storage"), cfg.clone()).await.expect("init failed");
+        let reader = archive.reader();
 
         // Keep a map of inserted items for verification
         let mut items = Vec::new();
@@ -74,6 +77,12 @@ fn fuzz(data: FuzzInput) {
 
         // Track written indices
         let mut written_indices = std::collections::HashSet::new();
+
+        // What readers see: everything the last sync covered, minus anything pruned since.
+        let mut published: Vec<(u64, RawKey, RawValue)> = Vec::new();
+
+        // Durability handles still in flight, awaited once every operation has run.
+        let mut pending_syncs = Vec::new();
 
         for op in &data.operations {
             match op {
@@ -195,24 +204,42 @@ fn fuzz(data: FuzzInput) {
                 ArchiveOperation::Prune(min) => {
                     let min = min - min % cfg.items_per_section.get();
                     archive = archive.prune(min).await.expect("prune failed");
-                    match oldest_allowed {
-                        None => {
-                            oldest_allowed = Some(min);
-                            items.retain(|(i, _, _)| *i >= min);
-                            written_indices.retain(|i| *i >= min);
-                        }
-                        Some(already_pruned) => {
-                            if min > already_pruned {
-                                oldest_allowed = Some(min);
-                                items.retain(|(i, _, _)| *i >= min);
-                                written_indices.retain(|i| *i >= min);
-                            }
-                        }
+                    if oldest_allowed.is_none_or(|already_pruned| min > already_pruned) {
+                        oldest_allowed = Some(min);
+                        items.retain(|(i, _, _)| *i >= min);
+                        written_indices.retain(|i| *i >= min);
+                        // A prune hides state at once, with no publish.
+                        published.retain(|(i, _, _)| *i >= min);
                     }
                 }
 
                 ArchiveOperation::Sync => {
                     archive = archive.sync().await.expect("sync failed");
+                    // A blocking sync publishes everything accepted so far.
+                    published = items.clone();
+                }
+
+                ArchiveOperation::StartSync => {
+                    let handle;
+                    (archive, handle) = archive.start_sync().await.expect("start_sync failed");
+                    // Publishing follows the flush, so readers see everything accepted before the
+                    // handle resolves. Hold the handle so later operations run while durability is
+                    // still pending, which is what makes this different from a blocking sync.
+                    published = items.clone();
+                    pending_syncs.push(handle);
+                }
+
+                ArchiveOperation::ReaderGet(index) => {
+                    let result = reader.get(*index).await.expect("reader get failed");
+                    let expected = published
+                        .iter()
+                        .find(|(i, _, _)| *i == *index)
+                        .map(|(_, _, value)| value);
+                    assert_eq!(
+                        result.as_ref().map(|value| value.as_ref()),
+                        expected.map(|value| value.as_slice()),
+                        "reader value mismatch for index {index}",
+                    );
                 }
 
                 ArchiveOperation::NextGap { start } => {
@@ -235,6 +262,11 @@ fn fuzz(data: FuzzInput) {
                         }
                 }
             }
+        }
+
+        // Every in-flight durability handle must resolve.
+        for handle in pending_syncs {
+            handle.await.expect("start_sync handle failed");
         }
 
         archive = archive.sync().await.expect("final sync failed");

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -39,6 +39,8 @@ pub enum Error {
     RecordCorrupted,
     #[error("record too large")]
     RecordTooLarge,
+    #[error("section holds too many records: {0}")]
+    SectionFull(u64),
 }
 
 /// A write-once key-value store addressed by both an index and a key.
@@ -1289,5 +1291,15 @@ mod tests {
         value: i32,
     ) {
         assert_archive_futures_are_send(archive, key, value);
+    }
+
+    #[allow(dead_code)]
+    fn assert_prunable_reader_futures_are_send(
+        archive: &prunable::Archive<TwoCap, Context, FixedBytes<64>, i32>,
+    ) {
+        fn assert_send_sync<T: Send + Sync>(_: &T) {}
+        let reader = archive.reader();
+        assert_send_sync(&reader);
+        assert_send(reader.get(1));
     }
 }

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -58,13 +58,20 @@
 //! _To avoid random memory reads in the common case, the in-memory index directly stores the first
 //! item in the linked list instead of a pointer to the first item._
 //!
-//! `index` is the key to the map used to serve lookups by `index` that stores the position in the
-//! index journal (selected by `section = index / items_per_section * items_per_section` to minimize
-//! the number of open blobs):
+//! Lookups by `index` go through a map keyed by `index` (selected by
+//! `section = index / items_per_section * items_per_section` to minimize the number of open
+//! blobs). Its value records where the item lives, so a lookup by index reads the value blob
+//! directly and never visits the index journal:
 //!
 //! ```text
-//! // Maps index -> position in index journal
-//! indices: BTreeMap<u64, u64>
+//! // Maps index -> where the item lives
+//! locations: BTreeMap<u64, Location>
+//!
+//! struct Location {
+//!     value_offset: u64,  // byte offset of the value's frame
+//!     position: u32,      // the record's position in its section, for key lookups
+//!     value_size: u32,    // byte length of that frame
+//! }
 //! ```
 //!
 //! _If the [Translator] provided by the caller does not uniformly distribute keys across the key
@@ -74,25 +81,26 @@
 //! ## Memory Overhead
 //!
 //! [Archive] uses two maps to enable lookups by both index and key. The memory used to track each
-//! index item is `8 + 8` (where `8` is the index and `8` is the position in the index journal).
-//! The memory used to track each key item is `~translated(key).len() + 16` bytes (where `16` is the
-//! size of the `Record` struct). This means that an [Archive] employing a [Translator] that uses
-//! the first `8` bytes of a key will use `~40` bytes to index each key.
+//! index item is `8 + 16` (where `8` is the index and `16` is a `Location`, whose fields are
+//! ordered to avoid padding). The memory used to track each key item is
+//! `~translated(key).len() + 16` bytes (where `16` is the size of the `Record` struct). This means
+//! that an [Archive] employing a [Translator] that uses the first `8` bytes of a key will use
+//! `~48` bytes to index each key.
 //!
 //! ### MultiArchive Overhead
 //!
-//! [Archive] stores index positions in a dual-map layout:
-//! - `indices: BTreeMap<u64, u64>` tracks the first position for each index.
-//! - `extra_indices: BTreeMap<u64, Vec<u64>>` tracks additional positions for indices written via
+//! [Archive] stores locations in a dual-map layout:
+//! - `locations: BTreeMap<u64, Location>` tracks the first item at each index.
+//! - `extras: BTreeMap<u64, Vec<Location>>` tracks additional items at indices written via
 //!   [crate::archive::MultiArchive::put_multi].
 //!
 //! This means the baseline overhead above remains unchanged for the first item at an index. For
 //! indices with duplicates, the additional in-memory payload is:
-//! - one `Vec<u64>` header (`24` bytes), and
-//! - `n * 8` bytes for `n` additional positions.
+//! - one `Vec<Location>` header (`24` bytes), and
+//! - `n * 16` bytes for `n` additional locations.
 //!
-//! Equivalently, this is `24 + (n * 8)` bytes per duplicated index, excluding `BTreeMap` node
-//! overhead for `extra_indices`.
+//! Equivalently, this is `24 + (n * 16)` bytes per duplicated index, excluding `BTreeMap` node
+//! overhead for `extras`.
 //!
 //! # Pruning
 //!
@@ -110,10 +118,14 @@
 //!
 //! # Read Path
 //!
-//! All reads (by index or key) first read the index entry from the index journal to get the
-//! value location (offset and size), then read the value from the value blob. The index journal
-//! uses a page cache for caching, so hot entries are served from memory. Values are read directly
-//! from disk without caching to avoid polluting the page cache with large values.
+//! A read by index takes the value's location from memory and reads the value blob once. A read
+//! by key must find which of its translated-key candidates actually holds the key, so it reads
+//! those candidates' index journal records first. The index journal uses a page cache, so hot
+//! records are served from memory. Values are read straight from disk, so large values never
+//! evict anything from that cache.
+//!
+//! A read by index never touches the index journal, so corruption there surfaces at init replay
+//! instead. Values carry their own checksum, which every read verifies.
 //!
 //! # Compression
 //!
@@ -126,6 +138,34 @@
 //!
 //! [Archive] tracks gaps in the index space to enable the caller to efficiently fetch unknown keys
 //! using `next_gap`. This is a very common pattern when syncing blocks in a blockchain.
+//!
+//! # Readers
+//!
+//! [Archive::reader] returns a cloneable [Reader] that serves reads by index from other tasks.
+//! Resolving a key needs the in-memory key index, which the writer keeps to itself.
+//!
+//! - A put is invisible to readers until a sync covers it. Both [crate::archive::Archive::sync]
+//!   and [crate::archive::Archive::start_sync] publish, because both flush before they return.
+//!   [crate::archive::Archive::start_sync] publishes without waiting for durability, so a reader
+//!   can serve a write that a crash would lose. [crate::archive::Archive::sync] publishes after
+//!   its fsync, so a value it covers stays invisible for that fsync's duration.
+//! - A read by index serves the first item stored there, so items added by
+//!   [crate::archive::MultiArchive::put_multi] are unreachable through a [Reader].
+//! - A prune takes effect immediately: it drops each index and its section together, so a reader
+//!   cannot find an entry whose section is gone. A read already under way finishes, because the
+//!   blob it holds outlives the name.
+//! - Each publish stores one blob handle per synced section. The `gets` counter counts writer
+//!   and reader traffic together.
+//!
+//! ## Concurrency
+//!
+//! The writer and its readers share one lock over the location map and the captures. Two rules
+//! keep contention low:
+//!
+//! - No I/O and no `.await` happens under a guard. Critical sections are map lookups and handle
+//!   clones, so neither side ever waits on the other's disk.
+//!
+//! Readers see no single point in time: two reads can observe different states.
 //!
 //! # Example
 //!
@@ -170,6 +210,8 @@ use crate::translator::Translator;
 use commonware_runtime::buffer::paged::CacheRef;
 use std::num::{NonZeroU64, NonZeroUsize};
 
+mod reader;
+pub use reader::Reader;
 mod storage;
 pub use storage::Archive;
 
@@ -223,8 +265,8 @@ mod tests {
     use commonware_codec::{DecodeExt, Error as CodecError};
     use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{
-        BufferPooler, Error as RError, Metrics as _, Runner, Spawner as _, Supervisor as _,
-        deterministic,
+        BufferPooler, Error as RError, Metrics as _, Runner, Spawner as _, Storage as _,
+        Supervisor as _, deterministic,
         mocks::{
             DelayedSyncContext, PendingSyncs, fail_pending_syncs, release_next_pending_syncs,
             release_pending_syncs,
@@ -1422,6 +1464,9 @@ mod tests {
             assert!(archive.has_at(1, &test_key("aaaa2")).await.unwrap());
             assert!(!archive.has_at(1, &test_key("bbbb")).await.unwrap());
 
+            // Replay also rebuilds where each of their values lives, not just its record.
+            assert_eq!(archive.get_all(1).await.unwrap(), Some(vec![10, 20]));
+
             // Pruned indices report absent
             let archive = archive.prune(2).await.unwrap();
             assert!(!archive.has_at(1, &test_key("aaaa1")).await.unwrap());
@@ -1563,5 +1608,366 @@ mod tests {
                 .expect("Failed to put_multi_sync below floor");
             assert_eq!(archive.get_all(2).await.expect("Failed to get data"), None);
         });
+    }
+
+    #[test_traced]
+    fn test_reader_lag_until_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            assert_eq!(reader.get(1).await.unwrap(), None);
+
+            // An unsynced put is visible to the writer but not to readers.
+            let archive = archive
+                .put(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to put");
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(10));
+            assert_eq!(reader.get(1).await.unwrap(), None);
+
+            // The sync publishes it.
+            let archive = archive.sync().await.expect("Failed to sync");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_start_sync_publishes_before_its_handle_completes() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = PendingSyncs::default();
+            let context = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+
+            // start_sync flushes before it returns, so the write is readable even though the
+            // sync itself has not completed.
+            let (archive, handle) = archive
+                .put_start_sync(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to start sync");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+
+            release_pending_syncs(&pending);
+            handle.await.expect("sync handle should complete");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_stops_serving_at_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // One item per section so pruning drops whole sections.
+            let cfg = test_config(&context, NZU64!(1));
+            let mut archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            for index in 1u64..=5 {
+                archive = archive
+                    .put(index, test_key(&format!("k{index}")), index as i32)
+                    .await
+                    .expect("Failed to put");
+            }
+            let archive = archive.sync().await.expect("Failed to sync");
+            assert_eq!(reader.get(1).await.unwrap(), Some(1));
+
+            // Pruning drops each index and its section together, so it takes effect at once
+            // rather than at the next sync.
+            let archive = archive.prune(4).await.expect("Failed to prune");
+            assert_eq!(reader.get(1).await.unwrap(), None);
+            assert_eq!(reader.get(4).await.unwrap(), Some(4));
+            assert_eq!(reader.get(5).await.unwrap(), Some(5));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_serves_after_destroy() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            let archive = archive
+                .put_sync(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to put_sync");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+
+            // Destroying unlinks the blobs but leaves the captured handles readable, so the
+            // reader keeps serving what it already had.
+            archive.destroy().await.expect("Failed to destroy");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+        });
+    }
+
+    #[test_traced]
+    fn test_init_tolerates_lost_value_blob() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            archive
+                .put_sync(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to put_sync");
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+
+            // Lose the value blob. Recovery rewinds the index and init must still succeed,
+            // since capturing for readers must not turn a warned-about state into a failure.
+            context
+                .remove(&cfg.value_partition, Some(&0u64.to_be_bytes()))
+                .await
+                .expect("Failed to remove value blob");
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .expect("init must tolerate a lost value blob");
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), None);
+            let reader = archive.reader();
+            assert_eq!(reader.get(1).await.unwrap(), None);
+
+            // Init left the archive usable, so a fresh write publishes normally. Without this the
+            // assertions above hold for an archive that recovered into a dead state.
+            let archive = archive
+                .put_sync(1, test_key("aaa"), 20)
+                .await
+                .expect("Failed to put_sync after recovery");
+            assert_eq!(reader.get(1).await.unwrap(), Some(20));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_ignores_writes_after_its_capture() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // One section holds everything, so the second put lands in a section the reader
+            // has already captured.
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            let archive = archive
+                .put_sync(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to put_sync");
+
+            // The writer keeps appending to the captured section. The new entry is in the shared
+            // map at once, so the capture's size is what hides it.
+            let archive = archive.put(2, test_key("bbb"), 20).await.unwrap();
+            assert_eq!(reader.get(2).await.unwrap(), None);
+
+            let archive = archive.sync().await.expect("Failed to sync");
+            assert_eq!(reader.get(2).await.unwrap(), Some(20));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_reads_values_buffered_until_the_capture() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // These values overrun the value write buffer many times over, so some sit in it
+            // unflushed before the sync. Every value a reader can see must be on the blob the
+            // capture holds.
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let mut archive = Archive::<_, _, FixedBytes<64>, FixedBytes<512>>::init(
+                context.child("storage"),
+                cfg,
+            )
+            .await
+            .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            let value = |index: u64| FixedBytes::<512>::new([index as u8; 512]);
+            for index in 0u64..16 {
+                archive = archive
+                    .put(index, test_key(&format!("k{index}")), value(index))
+                    .await
+                    .expect("Failed to put");
+            }
+            let mut archive = archive.sync().await.expect("Failed to sync");
+            for index in 0u64..16 {
+                assert_eq!(
+                    reader.get(index).await.unwrap(),
+                    Some(value(index)),
+                    "value {index} must be readable"
+                );
+            }
+
+            // Writes after the capture stay invisible, values included.
+            for index in 16u64..24 {
+                archive = archive
+                    .put(index, test_key(&format!("k{index}")), value(index))
+                    .await
+                    .expect("Failed to put");
+            }
+            for index in 16u64..24 {
+                assert_eq!(reader.get(index).await.unwrap(), None);
+            }
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_duplicate_put_keeps_earlier_entry_visible() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            let archive = archive
+                .put_multi_sync(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to put_multi_sync");
+
+            // A second entry at the same index goes to the extras, so the first stays put and
+            // the reader keeps returning it.
+            let archive = archive
+                .put_multi(1, test_key("bbb"), 20)
+                .await
+                .expect("Failed to put_multi");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+
+            let archive = archive.sync().await.expect("Failed to sync");
+            assert_eq!(reader.get(1).await.unwrap(), Some(10));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_serves_recovered_state_after_restart() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            // One item per section, so recovery has to key each capture by its own section.
+            let cfg = test_config(&context, NZU64!(1));
+            let mut archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            for index in 1u64..=3 {
+                archive = archive
+                    .put(index, test_key(&format!("k{index}")), index as i32)
+                    .await
+                    .expect("Failed to put");
+            }
+            archive.sync().await.expect("Failed to sync");
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let cfg = test_config(&context, NZU64!(1));
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .expect("Failed to reopen archive");
+
+            // Recovered state publishes at init, before any new sync.
+            let reader = archive.reader();
+            for index in 1u64..=3 {
+                assert_eq!(reader.get(index).await.unwrap(), Some(index as i32));
+            }
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_metrics_aggregate_with_writer() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let reader = archive.reader();
+            let archive = archive
+                .put_sync(1, test_key("aaa"), 10)
+                .await
+                .expect("Failed to put_sync");
+
+            archive.get(Identifier::Index(1)).await.unwrap();
+            reader.get(1).await.unwrap();
+            assert!(has_metric_value(&context.encode(), "gets_total", 2));
+
+            archive.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_reader_concurrent_with_writer_is_deterministic_slow_() {
+        fn run() -> String {
+            let executor = deterministic::Runner::default();
+            executor.start(|context| async move {
+                let cfg = test_config(&context, NZU64!(4));
+                let mut archive =
+                    Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
+                        .await
+                        .expect("Failed to initialize archive");
+                let reader = archive.reader();
+
+                // A concurrent task reads while the writer appends, syncs, and prunes. Every value
+                // it sees must be the one written there, and it must see at least one.
+                let poller = context.child("poller").spawn(move |_| async move {
+                    let mut seen = 0usize;
+                    for _ in 0..64 {
+                        for index in 0u64..32 {
+                            if let Some(value) = reader.get(index).await.expect("read must succeed")
+                            {
+                                assert_eq!(value, index as i32);
+                                seen += 1;
+                            }
+                        }
+                        commonware_runtime::reschedule().await;
+                    }
+                    assert!(seen > 0, "reader never observed a published value");
+                });
+
+                for index in 0u64..32 {
+                    archive = archive
+                        .put(index, test_key(&format!("k{index}")), index as i32)
+                        .await
+                        .expect("Failed to put");
+                    if index.is_multiple_of(3) {
+                        archive = archive.sync().await.expect("Failed to sync");
+                    }
+                    if index == 20 {
+                        archive = archive.prune(8).await.expect("Failed to prune");
+                    }
+                }
+                drop(archive);
+                poller.await.expect("poller failed");
+                context.auditor().state()
+            })
+        }
+
+        assert_eq!(run(), run());
     }
 }

--- a/storage/src/archive/prunable/reader.rs
+++ b/storage/src/archive/prunable/reader.rs
@@ -1,0 +1,159 @@
+//! Read half of the prunable archive.
+//!
+//! The writer keeps where each item lives, plus a handle on each section's value blob bounded by
+//! the bytes flushed when it was taken, in a [State] behind a lock. A read holds the lock long
+//! enough to copy one [Location] and clone one [Capture], then does its I/O with nothing held.
+//!
+//! Reads see what the last publish installed, so a put is invisible until then. Publishing follows
+//! the flush, not the fsync, so a reader can serve a value a crash would lose.
+
+use crate::{archive::Error, journal::segmented::glob::Capture};
+use commonware_codec::CodecShared;
+use commonware_runtime::{Blob, telemetry::metrics::Counter};
+use commonware_utils::sync::RwLock;
+use std::{collections::BTreeMap, sync::Arc};
+
+/// The section holding `index`.
+pub(super) const fn section(index: u64, items_per_section: u64) -> u64 {
+    (index / items_per_section) * items_per_section
+}
+
+/// Where one stored item lives.
+#[derive(Clone, Copy)]
+pub(super) struct Location {
+    /// Byte offset of the item's value frame in its section's value blob.
+    pub value_offset: u64,
+    /// The record's position within its section of the index journal. Only key lookups read it.
+    pub position: u32,
+    /// Byte length of the value frame, including the trailing checksum.
+    pub value_size: u32,
+}
+
+/// State the writer shares with its readers.
+pub(super) struct State<B: Blob, V: CodecShared> {
+    /// Where each index's first item lives.
+    pub locations: BTreeMap<u64, Location>,
+
+    /// Each section's value blob, bounded by the bytes flushed at the last publish.
+    pub captures: BTreeMap<u64, Capture<B, V>>,
+}
+
+/// A cloneable handle serving reads by index from the archive's last published state.
+pub struct Reader<B: Blob, V: CodecShared> {
+    state: Arc<RwLock<State<B, V>>>,
+    items_per_section: u64,
+    gets: Counter,
+}
+
+impl<B: Blob, V: CodecShared> Clone for Reader<B, V> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+            items_per_section: self.items_per_section,
+            gets: self.gets.clone(),
+        }
+    }
+}
+
+impl<B: Blob, V: CodecShared> Reader<B, V> {
+    pub(super) const fn new(
+        state: Arc<RwLock<State<B, V>>>,
+        items_per_section: u64,
+        gets: Counter,
+    ) -> Self {
+        Self {
+            state,
+            items_per_section,
+            gets,
+        }
+    }
+
+    /// Where `index` can be read, or `None` if it is absent, pruned, or not yet published.
+    fn locate(&self, index: u64) -> Option<(Capture<B, V>, Location)> {
+        let state = self.state.read();
+        let location = *state.locations.get(&index)?;
+        let capture = state
+            .captures
+            .get(&section(index, self.items_per_section))?;
+        capture
+            .covers(location.value_offset, location.value_size)
+            .then(|| (capture.clone(), location))
+    }
+
+    /// See [crate::archive::Archive::get] for [crate::archive::Identifier::Index].
+    ///
+    /// Returns `None` when the index is absent, pruned, or not yet published. A value that is
+    /// published but unreadable is an error, so corruption is not mistaken for absence.
+    pub async fn get(&self, index: u64) -> Result<Option<V>, Error> {
+        self.gets.inc();
+        let Some((capture, location)) = self.locate(index) else {
+            return Ok(None);
+        };
+        Ok(Some(
+            capture
+                .get(location.value_offset, location.value_size)
+                .await?,
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::journal::segmented::glob::{Config as GlobConfig, Glob};
+    use commonware_macros::test_traced;
+    use commonware_runtime::{
+        Runner, Supervisor as _, deterministic, telemetry::metrics::MetricsExt as _,
+    };
+    use commonware_utils::NZUsize;
+
+    /// A reader over one section holding one value frame at `(offset, size)`.
+    fn reader_over<B: Blob>(
+        capture: Capture<B, i32>,
+        offset: u64,
+        size: u32,
+        gets: Counter,
+    ) -> Reader<B, i32> {
+        let location = Location {
+            value_offset: offset,
+            position: 0,
+            value_size: size,
+        };
+        let state = State {
+            locations: BTreeMap::from([(0, location)]),
+            captures: BTreeMap::from([(0, capture)]),
+        };
+        Reader::new(Arc::new(RwLock::new(state)), 1, gets)
+    }
+
+    #[test_traced]
+    fn test_reader_reports_an_unreadable_value_as_an_error() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let glob = Glob::<_, i32>::init(
+                context.child("glob"),
+                GlobConfig {
+                    partition: "values".into(),
+                    compression: None,
+                    codec_config: (),
+                    write_buffer: NZUsize!(64),
+                },
+            )
+            .await
+            .expect("Failed to init glob");
+            let (glob, offset, size) = glob.append(0, &7).await.expect("Failed to append");
+            let (_, capture) = glob.capture_section(0).await.expect("Failed to capture");
+            let capture = capture.expect("section must exist");
+
+            // The frame reads back as written.
+            let gets = context.counter("gets", "gets");
+            let reader = reader_over(capture.clone(), offset, size, gets.clone());
+            assert_eq!(reader.get(0).await.unwrap(), Some(7));
+
+            // A location one byte into the frame stays inside the capture but fails its checksum.
+            // Corruption must not read as absence, or a peer would retry a hole forever.
+            let reader = reader_over(capture, offset + 1, size - 1, gets);
+            assert!(reader.get(0).await.is_err());
+        });
+    }
+}

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -1,4 +1,7 @@
-use super::{Config, Translator};
+use super::{
+    Config, Translator,
+    reader::{Location, Reader, State, section},
+};
 use crate::{
     Context,
     archive::{Error, Identifier},
@@ -13,8 +16,11 @@ use commonware_runtime::{
     Buf, BufMut, Handle,
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
 };
-use commonware_utils::Array;
-use std::collections::{BTreeMap, BTreeSet, btree_map};
+use commonware_utils::{Array, sync::RwLock};
+use std::{
+    collections::{BTreeMap, BTreeSet, btree_map},
+    sync::Arc,
+};
 use tracing::debug;
 
 /// Index entry for the archive.
@@ -126,17 +132,18 @@ struct Inner<T: Translator, E: Context, K: Array, V: CodecShared> {
     /// Oldest allowed section to read from. Updated when `prune` is called.
     oldest_allowed: Option<u64>,
 
-    /// Maps translated key representation to its corresponding index.
+    /// Maps translated key representation to its corresponding index. Not shared, since only
+    /// the writer resolves keys.
     keys: Index<T, u64>,
 
-    /// Maps index to its first position in the index journal.
-    indices: BTreeMap<u64, u64>,
+    /// Where each item lives, and the captures readers serve from (see [super::reader]).
+    state: Arc<RwLock<State<E::Blob, V>>>,
 
-    /// Additional positions for indices that have more than one entry.
-    /// Only populated when used via [crate::archive::MultiArchive::put_multi].
-    extra_indices: BTreeMap<u64, Vec<u64>>,
+    /// Later locations for indices holding more than one item, populated only by
+    /// [crate::archive::MultiArchive::put_multi]. Not shared, since readers serve the first.
+    extras: BTreeMap<u64, Vec<Location>>,
 
-    /// Interval tracking for gap detection.
+    /// Interval tracking for gap detection. Not shared, since readers do not query gaps.
     intervals: RMap,
 
     // Metrics
@@ -151,25 +158,7 @@ struct Inner<T: Translator, E: Context, K: Array, V: CodecShared> {
 impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
     /// Calculate the section for a given index.
     const fn section(&self, index: u64) -> u64 {
-        (index / self.items_per_section) * self.items_per_section
-    }
-
-    /// Returns true when `index` is below the prune floor.
-    const fn pruned(&self, index: u64) -> bool {
-        match self.oldest_allowed {
-            Some(oldest_allowed) => index < oldest_allowed,
-            None => false,
-        }
-    }
-
-    /// Iterate over all positions for a given index (first + extras).
-    fn iter_positions(&self, index: u64) -> impl Iterator<Item = u64> + '_ {
-        self.indices.get(&index).into_iter().copied().chain(
-            self.extra_indices
-                .get(&index)
-                .into_iter()
-                .flat_map(|v| v.iter().copied()),
-        )
+        section(index, self.items_per_section)
     }
 
     /// See [Archive::init].
@@ -188,35 +177,52 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
             Oversized::init(context.child("oversized"), oversized_cfg, None).await?;
 
         // Initialize keys and replay index journal (no values read!)
-        let mut indices: BTreeMap<u64, u64> = BTreeMap::new();
-        let mut extra_indices: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
+        let items_per_section = cfg.items_per_section.get();
+        let mut locations: BTreeMap<u64, Location> = BTreeMap::new();
+        let mut extras: BTreeMap<u64, Vec<Location>> = BTreeMap::new();
         let mut keys = Index::new(context.child("index"), cfg.translator.clone());
         let mut intervals = RMap::new();
-        let oversized = {
+        let mut oversized = {
             debug!("initializing archive from index journal");
             let mut replay = oversized.replay(0, 0, cfg.replay_buffer).await?;
             while let Some(result) = replay.next().await {
-                let (_section, position, entry) = result?;
+                let (_section, position, record) = result?;
 
-                // Store index location (position in index journal)
-                match indices.entry(entry.index) {
+                // Store where the item lives
+                let location = Location {
+                    value_offset: record.value_offset,
+                    position: u32::try_from(position).map_err(|_| Error::SectionFull(position))?,
+                    value_size: record.value_size,
+                };
+                match locations.entry(record.index) {
                     btree_map::Entry::Vacant(e) => {
-                        e.insert(position);
+                        e.insert(location);
                     }
                     btree_map::Entry::Occupied(_) => {
-                        extra_indices.entry(entry.index).or_default().push(position);
+                        extras.entry(record.index).or_default().push(location);
                     }
                 }
 
                 // Store index in keys
-                keys.insert(&entry.key, entry.index);
+                keys.insert(&record.key, record.index);
 
                 // Store index in intervals
-                intervals.insert(entry.index);
+                intervals.insert(record.index);
             }
             debug!("archive initialized");
             replay.finish()?
         };
+
+        // Capture the recovered sections so readers work immediately after restart. Repair can
+        // leave an index section whose values are gone, which captures as nothing.
+        let mut captures = BTreeMap::new();
+        for section in oversized.sections().collect::<Vec<_>>() {
+            let capture;
+            (oversized, capture) = oversized.capture_values(section).await?;
+            if let Some(capture) = capture {
+                captures.insert(section, capture);
+            }
+        }
 
         // Initialize metrics
         let items_tracked = context.gauge("items_tracked", "Number of items tracked");
@@ -228,19 +234,21 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         let gets = context.counter("gets", "Number of gets performed");
         let has = context.counter("has", "Number of has performed");
         let syncs = context.counter("syncs", "Number of syncs called");
-        let _ = items_tracked.try_set(indices.len());
+        let _ = items_tracked.try_set(locations.len());
 
-        // Return populated archive
         Ok(Self {
-            items_per_section: cfg.items_per_section.get(),
+            items_per_section,
             oversized,
             pending: BTreeSet::new(),
             requested: BTreeSet::new(),
             oldest_allowed: None,
-            indices,
-            extra_indices,
-            intervals,
             keys,
+            state: Arc::new(RwLock::new(State {
+                locations,
+                captures,
+            })),
+            extras,
+            intervals,
             items_tracked,
             indices_pruned,
             unnecessary_reads,
@@ -250,101 +258,26 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         })
     }
 
-    async fn get_index(&self, index: u64) -> Result<Option<V>, Error> {
-        // Update metrics
-        self.gets.inc();
-
-        // Get first position at this index
-        let position = match self.indices.get(&index) {
-            Some(&position) => position,
-            None => return Ok(None),
-        };
-
-        // Fetch index entry to get value location
-        let section = self.section(index);
-        let entry = self.oversized.get(section, position).await?;
-        let (value_offset, value_size) = entry.value_location();
-
-        // Fetch value directly from blob storage (bypasses page cache)
-        let value = self
-            .oversized
-            .get_value(section, value_offset, value_size)
-            .await?;
-        Ok(Some(value))
-    }
-
-    async fn get_key(&self, key: &K) -> Result<Option<V>, Error> {
-        // Update metrics
-        self.gets.inc();
-
-        // Fetch index
-        let iter = self.keys.get(key);
-        for index in iter {
-            // Continue if index is no longer allowed due to pruning.
-            if self.pruned(*index) {
-                continue;
-            }
-
-            // Get all positions at this index
-            if !self.indices.contains_key(index) {
-                return Err(Error::RecordCorrupted);
-            }
-            let section = self.section(*index);
-
-            for position in self.iter_positions(*index) {
-                // Fetch index entry from index journal to verify key
-                let entry = self.oversized.get(section, position).await?;
-
-                // Verify key matches
-                if entry.key.as_ref() == key.as_ref() {
-                    // Fetch value directly from blob storage (bypasses page cache)
-                    let (value_offset, value_size) = entry.value_location();
-                    let value = self
-                        .oversized
-                        .get_value(section, value_offset, value_size)
-                        .await?;
-                    return Ok(Some(value));
-                }
-                self.unnecessary_reads.inc();
-            }
-        }
-
-        Ok(None)
-    }
-
-    /// Check whether any retained index stores `key`.
+    /// Capture `sections` and publish them to readers.
     ///
-    /// Confirms translated-key candidates against index journal entries,
-    /// never reading values.
-    async fn has_key(&self, key: &K) -> Result<bool, Error> {
-        for index in self.keys.get(key) {
-            // Continue if index is no longer allowed due to pruning.
-            if self.pruned(*index) {
-                continue;
-            }
-
-            // Get all positions at this index
-            if !self.indices.contains_key(index) {
-                return Err(Error::RecordCorrupted);
-            }
-            let section = self.section(*index);
-
-            for position in self.iter_positions(*index) {
-                // Fetch index entry from index journal to verify key
-                let entry = self.oversized.get(section, position).await?;
-                if entry.key.as_ref() == key.as_ref() {
-                    return Ok(true);
-                }
-                self.unnecessary_reads.inc();
+    /// Captures are taken before the guard, so no read waits on I/O. Callers publish after
+    /// syncing, so each capture's flush has nothing to write.
+    async fn publish(
+        mut self: Box<Self>,
+        sections: impl IntoIterator<Item = u64>,
+    ) -> Result<Box<Self>, Error> {
+        let mut captured = Vec::new();
+        for section in sections {
+            // A section with writes to publish still has its value blob open, so never `None`.
+            let capture;
+            (self.oversized, capture) = self.oversized.capture_values(section).await?;
+            if let Some(capture) = capture {
+                captured.push((section, capture));
             }
         }
 
-        Ok(false)
-    }
-
-    fn has_index(&self, index: u64) -> bool {
-        // Check if index exists
-        self.indices.contains_key(&index)
+        self.state.write().captures.extend(captured);
+        Ok(self)
     }
 
     async fn put_internal(
@@ -362,24 +295,44 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         }
 
         // Check for existing index when enforcing single-item semantics.
-        if skip_if_index_exists && self.indices.contains_key(&index) {
+        if skip_if_index_exists && self.state.read().locations.contains_key(&index) {
             return Ok((self, true));
         }
 
-        // Write value and index entry atomically (glob first, then index)
+        // Refuse before appending, so a section that cannot be tracked is never written. A
+        // `Location` holds its position in a u32, which bounds a section's record count.
         let section = self.section(index);
-        let entry = Record::new(index, key.clone(), 0, 0);
-        let position;
-        (self.oversized, position, _, _) = self.oversized.append(section, entry, &data).await?;
+        let position = self.oversized.records(section)?;
+        if u32::try_from(position).is_err() {
+            return Err(Error::SectionFull(position));
+        }
 
-        // Store index location
-        match self.indices.entry(index) {
-            btree_map::Entry::Vacant(e) => {
-                e.insert(position);
-            }
-            btree_map::Entry::Occupied(_) => {
-                self.extra_indices.entry(index).or_default().push(position);
-            }
+        // Write value and index entry atomically (glob first, then index)
+        let record = Record::new(index, key.clone(), 0, 0);
+        let (position, value_offset, value_size);
+        (self.oversized, position, value_offset, value_size) =
+            self.oversized.append(section, record, &data).await?;
+        let location = Location {
+            value_offset,
+            position: u32::try_from(position).map_err(|_| Error::SectionFull(position))?,
+            value_size,
+        };
+
+        // Store where the item lives. Readers see it once a sync publishes the section.
+        let (extra, items) = {
+            let mut state = self.state.write();
+            let extra = match state.locations.entry(index) {
+                btree_map::Entry::Vacant(e) => {
+                    e.insert(location);
+                    None
+                }
+                // Readers serve the first item at an index, so later ones go to `extras`.
+                btree_map::Entry::Occupied(_) => Some(location),
+            };
+            (extra, state.locations.len())
+        };
+        if let Some(location) = extra {
+            self.extras.entry(index).or_default().push(location);
         }
 
         // Store interval
@@ -393,7 +346,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         self.pending.insert(section);
 
         // Update metrics
-        let _ = self.items_tracked.try_set(self.indices.len());
+        let _ = self.items_tracked.try_set(items);
         Ok((self, true))
     }
 
@@ -412,23 +365,33 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         }
         debug!(min, "pruning archive");
 
+        // Cut locations and their captures under one guard, before the journal drops anything, so
+        // no reader can serve below the new floor. A read already under way finishes, since its
+        // blob outlives the name.
+        let (pruned, stale, items) = {
+            let mut state = self.state.write();
+            let State {
+                locations,
+                captures,
+            } = &mut *state;
+            let kept = locations.split_off(&min);
+            let pruned = std::mem::replace(locations, kept);
+            let kept = captures.split_off(&min);
+            let stale = std::mem::replace(captures, kept);
+            (pruned, stale, locations.len())
+        };
+        self.indices_pruned.inc_by(pruned.len() as u64);
+        self.extras = self.extras.split_off(&min);
+
+        // Releasing the last handle on a pruned blob closes it, so do that with no reader waiting.
+        drop(stale);
+
         // Prune oversized journal (handles both index and values)
         (self.oversized, _) = self.oversized.prune(min).await?;
 
         // Remove pending and requested sync work (no need to call `sync` as we are pruning)
         self.pending = self.pending.split_off(&min);
         self.requested = self.requested.split_off(&min);
-
-        // Remove all indices that are less than min
-        loop {
-            let next = match self.indices.first_key_value() {
-                Some((index, _)) if *index < min => *index,
-                _ => break,
-            };
-            self.indices.remove(&next).unwrap();
-            self.extra_indices.remove(&next);
-            self.indices_pruned.inc();
-        }
 
         // Remove all keys from interval tree less than min
         if min > 0 {
@@ -437,15 +400,94 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
         // Update last pruned (to prevent reads from pruned sections)
         self.oldest_allowed = Some(min);
-        let _ = self.items_tracked.try_set(self.indices.len());
+        let _ = self.items_tracked.try_set(items);
         Ok(self)
+    }
+
+    /// Where the first item at `index` lives, if any.
+    ///
+    /// Pruning trims `locations` under the same guard that raises the floor, so an index below
+    /// the floor is already absent.
+    fn locate(&self, index: u64) -> Option<Location> {
+        self.state.read().locations.get(&index).copied()
+    }
+
+    /// Where every item at `index` lives, first one first.
+    ///
+    /// The trailing slice is empty unless `put_multi` stored more than one item here.
+    fn locate_all(&self, index: u64) -> Option<(Location, &[Location])> {
+        let first = self.locate(index)?;
+        let rest = self.extras.get(&index).map_or(&[][..], Vec::as_slice);
+        Some((first, rest))
+    }
+
+    /// Read the value at `location` in `section`.
+    async fn read_value(&self, section: u64, location: &Location) -> Result<V, Error> {
+        // Fetch value directly from blob storage (bypasses page cache)
+        Ok(self
+            .oversized
+            .get_value(section, location.value_offset, location.value_size)
+            .await?)
+    }
+
+    /// Which of `index`'s locations holds `key`, if any.
+    ///
+    /// Confirms translated-key candidates against index journal records, never reading values.
+    async fn match_key(
+        &self,
+        index: u64,
+        (first, rest): (Location, &[Location]),
+        key: &K,
+    ) -> Result<Option<Location>, Error> {
+        let section = self.section(index);
+        for location in std::iter::once(first).chain(rest.iter().copied()) {
+            let record = self
+                .oversized
+                .get(section, u64::from(location.position))
+                .await?;
+            if record.key.as_ref() == key.as_ref() {
+                return Ok(Some(location));
+            }
+            self.unnecessary_reads.inc();
+        }
+        Ok(None)
+    }
+
+    /// The section and location stored under `key` at one of its candidate indices.
+    async fn locate_key(&self, key: &K) -> Result<Option<(u64, Location)>, Error> {
+        // Keys are pruned lazily, so a candidate below the floor may still be listed.
+        let oldest_allowed = self.oldest_allowed.unwrap_or(0);
+        for index in self.keys.get(key) {
+            if *index < oldest_allowed {
+                continue;
+            }
+            // The key index must never name an index with nothing stored at it.
+            let Some(locations) = self.locate_all(*index) else {
+                return Err(Error::RecordCorrupted);
+            };
+            if let Some(location) = self.match_key(*index, locations, key).await? {
+                return Ok(Some((self.section(*index), location)));
+            }
+        }
+        Ok(None)
     }
 
     /// See [crate::archive::Archive::get].
     async fn get(&self, identifier: Identifier<'_, K>) -> Result<Option<V>, Error> {
+        self.gets.inc();
         match identifier {
-            Identifier::Index(index) => self.get_index(index).await,
-            Identifier::Key(key) => self.get_key(key).await,
+            Identifier::Index(index) => {
+                let Some(location) = self.locate(index) else {
+                    return Ok(None);
+                };
+                Ok(Some(self.read_value(self.section(index), &location).await?))
+            }
+            Identifier::Key(key) => {
+                let Some((section, location)) = self.locate_key(key).await? else {
+                    return Ok(None);
+                };
+                Ok(Some(self.read_value(section, &location).await?))
+            }
         }
     }
 
@@ -453,8 +495,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
     async fn has(&self, identifier: Identifier<'_, K>) -> Result<bool, Error> {
         self.has.inc();
         match identifier {
-            Identifier::Index(index) => Ok(self.has_index(index)),
-            Identifier::Key(key) => self.has_key(key).await,
+            Identifier::Index(index) => Ok(self.locate(index).is_some()),
+            Identifier::Key(key) => Ok(self.locate_key(key).await?.is_some()),
         }
     }
 
@@ -462,6 +504,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
     async fn sync(mut self: Box<Self>) -> Result<Box<Self>, Error> {
         // Update metrics (`requested` sections were already counted by `start_sync`)
         self.syncs.inc_by(self.pending.len() as u64);
+        let dirty: Vec<u64> = self.pending.iter().copied().collect();
         self.requested.append(&mut self.pending);
 
         // Sync oversized journal (handles both index and values). Re-syncing `requested` sections
@@ -469,6 +512,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         self.oversized = self.oversized.sync(&self.requested).await?;
 
         self.requested.clear();
+
+        self = self.publish(dirty).await?;
         Ok(self)
     }
 
@@ -480,9 +525,14 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         // Move sections into `requested` rather than dropping them: section buffers reuse
         // in-flight syncs, so re-requesting a section makes this handle observe outstanding work
         // without issuing a new sync.
+        let dirty: Vec<u64> = self.pending.iter().copied().collect();
         self.requested.append(&mut self.pending);
+
         let handle;
         (self.oversized, handle) = self.oversized.start_sync(&self.requested).await?;
+
+        // Publish without waiting for durability
+        self = self.publish(dirty).await?;
         Ok((self, handle))
     }
 
@@ -523,30 +573,15 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
     /// See [crate::archive::MultiArchive::get_all].
     async fn get_all(&self, index: u64) -> Result<Option<Vec<V>>, Error> {
-        // Update metrics
         self.gets.inc();
-
-        // Check if the index exists.
-        if !self.indices.contains_key(&index) {
+        let Some((first, rest)) = self.locate_all(index) else {
             return Ok(None);
-        }
+        };
 
-        // Get all positions at this index
         let section = self.section(index);
-        let extra_count = self.extra_indices.get(&index).map_or(0, Vec::len);
-
-        let mut values = Vec::with_capacity(1 + extra_count);
-        for position in self.iter_positions(index) {
-            // Fetch index entry from index journal to verify key
-            let entry = self.oversized.get(section, position).await?;
-
-            // Fetch value directly from blob storage (bypasses page cache)
-            let (value_offset, value_size) = entry.value_location();
-            let value = self
-                .oversized
-                .get_value(section, value_offset, value_size)
-                .await?;
-            values.push(value);
+        let mut values = Vec::with_capacity(1 + rest.len());
+        for location in std::iter::once(first).chain(rest.iter().copied()) {
+            values.push(self.read_value(section, &location).await?);
         }
         Ok(Some(values))
     }
@@ -555,27 +590,15 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
     async fn has_at(&self, index: u64, key: &K) -> Result<bool, Error> {
         self.has.inc();
 
-        // Ignore pruned indices.
-        if self.pruned(index) {
-            return Ok(false);
-        }
-
-        // A key absent from the in-memory index is not stored anywhere, so
-        // absence is decided without touching disk. A translated-key hit may
-        // be a collision, so confirm against the stored keys at `index`
-        // (reads index journal entries, never values).
+        // A key absent from the in-memory index is not stored anywhere, so absence is decided
+        // without touching disk. A translated-key hit may be a collision, so confirm it.
         if !self.keys.get(key).any(|candidate| *candidate == index) {
             return Ok(false);
         }
-        let section = self.section(index);
-        for position in self.iter_positions(index) {
-            let entry = self.oversized.get(section, position).await?;
-            if entry.key.as_ref() == key.as_ref() {
-                return Ok(true);
-            }
-            self.unnecessary_reads.inc();
-        }
-        Ok(false)
+        let Some(locations) = self.locate_all(index) else {
+            return Ok(false);
+        };
+        Ok(self.match_key(index, locations, key).await?.is_some())
     }
 }
 
@@ -612,6 +635,21 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Archive<T, E, K, V> {
     pub async fn prune(mut self, min: u64) -> Result<Self, Error> {
         self.0 = self.0.prune(min).await?;
         Ok(self)
+    }
+
+    /// A cloneable handle serving reads by index from the last published state.
+    ///
+    /// A put is invisible until a sync covers it. Both sync paths publish, since both flush
+    /// before returning. Reads outlive the archive, still serving that state.
+    ///
+    /// Serves the first item at an index, so items added by
+    /// [crate::archive::MultiArchive::put_multi] are unreachable through it.
+    pub fn reader(&self) -> Reader<E::Blob, V> {
+        Reader::new(
+            self.0.state.clone(),
+            self.0.items_per_section,
+            self.0.gets.clone(),
+        )
     }
 }
 

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -30,9 +30,44 @@ use super::manager::{Config as ManagerConfig, Manager, WriteFactory};
 use crate::{Context, journal::Error};
 use commonware_codec::{Codec, CodecShared, FixedSize};
 use commonware_cryptography::{Crc32, crc32};
-use commonware_runtime::{BufMut, Error as RError, Handle};
-use std::{io::Cursor, num::NonZeroUsize};
+use commonware_runtime::{Blob, BufMut, Error as RError, Handle, IoBuf};
+use std::{io::Cursor, num::NonZeroUsize, sync::Arc};
 use zstd::{bulk::compress, decode_all};
+
+/// Decode a value frame (`[data][crc32]`). Verifies the checksum, then decompresses and
+/// decodes.
+pub(super) fn decode_frame<V: CodecShared>(
+    buf: IoBuf,
+    compression: Option<u8>,
+    codec_config: &V::Cfg,
+) -> Result<V, Error> {
+    if buf.len() < crc32::Digest::SIZE {
+        return Err(Error::Runtime(RError::BlobInsufficientLength));
+    }
+
+    let data_len = buf.len() - crc32::Digest::SIZE;
+    let compressed_data = &buf.as_ref()[..data_len];
+    let stored_checksum = u32::from_be_bytes(
+        buf.as_ref()[data_len..]
+            .try_into()
+            .expect("checksum is 4 bytes"),
+    );
+
+    // Verify checksum
+    let checksum = Crc32::checksum(compressed_data);
+    if checksum != stored_checksum {
+        return Err(Error::ChecksumMismatch(stored_checksum, checksum));
+    }
+
+    // Decompress if needed and decode
+    if compression.is_some() {
+        let decompressed =
+            decode_all(Cursor::new(compressed_data)).map_err(|_| Error::DecompressionFailed)?;
+        V::decode_cfg(decompressed.as_ref(), codec_config).map_err(Error::Codec)
+    } else {
+        V::decode_cfg(compressed_data, codec_config).map_err(Error::Codec)
+    }
+}
 
 /// Configuration for blob storage.
 #[derive(Clone)]
@@ -57,8 +92,8 @@ struct Inner<E: Context, V: Codec> {
     /// Compression level (if enabled).
     compression: Option<u8>,
 
-    /// Codec configuration.
-    codec_config: V::Cfg,
+    /// Codec configuration, shared with captures so they can decode values.
+    codec_config: Arc<V::Cfg>,
 }
 
 impl<E: Context, V: CodecShared> Inner<E, V> {
@@ -76,7 +111,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         Ok(Self {
             manager,
             compression: cfg.compression,
-            codec_config: cfg.codec_config,
+            codec_config: Arc::new(cfg.codec_config),
         })
     }
 
@@ -119,36 +154,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 
         // Read via buffered writer (handles read-through for buffered data)
         let buf = writer.read_at(offset, size as usize).await?.coalesce();
-
-        // Entry format: [compressed_data] [crc32 (4 bytes)]
-        if buf.len() < crc32::Digest::SIZE {
-            return Err(Error::Runtime(RError::BlobInsufficientLength));
-        }
-
-        let data_len = buf.len() - crc32::Digest::SIZE;
-        let compressed_data = &buf.as_ref()[..data_len];
-        let stored_checksum = u32::from_be_bytes(
-            buf.as_ref()[data_len..]
-                .try_into()
-                .expect("checksum is 4 bytes"),
-        );
-
-        // Verify checksum
-        let checksum = Crc32::checksum(compressed_data);
-        if checksum != stored_checksum {
-            return Err(Error::ChecksumMismatch(stored_checksum, checksum));
-        }
-
-        // Decompress if needed and decode
-        let value = if self.compression.is_some() {
-            let decompressed =
-                decode_all(Cursor::new(compressed_data)).map_err(|_| Error::DecompressionFailed)?;
-            V::decode_cfg(decompressed.as_ref(), &self.codec_config).map_err(Error::Codec)?
-        } else {
-            V::decode_cfg(compressed_data, &self.codec_config).map_err(Error::Codec)?
-        };
-
-        Ok(value)
+        decode_frame(buf, self.compression, self.codec_config.as_ref())
     }
 
     /// See [Glob::verify].
@@ -293,6 +299,37 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
         self.0.get(section, offset, size).await
     }
 
+    /// Flush `section` and capture a handle on its value blob, or `None` if the section does not
+    /// exist.
+    ///
+    /// The flush is what makes the capture cover every byte accepted so far. It writes nothing
+    /// when the section has no buffered bytes, such as right after a sync.
+    ///
+    /// # Errors
+    ///
+    /// - [Error::AlreadyPrunedToSection] if the section has been pruned.
+    /// - [Error::Runtime] if the flush fails, which is fatal to the journal.
+    pub(crate) async fn capture_section(
+        mut self,
+        section: u64,
+    ) -> Result<(Self, Option<Capture<E::Blob, V>>), Error> {
+        self.0.manager.prune_guard(section)?;
+        let (blob, size) = {
+            let Some(writer) = self.0.manager.get_mut(section) else {
+                return Ok((self, None));
+            };
+            writer.flush().await?;
+            (writer.blob().clone(), writer.size())
+        };
+        let capture = Capture {
+            blob,
+            size,
+            compression: self.0.compression,
+            codec_config: self.0.codec_config.clone(),
+        };
+        Ok((self, Some(capture)))
+    }
+
     /// Check whether the entry at `(offset, size)` in `section` has a valid trailing checksum.
     ///
     /// Returns `Ok(false)` if the frame is smaller than its checksum trailer, the section
@@ -396,6 +433,61 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
     /// Destroy all blobs.
     pub async fn destroy(self) -> Result<(), Error> {
         self.0.destroy().await
+    }
+}
+
+/// An immutable, shareable read handle over one section's value bytes.
+///
+/// Frames are appended and never rewritten, so a frame within `size` reads the same bytes for as
+/// long as the capture lives. That holds after the writer appends, syncs, or prunes, since
+/// removing a section unlinks its name but leaves open handles readable.
+pub(crate) struct Capture<B: Blob, V: CodecShared> {
+    blob: B,
+
+    /// Bytes the capture covers. Frames at or past this were appended after it was taken.
+    size: u64,
+
+    compression: Option<u8>,
+    codec_config: Arc<V::Cfg>,
+}
+
+impl<B: Blob, V: CodecShared> Clone for Capture<B, V> {
+    fn clone(&self) -> Self {
+        Self {
+            blob: self.blob.clone(),
+            size: self.size,
+            compression: self.compression,
+            codec_config: self.codec_config.clone(),
+        }
+    }
+}
+
+impl<B: Blob, V: CodecShared> Capture<B, V> {
+    /// Whether the frame at `(offset, size)` falls inside the capture.
+    pub(crate) fn covers(&self, offset: u64, size: u32) -> bool {
+        offset
+            .checked_add(u64::from(size))
+            .is_some_and(|end| end <= self.size)
+    }
+
+    /// Read the value frame at `(offset, size)` (see [Glob::get]).
+    ///
+    /// # Errors
+    ///
+    /// - [Error::Runtime] with [RError::BlobInsufficientLength] when the frame is not covered by
+    ///   the capture.
+    /// - [Error::ChecksumMismatch] when the frame's bytes do not match its checksum.
+    pub(crate) async fn get(&self, offset: u64, size: u32) -> Result<V, Error> {
+        if !self.covers(offset, size) {
+            return Err(Error::Runtime(RError::BlobInsufficientLength));
+        }
+        let buf = self
+            .blob
+            .read_at(offset, size as usize)
+            .await?
+            .freeze()
+            .coalesce();
+        decode_frame(buf, self.compression, self.codec_config.as_ref())
     }
 }
 

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -54,7 +54,7 @@
 
 use super::{
     fixed::{Config as FixedConfig, Journal as FixedJournal, Replay as FixedReplay},
-    glob::{Config as GlobConfig, Glob},
+    glob::{Capture, Config as GlobConfig, Glob},
 };
 use crate::{Context, journal::Error};
 use commonware_codec::{Codec, CodecFixed, CodecShared};
@@ -471,6 +471,16 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         self.values.get(section, offset, size).await
     }
 
+    /// See [Glob::capture_section].
+    pub(crate) async fn capture_values(
+        mut self,
+        section: u64,
+    ) -> Result<(Self, Option<Capture<E::Blob, V>>), Error> {
+        let capture;
+        (self.values, capture) = self.values.capture_section(section).await?;
+        Ok((self, capture))
+    }
+
     /// Consumes the journal and returns an owned [Replay] reader over index entries
     /// starting from `start_position` in `start_section`.
     ///
@@ -621,6 +631,11 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         self.index.size(section)
     }
 
+    /// The number of index records in `section`, which is the position the next append takes.
+    pub fn records(&self, section: u64) -> Result<u64, Error> {
+        self.index.section_len(section)
+    }
+
     /// Get the value size for a section, derived from the last entry's location.
     pub async fn value_size(&self, section: u64) -> Result<u64, Error> {
         match self.index.last(section).await {
@@ -641,6 +656,11 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// section pruned in a previous execution reports false.
     pub fn pruned(&self, section: u64) -> bool {
         self.index.pruned(section)
+    }
+
+    /// Returns an iterator over all section numbers.
+    pub fn sections(&self) -> impl Iterator<Item = u64> + '_ {
+        self.index.sections()
     }
 
     /// Returns the oldest section number, if any exist.
@@ -700,8 +720,8 @@ mod tests {
     use commonware_cryptography::Crc32;
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        Blob as _, Buf, BufMut, BufferPooler, Runner, Storage as _, Supervisor as _, WriteOptions,
-        buffer::paged::CacheRef, deterministic, mocks::SyncFaultContext,
+        Blob, Buf, BufMut, BufferPooler, Metrics as _, Runner, Storage, Supervisor as _,
+        WriteOptions, buffer::paged::CacheRef, deterministic, mocks::SyncFaultContext,
     };
     use commonware_utils::{NZU16, NZUsize};
 
@@ -4171,6 +4191,287 @@ mod tests {
                 Err(Error::AlreadyPrunedToSection(1))
             ));
             assert!(oversized.last(1).await.unwrap().is_some());
+
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    /// The value of the runtime's storage-write counter.
+    fn storage_writes(context: &deterministic::Context) -> u64 {
+        context
+            .encode()
+            .lines()
+            .find_map(|line| line.strip_prefix("runtime_storage_writes_total "))
+            .expect("storage_writes metric must be registered")
+            .parse()
+            .expect("metric must be an integer")
+    }
+
+    /// Append `(id, [id; 16])` pairs at the given `(section, id)` coordinates, returning
+    /// each append's `(section, position, offset, size)`.
+    async fn append_pairs(
+        oversized: &mut Option<Oversized<deterministic::Context, TestEntry, TestValue>>,
+        pairs: &[(u64, u8)],
+    ) -> Vec<(u64, u64, u64, u32)> {
+        let mut located = Vec::new();
+        for &(section, id) in pairs {
+            let (journal, position, offset, size) = oversized
+                .take()
+                .unwrap()
+                .append(section, TestEntry::new(id as u64, 0, 0), &[id; 16])
+                .await
+                .expect("Failed to append");
+            *oversized = Some(journal);
+            located.push((section, position, offset, size));
+        }
+        located
+    }
+
+    /// The deterministic runtime's blob type.
+    type TestBlob = <deterministic::Context as Storage>::Blob;
+
+    /// Assert `capture` returns the same values as the live journal for every location in
+    /// `located` belonging to `section`.
+    async fn assert_value_parity(
+        oversized: &Oversized<deterministic::Context, TestEntry, TestValue>,
+        capture: &Capture<TestBlob, TestValue>,
+        section: u64,
+        located: &[(u64, u64, u64, u32)],
+    ) {
+        for &(_, _, offset, size) in located.iter().filter(|(s, ..)| *s == section) {
+            let live = oversized
+                .get_value(section, offset, size)
+                .await
+                .expect("live get_value");
+            assert_eq!(
+                live,
+                capture.get(offset, size).await.expect("capture value")
+            );
+        }
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_parity() {
+        for compression in [None, Some(3)] {
+            let executor = deterministic::Runner::default();
+            executor.start(|context| async move {
+                let mut cfg = test_cfg(&context);
+                cfg.compression = compression;
+                let oversized: Oversized<_, TestEntry, TestValue> =
+                    Oversized::init(context.child("journal"), cfg, None)
+                        .await
+                        .expect("Failed to init");
+                let mut slot = Some(oversized);
+                let located =
+                    append_pairs(&mut slot, &[(1, 1), (1, 2), (1, 3), (2, 4), (2, 5)]).await;
+                let mut oversized = slot.unwrap().sync(&[1, 2]).await.expect("Failed to sync");
+
+                for section in [1, 2] {
+                    let capture;
+                    (oversized, capture) = oversized
+                        .capture_values(section)
+                        .await
+                        .expect("Failed to capture");
+                    let capture = capture.expect("section must exist");
+                    assert_value_parity(&oversized, &capture, section, &located).await;
+                }
+
+                oversized.destroy().await.expect("Failed to destroy");
+            });
+        }
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_excludes_later_appends() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("journal"), test_cfg(&context), None)
+                    .await
+                    .expect("Failed to init");
+            let mut slot = Some(oversized);
+            let located = append_pairs(&mut slot, &[(1, 1), (1, 2)]).await;
+            let mut oversized = slot.unwrap().sync(1).await.expect("Failed to sync");
+
+            let capture;
+            (oversized, capture) = oversized
+                .capture_values(1)
+                .await
+                .expect("Failed to capture");
+            let capture = capture.expect("section must exist");
+
+            // A later append (synced or not) sits past the capture's size.
+            let mut slot = Some(oversized);
+            let late = append_pairs(&mut slot, &[(1, 3)]).await;
+            let oversized = slot.unwrap().sync(1).await.expect("Failed to sync");
+            let (_, _, offset, size) = late[0];
+            assert!(oversized.get_value(1, offset, size).await.is_ok());
+            assert!(matches!(
+                capture.get(offset, size).await,
+                Err(Error::Runtime(RError::BlobInsufficientLength))
+            ));
+            assert_value_parity(&oversized, &capture, 1, &located).await;
+
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_survives_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("journal"), test_cfg(&context), None)
+                    .await
+                    .expect("Failed to init");
+            let mut slot = Some(oversized);
+            let located = append_pairs(&mut slot, &[(1, 1), (2, 2)]).await;
+            let mut oversized = slot.unwrap().sync(&[1, 2]).await.expect("Failed to sync");
+
+            let capture;
+            (oversized, capture) = oversized
+                .capture_values(1)
+                .await
+                .expect("Failed to capture");
+            let capture = capture.expect("section must exist");
+
+            // Prune section 1 away. The live journal rejects reads, the capture keeps serving
+            // through the handle it holds.
+            let (oversized, pruned) = oversized.prune(2).await.expect("Failed to prune");
+            assert!(pruned);
+            let (section, _, offset, size) = located[0];
+            assert!(oversized.get_value(section, offset, size).await.is_err());
+            assert_eq!(
+                capture.get(offset, size).await.expect("capture value"),
+                [1; 16]
+            );
+
+            // Capturing a pruned section is an error rather than an empty capture. The error
+            // destroys the journal, so this is the last thing the test can do with it.
+            assert!(matches!(
+                oversized.capture_values(section).await,
+                Err(Error::AlreadyPrunedToSection(2))
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_before_sync_observes_accepted_appends() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("journal"), test_cfg(&context), None)
+                    .await
+                    .expect("Failed to init");
+            let mut slot = Some(oversized);
+            let located = append_pairs(&mut slot, &[(1, 1), (1, 2)]).await;
+            let mut oversized = slot.unwrap();
+
+            // Without a sync, the capture's flush is what puts the buffered values on the blob.
+            let capture;
+            (oversized, capture) = oversized
+                .capture_values(1)
+                .await
+                .expect("Failed to capture");
+            let capture = capture.expect("section must exist");
+            assert_value_parity(&oversized, &capture, 1, &located).await;
+
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_after_sync_writes_nothing() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("journal"), test_cfg(&context), None)
+                    .await
+                    .expect("Failed to init");
+            let mut slot = Some(oversized);
+            append_pairs(&mut slot, &[(1, 1), (1, 2)]).await;
+            let mut oversized = slot.unwrap().sync(1).await.expect("Failed to sync");
+
+            let writes = storage_writes(&context);
+            let capture;
+            (oversized, capture) = oversized
+                .capture_values(1)
+                .await
+                .expect("Failed to capture");
+            assert!(capture.is_some(), "section must exist");
+            assert_eq!(
+                storage_writes(&context),
+                writes,
+                "a post-sync capture must not write to storage"
+            );
+
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_none_without_value_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), cfg.clone(), None)
+                    .await
+                    .expect("Failed to init");
+            (oversized, _, _, _) = oversized
+                .append(1, TestEntry::new(1, 0, 0), &[1; 16])
+                .await
+                .expect("Failed to append");
+            oversized = oversized.sync(1).await.expect("Failed to sync");
+            drop(oversized);
+
+            // Losing the value blob makes repair rewind the index section to zero entries, so a
+            // capture must find nothing rather than fail.
+            context
+                .remove(&cfg.value_partition, Some(&1u64.to_be_bytes()))
+                .await
+                .expect("Failed to remove value blob");
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), cfg, None)
+                    .await
+                    .expect("Failed to reinit");
+            let capture;
+            (oversized, capture) = oversized.capture_values(1).await.expect("capture failed");
+            assert!(capture.is_none());
+
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_capture_values_rejects_torn_value() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("journal"), test_cfg(&context), None)
+                    .await
+                    .expect("Failed to init");
+            let mut slot = Some(oversized);
+            let located = append_pairs(&mut slot, &[(1, 1)]).await;
+            let mut oversized = slot.unwrap().sync(1).await.expect("Failed to sync");
+
+            // Corrupt the value bytes, then capture. The capture must surface the mismatch.
+            let (_, _, offset, size) = located[0];
+            oversized
+                .values
+                .inject(1, offset, vec![0xFF; size as usize])
+                .await
+                .expect("Failed to corrupt value bytes");
+            let capture;
+            (oversized, capture) = oversized
+                .capture_values(1)
+                .await
+                .expect("Failed to capture");
+            let capture = capture.expect("section must exist");
+            assert!(matches!(
+                capture.get(offset, size).await,
+                Err(Error::ChecksumMismatch(_, _))
+            ));
 
             oversized.destroy().await.expect("Failed to destroy");
         });


### PR DESCRIPTION
# Serve finalized backfill off the marshal actor loop

Marshal's core is a single task running a `select!` loop. One of its arms answers a peer asking for a finalized block, and it answers by reading two archives from disk inline. Consensus processing waits on those reads. A peer that has been offline for a while streams requests for old heights, which turns into sustained random disk I/O sitting directly in front of the loop that is supposed to be running consensus.

This PR moves that work to its own task. It does so by giving `archive::prunable::Archive` a read handle that another task can hold and use while the writer keeps writing.

## Why this needed a storage change

The archive's reads borrow (`get(&self)`) and its writes consume (`put(self) -> Self`). No borrow can survive a write, so a spawned task cannot hold a `&Archive`. It needs something owned and independent.

Reading also needed the writer's in-memory map. Index-journal records are appended in arrival order, so height H's record position depends on when H showed up, not on the number H, and there is no arithmetic that recovers it. A second reader therefore needed a map that is large and changes on every put.

Two changes make that map shareable:

**The map now records where the value is, not where the record is.** It was `index -> position in the index journal`. It is now `index -> Location { value_offset, position, value_size }`. A read by index goes straight to the value blob and never touches the index journal, so it costs one disk read instead of two. `position` is kept only for lookups by key, which still read the record to compare the stored key and rule out a translator collision.

**The map lives behind a lock, alongside the file handles a reader needs.** `Arc<RwLock<State>>` holds the location map and, per section, a `Capture`: a cloned blob handle plus the byte length the writer had flushed when it was taken. A read takes the lock long enough to copy one `Location` and clone one `Capture`, drops it, and then does its I/O with nothing held. No guard is ever held across an `.await`, and no I/O happens under one, so a read never waits on the writer's disk and the writer never waits on a reader's.

`Capture`'s length is what makes a live map safe to pair with lagging file handles. Value frames are appended and never rewritten, so a frame that fits inside the captured length reads the same bytes for as long as the capture lives, and anything written afterwards sits beyond it and is simply invisible.

## What a reader sees, and when

A put is invisible to readers until the store publishes it. Publishing happens inside `sync` and `start_sync`, both of which flush before returning, and it re-captures exactly the sections that call covered.

Publishing follows the flush, not the fsync. A reader can therefore serve a value that a crash would lose. For handing finalized blocks to peers that is the right trade: the block is finalized and the peer's copy stays valid whatever happens to our disk, and if we lose it we refetch it like any other gap.

A height that no started sync has flushed yet is reported as missing. The actor forwards finalized requests at the tail of each batch, after that batch's sync has been started and has published, so a height finalized or backfilled during the batch is served rather than missed. Anything that still misses reaches the peer as a resolver error, which retries.

A pruned height disappears immediately: `prune` drops a section's locations and its capture under one guard before the journal removes any files. A read already under way finishes normally, because a blob handle stays readable after its name is unlinked.

Corruption is not reported as absence. A value inside the captured range that fails its checksum is an error, not a miss, so a peer does not retry a hole forever and the condition shows up in metrics.

## Marshal

`Certificates` and `Blocks` gain `reader()`. `prunable::Archive` returns one; `immutable::Archive` returns `None` and keeps the inline path unchanged.

When both finalized stores expose a reader, the actor spawns a serving task holding both. `Key::Finalized` produce requests are forwarded to it; every other produce key is still answered inline. The task serves at most `max_repair` requests at once with the same number able to queue, and drops anything it cannot take, which the peer sees as a retryable error. It never panics: unlike the inline path, a read failure there is survivable, so it is logged and counted.

Both paths encode the response through the same function, so the wire format is identical whichever answers.

## What this costs

**Memory.** A `Location` is 16 bytes where a position was 8, so tracking each index item goes from `8 + 8` to `8 + 16` bytes, and an archive using an 8-byte translated key goes from about 40 to about 48 bytes per key. Every `prunable::Archive` pays this, including ones that never build a reader.

**A lock on the put path.** Each put takes a read guard for the duplicate check and a write guard for the insert. Both cover a map operation with no I/O.

**One detection path narrows.** A read by index no longer reads the index-journal record, so corruption there surfaces at startup replay rather than incidentally at read time. Values carry their own checksum, which every read still verifies, so nothing is served unverified.

## Breaking changes

`Certificates` and `Blocks` gain a required associated type (`Reader`) and a required method (`reader`). Both traits are BETA and are implemented by applications, so any external implementation must add both. Adding an associated type cannot be made backward compatible, since associated-type defaults are not stable.

`archive::Error` gains a `SectionFull` variant, which breaks exhaustive matches on it.

## What does not change

No on-disk format changes, so there is no migration and existing archives open as they are. The writer's own behavior is unchanged apart from the map contents and the lock: same recovery, same pruning, same durability. Deployments using immutable archives for finalized storage are unaffected.

## Metrics

`forwarded` and `dropped` on the mailbox, `served`, `missing`, and `failed` on the serving task. `missing` covers a height that is not yet published or already pruned; `failed` covers a read that returned an error, so persistent corruption is visible rather than hidden among ordinary misses.

`produce_serving_duration` measures the time the actor loop still spends answering produce requests inline.