### PR TITLE
Fix check_notarization_unlocks_finalize_quorum

### DIFF
--- a/consensus/fuzz/src/invariants.rs
+++ b/consensus/fuzz/src/invariants.rs
@@ -2260,20 +2260,12 @@ fn check_fuzz_invariants<E, S, L>(
     }
 }
 
-/// A locally observed notarization makes its exact proposal authoritative for
-/// finalization recovery. If the node also retains a quorum of valid finalize
-/// votes for that proposal, it must recover a finalization even when it never
-/// observed a proposal from the round's leader.
-///
-/// Scoped to the node whose inbound leader proposals and finalizations the
-/// harness omits: that omission is what rules out the benign reasons a correct
-/// node can hold votes it cannot use, so this must not run over every audited
-/// reporter. A higher finalized view exempts recovery because the batcher
-/// stops processing rounds below its floor. The leader is derived from the
-/// certificate-less elector of the single-epoch, four-correct-node target.
-pub fn check_notarization_unlocks_finalize_quorum<E, S, L>(
+/// Collects proposals whose recorded notarization and quorum of valid finalize
+/// votes lack both an exact finalization and a higher finalized floor.
+pub fn unresolved_finalize_recoveries<E, S, L>(
     reporter: &RecordingReporter<E, S, L, Sha256Digest>,
-) where
+) -> BTreeMap<Proposal<Sha256Digest>, usize>
+where
     E: CryptoRng,
     S: Scheme<Sha256Digest>,
     L: Elector<S>,
@@ -2325,17 +2317,74 @@ pub fn check_notarization_unlocks_finalize_quorum<E, S, L>(
         }
     }
 
+    let mut pending = BTreeMap::new();
     for proposal in notarizations {
         let signers = finalize_signers.get(&proposal).map_or(0, BTreeSet::len);
         if leader_notarizes.contains(&proposal.round) || signers < quorum {
             continue;
         }
-        assert!(
-            finalizations.contains(&proposal) || finalized_floor > proposal.round.view(),
-            "Invariant violation: notarization plus finalize quorum without a leader proposal did not produce an exact finalization: observer {:?}, proposal {proposal:?}, signers {signers}, required {quorum}",
-            audit.observer().as_ref(),
-        );
+        if finalizations.contains(&proposal) || finalized_floor > proposal.round.view() {
+            continue;
+        }
+        pending.insert(proposal, signers);
     }
+    pending
+}
+
+/// A locally observed notarization makes its exact proposal authoritative for
+/// finalization recovery. If the node also retains a quorum of valid finalize
+/// votes for that proposal, it must recover a finalization even when it never
+/// observed a proposal from the round's leader.
+///
+/// Scoped to the node whose inbound leader proposals and finalizations the
+/// harness omits: that omission is what rules out the benign reasons a correct
+/// node can hold votes it cannot use, so this must not run over every audited
+/// reporter. A higher finalized view exempts recovery because the batcher
+/// stops processing rounds below its floor. The leader is derived from the
+/// certificate-less elector of the single-epoch, four-correct-node target.
+/// The single-snapshot form assumes a stable log; truncating harnesses must use
+/// [`unresolved_finalize_recoveries`] and [`check_finalize_recoveries_drained`].
+pub fn check_notarization_unlocks_finalize_quorum<E, S, L>(
+    reporter: &RecordingReporter<E, S, L, Sha256Digest>,
+) where
+    E: CryptoRng,
+    S: Scheme<Sha256Digest>,
+    L: Elector<S>,
+    L::Elector: Clone,
+{
+    let pending = unresolved_finalize_recoveries(reporter);
+    let quorum = bounds::quorum(
+        u32::try_from(reporter.inner().participants.len()).expect("participant count exceeds u32"),
+    ) as usize;
+    assert!(
+        pending.is_empty(),
+        "Invariant violation: notarization plus finalize quorum without a leader proposal did not produce an exact finalization: observer {:?}, pending {pending:?}, required {quorum}",
+        reporter.audit().observer().as_ref(),
+    );
+}
+
+/// Second-snapshot form: judges only recoveries pending in `earlier` that are
+/// still pending now. In-flight recovery needs no timers, so one quiescing
+/// sleep drains it; a survivor is genuinely stuck.
+pub fn check_finalize_recoveries_drained<E, S, L>(
+    reporter: &RecordingReporter<E, S, L, Sha256Digest>,
+    earlier: &BTreeMap<Proposal<Sha256Digest>, usize>,
+) where
+    E: CryptoRng,
+    S: Scheme<Sha256Digest>,
+    L: Elector<S>,
+    L::Elector: Clone,
+{
+    let mut pending = unresolved_finalize_recoveries(reporter);
+    pending.retain(|proposal, _| earlier.contains_key(proposal));
+    let quorum = bounds::quorum(
+        u32::try_from(reporter.inner().participants.len()).expect("participant count exceeds u32"),
+    ) as usize;
+    assert!(
+        pending.is_empty(),
+        "Invariant violation: notarization plus finalize quorum without a leader proposal did not produce an exact finalization after quiescence: observer {:?}, pending {pending:?}, required {quorum}",
+        reporter.audit().observer().as_ref(),
+    );
 }
 
 fn record_exact_proposal<P: AsRef<[u8]> + PartialEq>(
@@ -3702,6 +3751,79 @@ mod tests {
                 Finalize::sign(&schemes[signer], proposal.clone()).unwrap(),
             ));
         }
+    }
+
+    fn record_pending_finalize_recovery(
+        reporter: &mut AuditReporter,
+        schemes: &[id_mock::Scheme],
+        proposal: &Proposal<Sha256Digest>,
+    ) {
+        record_finalize_votes(reporter, schemes, proposal, 0..Q);
+        reporter.report(Activity::Notarization(notarization_activity(
+            schemes,
+            proposal.round.view().get(),
+            proposal.parent.get(),
+            proposal.payload.as_ref()[0],
+        )));
+    }
+
+    #[test]
+    fn finalize_recovery_drained_by_exact_finalization_passes() {
+        let (participants, schemes) = vote_fixture();
+        let mut reporter = audit_reporter(3, &participants, &schemes);
+        let proposal = proposal(5, 4, 0xA);
+
+        record_pending_finalize_recovery(&mut reporter, &schemes, &proposal);
+        let earlier = unresolved_finalize_recoveries(&reporter);
+        assert_eq!(earlier.get(&proposal), Some(&Q));
+        reporter.report(Activity::Finalization(finalization_activity(
+            &schemes, 5, 4, 0xA,
+        )));
+
+        check_finalize_recoveries_drained(&reporter, &earlier);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "notarization plus finalize quorum without a leader proposal did not produce an exact finalization after quiescence"
+    )]
+    fn finalize_recovery_pending_across_quiescence_panics() {
+        let (participants, schemes) = vote_fixture();
+        let mut reporter = audit_reporter(3, &participants, &schemes);
+        let proposal = proposal(5, 4, 0xA);
+
+        record_pending_finalize_recovery(&mut reporter, &schemes, &proposal);
+        let earlier = unresolved_finalize_recoveries(&reporter);
+
+        check_finalize_recoveries_drained(&reporter, &earlier);
+    }
+
+    #[test]
+    fn finalize_recovery_appearing_only_at_second_snapshot_is_pending() {
+        let (participants, schemes) = vote_fixture();
+        let mut reporter = audit_reporter(3, &participants, &schemes);
+        let proposal = proposal(5, 4, 0xA);
+        let earlier = BTreeMap::new();
+
+        record_pending_finalize_recovery(&mut reporter, &schemes, &proposal);
+
+        check_finalize_recoveries_drained(&reporter, &earlier);
+    }
+
+    #[test]
+    fn finalize_recovery_drained_by_higher_floor_passes() {
+        let (participants, schemes) = vote_fixture();
+        let mut reporter = audit_reporter(3, &participants, &schemes);
+        let proposal = proposal(5, 4, 0xA);
+
+        record_pending_finalize_recovery(&mut reporter, &schemes, &proposal);
+        let earlier = unresolved_finalize_recoveries(&reporter);
+        assert_eq!(earlier.get(&proposal), Some(&Q));
+        reporter.report(Activity::Finalization(finalization_activity(
+            &schemes, 6, 5, 0xB,
+        )));
+
+        check_finalize_recoveries_drained(&reporter, &earlier);
     }
 
     #[test]

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -2317,7 +2317,16 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
         );
         invariants::check::<P>(term_length, reporter_only.as_slice());
         if let Some(index) = omitted_reporter {
-            invariants::check_notarization_unlocks_finalize_quorum(&reporter_only[index]);
+            // The finalizer wait excludes the victim, so a recovery whose
+            // trigger is already in its log can still be in flight between
+            // batcher and voter. Recovery is message-driven: one quiescing
+            // sleep drains it, and only a recovery pending across both
+            // snapshots is genuinely stuck.
+            let earlier = invariants::unresolved_finalize_recoveries(&reporter_only[index]);
+            if !earlier.is_empty() {
+                context.sleep(MAX_SLEEP_DURATION).await;
+                invariants::check_finalize_recoveries_drained(&reporter_only[index], &earlier);
+            }
         }
         (true, rejected_certification_observed)
     })


### PR DESCRIPTION
Problem: In the notarize-omission fuzz target, the victim node can only finalize via local recovery (notarization's exact proposal + retained finalize-vote quorum). The invariant checking this fired on healthy runs: the harness's finish line excludes the victim, so it could snapshot while the recovered Finalization was still queued between batcher and voter — premise in the log, conclusion in flight.

Fix: Judge the log at two snapshots instead. Split the invariant into a pure collector (unresolved_finalize_recoveries), the original single-snapshot assert, and check_finalize_recoveries_drained. The harness takes snapshot 1; only if it would fire, it sleeps MAX_SLEEP_DURATION and asserts on recoveries pending in both snapshots.
