### PR TITLE
[storage] Slim Readable to synchronous node resolution

### DIFF
--- a/docs/blogs/pipelining-simplex.html
+++ b/docs/blogs/pipelining-simplex.html
@@ -95,8 +95,8 @@ deployment of 50 validators, it sustained 200 blocks per second with
 Chou</a></div>
                         <div class="date">August 12th, 2026</div>
         </div>
-        <p>Simplex can now produce blocks as fast as its leader can build
-        them.</p>
+        <p>Simplex can now produce blocks as fast as its leader can
+        build them.</p>
         <p>Today, we’re introducing <a
         href="https://github.com/commonwarexyz/monorepo/pull/3352">Stable
         Leader</a> and <a
@@ -105,16 +105,16 @@ Chou</a></div>
         href="https://eprint.iacr.org/2023/463">Simplex</a> views.
         Stable Leader keeps one proposer for many views in a row,
         reducing handoff overhead. Optimistic Validation lets that
-        leader keep proposing and validators keep voting without
-        waiting for the previous view’s notarization. Together, they
-        turn Simplex into a high-frequency decentralized sequencer, with
+        leader keep proposing and validators keep voting without waiting
+        for the previous view’s notarization. Together, they turn
+        Simplex into a high-frequency decentralized sequencer, with
         several views moving through the network at once. For users,
         more frequent proposals mean less time waiting for a transaction
         to enter the next block.</p>
         <p>In a global deployment with 50 validators, this Simplex
         variant sustained 200 blocks per second with 300ms finality to
-        your browser. At 5ms per block, Simplex moves faster
-        than most monitors refresh.</p>
+        your browser. At 5ms per block, Simplex moves faster than most
+        monitors refresh.</p>
         <style>
           .simplex-loop {
             aspect-ratio: 1024 / 430;
@@ -174,8 +174,8 @@ Chou</a></div>
         href="https://eprint.iacr.org/2023/1916">Sing a Song of
         Simplex</a> and Commonware’s <a
         href="https://arxiv.org/abs/2603.11797">Carnot</a>. One leader
-        proposes throughout the term, reducing proposer handoffs
-        from one per view to one per term. Within the term, the leader
+        proposes throughout the term, reducing proposer handoffs from
+        one per view to one per term. Within the term, the leader
         already knows the previous block and its ancestry before a
         single network message arrives. An honest leader also knows it
         did not equivocate, so it can begin building and distributing
@@ -271,10 +271,10 @@ Chou</a></div>
         proposal.</p>
         <p>Longer terms reduce handoff overhead but give one leader more
         consecutive proposals. With 5ms views, a 10,000-view term lasts
-        roughly 50 seconds. If a leader goes offline,
-        nullifying its first stalled view skips the rest of the term and
-        rotates to the next leader. One timeout therefore covers the
-        offline leader’s entire term.</p>
+        roughly 50 seconds. If a leader goes offline, nullifying its
+        first stalled view skips the rest of the term and rotates to the
+        next leader. One timeout therefore covers the offline leader’s
+        entire term.</p>
         <p>A Byzantine leader could still finalize blocks while
         selectively censoring transactions. This risk also exists with
         rotating leaders, but longer terms can increase inclusion delay
@@ -291,8 +291,8 @@ Chou</a></div>
         new data. That finer schedule means orderbooks, batchers, and
         games respond to new input as fast as a traditional web
         page.</p>
-        <p>This design maintains a single proposal chain. Within a stable
-        term, the leader knows the parent it is extending, so
+        <p>This design maintains a single proposal chain. Within a
+        stable term, the leader knows the parent it is extending, so
         applications can evaluate stateful transitions against a
         predictable pending state. Multiple Concurrent Proposer
         constructions address a different bottleneck. <a

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -227,7 +227,6 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> Readable
 {
     type Family = F;
     type Digest = D;
-    type Error = merkle::Error<F>;
 
     fn size(&self) -> Position<F> {
         self.inner.size()
@@ -235,10 +234,6 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> Readable
 
     fn get_node(&self, pos: Position<F>) -> Option<D> {
         self.inner.get_node(pos)
-    }
-
-    fn pruning_boundary(&self) -> Location<F> {
-        self.inner.pruning_boundary()
     }
 }
 

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -569,7 +569,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
             parent_size: mem.size(),
             base_size: mem.size(),
             ancestor_base_size: mem.size(),
-            pruning_boundary: Readable::pruning_boundary(mem),
+            pruning_boundary: mem.pruning_boundary(),
             ancestor_appended: Vec::new(),
             ancestor_overwrites: Vec::new(),
             strategy,
@@ -699,7 +699,6 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
 impl<F: Family, D: Digest, S: Strategy> Readable for MerkleizedBatch<F, D, S> {
     type Family = F;
     type Digest = D;
-    type Error = Error<F>;
 
     fn size(&self) -> Position<F> {
         Self::size(self)
@@ -707,10 +706,6 @@ impl<F: Family, D: Digest, S: Strategy> Readable for MerkleizedBatch<F, D, S> {
 
     fn get_node(&self, pos: Position<F>) -> Option<D> {
         Self::get_node(self, pos)
-    }
-
-    fn pruning_boundary(&self) -> Location<F> {
-        Self::pruning_boundary(self)
     }
 }
 

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -169,10 +169,18 @@ impl<F: Family, D: Digest> Mem<F, D> {
         Location::try_from(self.size()).expect("invalid merkle size")
     }
 
+    /// Return the leaf location pruning has been performed up to, or 0 if never pruned.
+    ///
+    /// Nodes below this location are dropped except for those pinned for root computation and
+    /// proof generation, which [`Self::get_node`] still returns.
+    pub fn pruning_boundary(&self) -> Location<F> {
+        Location::try_from(self.pruning_boundary).expect("valid pruning_boundary")
+    }
+
     /// Returns `[start, end)` where `start` is the oldest retained leaf and `end` is the total
     /// leaf count.
     pub fn bounds(&self) -> Range<Location<F>> {
-        Location::try_from(self.pruning_boundary).expect("valid pruning_boundary")..self.leaves()
+        self.pruning_boundary()..self.leaves()
     }
 
     /// Return a new iterator over the peaks.
@@ -470,7 +478,6 @@ impl<F: Family, D: Digest> Mem<F, D> {
 impl<F: Family, D: Digest> Readable for Mem<F, D> {
     type Family = F;
     type Digest = D;
-    type Error = Error<F>;
 
     fn size(&self) -> Position<F> {
         self.size()
@@ -478,10 +485,6 @@ impl<F: Family, D: Digest> Readable for Mem<F, D> {
 
     fn get_node(&self, pos: Position<F>) -> Option<D> {
         self.get_node(pos)
-    }
-
-    fn pruning_boundary(&self) -> Location<F> {
-        Location::try_from(self.pruning_boundary).expect("valid pruning_boundary")
     }
 }
 

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -961,16 +961,11 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
 }
 
 /// The [`Readable`] implementation for the full structure operates only on the in-memory
-/// portion. After [`Merkle::sync`], nodes that have been flushed to the journal are no longer
-/// accessible through this interface. In particular, [`Readable::get_node`] returns `None` for
-/// flushed positions, and [`Readable::pruning_boundary`] reflects the in-memory boundary (which may
-/// be tighter than the journal's prune boundary reported by [`Merkle::bounds`]). This means
-/// batch operations like `update_leaf` will correctly reject leaves that have been synced out of
-/// memory with [`Error::ElementPruned`].
+/// portion. After [`Merkle::sync`], nodes flushed to the journal are no longer accessible
+/// through this interface, even though [`Merkle::bounds`] still reports them as retained.
 impl<F: Family, E: Context, D: Digest, S: Strategy> Readable for Merkle<F, E, D, S> {
     type Family = F;
     type Digest = D;
-    type Error = Error<F>;
 
     fn size(&self) -> Position<F> {
         self.size()
@@ -978,10 +973,6 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Readable for Merkle<F, E, D,
 
     fn get_node(&self, pos: Position<F>) -> Option<D> {
         self.mem.get_node(pos)
-    }
-
-    fn pruning_boundary(&self) -> Location<F> {
-        self.mem.pruning_boundary()
     }
 }
 
@@ -3630,7 +3621,7 @@ mod tests {
     }
 
     /// Regression: update_leaf on a synced-out leaf must return ElementPruned, not panic.
-    /// Before the fix, `Readable::pruning_boundary` returned the journal's prune boundary
+    /// Before the fix, the batch took its pruning boundary from the journal's prune boundary
     /// (which could be 0), so the batch accepted the update. During merkleize, get_node
     /// returned None for the synced-out sibling and hit an expect panic.
     async fn full_update_leaf_after_sync_returns_pruned_inner<F: Family>(

--- a/storage/src/merkle/read.rs
+++ b/storage/src/merkle/read.rs
@@ -1,14 +1,14 @@
 //! Shared read-only trait for merkleized data structures.
 
-use crate::merkle::{Family, Location, Position};
+use crate::merkle::{Family, Position};
 use alloc::sync::Arc;
 use commonware_cryptography::Digest;
-use core::ops::Range;
 
 /// Read-only interface for a merkleized data structure.
 ///
-/// This trait covers structural reads (size, leaves, retained nodes, pruning boundary). Proof
-/// construction stays on concrete types because it depends on caller-selected bagging.
+/// Synchronous node resolution over whatever this view holds: `get_node` serves only what it
+/// can resolve without I/O and reports everything else as absent. Proof construction stays on
+/// concrete types because it depends on caller-selected bagging.
 pub trait Readable: Send + Sync {
     /// The Merkle family implemented by this structure.
     type Family: Family;
@@ -16,33 +16,16 @@ pub trait Readable: Send + Sync {
     /// The digest type used by this structure.
     type Digest: Digest;
 
-    /// The error type returned by structural reads.
-    type Error;
-
     /// Total number of nodes (retained + pruned).
     fn size(&self) -> Position<Self::Family>;
 
-    /// Digest of the node at `pos`, or `None` if pruned / out of bounds.
+    /// Digest of the node at `pos`, or `None` if this structure cannot serve it.
     fn get_node(&self, pos: Position<Self::Family>) -> Option<Self::Digest>;
-
-    /// Leaf location up to which pruning has been performed, or 0 if never pruned.
-    fn pruning_boundary(&self) -> Location<Self::Family>;
-
-    /// Total number of leaves.
-    fn leaves(&self) -> Location<Self::Family> {
-        Location::try_from(self.size()).expect("invalid merkle size")
-    }
-
-    /// `[start, end)` range of retained leaf locations.
-    fn bounds(&self) -> Range<Location<Self::Family>> {
-        self.pruning_boundary()..self.leaves()
-    }
 }
 
 impl<T: Readable> Readable for Arc<T> {
     type Family = T::Family;
     type Digest = T::Digest;
-    type Error = T::Error;
 
     fn size(&self) -> Position<Self::Family> {
         (**self).size()
@@ -50,9 +33,5 @@ impl<T: Readable> Readable for Arc<T> {
 
     fn get_node(&self, pos: Position<Self::Family>) -> Option<Self::Digest> {
         (**self).get_node(pos)
-    }
-
-    fn pruning_boundary(&self) -> Location<Self::Family> {
-        (**self).pruning_boundary()
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -161,7 +161,7 @@ struct BatchStorageAdapter<
     'a,
     F: Graftable,
     D: Digest,
-    R: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
+    R: Readable<Family = F, Digest = D>,
     S: MerkleStorage<F, Digest = D>,
 > {
     batch: &'a R,
@@ -173,7 +173,7 @@ impl<
     'a,
     F: Graftable,
     D: Digest,
-    R: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
+    R: Readable<Family = F, Digest = D>,
     S: MerkleStorage<F, Digest = D>,
 > BatchStorageAdapter<'a, F, D, R, S>
 {
@@ -186,12 +186,8 @@ impl<
     }
 }
 
-impl<
-    F: Graftable,
-    D: Digest,
-    R: Readable<Family = F, Digest = D, Error = merkle::Error<F>>,
-    S: MerkleStorage<F, Digest = D>,
-> MerkleStorage<F> for BatchStorageAdapter<'_, F, D, R, S>
+impl<F: Graftable, D: Digest, R: Readable<Family = F, Digest = D>, S: MerkleStorage<F, Digest = D>>
+    MerkleStorage<F> for BatchStorageAdapter<'_, F, D, R, S>
 {
     type Digest = D;
 
@@ -218,7 +214,6 @@ struct BatchOverMem<'a, F: Graftable, D: Digest, S: Strategy> {
 impl<F: Graftable, D: Digest, S: Strategy> Readable for BatchOverMem<'_, F, D, S> {
     type Family = F;
     type Digest = D;
-    type Error = merkle::Error<F>;
 
     fn size(&self) -> Position<F> {
         self.batch.size()
@@ -229,10 +224,6 @@ impl<F: Graftable, D: Digest, S: Strategy> Readable for BatchOverMem<'_, F, D, S
             return Some(d);
         }
         self.mem.get_node(pos)
-    }
-
-    fn pruning_boundary(&self) -> Location<F> {
-        self.batch.pruning_boundary()
     }
 }
 

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -428,7 +428,7 @@ pub(super) struct Storage<
     'a,
     F: Graftable,
     H: Hasher,
-    G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
+    G: Readable<Family = F, Digest = H::Digest>,
     S: StorageTrait<F, Digest = H::Digest>,
 > {
     grafted_tree: &'a G,
@@ -441,7 +441,7 @@ impl<
     'a,
     F: Graftable,
     H: Hasher,
-    G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
+    G: Readable<Family = F, Digest = H::Digest>,
     S: StorageTrait<F, Digest = H::Digest>,
 > Storage<'a, F, H, G, S>
 {
@@ -493,7 +493,7 @@ impl<
 impl<
     F: Graftable,
     H: Hasher,
-    G: Readable<Family = F, Digest = H::Digest, Error = merkle::Error<F>>,
+    G: Readable<Family = F, Digest = H::Digest>,
     S: StorageTrait<F, Digest = H::Digest>,
 > StorageTrait<F> for Storage<'_, F, H, G, S>
 {


### PR DESCRIPTION
## Summary

`Readable` now carries only what its consumers dispatch on -- `size` and `get_node`: synchronous node resolution over whatever the implementing view holds, the sync counterpart of the async `merkle::storage::Storage`.

Four members are removed: `pruning_boundary`, the `bounds()` and `leaves()` defaults, and the `Error` associated type.

### Why `pruning_boundary` had to go

It meant something different in every implementation, so no accurate shared contract could be written:

| Impl | What the value was |
|---|---|
| `Mem` | the location pruning was performed to |
| `full::Merkle` | the in-memory boundary, which *flushing* raises without anything being pruned |
| `merkle::batch::MerkleizedBatch` | a value inherited from the parent `Mem`, describing data the batch does not hold |

Availability was decoupled from the boundary in both directions: `Mem` serves pinned nodes *below* it (out of `pinned_nodes`), while a batch serves almost nothing *above* it, since its `get_node` only covers the batch chain.

### Why the others followed

- `bounds()` was defined in terms of `pruning_boundary` and had no callers through the trait at all -- every `.bounds()` in the workspace resolves to an inherent method on a concrete type, so deleting the default produced zero call-site errors. The inherent `bounds()` on `Mem` and `Merkle` are untouched.
- `leaves()` duplicated inherent methods that already exist on every implementing type, and no caller dispatched on the trait's copy.
- `Error` became unreferenced the moment no trait method returned `Result`: it was constrained at every use site (`Error = merkle::Error<F>`) but never read.

None of the four was consumed polymorphically; every surviving call resolves on a concrete type or an inherent method. `Mem` gains an inherent `pruning_boundary` accessor for the one site in `merkle::batch` that needed trait-qualified access.

### `get_node` contract

The trait documented `None` as meaning "pruned / out of bounds". No implementation restricts it that way: `full::Merkle` returns `None` for **flushed** positions the journal still retains, a merkleized batch returns `None` for every position it did not touch, and the layered adapters in `qmdb::current` use `None` as a fall-through signal. The contract is now stated as a property of the interface (whether *this* view can serve the node) rather than a claim about the underlying data.

## Behavior

Unchanged. The load-bearing case is `update_leaf` rejecting leaves synced out of memory with `ElementPruned`: batches forked from a persisted tree capture the same in-memory boundary as before, now via the inherent method rather than the trait. The existing `update_leaf_after_sync_returns_pruned` regression test covers exactly that path and passes for both mmr and mmb.

## Validation

The full storage merkle and qmdb suites pass under `--profile all` (slow tests included). `just check-stability` is clean, rustdoc is clean under `-D warnings`, and `cargo check --workspace --all-targets` is clean -- the last of those matters because this removes public trait members, so any dependent crate implementing `Readable` would have surfaced.

