### PR TITLE
[storage] Retain Merkle ancestors in detached workers

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -1057,7 +1057,7 @@ mod tests {
             },
             operation::Committable,
         },
-        utils::{DropMonitor, block_rayon},
+        utils::detached::{DropMonitor, block_strategy},
     };
     use commonware_codec::Encode;
     use commonware_cryptography::{Sha256, sha256::Digest};
@@ -3616,7 +3616,7 @@ mod tests {
             let c_batch = b.new_batch::<Sha256>();
             drop(b);
 
-            let release = block_rayon(journal.strategy(), 2);
+            let release = block_strategy(journal.strategy(), 2);
             let (item, clean_drop) = DropMonitor::tracked(create_operation::<mmr::Family>(10));
             let mut merkleize = Box::pin(journal.merkleize(c_batch, vec![item], 0));
             assert!(futures::poll!(merkleize.as_mut()).is_pending());

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -345,6 +345,7 @@ where
     where
         C::Item: 'static,
     {
+        let ancestors = batch.inner.retain_ancestors();
         let mem = self.merkle.snapshot();
         let hasher = self.hasher.clone();
         let strategy = self.strategy().clone();
@@ -352,6 +353,7 @@ where
             .spawn(move |_| {
                 let merkleized = batch.add_many(items).merkleize(&mem);
                 let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
+                drop(ancestors);
                 Ok((merkleized, root))
             })
             .await
@@ -1055,6 +1057,7 @@ mod tests {
             },
             operation::Committable,
         },
+        utils::{DropMonitor, block_rayon},
     };
     use commonware_codec::Encode;
     use commonware_cryptography::{Sha256, sha256::Digest};
@@ -1075,6 +1078,7 @@ mod tests {
     use std::{
         future::Future,
         num::{NonZeroU16, NonZeroUsize},
+        time::Duration,
     };
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
@@ -3531,5 +3535,103 @@ mod tests {
     fn test_apply_batch_after_committed_ancestor_dropped_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_apply_batch_after_committed_ancestor_dropped_inner::<mmb::Family>);
+    }
+
+    /// Merkleization can consume the last strong handle to an uncommitted parent after an older
+    /// prefix has been committed.
+    async fn test_merkleize_with_retained_parent_inner<F: Family + PartialEq>(context: Context) {
+        let mut journal =
+            create_empty_journal::<F>(context.child("storage"), "retained-parent").await;
+
+        let a_items = (0..8u8).map(create_operation::<F>).collect();
+        let (a, _) = journal
+            .merkleize(journal.new_batch(), a_items, 0)
+            .await
+            .unwrap();
+        let b_items = (8..10u8).map(create_operation::<F>).collect();
+        let (b, _) = journal
+            .merkleize(a.new_batch::<Sha256>(), b_items, 0)
+            .await
+            .unwrap();
+
+        journal = journal.apply_batch(&a).await.unwrap();
+        drop(a);
+
+        let c_batch = b.new_batch::<Sha256>();
+        drop(b);
+        let (c, expected_root) = journal
+            .merkleize(c_batch, vec![create_operation::<F>(10)], 0)
+            .await
+            .unwrap();
+        journal = journal.apply_batch(&c).await.unwrap();
+
+        assert_eq!(journal_root(&journal), expected_root);
+        assert_eq!(*journal.size(), 11);
+    }
+
+    #[test_traced("INFO")]
+    fn test_merkleize_with_retained_parent_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_merkleize_with_retained_parent_inner::<mmb::Family>);
+    }
+
+    /// A detached merkleization job owns the full ancestor chain after its waiter is dropped.
+    #[test_traced("INFO")]
+    fn test_merkleize_retains_ancestors_after_cancellation() {
+        deterministic::Runner::default().start(|context| async move {
+            let strategy = Rayon::new(NZUsize!(2)).unwrap();
+            let merkle_cfg = merkle_config_with("cancelled-merkleize", &context, strategy);
+            let journal_cfg = journal_config("cancelled-merkleize", &context);
+            type RayonJournal = Journal<
+                mmr::Family,
+                Context,
+                ContiguousJournal<Context, DropMonitor<TestOp<mmr::Family>>>,
+                Sha256,
+                Rayon,
+            >;
+            let journal = RayonJournal::new(
+                context,
+                merkle_cfg,
+                journal_cfg,
+                |_: &DropMonitor<TestOp<mmr::Family>>| false,
+                ForwardFold,
+            )
+            .await
+            .unwrap();
+
+            let a_items = (0..8u8)
+                .map(create_operation::<mmr::Family>)
+                .map(DropMonitor::untracked)
+                .collect();
+            let a_batch = journal.new_batch().add_many(a_items);
+            let a = journal.merkle.with_mem(|mem| a_batch.merkleize(mem));
+            let b_items = (8..10u8)
+                .map(create_operation::<mmr::Family>)
+                .map(DropMonitor::untracked)
+                .collect();
+            let b_batch = a.new_batch::<Sha256>().add_many(b_items);
+            let b = journal.merkle.with_mem(|mem| b_batch.merkleize(mem));
+
+            let ancestor = Arc::downgrade(&a.inner);
+            let c_batch = b.new_batch::<Sha256>();
+            drop(b);
+
+            let release = block_rayon(journal.strategy(), 2);
+            let (item, clean_drop) = DropMonitor::tracked(create_operation::<mmr::Family>(10));
+            let mut merkleize = Box::pin(journal.merkleize(c_batch, vec![item], 0));
+            assert!(futures::poll!(merkleize.as_mut()).is_pending());
+            drop(merkleize);
+            drop(a);
+
+            assert!(ancestor.upgrade().is_some());
+            drop(release);
+            assert!(
+                clean_drop
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("detached merkleization did not finish"),
+                "detached merkleization panicked"
+            );
+            assert!(ancestor.upgrade().is_none());
+        });
     }
 }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -3537,42 +3537,53 @@ mod tests {
         executor.start(test_apply_batch_after_committed_ancestor_dropped_inner::<mmb::Family>);
     }
 
-    /// Merkleization can consume the last strong handle to an uncommitted parent after an older
-    /// prefix has been committed.
-    async fn test_merkleize_with_retained_parent_inner<F: Family + PartialEq>(context: Context) {
+    /// Merkleization retains a speculative suffix after its committed prefix is released.
+    async fn test_merkleize_after_committed_prefix_dropped_inner<F: Family + PartialEq>(
+        context: Context,
+    ) {
         let mut journal =
-            create_empty_journal::<F>(context.child("storage"), "retained-parent").await;
+            create_empty_journal::<F>(context.child("storage"), "committed-prefix").await;
 
-        let a_items = (0..8u8).map(create_operation::<F>).collect();
-        let (a, _) = journal
-            .merkleize(journal.new_batch(), a_items, 0)
+        // Build a speculative suffix over a prefix that will be committed independently.
+        let prefix_items = (0..8u8).map(create_operation::<F>).collect();
+        let (prefix, _) = journal
+            .merkleize(journal.new_batch(), prefix_items, 0)
             .await
             .unwrap();
-        let b_items = (8..10u8).map(create_operation::<F>).collect();
-        let (b, _) = journal
-            .merkleize(a.new_batch::<Sha256>(), b_items, 0)
+        let pending_items = (8..10u8).map(create_operation::<F>).collect();
+        let (pending, _) = journal
+            .merkleize(prefix.new_batch::<Sha256>(), pending_items, 0)
             .await
             .unwrap();
 
-        journal = journal.apply_batch(&a).await.unwrap();
-        drop(a);
+        // Commit and release the prefix. Its Merkle nodes now resolve through the snapshot.
+        journal = journal.apply_batch(&prefix).await.unwrap();
+        drop(prefix);
 
-        let c_batch = b.new_batch::<Sha256>();
-        drop(b);
-        let (c, expected_root) = journal
-            .merkleize(c_batch, vec![create_operation::<F>(10)], 0)
+        // The child batch is the pending suffix's only remaining owner. Merkleization must retain
+        // that suffix through root computation.
+        let child_batch = pending.new_batch::<Sha256>();
+        drop(pending);
+        let (child, expected_root) = journal
+            .merkleize(child_batch, vec![create_operation::<F>(10)], 0)
             .await
             .unwrap();
-        journal = journal.apply_batch(&c).await.unwrap();
+        journal = journal.apply_batch(&child).await.unwrap();
 
         assert_eq!(journal_root(&journal), expected_root);
         assert_eq!(*journal.size(), 11);
     }
 
     #[test_traced("INFO")]
-    fn test_merkleize_with_retained_parent_mmb() {
+    fn test_merkleize_after_committed_prefix_dropped_mmr() {
         let executor = deterministic::Runner::default();
-        executor.start(test_merkleize_with_retained_parent_inner::<mmb::Family>);
+        executor.start(test_merkleize_after_committed_prefix_dropped_inner::<mmr::Family>);
+    }
+
+    #[test_traced("INFO")]
+    fn test_merkleize_after_committed_prefix_dropped_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_merkleize_after_committed_prefix_dropped_inner::<mmb::Family>);
     }
 
     /// A detached merkleization job owns the full ancestor chain after its waiter is dropped.

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -141,6 +141,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 
     /// Retain the live ancestor chain while consuming this batch in a multi-step operation.
+    #[cfg(feature = "std")]
     pub(crate) fn retain_ancestors(&self) -> Vec<Arc<MerkleizedBatch<F, D, S>>> {
         let mut ancestors = Vec::new();
         let mut current = Some(Arc::clone(&self.parent));

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -140,6 +140,17 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         &self.parent.strategy
     }
 
+    /// Retain the live ancestor chain while consuming this batch in a multi-step operation.
+    pub(crate) fn retain_ancestors(&self) -> Vec<Arc<MerkleizedBatch<F, D, S>>> {
+        let mut ancestors = Vec::new();
+        let mut current = Some(Arc::clone(&self.parent));
+        while let Some(batch) = current {
+            current = batch.parent.as_ref().and_then(Weak::upgrade);
+            ancestors.push(batch);
+        }
+        ancestors
+    }
+
     /// The total number of nodes visible through this batch.
     pub(crate) fn size(&self) -> Position<F> {
         Position::new(*self.parent.size() + self.appended.len() as u64)

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -140,7 +140,9 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         &self.parent.strategy
     }
 
-    /// Retain the live ancestor chain while consuming this batch in a multi-step operation.
+    /// Retain the live parent chain up to the first dropped weak link.
+    ///
+    /// Nodes beyond that link are read from committed state.
     #[cfg(feature = "std")]
     pub(crate) fn retain_ancestors(&self) -> Vec<Arc<MerkleizedBatch<F, D, S>>> {
         let mut ancestors = Vec::new();

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -50,7 +50,9 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self.inner.leaves()
     }
 
-    /// Retain the live ancestor chain while consuming this batch in a multi-step operation.
+    /// Retain the live parent chain up to the first dropped weak link.
+    ///
+    /// Nodes beyond that link are read from committed state.
     pub(crate) fn retain_ancestors(&self) -> Vec<Arc<batch::MerkleizedBatch<F, D, S>>> {
         self.inner.retain_ancestors()
     }

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -50,6 +50,11 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self.inner.leaves()
     }
 
+    /// Retain the live ancestor chain while consuming this batch in a multi-step operation.
+    pub(crate) fn retain_ancestors(&self) -> Vec<Arc<batch::MerkleizedBatch<F, D, S>>> {
+        self.inner.retain_ancestors()
+    }
+
     /// Consume this batch and produce an immutable [`batch::MerkleizedBatch`] with computed root.
     pub fn merkleize(
         self,

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -58,7 +58,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::mmb,
+        merkle::{mmb, mmr},
         utils::detached::{DropMonitor, block_strategy},
     };
     use commonware_cryptography::Sha256;
@@ -68,32 +68,38 @@ mod tests {
     use commonware_utils::NZUsize;
     use std::time::Duration;
 
-    async fn test_merkleize_ops_with_retained_parent_inner<F: Family>() {
+    /// Merkleization retains a speculative suffix after its committed prefix is released.
+    async fn test_merkleize_ops_after_committed_prefix_dropped_inner<F: Family>() {
         let mut merkle =
             compact::Merkle::<F, <Sha256 as Hasher>::Digest, Sequential>::new(Sequential);
 
-        let (a, _) =
+        // Build a speculative suffix over a prefix that will be committed independently.
+        let (prefix, _) =
             merkleize_ops::<F, Sha256, _, _>(&merkle, merkle.new_batch(), (0..8u64).collect(), 0)
                 .await
                 .unwrap();
-        let (b, _) = merkleize_ops::<F, Sha256, _, _>(
+        let (pending, _) = merkleize_ops::<F, Sha256, _, _>(
             &merkle,
-            compact::UnmerkleizedBatch::wrap(a.new_batch()),
+            compact::UnmerkleizedBatch::wrap(prefix.new_batch()),
             vec![8u64, 9],
             0,
         )
         .await
         .unwrap();
 
-        merkle.apply_batch(&a).unwrap();
-        drop(a);
+        // Commit and release the prefix. Its Merkle nodes now resolve through the snapshot.
+        merkle.apply_batch(&prefix).unwrap();
+        drop(prefix);
 
-        let c_batch = compact::UnmerkleizedBatch::wrap(b.new_batch());
-        drop(b);
-        let (c, expected_root) = merkleize_ops::<F, Sha256, _, _>(&merkle, c_batch, vec![10u64], 0)
-            .await
-            .unwrap();
-        merkle.apply_batch(&c).unwrap();
+        // The child batch is the pending suffix's only remaining owner. Merkleization must retain
+        // that suffix through root computation.
+        let child_batch = compact::UnmerkleizedBatch::wrap(pending.new_batch());
+        drop(pending);
+        let (child, expected_root) =
+            merkleize_ops::<F, Sha256, _, _>(&merkle, child_batch, vec![10u64], 0)
+                .await
+                .unwrap();
+        merkle.apply_batch(&child).unwrap();
 
         assert_eq!(*merkle.leaves(), 11);
         assert_eq!(
@@ -103,9 +109,15 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_merkleize_ops_with_retained_parent_mmb() {
+    fn test_merkleize_ops_after_committed_prefix_dropped_mmr() {
         deterministic::Runner::default()
-            .start(|_| test_merkleize_ops_with_retained_parent_inner::<mmb::Family>());
+            .start(|_| test_merkleize_ops_after_committed_prefix_dropped_inner::<mmr::Family>());
+    }
+
+    #[test_traced]
+    fn test_merkleize_ops_after_committed_prefix_dropped_mmb() {
+        deterministic::Runner::default()
+            .start(|_| test_merkleize_ops_after_committed_prefix_dropped_inner::<mmb::Family>());
     }
 
     /// A detached merkleization job owns the full ancestor chain after its waiter is dropped.

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -30,6 +30,7 @@ where
     Op: EncodeShared + 'static,
 {
     let first_leaf = batch.leaves();
+    let ancestors = batch.retain_ancestors();
     let mem = merkle.snapshot();
     let strategy = merkle.strategy().clone();
     strategy
@@ -47,7 +48,111 @@ where
             let batch = batch.add_leaf_digests(leaf_digests);
             let merkleized = batch.merkleize(&mem, &hasher);
             let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
+            drop(ancestors);
             Ok((merkleized, root))
         })
         .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        merkle::mmb,
+        utils::{DropMonitor, block_rayon},
+    };
+    use commonware_cryptography::Sha256;
+    use commonware_macros::test_traced;
+    use commonware_parallel::{Rayon, Sequential};
+    use commonware_runtime::{Runner as _, deterministic};
+    use commonware_utils::NZUsize;
+    use std::time::Duration;
+
+    async fn test_merkleize_ops_with_retained_parent_inner<F: Family>() {
+        let mut merkle =
+            compact::Merkle::<F, <Sha256 as Hasher>::Digest, Sequential>::new(Sequential);
+
+        let (a, _) =
+            merkleize_ops::<F, Sha256, _, _>(&merkle, merkle.new_batch(), (0..8u64).collect(), 0)
+                .await
+                .unwrap();
+        let (b, _) = merkleize_ops::<F, Sha256, _, _>(
+            &merkle,
+            compact::UnmerkleizedBatch::wrap(a.new_batch()),
+            vec![8u64, 9],
+            0,
+        )
+        .await
+        .unwrap();
+
+        merkle.apply_batch(&a).unwrap();
+        drop(a);
+
+        let c_batch = compact::UnmerkleizedBatch::wrap(b.new_batch());
+        drop(b);
+        let (c, expected_root) = merkleize_ops::<F, Sha256, _, _>(&merkle, c_batch, vec![10u64], 0)
+            .await
+            .unwrap();
+        merkle.apply_batch(&c).unwrap();
+
+        assert_eq!(*merkle.leaves(), 11);
+        assert_eq!(
+            merkle.root(&qmdb::hasher::<Sha256>(), 0).unwrap(),
+            expected_root
+        );
+    }
+
+    #[test_traced]
+    fn test_merkleize_ops_with_retained_parent_mmb() {
+        deterministic::Runner::default()
+            .start(|_| test_merkleize_ops_with_retained_parent_inner::<mmb::Family>());
+    }
+
+    /// A detached merkleization job owns the full ancestor chain after its waiter is dropped.
+    #[test_traced]
+    fn test_merkleize_ops_retains_ancestors_after_cancellation() {
+        deterministic::Runner::default().start(|_| async move {
+            let strategy = Rayon::new(NZUsize!(2)).unwrap();
+            let merkle =
+                compact::Merkle::<mmb::Family, <Sha256 as Hasher>::Digest, _>::new(strategy);
+            let hasher = qmdb::hasher::<Sha256>();
+
+            let mut a_batch = merkle.new_batch();
+            for i in 0..8u64 {
+                a_batch = a_batch.add(&hasher, &i.to_be_bytes());
+            }
+            let a = merkle.with_mem(|mem| a_batch.merkleize(mem, &hasher));
+            let mut b_batch = compact::UnmerkleizedBatch::wrap(a.new_batch());
+            for i in 8..10u64 {
+                b_batch = b_batch.add(&hasher, &i.to_be_bytes());
+            }
+            let b = merkle.with_mem(|mem| b_batch.merkleize(mem, &hasher));
+
+            let ancestor = Arc::downgrade(&a);
+            let c_batch = compact::UnmerkleizedBatch::wrap(b.new_batch());
+            drop(b);
+
+            let release = block_rayon(merkle.strategy(), 2);
+            let (op, clean_drop) = DropMonitor::tracked(10u64);
+            let mut merkleize = Box::pin(merkleize_ops::<mmb::Family, Sha256, _, _>(
+                &merkle,
+                c_batch,
+                vec![op],
+                0,
+            ));
+            assert!(futures::poll!(merkleize.as_mut()).is_pending());
+            drop(merkleize);
+            drop(a);
+
+            assert!(ancestor.upgrade().is_some());
+            drop(release);
+            assert!(
+                clean_drop
+                    .recv_timeout(Duration::from_secs(10))
+                    .expect("detached merkleization did not finish"),
+                "detached merkleization panicked"
+            );
+            assert!(ancestor.upgrade().is_none());
+        });
+    }
 }

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -59,7 +59,7 @@ mod tests {
     use super::*;
     use crate::{
         merkle::mmb,
-        utils::{DropMonitor, block_rayon},
+        utils::detached::{DropMonitor, block_strategy},
     };
     use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
@@ -132,7 +132,7 @@ mod tests {
             let c_batch = compact::UnmerkleizedBatch::wrap(b.new_batch());
             drop(b);
 
-            let release = block_rayon(merkle.strategy(), 2);
+            let release = block_strategy(merkle.strategy(), 2);
             let (op, clean_drop) = DropMonitor::tracked(10u64);
             let mut merkleize = Box::pin(merkleize_ops::<mmb::Family, Sha256, _, _>(
                 &merkle,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -742,6 +742,44 @@ where
     overlay
 }
 
+async fn merkleize_grafted_batch<F, H, S, const N: usize>(
+    strategy: &S,
+    grafted_parent: Arc<GenericMerkleizedBatch<F, H::Digest, S>>,
+    grafted_tree: &Arc<Mem<F, H::Digest>>,
+    graft_inputs: Vec<(usize, H::Digest, [u8; N])>,
+    grafting_height: u32,
+) -> Arc<GenericMerkleizedBatch<F, H::Digest, S>>
+where
+    F: Graftable,
+    H: Hasher,
+    S: Strategy,
+{
+    let old_grafted_leaves = *grafted_parent.leaves() as usize;
+    let mut grafted_batch = grafted_parent.new_batch();
+    let ancestors = grafted_batch.retain_ancestors();
+    let grafted_tree = Arc::clone(grafted_tree);
+    strategy
+        .clone()
+        .spawn(move |strategy| {
+            let new_leaves =
+                grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
+            for (chunk_idx, digest) in new_leaves {
+                if chunk_idx < old_grafted_leaves {
+                    grafted_batch = grafted_batch
+                        .update_leaf_digest(Location::<F>::new(chunk_idx as u64), digest)
+                        .expect("update_leaf_digest failed");
+                } else {
+                    grafted_batch = grafted_batch.add_leaf_digest(digest);
+                }
+            }
+            let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
+            let merkleized = grafted_batch.merkleize(&grafted_tree, &grafted_hasher);
+            drop(ancestors);
+            merkleized
+        })
+        .await
+}
+
 /// Compute the current layer (bitmap + grafted MMR + canonical root) on top of a merkleized any
 /// batch.
 ///
@@ -829,33 +867,20 @@ where
     // grafted tree) instead of occupying the calling task. An empty graft set hashes
     // nothing, so it merkleizes inline rather than paying for a job handoff.
     let graft_inputs = read_graft_inputs::<F, _, N>(&ops_tree_adapter, chunks_to_update).await?;
-    let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
     let grafted_batch = if graft_inputs.is_empty() {
+        let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
         grafted_parent
             .new_batch()
             .merkleize(&current_db.grafted_tree, &grafted_hasher)
     } else {
-        let grafted_parent = Arc::clone(grafted_parent);
-        let grafted_tree = Arc::clone(&current_db.grafted_tree);
-        current_db
-            .strategy
-            .clone()
-            .spawn(move |strategy| {
-                let new_leaves = grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
-                let mut grafted_batch = grafted_parent.new_batch();
-                let old_grafted_leaves = *grafted_parent.leaves() as usize;
-                for (chunk_idx, digest) in new_leaves {
-                    if chunk_idx < old_grafted_leaves {
-                        grafted_batch = grafted_batch
-                            .update_leaf_digest(Location::<F>::new(chunk_idx as u64), digest)
-                            .expect("update_leaf_digest failed");
-                    } else {
-                        grafted_batch = grafted_batch.add_leaf_digest(digest);
-                    }
-                }
-                grafted_batch.merkleize(&grafted_tree, &grafted_hasher)
-            })
-            .await
+        merkleize_grafted_batch::<F, H, S, N>(
+            &current_db.strategy,
+            Arc::clone(grafted_parent),
+            &current_db.grafted_tree,
+            graft_inputs,
+            grafting_height,
+        )
+        .await
     };
 
     // Build the layered bitmap (parent + overlay) before computing the canonical root, so that
@@ -1297,8 +1322,16 @@ mod trait_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::mmr;
-    use commonware_utils::bitmap::Prunable as BitMap;
+    use crate::{mmb, mmr, utils::block_rayon};
+    use commonware_cryptography::Sha256;
+    use commonware_macros::test_traced;
+    use commonware_parallel::Rayon;
+    use commonware_utils::{NZUsize, bitmap::Prunable as BitMap};
+    use std::{
+        future::Future as _,
+        task::Context as TaskContext,
+        time::{Duration, Instant},
+    };
 
     // N=4 -> CHUNK_SIZE_BITS = 32
     const N: usize = 4;
@@ -1311,6 +1344,92 @@ mod tests {
             bm.push(b);
         }
         bm
+    }
+
+    fn grafted_chain(
+        strategy: &Rayon,
+        mem: &Arc<Mem<mmb::Family, <Sha256 as Hasher>::Digest>>,
+    ) -> (
+        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>,
+        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>,
+    ) {
+        let hasher = grafting::hasher::<mmb::Family, Sha256>(grafting::height::<1>());
+        let a = mem
+            .new_batch_with_strategy(strategy.clone())
+            .add_leaf_digest(Sha256::hash(&[b"a-0"]))
+            .add_leaf_digest(Sha256::hash(&[b"a-1"]))
+            .merkleize(mem, &hasher);
+        let b = a
+            .new_batch()
+            .add_leaf_digest(Sha256::hash(&[b"b-0"]))
+            .merkleize(mem, &hasher);
+        (a, b)
+    }
+
+    /// A detached grafted-tree merkleization owns the full ancestor chain after cancellation.
+    #[test_traced]
+    fn test_grafted_merkleize_retains_ancestors_after_cancellation() {
+        let strategy = Rayon::new(NZUsize!(2)).unwrap();
+        let mem = Arc::new(Mem::<mmb::Family, <Sha256 as Hasher>::Digest>::new());
+        let grafting_height = grafting::height::<1>();
+        let graft_inputs = || vec![(0, Sha256::hash(&[b"replacement"]), [1u8; 1])];
+        let waker = futures::task::noop_waker();
+        let mut context = TaskContext::from_waker(&waker);
+
+        // Observe the worker result so a missing grandparent fails the test directly.
+        let (a, b) = grafted_chain(&strategy, &mem);
+        let ancestor = Arc::downgrade(&a);
+        let release = block_rayon(&strategy, 2);
+        let mut merkleize = Box::pin(merkleize_grafted_batch::<
+            mmb::Family,
+            Sha256,
+            _,
+            1,
+        >(
+            &strategy,
+            Arc::clone(&b),
+            &mem,
+            graft_inputs(),
+            grafting_height,
+        ));
+        assert!(merkleize.as_mut().poll(&mut context).is_pending());
+        drop(b);
+        drop(a);
+        drop(release);
+        let _ = futures::executor::block_on(merkleize);
+        assert!(ancestor.upgrade().is_none());
+
+        // Drop the waiter while the worker is queued to prove the guard moved with it.
+        let (a, b) = grafted_chain(&strategy, &mem);
+        let ancestor = Arc::downgrade(&a);
+        let release = block_rayon(&strategy, 2);
+        let mut merkleize = Box::pin(merkleize_grafted_batch::<
+            mmb::Family,
+            Sha256,
+            _,
+            1,
+        >(
+            &strategy,
+            Arc::clone(&b),
+            &mem,
+            graft_inputs(),
+            grafting_height,
+        ));
+        assert!(merkleize.as_mut().poll(&mut context).is_pending());
+        drop(merkleize);
+        drop(b);
+        drop(a);
+        assert!(ancestor.upgrade().is_some());
+
+        drop(release);
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while ancestor.upgrade().is_some() {
+            assert!(
+                Instant::now() < deadline,
+                "detached grafted merkleization did not release its ancestors"
+            );
+            std::thread::yield_now();
+        }
     }
 
     // ---- build_chunk_overlay tests ----

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1322,7 +1322,7 @@ mod trait_impls {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{mmb, mmr, utils::block_rayon};
+    use crate::{mmb, mmr, utils::detached::block_strategy};
     use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
     use commonware_parallel::Rayon;
@@ -1377,7 +1377,7 @@ mod tests {
         // Observe the worker result so a missing grandparent fails the test directly.
         let (a, b) = grafted_chain(&strategy, &mem);
         let ancestor = Arc::downgrade(&a);
-        let release = block_rayon(&strategy, 2);
+        let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
             &strategy,
             Arc::clone(&b),
@@ -1395,7 +1395,7 @@ mod tests {
         // Drop the waiter while the worker is queued to prove the guard moved with it.
         let (a, b) = grafted_chain(&strategy, &mem);
         let ancestor = Arc::downgrade(&a);
-        let release = block_rayon(&strategy, 2);
+        let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
             &strategy,
             Arc::clone(&b),

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1336,6 +1336,8 @@ mod tests {
     // N=4 -> CHUNK_SIZE_BITS = 32
     const N: usize = 4;
     type Bm = BitMap<N>;
+    type GraftedBatch =
+        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>;
     type Location = mmr::Location;
 
     fn make_bitmap(bits: &[bool]) -> Bm {
@@ -1349,10 +1351,7 @@ mod tests {
     fn grafted_chain(
         strategy: &Rayon,
         mem: &Arc<Mem<mmb::Family, <Sha256 as Hasher>::Digest>>,
-    ) -> (
-        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>,
-        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>,
-    ) {
+    ) -> (GraftedBatch, GraftedBatch) {
         let hasher = grafting::hasher::<mmb::Family, Sha256>(grafting::height::<1>());
         let a = mem
             .new_batch_with_strategy(strategy.clone())

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -742,6 +742,7 @@ where
     overlay
 }
 
+/// Merkleize grafted chunk digests while retaining the live ancestor chain.
 async fn merkleize_grafted_batch<F, H, S, const N: usize>(
     strategy: &S,
     grafted_parent: Arc<GenericMerkleizedBatch<F, H::Digest, S>>,

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -761,8 +761,7 @@ where
     strategy
         .clone()
         .spawn(move |strategy| {
-            let new_leaves =
-                grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
+            let new_leaves = grafting::graft_chunk_digests::<H, _, N>(&strategy, graft_inputs);
             for (chunk_idx, digest) in new_leaves {
                 if chunk_idx < old_grafted_leaves {
                     grafted_batch = grafted_batch
@@ -1336,8 +1335,7 @@ mod tests {
     // N=4 -> CHUNK_SIZE_BITS = 32
     const N: usize = 4;
     type Bm = BitMap<N>;
-    type GraftedBatch =
-        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>;
+    type GraftedBatch = Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>;
     type Location = mmr::Location;
 
     fn make_bitmap(bits: &[bool]) -> Bm {
@@ -1379,12 +1377,7 @@ mod tests {
         let (a, b) = grafted_chain(&strategy, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_rayon(&strategy, 2);
-        let mut merkleize = Box::pin(merkleize_grafted_batch::<
-            mmb::Family,
-            Sha256,
-            _,
-            1,
-        >(
+        let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
             &strategy,
             Arc::clone(&b),
             &mem,
@@ -1402,12 +1395,7 @@ mod tests {
         let (a, b) = grafted_chain(&strategy, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_rayon(&strategy, 2);
-        let mut merkleize = Box::pin(merkleize_grafted_batch::<
-            mmb::Family,
-            Sha256,
-            _,
-            1,
-        >(
+        let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
             &strategy,
             Arc::clone(&b),
             &mem,

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -1,102 +1,10 @@
 //! Utilities for storage tests and fuzz targets.
 
+#[cfg(test)]
+pub(crate) mod detached;
+
 use commonware_utils::bitmap::BitMap;
 use std::{collections::BTreeMap, num::NonZeroU64};
-#[cfg(test)]
-use {
-    commonware_codec::{Error as CodecError, FixedSize, Read, Write},
-    commonware_parallel::{Rayon, Strategy as _},
-    commonware_runtime::{Buf, BufMut},
-    commonware_utils::sync::Mutex,
-    std::{
-        sync::{Arc, mpsc},
-        thread,
-        time::Duration,
-    },
-};
-
-/// Occupy `workers` Rayon workers until the returned sender is dropped.
-#[cfg(test)]
-pub(crate) fn block_rayon(strategy: &Rayon, workers: usize) -> mpsc::Sender<()> {
-    let (started_tx, started_rx) = mpsc::channel();
-    let (release_tx, release_rx) = mpsc::channel();
-    let release_rx = Arc::new(Mutex::new(release_rx));
-    for _ in 0..workers {
-        let started_tx = started_tx.clone();
-        let release_rx = Arc::clone(&release_rx);
-        drop(strategy.spawn(move |_| {
-            started_tx.send(()).unwrap();
-            let _ = release_rx.lock().recv();
-        }));
-    }
-    drop(started_tx);
-    for _ in 0..workers {
-        started_rx
-            .recv_timeout(Duration::from_secs(10))
-            .expect("strategy worker did not start");
-    }
-    release_tx
-}
-
-/// An item that preserves `T`'s encoding and reports whether its tracked instance unwound.
-#[cfg(test)]
-pub(crate) struct DropMonitor<T> {
-    inner: T,
-    clean_drop: Option<mpsc::Sender<bool>>,
-}
-
-#[cfg(test)]
-impl<T> DropMonitor<T> {
-    /// Create an item that does not report when it is dropped.
-    pub(crate) const fn untracked(inner: T) -> Self {
-        Self {
-            inner,
-            clean_drop: None,
-        }
-    }
-
-    /// Create an item and a receiver that reports whether it was dropped outside an unwind.
-    pub(crate) fn tracked(inner: T) -> (Self, mpsc::Receiver<bool>) {
-        let (clean_drop, receiver) = mpsc::channel();
-        (
-            Self {
-                inner,
-                clean_drop: Some(clean_drop),
-            },
-            receiver,
-        )
-    }
-}
-
-#[cfg(test)]
-impl<T: FixedSize> FixedSize for DropMonitor<T> {
-    const SIZE: usize = T::SIZE;
-}
-
-#[cfg(test)]
-impl<T: Write> Write for DropMonitor<T> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.inner.write(buf);
-    }
-}
-
-#[cfg(test)]
-impl<T: Read> Read for DropMonitor<T> {
-    type Cfg = T::Cfg;
-
-    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, CodecError> {
-        T::read_cfg(buf, cfg).map(Self::untracked)
-    }
-}
-
-#[cfg(test)]
-impl<T> Drop for DropMonitor<T> {
-    fn drop(&mut self) {
-        if let Some(clean_drop) = self.clean_drop.take() {
-            let _ = clean_drop.send(!thread::panicking());
-        }
-    }
-}
 
 /// Build ordinal recovery bitmaps from absolute item indices.
 ///

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -2,6 +2,101 @@
 
 use commonware_utils::bitmap::BitMap;
 use std::{collections::BTreeMap, num::NonZeroU64};
+#[cfg(test)]
+use {
+    commonware_codec::{Error as CodecError, FixedSize, Read, Write},
+    commonware_parallel::{Rayon, Strategy as _},
+    commonware_runtime::{Buf, BufMut},
+    commonware_utils::sync::Mutex,
+    std::{
+        sync::{Arc, mpsc},
+        thread,
+        time::Duration,
+    },
+};
+
+/// Occupy `workers` Rayon workers until the returned sender is dropped.
+#[cfg(test)]
+pub(crate) fn block_rayon(strategy: &Rayon, workers: usize) -> mpsc::Sender<()> {
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    for _ in 0..workers {
+        let started_tx = started_tx.clone();
+        let release_rx = Arc::clone(&release_rx);
+        drop(strategy.spawn(move |_| {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.lock().recv();
+        }));
+    }
+    drop(started_tx);
+    for _ in 0..workers {
+        started_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("strategy worker did not start");
+    }
+    release_tx
+}
+
+/// An item that preserves `T`'s encoding and reports whether its tracked instance unwound.
+#[cfg(test)]
+pub(crate) struct DropMonitor<T> {
+    inner: T,
+    clean_drop: Option<mpsc::Sender<bool>>,
+}
+
+#[cfg(test)]
+impl<T> DropMonitor<T> {
+    /// Create an item that does not report when it is dropped.
+    pub(crate) const fn untracked(inner: T) -> Self {
+        Self {
+            inner,
+            clean_drop: None,
+        }
+    }
+
+    /// Create an item and a receiver that reports whether it was dropped outside an unwind.
+    pub(crate) fn tracked(inner: T) -> (Self, mpsc::Receiver<bool>) {
+        let (clean_drop, receiver) = mpsc::channel();
+        (
+            Self {
+                inner,
+                clean_drop: Some(clean_drop),
+            },
+            receiver,
+        )
+    }
+}
+
+#[cfg(test)]
+impl<T: FixedSize> FixedSize for DropMonitor<T> {
+    const SIZE: usize = T::SIZE;
+}
+
+#[cfg(test)]
+impl<T: Write> Write for DropMonitor<T> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.inner.write(buf);
+    }
+}
+
+#[cfg(test)]
+impl<T: Read> Read for DropMonitor<T> {
+    type Cfg = T::Cfg;
+
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, CodecError> {
+        T::read_cfg(buf, cfg).map(Self::untracked)
+    }
+}
+
+#[cfg(test)]
+impl<T> Drop for DropMonitor<T> {
+    fn drop(&mut self) {
+        if let Some(clean_drop) = self.clean_drop.take() {
+            let _ = clean_drop.send(!thread::panicking());
+        }
+    }
+}
 
 /// Build ordinal recovery bitmaps from absolute item indices.
 ///

--- a/storage/src/utils/detached.rs
+++ b/storage/src/utils/detached.rs
@@ -1,0 +1,87 @@
+//! Test support for detached strategy jobs.
+
+use commonware_codec::{Error as CodecError, FixedSize, Read, Write};
+use commonware_parallel::{Rayon, Strategy as _};
+use commonware_runtime::{Buf, BufMut};
+use commonware_utils::sync::Mutex;
+use std::{
+    sync::{Arc, mpsc},
+    thread,
+    time::Duration,
+};
+
+/// Occupy `workers` Rayon workers until the returned sender is dropped.
+pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<()> {
+    let (started_tx, started_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let release_rx = Arc::new(Mutex::new(release_rx));
+    for _ in 0..workers {
+        let started_tx = started_tx.clone();
+        let release_rx = Arc::clone(&release_rx);
+        drop(strategy.spawn(move |_| {
+            started_tx.send(()).unwrap();
+            let _ = release_rx.lock().recv();
+        }));
+    }
+    drop(started_tx);
+    for _ in 0..workers {
+        started_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("strategy worker did not start");
+    }
+    release_tx
+}
+
+/// An item that preserves `T`'s encoding and reports whether its tracked instance unwound.
+pub(crate) struct DropMonitor<T> {
+    inner: T,
+    clean_drop: Option<mpsc::Sender<bool>>,
+}
+
+impl<T> DropMonitor<T> {
+    /// Create an item that does not report when it is dropped.
+    pub(crate) const fn untracked(inner: T) -> Self {
+        Self {
+            inner,
+            clean_drop: None,
+        }
+    }
+
+    /// Create an item and a receiver that reports whether it was dropped outside an unwind.
+    pub(crate) fn tracked(inner: T) -> (Self, mpsc::Receiver<bool>) {
+        let (clean_drop, receiver) = mpsc::channel();
+        (
+            Self {
+                inner,
+                clean_drop: Some(clean_drop),
+            },
+            receiver,
+        )
+    }
+}
+
+impl<T: FixedSize> FixedSize for DropMonitor<T> {
+    const SIZE: usize = T::SIZE;
+}
+
+impl<T: Write> Write for DropMonitor<T> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.inner.write(buf);
+    }
+}
+
+impl<T: Read> Read for DropMonitor<T> {
+    type Cfg = T::Cfg;
+
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, CodecError> {
+        T::read_cfg(buf, cfg).map(Self::untracked)
+    }
+}
+
+impl<T> Drop for DropMonitor<T> {
+    fn drop(&mut self) {
+        if let Some(clean_drop) = self.clean_drop.take() {
+            let _ = clean_drop.send(!thread::panicking());
+        }
+    }
+}


### PR DESCRIPTION
Merkle batches intentionally hold weak parent links, so a detached merkleization job must retain every uncommitted ancestor that may provide nodes absent from its committed snapshot. Without that ownership, applying and dropping an older view or cancelling the waiting future can let a `Strategy::spawn` worker outlive the stack it is traversing, producing `peak missing` or missing-child panics.

- Capture the full live ancestor chain before snapshotting or handing work to the strategy.
- Move that guard into the detached authenticated-Journal, compact-QMDB, and Current-QMDB graft workers, retaining it through each worker’s last ancestor lookup.
- Add regressions for committed-prefix view stacks and cancelled, queued Rayon jobs, including clean ancestor release after completion.