### PR TITLE
Fuzz: block-level fault injection for simplex and marshal consensus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,7 @@ dependencies = [
  "proptest",
  "rand 0.10.2",
  "rand_core 0.10.1",
+ "rand_distr",
  "sancov",
  "tracing",
  "tracing-subscriber",

--- a/consensus/fuzz/Cargo.toml
+++ b/consensus/fuzz/Cargo.toml
@@ -42,6 +42,7 @@ futures.workspace = true
 libfuzzer-sys.workspace = true
 rand.workspace = true
 rand_core.workspace = true
+rand_distr.workspace = true
 sancov.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
@@ -260,6 +261,13 @@ doc = false
 bench = false
 
 [[bin]]
+name = "simplex_cert_mock_byzantine_first_leader"
+path = "fuzz_targets/simplex_cert_mock_byzantine_first_leader.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "simplex_id_state_cov"
 path = "fuzz_targets/simplex_id_state_cov.rs"
 test = false
@@ -402,6 +410,13 @@ bench = false
 [[bin]]
 name = "marshal_e2e_standard_deferred_cert_mock_disrupter"
 path = "fuzz_targets/marshal_e2e_standard_deferred_cert_mock_disrupter.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "marshal_e2e_standard_deferred_cert_mock_block_dissemination"
+path = "fuzz_targets/marshal_e2e_standard_deferred_cert_mock_block_dissemination.rs"
 test = false
 doc = false
 bench = false

--- a/consensus/fuzz/fuzz_targets/marshal_e2e_standard_deferred_cert_mock_block_dissemination.rs
+++ b/consensus/fuzz/fuzz_targets/marshal_e2e_standard_deferred_cert_mock_block_dissemination.rs
@@ -1,0 +1,16 @@
+#![no_main]
+
+#[cfg(feature = "mocks")]
+mod fuzz {
+    use commonware_consensus_fuzz::{
+        SimplexCertificateMockByzantineFirstLeader,
+        marshal::{MarshalDisrupterInput, fuzz_marshal_standard_block_dissemination},
+    };
+    use libfuzzer_sys::fuzz_target;
+
+    fuzz_target!(|input: MarshalDisrupterInput| {
+        fuzz_marshal_standard_block_dissemination::<SimplexCertificateMockByzantineFirstLeader>(
+            input,
+        );
+    });
+}

--- a/consensus/fuzz/fuzz_targets/simplex_cert_mock_byzantine_first_leader.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_cert_mock_byzantine_first_leader.rs
@@ -1,0 +1,13 @@
+#![no_main]
+
+#[cfg(feature = "mocks")]
+mod fuzz {
+    use commonware_consensus_fuzz::{
+        CodeCoverage, FuzzInput, SimplexCertificateMockByzantineFirstLeader, Standard, fuzz,
+    };
+    use libfuzzer_sys::fuzz_target;
+
+    fuzz_target!(|input: FuzzInput| {
+        fuzz::<SimplexCertificateMockByzantineFirstLeader, Standard, CodeCoverage>(input);
+    });
+}

--- a/consensus/fuzz/src/block_relay.rs
+++ b/consensus/fuzz/src/block_relay.rs
@@ -1,0 +1,580 @@
+use bytes::Bytes;
+use commonware_actor::Feedback;
+use commonware_codec::{DecodeExt, Encode};
+use commonware_consensus::{
+    Automaton as Au, CertifiableAutomaton as CAu, Relay as Re,
+    simplex::{
+        Plan,
+        mocks::application::{self, Certifier},
+        types::{Context, Proposal},
+    },
+    types::{Round, View},
+};
+use commonware_cryptography::{Hasher, PublicKey, Sha256, sha256::Digest as Sha256Digest};
+use commonware_macros::select_loop;
+use commonware_p2p::Recipients;
+use commonware_runtime::{Clock, ContextCell, Handle, Spawner, spawn_cell};
+use commonware_utils::{
+    channel::{
+        fallible::{FallibleExt, OneshotExt},
+        mpsc, oneshot,
+    },
+    sync::Mutex,
+};
+use rand::{Rng, RngExt as _};
+use rand_distr::{Distribution, Normal};
+use std::{
+    collections::{BTreeMap, HashMap, HashSet, btree_map::Entry},
+    sync::Arc,
+    time::Duration,
+};
+use tracing::{debug, error, warn};
+
+pub(crate) const RELAY_TAG_TWIN_PRIMARY: u64 = 1;
+pub(crate) const RELAY_TAG_TWIN_SECONDARY: u64 = 2;
+
+type Filter<P> = Arc<dyn Fn(&P, Option<u64>, &P, u64, &Sha256Digest, &Bytes) -> bool + Send + Sync>;
+
+#[derive(Clone, Copy)]
+pub(crate) struct Registration {
+    tag: u64,
+}
+
+#[derive(Clone)]
+struct Listener {
+    registration: Registration,
+    sender: mpsc::UnboundedSender<(Sha256Digest, Bytes)>,
+}
+
+/// Fuzz-local block relay with per-recipient filtering.
+pub(crate) struct Relay<P: PublicKey> {
+    recipients: Mutex<BTreeMap<P, Vec<Listener>>>,
+    filter: Mutex<Option<Filter<P>>>,
+}
+
+impl<P: PublicKey> Relay<P> {
+    pub(crate) const fn new() -> Self {
+        Self {
+            recipients: Mutex::new(BTreeMap::new()),
+            filter: Mutex::new(None),
+        }
+    }
+
+    pub(crate) fn set_filter(
+        &self,
+        filter: impl Fn(&P, Option<u64>, &P, u64, &Sha256Digest, &Bytes) -> bool + Send + Sync + 'static,
+    ) {
+        *self.filter.lock() = Some(Arc::new(filter));
+    }
+
+    pub(crate) fn register_with_tag(
+        &self,
+        public_key: P,
+        tag: u64,
+    ) -> (Registration, mpsc::UnboundedReceiver<(Sha256Digest, Bytes)>) {
+        let (sender, receiver) = mpsc::unbounded_channel();
+        let registration = Registration { tag };
+        {
+            let mut recipients = self.recipients.lock();
+            match recipients.entry(public_key.clone()) {
+                Entry::Vacant(vacant) => {
+                    vacant.insert(vec![Listener {
+                        registration,
+                        sender,
+                    }]);
+                }
+                Entry::Occupied(mut occupied) => {
+                    warn!(?public_key, "duplicate block relay registration");
+                    occupied.get_mut().push(Listener {
+                        registration,
+                        sender,
+                    });
+                }
+            }
+        }
+        (registration, receiver)
+    }
+
+    pub(crate) fn broadcast(
+        &self,
+        sender: &P,
+        recipients: Recipients<P>,
+        (payload, data): (Sha256Digest, Bytes),
+    ) {
+        self.broadcast_from(None, sender, recipients, (payload, data));
+    }
+
+    pub(crate) fn broadcast_with_tag(
+        &self,
+        sender: &P,
+        sender_tag: u64,
+        recipients: Recipients<P>,
+        (payload, data): (Sha256Digest, Bytes),
+    ) {
+        self.broadcast_from(
+            Some(Registration { tag: sender_tag }),
+            sender,
+            recipients,
+            (payload, data),
+        );
+    }
+
+    fn broadcast_from(
+        &self,
+        registration: Option<Registration>,
+        sender: &P,
+        recipients: Recipients<P>,
+        (payload, data): (Sha256Digest, Bytes),
+    ) {
+        let channels = {
+            let mut channels = Vec::new();
+            let registered = self.recipients.lock();
+            let filter = self.filter.lock().clone();
+            let allow = |recipient: &P, listener: &Listener| {
+                if recipient == sender
+                    && registration
+                        .is_some_and(|registration| listener.registration.tag == registration.tag)
+                {
+                    return false;
+                }
+                filter.as_ref().is_none_or(|filter| {
+                    filter(
+                        sender,
+                        registration.map(|registration| registration.tag),
+                        recipient,
+                        listener.registration.tag,
+                        &payload,
+                        &data,
+                    )
+                })
+            };
+            match recipients {
+                Recipients::All => {
+                    for (public_key, listeners) in registered.iter() {
+                        for listener in listeners {
+                            if allow(public_key, listener) {
+                                channels.push((public_key.clone(), listener.sender.clone()));
+                            }
+                        }
+                    }
+                }
+                Recipients::Some(peers) => {
+                    for public_key in peers {
+                        if let Some(listeners) = registered.get(&public_key) {
+                            for listener in listeners {
+                                if allow(&public_key, listener) {
+                                    channels.push((public_key.clone(), listener.sender.clone()));
+                                }
+                            }
+                        }
+                    }
+                }
+                Recipients::One(public_key) => {
+                    if let Some(listeners) = registered.get(&public_key) {
+                        for listener in listeners {
+                            if allow(&public_key, listener) {
+                                channels.push((public_key.clone(), listener.sender.clone()));
+                            }
+                        }
+                    }
+                }
+            }
+            channels
+        };
+        for (recipient, listener) in channels {
+            if let Err(e) = listener.send((payload, data.clone())) {
+                error!(?e, ?recipient, "failed to send block relay payload");
+            }
+        }
+    }
+}
+
+type Latency = (f64, f64);
+type Waiters<P> = HashMap<Sha256Digest, Vec<(Context<Sha256Digest, P>, oneshot::Sender<bool>)>>;
+type CertWaiters = HashMap<Sha256Digest, Vec<(Round, oneshot::Sender<bool>)>>;
+
+pub(crate) struct Config<P: PublicKey> {
+    pub(crate) relay: Arc<Relay<P>>,
+    pub(crate) me: P,
+    pub(crate) propose_latency: Latency,
+    pub(crate) verify_latency: Latency,
+    pub(crate) certify_latency: Latency,
+    pub(crate) should_certify: Certifier<Sha256Digest>,
+}
+
+pub(crate) enum Message<P: PublicKey> {
+    Propose {
+        context: Context<Sha256Digest, P>,
+        response: oneshot::Sender<Sha256Digest>,
+    },
+    Verify {
+        context: Context<Sha256Digest, P>,
+        payload: Sha256Digest,
+        response: oneshot::Sender<bool>,
+    },
+    Certify {
+        round: Round,
+        payload: Sha256Digest,
+        response: oneshot::Sender<bool>,
+    },
+    Broadcast {
+        payload: Sha256Digest,
+        plan: Plan<P>,
+    },
+}
+
+#[derive(Clone)]
+pub(crate) struct Mailbox<P: PublicKey> {
+    sender: mpsc::UnboundedSender<Message<P>>,
+}
+
+impl<P: PublicKey> Mailbox<P> {
+    const fn new(sender: mpsc::UnboundedSender<Message<P>>) -> Self {
+        Self { sender }
+    }
+}
+
+impl<P: PublicKey> Au for Mailbox<P> {
+    type Digest = Sha256Digest;
+    type Context = Context<Sha256Digest, P>;
+
+    async fn propose(&mut self, context: Self::Context) -> oneshot::Receiver<Self::Digest> {
+        let (response, receiver) = oneshot::channel();
+        self.sender
+            .send_lossy(Message::Propose { context, response });
+        receiver
+    }
+
+    async fn verify(
+        &mut self,
+        context: Self::Context,
+        payload: Self::Digest,
+    ) -> oneshot::Receiver<bool> {
+        let (response, receiver) = oneshot::channel();
+        self.sender.send_lossy(Message::Verify {
+            context,
+            payload,
+            response,
+        });
+        receiver
+    }
+}
+
+impl<P: PublicKey> CAu for Mailbox<P> {
+    async fn certify(&mut self, round: Round, payload: Self::Digest) -> oneshot::Receiver<bool> {
+        let (response, receiver) = oneshot::channel();
+        self.sender.send_lossy(Message::Certify {
+            round,
+            payload,
+            response,
+        });
+        receiver
+    }
+}
+
+impl<P: PublicKey> Re for Mailbox<P> {
+    type Digest = Sha256Digest;
+    type PublicKey = P;
+    type Plan = Plan<P>;
+
+    fn broadcast(&mut self, payload: Self::Digest, plan: Plan<P>) -> Feedback {
+        if self.sender.send_lossy(Message::Broadcast { payload, plan }) {
+            Feedback::Ok
+        } else {
+            Feedback::Closed
+        }
+    }
+}
+
+/// Fuzz-local mock application backed by the filterable relay above.
+///
+/// Unlike the consensus mock application, certification waits for missing block
+/// contents so payload-denial schedules can exercise pending certify behavior.
+pub(crate) struct Application<E: Clock + Rng + Spawner, P: PublicKey> {
+    context: ContextCell<E>,
+    me: P,
+    relay: Arc<Relay<P>>,
+    relay_registration: Registration,
+    broadcast: mpsc::UnboundedReceiver<(Sha256Digest, Bytes)>,
+    mailbox: mpsc::UnboundedReceiver<Message<P>>,
+    propose_latency: Normal<f64>,
+    verify_latency: Normal<f64>,
+    certify_latency: Normal<f64>,
+    should_certify: Certifier<Sha256Digest>,
+    pending: HashMap<Sha256Digest, Bytes>,
+    seen: HashMap<Sha256Digest, Bytes>,
+    verified: HashSet<Sha256Digest>,
+    pending_certifications: Vec<oneshot::Sender<bool>>,
+    certification_waiters: CertWaiters,
+}
+
+impl<E: Clock + Rng + Spawner, P: PublicKey> Application<E, P> {
+    pub(crate) fn new(context: E, cfg: Config<P>) -> (Self, Mailbox<P>) {
+        Self::new_with_relay_tag(context, cfg, 0)
+    }
+
+    pub(crate) fn new_with_relay_tag(
+        context: E,
+        cfg: Config<P>,
+        relay_tag: u64,
+    ) -> (Self, Mailbox<P>) {
+        let (relay_registration, broadcast) =
+            cfg.relay.register_with_tag(cfg.me.clone(), relay_tag);
+        let propose_latency = Normal::new(cfg.propose_latency.0, cfg.propose_latency.1).unwrap();
+        let verify_latency = Normal::new(cfg.verify_latency.0, cfg.verify_latency.1).unwrap();
+        let certify_latency = Normal::new(cfg.certify_latency.0, cfg.certify_latency.1).unwrap();
+        let (sender, receiver) = mpsc::unbounded_channel();
+        (
+            Self {
+                context: ContextCell::new(context),
+                me: cfg.me,
+                relay: cfg.relay,
+                relay_registration,
+                broadcast,
+                mailbox: receiver,
+                propose_latency,
+                verify_latency,
+                certify_latency,
+                should_certify: cfg.should_certify,
+                pending: HashMap::new(),
+                seen: HashMap::new(),
+                verified: HashSet::new(),
+                pending_certifications: Vec::new(),
+                certification_waiters: HashMap::new(),
+            },
+            Mailbox::new(sender),
+        )
+    }
+
+    async fn propose(&mut self, context: Context<Sha256Digest, P>) -> Sha256Digest {
+        let duration = self.propose_latency.sample(self.context.as_mut());
+        self.context
+            .sleep(Duration::from_millis(duration as u64))
+            .await;
+        let contents = (
+            context.round,
+            context.parent.1,
+            self.context.random::<u64>(),
+        )
+            .encode();
+        let payload = Sha256::hash(&[&contents]);
+        self.verified.insert(payload);
+        self.pending.insert(payload, contents);
+        payload
+    }
+
+    async fn verify(
+        &mut self,
+        context: Context<Sha256Digest, P>,
+        payload: Sha256Digest,
+        mut contents: Bytes,
+    ) -> bool {
+        let duration = self.verify_latency.sample(self.context.as_mut());
+        self.context
+            .sleep(Duration::from_millis(duration as u64))
+            .await;
+        let Ok((parsed_round, parent, _)) = <(Round, Sha256Digest, u64)>::decode(&mut contents)
+        else {
+            return false;
+        };
+        if parsed_round != context.round || parent != context.parent.1 {
+            return false;
+        }
+        self.verified.insert(payload);
+        true
+    }
+
+    async fn certify(&mut self, round: Round, payload: Sha256Digest) -> Option<bool> {
+        let duration = self.certify_latency.sample(self.context.as_mut());
+        self.context
+            .sleep(Duration::from_millis(duration as u64))
+            .await;
+        match &self.should_certify {
+            Certifier::Always => Some(true),
+            Certifier::Custom(func) => Some(func(round, payload)),
+            Certifier::Cancel | Certifier::Pending => None,
+        }
+    }
+
+    fn broadcast(&mut self, payload: Sha256Digest, plan: Plan<P>) {
+        let (contents, recipients) = match plan {
+            Plan::Propose { .. } => {
+                let contents = self.pending.remove(&payload).expect("missing payload");
+                self.seen.insert(payload, contents.clone());
+                (contents, Recipients::All)
+            }
+            Plan::Forward { recipients, .. } => {
+                let contents = match self.seen.get(&payload).cloned() {
+                    Some(contents) => contents,
+                    None => {
+                        let Some(contents) = self.pending.get(&payload).cloned() else {
+                            debug!("payload not found for forwarding");
+                            return;
+                        };
+                        self.seen.insert(payload, contents.clone());
+                        contents
+                    }
+                };
+                (contents, recipients)
+            }
+        };
+        self.relay.broadcast_from(
+            Some(self.relay_registration),
+            &self.me,
+            recipients,
+            (payload, contents),
+        );
+    }
+
+    pub(crate) fn start(mut self) -> Handle<()> {
+        spawn_cell!(self.context, self.run())
+    }
+
+    async fn run(mut self) {
+        let mut waiters: Waiters<P> = HashMap::new();
+
+        select_loop! {
+            self.context,
+            on_stopped => {
+                debug!("context shutdown, stopping fuzz application");
+            },
+            Some(message) = self.mailbox.recv() else break => {
+                match message {
+                    Message::Propose { context, response } => {
+                        let digest = self.propose(context).await;
+                        response.send_lossy(digest);
+                    }
+                    Message::Verify {
+                        context,
+                        payload,
+                        response,
+                    } => {
+                        if let Some(contents) = self.seen.get(&payload) {
+                            let verified = self.verify(context, payload, contents.clone()).await;
+                            response.send_lossy(verified);
+                        } else {
+                            waiters
+                                .entry(payload)
+                                .or_default()
+                                .push((context, response));
+                        }
+                    }
+                    Message::Certify {
+                        round,
+                        payload,
+                        response,
+                    } => {
+                        if matches!(self.should_certify, Certifier::Cancel) {
+                            // Cancel: drop sender -> immediate RecvError on receiver.
+                            drop(response);
+                        } else if !self.seen.contains_key(&payload) {
+                            self.certification_waiters
+                                .entry(payload)
+                                .or_default()
+                                .push((round, response));
+                        } else if let Some(certified) = self.certify(round, payload).await {
+                            response.send_lossy(certified);
+                        } else if matches!(self.should_certify, Certifier::Pending) {
+                            self.pending_certifications.push(response);
+                        }
+                    }
+                    Message::Broadcast { payload, plan } => {
+                        self.broadcast(payload, plan);
+                    }
+                }
+            },
+            Some((digest, contents)) = self.broadcast.recv() else break => {
+                self.seen.insert(digest, contents.clone());
+                if let Some(waiters) = waiters.remove(&digest) {
+                    for (context, sender) in waiters {
+                        let verified = self.verify(context, digest, contents.clone()).await;
+                        sender.send_lossy(verified);
+                    }
+                }
+                if let Some(waiters) = self.certification_waiters.remove(&digest) {
+                    for (round, sender) in waiters {
+                        if let Some(certified) = self.certify(round, digest).await {
+                            sender.send_lossy(certified);
+                        } else if matches!(self.should_certify, Certifier::Pending) {
+                            self.pending_certifications.push(sender);
+                        }
+                    }
+                }
+            },
+        }
+    }
+}
+
+pub(crate) fn mock_block_round(contents: &Bytes) -> Option<Round> {
+    <(Round, Sha256Digest, u64)>::decode(&mut contents.as_ref())
+        .ok()
+        .map(|(round, _, _)| round)
+}
+
+pub(crate) fn mock_block_view(contents: &Bytes) -> Option<View> {
+    mock_block_round(contents).map(|round| round.view())
+}
+
+pub(crate) fn mock_block(round: Round, parent: Sha256Digest, nonce: u64) -> (Sha256Digest, Bytes) {
+    let contents = (round, parent, nonce).encode();
+    let payload = Sha256::hash(&[&contents]);
+    (payload, contents)
+}
+
+pub(crate) fn genesis_backed_mock_block(
+    proposal: &Proposal<Sha256Digest>,
+    nonce: u64,
+) -> Option<(Proposal<Sha256Digest>, Bytes)> {
+    if !proposal.parent.is_zero() {
+        return None;
+    }
+    let (payload, contents) = mock_block(
+        proposal.round,
+        application::genesis::<Sha256>(proposal.round.epoch()),
+        nonce,
+    );
+    Some((
+        Proposal::new(proposal.round, proposal.parent, payload),
+        contents,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_p2p::Recipients;
+
+    #[test]
+    fn broadcast_with_tag_exposes_sender_tag_to_filter() {
+        let relay = Relay::new();
+        let sender = crate::id_mock::PublicKey::from_index(0);
+        let recipient = crate::id_mock::PublicKey::from_index(1);
+        let (_primary, mut primary_rx) =
+            relay.register_with_tag(recipient.clone(), RELAY_TAG_TWIN_PRIMARY);
+        let (_secondary, mut secondary_rx) =
+            relay.register_with_tag(recipient.clone(), RELAY_TAG_TWIN_SECONDARY);
+        relay.set_filter(|_, sender_tag, _, recipient_tag, _, _| {
+            sender_tag != Some(RELAY_TAG_TWIN_SECONDARY)
+                || recipient_tag == RELAY_TAG_TWIN_SECONDARY
+        });
+        let payload = Sha256Digest::from([1u8; 32]);
+        let contents = Bytes::from_static(b"block");
+
+        relay.broadcast(
+            &sender,
+            Recipients::One(recipient.clone()),
+            (payload, contents.clone()),
+        );
+        assert!(primary_rx.try_recv().is_ok());
+        assert!(secondary_rx.try_recv().is_ok());
+
+        relay.broadcast_with_tag(
+            &sender,
+            RELAY_TAG_TWIN_SECONDARY,
+            Recipients::One(recipient),
+            (payload, contents),
+        );
+        assert!(primary_rx.try_recv().is_err());
+        assert!(secondary_rx.try_recv().is_ok());
+    }
+}

--- a/consensus/fuzz/src/block_relay.rs
+++ b/consensus/fuzz/src/block_relay.rs
@@ -25,7 +25,10 @@ use rand::{Rng, RngExt as _};
 use rand_distr::{Distribution, Normal};
 use std::{
     collections::{BTreeMap, HashMap, HashSet, btree_map::Entry},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 use tracing::{debug, error, warn};
@@ -50,6 +53,7 @@ struct Listener {
 pub(crate) struct Relay<P: PublicKey> {
     recipients: Mutex<BTreeMap<P, Vec<Listener>>>,
     filter: Mutex<Option<Filter<P>>>,
+    certify_requires_block: AtomicBool,
 }
 
 impl<P: PublicKey> Relay<P> {
@@ -57,7 +61,23 @@ impl<P: PublicKey> Relay<P> {
         Self {
             recipients: Mutex::new(BTreeMap::new()),
             filter: Mutex::new(None),
+            certify_requires_block: AtomicBool::new(false),
         }
+    }
+
+    /// When enabled, a mock [`Application`] backed by this relay holds a certify
+    /// request open until the payload's block bytes arrive, so a withheld block
+    /// yields a genuinely pending certify. Left off (the default), certification
+    /// follows the [`Certifier`] regardless of block possession, matching the
+    /// upstream mock application; harnesses whose block drops are recoverable
+    /// in-flight faults (e.g. ByzzFuzz pre-GST partitions) rely on that.
+    pub(crate) fn set_certify_requires_block(&self, requires: bool) {
+        self.certify_requires_block
+            .store(requires, Ordering::Relaxed);
+    }
+
+    pub(crate) fn certify_requires_block(&self) -> bool {
+        self.certify_requires_block.load(Ordering::Relaxed)
     }
 
     pub(crate) fn set_filter(
@@ -467,7 +487,9 @@ impl<E: Clock + Rng + Spawner, P: PublicKey> Application<E, P> {
                         if matches!(self.should_certify, Certifier::Cancel) {
                             // Cancel: drop sender -> immediate RecvError on receiver.
                             drop(response);
-                        } else if !self.seen.contains_key(&payload) {
+                        } else if self.relay.certify_requires_block()
+                            && !self.seen.contains_key(&payload)
+                        {
                             self.certification_waiters
                                 .entry(payload)
                                 .or_default()

--- a/consensus/fuzz/src/byzzfuzz/runner.rs
+++ b/consensus/fuzz/src/byzzfuzz/runner.rs
@@ -7,10 +7,10 @@
 use super::BYZANTINE_IDX;
 use crate::{
     CertifyChoice, EPOCH, FAULT_INJECTION_RATIO, FAULT_PHASE, N4F0C4, PublicKeyOf, SniffChannel,
-    SniffingReceiver,
+    SniffingReceiver, block_relay,
     byzzfuzz::{
         ByzzFuzz,
-        fault::ProcessFault,
+        fault::{NetworkFault, ProcessFault},
         forwarder,
         injector::ByzzFuzzInjector,
         intercept::{self, FaultGate, SenderViewCell},
@@ -20,14 +20,14 @@ use crate::{
     },
     happens_before, invariants,
     simplex::Simplex,
-    sniff_sink, spawn_honest_validator,
+    sniff_sink, spawn_filtered_honest_validator,
     utils::Partition,
 };
 use bytes::Bytes;
 use commonware_codec::Encode;
 use commonware_consensus::{
     Monitor as _,
-    simplex::mocks::{relay, reporter::Reporter},
+    simplex::mocks::reporter::Reporter,
     types::{Epoch, View},
 };
 use commonware_cryptography::{
@@ -75,6 +75,23 @@ struct EngineSetup<P: Simplex> {
 
 fn genesis_payload() -> Sha256Digest {
     Sha256::hash(&[&(Bytes::from_static(b"genesis"), Epoch::new(EPOCH)).encode()])
+}
+
+fn block_partition_allows<P: commonware_cryptography::PublicKey>(
+    participants: &[P],
+    sender_idx: usize,
+    recipient: &P,
+    schedule: &[NetworkFault],
+    view: u64,
+) -> bool {
+    let mut active = schedule
+        .iter()
+        .filter(|fault| fault.view.get() == view)
+        .map(|fault| fault.partition);
+    let Some(recipient_idx) = participants.iter().position(|p| p == recipient) else {
+        return true;
+    };
+    active.all(|partition| partition.connected(sender_idx, recipient_idx))
 }
 
 /// Sample `(c, d, r)` from `context` and build the per-validator
@@ -172,10 +189,44 @@ where
     // replay the genesis payload and parent view before any proposal is seen.
     let pool = ObservedState::new_with_genesis(genesis_payload());
 
-    let relay = Arc::new(relay::Relay::<Sha256Digest, _>::new());
+    let relay = Arc::new(block_relay::Relay::new());
     let mut reporters = Vec::new();
     let config = input.configuration;
     let mut byzantine_view = None;
+    let sender_views: Arc<[SenderViewCell]> = (0..config.n as usize)
+        .map(|_| SenderViewCell::new())
+        .collect::<Vec<_>>()
+        .into();
+    {
+        let gate = gate.clone();
+        let network_schedule = network_schedule.clone();
+        let participants = participants_arc.clone();
+        let sender_views = sender_views.clone();
+        relay.set_filter(move |sender, _, recipient, _, _, contents| {
+            let Some(sender_idx) = participants.iter().position(|p| p == sender) else {
+                return true;
+            };
+            if let Some(view) = block_relay::mock_block_view(contents) {
+                sender_views[sender_idx].update(view.get());
+            }
+            if gate.gst_reached() {
+                return true;
+            }
+            let view = sender_views[sender_idx].get();
+            let schedule = network_schedule.lock();
+            let allowed =
+                block_partition_allows(participants.as_ref(), sender_idx, recipient, &schedule, view);
+            if !allowed {
+                let recipient_idx = participants
+                    .iter()
+                    .position(|participant| participant == recipient);
+                log::push(format!(
+                    "byzzfuzz: drop channel=Block view={view} sender={sender_idx} recipient={recipient_idx:?} reason=partition",
+                ));
+            }
+            allowed
+        });
+    }
 
     // Cloned byzantine vote sender for the injector. Grabbed BEFORE
     // split_with so injector emissions bypass the forwarder. Cert and
@@ -194,7 +245,7 @@ where
             injector_vote_sender = Some(vote_sender.clone());
         }
 
-        let sender_view = intercept::SenderViewCell::new();
+        let sender_view = sender_views[i].clone();
         if i == BYZANTINE_IDX {
             byzantine_view = Some(sender_view.clone());
         }
@@ -295,7 +346,7 @@ where
             .child("validator")
             .with_attribute("public_key", &validator);
         let spawn = || {
-            spawn_honest_validator::<P, _, _, _, _, _, _, _>(
+            spawn_filtered_honest_validator::<P, _, _, _, _, _, _, _>(
                 ctx,
                 &oracle,
                 &participants,
@@ -573,7 +624,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        CertifyChoice, FuzzInput, N4F0C4, ReporterWiring, simplex::SimplexId,
+        BlockFilterChoice, CertifyChoice, FuzzInput, N4F0C4, ReporterWiring, simplex::SimplexId,
         strategy::StrategyChoice, utils::Partition,
     };
     use commonware_consensus::{simplex::ForwardingPolicy, types::TermLength};
@@ -594,6 +645,7 @@ mod tests {
             mailbox_size: NonZeroUsize::new(1024).unwrap(),
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
+            block_filter: BlockFilterChoice::None,
             reporting: ReporterWiring::Solo,
         }
     }

--- a/consensus/fuzz/src/chaos/runner.rs
+++ b/consensus/fuzz/src/chaos/runner.rs
@@ -665,7 +665,9 @@ mod tests {
     use super::*;
     #[cfg(feature = "mocks")]
     use crate::simplex::SimplexCertificateMock;
-    use crate::{FuzzInput, ReporterWiring, simplex::SimplexId, strategy::StrategyChoice};
+    use crate::{
+        BlockFilterChoice, FuzzInput, ReporterWiring, simplex::SimplexId, strategy::StrategyChoice,
+    };
     use commonware_consensus::simplex::ForwardingPolicy;
     use std::num::NonZeroUsize;
 
@@ -689,6 +691,7 @@ mod tests {
             mailbox_size: NonZeroUsize::new(1024).unwrap(),
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
+            block_filter: BlockFilterChoice::None,
             reporting: ReporterWiring::Solo,
         }
     }

--- a/consensus/fuzz/src/disrupter.rs
+++ b/consensus/fuzz/src/disrupter.rs
@@ -1,4 +1,9 @@
-use crate::{EPOCH, strategy::Strategy, types::Message};
+use crate::{
+    EPOCH,
+    block_relay::{self, Relay as BlockRelay},
+    strategy::Strategy,
+    types::Message,
+};
 use commonware_codec::{Encode, Read, ReadExt};
 use commonware_consensus::{
     Viewable,
@@ -11,11 +16,13 @@ use commonware_consensus::{
 use commonware_cryptography::sha256::Digest as Sha256Digest;
 use commonware_p2p::{Receiver, Recipients, Sender};
 use commonware_runtime::{Clock, ContextCell, Handle, IoBuf, Spawner, spawn_cell};
+use commonware_utils::ordered::Quorum;
 use rand::RngExt as _;
 use rand_core::CryptoRng;
 use std::{
     collections::VecDeque,
     future::{Future as _, poll_fn},
+    sync::Arc,
     task::Poll,
     time::Duration,
 };
@@ -58,6 +65,8 @@ pub struct Disrupter<
     last_nullified_view: u64,
     last_notarized_view: u64,
     latest_proposals: VecDeque<Proposal<Sha256Digest>>,
+    block_relay: Option<Arc<BlockRelay<S::PublicKey>>>,
+    block_relay_tag: Option<u64>,
 }
 
 impl<E: Clock + Spawner + CryptoRng, S: Scheme<Sha256Digest>, St: Strategy + 'static>
@@ -78,11 +87,46 @@ where
     /// Like [`Self::new`] but stamps emitted messages with `epoch` instead of the
     /// harness-wide [`EPOCH`].
     pub fn new_with_epoch(
+        context: E,
+        scheme: S,
+        strategy: St,
+        required_containers: u64,
+        epoch: Epoch,
+    ) -> Self {
+        Self::new_with_epoch_and_relay(context, scheme, strategy, required_containers, epoch, None)
+    }
+
+    /// Like [`Self::new_with_epoch`] but also publishes generated mock blocks
+    /// through the fuzz-local block relay.
+    pub(crate) fn new_with_epoch_and_relay(
+        context: E,
+        scheme: S,
+        strategy: St,
+        required_containers: u64,
+        epoch: Epoch,
+        block_relay: Option<Arc<BlockRelay<S::PublicKey>>>,
+    ) -> Self {
+        Self::new_with_epoch_relay_and_tag(
+            context,
+            scheme,
+            strategy,
+            required_containers,
+            epoch,
+            block_relay,
+            None,
+        )
+    }
+
+    /// Like [`Self::new_with_epoch_and_relay`] but tags generated block relay
+    /// broadcasts as one half of a simulated twin identity.
+    pub(crate) fn new_with_epoch_relay_and_tag(
         mut context: E,
         scheme: S,
         strategy: St,
         required_containers: u64,
         epoch: Epoch,
+        block_relay: Option<Arc<BlockRelay<S::PublicKey>>>,
+        block_relay_tag: Option<u64>,
     ) -> Self {
         let faulty_views = strategy.disrupter_faults(required_containers, &mut context);
         Self {
@@ -96,6 +140,8 @@ where
             strategy,
             faulty_views,
             epoch,
+            block_relay,
+            block_relay_tag,
         }
     }
 
@@ -108,6 +154,41 @@ where
             proposal.parent,
             proposal.payload,
         )
+    }
+
+    fn attach_mock_block(
+        &mut self,
+        proposal: Proposal<Sha256Digest>,
+        recipients: Recipients<S::PublicKey>,
+    ) -> Proposal<Sha256Digest> {
+        let proposal = self.normalize_epoch(proposal);
+        let Some(block_relay) = &self.block_relay else {
+            return proposal;
+        };
+        if self.strategy.preserves_proposal_payload() {
+            return proposal;
+        }
+        let Some(me) = self.scheme.me() else {
+            return proposal;
+        };
+        let Some(sender) = self.scheme.participants().key(me).cloned() else {
+            return proposal;
+        };
+        let Some((proposal, contents)) =
+            block_relay::genesis_backed_mock_block(&proposal, self.context.random::<u64>())
+        else {
+            return proposal;
+        };
+        match self.block_relay_tag {
+            Some(tag) => block_relay.broadcast_with_tag(
+                &sender,
+                tag,
+                recipients,
+                (proposal.payload, contents),
+            ),
+            None => block_relay.broadcast(&sender, recipients, (proposal.payload, contents)),
+        }
+        proposal
     }
 
     fn message(&mut self) -> Message {
@@ -331,7 +412,8 @@ where
                     self.last_notarized_view,
                     self.last_nullified_view,
                 );
-                if let Some(v) = Notarize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+                let proposal = self.attach_mock_block(proposal, Recipients::All);
+                if let Some(v) = Notarize::sign(&self.scheme, proposal) {
                     let msg = Vote::<S, Sha256Digest>::Notarize(v).encode();
                     let _ = sender.send(Recipients::All, msg, true);
                 }
@@ -345,7 +427,8 @@ where
                     self.last_notarized_view,
                     self.last_nullified_view,
                 );
-                if let Some(v) = Finalize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+                let proposal = self.attach_mock_block(proposal, Recipients::All);
+                if let Some(v) = Finalize::sign(&self.scheme, proposal) {
                     let msg = Vote::<S, Sha256Digest>::Finalize(v).encode();
                     let _ = sender.send(Recipients::All, msg, true);
                 }
@@ -452,7 +535,8 @@ where
                 self.last_notarized_view,
                 self.last_nullified_view,
             );
-            if let Some(vote) = Notarize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+            let proposal = self.attach_mock_block(proposal, Recipients::One(victim.clone()));
+            if let Some(vote) = Notarize::sign(&self.scheme, proposal) {
                 let message = Vote::<S, Sha256Digest>::Notarize(vote).encode();
                 let _ = sender.send(Recipients::One(victim.clone()), message, true);
             }
@@ -472,7 +556,8 @@ where
             self.last_notarized_view,
             self.last_nullified_view,
         );
-        if let Some(vote) = Notarize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+        let proposal = self.attach_mock_block(proposal, Recipients::All);
+        if let Some(vote) = Notarize::sign(&self.scheme, proposal) {
             let message = Vote::<S, Sha256Digest>::Notarize(vote).encode();
             let _ = sender.send(Recipients::All, message, true);
         }
@@ -502,7 +587,8 @@ where
                     self.last_notarized_view,
                     self.last_nullified_view,
                 );
-                if let Some(vote) = Notarize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+                let proposal = self.attach_mock_block(proposal, recipients.clone());
+                if let Some(vote) = Notarize::sign(&self.scheme, proposal) {
                     let msg = Vote::<S, Sha256Digest>::Notarize(vote).encode();
                     let _ = sender.send(recipients, msg, true);
                 }
@@ -516,7 +602,8 @@ where
                     self.last_notarized_view,
                     self.last_nullified_view,
                 );
-                if let Some(vote) = Finalize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+                let proposal = self.attach_mock_block(proposal, recipients.clone());
+                if let Some(vote) = Finalize::sign(&self.scheme, proposal) {
                     let msg = Vote::<S, Sha256Digest>::Finalize(vote).encode();
                     let _ = sender.send(recipients, msg, true);
                 }
@@ -544,11 +631,84 @@ where
                     self.last_notarized_view,
                     self.last_nullified_view,
                 );
-                if let Some(vote) = Notarize::sign(&self.scheme, self.normalize_epoch(proposal)) {
+                let proposal = self.attach_mock_block(proposal, recipients.clone());
+                if let Some(vote) = Notarize::sign(&self.scheme, proposal) {
                     let message = Vote::<S, Sha256Digest>::Notarize(vote).encode();
                     let _ = sender.send(recipients, message, true);
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        id_mock,
+        strategy::{HeaderMutation, HeaderScope, SmallScope, SplitHeader},
+    };
+    use commonware_runtime::{Runner as _, Supervisor as _};
+
+    fn genesis_parent_proposal(payload: Sha256Digest) -> Proposal<Sha256Digest> {
+        Proposal::new(
+            Round::new(Epoch::new(EPOCH), View::new(1)),
+            View::new(0),
+            payload,
+        )
+    }
+
+    #[test]
+    fn attach_mock_block_preserves_header_strategy_payloads() {
+        let executor = commonware_runtime::deterministic::Runner::seeded(17);
+        executor.start(|mut context| async move {
+            let (_, schemes) = id_mock::fixture(&mut context, b"disrupter_attach", 4);
+            let payload = Sha256Digest::from([7u8; 32]);
+            let proposal = genesis_parent_proposal(payload);
+
+            let relay = Arc::new(BlockRelay::new());
+            let mut header = Disrupter::new_with_epoch_and_relay(
+                context.child("header"),
+                schemes[0].clone(),
+                HeaderScope {
+                    fault_rounds: 1,
+                    fault_rounds_bound: 1,
+                    mutation: HeaderMutation::PreviousParent,
+                },
+                1,
+                Epoch::new(EPOCH),
+                Some(relay.clone()),
+            );
+            let attached = header.attach_mock_block(proposal.clone(), Recipients::All);
+            assert_eq!(attached.payload, payload);
+
+            let mut split = Disrupter::new_with_epoch_and_relay(
+                context.child("split"),
+                schemes[0].clone(),
+                SplitHeader {
+                    fault_rounds: 1,
+                    fault_rounds_bound: 1,
+                },
+                1,
+                Epoch::new(EPOCH),
+                Some(relay.clone()),
+            );
+            let attached = split.attach_mock_block(proposal.clone(), Recipients::All);
+            assert_eq!(attached.payload, payload);
+
+            let mut small = Disrupter::new_with_epoch_and_relay(
+                context.child("small"),
+                schemes[0].clone(),
+                SmallScope {
+                    fault_rounds: 1,
+                    fault_rounds_bound: 1,
+                },
+                1,
+                Epoch::new(EPOCH),
+                Some(relay),
+            );
+            let attached = small.attach_mock_block(proposal, Recipients::All);
+            assert_ne!(attached.payload, payload);
+        });
     }
 }

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -713,6 +713,9 @@ pub(crate) async fn setup_network<P: simplex::Simplex>(
 /// The marshal liveness target passes `Epoch::zero()` so the disrupter shares
 /// the epoch its honest engines run in (making it an in-epoch adversary rather
 /// than wrong-epoch noise).
+// Only the mocks-gated marshal end-to-end runner calls this thin wrapper; the
+// other disrupter paths use the `_and_relay`/`_relay_and_tag` variants directly.
+#[cfg(feature = "mocks")]
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
     context: deterministic::Context,

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -2289,6 +2289,13 @@ fn run_standard_once<P: simplex::Simplex>(
         }
 
         let relay = Arc::new(block_relay::Relay::new());
+        // A withheld block should hold certification pending only for the
+        // DropRecipient scenario (whose liveness is left unbounded); other
+        // runs certify per the Certifier as the upstream mock does.
+        relay.set_certify_requires_block(matches!(
+            input.block_filter,
+            BlockFilterChoice::DropRecipient { .. }
+        ));
         configure_block_filter::<P>(&relay, &participants, &input.partition, input.block_filter);
         let mut reporters = Vec::new();
         let config = input.configuration;
@@ -2535,6 +2542,13 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
         }
 
         let relay = Arc::new(block_relay::Relay::new());
+        // A withheld block should hold certification pending only for the
+        // DropRecipient scenario (whose liveness is left unbounded); other
+        // runs certify per the Certifier as the upstream mock does.
+        relay.set_certify_requires_block(matches!(
+            input.block_filter,
+            BlockFilterChoice::DropRecipient { .. }
+        ));
         configure_block_filter::<P>(&relay, &participants, &input.partition, input.block_filter);
         let mut reporters = Vec::new();
         let config = input.configuration;
@@ -2790,6 +2804,13 @@ fn run_with_faulty_messaging<P: simplex::Simplex>(mut input: FuzzInput) {
             setup_network::<P>(&mut context, &input).await;
 
         let relay = Arc::new(block_relay::Relay::new());
+        // A withheld block should hold certification pending only for the
+        // DropRecipient scenario (whose liveness is left unbounded); other
+        // runs certify per the Certifier as the upstream mock does.
+        relay.set_certify_requires_block(matches!(
+            input.block_filter,
+            BlockFilterChoice::DropRecipient { .. }
+        ));
         configure_block_filter::<P>(&relay, &participants, &input.partition, input.block_filter);
         let mut reporters = Vec::new();
         let config = input.configuration;

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -4,6 +4,7 @@ pub mod aggregation;
 pub mod aggregation_certificate_mock;
 #[cfg(feature = "mocks")]
 pub mod aggregation_decode;
+pub(crate) mod block_relay;
 pub mod bounds;
 pub mod byzzfuzz;
 pub(crate) mod chaos;
@@ -47,9 +48,9 @@ use arbitrary::Arbitrary;
 use commonware_actor::Feedback;
 use commonware_codec::{Decode, DecodeExt};
 use commonware_consensus::{
-    CertifiableAutomaton, Monitor, Reporter, Reporters, Viewable,
+    CertifiableAutomaton, Monitor, Relay as ConsensusRelay, Reporter, Reporters, Viewable,
     simplex::{
-        Engine, Floor, ForwardingPolicy, config,
+        Engine, Floor, ForwardingPolicy, Plan, config,
         elector::Config as ElectorConfig,
         mocks::{application, relay, reporter, twins},
         types::{Activity, Certificate, Context as SimplexContext, Vote},
@@ -59,7 +60,7 @@ use commonware_consensus::{
 use commonware_cryptography::{
     PublicKey as CryptoPublicKey, Sha256, certificate::Verifier, sha256::Digest as Sha256Digest,
 };
-use commonware_p2p::simulated::{Config as NetworkConfig, Link, Network, Oracle};
+use commonware_p2p::simulated::{Config as NetworkConfig, Link, Network, Oracle, SplitTarget};
 use commonware_parallel::Sequential;
 use commonware_resolver::p2p::mocks::{Message as ResolverMessage, Payload as ResolverPayload};
 use commonware_runtime::{
@@ -75,13 +76,13 @@ use commonware_utils::{
     sync::Once,
 };
 use futures::future::join_all;
-#[cfg(feature = "mocks")]
-pub use simplex::SimplexCertificateMock;
 pub use simplex::{
     SimplexBls12381MinPk, SimplexBls12381MinPkCustomRandom, SimplexBls12381MinSig,
     SimplexBls12381MultisigMinPk, SimplexBls12381MultisigMinSig, SimplexEd25519,
     SimplexEd25519CustomRoundRobin, SimplexId, SimplexSecp256r1,
 };
+#[cfg(feature = "mocks")]
+pub use simplex::{SimplexCertificateMock, SimplexCertificateMockByzantineFirstLeader};
 use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt,
@@ -257,6 +258,63 @@ impl CertifyChoice {
     }
 }
 
+/// Per-iteration filter for fuzz-local mock block payload delivery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockFilterChoice {
+    None,
+    DropRecipient { view: View, target_idx: u8 },
+}
+
+fn configure_block_filter<P: simplex::Simplex>(
+    relay: &Arc<block_relay::Relay<PublicKeyOf<P>>>,
+    participants: &[PublicKeyOf<P>],
+    partition: &Partition,
+    choice: BlockFilterChoice,
+) {
+    let drop_target = match choice {
+        BlockFilterChoice::DropRecipient { view, target_idx } => participants
+            .get(target_idx as usize)
+            .cloned()
+            .map(|target| (view, target)),
+        BlockFilterChoice::None => None,
+    };
+    let static_partition = partition.set_partition().copied();
+    let schedule = partition.schedule().map(<[_]>::to_vec).unwrap_or_default();
+    if drop_target.is_none() && static_partition.is_none() && schedule.is_empty() {
+        return;
+    }
+
+    let participants: Arc<[PublicKeyOf<P>]> = participants.to_vec().into();
+    relay.set_filter(move |sender, _, recipient, _, _, contents| {
+        let block_view = block_relay::mock_block_view(contents);
+        if let Some((view, target)) = &drop_target
+            && block_view == Some(*view)
+            && recipient == target
+        {
+            return false;
+        }
+
+        let active_partition = static_partition
+            .or_else(|| block_view.and_then(|view| scheduled_partition(&schedule, view.get())));
+        let Some(active_partition) = active_partition else {
+            return true;
+        };
+        let Some(sender_idx) = participants
+            .iter()
+            .position(|participant| participant == sender)
+        else {
+            return true;
+        };
+        let Some(recipient_idx) = participants
+            .iter()
+            .position(|participant| participant == recipient)
+        else {
+            return true;
+        };
+        active_partition.connected(sender_idx, recipient_idx)
+    });
+}
+
 /// Per-iteration shape of the [Reporters] combinator wrapping each honest
 /// engine's reporter, driving coverage of `commonware_consensus::reporter`.
 /// Compromised twin engines keep raw reporters. The real reporter is always
@@ -352,6 +410,7 @@ impl fmt::Debug for FuzzInputDebug<'_> {
             .field("mailbox_size", &input.mailbox_size)
             .field("forwarding", &input.forwarding)
             .field("certify", &input.certify)
+            .field("block_filter", &input.block_filter)
             .field("reporting", &input.reporting)
             .finish()
     }
@@ -417,13 +476,17 @@ pub struct FuzzInput {
     /// Per-iteration certify policy threaded into every honest validator
     /// the harness spawns.
     pub certify: CertifyChoice,
+    /// Per-iteration fuzz-local mock block relay filter.
+    pub block_filter: BlockFilterChoice,
     /// Per-iteration reporter wiring threaded into every honest engine
     /// the harness spawns.
     pub reporting: ReporterWiring,
 }
 
 fn should_bound_standard_liveness(input: &FuzzInput) -> bool {
-    input.partition.is_connected() && input.configuration.is_valid()
+    input.partition.is_connected()
+        && input.configuration.is_valid()
+        && matches!(input.block_filter, BlockFilterChoice::None)
 }
 
 impl Arbitrary<'_> for FuzzInput {
@@ -502,6 +565,16 @@ impl Arbitrary<'_> for FuzzInput {
             CertifyChoice::Always
         };
 
+        let block_filter = if configuration == N4F1C3 && u.int_in_range(0..=9)? == 0 {
+            BlockFilterChoice::DropRecipient {
+                view: View::new(u.int_in_range(1..=fault_rounds_bound)?),
+                target_idx: u
+                    .int_in_range(configuration.faults as u8..=configuration.n as u8 - 1)?,
+            }
+        } else {
+            BlockFilterChoice::None
+        };
+
         let reporting = ReporterWiring::arbitrary(u)?;
 
         let mailbox_size = fuzz_mailbox_size(u)?;
@@ -526,6 +599,7 @@ impl Arbitrary<'_> for FuzzInput {
             mailbox_size,
             forwarding,
             certify,
+            block_filter,
             reporting,
         })
     }
@@ -635,39 +709,7 @@ pub(crate) async fn setup_network<P: simplex::Simplex>(
     (oracle, participants, schemes, registrations)
 }
 
-/// Start a Disrupter with the given strategy and network channels, using the
-/// harness-wide [`EPOCH`] for emitted messages.
-fn start_disrupter<P: simplex::Simplex>(
-    context: deterministic::Context,
-    scheme: P::Scheme,
-    strategy: &StrategyChoice,
-    required_containers: u64,
-    vote_network: (
-        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
-        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
-    ),
-    certificate_network: (
-        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
-        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
-    ),
-    resolver_network: (
-        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
-        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
-    ),
-) {
-    start_disrupter_with_epoch::<P>(
-        context,
-        scheme,
-        strategy,
-        required_containers,
-        Epoch::new(EPOCH),
-        vote_network,
-        certificate_network,
-        resolver_network,
-    );
-}
-
-/// Like [`start_disrupter`] but stamps emitted byzantine messages with `epoch`.
+/// Start a Disrupter with an explicit consensus `epoch`.
 /// The marshal liveness target passes `Epoch::zero()` so the disrupter shares
 /// the epoch its honest engines run in (making it an in-epoch adversary rather
 /// than wrong-epoch noise).
@@ -691,12 +733,82 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
         impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
     ),
 ) {
+    start_disrupter_with_epoch_and_relay::<P>(
+        context,
+        scheme,
+        strategy,
+        required_containers,
+        epoch,
+        vote_network,
+        certificate_network,
+        resolver_network,
+        None,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_disrupter_with_epoch_and_relay<P: simplex::Simplex>(
+    context: deterministic::Context,
+    scheme: P::Scheme,
+    strategy: &StrategyChoice,
+    required_containers: u64,
+    epoch: Epoch,
+    vote_network: (
+        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ),
+    certificate_network: (
+        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ),
+    resolver_network: (
+        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ),
+    block_relay: Option<Arc<block_relay::Relay<PublicKeyOf<P>>>>,
+) {
+    start_disrupter_with_epoch_relay_and_tag::<P>(
+        context,
+        scheme,
+        strategy,
+        required_containers,
+        epoch,
+        vote_network,
+        certificate_network,
+        resolver_network,
+        block_relay,
+        None,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_disrupter_with_epoch_relay_and_tag<P: simplex::Simplex>(
+    context: deterministic::Context,
+    scheme: P::Scheme,
+    strategy: &StrategyChoice,
+    required_containers: u64,
+    epoch: Epoch,
+    vote_network: (
+        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ),
+    certificate_network: (
+        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ),
+    resolver_network: (
+        impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+        impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ),
+    block_relay: Option<Arc<block_relay::Relay<PublicKeyOf<P>>>>,
+    block_relay_tag: Option<u64>,
+) {
     match *strategy {
         StrategyChoice::SmallScope {
             fault_rounds,
             fault_rounds_bound,
         } => {
-            let disrupter = Disrupter::new_with_epoch(
+            let disrupter = Disrupter::new_with_epoch_relay_and_tag(
                 context,
                 scheme,
                 SmallScope {
@@ -705,19 +817,28 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
                 },
                 required_containers,
                 epoch,
+                block_relay,
+                block_relay_tag,
             );
             disrupter.start(vote_network, certificate_network, resolver_network);
         }
         StrategyChoice::AnyScope => {
-            let disrupter =
-                Disrupter::new_with_epoch(context, scheme, AnyScope, required_containers, epoch);
+            let disrupter = Disrupter::new_with_epoch_relay_and_tag(
+                context,
+                scheme,
+                AnyScope,
+                required_containers,
+                epoch,
+                block_relay,
+                block_relay_tag,
+            );
             disrupter.start(vote_network, certificate_network, resolver_network);
         }
         StrategyChoice::FutureScope {
             fault_rounds,
             fault_rounds_bound,
         } => {
-            let disrupter = Disrupter::new_with_epoch(
+            let disrupter = Disrupter::new_with_epoch_relay_and_tag(
                 context,
                 scheme,
                 FutureScope {
@@ -726,6 +847,8 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
                 },
                 required_containers,
                 epoch,
+                block_relay,
+                block_relay_tag,
             );
             disrupter.start(vote_network, certificate_network, resolver_network);
         }
@@ -734,7 +857,7 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
             fault_rounds_bound,
             mutation,
         } => {
-            let disrupter = Disrupter::new_with_epoch(
+            let disrupter = Disrupter::new_with_epoch_relay_and_tag(
                 context,
                 scheme,
                 HeaderScope {
@@ -744,6 +867,8 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
                 },
                 required_containers,
                 epoch,
+                block_relay,
+                block_relay_tag,
             );
             disrupter.start(vote_network, certificate_network, resolver_network);
         }
@@ -751,7 +876,7 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
             fault_rounds,
             fault_rounds_bound,
         } => {
-            let disrupter = Disrupter::new_with_epoch(
+            let disrupter = Disrupter::new_with_epoch_relay_and_tag(
                 context,
                 scheme,
                 SplitHeader {
@@ -760,28 +885,32 @@ pub(crate) fn start_disrupter_with_epoch<P: simplex::Simplex>(
                 },
                 required_containers,
                 epoch,
+                block_relay,
+                block_relay_tag,
             );
             disrupter.start(vote_network, certificate_network, resolver_network);
         }
     }
 }
 
-/// Spawn a Disrupter for a Byzantine node.
-fn spawn_disrupter<P: simplex::Simplex>(
+fn spawn_disrupter_with_relay<P: simplex::Simplex>(
     context: deterministic::Context,
     scheme: P::Scheme,
     input: &FuzzInput,
     channels: NetworkChannels<PublicKeyOf<P>>,
+    block_relay: Option<Arc<block_relay::Relay<PublicKeyOf<P>>>>,
 ) {
     let (vote_network, certificate_network, resolver_network) = channels;
-    start_disrupter::<P>(
+    start_disrupter_with_epoch_and_relay::<P>(
         context.child("disrupter"),
         scheme,
         &input.strategy,
         input.required_containers,
+        Epoch::new(EPOCH),
         vote_network,
         certificate_network,
         resolver_network,
+        block_relay,
     );
 }
 
@@ -996,82 +1125,6 @@ where
     .reporter
 }
 
-/// Spawn an honest validator instrumented with the fuzz-only append-only
-/// reporter and automaton history, dropping the task handles. A thin wrapper
-/// over [`build_validator_with_reporter`] with the [`RecordingReporter`] family,
-/// which owns the recording instrumentation.
-#[allow(clippy::too_many_arguments)]
-fn spawn_audited_validator<
-    P,
-    EC,
-    PendingSender,
-    PendingReceiver,
-    RecoveredSender,
-    RecoveredReceiver,
-    ResolverSender,
-    ResolverReceiver,
->(
-    context: deterministic::Context,
-    oracle: &Oracle<PublicKeyOf<P>, deterministic::Context>,
-    participants: &[PublicKeyOf<P>],
-    scheme: P::Scheme,
-    validator: PublicKeyOf<P>,
-    elector: EC,
-    relay: Arc<relay::Relay<Sha256Digest, PublicKeyOf<P>>>,
-    leader_timeout: Duration,
-    certification_timeout: Duration,
-    mailbox_size: NonZeroUsize,
-    forwarding: ForwardingPolicy,
-    pending: (PendingSender, PendingReceiver),
-    recovered: (RecoveredSender, RecoveredReceiver),
-    resolver: (ResolverSender, ResolverReceiver),
-    certify: CertifyChoice,
-    wiring: ReporterWiring,
-) -> RecordingReporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
-where
-    P: simplex::Simplex,
-    EC: ElectorConfig<P::Scheme> + Clone + Send + 'static,
-    PendingSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
-    PendingReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
-    RecoveredSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
-    RecoveredReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
-    ResolverSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
-    ResolverReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
-{
-    let partition = validator.to_string();
-    build_validator_with_reporter::<
-        P,
-        EC,
-        RecordingReporter<deterministic::Context, P::Scheme, EC, Sha256Digest>,
-        _,
-        _,
-        _,
-        _,
-        _,
-        _,
-    >(
-        None,
-        context,
-        oracle,
-        participants,
-        scheme,
-        validator,
-        elector,
-        relay,
-        leader_timeout,
-        certification_timeout,
-        mailbox_size,
-        forwarding,
-        partition,
-        pending,
-        recovered,
-        resolver,
-        certify,
-        wiring,
-    )
-    .reporter
-}
-
 /// Build an honest validator (application, reporter, engine) and RETAIN its task
 /// handles in a [`ManagedValidator`], instead of dropping them like
 /// [`spawn_honest_validator`]. The storage partition is `validator.to_string()`,
@@ -1137,11 +1190,99 @@ where
     )
 }
 
+#[allow(clippy::too_many_arguments)]
+fn start_validator_engine<
+    P,
+    EC,
+    Automaton,
+    Relay,
+    R,
+    PendingSender,
+    PendingReceiver,
+    RecoveredSender,
+    RecoveredReceiver,
+    ResolverSender,
+    ResolverReceiver,
+>(
+    context: &deterministic::Context,
+    oracle: &Oracle<PublicKeyOf<P>, deterministic::Context>,
+    scheme: P::Scheme,
+    validator: PublicKeyOf<P>,
+    elector: EC,
+    automaton: Automaton,
+    relay: Relay,
+    reporter: R,
+    partition: String,
+    leader_timeout: Duration,
+    certification_timeout: Duration,
+    mailbox_size: NonZeroUsize,
+    forwarding: ForwardingPolicy,
+    pending: (PendingSender, PendingReceiver),
+    recovered: (RecoveredSender, RecoveredReceiver),
+    resolver: (ResolverSender, ResolverReceiver),
+) -> Handle<()>
+where
+    P: simplex::Simplex,
+    EC: ElectorConfig<P::Scheme> + Clone + Send + 'static,
+    Automaton: CertifiableAutomaton<
+            Context = SimplexContext<Sha256Digest, PublicKeyOf<P>>,
+            Digest = Sha256Digest,
+        > + Send
+        + 'static,
+    Relay: ConsensusRelay<
+            Digest = Sha256Digest,
+            PublicKey = PublicKeyOf<P>,
+            Plan = Plan<PublicKeyOf<P>>,
+        >,
+    R: Reporter<Activity = Activity<P::Scheme, Sha256Digest>>,
+    PendingSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    PendingReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    RecoveredSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    RecoveredReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ResolverSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    ResolverReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+{
+    let (vote_sender, vote_receiver) = pending;
+    let (certificate_sender, certificate_receiver) = recovered;
+    let (resolver_sender, resolver_receiver) = resolver;
+
+    let engine_cfg = config::Config {
+        blocker: oracle.control(validator),
+        scheme,
+        elector,
+        automaton,
+        relay,
+        reporter,
+        partition,
+        mailbox_size,
+        epoch: Epoch::new(EPOCH),
+        floor: Floor::Genesis(application::genesis::<Sha256>(Epoch::new(EPOCH))),
+        leader_timeout,
+        certification_timeout,
+        timeout_retry: Duration::from_secs(10),
+        fetch_timeout: Duration::from_secs(1),
+        view_retention: Delta::new(10),
+        skip_timeout: Duration::from_secs(11),
+        replay_buffer: NZUsize!(1024 * 1024),
+        write_buffer: NZUsize!(1024 * 1024),
+        page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
+        strategy: Sequential,
+        forwarding,
+        track_historical_votes: false,
+    };
+    let engine = Engine::new(context.child("engine"), engine_cfg);
+    engine.start(
+        (vote_sender, vote_receiver),
+        (certificate_sender, certificate_receiver),
+        (resolver_sender, resolver_receiver),
+    )
+}
+
 /// A reporter family the managed-validator builder can instantiate: how a
 /// fresh instance is constructed and which automaton the engine drives. The
 /// mock family runs the application directly; the recording family wraps it
 /// in its audit-history recorder.
-pub(crate) trait HarnessReporter<P, EC>:
+pub(crate) trait HarnessReporter<P, EC, Mailbox>:
     Reporter<Activity = Activity<P::Scheme, Sha256Digest>> + Clone
 where
     P: simplex::Simplex,
@@ -1159,14 +1300,10 @@ where
         config: reporter::Config<P::Scheme, EC>,
     ) -> Self;
 
-    fn automaton(
-        &self,
-        context: &deterministic::Context,
-        application: application::Mailbox<Sha256Digest, PublicKeyOf<P>>,
-    ) -> Self::Automaton;
+    fn automaton(&self, context: &deterministic::Context, application: Mailbox) -> Self::Automaton;
 }
 
-impl<P, EC> HarnessReporter<P, EC>
+impl<P, EC> HarnessReporter<P, EC, application::Mailbox<Sha256Digest, PublicKeyOf<P>>>
     for reporter::Reporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
 where
     P: simplex::Simplex,
@@ -1191,7 +1328,32 @@ where
     }
 }
 
-impl<P, EC> HarnessReporter<P, EC>
+impl<P, EC> HarnessReporter<P, EC, block_relay::Mailbox<PublicKeyOf<P>>>
+    for reporter::Reporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
+where
+    P: simplex::Simplex,
+    EC: ElectorConfig<P::Scheme>,
+{
+    type Automaton = block_relay::Mailbox<PublicKeyOf<P>>;
+
+    fn create(
+        context: deterministic::Context,
+        _observer: PublicKeyOf<P>,
+        config: reporter::Config<P::Scheme, EC>,
+    ) -> Self {
+        Self::new(context, config)
+    }
+
+    fn automaton(
+        &self,
+        _context: &deterministic::Context,
+        application: block_relay::Mailbox<PublicKeyOf<P>>,
+    ) -> Self::Automaton {
+        application
+    }
+}
+
+impl<P, EC> HarnessReporter<P, EC, application::Mailbox<Sha256Digest, PublicKeyOf<P>>>
     for RecordingReporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
 where
     P: simplex::Simplex,
@@ -1216,6 +1378,40 @@ where
         &self,
         context: &deterministic::Context,
         application: application::Mailbox<Sha256Digest, PublicKeyOf<P>>,
+    ) -> Self::Automaton {
+        RecordingAutomaton::new(
+            context.child("automaton_recorder"),
+            application,
+            self.audit(),
+        )
+    }
+}
+
+impl<P, EC> HarnessReporter<P, EC, block_relay::Mailbox<PublicKeyOf<P>>>
+    for RecordingReporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
+where
+    P: simplex::Simplex,
+    EC: ElectorConfig<P::Scheme>,
+{
+    type Automaton = RecordingAutomaton<
+        deterministic::Context,
+        block_relay::Mailbox<PublicKeyOf<P>>,
+        P::Scheme,
+        Sha256Digest,
+    >;
+
+    fn create(
+        context: deterministic::Context,
+        observer: PublicKeyOf<P>,
+        config: reporter::Config<P::Scheme, EC>,
+    ) -> Self {
+        Self::new(context, observer, 0, config)
+    }
+
+    fn automaton(
+        &self,
+        context: &deterministic::Context,
+        application: block_relay::Mailbox<PublicKeyOf<P>>,
     ) -> Self::Automaton {
         RecordingAutomaton::new(
             context.child("automaton_recorder"),
@@ -1267,7 +1463,7 @@ pub(crate) fn build_validator_with_reporter<
 where
     P: simplex::Simplex,
     EC: ElectorConfig<P::Scheme> + Clone + Send + 'static,
-    R: HarnessReporter<P, EC>,
+    R: HarnessReporter<P, EC, application::Mailbox<Sha256Digest, PublicKeyOf<P>>>,
     PendingSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
     PendingReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
     RecoveredSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
@@ -1287,10 +1483,6 @@ where
         }
     };
 
-    let (vote_sender, vote_receiver) = pending;
-    let (certificate_sender, certificate_receiver) = recovered;
-    let (resolver_sender, resolver_receiver) = resolver;
-
     let validator_idx = participants
         .iter()
         .position(|p| p == &validator)
@@ -1307,37 +1499,24 @@ where
     let app_handle = actor.start();
     let automaton = reporter.automaton(&context, application.clone());
 
-    let blocker = oracle.control(validator.clone());
     let stored_scheme = scheme.clone();
-    let engine_cfg = config::Config {
-        blocker,
+    let engine_handle = start_validator_engine::<P, EC, _, _, _, _, _, _, _, _, _>(
+        &context,
+        oracle,
         scheme,
+        validator.clone(),
         elector,
         automaton,
-        relay: application.clone(),
-        reporter: wiring.wire(reporter.clone()),
-        partition: partition.clone(),
-        mailbox_size,
-        epoch: Epoch::new(EPOCH),
-        floor: Floor::Genesis(application::genesis::<Sha256>(Epoch::new(EPOCH))),
+        application.clone(),
+        wiring.wire(reporter.clone()),
+        partition.clone(),
         leader_timeout,
         certification_timeout,
-        timeout_retry: Duration::from_secs(10),
-        fetch_timeout: Duration::from_secs(1),
-        view_retention: Delta::new(10),
-        skip_timeout: Duration::from_secs(11),
-        replay_buffer: NZUsize!(1024 * 1024),
-        write_buffer: NZUsize!(1024 * 1024),
-        page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-        strategy: Sequential,
+        mailbox_size,
         forwarding,
-        track_historical_votes: false,
-    };
-    let engine = Engine::new(context.child("engine"), engine_cfg);
-    let engine_handle = engine.start(
-        (vote_sender, vote_receiver),
-        (certificate_sender, certificate_receiver),
-        (resolver_sender, resolver_receiver),
+        pending,
+        recovered,
+        resolver,
     );
 
     ManagedValidator {
@@ -1353,6 +1532,229 @@ where
     }
 }
 
+/// Spawn an honest validator backed by the fuzz-local filterable block relay.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn spawn_filtered_honest_validator<
+    P,
+    EC,
+    PendingSender,
+    PendingReceiver,
+    RecoveredSender,
+    RecoveredReceiver,
+    ResolverSender,
+    ResolverReceiver,
+>(
+    context: deterministic::Context,
+    oracle: &Oracle<PublicKeyOf<P>, deterministic::Context>,
+    participants: &[PublicKeyOf<P>],
+    scheme: P::Scheme,
+    validator: PublicKeyOf<P>,
+    elector: EC,
+    relay: Arc<block_relay::Relay<PublicKeyOf<P>>>,
+    leader_timeout: Duration,
+    certification_timeout: Duration,
+    mailbox_size: NonZeroUsize,
+    forwarding: ForwardingPolicy,
+    pending: (PendingSender, PendingReceiver),
+    recovered: (RecoveredSender, RecoveredReceiver),
+    resolver: (ResolverSender, ResolverReceiver),
+    certify: CertifyChoice,
+    wiring: ReporterWiring,
+) -> reporter::Reporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
+where
+    P: simplex::Simplex,
+    EC: ElectorConfig<P::Scheme> + Clone + Send + 'static,
+    PendingSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    PendingReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    RecoveredSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    RecoveredReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ResolverSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    ResolverReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+{
+    spawn_filtered_validator_with_reporter::<
+        P,
+        EC,
+        reporter::Reporter<deterministic::Context, P::Scheme, EC, Sha256Digest>,
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
+    >(
+        context,
+        oracle,
+        participants,
+        scheme,
+        validator,
+        elector,
+        relay,
+        leader_timeout,
+        certification_timeout,
+        mailbox_size,
+        forwarding,
+        pending,
+        recovered,
+        resolver,
+        certify,
+        wiring,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_filtered_audited_validator<
+    P,
+    EC,
+    PendingSender,
+    PendingReceiver,
+    RecoveredSender,
+    RecoveredReceiver,
+    ResolverSender,
+    ResolverReceiver,
+>(
+    context: deterministic::Context,
+    oracle: &Oracle<PublicKeyOf<P>, deterministic::Context>,
+    participants: &[PublicKeyOf<P>],
+    scheme: P::Scheme,
+    validator: PublicKeyOf<P>,
+    elector: EC,
+    relay: Arc<block_relay::Relay<PublicKeyOf<P>>>,
+    leader_timeout: Duration,
+    certification_timeout: Duration,
+    mailbox_size: NonZeroUsize,
+    forwarding: ForwardingPolicy,
+    pending: (PendingSender, PendingReceiver),
+    recovered: (RecoveredSender, RecoveredReceiver),
+    resolver: (ResolverSender, ResolverReceiver),
+    certify: CertifyChoice,
+    wiring: ReporterWiring,
+) -> RecordingReporter<deterministic::Context, P::Scheme, EC, Sha256Digest>
+where
+    P: simplex::Simplex,
+    EC: ElectorConfig<P::Scheme> + Clone + Send + 'static,
+    PendingSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    PendingReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    RecoveredSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    RecoveredReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ResolverSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    ResolverReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+{
+    spawn_filtered_validator_with_reporter::<
+        P,
+        EC,
+        RecordingReporter<deterministic::Context, P::Scheme, EC, Sha256Digest>,
+        _,
+        _,
+        _,
+        _,
+        _,
+        _,
+    >(
+        context,
+        oracle,
+        participants,
+        scheme,
+        validator,
+        elector,
+        relay,
+        leader_timeout,
+        certification_timeout,
+        mailbox_size,
+        forwarding,
+        pending,
+        recovered,
+        resolver,
+        certify,
+        wiring,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_filtered_validator_with_reporter<
+    P,
+    EC,
+    R,
+    PendingSender,
+    PendingReceiver,
+    RecoveredSender,
+    RecoveredReceiver,
+    ResolverSender,
+    ResolverReceiver,
+>(
+    context: deterministic::Context,
+    oracle: &Oracle<PublicKeyOf<P>, deterministic::Context>,
+    participants: &[PublicKeyOf<P>],
+    scheme: P::Scheme,
+    validator: PublicKeyOf<P>,
+    elector: EC,
+    relay: Arc<block_relay::Relay<PublicKeyOf<P>>>,
+    leader_timeout: Duration,
+    certification_timeout: Duration,
+    mailbox_size: NonZeroUsize,
+    forwarding: ForwardingPolicy,
+    pending: (PendingSender, PendingReceiver),
+    recovered: (RecoveredSender, RecoveredReceiver),
+    resolver: (ResolverSender, ResolverReceiver),
+    certify: CertifyChoice,
+    wiring: ReporterWiring,
+) -> R
+where
+    P: simplex::Simplex,
+    EC: ElectorConfig<P::Scheme> + Clone + Send + 'static,
+    R: HarnessReporter<P, EC, block_relay::Mailbox<PublicKeyOf<P>>>,
+    PendingSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    PendingReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    RecoveredSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    RecoveredReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+    ResolverSender: commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
+    ResolverReceiver: commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
+{
+    let reporter_cfg = reporter::Config {
+        participants: participants.try_into().expect("public keys are unique"),
+        scheme: scheme.clone(),
+        elector: elector.clone(),
+    };
+    let reporter = R::create(context.child("reporter"), validator.clone(), reporter_cfg);
+
+    let validator_idx = participants
+        .iter()
+        .position(|p| p == &validator)
+        .expect("validator must be in participants");
+    let app_cfg = block_relay::Config::<_> {
+        relay,
+        me: validator.clone(),
+        propose_latency: (10.0, 5.0),
+        verify_latency: (10.0, 5.0),
+        certify_latency: (10.0, 5.0),
+        should_certify: certify.into_certifier(validator_idx),
+    };
+    let (actor, application) = block_relay::Application::new(context.child("application"), app_cfg);
+    let _app_handle = actor.start();
+    let automaton = reporter.automaton(&context, application.clone());
+
+    let partition = validator.to_string();
+    let _engine_handle = start_validator_engine::<P, EC, _, _, _, _, _, _, _, _, _>(
+        &context,
+        oracle,
+        scheme,
+        validator,
+        elector,
+        automaton,
+        application.clone(),
+        wiring.wire(reporter.clone()),
+        partition,
+        leader_timeout,
+        certification_timeout,
+        mailbox_size,
+        forwarding,
+        pending,
+        recovered,
+        resolver,
+    );
+
+    reporter
+}
+
 #[allow(clippy::too_many_arguments)]
 fn spawn_honest_validator_in_faulty_messaging<P: simplex::Simplex>(
     context: deterministic::Context,
@@ -1362,7 +1764,7 @@ fn spawn_honest_validator_in_faulty_messaging<P: simplex::Simplex>(
     scheme: P::Scheme,
     validator: PublicKeyOf<P>,
     byzantine_router: crate::network::Router<PublicKeyOf<P>, deterministic::Context>,
-    relay: Arc<relay::Relay<Sha256Digest, PublicKeyOf<P>>>,
+    relay: Arc<block_relay::Relay<PublicKeyOf<P>>>,
     leader_timeout: Duration,
     certification_timeout: Duration,
     mailbox_size: NonZeroUsize,
@@ -1398,7 +1800,7 @@ fn spawn_honest_validator_in_faulty_messaging<P: simplex::Simplex>(
         });
     let resolver_receiver = ByzantineFirstReceiver::new(resolver_primary, resolver_secondary);
 
-    spawn_honest_validator::<P, _, _, _, _, _, _, _>(
+    spawn_filtered_honest_validator::<P, _, _, _, _, _, _, _>(
         context,
         oracle,
         participants,
@@ -1883,7 +2285,8 @@ fn run_standard_once<P: simplex::Simplex>(
             .await;
         }
 
-        let relay = Arc::new(relay::Relay::<Sha256Digest, _>::new());
+        let relay = Arc::new(block_relay::Relay::new());
+        configure_block_filter::<P>(&relay, &participants, &input.partition, input.block_filter);
         let mut reporters = Vec::new();
         let config = input.configuration;
         let term_length = P::effective_term_length(input.term_length);
@@ -1895,7 +2298,13 @@ fn run_standard_once<P: simplex::Simplex>(
             let ctx = context
                 .child("validator")
                 .with_attribute("public_key", &validator);
-            spawn_disrupter::<P>(ctx, schemes[i].clone(), &input, channels);
+            spawn_disrupter_with_relay::<P>(
+                ctx,
+                schemes[i].clone(),
+                &input,
+                channels,
+                Some(relay.clone()),
+            );
         }
 
         // Spawn honest validators
@@ -1949,7 +2358,7 @@ fn run_standard_once<P: simplex::Simplex>(
                 .child("validator")
                 .with_attribute("public_key", &validator);
             let spawn = || {
-                spawn_honest_validator::<P, _, _, _, _, _, _, _>(
+                spawn_filtered_honest_validator::<P, _, _, _, _, _, _, _>(
                     ctx,
                     &oracle,
                     &participants,
@@ -2122,7 +2531,8 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
             .await;
         }
 
-        let relay = Arc::new(relay::Relay::<Sha256Digest, _>::new());
+        let relay = Arc::new(block_relay::Relay::new());
+        configure_block_filter::<P>(&relay, &participants, &input.partition, input.block_filter);
         let mut reporters = Vec::new();
         let config = input.configuration;
         let term_length = P::effective_term_length(input.term_length);
@@ -2141,7 +2551,7 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
                 // correct applications consistently reject it. Its raw reporter
                 // is intentionally excluded from the correct audit set below.
                 let (pending, recovered, resolver) = channels;
-                let _ = spawn_honest_validator::<P, _, _, _, _, _, _, _>(
+                let _ = spawn_filtered_honest_validator::<P, _, _, _, _, _, _, _>(
                     ctx,
                     &oracle,
                     &participants,
@@ -2160,7 +2570,13 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
                     ReporterWiring::Solo,
                 );
             } else {
-                spawn_disrupter::<P>(ctx, schemes[i].clone(), &input, channels);
+                spawn_disrupter_with_relay::<P>(
+                    ctx,
+                    schemes[i].clone(),
+                    &input,
+                    channels,
+                    Some(relay.clone()),
+                );
             }
         }
 
@@ -2194,7 +2610,7 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
                         FinalizationOmissionChannel::Resolver,
                         omission.omitted_finalizations.clone(),
                     );
-                spawn_audited_validator::<P, _, _, _, _, _, _, _>(
+                spawn_filtered_audited_validator::<P, _, _, _, _, _, _, _>(
                     ctx,
                     &oracle,
                     &participants,
@@ -2213,7 +2629,7 @@ fn run_audited_standard_once_with<P: simplex::Simplex>(
                     input.reporting,
                 )
             } else {
-                spawn_audited_validator::<P, _, _, _, _, _, _, _>(
+                spawn_filtered_audited_validator::<P, _, _, _, _, _, _, _>(
                     ctx,
                     &oracle,
                     &participants,
@@ -2356,6 +2772,7 @@ fn run_with_faulty_messaging<P: simplex::Simplex>(mut input: FuzzInput) {
     input.degraded_network = false;
     // Three honest certifiers are exactly the finalize quorum here.
     input.certify = CertifyChoice::Always;
+    input.block_filter = BlockFilterChoice::None;
 
     let cfg = bounded_fuzz_runtime_config(&input.raw_bytes, input.required_containers);
     let executor = deterministic::Runner::new(cfg);
@@ -2369,7 +2786,8 @@ fn run_with_faulty_messaging<P: simplex::Simplex>(mut input: FuzzInput) {
         let (oracle, participants, schemes, mut registrations) =
             setup_network::<P>(&mut context, &input).await;
 
-        let relay = Arc::new(relay::Relay::<Sha256Digest, _>::new());
+        let relay = Arc::new(block_relay::Relay::new());
+        configure_block_filter::<P>(&relay, &participants, &input.partition, input.block_filter);
         let mut reporters = Vec::new();
         let config = input.configuration;
         let term_length = P::effective_term_length(input.term_length);
@@ -2401,7 +2819,13 @@ fn run_with_faulty_messaging<P: simplex::Simplex>(mut input: FuzzInput) {
             let ctx = context
                 .child("validator")
                 .with_attribute("public_key", &validator);
-            spawn_disrupter::<P>(ctx, schemes[i].clone(), &input, channels);
+            spawn_disrupter_with_relay::<P>(
+                ctx,
+                schemes[i].clone(),
+                &input,
+                channels,
+                Some(relay.clone()),
+            );
         }
 
         // Spawn honest validators
@@ -2444,7 +2868,7 @@ fn run_with_faulty_messaging<P: simplex::Simplex>(mut input: FuzzInput) {
         .await;
 
         // Wait for finalization or timeout
-        if input.partition.is_connected() && config.is_valid() {
+        if should_bound_standard_liveness(&input) {
             let mut finalizers = Vec::new();
             for (validator, reporter) in reporters.iter_mut() {
                 let required_containers = input.required_containers;
@@ -2611,6 +3035,15 @@ pub(crate) trait TwinsBackend<P: simplex::Simplex> {
         cases: Vec<twins::Case>,
     ) -> Option<TwinsCase<Self::Case>>;
 
+    /// Called after case selection and before any twin half is spawned.
+    fn configure_topology(
+        &mut self,
+        _state: &mut Self::State,
+        _topology: &TwinsTopology<P, Self::Case>,
+        _participants: &Arc<[PublicKeyOf<P>]>,
+    ) {
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn spawn_primary(
         &mut self,
@@ -2640,6 +3073,19 @@ pub(crate) trait TwinsBackend<P: simplex::Simplex> {
     /// secondary half. `None` delegates secondary engine construction to the
     /// backend.
     fn disrupter(&self) -> Option<TwinsDisrupter>;
+
+    /// Return a filterable block relay for a Disrupter-backed secondary half.
+    fn disrupter_block_relay(
+        &self,
+        _state: &Self::State,
+    ) -> Option<Arc<block_relay::Relay<PublicKeyOf<P>>>> {
+        None
+    }
+
+    /// Sender tag for block broadcasts emitted by a Disrupter-backed twin half.
+    fn disrupter_block_relay_tag(&self) -> Option<u64> {
+        None
+    }
 
     #[allow(clippy::too_many_arguments)]
     fn spawn_secondary(
@@ -2735,6 +3181,7 @@ pub(crate) async fn run_twins_with_backend<P, B>(
         term_length,
         data: case.data,
     };
+    backend.configure_topology(&mut setup.state, &topology, &participants);
 
     for idx in case.compromised {
         let validator = participants[idx].clone();
@@ -2811,7 +3258,7 @@ pub(crate) async fn run_twins_with_backend<P, B>(
             (resolver_sender_primary, resolver_receiver_primary),
         );
         if let Some(disrupter) = backend.disrupter() {
-            start_disrupter_with_epoch::<P>(
+            start_disrupter_with_epoch_relay_and_tag::<P>(
                 node_context.child("secondary"),
                 scheme,
                 &disrupter.strategy,
@@ -2820,6 +3267,8 @@ pub(crate) async fn run_twins_with_backend<P, B>(
                 (vote_sender_secondary, vote_receiver_secondary),
                 (certificate_sender_secondary, certificate_receiver_secondary),
                 (resolver_sender_secondary, resolver_receiver_secondary),
+                backend.disrupter_block_relay(&setup.state),
+                backend.disrupter_block_relay_tag(),
             );
         } else {
             backend.spawn_secondary(
@@ -2907,7 +3356,7 @@ struct MockTwinsBackend<P: simplex::Simplex> {
 }
 
 struct MockTwinsState<P: simplex::Simplex> {
-    relay: Arc<relay::Relay<Sha256Digest, PublicKeyOf<P>>>,
+    relay: Arc<block_relay::Relay<PublicKeyOf<P>>>,
     reporters: Vec<TwinsReporter<P>>,
     twin_observers: Vec<TwinsReporter<P>>,
     honest_start: usize,
@@ -2945,6 +3394,7 @@ impl<P: simplex::Simplex> MockTwinsBackend<P> {
         idx: usize,
         topology: &TwinsTopology<P, ()>,
         partition: String,
+        relay_tag: u64,
         vote: (
             impl commonware_p2p::Sender<PublicKey = PublicKeyOf<P>>,
             impl commonware_p2p::Receiver<PublicKey = PublicKeyOf<P>>,
@@ -2967,7 +3417,7 @@ impl<P: simplex::Simplex> MockTwinsBackend<P> {
             elector: topology.elector.clone(),
         };
         let reporter = reporter::Reporter::new(context.child("reporter"), reporter_cfg);
-        let app_cfg = application::Config::<Sha256, _> {
+        let app_cfg = block_relay::Config::<_> {
             relay: state.relay.clone(),
             me: validator.clone(),
             propose_latency: (10.0, 5.0),
@@ -2975,8 +3425,11 @@ impl<P: simplex::Simplex> MockTwinsBackend<P> {
             certify_latency: (10.0, 5.0),
             should_certify: application::Certifier::Always,
         };
-        let (actor, application) =
-            application::Application::new(context.child("application"), app_cfg);
+        let (actor, application) = block_relay::Application::new_with_relay_tag(
+            context.child("application"),
+            app_cfg,
+            relay_tag,
+        );
         actor.start();
         let engine = Engine::new(
             context.child("engine"),
@@ -3036,7 +3489,7 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
             schemes,
             registrations,
             state: MockTwinsState {
-                relay: Arc::new(relay::Relay::new()),
+                relay: Arc::new(block_relay::Relay::new()),
                 reporters: Vec::new(),
                 twin_observers: Vec::new(),
                 honest_start: 0,
@@ -3081,6 +3534,49 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
         })
     }
 
+    fn configure_topology(
+        &mut self,
+        state: &mut Self::State,
+        topology: &TwinsTopology<P, Self::Case>,
+        participants: &Arc<[PublicKeyOf<P>]>,
+    ) {
+        let scenario = topology.scenario.clone();
+        let term_length = topology.term_length;
+        let participants = participants.clone();
+        state.relay.set_filter(
+            move |sender, sender_tag, recipient, recipient_tag, _, contents| {
+                let Some(view) = block_relay::mock_block_view(contents) else {
+                    return true;
+                };
+                if !participants.iter().any(|participant| participant == sender) {
+                    return true;
+                }
+                let (primary, secondary) =
+                    scenario.partitions(view, term_length, participants.as_ref());
+                let sender_permits_recipient = match sender_tag {
+                    Some(block_relay::RELAY_TAG_TWIN_PRIMARY) => primary.contains(recipient),
+                    Some(block_relay::RELAY_TAG_TWIN_SECONDARY) => secondary.contains(recipient),
+                    _ => true,
+                };
+                if !sender_permits_recipient {
+                    return false;
+                }
+
+                match recipient_tag {
+                    block_relay::RELAY_TAG_TWIN_PRIMARY => matches!(
+                        scenario.route(view, term_length, sender, participants.as_ref()),
+                        SplitTarget::Primary | SplitTarget::Both
+                    ),
+                    block_relay::RELAY_TAG_TWIN_SECONDARY => matches!(
+                        scenario.route(view, term_length, sender, participants.as_ref()),
+                        SplitTarget::Secondary | SplitTarget::Both
+                    ),
+                    _ => true,
+                }
+            },
+        );
+    }
+
     fn spawn_primary(
         &mut self,
         context: deterministic::Context,
@@ -3114,6 +3610,7 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
             idx,
             topology,
             format!("twin_{idx}_primary"),
+            block_relay::RELAY_TAG_TWIN_PRIMARY,
             vote,
             certificate,
             resolver,
@@ -3130,6 +3627,17 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
             required_containers: self.input.required_containers,
             epoch: Epoch::new(EPOCH),
         })
+    }
+
+    fn disrupter_block_relay(
+        &self,
+        state: &Self::State,
+    ) -> Option<Arc<block_relay::Relay<PublicKeyOf<P>>>> {
+        Some(state.relay.clone())
+    }
+
+    fn disrupter_block_relay_tag(&self) -> Option<u64> {
+        Some(block_relay::RELAY_TAG_TWIN_SECONDARY)
     }
 
     fn spawn_secondary(
@@ -3169,6 +3677,7 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
             idx,
             topology,
             format!("twin_{idx}_secondary"),
+            block_relay::RELAY_TAG_TWIN_SECONDARY,
             vote,
             certificate,
             resolver,
@@ -3231,26 +3740,28 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
         };
         let spawn = || {
             if self.record_audit {
-                TwinsReporter::Recording(spawn_audited_validator::<P, _, _, _, _, _, _, _>(
-                    context,
-                    oracle,
-                    participants.as_ref(),
-                    scheme,
-                    validator,
-                    topology.elector.clone(),
-                    state.relay.clone(),
-                    Duration::from_secs(1),
-                    Duration::from_millis(1_500),
-                    self.input.mailbox_size,
-                    self.input.forwarding,
-                    pending,
-                    recovered,
-                    resolver,
-                    self.input.certify,
-                    self.input.reporting,
-                ))
+                TwinsReporter::Recording(
+                    spawn_filtered_audited_validator::<P, _, _, _, _, _, _, _>(
+                        context,
+                        oracle,
+                        participants.as_ref(),
+                        scheme,
+                        validator,
+                        topology.elector.clone(),
+                        state.relay.clone(),
+                        Duration::from_secs(1),
+                        Duration::from_millis(1_500),
+                        self.input.mailbox_size,
+                        self.input.forwarding,
+                        pending,
+                        recovered,
+                        resolver,
+                        self.input.certify,
+                        self.input.reporting,
+                    ),
+                )
             } else {
-                TwinsReporter::Summary(spawn_honest_validator::<P, _, _, _, _, _, _, _>(
+                TwinsReporter::Summary(spawn_filtered_honest_validator::<P, _, _, _, _, _, _, _>(
                     context,
                     oracle,
                     participants.as_ref(),
@@ -3291,7 +3802,7 @@ impl<P: simplex::Simplex> TwinsBackend<P> for MockTwinsBackend<P> {
         state: &mut Self::State,
         prefix_end: View,
     ) {
-        if !self.input.configuration.is_valid() {
+        if !self.input.configuration.is_valid() || matches!(self.role, TwinsRole::Mutator) {
             context.sleep(MAX_SLEEP_DURATION).await;
             return;
         }
@@ -4026,6 +4537,7 @@ mod tests {
             mailbox_size: DEFAULT_MAILBOX_SIZE,
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
+            block_filter: BlockFilterChoice::None,
             reporting: ReporterWiring::Solo,
         }
     }

--- a/consensus/fuzz/src/mallory/runner.rs
+++ b/consensus/fuzz/src/mallory/runner.rs
@@ -1541,7 +1541,7 @@ fn run_inner<P: Simplex>(
 mod tests {
     use super::*;
     use crate::{
-        CertifyChoice, FuzzInput, N4F0C4, ReporterWiring, simplex::SimplexId,
+        BlockFilterChoice, CertifyChoice, FuzzInput, N4F0C4, ReporterWiring, simplex::SimplexId,
         strategy::StrategyChoice, utils::Partition,
     };
     use commonware_consensus::{simplex::ForwardingPolicy, types::TermLength};
@@ -1569,6 +1569,7 @@ mod tests {
             mailbox_size: NonZeroUsize::new(1024).unwrap(),
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
+            block_filter: BlockFilterChoice::None,
             reporting: ReporterWiring::Solo,
         }
     }

--- a/consensus/fuzz/src/marshal/end_to_end/block_disrupter.rs
+++ b/consensus/fuzz/src/marshal/end_to_end/block_disrupter.rs
@@ -3,7 +3,8 @@
 //! In the standard disrupter target the byzantine node (index [`BYZANTINE_IDX`])
 //! runs only a simplex [`Disrupter`](crate::disrupter::Disrupter) on the
 //! vote/certificate/resolver channels and no marshal stack, so it never emits on
-//! the block-gossip channel (id 2). This actor gives it a [`buffered::Engine`] on
+//! the block-gossip channel (id 2). This actor gives it a
+//! [`buffered::Engine`](commonware_broadcast::buffered::Engine) on
 //! that channel and, at the first view of the term it is pinned to lead (view 1,
 //! whose parent is genesis), acts as a byzantine leader that either delivers
 //! different blocks to disjoint replica sets, withholds the block entirely, or

--- a/consensus/fuzz/src/marshal/end_to_end/block_disrupter.rs
+++ b/consensus/fuzz/src/marshal/end_to_end/block_disrupter.rs
@@ -1,0 +1,190 @@
+//! Byzantine block-dissemination faults on the marshal block-gossip channel.
+//!
+//! In the standard disrupter target the byzantine node (index [`BYZANTINE_IDX`])
+//! runs only a simplex [`Disrupter`](crate::disrupter::Disrupter) on the
+//! vote/certificate/resolver channels and no marshal stack, so it never emits on
+//! the block-gossip channel (id 2). This actor gives it a [`buffered::Engine`] on
+//! that channel and, at the first view of the term it is pinned to lead (view 1,
+//! whose parent is genesis), acts as a byzantine leader that either delivers
+//! different blocks to disjoint replica sets, withholds the block entirely, or
+//! delivers it to only a partition. A matching [`Notarize`] (payload equal to
+//! the block digest) is sent on the vote channel so honest replicas fetch and
+//! act on what they receive.
+//!
+//! With a stable term (`term_length > 1`) the byzantine leads views
+//! `1..=term_length`; it disseminates only at view 1 and stays silent for the
+//! rest of its term. Honest nodes nullify the first view they enter (via the
+//! per-view leader/certification timeout), and that nullification covers the
+//! whole term, advancing them to the next term without entering the remaining
+//! views. The fault is confined to the byzantine's own leader views and never
+//! touches honest-led traffic.
+//! Every block made available to a notarizing quorum is held by at least two
+//! honest replicas, so it is backfillable once the network heals at GST and
+//! honest liveness is preserved. Only a single vote is ever signed; no full
+//! certificate is forged (which would strand a block no honest node holds and
+//! stall progress).
+
+use super::twins::{B, Ctx, PublicKeyOf, SchemeOf};
+use crate::{BYZANTINE_IDX, simplex::Simplex};
+use commonware_codec::Encode as _;
+use commonware_consensus::{
+    marshal::mocks::harness::TEST_QUOTA,
+    simplex::types::{Notarize, Proposal, Vote},
+    types::{Epoch, Height, Round, View},
+};
+use commonware_cryptography::{Digestible as _, Sha256, sha256::Digest as Sha256Digest};
+use commonware_p2p::{
+    Recipients, Sender as _,
+    simulated::{Oracle, Sender},
+};
+use commonware_runtime::{Clock as _, Spawner as _, Supervisor as _, deterministic};
+use commonware_utils::NZUsize;
+use std::{sync::Arc, time::Duration};
+
+/// Delay before the byzantine leader disseminates, giving honest engines time to
+/// enter the attack view. Well under the marshal engines' one-second leader
+/// timeout so the proposal still arrives before they nullify.
+const DISSEMINATE_DELAY: Duration = Duration::from_millis(250);
+
+/// How the byzantine leader disseminates the block it is pinned to propose.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MarshalBroadcastFault {
+    /// Announce the proposal but never disseminate its block: honest replicas
+    /// cannot fetch it and nullify the view.
+    Omit,
+    /// Deliver the block (and proposal) to every honest replica but one; the
+    /// excluded replica must backfill it after GST.
+    Partition,
+    /// Deliver two conflicting blocks to disjoint honest replica sets, each with
+    /// its own matching proposal.
+    Equivocate,
+}
+
+impl MarshalBroadcastFault {
+    /// Samples a mode from a dedicated RNG so the runtime schedule RNG (seeded
+    /// from the same bytes) is left undisturbed.
+    pub(crate) fn sample(rng: &mut commonware_utils::FuzzRng) -> Self {
+        use rand::RngExt as _;
+        match rng.random_range(0..3u8) {
+            0 => Self::Omit,
+            1 => Self::Partition,
+            _ => Self::Equivocate,
+        }
+    }
+}
+
+/// Starts the byzantine block-disseminator on channel 2 for `byzantine`.
+///
+/// `attack_view` must be a view `byzantine` leads whose parent is the genesis
+/// block; `genesis` is that genesis block's digest. If `byzantine` is not the
+/// elected leader of `attack_view`, honest replicas reject the fabricated
+/// proposals (their embedded leader will not match) and the run proceeds as if
+/// no block were proposed.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn start<P: Simplex>(
+    context: deterministic::Context,
+    oracle: &Oracle<PublicKeyOf<P>, deterministic::Context>,
+    scheme: SchemeOf<P>,
+    byzantine: PublicKeyOf<P>,
+    participants: Vec<PublicKeyOf<P>>,
+    mut vote_sender: Sender<PublicKeyOf<P>, deterministic::Context>,
+    genesis: Sha256Digest,
+    attack_view: View,
+    fault: MarshalBroadcastFault,
+) {
+    let (broadcast_sender, broadcast_receiver) = oracle
+        .control(byzantine.clone())
+        .register(2, TEST_QUOTA)
+        .await
+        .expect("byzantine block-gossip channel registration failed");
+    let (engine, mailbox) = commonware_broadcast::buffered::Engine::new(
+        context.child("broadcast"),
+        commonware_broadcast::buffered::Config {
+            public_key: byzantine.clone(),
+            mailbox_size: NZUsize!(100),
+            deque_size: 10,
+            priority: false,
+            codec_config: (),
+            peer_provider: oracle.manager(),
+        },
+    );
+    let mailbox: commonware_broadcast::buffered::Mailbox<PublicKeyOf<P>, B<P>> = mailbox;
+    engine.start((broadcast_sender, broadcast_receiver));
+
+    let honest: Vec<PublicKeyOf<P>> = participants
+        .iter()
+        .enumerate()
+        .filter(|(idx, _)| *idx != BYZANTINE_IDX)
+        .map(|(_, key)| key.clone())
+        .collect();
+
+    let round = Round::new(Epoch::zero(), attack_view);
+    let parent_view = View::zero();
+    let build = move |timestamp: u64| -> B<P> {
+        let block_context = Ctx::<P> {
+            round,
+            leader: byzantine.clone(),
+            parent: (parent_view, genesis),
+        };
+        B::<P>::new::<Sha256>(
+            block_context,
+            genesis,
+            Height::new(attack_view.get()),
+            timestamp,
+        )
+    };
+
+    context.spawn(move |context| async move {
+        context.sleep(DISSEMINATE_DELAY).await;
+
+        let announce = |sender: &mut Sender<PublicKeyOf<P>, deterministic::Context>,
+                        block: &B<P>,
+                        to: Recipients<PublicKeyOf<P>>| {
+            let proposal = Proposal::new(round, parent_view, block.digest());
+            if let Some(vote) = Notarize::sign(&scheme, proposal) {
+                let message = Vote::<SchemeOf<P>, Sha256Digest>::Notarize(vote).encode();
+                let _ = sender.send(to, message, true);
+            }
+        };
+
+        match fault {
+            MarshalBroadcastFault::Omit => {
+                // Announce the block to every honest replica but never gossip it.
+                let block = build(0);
+                announce(&mut vote_sender, &block, Recipients::Some(honest.clone()));
+            }
+            MarshalBroadcastFault::Partition => {
+                // Deliver to every honest replica but the last; it backfills.
+                let block = build(0);
+                let served = if honest.len() > 1 {
+                    honest[..honest.len() - 1].to_vec()
+                } else {
+                    honest.clone()
+                };
+                mailbox.broadcast_shared(Recipients::Some(served.clone()), Arc::new(block.clone()));
+                announce(&mut vote_sender, &block, Recipients::Some(served));
+            }
+            MarshalBroadcastFault::Equivocate => {
+                // Two conflicting blocks (distinct timestamps -> distinct
+                // digests) to disjoint honest sets, each with its own proposal.
+                let (first, rest) = honest.split_at(1.min(honest.len()));
+                let block_a = build(0);
+                let block_b = build(1);
+                if !first.is_empty() {
+                    mailbox.broadcast_shared(
+                        Recipients::Some(first.to_vec()),
+                        Arc::new(block_a.clone()),
+                    );
+                    announce(&mut vote_sender, &block_a, Recipients::Some(first.to_vec()));
+                }
+                if !rest.is_empty() {
+                    mailbox.broadcast_shared(
+                        Recipients::Some(rest.to_vec()),
+                        Arc::new(block_b.clone()),
+                    );
+                    announce(&mut vote_sender, &block_b, Recipients::Some(rest.to_vec()));
+                }
+            }
+        }
+    });
+}

--- a/consensus/fuzz/src/marshal/end_to_end/input.rs
+++ b/consensus/fuzz/src/marshal/end_to_end/input.rs
@@ -16,7 +16,8 @@ use crate::{
     utils::{Partition, SetPartition},
 };
 use arbitrary::Arbitrary;
-use commonware_consensus::simplex::ForwardingPolicy;
+use commonware_consensus::{simplex::ForwardingPolicy, types::TermLength};
+use commonware_utils::NZU32;
 
 const MIN_REQUIRED: u64 = 1;
 pub(super) const MAX_TWINS_ROUNDS: u8 = 6;
@@ -34,10 +35,20 @@ fn sample_fault_rounds(
     Ok((fault_rounds, fault_rounds_bound))
 }
 
+/// Largest term length the block-dissemination target explores. Bounds how many
+/// consecutive views a byzantine stable leader holds; the "views 1 and 2" case
+/// is `term_length == 2`.
+const MAX_TERM_LENGTH: u32 = 4;
+
 #[derive(Debug, Clone)]
 pub struct MarshalDisrupterInput {
     pub raw_bytes: Vec<u8>,
     pub required_containers: u64,
+    /// Leadership term length. Consumed only by the block-dissemination target,
+    /// where the byzantine-first-leader elector makes index 0 a stable leader of
+    /// the whole first term (views `1..=term_length`); the other disrupter
+    /// targets keep single-view (rotating) terms.
+    pub term_length: TermLength,
     pub degraded_network: bool,
     pub partition: Partition,
     pub strategy: StrategyChoice,
@@ -53,6 +64,7 @@ impl Arbitrary<'_> for MarshalDisrupterInput {
 
         let degraded_network = partition == Partition::Connected && u.int_in_range(0..=9)? == 0;
         let required_containers = u.int_in_range(MIN_REQUIRED..=MAX_REQUIRED)?;
+        let term_length = TermLength::new(NZU32!(u.int_in_range(1..=MAX_TERM_LENGTH)?));
 
         let strategy = match u.int_in_range(0..=9)? {
             0 => StrategyChoice::AnyScope,
@@ -86,6 +98,7 @@ impl Arbitrary<'_> for MarshalDisrupterInput {
         Ok(Self {
             raw_bytes,
             required_containers,
+            term_length,
             degraded_network,
             partition,
             strategy,

--- a/consensus/fuzz/src/marshal/end_to_end/mod.rs
+++ b/consensus/fuzz/src/marshal/end_to_end/mod.rs
@@ -33,6 +33,7 @@
 use commonware_consensus::marshal::mocks::harness::BLOCKS_PER_EPOCH;
 
 mod app;
+mod block_disrupter;
 mod coding_disrupter;
 pub(crate) mod coding_stack;
 mod input;
@@ -43,8 +44,8 @@ pub(crate) mod twins;
 
 pub use input::{MarshalDisrupterInput, MarshalTwinsInput, NotarizationBlockSplitScenarioInput};
 pub use runner::{
-    fuzz_marshal_coding_disrupter, fuzz_marshal_standard_certificate_poison,
-    fuzz_marshal_standard_disrupter,
+    fuzz_marshal_coding_disrupter, fuzz_marshal_standard_block_dissemination,
+    fuzz_marshal_standard_certificate_poison, fuzz_marshal_standard_disrupter,
 };
 pub use scenario::{
     DropRule, PreGstAction, Role, ScenarioTemplate, fuzz_marshal_standard_scenarios,

--- a/consensus/fuzz/src/marshal/end_to_end/runner.rs
+++ b/consensus/fuzz/src/marshal/end_to_end/runner.rs
@@ -49,7 +49,7 @@ use super::{
         AlwaysAcceptBlockBuilderApp, ApplicationChoice, BlockContextRegistry, DeliveryReporter,
         FaultyConfig,
     },
-    coding_disrupter,
+    block_disrupter, coding_disrupter,
     coding_stack::{
         CodingB, CodingCtx, coding_genesis, coding_marshaled, setup_validator_coding,
         start_engine_coding_with_networks,
@@ -127,6 +127,7 @@ impl fmt::Debug for MarshalDisrupterInputDebug<'_> {
             .debug_struct("MarshalDisrupterInput")
             .field("raw_bytes_len", &input.raw_bytes.len())
             .field("required_containers", &input.required_containers)
+            .field("term_length", &input.term_length)
             .field("degraded_network", &input.degraded_network)
             .field("partition", &input.partition)
             .field("strategy", &input.strategy)
@@ -295,7 +296,23 @@ async fn run_liveness_phases<BL, KEY>(
 /// deferred. Cluster: `N4F1C3`, disrupter only (no Twins). Liveness: checked.
 /// App: fixed always-accept.
 pub fn fuzz_marshal_standard_disrupter<P: Simplex>(input: MarshalDisrupterInput) {
-    run_standard_disrupter::<P>(input, None);
+    run_standard_disrupter::<P>(input, None, None);
+}
+
+/// The cluster of [`fuzz_marshal_standard_disrupter`] with the byzantine node
+/// additionally acting as a faulty block-gossip leader on its pinned view.
+///
+/// The byzantine node leads view 1 (its parent is genesis) and disseminates the
+/// block it proposes under a fuzzer-selected [`MarshalBroadcastFault`]: it
+/// withholds the block, delivers it to only a partition, or delivers two
+/// conflicting blocks to disjoint replica sets. Honest nodes must still route
+/// around the byzantine-led view and deliver the target number of ordered
+/// blocks. Instantiate with a `P` whose elector pins the byzantine index to
+/// view 1 (see `SimplexCertificateMockByzantineFirstLeader`).
+pub fn fuzz_marshal_standard_block_dissemination<P: Simplex>(input: MarshalDisrupterInput) {
+    let mut mode_rng = FuzzRng::new(input.raw_bytes.clone());
+    let fault = block_disrupter::MarshalBroadcastFault::sample(&mut mode_rng);
+    run_standard_disrupter::<P>(input, None, Some(fault));
 }
 
 /// The cluster of [`fuzz_marshal_standard_disrupter`] with one honest node's
@@ -313,16 +330,26 @@ pub fn fuzz_marshal_standard_certificate_poison<P: Simplex>(mut input: MarshalDi
     // would move on, so lossy links are the only fault that produces one.
     input.partition = Partition::Connected;
     input.degraded_network = true;
-    run_standard_disrupter::<P>(input, Some(CertificatePoison::new()));
+    run_standard_disrupter::<P>(input, Some(CertificatePoison::new()), None);
 }
 
 fn run_standard_disrupter<P: Simplex>(
     input: MarshalDisrupterInput,
     poison: Option<CertificatePoison<PublicKeyOf<P>>>,
+    broadcast_fault: Option<block_disrupter::MarshalBroadcastFault>,
 ) {
     let rng = FuzzRng::new(input.raw_bytes.clone());
     let cfg = deterministic::Config::new().with_rng(Box::new(rng));
     let executor = deterministic::Runner::new(cfg);
+
+    // Only the block-dissemination target honors the fuzzed term length (its
+    // elector makes the byzantine a stable leader of the first term); the plain
+    // disrupter and poison targets keep single-view rotating terms.
+    let term_length = if broadcast_fault.is_some() {
+        input.term_length
+    } else {
+        TermLength::ONE
+    };
 
     executor.start(|mut context| async move {
         // Shared fixture: the same participants/schemes drive the byzantine
@@ -373,19 +400,45 @@ fn run_standard_disrupter<P: Simplex>(
                 register_engine_networks::<P>(&oracle, validator.clone()).await;
 
             if idx == BYZANTINE_IDX {
-                start_disrupter_with_epoch::<P>(
-                    context
-                        .child("validator")
-                        .with_attribute("public_key", validator)
-                        .child("disrupter"),
-                    scheme,
-                    &input.strategy,
-                    required,
-                    Epoch::zero(),
-                    vote,
-                    certificate,
-                    resolver,
-                );
+                let validator_ctx = context
+                    .child("validator")
+                    .with_attribute("public_key", validator);
+                if let Some(fault) = broadcast_fault {
+                    // Block-dissemination leader: the byzantine acts solely as a
+                    // faulty block-gossip leader over its stable term. Running the
+                    // generic Disrupter alongside would let its view-1 proposal
+                    // shadow the coordinated one (the batcher makes the first
+                    // leader proposal authoritative), silently degrading the
+                    // dissemination fault; vote/certificate/resolver faults are
+                    // covered by the sibling disrupter target instead. The
+                    // byzantine is silent past view 1, so honest nodes nullify the
+                    // first view of its term on the per-view timeout and that
+                    // term-covering nullification advances them past the rest.
+                    let (vote_sender, _vote_receiver) = vote;
+                    block_disrupter::start::<P>(
+                        validator_ctx.child("block_disrupter"),
+                        &oracle,
+                        scheme,
+                        validator.clone(),
+                        participants.clone(),
+                        vote_sender,
+                        genesis_commitment,
+                        View::new(1),
+                        fault,
+                    )
+                    .await;
+                } else {
+                    start_disrupter_with_epoch::<P>(
+                        validator_ctx.child("disrupter"),
+                        scheme,
+                        &input.strategy,
+                        required,
+                        Epoch::zero(),
+                        vote,
+                        certificate,
+                        resolver,
+                    );
+                }
                 continue;
             }
 
@@ -462,7 +515,7 @@ fn run_standard_disrupter<P: Simplex>(
                 &oracle,
                 validator.clone(),
                 scheme,
-                P::elector(TermLength::ONE),
+                P::elector(term_length),
                 observed,
                 builder,
                 node.mailbox.clone(),
@@ -637,11 +690,34 @@ mod tests {
     use crate::{SimplexId, strategy::StrategyChoice, utils::Partition};
     use commonware_consensus::simplex::ForwardingPolicy;
 
+    #[cfg(feature = "mocks")]
+    #[test]
+    fn block_dissemination_runs_under_byzantine_first_leader() {
+        use commonware_consensus::types::TermLength;
+        for term_length in [
+            TermLength::ONE,
+            TermLength::new(commonware_utils::NZU32!(2)),
+        ] {
+            fuzz_marshal_standard_block_dissemination::<
+                crate::SimplexCertificateMockByzantineFirstLeader,
+            >(MarshalDisrupterInput {
+                raw_bytes: vec![],
+                required_containers: 1,
+                term_length,
+                degraded_network: true,
+                partition: Partition::Connected,
+                strategy: StrategyChoice::AnyScope,
+                forwarding: ForwardingPolicy::Disabled,
+            });
+        }
+    }
+
     #[test]
     fn coding_disrupter_runs_under_strict_id_certificates() {
         fuzz_marshal_coding_disrupter::<SimplexId>(MarshalDisrupterInput {
             raw_bytes: vec![0],
             required_containers: 1,
+            term_length: commonware_consensus::types::TermLength::ONE,
             degraded_network: false,
             partition: Partition::Connected,
             strategy: StrategyChoice::SmallScope {

--- a/consensus/fuzz/src/marshal/end_to_end/runner.rs
+++ b/consensus/fuzz/src/marshal/end_to_end/runner.rs
@@ -303,7 +303,7 @@ pub fn fuzz_marshal_standard_disrupter<P: Simplex>(input: MarshalDisrupterInput)
 /// additionally acting as a faulty block-gossip leader on its pinned view.
 ///
 /// The byzantine node leads view 1 (its parent is genesis) and disseminates the
-/// block it proposes under a fuzzer-selected [`MarshalBroadcastFault`]: it
+/// block it proposes under a fuzzer-selected `MarshalBroadcastFault`: it
 /// withholds the block, delivers it to only a partition, or delivers two
 /// conflicting blocks to disjoint replica sets. Honest nodes must still route
 /// around the byzantine-led view and deliver the target number of ordered

--- a/consensus/fuzz/src/marshal/mod.rs
+++ b/consensus/fuzz/src/marshal/mod.rs
@@ -40,8 +40,9 @@ pub mod store;
 pub use end_to_end::{
     DropRule, MarshalDisrupterInput, MarshalTwinsInput, NotarizationBlockSplitScenarioInput,
     PreGstAction, Role, ScenarioTemplate, fuzz_marshal_coding_disrupter, fuzz_marshal_coding_twins,
-    fuzz_marshal_standard_certificate_poison, fuzz_marshal_standard_deferred_id_twins_split_header,
-    fuzz_marshal_standard_disrupter, fuzz_marshal_standard_inline_id_twins_split_header,
-    fuzz_marshal_standard_scenarios, fuzz_marshal_standard_twins,
+    fuzz_marshal_standard_block_dissemination, fuzz_marshal_standard_certificate_poison,
+    fuzz_marshal_standard_deferred_id_twins_split_header, fuzz_marshal_standard_disrupter,
+    fuzz_marshal_standard_inline_id_twins_split_header, fuzz_marshal_standard_scenarios,
+    fuzz_marshal_standard_twins,
 };
 pub use store::{MarshalActorStoreInput, fuzz_marshal_actor_store};

--- a/consensus/fuzz/src/simplex.rs
+++ b/consensus/fuzz/src/simplex.rs
@@ -1,16 +1,16 @@
 #[cfg(feature = "mocks")]
 use crate::simplex_certificate_mock as cert_mock;
-use crate::{Configuration, N4F1C3, id_mock};
+use crate::{BYZANTINE_IDX, Configuration, N4F1C3, id_mock};
 use commonware_codec::Read;
 use commonware_consensus::{
     simplex::{
-        elector::{Config as ElectorConfig, Random, RoundRobin},
+        elector::{Config as ElectorConfig, Elector, Random, RoundRobin, Terms},
         scheme::{
             Scheme, bls12381_multisig, bls12381_threshold::vrf as bls12381_threshold_vrf, ed25519,
             secp256r1,
         },
     },
-    types::{TermLength, View},
+    types::{Participant, Round, TermLength, View},
 };
 use commonware_cryptography::{
     PublicKey, Sha256,
@@ -28,6 +28,47 @@ pub(crate) fn round_robin(term_length: TermLength) -> RoundRobin {
         RoundRobin::default()
     } else {
         RoundRobin::default().with_term(term_length, Duration::from_secs(12))
+    }
+}
+
+#[derive(Clone)]
+pub struct ByzantineFirstLeaderRoundRobin {
+    term_length: TermLength,
+}
+
+impl Default for ByzantineFirstLeaderRoundRobin {
+    fn default() -> Self {
+        Self {
+            term_length: TermLength::ONE,
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ByzantineFirstLeaderElector<S: Scheme<Sha256Digest>> {
+    fallback: <RoundRobin<Sha256> as ElectorConfig<S>>::Elector,
+}
+
+impl<S: Scheme<Sha256Digest>> ElectorConfig<S> for ByzantineFirstLeaderRoundRobin {
+    type Elector = ByzantineFirstLeaderElector<S>;
+
+    fn build(self, participants: &commonware_utils::ordered::Set<S::PublicKey>) -> Self::Elector {
+        Self::Elector {
+            fallback: round_robin(self.term_length).build(participants),
+        }
+    }
+}
+
+impl<S: Scheme<Sha256Digest>> Elector<S> for ByzantineFirstLeaderElector<S> {
+    fn terms(&self) -> Terms {
+        self.fallback.terms()
+    }
+
+    fn elect(&self, round: Round, certificate: Option<&S::Certificate>) -> Participant {
+        if round.view().term_index(self.terms().length()) == 1 {
+            return Participant::from_usize(BYZANTINE_IDX);
+        }
+        self.fallback.elect(round, certificate)
     }
 }
 
@@ -190,6 +231,36 @@ impl Simplex for SimplexCertificateMock {
 
     fn audit_rejection_view(configuration: Configuration) -> Option<View> {
         (configuration == N4F1C3).then(|| View::new(3))
+    }
+}
+
+#[cfg(feature = "mocks")]
+pub struct SimplexCertificateMockByzantineFirstLeader;
+
+#[cfg(feature = "mocks")]
+impl Simplex for SimplexCertificateMockByzantineFirstLeader {
+    type Scheme = cert_mock::Scheme<Ed25519PublicKey, false>;
+
+    type Elector = ByzantineFirstLeaderRoundRobin;
+
+    fn elector(term_length: TermLength) -> Self::Elector {
+        ByzantineFirstLeaderRoundRobin { term_length }
+    }
+
+    fn setup(
+        context: &mut deterministic::Context,
+        namespace: &[u8],
+        n: u32,
+    ) -> (
+        Vec<<Self::Scheme as certificate::Verifier>::PublicKey>,
+        Vec<Self::Scheme>,
+    ) {
+        let fixture = cert_mock::fixture_with::<false, true, true, _>(context, namespace, n);
+        (fixture.participants, fixture.schemes)
+    }
+
+    fn audit_rejection_view(configuration: Configuration) -> Option<View> {
+        (configuration == N4F1C3).then(|| View::new(1))
     }
 }
 
@@ -366,15 +437,16 @@ impl Simplex for SimplexSecp256r1 {
 mod tests {
     use super::*;
     use crate::{
-        CertifyChoice, CodeCoverage, FaultyMessaging, FuzzInput, N4F1C3, ReporterWiring, Standard,
-        TwinsMutator, fuzz, strategy::StrategyChoice, utils::Partition,
+        BYZANTINE_IDX, BlockFilterChoice, CertifyChoice, CodeCoverage, FaultyMessaging, FuzzInput,
+        N4F1C3, ReporterWiring, Standard, TwinsMutator, fuzz, strategy::StrategyChoice,
+        utils::Partition,
     };
     use commonware_consensus::{
         simplex::{ForwardingPolicy, mocks::application::Certifier},
-        types::TermLength,
+        types::{Epoch, Round, TermLength},
     };
     use commonware_macros::{test_group, test_traced};
-    use commonware_utils::NZU32;
+    use commonware_utils::{NZU32, TryCollect, ordered::Set};
     use proptest::prelude::*;
 
     const TEST_CONTAINERS: u64 = 1000;
@@ -421,6 +493,36 @@ mod tests {
         }
     }
 
+    #[test]
+    fn byzantine_first_leader_round_robin_pins_first_stable_term() {
+        let participants = (0..4)
+            .map(id_mock::PublicKey::from_index)
+            .try_collect::<Set<_>>()
+            .expect("public keys are unique");
+        let term_length = TermLength::new(NZU32!(2));
+        let elector: ByzantineFirstLeaderElector<id_mock::Scheme> =
+            ByzantineFirstLeaderRoundRobin { term_length }.build(&participants);
+
+        assert_eq!(
+            elector
+                .elect(Round::new(Epoch::new(crate::EPOCH), View::new(1)), None)
+                .get() as usize,
+            BYZANTINE_IDX
+        );
+        assert_eq!(
+            elector
+                .elect(Round::new(Epoch::new(crate::EPOCH), View::new(2)), None)
+                .get() as usize,
+            BYZANTINE_IDX
+        );
+        assert_ne!(
+            elector
+                .elect(Round::new(Epoch::new(crate::EPOCH), View::new(3)), None)
+                .get() as usize,
+            BYZANTINE_IDX
+        );
+    }
+
     fn test_input(seed: u64, containers: u64, term_length: TermLength) -> FuzzInput {
         FuzzInput {
             raw_bytes: seed.to_be_bytes().to_vec(),
@@ -434,6 +536,7 @@ mod tests {
             mailbox_size: crate::DEFAULT_MAILBOX_SIZE,
             forwarding: ForwardingPolicy::Disabled,
             certify: CertifyChoice::Always,
+            block_filter: BlockFilterChoice::None,
             reporting: ReporterWiring::Solo,
         }
     }

--- a/consensus/fuzz/src/simplex_node.rs
+++ b/consensus/fuzz/src/simplex_node.rs
@@ -1,5 +1,6 @@
 use crate::{
-    FuzzInput, MAX_REQUIRED_CONTAINERS, N4F3C1, PublicKeyOf, StrategyChoice, simplex,
+    BlockFilterChoice, FuzzInput, MAX_REQUIRED_CONTAINERS, N4F3C1, PublicKeyOf, StrategyChoice,
+    simplex,
     strategy::{SmallScope, Strategy},
     utils::Partition,
 };
@@ -1525,6 +1526,7 @@ where
         mailbox_size: input.mailbox_size,
         forwarding: input.forwarding,
         certify: input.certify,
+        block_filter: BlockFilterChoice::None,
         reporting: input.reporting,
     };
 

--- a/consensus/fuzz/src/strategy.rs
+++ b/consensus/fuzz/src/strategy.rs
@@ -77,6 +77,12 @@ pub trait Strategy: Send + Sync {
 
     fn repeated_proposal_index(&self, rng: &mut impl Rng, proposals_len: usize) -> Option<usize>;
 
+    /// Whether proposal mutations are specifically probing header changes and
+    /// must preserve the payload digest exactly.
+    fn preserves_proposal_payload(&self) -> bool {
+        false
+    }
+
     fn network_faults(
         &self,
         required_containers: u64,
@@ -962,6 +968,10 @@ macro_rules! impl_header_scope {
                 proposals_len: usize,
             ) -> Option<usize> {
                 self.inner().repeated_proposal_index(rng, proposals_len)
+            }
+
+            fn preserves_proposal_payload(&self) -> bool {
+                true
             }
 
             fn network_faults(


### PR DESCRIPTION
Summary

Consensus fuzzers could previously only fault-inject on simplex messages (vote / certificate / resolver). This adds fault injection on block dissemination and a pinned byzantine-first-leader elector so byzantine-led-view scenarios (payload asymmetry, stable leaders) become fuzzer-reachable. All changes are fuzz-only — consensus/src is untouched.

Simplex
- New fuzz-local block_relay.rs: a filterable mock relay + application. certify parks while a block is unseen, so payload-denial produces a genuine pending-certify instead of a scripted one.
- ByzantineFirstLeaderRoundRobin elector pins index 0 to the first term (views 1..=term_length); new simplex_cert_mock_byzantine_first_leader target.
- Block filtering wired into Standard / FaultyMessaging / Twins / ByzzFuzz: Twins mirrors Scenario partitions/route, ByzzFuzz mirrors pre-GST partition faults, Standard adds a fuzzed per-view block drop (BlockFilterChoice). The disrupter attaches genesis-backed mock blocks for its proposals (skipped for payload-preserving header strategies).
- Refactors: generic HarnessReporter dedupes the filtered/unfiltered validator builders; restored Normal latency sampling parity.

Marshal end-to-end
- New block_disrupter.rs: gives the byzantine node its own buffered::Engine on the block-gossip channel and, as a stable leader of its term, disseminates a faulty block under a fuzzer-selected mode — equivocate (distinct blocks to disjoint replicas), omit, or partition — with a coordinated notarize so honest replicas fetch and act on it.
- New fuzzed MarshalDisrupterInput.term_length: the byzantine-first-leader elector makes index 0 a stable leader over views 1..=term_length ("views 1 and 2" is the term_length == 2 case); later term views are bounded by term-covering nullification.
- New target marshal_e2e_standard_deferred_cert_mock_block_dissemination, reusing the existing liveness and safety invariants (in-order delivery, cross-node agreement, certification-agreement, header-mismatch); the byzantine node is excluded from all oracles.