### PR TITLE
fix(utils): implement Deref for NonEmptyRange and add unit test

### DIFF
--- a/utils/src/range.rs
+++ b/utils/src/range.rs
@@ -40,6 +40,14 @@ impl<Idx: Copy> NonEmptyRange<Idx> {
     }
 }
 
+impl<Idx> core::ops::Deref for NonEmptyRange<Idx> {
+    type Target = Range<Idx>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl<Idx: PartialOrd> TryFrom<Range<Idx>> for NonEmptyRange<Idx> {
     type Error = EmptyRange;
 
@@ -197,6 +205,13 @@ mod tests {
                 Err(CodecError::Invalid("NonEmptyRange", "start must be < end"))
             ));
         }
+    }
+
+    #[test]
+    fn test_non_empty_range_deref() {
+        let r = NonEmptyRange::new(0u32..5).unwrap();
+        assert!(r.contains(&3));
+        assert_eq!(r.len(), 5);
     }
 
     #[cfg(feature = "arbitrary")]


### PR DESCRIPTION
Implemented core::ops::Deref for NonEmptyRange<Idx> in utils/src/range.rs with Target = Range<Idx>. Previously, code taking &NonEmptyRange<Idx> could not directly call std Range methods like .contains() or .len() without explicit ownership or tuple field access. Added test_non_empty_range_deref unit test.