### PR TITLE
[storage] Batch the graft-input node reads

### DIFF
--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -415,10 +415,6 @@ pub enum Error<F: Family> {
     #[error("data corrupted: {0}")]
     DataCorrupted(&'static str),
 
-    /// A required grafted leaf digest is missing.
-    #[error("missing grafted leaf digest: {0}")]
-    MissingGraftedLeaf(Position<F>),
-
     /// Bit offset is out of bounds.
     #[error("bit offset {0} out of bounds (size: {1})")]
     BitOutOfBounds(u64, u64),

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -639,6 +639,47 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         }
     }
 
+    /// Batched [`Self::get_node`]: `positions` must be strictly increasing. Memory-resident
+    /// nodes are served directly; the rest go through the journal's batched read, which
+    /// serves page-cache hits in bulk and fetches misses concurrently.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ElementPruned`] for the first of `positions` that falls below the
+    /// journal's pruning boundary.
+    pub async fn get_nodes(&self, positions: &[Position<F>]) -> Result<Vec<D>, Error<F>> {
+        debug_assert!(positions.is_sorted_by(|a, b| a < b));
+        let bounds = self.journal.bounds();
+        let mut nodes = vec![None; positions.len()];
+        let mut journal_positions = Vec::with_capacity(positions.len());
+        for (slot, &position) in nodes.iter_mut().zip(positions) {
+            if let Some(node) = self.mem.get_node(position) {
+                *slot = Some(node);
+            } else if *position >= bounds.start {
+                // In-subsequence order is preserved, so this stays strictly increasing.
+                journal_positions.push(*position);
+            } else {
+                return Err(Error::ElementPruned(position));
+            }
+        }
+        // Within-bounds reads are guaranteed not to return `ItemPruned` (see
+        // [`crate::journal::contiguous::Contiguous::read`]).
+        let items = if journal_positions.is_empty() {
+            Vec::new()
+        } else {
+            self.journal
+                .read_many(&journal_positions)
+                .await
+                .map_err(Error::Journal)?
+        };
+        // The unfilled slots are exactly the journal subsequence, in the order it was built.
+        let mut items = items.into_iter();
+        Ok(nodes
+            .into_iter()
+            .map(|node| node.unwrap_or_else(|| items.next().expect("one item per journal read")))
+            .collect())
+    }
+
     /// Return the pinned nodes needed to authenticate a lower leaf boundary at `loc`.
     pub async fn pinned_nodes_at(&self, loc: Location<F>) -> Result<Vec<D>, Error<F>> {
         if !loc.is_valid() {
@@ -987,6 +1028,10 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> crate::merkle::storage::Stor
 
     async fn get_node(&self, position: Position<F>) -> Result<Option<D>, Error<F>> {
         Self::get_node(self, position).await
+    }
+
+    async fn get_nodes(&self, positions: &[Position<F>]) -> Result<Vec<D>, Error<F>> {
+        Self::get_nodes(self, positions).await
     }
 }
 
@@ -1410,6 +1455,87 @@ mod tests {
         ));
 
         mmr.destroy().await.unwrap();
+    }
+
+    /// `get_nodes` must agree with per-position `get_node` on every available position
+    /// (journal-resident and memory-resident) and reject the positions `get_node` reports
+    /// as absent.
+    async fn full_get_nodes_matches_get_node_inner<F: Family>(context: deterministic::Context) {
+        let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+        let cfg = test_config(&context);
+        let mut mmr = Merkle::<F, _, Digest, Sequential>::init(context, &hasher, cfg)
+            .await
+            .unwrap();
+
+        // Flushed leaves (journal-resident after sync), a pruned prefix, then unflushed
+        // leaves on top (memory-resident).
+        const LEAF_COUNT: usize = 200;
+        let mut batch = mmr.new_batch();
+        for i in 0..LEAF_COUNT {
+            batch = batch.add(&hasher, &test_digest(i));
+        }
+        let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+        mmr = mmr.apply_batch(&batch).unwrap();
+        mmr = mmr.sync().await.unwrap();
+        mmr = mmr.prune(Location::<F>::new(50)).await.unwrap();
+        let mut batch = mmr.new_batch();
+        for i in LEAF_COUNT..LEAF_COUNT + 10 {
+            batch = batch.add(&hasher, &test_digest(i));
+        }
+        let batch = mmr.with_mem(|mem| batch.merkleize(mem, &hasher));
+        mmr = mmr.apply_batch(&batch).unwrap();
+
+        // Partition by what `get_node` reports, so both APIs are judged against the same
+        // notion of availability.
+        let all: Vec<Position<F>> = (0..*mmr.size()).map(Position::new).collect();
+        let mut absent = Vec::new();
+        let mut available = Vec::new();
+        for &position in &all {
+            match mmr.get_node(position).await.unwrap() {
+                Some(node) => available.push((position, node)),
+                None => absent.push(position),
+            }
+        }
+        assert!(!absent.is_empty(), "expected some pruned positions");
+        assert!(!available.is_empty(), "expected some available positions");
+
+        // Spanning the pruning boundary is an error naming a position `get_node` calls absent.
+        match mmr.get_nodes(&all).await {
+            Err(Error::ElementPruned(position)) => {
+                assert!(absent.contains(&position), "position {position}")
+            }
+            other => panic!("expected ElementPruned, got {other:?}"),
+        }
+
+        // Every available position, then a sparse subset (slot correspondence), then empty.
+        let positions: Vec<Position<F>> = available.iter().map(|&(pos, _)| pos).collect();
+        let batched = mmr.get_nodes(&positions).await.unwrap();
+        assert_eq!(batched.len(), available.len());
+        for (slot, &(position, node)) in available.iter().enumerate() {
+            assert_eq!(batched[slot], node, "position {position}");
+        }
+
+        let sparse: Vec<Position<F>> = positions.iter().copied().step_by(7).collect();
+        let batched = mmr.get_nodes(&sparse).await.unwrap();
+        for (slot, &position) in sparse.iter().enumerate() {
+            let single = mmr.get_node(position).await.unwrap().unwrap();
+            assert_eq!(batched[slot], single, "position {position}");
+        }
+
+        assert!(mmr.get_nodes(&[]).await.unwrap().is_empty());
+        mmr.destroy().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_full_get_nodes_matches_get_node_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(full_get_nodes_matches_get_node_inner::<mmr::Family>);
+    }
+
+    #[test_traced]
+    fn test_full_get_nodes_matches_get_node_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(full_get_nodes_matches_get_node_inner::<mmb::Family>);
     }
 
     #[test_traced]

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -648,7 +648,10 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Returns [`Error::ElementPruned`] for the first of `positions` that falls below the
     /// journal's pruning boundary.
     pub async fn get_nodes(&self, positions: &[Position<F>]) -> Result<Vec<D>, Error<F>> {
-        debug_assert!(positions.is_sorted_by(|a, b| a < b));
+        assert!(
+            positions.is_sorted_by(|a, b| a < b),
+            "positions must be strictly increasing"
+        );
         let bounds = self.journal.bounds();
         let mut nodes = vec![None; positions.len()];
         let mut journal_positions = Vec::with_capacity(positions.len());
@@ -662,6 +665,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
                 return Err(Error::ElementPruned(position));
             }
         }
+
         // Within-bounds reads are guaranteed not to return `ItemPruned` (see
         // [`crate::journal::contiguous::Contiguous::read`]).
         let items = if journal_positions.is_empty() {
@@ -672,6 +676,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
                 .await
                 .map_err(Error::Journal)?
         };
+
         // The unfilled slots are exactly the journal subsequence, in the order it was built.
         let mut items = items.into_iter();
         Ok(nodes

--- a/storage/src/merkle/storage.rs
+++ b/storage/src/merkle/storage.rs
@@ -35,7 +35,10 @@ pub trait Storage<F: Family>: Send + Sync {
         positions: &[Position<F>],
     ) -> impl Future<Output = Result<Vec<Self::Digest>, Error<F>>> + Send {
         async move {
-            debug_assert!(positions.is_sorted_by(|a, b| a < b));
+            assert!(
+                positions.is_sorted_by(|a, b| a < b),
+                "positions must be strictly increasing"
+            );
             let mut nodes = Vec::with_capacity(positions.len());
             for &position in positions {
                 let node = self

--- a/storage/src/merkle/storage.rs
+++ b/storage/src/merkle/storage.rs
@@ -17,6 +17,36 @@ pub trait Storage<F: Family>: Send + Sync {
         &self,
         position: Position<F>,
     ) -> impl Future<Output = Result<Option<Self::Digest>, Error<F>>> + Send;
+
+    /// Return the specified nodes of the structure. `positions` must be strictly increasing.
+    ///
+    /// Slot `i` of the result holds the node at `positions[i]`. Unlike [`Storage::get_node`],
+    /// an unavailable node is an error rather than an absent value: this serves callers that
+    /// require every requested node. The default reads each node individually; implementations
+    /// backed by a batched read path should override it so cache hits are served in bulk and
+    /// misses are fetched concurrently rather than faulted one at a time.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ElementPruned`] for the first of `positions` where [`Storage::get_node`]
+    /// would yield `None`.
+    fn get_nodes(
+        &self,
+        positions: &[Position<F>],
+    ) -> impl Future<Output = Result<Vec<Self::Digest>, Error<F>>> + Send {
+        async move {
+            debug_assert!(positions.is_sorted_by(|a, b| a < b));
+            let mut nodes = Vec::with_capacity(positions.len());
+            for &position in positions {
+                let node = self
+                    .get_node(position)
+                    .await?
+                    .ok_or(Error::ElementPruned(position))?;
+                nodes.push(node);
+            }
+            Ok(nodes)
+        }
+    }
 }
 
 impl<F, D> Storage<F> for Mem<F, D>
@@ -32,5 +62,69 @@ where
 
     async fn get_node(&self, position: Position<F>) -> Result<Option<D>, Error<F>> {
         Ok(Self::get_node(self, position))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::merkle::{Bagging::ForwardFold, Location, hasher::Standard, mmr};
+    use commonware_cryptography::{Sha256, sha256};
+    use commonware_runtime::{Runner as _, deterministic};
+
+    type D = sha256::Digest;
+    type F = mmr::Family;
+
+    /// The default [`Storage::get_nodes`] serves retained positions and rejects pruned ones, so
+    /// implementations that do not override it inherit the strict contract. Exercised through
+    /// [`Mem`], which prunes and takes the default.
+    #[test]
+    fn test_default_get_nodes_rejects_pruned() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+            let mut mem = Mem::<F, D>::new();
+            let batch = {
+                let mut batch = mem.new_batch();
+                for i in 0u64..64 {
+                    batch = batch.add(&hasher, &hasher.digest(&i.to_be_bytes()));
+                }
+                batch.merkleize(&mem, &hasher)
+            };
+            mem.apply_batch(&batch).unwrap();
+            mem.prune(Location::new(20)).unwrap();
+
+            // Partition by what `get_node` reports, so both methods are judged against the
+            // same notion of availability.
+            let mut absent = Vec::new();
+            let mut available = Vec::new();
+            for position in (0..*mem.size()).map(Position::new) {
+                match Mem::get_node(&mem, position) {
+                    Some(node) => available.push((position, node)),
+                    None => absent.push(position),
+                }
+            }
+            assert!(!absent.is_empty(), "expected some pruned positions");
+            assert!(!available.is_empty(), "expected some available positions");
+
+            // Retained positions come back in slot order.
+            let positions: Vec<Position<F>> = available.iter().map(|&(pos, _)| pos).collect();
+            let nodes = Storage::get_nodes(&mem, &positions).await.unwrap();
+            assert_eq!(nodes.len(), available.len());
+            for (slot, &(position, node)) in available.iter().enumerate() {
+                assert_eq!(nodes[slot], node, "position {position}");
+            }
+
+            // A pruned position is rejected by name, alone and alongside retained positions.
+            let pruned = absent[0];
+            let mut mixed = vec![pruned, *positions.last().unwrap()];
+            mixed.sort();
+            for request in [vec![pruned], mixed] {
+                match Storage::get_nodes(&mem, &request).await {
+                    Err(Error::ElementPruned(position)) => assert_eq!(position, pruned),
+                    other => panic!("expected ElementPruned({pruned}), got {other:?}"),
+                }
+            }
+        });
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -200,6 +200,31 @@ impl<F: Graftable, D: Digest, R: Readable<Family = F, Digest = D>, S: MerkleStor
         }
         self.base.get_node(pos).await
     }
+
+    async fn get_nodes(&self, positions: &[Position<F>]) -> Result<Vec<D>, merkle::Error<F>> {
+        let mut nodes = vec![None; positions.len()];
+        let mut base_positions = Vec::with_capacity(positions.len());
+
+        // Look up nodes already in the batch chain.
+        for (slot, &pos) in nodes.iter_mut().zip(positions) {
+            match self.batch.get_node(pos) {
+                Some(node) => *slot = Some(node),
+                None => base_positions.push(pos),
+            }
+        }
+
+        // Look up remaining nodes from the base.
+        let base_nodes = if base_positions.is_empty() {
+            Vec::new()
+        } else {
+            self.base.get_nodes(&base_positions).await?
+        };
+        let mut base_nodes = base_nodes.into_iter();
+        Ok(nodes
+            .into_iter()
+            .map(|node| node.unwrap_or_else(|| base_nodes.next().expect("one node per base read")))
+            .collect())
+    }
 }
 
 /// Layers a [`GenericMerkleizedBatch`] over a [`Mem`] for node resolution.

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -44,7 +44,6 @@ use commonware_utils::{
     sequence::prefixed_u64::U64,
 };
 use core::{num::NonZeroU64, ops::Range};
-use futures::future::try_join_all;
 use std::{collections::BTreeMap, sync::Arc};
 use tracing::{error, warn};
 
@@ -1111,17 +1110,24 @@ pub(super) async fn read_graft_inputs<F: merkle::Graftable, D: Digest, const N: 
     let grafting_height = grafting::height::<N>();
 
     // Each graftable chunk has a single h=G ancestor at the deterministic
-    // `subtree_root_position(chunk_idx << G, G)`. Look it up directly.
-    try_join_all(chunks.into_iter().map(|(chunk_idx, chunk)| async move {
-        let leaf_start = Location::<F>::new((chunk_idx as u64) << grafting_height);
-        let pos = F::subtree_root_position(leaf_start, grafting_height);
-        let chunk_ops_digest = ops_tree
-            .get_node(pos)
-            .await?
-            .ok_or(merkle::Error::<F>::MissingGraftedLeaf(pos))?;
-        Ok::<_, Error<F>>((chunk_idx, chunk_ops_digest, chunk))
-    }))
-    .await
+    // `subtree_root_position(chunk_idx << G, G)`.
+    let chunks: Vec<(usize, [u8; N])> = chunks.into_iter().collect();
+    let positions: Vec<Position<F>> = chunks
+        .iter()
+        .map(|&(chunk_idx, _)| {
+            let leaf_start = Location::<F>::new((chunk_idx as u64) << grafting_height);
+            F::subtree_root_position(leaf_start, grafting_height)
+        })
+        .collect();
+
+    // Chunk indices ascend and subtree roots ascend with their leaf ranges, satisfying
+    // `get_nodes`'s ordering requirement.
+    let nodes = ops_tree.get_nodes(&positions).await?;
+    Ok(chunks
+        .into_iter()
+        .zip(nodes)
+        .map(|((chunk_idx, chunk), chunk_ops_digest)| (chunk_idx, chunk_ops_digest, chunk))
+        .collect())
 }
 
 /// Compute grafted leaf digests for the given bitmap chunks as `(chunk_idx, digest)` pairs.


### PR DESCRIPTION
## Summary

When a `current` DB merkleizes a commit, it reads one small ops-tree node for every bitmap chunk the commit touched. `read_graft_inputs` issued these one node at a time via `get_node`. The buffered blob backend performs its `pread` synchronously when polled, so every page-cache miss was a blocking read executed serially on the same thread that is doing the merkleize. Even cache hits paid a per-node future, a lock acquisition, and a metrics update, thousands of times per commit.

This change fetches the whole set in one call instead:

- New `Storage::get_nodes` takes a sorted list of positions and returns one node per slot. Unlike `get_node`, an unavailable node is an `ElementPruned` error rather than an absent value, which suits the callers that require every node they ask for; `get_node` keeps its `Option` so callers can still probe for pruned nodes without an error. The default implementation is a `get_node` loop, so no other impl needs to change.
- The persisted tree implements it by serving memory-resident nodes directly and handing the rest to the node journal's existing `read_many`, which resolves all cache hits under one lock per blob and fetches the misses concurrently.
- `read_graft_inputs` becomes a single `get_nodes` call.
- `Error::MissingGraftedLeaf` is removed. `read_graft_inputs` was its only raise site, and the batched call now reports the unavailable position itself.

## Why these reads may miss the cache

The node a chunk needs is determined by where that chunk sits in history, and a commit touches chunks spread across *all* of history. So the read set is large and effectively random. A cache bigger than the database still misses the first time each page is touched; a cache smaller than the working set misses constantly. There is no cache size at which these reads are free -- which is why fetching them well matters.

## Benchmarks

eth-replay follower (EPYC 9354P, 20k-block windows from a 5M-block seed, mimalloc, paired A/B, identical `db_bytes` in every pair), measured against main at both a 1-thread and an 8-thread strategy pool:

| | wall | merkleize |
|---|---|---|
| main, 8 threads | 54.22s | 31.52s |
| this PR, 8 threads | 51.55s (**-4.9%**) | 29.16s (**-7.5%**) |
| main, 1 thread | 45.02s | 27.35s |
| this PR, 1 thread | 42.60s (**-5.4%**) | 25.12s (**-8.1%**) |

The win does not depend on the strategy pool: the mechanism is bulk page-cache passes and runtime-level IO concurrency, not pool parallelism. It is slightly larger with the minimal pool, where the one thread does all the work and serial faulting costs it most. (The 1-thread rows are faster overall because this workload's parallel duty cycle is too low to pay for an idle pool; see #4432 for that analysis.)

Cache pressure changes the magnitude but not the direction. Under the pending performance stack (#4423 + #4432 + #4454 + #4440, 8 threads, both arms), whose pipelined merkleize already overlaps part of these reads with hashing -- which is why the percentages are smaller than above:

| scenario | wall | merkleize |
|---|---|---|
| cache smaller than working set (2G): constant misses | 83.1s -> 80.1s (**-3.7%**) | 54.8s -> 51.7s (**-5.6%**) |
| cache larger than data (16G / 32G / 64G): misses only on first touch of each page | -1.2% to -2.4% | -2.5% to -3.2% |
| 100k-block run (32G cache) | 192.3s -> 190.9s (-0.7%) | 114.3s -> 112.4s (-1.7%) |

This change touches different code regions than that stack and merges with it in either order.

Read-syscall counts per arm (strace attached after init) pin down the mechanism:

- With ample cache, both arms take ~0.9M misses per window -- all first touches, nearly independent of cache size. The win there comes from bulk-serving the hits and overlapping the misses.
- With the 2G cache, misses grow 7x (~6.4M) and **both arms take the same number** -- yet the win nearly doubles. The improvement is not fewer reads; it is that misses no longer execute one at a time on the merkleize thread.
- Every run was served from OS memory (zero block-device reads). Against real disk latency, the gap should widen further.

## Microbenchmarks

Both measured as `origin/main` vs this branch alone (no other changes in the diff), on the same host.

constantinople `current::ordered::fixed::mmb` (1M keys, 32k reads + 32k updates per iteration, p50 over 15 iterations, paired A/B x2). Speculative roots are bit-identical between the two binaries at every iteration.

| page cache | main | this PR |
|---|---|---|
| 512 MiB (working set fits) | 28.50ms | 27.18ms (**-4.6%**) |
| 32 MiB (thrashing) | 157.1ms | 155.4ms (-1.1%) |

The absolute saving is similar in both regimes (~1.3-1.7ms per commit); at 32 MiB the rest of the pipeline balloons on value-read misses this PR does not touch, which shrinks the percentage.

criterion `qmdb::merkleize`, all `current` variants (80 variant/config combinations, two paired runs each): this PR is faster in 78 of 80, typically -1% to -4%, with the `ordered` variants clustering at -2% to -4.6%.

## Validation

- New test: the persisted tree's `get_nodes` agrees with per-position `get_node` on every available position (journal-resident and memory-resident) and rejects the positions `get_node` reports as absent, for both mmr and mmb families.
- New test: the default `get_nodes` serves retained positions and rejects pruned ones, so implementations that do not override it inherit the strict contract.
- The qmdb, merkle, and journal suites pass on this base; `--no-default-features` clean.




