### PR TITLE
[storage, runtime] Add flush() for pushing buffered state to storage without durability

### DIFF
--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -846,6 +846,15 @@ impl<B: Blob> Writer<B> {
         Ok(self.sealed_handle(self.cache_ref.next_id()))
     }
 
+    /// Flushes buffered data (including any partial page) to the blob without making it durable.
+    ///
+    /// Flushed bytes are not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [`Self::sync`]) completes.
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.flush_internal(true, false).await?;
+        Ok(())
+    }
+
     /// Flushes buffered data and makes all pending mutations durable.
     ///
     /// A newly flushed write can carry [`WriteOptions::SYNC`] when no earlier mutation is pending.
@@ -2300,6 +2309,54 @@ mod tests {
                 .unwrap();
             let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies flush writes buffered bytes (including a partial page) without any sync.
+    fn test_flush_writes_without_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let blob = SyncTrackingBlob::new();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Flushing an empty writer performs no blob operations.
+            append.flush().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // A buffered partial page reaches the blob on flush, with no sync issued and no
+            // durability provided.
+            let data = b"hello world";
+            append.append(data).await.unwrap();
+            append.flush().await.unwrap();
+            let (durable, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert!(blob.size() > 0);
+            assert!(durable.is_empty());
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // Flushed bytes remain readable.
+            let read = append.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data);
+
+            // Re-flushing an unchanged partial page writes nothing new.
+            append.flush().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // A later sync provides the durability barrier.
+            append.sync().await.unwrap();
+            let (_, _, full_syncs, range_syncs) = blob.snapshot();
+            assert!(full_syncs + range_syncs > 0);
         });
     }
 

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -834,6 +834,15 @@ impl<B: Blob> Writer<B> {
         Ok(self.sealed_handle(self.cache_ref.next_id()))
     }
 
+    /// Flushes buffered data (including any partial page) to the blob without making it durable.
+    ///
+    /// Flushed bytes are not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [`Self::sync`]) completes.
+    pub async fn flush(&mut self) -> Result<(), Error> {
+        self.flush_internal(true, false).await?;
+        Ok(())
+    }
+
     /// Flushes buffered data and makes all pending mutations durable.
     ///
     /// A newly flushed write can carry [`WriteOptions::SYNC`] when no earlier mutation is pending.
@@ -2231,6 +2240,54 @@ mod tests {
                 .unwrap();
             let read = reopened.read_at(0, data.len()).await.unwrap().coalesce();
             assert_eq!(read.as_ref(), data);
+        });
+    }
+
+    #[test_traced("DEBUG")]
+    // Verifies flush writes buffered bytes (including a partial page) without any sync.
+    fn test_flush_writes_without_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let blob = SyncTrackingBlob::new();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob.clone(), 0, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Flushing an empty writer performs no blob operations.
+            append.flush().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 0);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // A buffered partial page reaches the blob on flush, with no sync issued and no
+            // durability provided.
+            let data = b"hello world";
+            append.append(data).await.unwrap();
+            append.flush().await.unwrap();
+            let (durable, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert!(blob.size() > 0);
+            assert!(durable.is_empty());
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // Flushed bytes remain readable.
+            let read = append.read_at(0, data.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), data);
+
+            // Re-flushing an unchanged partial page writes nothing new.
+            append.flush().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 0);
+            assert_eq!(range_syncs, 0);
+
+            // A later sync provides the durability barrier.
+            append.sync().await.unwrap();
+            let (_, _, full_syncs, range_syncs) = blob.snapshot();
+            assert!(full_syncs + range_syncs > 0);
         });
     }
 

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -397,6 +397,19 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. `sync()`) completes.
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        (self.journal, self.merkle) = try_join!(
+            self.journal.flush().map_err(Error::Journal),
+            self.merkle.flush().map_err(Error::Merkle)
+        )?;
+
+        Ok(self)
+    }
+
     /// Durably persist the journal. This is faster than `sync()` but does not guarantee that the
     /// Merkle structure is durably persisted, meaning recovery may be required on startup in the
     /// event of a crash.
@@ -1009,6 +1022,10 @@ where
         Self::start_sync(self).await.map_err(Self::map_error)
     }
 
+    async fn flush(self) -> Result<Self, JournalError> {
+        Self::flush(self).await.map_err(Self::map_error)
+    }
+
     async fn commit(self) -> Result<Self, JournalError> {
         Self::commit(self).await.map_err(Self::map_error)
     }
@@ -1245,6 +1262,39 @@ mod tests {
                     .await
                     .unwrap()
                     .is_empty()
+            );
+        });
+    }
+
+    /// Flush preserves the root and reads, and a later sync makes everything durable.
+    #[test]
+    fn test_flush_preserves_state_and_usability() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut journal = create_empty_journal::<mmr::Family>(context, "flush").await;
+            for i in 0..5u8 {
+                let op = create_operation::<mmr::Family>(i);
+                (journal, _) = journal.append(&op).await.unwrap();
+            }
+            let root = journal.root(0).unwrap();
+
+            let mut journal = journal.flush().await.unwrap();
+            assert_eq!(journal.root(0).unwrap(), root);
+            assert_eq!(*journal.size(), 5);
+            assert_eq!(
+                Contiguous::read(&journal, 0).await.unwrap(),
+                create_operation::<mmr::Family>(0)
+            );
+
+            // Appends continue after a flush and a later sync persists everything.
+            for i in 5..8u8 {
+                let op = create_operation::<mmr::Family>(i);
+                (journal, _) = journal.append(&op).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(*journal.size(), 8);
+            assert_eq!(
+                Contiguous::read(&journal, 7).await.unwrap(),
+                create_operation::<mmr::Family>(7)
             );
         });
     }

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -402,6 +402,19 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. `sync()`) completes.
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        (self.journal, self.merkle) = try_join!(
+            self.journal.flush().map_err(Error::Journal),
+            self.merkle.flush().map_err(Error::Merkle)
+        )?;
+
+        Ok(self)
+    }
+
     /// Durably persist the journal. This is faster than `sync()` but does not guarantee that the
     /// Merkle structure is durably persisted, meaning recovery may be required on startup in the
     /// event of a crash.
@@ -1013,6 +1026,10 @@ where
         Self::start_sync(self).await.map_err(Self::map_error)
     }
 
+    async fn flush(self) -> Result<Self, JournalError> {
+        Self::flush(self).await.map_err(Self::map_error)
+    }
+
     async fn commit(self) -> Result<Self, JournalError> {
         Self::commit(self).await.map_err(Self::map_error)
     }
@@ -1241,6 +1258,39 @@ mod tests {
                     .await
                     .unwrap()
                     .is_empty()
+            );
+        });
+    }
+
+    /// Flush preserves the root and reads, and a later sync makes everything durable.
+    #[test]
+    fn test_flush_preserves_state_and_usability() {
+        deterministic::Runner::default().start(|context| async move {
+            let mut journal = create_empty_journal::<mmr::Family>(context, "flush").await;
+            for i in 0..5u8 {
+                let op = create_operation::<mmr::Family>(i);
+                (journal, _) = journal.append(&op).await.unwrap();
+            }
+            let root = journal.root(0).unwrap();
+
+            let mut journal = journal.flush().await.unwrap();
+            assert_eq!(journal.root(0).unwrap(), root);
+            assert_eq!(*journal.size(), 5);
+            assert_eq!(
+                Contiguous::read(&journal, 0).await.unwrap(),
+                create_operation::<mmr::Family>(0)
+            );
+
+            // Appends continue after a flush and a later sync persists everything.
+            for i in 5..8u8 {
+                let op = create_operation::<mmr::Family>(i);
+                (journal, _) = journal.append(&op).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            assert_eq!(*journal.size(), 8);
+            assert_eq!(
+                Contiguous::read(&journal, 7).await.unwrap(),
+                create_operation::<mmr::Family>(7)
             );
         });
     }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -430,6 +430,14 @@ impl<E: Context> Writable<E> {
         Ok(())
     }
 
+    /// Flush the tail writer's buffered bytes to storage without syncing.
+    ///
+    /// Flushed bytes are not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [`Self::start_sync`]) completes.
+    pub(super) async fn flush(&mut self) -> Result<(), Error> {
+        self.tail.flush().await.map_err(Error::Runtime)
+    }
+
     /// Start syncing the tail, returning a handle that completes once both the tail and its
     /// predecessor are durable.
     pub(super) async fn start_sync(&mut self) -> Handle<()> {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -867,6 +867,13 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         Ok((journal, handle))
     }
 
+    /// See [Journal::flush].
+    pub(crate) async fn flush(mut self: Box<Self>) -> Result<Box<Self>, Error> {
+        self.metrics.flush_calls.inc();
+        self.blobs.flush().await?;
+        Ok(self)
+    }
+
     /// See [Journal::commit].
     pub(crate) async fn commit(mut self: Box<Self>) -> Result<Box<Self>, Error> {
         let _timer = self.metrics.commit_timer();
@@ -1234,6 +1241,15 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn clear_to_size(mut self, new_size: u64) -> Result<Self, Error> {
         self.0 = self.0.clear_to_size(new_size).await?;
+        Ok(self)
+    }
+
+    /// Flush buffered appends to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. `sync()`) completes. Does not advance the recovery watermark.
+    pub async fn flush(mut self) -> Result<Self, Error> {
+        self.0 = self.0.flush().await?;
         Ok(self)
     }
 
@@ -1713,6 +1729,10 @@ impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
 
     async fn start_sync(self) -> Result<(Self, Handle<()>), Error> {
         Self::start_sync(self).await
+    }
+
+    async fn flush(self) -> Result<Self, Error> {
+        Self::flush(self).await
     }
 
     async fn commit(self) -> Result<Self, Error> {
@@ -3608,6 +3628,63 @@ mod tests {
                 journal.read(7).await,
                 Err(Error::ItemOutOfRange(7))
             ));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_flush() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            for i in 0..3u64 {
+                (journal, _) = journal
+                    .append(&test_digest(i))
+                    .await
+                    .expect("failed to append data");
+            }
+
+            // Flush leaves the journal fully usable: reads, appends, and a later sync.
+            let journal = journal.flush().await.expect("failed to flush journal");
+            assert_eq!(journal.bounds(), 0..3);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(0));
+            drop(journal);
+
+            // Flush provides no durability: a reopen recovers only durable state.
+            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to re-initialize journal");
+            assert_eq!(journal.bounds(), 0..0);
+
+            // Appends after a flush become durable through a later sync.
+            for i in 0..6u64 {
+                (journal, _) = journal
+                    .append(&test_digest(i))
+                    .await
+                    .expect("failed to append data");
+            }
+            let mut journal = journal.flush().await.expect("failed to flush journal");
+            for i in 6..9u64 {
+                (journal, _) = journal
+                    .append(&test_digest(i))
+                    .await
+                    .expect("failed to append data");
+            }
+            let journal = journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("third"), cfg.clone())
+                .await
+                .expect("failed to re-initialize journal");
+            assert_eq!(journal.bounds(), 0..9);
+            for i in 0..9u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
 
             journal.destroy().await.unwrap();
         });
@@ -5714,6 +5791,7 @@ mod tests {
             let items: Vec<_> = (0..5).map(test_digest).collect();
             (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
             (journal, _) = journal.append(&test_digest(5)).await.unwrap();
+            journal = journal.flush().await.unwrap();
             journal = journal.commit().await.unwrap();
             journal = journal.sync().await.unwrap();
             let handle;
@@ -5740,6 +5818,7 @@ mod tests {
                 "fixed_metrics_read_many_calls_total 1",
                 "fixed_metrics_items_read_total 5",
                 "fixed_metrics_start_sync_calls_total 1",
+                "fixed_metrics_flush_calls_total 1",
                 "fixed_metrics_commit_calls_total 1",
                 "fixed_metrics_sync_calls_total 1",
                 "fixed_metrics_append_duration_count 1",

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -868,6 +868,13 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         Ok((journal, handle))
     }
 
+    /// See [Journal::flush].
+    pub(crate) async fn flush(mut self: Box<Self>) -> Result<Box<Self>, Error> {
+        self.metrics.flush_calls.inc();
+        self.blobs.flush().await?;
+        Ok(self)
+    }
+
     /// See [Journal::commit].
     pub(crate) async fn commit(mut self: Box<Self>) -> Result<Box<Self>, Error> {
         let _timer = self.metrics.commit_timer();
@@ -1235,6 +1242,15 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     #[commonware_macros::stability(ALPHA)]
     pub(crate) async fn clear_to_size(mut self, new_size: u64) -> Result<Self, Error> {
         self.0 = self.0.clear_to_size(new_size).await?;
+        Ok(self)
+    }
+
+    /// Flush buffered appends to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. `sync()`) completes. Does not advance the recovery watermark.
+    pub async fn flush(mut self) -> Result<Self, Error> {
+        self.0 = self.0.flush().await?;
         Ok(self)
     }
 
@@ -1721,6 +1737,10 @@ impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
 
     async fn start_sync(self) -> Result<(Self, Handle<()>), Error> {
         Self::start_sync(self).await
+    }
+
+    async fn flush(self) -> Result<Self, Error> {
+        Self::flush(self).await
     }
 
     async fn commit(self) -> Result<Self, Error> {
@@ -3708,6 +3728,63 @@ mod tests {
                 journal.read(7).await,
                 Err(Error::ItemOutOfRange(7))
             ));
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_fixed_journal_flush() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            for i in 0..3u64 {
+                (journal, _) = journal
+                    .append(&test_digest(i))
+                    .await
+                    .expect("failed to append data");
+            }
+
+            // Flush leaves the journal fully usable: reads, appends, and a later sync.
+            let journal = journal.flush().await.expect("failed to flush journal");
+            assert_eq!(journal.bounds(), 0..3);
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(0));
+            drop(journal);
+
+            // Flush provides no durability: a reopen recovers only durable state.
+            let mut journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
+                .await
+                .expect("failed to re-initialize journal");
+            assert_eq!(journal.bounds(), 0..0);
+
+            // Appends after a flush become durable through a later sync.
+            for i in 0..6u64 {
+                (journal, _) = journal
+                    .append(&test_digest(i))
+                    .await
+                    .expect("failed to append data");
+            }
+            let mut journal = journal.flush().await.expect("failed to flush journal");
+            for i in 6..9u64 {
+                (journal, _) = journal
+                    .append(&test_digest(i))
+                    .await
+                    .expect("failed to append data");
+            }
+            let journal = journal.sync().await.expect("failed to sync journal");
+            drop(journal);
+
+            let journal = Journal::<_, Digest>::init(context.child("third"), cfg.clone())
+                .await
+                .expect("failed to re-initialize journal");
+            assert_eq!(journal.bounds(), 0..9);
+            for i in 0..9u64 {
+                assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
+            }
 
             journal.destroy().await.unwrap();
         });
@@ -5817,6 +5894,7 @@ mod tests {
             let items: Vec<_> = (0..5).map(test_digest).collect();
             (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
             (journal, _) = journal.append(&test_digest(5)).await.unwrap();
+            journal = journal.flush().await.unwrap();
             journal = journal.commit().await.unwrap();
             journal = journal.sync().await.unwrap();
             let handle;
@@ -5843,6 +5921,7 @@ mod tests {
                 "fixed_metrics_read_many_calls_total 1",
                 "fixed_metrics_items_read_total 5",
                 "fixed_metrics_start_sync_calls_total 1",
+                "fixed_metrics_flush_calls_total 1",
                 "fixed_metrics_commit_calls_total 1",
                 "fixed_metrics_sync_calls_total 1",
                 "fixed_metrics_append_duration_count 1",

--- a/storage/src/journal/contiguous/metrics.rs
+++ b/storage/src/journal/contiguous/metrics.rs
@@ -51,6 +51,8 @@ pub(super) struct Metrics<E: Clock> {
     pub items_read: Counter,
     /// Syncs begun via `start_sync`, excluding those issued by `commit` and `sync`.
     pub start_sync_calls: Counter,
+    /// Flush calls (buffered appends pushed to storage without durability).
+    pub flush_calls: Counter,
     /// Durable commit calls that do not fully sync all indexes.
     pub commit_calls: Counter,
     /// Duration of commit calls that do not fully sync all indexes.
@@ -115,6 +117,7 @@ impl<E: RuntimeMetrics + Clock> Metrics<E> {
                 "Number of items returned by point reads, batch reads, and sync probes",
             ),
             start_sync_calls: context.counter("start_sync_calls", "Number of start_sync calls"),
+            flush_calls: context.counter("flush_calls", "Number of flush calls"),
             commit_calls: context.counter("commit_calls", "Number of commit calls"),
             commit_duration: Timed::register(
                 &context,

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -301,6 +301,12 @@ pub trait Mutable: Contiguous + Sized {
     /// fails.
     fn rewind(self, size: u64) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
+    /// Flush buffered appends to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later
+    /// durability operation (e.g. [Self::sync]) completes.
+    fn flush(self) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
+
     /// Begin durably persisting the current state of the journal.
     ///
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit]

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -304,6 +304,12 @@ pub trait Mutable: Contiguous + Sized {
     /// fails.
     fn rewind(self, size: u64) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
 
+    /// Flush buffered appends to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later
+    /// durability operation (e.g. [Self::sync]) completes.
+    fn flush(self) -> impl std::future::Future<Output = Result<Self, Error>> + Send;
+
     /// Begin durably persisting the current state of the journal.
     ///
     /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit]

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1620,6 +1620,14 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         Ok((self, handle))
     }
 
+    /// See [Journal::flush].
+    pub(crate) async fn flush(mut self: Box<Self>) -> Result<Box<Self>, Error> {
+        self.metrics.flush_calls.inc();
+        self.blobs.flush().await?;
+        self.offsets = self.offsets.flush().await?;
+        Ok(self)
+    }
+
     /// See [Journal::commit].
     pub(crate) async fn commit(mut self: Box<Self>) -> Result<Box<Self>, Error> {
         let _timer = self.metrics.commit_timer();
@@ -2328,6 +2336,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok((self, pruned))
     }
 
+    /// Flush buffered appends to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. `sync()`) completes. Does not advance the recovery watermark.
+    pub async fn flush(mut self) -> Result<Self, Error> {
+        self.0 = self.0.flush().await?;
+        Ok(self)
+    }
+
     /// Persist data blobs so committed data survives a crash.
     ///
     /// Does not advance the recovery watermark, so reopen may replay entries above it.
@@ -2460,6 +2477,10 @@ impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
 
     async fn start_sync(self) -> Result<(Self, Handle<()>), Error> {
         Self::start_sync(self).await
+    }
+
+    async fn flush(self) -> Result<Self, Error> {
+        Self::flush(self).await
     }
 
     async fn commit(self) -> Result<Self, Error> {
@@ -5379,6 +5400,62 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_variable_flush() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "flush".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            for i in 0..3u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+
+            // Flush leaves the journal fully usable: reads, appends, and a later sync.
+            let journal = journal.flush().await.unwrap();
+            assert_eq!(journal.bounds(), 0..3);
+            assert_eq!(journal.read(0).await.unwrap(), 0);
+            drop(journal);
+
+            // Flush provides no durability: a reopen recovers only durable state.
+            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+
+            // Appends after a flush become durable through a later sync.
+            for i in 0..6u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.flush().await.unwrap();
+            for i in 6..9u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..9);
+            for i in 0..9u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_variable_rewind_commit_reopen() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -7706,6 +7783,7 @@ mod tests {
             reader.read_many(&[1, 2]).await.unwrap();
             reader.try_read_sync(3).unwrap();
             drop(reader);
+            journal = journal.flush().await.unwrap();
             journal = journal.commit().await.unwrap();
             journal = journal.sync().await.unwrap();
             let handle;
@@ -7726,6 +7804,7 @@ mod tests {
                 "variable_metrics_read_many_calls_total 1",
                 "variable_metrics_items_read_total 4",
                 "variable_metrics_start_sync_calls_total 1",
+                "variable_metrics_flush_calls_total 1",
                 "variable_metrics_commit_calls_total 1",
                 "variable_metrics_sync_calls_total 1",
                 "variable_metrics_append_duration_count 1",
@@ -7738,6 +7817,7 @@ mod tests {
                 "variable_metrics_cache_misses_total 0",
                 "variable_metrics_data_tracked",
                 "variable_metrics_offsets_size 4",
+                "variable_metrics_offsets_flush_calls_total 1",
                 "variable_metrics_offsets_blobs_tracked",
             ] {
                 assert!(buffer.contains(expected), "{expected}\n{buffer}");

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1622,6 +1622,14 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         Ok((self, handle))
     }
 
+    /// See [Journal::flush].
+    pub(crate) async fn flush(mut self: Box<Self>) -> Result<Box<Self>, Error> {
+        self.metrics.flush_calls.inc();
+        self.blobs.flush().await?;
+        self.offsets = self.offsets.flush().await?;
+        Ok(self)
+    }
+
     /// See [Journal::commit].
     pub(crate) async fn commit(mut self: Box<Self>) -> Result<Box<Self>, Error> {
         let _timer = self.metrics.commit_timer();
@@ -2334,6 +2342,15 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok((self, pruned))
     }
 
+    /// Flush buffered appends to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. `sync()`) completes. Does not advance the recovery watermark.
+    pub async fn flush(mut self) -> Result<Self, Error> {
+        self.0 = self.0.flush().await?;
+        Ok(self)
+    }
+
     /// Persist data blobs so committed data survives a crash.
     ///
     /// Does not advance the recovery watermark, so reopen may replay entries above it.
@@ -2470,6 +2487,10 @@ impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
 
     async fn start_sync(self) -> Result<(Self, Handle<()>), Error> {
         Self::start_sync(self).await
+    }
+
+    async fn flush(self) -> Result<Self, Error> {
+        Self::flush(self).await
     }
 
     async fn commit(self) -> Result<Self, Error> {
@@ -5500,6 +5521,62 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_variable_flush() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "flush".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+
+            for i in 0..3u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+
+            // Flush leaves the journal fully usable: reads, appends, and a later sync.
+            let journal = journal.flush().await.unwrap();
+            assert_eq!(journal.bounds(), 0..3);
+            assert_eq!(journal.read(0).await.unwrap(), 0);
+            drop(journal);
+
+            // Flush provides no durability: a reopen recovers only durable state.
+            let mut journal = Journal::<_, u64>::init(context.child("second"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..0);
+
+            // Appends after a flush become durable through a later sync.
+            for i in 0..6u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let mut journal = journal.flush().await.unwrap();
+            for i in 6..9u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+            drop(journal);
+
+            let journal = Journal::<_, u64>::init(context.child("third"), cfg.clone())
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..9);
+            for i in 0..9u64 {
+                assert_eq!(journal.read(i).await.unwrap(), i * 100);
+            }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_variable_rewind_commit_reopen() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -7827,6 +7904,7 @@ mod tests {
             reader.read_many(&[1, 2]).await.unwrap();
             reader.try_read_sync(3).unwrap();
             drop(reader);
+            journal = journal.flush().await.unwrap();
             journal = journal.commit().await.unwrap();
             journal = journal.sync().await.unwrap();
             let handle;
@@ -7847,6 +7925,7 @@ mod tests {
                 "variable_metrics_read_many_calls_total 1",
                 "variable_metrics_items_read_total 4",
                 "variable_metrics_start_sync_calls_total 1",
+                "variable_metrics_flush_calls_total 1",
                 "variable_metrics_commit_calls_total 1",
                 "variable_metrics_sync_calls_total 1",
                 "variable_metrics_append_duration_count 1",
@@ -7859,6 +7938,7 @@ mod tests {
                 "variable_metrics_cache_misses_total 0",
                 "variable_metrics_data_tracked",
                 "variable_metrics_offsets_size 4",
+                "variable_metrics_offsets_flush_calls_total 1",
                 "variable_metrics_offsets_blobs_tracked",
             ] {
                 assert!(buffer.contains(expected), "{expected}\n{buffer}");

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -699,8 +699,10 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Flush all nodes cached in the in-memory structure to the journal without forcing them to
     /// disk. Flushed nodes are pruned from the in-memory structure and remain readable through the
     /// journal, but they are not guaranteed to survive a crash until [Self::sync] is called.
-    pub async fn flush(self) -> Result<Self, Error<F>> {
-        self.flush_internal().await
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        self = self.flush_internal().await?;
+        self.journal = self.journal.flush().await.map_err(Error::Journal)?;
+        Ok(self)
     }
 
     /// Flush all nodes cached in the in-memory structure to the journal and make them durable.

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -653,8 +653,10 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// Flush all nodes cached in the in-memory structure to the journal without forcing them to
     /// disk. Flushed nodes are pruned from the in-memory structure and remain readable through the
     /// journal, but they are not guaranteed to survive a crash until [Self::sync] is called.
-    pub async fn flush(self) -> Result<Self, Error<F>> {
-        self.flush_internal().await
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        self = self.flush_internal().await?;
+        self.journal = self.journal.flush().await.map_err(Error::Journal)?;
+        Ok(self)
     }
 
     /// Flush all nodes cached in the in-memory structure to the journal and make them durable.

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -862,6 +862,17 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [Self::sync]) completes.
+    #[tracing::instrument(name = "qmdb.any.db.flush", level = "info", skip_all)]
+    #[boxed]
+    pub async fn flush(mut self) -> Result<Self, crate::qmdb::Error<F>> {
+        self.log = self.log.flush().await?;
+        Ok(self)
+    }
+
     /// Durably commit the journal state published by prior [`Db::apply_batch`]
     /// calls.
     #[tracing::instrument(

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -417,6 +417,45 @@ pub(crate) mod test {
         });
     }
 
+    /// Flush pushes buffered state to storage without durability and leaves the db usable.
+    #[test_traced]
+    fn test_flush_preserves_state_and_usability() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut db = create_test_db(context).await;
+            let key0 = Sha256::hash(&[&0u64.to_be_bytes()]);
+            let value0 = Sha256::hash(&[&100u64.to_be_bytes()]);
+            let batch = db
+                .new_batch()
+                .write(key0, Some(value0))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            (db, _) = db.apply_batch(batch).await.unwrap();
+            let root = db.root();
+
+            // Flush preserves the root and reads.
+            let mut db = db.flush().await.unwrap();
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(&key0).await.unwrap(), Some(value0));
+
+            // Batches continue to apply after a flush, and a later commit succeeds.
+            let key1 = Sha256::hash(&[&1u64.to_be_bytes()]);
+            let value1 = Sha256::hash(&[&200u64.to_be_bytes()]);
+            let batch = db
+                .new_batch()
+                .write(key1, Some(value1))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            (db, _) = db.apply_batch(batch).await.unwrap();
+            let db = db.commit().await.unwrap();
+            assert_eq!(db.get(&key1).await.unwrap(), Some(value1));
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// `get_many` over a batch large enough for the fused sharded path matches per-key `get`.
     #[test_traced]
     fn test_get_many_fused_sharded_matches_get() {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -734,6 +734,17 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [Self::sync]) completes.
+    #[tracing::instrument(name = "qmdb.current.db.flush", level = "info", skip_all)]
+    #[boxed]
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        self.any = self.any.flush().await?;
+        Ok(self)
+    }
+
     /// Durably commit the journal state published by prior [`Db::apply_batch`]
     /// calls.
     #[tracing::instrument(name = "qmdb.current.db.commit", level = "info", skip_all)]

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -735,6 +735,17 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [Self::sync]) completes.
+    #[tracing::instrument(name = "qmdb.current.db.flush", level = "info", skip_all)]
+    #[boxed]
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        self.any = self.any.flush().await?;
+        Ok(self)
+    }
+
     /// Durably commit the journal state published by prior [`Db::apply_batch`]
     /// calls.
     #[tracing::instrument(name = "qmdb.current.db.commit", level = "info", skip_all)]

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -667,6 +667,16 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [Self::sync]) completes.
+    #[tracing::instrument(name = "qmdb.immutable.db.flush", level = "info", skip_all)]
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        self.journal = self.journal.flush().await?;
+        Ok(self)
+    }
+
     /// Durably commit the journal state published by prior [`Immutable::apply_batch`] calls.
     #[tracing::instrument(name = "qmdb.immutable.db.commit", level = "info", skip_all)]
     pub async fn commit(mut self) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -490,6 +490,16 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [Self::sync]) completes.
+    #[tracing::instrument(name = "qmdb.keyless.db.flush", level = "info", skip_all)]
+    pub async fn flush(mut self) -> Result<Self, Error<F>> {
+        self.journal = self.journal.flush().await?;
+        Ok(self)
+    }
+
     /// Durably commit the journal state published by prior [`Keyless::apply_batch`] calls.
     #[tracing::instrument(name = "qmdb.keyless.db.commit", level = "info", skip_all)]
     pub async fn commit(mut self) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -547,6 +547,16 @@ where
         Ok((self, handle))
     }
 
+    /// Flush buffered state to storage without guaranteeing durability.
+    ///
+    /// Flushed state is not guaranteed to survive a crash until a later durability operation
+    /// (e.g. [Self::sync]) completes.
+    #[boxed]
+    pub async fn flush(mut self) -> Result<Self, Error> {
+        self.log = self.log.flush().await?;
+        Ok(self)
+    }
+
     /// Durably commit the journal state published by prior [`Db::apply_batch`] calls.
     #[boxed]
     pub async fn commit(mut self) -> Result<Self, Error> {


### PR DESCRIPTION
Adds a durability-free `flush()` through the qmdb write stack: it hands all app-level buffered bytes to the underlying blobs via plain writes, with no fsync and no durability bookkeeping. A crash after a flush still recovers to the last commit; the OS just gets to start writeback early.

## Layers

- **qmdb Db variants** (`any`, `current`, `store`, `keyless`, `immutable`): `flush()` passthrough mirroring each variant's `commit()` idiom.
- **Authenticated journal**: flushes the backing journal and the merkle structure concurrently, same shape as `commit()`.
- **`Merkle::flush`** (strengthened): after draining in-memory nodes into its journal, it now also drains that journal's write buffer to the blob. `commit()` on the authenticated journal therefore issues one extra small pwrite per commit on the merkle journal.
- **Contiguous journals** (fixed and variable): public `flush()` plus a new `Mutable::flush` trait method. The variable journal also flushes its offsets sub-journal. Each layer increments a new `flush_calls` metric.
- **Paged blob writer** (runtime): new `flush()` that writes buffered full and partial pages without syncing. Re-flushing an unchanged partial page is a no-op.

Flush never advances the durability barrier, recovery watermark, or checkpoint.

## Scope

Compact db variants are excluded: their merkle is peak-only in-memory and data is persisted solely via witness entries written at commit, so there is nothing meaningful to flush between commits.

## Testing

One behavioral test per distinct implementation: the paged writer test proves buffered bytes reach the blob with no sync issued and no durable bytes; the fixed and variable journal tests pin the contract (reopen after flush-without-sync recovers nothing; flush, append, then sync recovers everything); the authenticated journal test proves the root and reads survive a flush; a qmdb `any` end-to-end test covers the Db plumbing. The fixed and variable journal metrics tests assert the new `flush_calls` counters, including the variable journal's offsets counter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG6CDm2eHLMgiVupMECBiU