### PR TITLE
[workspace] Fix lints from the new stable clippy

### DIFF
--- a/cryptography/src/lthash/mod.rs
+++ b/cryptography/src/lthash/mod.rs
@@ -139,8 +139,9 @@ impl LtHash {
     /// Return the [Digest] of the current state.
     pub fn checksum(&self) -> Digest {
         let mut bytes = [0u8; LTHASH_SIZE];
-        for (chunk, val) in bytes.chunks_exact_mut(2).zip(&self.state) {
-            chunk.copy_from_slice(&val.to_le_bytes());
+        let (chunks, _) = bytes.as_chunks_mut::<2>();
+        for (chunk, val) in chunks.iter_mut().zip(&self.state) {
+            *chunk = val.to_le_bytes();
         }
         Blake3::hash(&[&bytes])
     }

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -64,8 +64,9 @@ const IV: [u32; 8] = [
 #[inline]
 fn digest_from_state(state: [u32; 8]) -> [u8; DIGEST_LENGTH] {
     let mut out = [0u8; DIGEST_LENGTH];
-    for (chunk, word) in out.chunks_exact_mut(4).zip(state) {
-        chunk.copy_from_slice(&word.to_be_bytes());
+    let (chunks, _) = out.as_chunks_mut::<4>();
+    for (chunk, word) in chunks.iter_mut().zip(state) {
+        *chunk = word.to_be_bytes();
     }
     out
 }

--- a/cryptography/src/zk/bulletproofs/benches/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/benches/ipa.rs
@@ -17,7 +17,9 @@ fn make_setup(len: usize) -> Setup<G1> {
     Setup::new(
         generators[0],
         generators[1..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| (chunk[0], chunk[1])),
     )
 }

--- a/cryptography/src/zk/bulletproofs/circuit.rs
+++ b/cryptography/src/zk/bulletproofs/circuit.rs
@@ -1904,7 +1904,9 @@ pub mod fuzz {
                 ipa::Setup::new(
                     gens[2 * TEST_SETUP_PAIRS],
                     gens[..2 * TEST_SETUP_PAIRS]
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| (c[0], c[1])),
                 ),
                 gens[2 * TEST_SETUP_PAIRS + 1],

--- a/cryptography/src/zk/bulletproofs/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/ipa.rs
@@ -865,7 +865,9 @@ pub mod fuzz {
             Setup::new(
                 generators[0],
                 generators[1..]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|chunk| (chunk[0], chunk[1])),
             )
         })

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1576,9 +1576,7 @@ impl<D: Digest, T: Clone> CoordinatorState<D, T> {
                 if let Some((anchor, targets)) = self.latest_tip.take() {
                     let generation = self.current_generation + 1;
                     self.current_generation = generation;
-                    for db in &mut self.dbs {
-                        *db = DbSyncState::Seeking { generation };
-                    }
+                    self.dbs.fill(DbSyncState::Seeking { generation });
                     self.generation_state
                         .insert(generation, (anchor, targets.clone()));
                     self.last_dispatched_anchor = anchor;

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -1,5 +1,5 @@
 use crate::{BufferPool, Error, IoBufs};
-use std::{convert::identity, net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _, BufReader},
     net::{
@@ -78,7 +78,7 @@ impl crate::Sink for Sink {
         // Time out if we take too long to write
         let result = timeout(write_timeout, send)
             .await
-            .map_or(Err(Error::Timeout), identity);
+            .unwrap_or(Err(Error::Timeout));
 
         // A failed send leaves the write-half unusable.
         if result.is_err() {
@@ -126,7 +126,7 @@ impl crate::Stream for Stream {
         // Time out if we take too long to read
         let result = timeout(self.read_timeout, recv)
             .await
-            .map_or(Err(Error::Timeout), identity);
+            .unwrap_or(Err(Error::Timeout));
 
         // Unpoison on success.
         if result.is_ok() {

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -578,8 +578,8 @@ impl<D: Digest> Proof<D> {
             }
         }
         let mut sorted: Vec<(u32, D)> = Vec::with_capacity(elements.len());
-        let mut leaf_chunks = elements.chunks_exact(2);
-        for chunk in &mut leaf_chunks {
+        let (leaf_chunks, leaf_rest) = elements.as_chunks::<2>();
+        for chunk in leaf_chunks {
             let (leaf_a, pos_a) = &chunk[0];
             let (leaf_b, pos_b) = &chunk[1];
             let (digest_a, digest_b) = H::hash_pair(
@@ -589,7 +589,7 @@ impl<D: Digest> Proof<D> {
             sorted.push((*pos_a, digest_a));
             sorted.push((*pos_b, digest_b));
         }
-        for (leaf, position) in leaf_chunks.remainder() {
+        for (leaf, position) in leaf_rest {
             let digest = H::hash(&[&position.to_be_bytes(), leaf.as_ref()]);
             sorted.push((*position, digest));
         }
@@ -649,8 +649,8 @@ impl<D: Digest> Proof<D> {
             }
 
             // Second pass: hash independent parent digests two at a time via `hash_pair`.
-            let mut parent_chunks = parents.chunks_exact(2);
-            for chunk in &mut parent_chunks {
+            let (parent_chunks, parent_rest) = parents.as_chunks::<2>();
+            for chunk in parent_chunks {
                 let (pos_a, left_a, right_a) = chunk[0];
                 let (pos_b, left_b, right_b) = chunk[1];
                 let (digest_a, digest_b) = H::hash_pair(
@@ -660,7 +660,7 @@ impl<D: Digest> Proof<D> {
                 next_level.push((pos_a, digest_a));
                 next_level.push((pos_b, digest_b));
             }
-            for &(pos, left, right) in parent_chunks.remainder() {
+            for &(pos, left, right) in parent_rest {
                 next_level.push((pos, H::hash(&[left.as_ref(), right.as_ref()])));
             }
             parents.clear();

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -423,8 +423,8 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         height: u32,
         output: &mut Vec<(Position<F>, D)>,
     ) {
-        let mut pairs = positions.chunks_exact(2);
-        for pair in &mut pairs {
+        let (pairs, pairs_rest) = positions.as_chunks::<2>();
+        for pair in pairs {
             let (left, right) = (pair[0], pair[1]);
             let (ll, lr) = self.child_digests(base, left, height);
             let (rl, rr) = self.child_digests(base, right, height);
@@ -433,7 +433,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             output.push((left, left_digest));
             output.push((right, right_digest));
         }
-        if let [pos] = pairs.remainder() {
+        if let [pos] = pairs_rest {
             let (left, right) = self.child_digests(base, *pos, height);
             output.push((*pos, hasher.node_digest(*pos, &left, &right)));
         }

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -527,11 +527,11 @@ impl<const N: usize> BitMap<N> {
     #[inline]
     fn count_ones_in_chunk_slice(chunks: &[[u8; N]]) -> u64 {
         let mut total = 0u64;
-        let mut words = chunks.as_flattened().chunks_exact(8);
-        for word in &mut words {
-            total += u64::from_le_bytes(word.try_into().unwrap()).count_ones() as u64;
+        let (words, rest) = chunks.as_flattened().as_chunks::<8>();
+        for word in words {
+            total += u64::from_le_bytes(*word).count_ones() as u64;
         }
-        for byte in words.remainder() {
+        for byte in rest {
             total += byte.count_ones() as u64;
         }
         total

--- a/utils/src/bitmap/roaring/container/bitmap.rs
+++ b/utils/src/bitmap/roaring/container/bitmap.rs
@@ -456,8 +456,9 @@ impl Write for Bitmap {
         // Preserve the codec's big-endian word order while collapsing 1024 small
         // `put_slice` calls into one bulk write.
         let mut bytes = [0u8; ENCODED_BYTES];
-        for (dst, &word) in bytes.chunks_exact_mut(8).zip(self.words.iter()) {
-            dst.copy_from_slice(&word.to_be_bytes());
+        let (chunks, _) = bytes.as_chunks_mut::<8>();
+        for (dst, &word) in chunks.iter_mut().zip(self.words.iter()) {
+            *dst = word.to_be_bytes();
         }
         buf.put_slice(&bytes);
     }
@@ -476,10 +477,9 @@ impl Read for Bitmap {
         let bytes = <[u8; ENCODED_BYTES]>::read(buf)?;
 
         let mut words = [0u64; WORDS];
-        for (word, chunk) in words.iter_mut().zip(bytes.chunks_exact(8)) {
-            let mut word_bytes = [0u8; 8];
-            word_bytes.copy_from_slice(chunk);
-            *word = u64::from_be_bytes(word_bytes);
+        let (chunks, _) = bytes.as_chunks::<8>();
+        for (word, chunk) in words.iter_mut().zip(chunks) {
+            *word = u64::from_be_bytes(*chunk);
         }
         Ok(Self::from(words))
     }


### PR DESCRIPTION
## Summary

A new stable clippy release flags patterns in pre-existing code across the workspace (manual `chunks_exact` slicing, redundant closures, and similar). Every open PR's lint CI is red until these are fixed on main, so they get their own PR instead of riding a feature branch.

Mechanical fixes only, no behavior changes: `cryptography` (lthash, sha256, bulletproofs), `glue`, `runtime` (tokio network), `storage` (bmt, merkle batch), and `utils` (bitmap). Extracted from #4432, where they were previously bundled (see the review thread there asking why lthash was touched).

## Validation

- workspace compiles with all targets; `just check-fmt` clean; lint CI on this PR is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG6CDm2eHLMgiVupMECBiU
