### PR TITLE
feat(codec): add Zeroed type

### DIFF
--- a/codec/conformance.toml
+++ b/codec/conformance.toml
@@ -146,6 +146,10 @@ hash = "dcb27e675ccce4ba82dd6979036b04198235bec00d3cefbc8e25a639ab4a162e"
 n_cases = 65536
 hash = "edc22446bb2952609d0c8daccf2d22f8ad2b71eedfcf45296c3f4db49d78404a"
 
+["commonware_codec::types::zeroed::tests::conformance::CodecConformance<Zeroed>"]
+n_cases = 65536
+hash = "b940ea97507616f77437c7c14ed93f854868ee780b8e8fa5ff1d7489f4369f52"
+
 ["commonware_codec::varint::tests::conformance::CodecConformance<SInt<i128>>"]
 n_cases = 65536
 hash = "42320f03747b52912d8dbb129a5958fe00ebd434a3381e3aa7daca2f48981113"

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -17,6 +17,7 @@ pub mod net;
 pub mod primitives;
 pub mod tuple;
 pub mod vec;
+pub mod zeroed;
 
 /// Read keyed items from [Buf] in ascending order.
 pub(crate) fn read_ordered_map<K, V, F>(

--- a/codec/src/types/zeroed.rs
+++ b/codec/src/types/zeroed.rs
@@ -1,0 +1,165 @@
+//! Implementation of [Zeroed], a fixed-count run of zero bytes.
+
+use crate::{BufsMut, EncodeSize, Error, Read, Write, util::at_least};
+use bytes::{Buf, BufMut};
+
+/// A value representing exactly `n` zeroed bytes.
+///
+/// Useful for padding or reserving space in an encoding without storing an
+/// explicit `[0; N]` buffer. Decoding rejects any input where one of the `n`
+/// bytes is non-zero, so `Zeroed` also acts as an assertion that a reserved
+/// region was actually left untouched.
+///
+/// `n` is not stored on the wire; the reader must already know it (supplied
+/// via [Read::Cfg]), the same way a fixed-length array's length is part of
+/// its type rather than its encoding.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Zeroed {
+    n: usize,
+}
+
+impl Zeroed {
+    /// Creates a [Zeroed] representing `n` zero bytes.
+    pub const fn new(n: usize) -> Self {
+        Self { n }
+    }
+
+    /// Returns the number of zero bytes this value represents.
+    pub const fn len(&self) -> usize {
+        self.n
+    }
+
+    /// Returns `true` if this represents zero bytes (i.e. `n == 0`).
+    pub const fn is_empty(&self) -> bool {
+        self.n == 0
+    }
+}
+
+impl Write for Zeroed {
+    #[inline]
+    fn write(&self, buf: &mut impl BufMut) {
+        // `BufMut` has no "write n zero bytes" primitive, so put_bytes (a
+        // memset under the hood, not n individual calls) is the cheapest
+        // portable way to do this without allocating a temporary buffer.
+        buf.put_bytes(0, self.n);
+    }
+
+    #[inline]
+    fn write_bufs(&self, buf: &mut impl BufsMut) {
+        buf.push(vec![0u8; self.n]);
+    }
+}
+
+impl EncodeSize for Zeroed {
+    #[inline]
+    fn encode_size(&self) -> usize {
+        self.n
+    }
+}
+
+impl Read for Zeroed {
+    type Cfg = usize;
+
+    #[inline]
+    fn read_cfg(buf: &mut impl Buf, n: &Self::Cfg) -> Result<Self, Error> {
+        at_least(buf, *n)?;
+        let mut bytes = vec![0u8; *n];
+        buf.copy_to_slice(&mut bytes);
+        if bytes.iter().any(|&b| b != 0) {
+            return Err(Error::Invalid("Zeroed", "bytes are not zero"));
+        }
+        Ok(Self { n: *n })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Decode, Encode};
+
+    #[test]
+    fn test_zeroed_round_trip() {
+        for n in [0, 1, 8, 300] {
+            let value = Zeroed::new(n);
+            let encoded = value.encode();
+            assert_eq!(encoded.len(), n);
+            assert!(encoded.iter().all(|&b| b == 0));
+
+            let decoded = Zeroed::decode_cfg(encoded, &n).unwrap();
+            assert_eq!(value, decoded);
+            assert_eq!(decoded.len(), n);
+        }
+    }
+
+    #[test]
+    fn test_zeroed_rejects_non_zero_byte() {
+        let mut bytes = vec![0u8; 8];
+        bytes[5] = 1;
+        assert!(matches!(
+            Zeroed::decode_cfg(bytes.as_slice(), &8),
+            Err(Error::Invalid("Zeroed", _))
+        ));
+    }
+
+    #[test]
+    fn test_zeroed_rejects_short_buffer() {
+        let bytes = vec![0u8; 4];
+        assert!(matches!(
+            Zeroed::decode_cfg(bytes.as_slice(), &8),
+            Err(Error::EndOfBuffer)
+        ));
+    }
+
+    #[test]
+    fn test_zeroed_is_empty() {
+        assert!(Zeroed::new(0).is_empty());
+        assert!(!Zeroed::new(1).is_empty());
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::*;
+        use crate::conformance::CodecConformance;
+        use arbitrary::Arbitrary;
+
+        /// Newtype wrapper implementing [Arbitrary] for [super::Zeroed].
+        ///
+        /// Wraps a small, arbitrary-length `n` rather than deriving `Zeroed`
+        /// directly, since [Read::Cfg] (the byte count) must be known
+        /// separately from the encoded value itself, same as [super::Bytes]'s
+        /// conformance wrapper carries its own length.
+        #[derive(Debug)]
+        struct Zeroed(super::Zeroed);
+
+        impl Write for Zeroed {
+            fn write(&self, buf: &mut impl BufMut) {
+                self.0.write(buf);
+            }
+        }
+
+        impl EncodeSize for Zeroed {
+            fn encode_size(&self) -> usize {
+                self.0.encode_size()
+            }
+        }
+
+        impl Read for Zeroed {
+            type Cfg = usize;
+
+            fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
+                Ok(Self(super::Zeroed::read_cfg(buf, cfg)?))
+            }
+        }
+
+        impl Arbitrary<'_> for Zeroed {
+            fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+                let n = u.arbitrary::<u8>()?;
+                Ok(Self(super::Zeroed::new(n as usize)))
+            }
+        }
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<Zeroed>
+        }
+    }
+}

--- a/codec/src/types/zeroed.rs
+++ b/codec/src/types/zeroed.rs
@@ -1,6 +1,6 @@
 //! Implementation of [Zeroed], a fixed-count run of zero bytes.
 
-use crate::{BufsMut, EncodeSize, Error, Read, Write, util::at_least};
+use crate::{BufsMut, EncodeSize, Error, Read, Write, util::ensure_zeros};
 use bytes::{Buf, BufMut};
 
 /// A value representing exactly `n` zeroed bytes.
@@ -55,6 +55,14 @@ impl EncodeSize for Zeroed {
     fn encode_size(&self) -> usize {
         self.n
     }
+
+    #[inline]
+    fn encode_inline_size(&self) -> usize {
+        // write_bufs pushes the zero region as a separate chunk via
+        // `BufsMut::push` rather than writing it into the inline buffer, so
+        // pooled encoding shouldn't reserve inline space for it too.
+        0
+    }
 }
 
 impl Read for Zeroed {
@@ -62,12 +70,7 @@ impl Read for Zeroed {
 
     #[inline]
     fn read_cfg(buf: &mut impl Buf, n: &Self::Cfg) -> Result<Self, Error> {
-        at_least(buf, *n)?;
-        let mut bytes = vec![0u8; *n];
-        buf.copy_to_slice(&mut bytes);
-        if bytes.iter().any(|&b| b != 0) {
-            return Err(Error::Invalid("Zeroed", "bytes are not zero"));
-        }
+        ensure_zeros(buf, *n)?;
         Ok(Self { n: *n })
     }
 }
@@ -92,12 +95,33 @@ mod tests {
     }
 
     #[test]
+    fn test_zeroed_write_bufs_matches_write() {
+        use crate::types::tests::TrackingWriteBuf;
+
+        for n in [0, 1, 8, 300] {
+            let value = Zeroed::new(n);
+
+            let direct = value.encode();
+
+            let mut pooled = TrackingWriteBuf::new();
+            value.write_bufs(&mut pooled);
+            let via_pool = pooled.freeze();
+
+            assert_eq!(
+                direct.as_ref(),
+                via_pool.as_ref(),
+                "write_bufs output must be byte-identical to write for n={n}"
+            );
+        }
+    }
+
+    #[test]
     fn test_zeroed_rejects_non_zero_byte() {
         let mut bytes = vec![0u8; 8];
         bytes[5] = 1;
         assert!(matches!(
             Zeroed::decode_cfg(bytes.as_slice(), &8),
-            Err(Error::Invalid("Zeroed", _))
+            Err(Error::Invalid("codec", _))
         ));
     }
 


### PR DESCRIPTION
## What

Adds `Zeroed`, a wrapper representing exactly `n` zero bytes — closes #1703.

Useful for padding or reserving space in an encoding, and doubles as an assertion that a reserved region was actually left untouched: decoding rejects any input where one of the `n` bytes is non-zero.

`n` is not stored on the wire; the reader supplies it externally via `Read::Cfg = usize`, the same way a fixed-length array's length is part of its type rather than its encoding.

## Implementation

Implements `Write`/`EncodeSize`/`Read` following the same shape as `Bytes` (`codec/src/types/bytes.rs`), minus the length prefix (`n` comes from `Cfg` here rather than being self-describing). `write()` uses `BufMut::put_bytes` rather than allocating a temporary zero buffer.

## Testing

Unit tests for round-tripping (n = 0, 1, 8, 300), rejecting a non-zero byte, rejecting a short buffer, and `is_empty()`.

Added the `arbitrary`-gated conformance test block following the `Bytes` pattern, and generated the baseline:

```
just test -p commonware-codec zeroed
# 46 passed, 0 failed

RUSTFLAGS="--cfg generate_conformance_tests" just regenerate-conformance -p commonware-codec
# adds the CodecConformance<Zeroed> entry to codec/conformance.toml
```

Both commits included — the type itself, and the generated conformance baseline as a separate commit so the hash's provenance is clear.

Closes #1703