### PR TITLE
[runtime/iobuf/freelist] simplify with striped mutexes

### DIFF
--- a/runtime/src/iobuf/benches/bench.rs
+++ b/runtime/src/iobuf/benches/bench.rs
@@ -7,8 +7,8 @@
 //!   provide the deep-clone baseline.
 //! - [`allocation`]: end-to-end steady-state `BufferPool` allocation and
 //!   reuse, compared against direct aligned allocation.
-//! - [`reuse`]: global reuse after partial lazy growth with thread-local
-//!   caching disabled.
+//! - [`reuse`]: end-to-end global reuse with thread-local caching disabled,
+//!   plus forced thread-local cache refill and spill cycles.
 //! - [`freelist`]: microbenchmarks of the global freelist that stores free
 //!   pooled buffers shared across threads, compared against `Mutex<Vec<_>>` and
 //!   `ArrayQueue`.

--- a/runtime/src/iobuf/benches/freelist.rs
+++ b/runtime/src/iobuf/benches/freelist.rs
@@ -7,7 +7,7 @@
 //! This module benchmarks that global freelist directly and compares three
 //! implementations behind the same batch-oriented take/put interface:
 //!
-//! - [`Freelist`]: a striped atomic bitmap freelist
+//! - [`Freelist`]: the production striped mutex freelist
 //! - `Mutex<Vec<_>>`: a simple locked batched baseline
 //! - `ArrayQueue<_>`: a bounded lock-free queue baseline
 //!
@@ -16,10 +16,10 @@
 //! steady-state shape of multi-threaded freelist reuse.
 //!
 //! The benchmarked values are [`PooledBuffer`] handles backed by initialized
-//! benchmark slots, keeping the baseline container shape close to the real
+//! benchmark owners, keeping the baseline container shape close to the real
 //! freelist.
 
-use super::utils::{Threading, measure};
+use super::utils::{Pattern, Threading, measure};
 use commonware_runtime::iobuf::bench::{Freelist, PooledBuffer, PooledOwner};
 use commonware_utils::sync::Mutex;
 use criterion::Criterion;
@@ -36,6 +36,7 @@ use std::{
 
 const SLOTS: &[usize] = &[16, 64, 512];
 const BATCH_SIZES: &[usize] = &[1, 2, 4, 8, 16, 32];
+const EMPTY_SLOTS: usize = 4_096;
 
 const BENCH_BUFFER_CAPACITY: usize = 256;
 const BENCH_BUFFER_ALIGNMENT: usize = 64;
@@ -45,14 +46,14 @@ const BENCH_LAYOUT: Layout =
         Err(_) => panic!("valid bench layout"),
     };
 
-/// Benchmark slot storage backing a set of [`PooledBuffer`] handles.
-type BenchSlots = Box<[CachePadded<UnsafeCell<PooledOwner>>]>;
+/// Benchmark owner storage backing a set of [`PooledBuffer`] handles.
+type BenchOwners = Box<[CachePadded<UnsafeCell<PooledOwner>>]>;
 
-fn new_buffers(capacity: usize) -> (BenchSlots, Vec<PooledBuffer>) {
-    let slots = (0..capacity)
-        .map(|slot| {
+fn new_buffers(capacity: usize) -> (BenchOwners, Vec<PooledBuffer>) {
+    let owners = (0..capacity)
+        .map(|owner_index| {
             CachePadded::new(UnsafeCell::new(PooledOwner::new(
-                slot as u32,
+                owner_index as u32,
                 BENCH_BUFFER_CAPACITY,
             )))
         })
@@ -60,16 +61,16 @@ fn new_buffers(capacity: usize) -> (BenchSlots, Vec<PooledBuffer>) {
         .into_boxed_slice();
 
     let buffers = (0..capacity)
-        .map(|slot| {
-            let slot_ptr = slots[slot].get();
-            let slot_ptr = NonNull::new(slot_ptr).expect("slot pointers are non-null");
-            // SAFETY: each benchmark slot is initialized once before the
+        .map(|owner_index| {
+            let owner_ptr = owners[owner_index].get();
+            let owner_ptr = NonNull::new(owner_ptr).expect("owner pointers are non-null");
+            // SAFETY: each benchmark owner is initialized once before the
             // buffer is published to a baseline container.
-            unsafe { PooledBuffer::new(slot_ptr, BENCH_LAYOUT, false) }
+            unsafe { PooledBuffer::new(owner_ptr, BENCH_LAYOUT, false) }
         })
         .collect();
 
-    (slots, buffers)
+    (owners, buffers)
 }
 
 trait FreelistImplementation: Send + Sync {
@@ -132,6 +133,42 @@ pub fn bench(c: &mut Criterion) {
             }
         }
     }
+
+    let threading = Threading::Multi {
+        threads: 8,
+        pattern: Pattern::Lockstep,
+    };
+    for parallelism in [8, EMPTY_SLOTS] {
+        bench_empty(c, threading, parallelism);
+    }
+}
+
+fn bench_empty(c: &mut Criterion, threading: Threading, parallelism: usize) {
+    let threads = threading.threads();
+    let name = format!(
+        "{}/impl=freelist slots={EMPTY_SLOTS} threads={threads} parallelism={parallelism} pattern=empty",
+        module_path!(),
+    );
+
+    c.bench_function(&name, |b| {
+        b.iter_custom(|iters| {
+            let shared = Arc::new(Freelist::new(
+                NonZeroU32::new(EMPTY_SLOTS as u32).expect("positive capacity"),
+                NonZeroUsize::new(parallelism).expect("positive parallelism"),
+                BENCH_LAYOUT,
+                false,
+            ));
+            measure(
+                iters,
+                threading,
+                move || Arc::clone(&shared),
+                |freelist| {
+                    // SAFETY: no buffer can escape an empty freelist.
+                    assert!(unsafe { freelist.take() }.is_none());
+                },
+            )
+        })
+    });
 }
 
 fn bench_case<S: FreelistImplementation>(
@@ -172,11 +209,11 @@ fn bench_name<S: FreelistImplementation>(
 }
 
 struct MutexVec {
-    _slots: BenchSlots,
+    _owners: BenchOwners,
     buffers: Mutex<Vec<PooledBuffer>>,
 }
 
-// SAFETY: benchmark slot buffers are mutated only while their corresponding
+// SAFETY: benchmark buffers are mutated only while their corresponding
 // buffer is exclusively owned by one worker or protected by the container.
 unsafe impl Send for MutexVec {}
 // SAFETY: shared access to buffers is synchronized by the mutex.
@@ -188,9 +225,9 @@ impl FreelistImplementation for MutexVec {
     }
 
     fn with_capacity(capacity: usize, _parallelism: usize) -> Self {
-        let (slots, buffers) = new_buffers(capacity);
+        let (owners, buffers) = new_buffers(capacity);
         Self {
-            _slots: slots,
+            _owners: owners,
             buffers: Mutex::new(buffers),
         }
     }
@@ -220,11 +257,11 @@ impl Drop for MutexVec {
 }
 
 struct ArrayQueueFreelist {
-    _slots: BenchSlots,
+    _owners: BenchOwners,
     queue: ArrayQueue<PooledBuffer>,
 }
 
-// SAFETY: benchmark slot buffers are mutated only while their corresponding
+// SAFETY: benchmark buffers are mutated only while their corresponding
 // buffer is exclusively owned by one worker or protected by the queue.
 unsafe impl Send for ArrayQueueFreelist {}
 // SAFETY: shared access to buffers is synchronized by `ArrayQueue`.
@@ -236,13 +273,13 @@ impl FreelistImplementation for ArrayQueueFreelist {
     }
 
     fn with_capacity(capacity: usize, _parallelism: usize) -> Self {
-        let (slots, buffers) = new_buffers(capacity);
+        let (owners, buffers) = new_buffers(capacity);
         let queue = ArrayQueue::new(capacity);
         for buffer in buffers {
             queue.push(buffer).expect("array queue prefill must fit");
         }
         Self {
-            _slots: slots,
+            _owners: owners,
             queue,
         }
     }
@@ -322,7 +359,7 @@ impl FreelistImplementation for Freelist {
             return;
         }
         // SAFETY: every held buffer was taken from this freelist by a distinct
-        // take, so slots are unique and each is returned exactly once. The
+        // take, so owners are unique and each is returned exactly once. The
         // drain iterator cannot panic.
         unsafe { self.put_batch(buffers.drain(..)) };
     }

--- a/runtime/src/iobuf/benches/freelist.rs
+++ b/runtime/src/iobuf/benches/freelist.rs
@@ -16,7 +16,7 @@
 //! steady-state shape of multi-threaded freelist reuse.
 //!
 //! The benchmarked values are [`PooledBuffer`] handles backed by initialized
-//! benchmark owners, keeping the baseline container shape close to the real
+//! benchmark slots, keeping the baseline container shape close to the real
 //! freelist.
 
 use super::utils::{Pattern, Threading, measure};
@@ -46,14 +46,14 @@ const BENCH_LAYOUT: Layout =
         Err(_) => panic!("valid bench layout"),
     };
 
-/// Benchmark owner storage backing a set of [`PooledBuffer`] handles.
-type BenchOwners = Box<[CachePadded<UnsafeCell<PooledOwner>>]>;
+/// Benchmark slot storage backing a set of [`PooledBuffer`] handles.
+type BenchSlots = Box<[CachePadded<UnsafeCell<PooledOwner>>]>;
 
-fn new_buffers(capacity: usize) -> (BenchOwners, Vec<PooledBuffer>) {
-    let owners = (0..capacity)
-        .map(|owner_index| {
+fn new_buffers(capacity: usize) -> (BenchSlots, Vec<PooledBuffer>) {
+    let slots = (0..capacity)
+        .map(|slot| {
             CachePadded::new(UnsafeCell::new(PooledOwner::new(
-                owner_index as u32,
+                slot as u32,
                 BENCH_BUFFER_CAPACITY,
             )))
         })
@@ -61,16 +61,16 @@ fn new_buffers(capacity: usize) -> (BenchOwners, Vec<PooledBuffer>) {
         .into_boxed_slice();
 
     let buffers = (0..capacity)
-        .map(|owner_index| {
-            let owner_ptr = owners[owner_index].get();
-            let owner_ptr = NonNull::new(owner_ptr).expect("owner pointers are non-null");
-            // SAFETY: each benchmark owner is initialized once before the
+        .map(|slot| {
+            let slot_ptr = slots[slot].get();
+            let slot_ptr = NonNull::new(slot_ptr).expect("slot pointers are non-null");
+            // SAFETY: each benchmark slot is initialized once before the
             // buffer is published to a baseline container.
-            unsafe { PooledBuffer::new(owner_ptr, BENCH_LAYOUT, false) }
+            unsafe { PooledBuffer::new(slot_ptr, BENCH_LAYOUT, false) }
         })
         .collect();
 
-    (owners, buffers)
+    (slots, buffers)
 }
 
 trait FreelistImplementation: Send + Sync {
@@ -209,7 +209,7 @@ fn bench_name<S: FreelistImplementation>(
 }
 
 struct MutexVec {
-    _owners: BenchOwners,
+    _slots: BenchSlots,
     buffers: Mutex<Vec<PooledBuffer>>,
 }
 
@@ -225,9 +225,9 @@ impl FreelistImplementation for MutexVec {
     }
 
     fn with_capacity(capacity: usize, _parallelism: usize) -> Self {
-        let (owners, buffers) = new_buffers(capacity);
+        let (slots, buffers) = new_buffers(capacity);
         Self {
-            _owners: owners,
+            _slots: slots,
             buffers: Mutex::new(buffers),
         }
     }
@@ -257,7 +257,7 @@ impl Drop for MutexVec {
 }
 
 struct ArrayQueueFreelist {
-    _owners: BenchOwners,
+    _slots: BenchSlots,
     queue: ArrayQueue<PooledBuffer>,
 }
 
@@ -273,13 +273,13 @@ impl FreelistImplementation for ArrayQueueFreelist {
     }
 
     fn with_capacity(capacity: usize, _parallelism: usize) -> Self {
-        let (owners, buffers) = new_buffers(capacity);
+        let (slots, buffers) = new_buffers(capacity);
         let queue = ArrayQueue::new(capacity);
         for buffer in buffers {
             queue.push(buffer).expect("array queue prefill must fit");
         }
         Self {
-            _owners: owners,
+            _slots: slots,
             queue,
         }
     }
@@ -359,7 +359,7 @@ impl FreelistImplementation for Freelist {
             return;
         }
         // SAFETY: every held buffer was taken from this freelist by a distinct
-        // take, so owners are unique and each is returned exactly once. The
+        // take, so slots are unique and each is returned exactly once. The
         // drain iterator cannot panic.
         unsafe { self.put_batch(buffers.drain(..)) };
     }

--- a/runtime/src/iobuf/benches/freelist.rs
+++ b/runtime/src/iobuf/benches/freelist.rs
@@ -213,7 +213,7 @@ struct MutexVec {
     buffers: Mutex<Vec<PooledBuffer>>,
 }
 
-// SAFETY: benchmark buffers are mutated only while their corresponding
+// SAFETY: benchmark slot buffers are mutated only while their corresponding
 // buffer is exclusively owned by one worker or protected by the container.
 unsafe impl Send for MutexVec {}
 // SAFETY: shared access to buffers is synchronized by the mutex.
@@ -261,7 +261,7 @@ struct ArrayQueueFreelist {
     queue: ArrayQueue<PooledBuffer>,
 }
 
-// SAFETY: benchmark buffers are mutated only while their corresponding
+// SAFETY: benchmark slot buffers are mutated only while their corresponding
 // buffer is exclusively owned by one worker or protected by the queue.
 unsafe impl Send for ArrayQueueFreelist {}
 // SAFETY: shared access to buffers is synchronized by `ArrayQueue`.

--- a/runtime/src/iobuf/benches/reuse.rs
+++ b/runtime/src/iobuf/benches/reuse.rs
@@ -1,9 +1,9 @@
-//! End-to-end buffer reuse after partial lazy growth.
+//! End-to-end buffer reuse.
 //!
-//! Each worker creates and returns a sparse batch before timing starts, then
-//! repeatedly allocates and returns that batch with thread-local caching
-//! disabled. This isolates whether lazy owner placement improves later global
-//! freelist access.
+//! The batch rows create and return sparse buffers before timing, then reuse
+//! them with thread-local caching disabled. The TLS rows use a working set one
+//! larger than the local cache, forcing one batched global refill and spill per
+//! iteration while retaining the surrounding local-cache work.
 
 use super::utils::start_pool;
 use commonware_runtime::{BufferPool, BufferPoolConfig, IoBufMut};
@@ -23,6 +23,7 @@ const CAPACITY: u32 = 4096;
 const PARALLELISM: usize = 8;
 const THREADS: usize = 8;
 const BATCHES: &[usize] = &[1, 8];
+const TLS_CACHE_CAPACITIES: &[usize] = &[16, 256];
 
 struct State {
     pool: BufferPool,
@@ -77,6 +78,18 @@ pub fn bench(c: &mut Criterion) {
             b.iter_custom(|iters| measure(iters, build_pool(), batch));
         });
     }
+
+    for &cache in TLS_CACHE_CAPACITIES {
+        // Exceeding the cache by one forces one refill and one spill each step.
+        let working_set = cache + 1;
+        let name = format!(
+            "{}/size={SIZE} capacity={CAPACITY} threads={THREADS} parallelism={PARALLELISM} mode=tls cache={cache} working_set={working_set}",
+            module_path!(),
+        );
+        c.bench_function(&name, |b| {
+            b.iter_custom(|iters| measure(iters, build_tls_pool(cache), working_set));
+        });
+    }
 }
 
 fn measure(iters: u64, pool: BufferPool, batch: usize) -> Duration {
@@ -126,6 +139,17 @@ fn build_pool() -> BufferPool {
         .with_size_class_range(NZUsize!(SIZE), NZUsize!(SIZE), NZU32!(CAPACITY))
         .with_parallelism(NZUsize!(PARALLELISM))
         .with_thread_cache_disabled();
+
+    start_pool(cfg)
+}
+
+fn build_tls_pool(cache: usize) -> BufferPool {
+    let cfg = BufferPoolConfig::for_network()
+        .with_pool_min_size(0)
+        .with_size_class_range(NZUsize!(SIZE), NZUsize!(SIZE), NZU32!(CAPACITY))
+        .with_parallelism(NZUsize!(PARALLELISM))
+        .with_prefill(true)
+        .with_max_thread_cache_capacity(NZUsize!(cache));
 
     start_pool(cfg)
 }

--- a/runtime/src/iobuf/benches/reuse.rs
+++ b/runtime/src/iobuf/benches/reuse.rs
@@ -35,14 +35,11 @@ impl State {
     fn new(pool: BufferPool, grown: &Barrier, batch: usize) -> Self {
         let mut buffers = Vec::with_capacity(batch);
         for _ in 0..batch {
-            buffers.push(
-                pool.try_alloc(SIZE)
-                    .expect("lazy-growth pool exhausted during setup"),
-            );
+            buffers.push(pool.try_alloc(SIZE).expect("pool exhausted during setup"));
         }
 
-        // Keep every new buffer checked out until all workers have created
-        // their batch, so setup cannot reuse an owner created by another worker.
+        // Keep every setup buffer checked out until all workers have built
+        // their batch, so setup cannot reuse a buffer held by another worker.
         grown.wait();
         buffers.clear();
 
@@ -59,7 +56,7 @@ impl State {
             self.buffers.push(
                 self.pool
                     .try_alloc(SIZE)
-                    .expect("lazy-growth pool exhausted during reuse"),
+                    .expect("pool exhausted during reuse"),
             );
         }
         black_box(self.buffers.as_slice());
@@ -75,7 +72,7 @@ pub fn bench(c: &mut Criterion) {
         );
 
         c.bench_function(&name, |b| {
-            b.iter_custom(|iters| measure(iters, build_pool(), batch));
+            b.iter_custom(|iters| measure(iters, build_pool(false, 0), batch));
         });
     }
 
@@ -87,7 +84,7 @@ pub fn bench(c: &mut Criterion) {
             module_path!(),
         );
         c.bench_function(&name, |b| {
-            b.iter_custom(|iters| measure(iters, build_tls_pool(cache), working_set));
+            b.iter_custom(|iters| measure(iters, build_pool(true, cache), working_set));
         });
     }
 }
@@ -133,23 +130,18 @@ fn measure(iters: u64, pool: BufferPool, batch: usize) -> Duration {
     })
 }
 
-fn build_pool() -> BufferPool {
+fn build_pool(tls_cache_enabled: bool, cache: usize) -> BufferPool {
     let cfg = BufferPoolConfig::for_network()
         .with_pool_min_size(0)
         .with_size_class_range(NZUsize!(SIZE), NZUsize!(SIZE), NZU32!(CAPACITY))
-        .with_parallelism(NZUsize!(PARALLELISM))
-        .with_thread_cache_disabled();
+        .with_parallelism(NZUsize!(PARALLELISM));
 
-    start_pool(cfg)
-}
-
-fn build_tls_pool(cache: usize) -> BufferPool {
-    let cfg = BufferPoolConfig::for_network()
-        .with_pool_min_size(0)
-        .with_size_class_range(NZUsize!(SIZE), NZUsize!(SIZE), NZU32!(CAPACITY))
-        .with_parallelism(NZUsize!(PARALLELISM))
-        .with_prefill(true)
-        .with_max_thread_cache_capacity(NZUsize!(cache));
+    let cfg = if tls_cache_enabled {
+        cfg.with_prefill(true)
+            .with_max_thread_cache_capacity(NZUsize!(cache))
+    } else {
+        cfg.with_thread_cache_disabled()
+    };
 
     start_pool(cfg)
 }

--- a/runtime/src/iobuf/benches/reuse.rs
+++ b/runtime/src/iobuf/benches/reuse.rs
@@ -2,7 +2,7 @@
 //!
 //! Each worker creates and returns a sparse batch before timing starts, then
 //! repeatedly allocates and returns that batch with thread-local caching
-//! disabled. This isolates whether lazy slot placement improves later global
+//! disabled. This isolates whether lazy owner placement improves later global
 //! freelist access.
 
 use super::utils::start_pool;
@@ -16,25 +16,24 @@ use std::{
     time::{Duration, Instant},
 };
 
-// Capacity 4096 yields 64 bitmap words. Sequential creation spreads the first
-// 64 slots across all words, while probe-affine creation gives each worker's
-// eight slots to its distinct home word. Any eight consecutive probe ids have
-// distinct home words, so the fixture is independent of the global id phase.
+// Capacity 4096 leaves ample global room for eight workers while parallelism 8
+// gives each worker an independent freelist stripe in the uncontended case.
 const SIZE: usize = 1024;
 const CAPACITY: u32 = 4096;
 const PARALLELISM: usize = 8;
 const THREADS: usize = 8;
-const BATCH: usize = 8;
+const BATCHES: &[usize] = &[1, 8];
 
 struct State {
     pool: BufferPool,
     buffers: Vec<IoBufMut>,
+    batch: usize,
 }
 
 impl State {
-    fn new(pool: BufferPool, grown: &Barrier) -> Self {
-        let mut buffers = Vec::with_capacity(BATCH);
-        for _ in 0..BATCH {
+    fn new(pool: BufferPool, grown: &Barrier, batch: usize) -> Self {
+        let mut buffers = Vec::with_capacity(batch);
+        for _ in 0..batch {
             buffers.push(
                 pool.try_alloc(SIZE)
                     .expect("lazy-growth pool exhausted during setup"),
@@ -42,16 +41,20 @@ impl State {
         }
 
         // Keep every new buffer checked out until all workers have created
-        // their batch, so setup cannot reuse a slot created by another worker.
+        // their batch, so setup cannot reuse an owner created by another worker.
         grown.wait();
         buffers.clear();
 
-        Self { pool, buffers }
+        Self {
+            pool,
+            buffers,
+            batch,
+        }
     }
 
     #[inline]
     fn step(&mut self) {
-        for _ in 0..BATCH {
+        for _ in 0..self.batch {
             self.buffers.push(
                 self.pool
                     .try_alloc(SIZE)
@@ -64,17 +67,19 @@ impl State {
 }
 
 pub fn bench(c: &mut Criterion) {
-    let name = format!(
-        "{}/size={SIZE} capacity={CAPACITY} threads={THREADS} parallelism={PARALLELISM} batch={BATCH}",
-        module_path!(),
-    );
+    for &batch in BATCHES {
+        let name = format!(
+            "{}/size={SIZE} capacity={CAPACITY} threads={THREADS} parallelism={PARALLELISM} batch={batch}",
+            module_path!(),
+        );
 
-    c.bench_function(&name, |b| {
-        b.iter_custom(|iters| measure(iters, build_pool()));
-    });
+        c.bench_function(&name, |b| {
+            b.iter_custom(|iters| measure(iters, build_pool(), batch));
+        });
+    }
 }
 
-fn measure(iters: u64, pool: BufferPool) -> Duration {
+fn measure(iters: u64, pool: BufferPool, batch: usize) -> Duration {
     thread::scope(|scope| {
         let grown = Arc::new(Barrier::new(THREADS));
         let ready = Arc::new(Barrier::new(THREADS + 1));
@@ -90,7 +95,7 @@ fn measure(iters: u64, pool: BufferPool) -> Duration {
             let finish = Arc::clone(&finish);
             let teardown = Arc::clone(&teardown);
             scope.spawn(move || {
-                let mut state = State::new(pool, &grown);
+                let mut state = State::new(pool, &grown, batch);
                 ready.wait();
                 launch.wait();
 

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -44,12 +44,12 @@
 //!
 //! # Availability hints and locking
 //!
-//! Each stripe has an [`AtomicBool`] that avoids locking a stripe known to be
-//! empty. The vector remains authoritative. The first put
-//! into an empty vector publishes `true`, and the take that removes the final
-//! slot publishes `false`. Both transitions happen while the stripe is locked.
-//! A concurrent operation may observe a transition in progress, but once an
-//! operation completes the hint reflects its result.
+//! Each stripe has an [`AtomicBool`] that avoids locking a stripe observed to
+//! be empty. The vector remains authoritative. The first put into an empty
+//! vector publishes `true`, and the take that removes the final slot publishes
+//! `false`. Both transitions happen while the stripe is locked. A taker may
+//! observe a stale `false` and skip that stripe unless it has synchronized with
+//! the thread that completed the put.
 //!
 //! Stripe locks are blocking. A take that observes a positive hint waits for
 //! that stripe even if a later stripe could satisfy it. A failed scan is one
@@ -115,11 +115,11 @@ const MAX_STRIPES: usize = 4_096;
 
 /// One cache-isolated collection of globally free slots with a fixed slot limit.
 struct Stripe {
-    /// Completion-accurate nonempty hint used to skip empty stripe locks.
+    /// Advisory nonempty hint used to skip stripe locks.
     ///
-    /// The value changes only while `free` is locked. `false` lets a taker skip
-    /// the mutex. `true` means the taker must lock and inspect `free`, which is
-    /// authoritative if another taker emptied the stripe in the meantime.
+    /// The value changes only while `free` is locked. `true` requires locking
+    /// and inspecting authoritative `free`. A taker may observe a stale `false`
+    /// unless it has synchronized with the thread that completed the insertion.
     available: AtomicBool,
     /// Slot ids currently owned by the global freelist in this stripe.
     free: Mutex<Vec<u32>>,
@@ -1151,9 +1151,10 @@ mod loom_tests {
         );
     }
 
-    /// Verifies that a completed return is discoverable by a later take.
+    /// Verifies that a release/acquire handoff makes a completed return
+    /// discoverable.
     #[test]
-    fn completed_put_is_discoverable() {
+    fn completed_put_is_discoverable_after_handoff() {
         loom::model(|| {
             let set = Arc::new(empty(1));
             let buffer = set.try_create(false).expect("creation permit");
@@ -1168,8 +1169,8 @@ mod loom_tests {
                 })
             };
 
-            // This flag orders the take after the put completes, so a miss
-            // would violate completed-operation discoverability.
+            // The release/acquire handoff orders the hint publication before
+            // the scan.
             while !returned.load(Ordering::Acquire) {
                 thread::yield_now();
             }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -113,7 +113,7 @@ const MIN_STRIPES: usize = 8;
 /// configured parallelism is extremely large.
 const MAX_STRIPES: usize = 4_096;
 
-/// One cache-isolated, hard-bounded collection of globally free slots.
+/// One cache-isolated collection of globally free slots with a fixed slot limit.
 struct Stripe {
     /// Completion-accurate nonempty hint used to skip empty stripe locks.
     ///
@@ -178,9 +178,9 @@ impl Stripe {
 ///
 /// The freelist owns every stable pooled-owner slot and the exact layout used
 /// for its data allocation. Globally available slots are stored as compact ids
-/// in hard-bounded stripes. Checked-out buffers and thread-local caches may
-/// temporarily own slots, but their leases keep this freelist alive until they
-/// return.
+/// in stripes with fixed slot limits. Checked-out buffers and thread-local
+/// caches may temporarily own slots, but their leases keep this freelist alive
+/// until they return.
 pub struct Freelist {
     /// Exact layout shared by every data allocation in this size class.
     layout: Layout,
@@ -300,7 +300,7 @@ impl Freelist {
     /// limits sum exactly to `capacity`.
     #[inline(always)]
     const fn stripe_capacity(capacity: usize, stripes: usize, stripe: usize) -> usize {
-        ((capacity - 1 - stripe) / stripes) + 1
+        (capacity - stripe).div_ceil(stripes)
     }
 
     /// Creates a new tracked buffer and assigns its permanent slot id.
@@ -361,8 +361,9 @@ impl Freelist {
     /// Returns several uniquely owned buffers to global availability.
     ///
     /// The iterator is consumed into compact slot ids before any slot is
-    /// published. Publication starts at the current thread's home and fills one
-    /// hard-bounded stripe at a time. No two stripe locks are held together.
+    /// published. Publication starts at the current thread's home and fills
+    /// each stripe only to its fixed slot limit. No two stripe locks are held
+    /// together.
     ///
     /// The iterator must contain distinct buffers created by this freelist. It
     /// should not panic because buffers yielded before a panic may leak.
@@ -388,10 +389,15 @@ impl Freelist {
         slots.push(second.into_slot());
         slots.extend(buffers.map(PooledBuffer::into_slot));
 
+        // The iterator is fully staged, so publication performs no caller work
+        // or scratch allocation while a stripe is locked.
         let start = self.home_stripe();
         while !slots.is_empty() {
             let before = slots.len();
             for offset in 0..self.stripes.len() {
+                // Fill only the stripe's fixed remaining room so pushes cannot
+                // allocate under the lock. Publish an empty-to-nonempty
+                // transition before unlocking.
                 let stripe = &self.stripes[(start + offset) & self.stripe_mask];
                 let mut free = stripe.lock();
                 let count = (stripe.limit - free.len()).min(slots.len());
@@ -400,7 +406,6 @@ impl Freelist {
                     free.push(slots.pop().expect("count is bounded by length"));
                 }
                 if was_empty && count != 0 {
-                    // One publication covers every slot inserted under this lock.
                     stripe.available.store(true, Ordering::Release);
                 }
                 if slots.is_empty() {
@@ -408,8 +413,9 @@ impl Freelist {
                 }
             }
 
+            // Valid returns guarantee aggregate room, but racing operations can
+            // move it throughout a pass. Yield only when the pass parks nothing.
             if slots.len() == before {
-                // Racing takes and puts can move aggregate room for a full pass.
                 thread::yield_now();
             }
         }
@@ -426,6 +432,10 @@ impl Freelist {
     #[inline]
     pub fn take(&self) -> Option<PooledBuffer> {
         let start = self.home_stripe();
+
+        // A negative hint can skip locking. A positive hint requires an
+        // authoritative check under the mutex because another taker may have
+        // emptied the stripe.
         for offset in 0..self.stripes.len() {
             let stripe = &self.stripes[(start + offset) & self.stripe_mask];
             if !stripe.available.load(Ordering::Acquire) {
@@ -465,6 +475,8 @@ impl Freelist {
             return 1;
         }
 
+        // Keep scans that observe only negative hints allocation-free. Reserve
+        // detached-slot scratch after the first positive hint but before locking.
         let mut detached = Vec::new();
         let start = self.home_stripe();
         for offset in 0..self.stripes.len() {
@@ -473,10 +485,11 @@ impl Freelist {
                 continue;
             }
             if detached.capacity() == 0 {
-                // Reserve only after a potentially productive hint, while
-                // keeping allocator work outside the critical section.
                 detached = Vec::with_capacity(max);
             }
+
+            // Detach only compact slot ids while this stripe is locked. Buffer
+            // reconstruction and caller callbacks remain outside every lock.
             let mut free = stripe.lock();
             while detached.len() < max {
                 let Some(slot) = stripe.pop(&mut free) else {
@@ -492,6 +505,9 @@ impl Freelist {
         if detached.is_empty() {
             return 0;
         }
+
+        // No stripe locks remain held, so callbacks may safely reenter the
+        // freelist while ownership of each detached slot is transferred.
         let count = detached.len();
         for slot in detached {
             on_buffer(self.claim(slot));

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1,7 +1,5 @@
 //! Striped global freelist for one buffer-pool size class.
 //!
-//! # Role
-//!
 //! Each size class has a fixed number of slots. A slot combines one stable
 //! [`PooledOwner`] record with one data allocation after that slot is created.
 //! The [`Freelist`] owns the slot table, the allocation layout, and every
@@ -81,31 +79,26 @@ use std::{
     sync::atomic::Ordering,
 };
 
-/// Synchronization types used by production and Loom builds.
-mod sync {
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "loom")] {
-            pub(super) use loom::{
-                cell::UnsafeCell,
-                sync::{
-                    Mutex,
-                    MutexGuard,
-                    atomic::{AtomicBool, AtomicUsize},
-                },
-                thread,
-            };
-        } else {
-            pub(super) use commonware_utils::sync::{Mutex, MutexGuard};
-            pub(super) use std::{
-                cell::UnsafeCell,
-                sync::atomic::{AtomicBool, AtomicUsize},
-                thread,
-            };
-        }
+cfg_if::cfg_if! {
+    if #[cfg(feature = "loom")] {
+        use loom::{
+            cell::UnsafeCell,
+            sync::{
+                Mutex,
+                MutexGuard,
+                atomic::{AtomicBool, AtomicUsize},
+            },
+            thread,
+        };
+    } else {
+        use commonware_utils::sync::{Mutex, MutexGuard};
+        use std::{
+            cell::UnsafeCell,
+            sync::atomic::{AtomicBool, AtomicUsize},
+            thread,
+        };
     }
 }
-
-use sync::{AtomicBool, AtomicUsize, Mutex, MutexGuard, UnsafeCell, thread};
 
 /// Preferred minimum stripe count when the capacity can support it.
 ///

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -431,11 +431,10 @@ impl Freelist {
     /// empty snapshot because a concurrent put may still be in progress.
     #[inline]
     pub fn take(&self) -> Option<PooledBuffer> {
-        let start = self.home_stripe();
-
         // A negative hint can skip locking. A positive hint requires an
         // authoritative check under the mutex because another taker may have
         // emptied the stripe.
+        let start = self.home_stripe();
         for offset in 0..self.stripes.len() {
             let stripe = &self.stripes[(start + offset) & self.stripe_mask];
             if !stripe.available.load(Ordering::Acquire) {
@@ -463,17 +462,20 @@ impl Freelist {
     /// stranded outside both the freelist and the caller.
     #[inline]
     pub fn take_batch(&self, max: usize, mut on_buffer: impl FnMut(PooledBuffer)) -> usize {
-        let max = max.min(self.slots.len());
-        if max == 0 {
-            return 0;
-        }
-        if max == 1 {
-            let Some(buffer) = self.take() else {
-                return 0;
-            };
-            on_buffer(buffer);
-            return 1;
-        }
+        // Clamp oversized requests to the freelist capacity. Empty requests
+        // return immediately, while singleton requests reuse the scalar path
+        // and avoid batch scratch allocation.
+        let max = match max.min(self.slots.len()) {
+            0 => return 0,
+            1 => {
+                let Some(buffer) = self.take() else {
+                    return 0;
+                };
+                on_buffer(buffer);
+                return 1;
+            }
+            max => max,
+        };
 
         // Keep scans that observe only negative hints allocation-free. Reserve
         // detached-slot scratch after the first positive hint but before locking.
@@ -502,6 +504,8 @@ impl Freelist {
             }
         }
 
+        // A positive hint can become stale before its stripe is locked, leaving
+        // the scan with allocated scratch but no detached slots.
         if detached.is_empty() {
             return 0;
         }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1,27 +1,75 @@
 //! Striped global freelist for one buffer-pool size class.
 //!
-//! A [Freelist] owns one stable [PooledOwner] record for every possible buffer
-//! in a size class. Globally free buffers are represented by owner indices in
-//! cache-isolated, mutex-protected vectors.
+//! # Role
 //!
-//! Each thread has one stable home stripe. Returns lock stripes from that home
-//! and spill past stripes at their exact preallocated limit. Those limits sum
-//! to the freelist capacity, so valid returns do not allocate while holding a
-//! lock. Takes skip stripes known to be empty, then lock and scan from the same
-//! home. The first insertion and last removal update one exact nonempty hint
-//! while holding the stripe lock, so empty probes avoid mutex traffic.
-//! Stripe locks are blocking. An operation can wait for a lock holder even
-//! when another stripe could otherwise satisfy it.
+//! Each size class has a fixed number of slots. A slot combines one stable
+//! [`PooledOwner`] record with one data allocation after that slot is created.
+//! The [`Freelist`] owns the slot table, the allocation layout, and every
+//! buffer currently available for global reuse.
 //!
-//! The freelist does not track global membership separately. Its caller must
-//! return only uniquely owned buffers created by this freelist, return each
-//! buffer exactly once, and provide distinct entries in every batch.
+//! A buffer moves through these ownership states:
 //!
-//! A [PooledBuffer] does not carry its allocation layout. Every created or
-//! claimed buffer must eventually return to this freelist before the freelist
-//! is dropped. An outstanding buffer that never returns leaks. Buffer-pool
-//! leases keep the owning size class and this freelist alive until valid
-//! returns complete.
+//! ```text
+//!                        create or take
+//!  +----------------+ --------------------> +-----------------------+
+//!  | global stripe  |                       | checked out or in TLS |
+//!  | Vec<slot id>   | <-------------------- | cache                 |
+//!  +----------------+          put          +-----------------------+
+//! ```
+//!
+//! The global representation is deliberately small. Stripes store only `u32`
+//! slot ids. The corresponding owner records never move:
+//!
+//! ```text
+//!  Freelist
+//!  +-- slots:   [ PooledOwner ][ PooledOwner ][ PooledOwner ] ...
+//!  +-- stripes: [ available | Mutex<Vec<u32>> | hard limit ] ...
+//!
+//!                      slot 5
+//!  stripe vector  --------------------->  slots[5]
+//! ```
+//!
+//! # Striping
+//!
+//! Every thread receives a stable process-local id. The low bits select that
+//! thread's home stripe. A put starts at the home stripe and continues in
+//! wrapped order only when a stripe has reached its hard limit. A take follows
+//! the same wrapped order and may claim any available slot. Slot ids can
+//! therefore migrate between stripes as buffers are returned by different
+//! threads.
+//!
+//! Stripe limits are fixed at construction and sum to the freelist capacity.
+//! Each vector requests its limit as initial capacity, and operations enforce
+//! that limit even if the allocator reserves more. A valid put therefore does
+//! not grow a vector while holding its lock. If racing operations move the
+//! remaining room during a complete scan, the put yields and retries.
+//!
+//! # Availability hints and locking
+//!
+//! Each stripe has an [`AtomicBool`] that avoids locking a stripe known to be
+//! empty. The vector remains authoritative. The first put
+//! into an empty vector publishes `true`, and the take that removes the final
+//! slot publishes `false`. Both transitions happen while the stripe is locked.
+//! A concurrent operation may observe a transition in progress, but once an
+//! operation completes the hint reflects its result.
+//!
+//! Stripe locks are blocking. A take that observes a positive hint waits for
+//! that stripe even if a later stripe could satisfy it. A failed scan is one
+//! bounded concurrent miss, not a linearizable snapshot of global emptiness.
+//! A retry may succeed after an overlapping return completes.
+//!
+//! # Caller contract
+//!
+//! This is not a general-purpose container. It relies on the buffer pool to
+//! maintain exclusive ownership. Callers must return only buffers created by
+//! this freelist, return each buffer exactly once, and provide distinct buffers
+//! in each batch. Violating that contract can duplicate a slot or exceed a
+//! stripe's aggregate capacity.
+//!
+//! [`PooledBuffer`] does not carry its allocation layout. Every created or
+//! claimed buffer must eventually return before this freelist is dropped. An
+//! outstanding buffer that never returns leaks. Buffer-pool leases keep the
+//! owning size class and this freelist alive until valid returns complete.
 
 use super::owner::{PooledBuffer, PooledOwner};
 use crossbeam_utils::CachePadded;
@@ -33,91 +81,157 @@ use std::{
     sync::atomic::Ordering,
 };
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "loom")] {
-        use loom::{
-            cell::UnsafeCell,
-            sync::{
-                Mutex,
-                MutexGuard,
-                atomic::{AtomicBool, AtomicUsize},
-            },
-            thread,
-        };
-    } else {
-        use commonware_utils::sync::{Mutex, MutexGuard};
-        use std::{
-            cell::UnsafeCell,
-            sync::atomic::{AtomicBool, AtomicUsize},
-            thread,
-        };
-    }
-}
-
-/// Maximum number of cache-isolated lock stripes in one freelist.
-const MAX_STRIPES: usize = 4_096;
-/// Minimum stripe target when capacity permits.
-const MIN_STRIPES: usize = 8;
-
-#[cfg(not(feature = "loom"))]
-#[inline(always)]
-fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock()
-}
-
-#[cfg(feature = "loom")]
-#[inline(always)]
-fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
-    mutex.lock().expect("freelist mutex must not be poisoned")
-}
-
-#[inline(always)]
-#[allow(clippy::missing_const_for_fn)]
-fn owner_ptr(owner: &UnsafeCell<PooledOwner>) -> ptr::NonNull<PooledOwner> {
+/// Synchronization types used by production and Loom builds.
+mod sync {
     cfg_if::cfg_if! {
-        if #[cfg(not(feature = "loom"))] {
-            ptr::NonNull::new(owner.get()).expect("owner pointers are non-null")
+        if #[cfg(feature = "loom")] {
+            pub(super) use loom::{
+                cell::UnsafeCell,
+                sync::{
+                    Mutex,
+                    MutexGuard,
+                    atomic::{AtomicBool, AtomicUsize},
+                },
+                thread,
+            };
         } else {
-            owner.with(|owner| {
-                ptr::NonNull::new(owner.cast_mut()).expect("owner pointers are non-null")
-            })
+            pub(super) use commonware_utils::sync::{Mutex, MutexGuard};
+            pub(super) use std::{
+                cell::UnsafeCell,
+                sync::atomic::{AtomicBool, AtomicUsize},
+                thread,
+            };
         }
     }
 }
 
-/// One hard-bounded free vector and its lock.
+use sync::{AtomicBool, AtomicUsize, Mutex, MutexGuard, UnsafeCell, thread};
+
+/// Preferred minimum stripe count when the capacity can support it.
+///
+/// The floor prevents a low or underestimated parallelism setting from
+/// collapsing ordinary pools onto one hot lock. Capacity still bounds the
+/// count, so small size classes never allocate empty stripes.
+const MIN_STRIPES: usize = 8;
+
+/// Maximum number of cache-isolated stripes in one freelist.
+///
+/// The cap bounds both cache-padded metadata and the cost of an empty scan when
+/// configured parallelism is extremely large.
+const MAX_STRIPES: usize = 4_096;
+
+/// One cache-isolated, hard-bounded collection of globally free slots.
 struct Stripe {
-    /// Exact nonempty hint, changed only while holding `free`.
+    /// Completion-accurate nonempty hint used to skip empty stripe locks.
+    ///
+    /// The value changes only while `free` is locked. `false` lets a taker skip
+    /// the mutex. `true` means the taker must lock and inspect `free`, which is
+    /// authoritative if another taker emptied the stripe in the meantime.
     available: AtomicBool,
+    /// Slot ids currently owned by the global freelist in this stripe.
     free: Mutex<Vec<u32>>,
+    /// Maximum number of slot ids that `free` may contain.
+    ///
+    /// The vector is created with this requested capacity during construction.
     limit: usize,
 }
 
-/// Bounded striped freelist of tracked buffers for one size class.
+impl Stripe {
+    /// Creates a stripe from its preallocated initial free-slot vector.
+    fn new(free: Vec<u32>, limit: usize) -> Self {
+        debug_assert!(free.len() <= limit);
+        debug_assert!(free.capacity() >= limit);
+        Self {
+            available: AtomicBool::new(!free.is_empty()),
+            free: Mutex::new(free),
+            limit,
+        }
+    }
+
+    /// Locks the authoritative free-slot vector.
+    ///
+    /// Production mutexes do not expose poisoning. Loom uses the standard
+    /// poisoning API, and a poisoned model indicates a prior test panic rather
+    /// than a recoverable freelist state.
+    #[inline(always)]
+    fn lock(&self) -> MutexGuard<'_, Vec<u32>> {
+        cfg_if::cfg_if! {
+            if #[cfg(feature = "loom")] {
+                self.free.lock().expect("freelist mutex must not be poisoned")
+            } else {
+                self.free.lock()
+            }
+        }
+    }
+
+    /// Removes one slot while maintaining the availability hint.
+    ///
+    /// `free` must be the guard obtained from [`Self::lock`] for this stripe.
+    #[inline(always)]
+    fn pop(&self, free: &mut MutexGuard<'_, Vec<u32>>) -> Option<u32> {
+        let Some(slot) = free.pop() else {
+            // A taker can load `true` before another taker removes the final
+            // slot. Reconfirm the now-authoritative empty state for later scans.
+            self.available.store(false, Ordering::Release);
+            return None;
+        };
+
+        if free.is_empty() {
+            // Publish the last removal before releasing the stripe lock.
+            self.available.store(false, Ordering::Release);
+        }
+        Some(slot)
+    }
+}
+
+/// Fixed-capacity striped freelist for one buffer-pool size class.
+///
+/// The freelist owns every stable pooled-owner slot and the exact layout used
+/// for its data allocation. Globally available slots are stored as compact ids
+/// in hard-bounded stripes. Checked-out buffers and thread-local caches may
+/// temporarily own slots, but their leases keep this freelist alive until they
+/// return.
 pub struct Freelist {
+    /// Exact layout shared by every data allocation in this size class.
     layout: Layout,
+    /// Number of permanent creation permits consumed so far.
+    ///
+    /// The cache padding isolates concurrent lazy creation from stripe state.
     created: CachePadded<AtomicUsize>,
-    owners: Box<[CachePadded<UnsafeCell<PooledOwner>>]>,
+    /// Stable owner record for every possible slot in this size class.
+    ///
+    /// Boxing prevents the records from moving after pointers escape.
+    slots: Box<[CachePadded<UnsafeCell<PooledOwner>>]>,
+    /// Cache-isolated free-slot vectors selected by thread home.
     stripes: Box<[CachePadded<Stripe>]>,
+    /// `stripes.len() - 1`, used for power-of-two wrapped indexing.
     stripe_mask: usize,
 }
 
-// SAFETY: owner storage is stable for the lifetime of the freelist. The buffer
-// pool contract places each created owner either outside the global freelist or
+// SAFETY: slot storage is stable for the lifetime of the freelist. The buffer
+// pool contract places each created slot either outside the global freelist or
 // in exactly one mutex-protected stripe.
 unsafe impl Send for Freelist {}
 // SAFETY: same ownership and locking discipline as the Send implementation.
 unsafe impl Sync for Freelist {}
 
 impl Freelist {
-    /// Creates a new fixed-capacity freelist.
+    /// Creates a fixed-capacity freelist for one allocation layout.
     ///
-    /// Parallelism selects a power-of-two stripe target with a floor of up to
-    /// [MIN_STRIPES] and a cap of [MAX_STRIPES]. Each stripe preallocates its
-    /// exact share of the total capacity.
+    /// `parallelism` selects a power-of-two stripe target. When capacity allows,
+    /// the target is at least [`MIN_STRIPES`] and never exceeds
+    /// [`MAX_STRIPES`]. The count also never exceeds the greatest power of two
+    /// no larger than `capacity`, which ensures every stripe has a nonzero hard
+    /// limit.
     ///
-    /// If prefill is true, all buffers are created and parked before this
-    /// method returns.
+    /// Each stripe preallocates its exact share of total capacity. If `prefill`
+    /// is `true`, every slot's data allocation is created and parked before
+    /// this method returns.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `layout` is zero-sized. Allocation failure invokes the
+    /// process allocation error handler.
     pub fn new(
         capacity: NonZeroU32,
         parallelism: NonZeroUsize,
@@ -129,29 +243,28 @@ impl Freelist {
         let stripe_count = Self::stripe_count(capacity, parallelism.get());
         let stripe_mask = stripe_count - 1;
 
-        let owners = (0..capacity)
-            .map(|owner_index| {
+        let slots = (0..capacity)
+            .map(|slot| {
                 CachePadded::new(UnsafeCell::new(PooledOwner::new(
-                    u32::try_from(owner_index).expect("owner index must fit in u32"),
+                    u32::try_from(slot).expect("slot must fit in u32"),
                     layout.size(),
                 )))
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
+        // Build the free vectors before their mutexes exist. This keeps prefill
+        // allocation and initialization outside every stripe lock.
         let mut free = (0..stripe_count)
-            .map(|stripe| {
-                Vec::with_capacity(Self::stripe_capacity(capacity, stripe_count, stripe))
-            })
+            .map(|stripe| Vec::with_capacity(Self::stripe_capacity(capacity, stripe_count, stripe)))
             .collect::<Vec<_>>();
 
         if prefill {
-            for owner_index in 0..capacity {
-                // SAFETY: construction exclusively initializes this stable owner.
-                let buffer = unsafe {
-                    PooledBuffer::new(owner_ptr(&owners[owner_index]), layout, false)
-                };
-                free[owner_index & stripe_mask].push(buffer.into_owner_index());
+            for slot in 0..capacity {
+                // SAFETY: construction exclusively initializes this stable slot.
+                let buffer =
+                    unsafe { PooledBuffer::new(Self::cell_ptr(&slots[slot]), layout, false) };
+                free[slot & stripe_mask].push(buffer.into_slot());
             }
         }
 
@@ -159,11 +272,8 @@ impl Freelist {
             .into_iter()
             .enumerate()
             .map(|(stripe, free)| {
-                CachePadded::new(Stripe {
-                    available: AtomicBool::new(!free.is_empty()),
-                    free: Mutex::new(free),
-                    limit: Self::stripe_capacity(capacity, stripe_count, stripe),
-                })
+                let limit = Self::stripe_capacity(capacity, stripe_count, stripe);
+                CachePadded::new(Stripe::new(free, limit))
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
@@ -171,12 +281,17 @@ impl Freelist {
         Self {
             layout,
             created: CachePadded::new(AtomicUsize::new(if prefill { capacity } else { 0 })),
-            owners,
+            slots,
             stripes,
             stripe_mask,
         }
     }
 
+    /// Selects a power-of-two stripe count from capacity and parallelism.
+    ///
+    /// The minimum protects low parallelism estimates from a single hot lock.
+    /// The maximum bounds metadata and empty scans. The capacity ceiling keeps
+    /// every stripe useful and makes wrapped indexing a mask operation.
     #[inline]
     fn stripe_count(capacity: usize, parallelism: usize) -> usize {
         let capacity_ceiling = 1usize << capacity.ilog2();
@@ -188,52 +303,58 @@ impl Freelist {
             .min(capacity_ceiling)
     }
 
+    /// Returns the exact hard limit for one stripe.
+    ///
+    /// Slots are distributed by `slot & (stripes - 1)` during prefill. This
+    /// formula gives the matching quotient plus remainder distribution, whose
+    /// limits sum exactly to `capacity`.
     #[inline(always)]
     const fn stripe_capacity(capacity: usize, stripes: usize, stripe: usize) -> usize {
         ((capacity - 1 - stripe) / stripes) + 1
     }
 
-    /// Creates a new tracked buffer and assigns its permanent owner index.
+    /// Creates a new tracked buffer and assigns its permanent slot id.
     ///
-    /// Returns None after all creation permits have been claimed. Draining
-    /// does not reopen permits.
+    /// Returns `None` after all creation permits have been consumed. Draining
+    /// does not reopen permits because each slot is initialized at most once.
     #[inline(always)]
     pub(super) fn try_create(&self, zeroed: bool) -> Option<PooledBuffer> {
-        let capacity = self.owners.len();
+        let capacity = self.slots.len();
         #[allow(deprecated)]
-        let owner_index = self
+        let slot = self
             .created
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |created| {
                 (created < capacity).then_some(created + 1)
             })
             .ok()?;
 
-        // SAFETY: creation admission assigns this owner exactly once. Its
+        // SAFETY: creation admission assigns this slot exactly once. Its
         // address remains stable for the freelist lifetime.
-        Some(unsafe { PooledBuffer::new(self.owner(owner_index as u32), self.layout, zeroed) })
+        Some(unsafe { PooledBuffer::new(self.slot(slot as u32), self.layout, zeroed) })
     }
 
-    /// Returns one tracked buffer, starting from this thread's home stripe.
-    #[inline]
+    /// Returns one uniquely owned buffer to global availability.
+    ///
+    /// The scan starts at the current thread's home stripe. Full stripes are
+    /// skipped in wrapped order. Under the caller contract, aggregate room
+    /// exists for every returned buffer, although racing operations can move
+    /// that room during a scan.
     pub fn put(&self, buffer: PooledBuffer) {
-        self.put_from(buffer, self.home_stripe());
-    }
-
-    /// Returns one buffer starting from an already-resolved home stripe.
-    fn put_from(&self, buffer: PooledBuffer, start: usize) {
-        let mut owner_index = Some(buffer.into_owner_index());
+        let start = self.home_stripe();
+        let slot = buffer.into_slot();
         loop {
             for offset in 0..self.stripes.len() {
                 let stripe = &self.stripes[(start + offset) & self.stripe_mask];
-                let mut free = lock(&stripe.free);
+                let mut free = stripe.lock();
                 if free.len() == stripe.limit {
                     continue;
                 }
 
                 let was_empty = free.is_empty();
                 debug_assert!(free.len() < free.capacity());
-                free.push(owner_index.take().expect("owner index is published once"));
+                free.push(slot);
                 if was_empty {
+                    // Publish the first insertion before releasing the lock.
                     stripe.available.store(true, Ordering::Release);
                 }
                 return;
@@ -245,134 +366,125 @@ impl Freelist {
         }
     }
 
-    /// Returns several tracked buffers, starting from this thread's home.
+    /// Returns several uniquely owned buffers to global availability.
     ///
-    /// The complete batch is collected before any buffer is published.
-    /// Publication fills one hard-bounded stripe at a time.
+    /// The iterator is consumed into compact slot ids before any slot is
+    /// published. Publication starts at the current thread's home and fills one
+    /// hard-bounded stripe at a time. No two stripe locks are held together.
     ///
-    /// The iterator should not panic. Buffers yielded before a panic may leak.
-    #[inline]
-    pub fn put_batch(&self, entries: impl IntoIterator<Item = PooledBuffer>) {
-        self.put_batch_from(entries, self.home_stripe());
-    }
-
-    /// Returns several buffers using an already-resolved home stripe.
-    fn put_batch_from(
-        &self,
-        entries: impl IntoIterator<Item = PooledBuffer>,
-        start: usize,
-    ) {
-        let mut entries = entries.into_iter();
-        let Some(first) = entries.next() else {
+    /// The iterator must contain distinct buffers created by this freelist. It
+    /// should not panic because buffers yielded before a panic may leak.
+    pub fn put_batch(&self, buffers: impl IntoIterator<Item = PooledBuffer>) {
+        let mut buffers = buffers.into_iter();
+        let Some(first) = buffers.next() else {
             return;
         };
-        let Some(second) = entries.next() else {
-            self.put_from(first, start);
+        let Some(second) = buffers.next() else {
+            self.put(first);
             return;
         };
 
-        let reserve = entries
+        let reserve = buffers
             .size_hint()
             .0
             .saturating_add(2)
-            .min(self.owners.len());
-        let mut owner_indices = Vec::with_capacity(reserve);
-        owner_indices.push(first.into_owner_index());
-        owner_indices.push(second.into_owner_index());
-        owner_indices.extend(entries.map(PooledBuffer::into_owner_index));
+            .min(self.slots.len());
+        let mut slots = Vec::with_capacity(reserve);
+        slots.push(first.into_slot());
+        slots.push(second.into_slot());
+        slots.extend(buffers.map(PooledBuffer::into_slot));
 
-        while !owner_indices.is_empty() {
-            let before = owner_indices.len();
+        let start = self.home_stripe();
+        while !slots.is_empty() {
+            let before = slots.len();
             for offset in 0..self.stripes.len() {
                 let stripe = &self.stripes[(start + offset) & self.stripe_mask];
-                let mut free = lock(&stripe.free);
-                let count = (stripe.limit - free.len()).min(owner_indices.len());
+                let mut free = stripe.lock();
+                let count = (stripe.limit - free.len()).min(slots.len());
                 let was_empty = free.is_empty();
                 for _ in 0..count {
                     debug_assert!(free.len() < free.capacity());
-                    free.push(owner_indices.pop().expect("count is bounded by length"));
+                    free.push(slots.pop().expect("count is bounded by length"));
                 }
                 if was_empty && count != 0 {
+                    // One publication covers every slot inserted under this lock.
                     stripe.available.store(true, Ordering::Release);
                 }
-                if owner_indices.is_empty() {
+                if slots.is_empty() {
                     return;
                 }
             }
 
-            if owner_indices.len() == before {
+            if slots.len() == before {
+                // Racing takes and puts can move aggregate room for a full pass.
                 thread::yield_now();
             }
         }
     }
 
-    /// Takes any one globally available buffer.
+    /// Takes any one globally available buffer, if observed.
     ///
-    /// The scan reports empty only after every stripe is either known empty or
-    /// observed empty under its mutex.
+    /// The scan starts at the current thread's home. Stripes with a negative
+    /// availability hint are skipped without locking. A positive stripe is
+    /// locked and checked authoritatively.
+    ///
+    /// `None` means this bounded scan found no slot. It is not a linearizable
+    /// empty snapshot because a concurrent put may still be in progress.
     #[inline]
     pub fn take(&self) -> Option<PooledBuffer> {
-        self.take_from(self.home_stripe())
-    }
-
-    /// Takes one buffer using an already-resolved home stripe.
-    #[inline(always)]
-    fn take_from(&self, start: usize) -> Option<PooledBuffer> {
+        let start = self.home_stripe();
         for offset in 0..self.stripes.len() {
             let stripe = &self.stripes[(start + offset) & self.stripe_mask];
             if !stripe.available.load(Ordering::Acquire) {
                 continue;
             }
-            let mut free = lock(&stripe.free);
-            if let Some(owner_index) = Self::pop_locked(stripe, &mut free) {
+            let mut free = stripe.lock();
+            if let Some(slot) = stripe.pop(&mut free) {
+                // Reconstructing the buffer touches only stable slot state, so
+                // keep it outside the critical section.
                 drop(free);
-                return Some(self.claim(owner_index));
+                return Some(self.claim(slot));
             }
         }
         None
     }
 
-    /// Takes up to max globally available buffers.
+    /// Takes up to `max` globally available buffers.
     ///
-    /// Claimed buffers are detached while their stripe is locked. All callback
-    /// invocations happen after every lock has been released. The callback must
-    /// not panic because remaining detached buffers would be stranded.
+    /// Slot ids are detached while each stripe is locked. All buffers are
+    /// reconstructed and passed to `on_buffer` only after every lock has been
+    /// released. A short result means the bounded scan found fewer than `max`
+    /// slots, not that no overlapping put can make more available.
+    ///
+    /// `on_buffer` must not panic because any remaining detached slots would be
+    /// stranded outside both the freelist and the caller.
     #[inline]
-    pub fn take_batch(&self, max: usize, mut on_entry: impl FnMut(PooledBuffer)) -> usize {
-        self.take_batch_from(max, self.home_stripe(), &mut on_entry)
-    }
-
-    /// Takes a batch using an already-resolved home stripe.
-    fn take_batch_from(
-        &self,
-        max: usize,
-        start: usize,
-        mut on_entry: impl FnMut(PooledBuffer),
-    ) -> usize {
-        let max = max.min(self.owners.len());
+    pub fn take_batch(&self, max: usize, mut on_buffer: impl FnMut(PooledBuffer)) -> usize {
+        let max = max.min(self.slots.len());
         if max == 0 {
             return 0;
         }
         if max == 1 {
-            let Some(buffer) = self.take_from(start) else {
+            let Some(buffer) = self.take() else {
                 return 0;
             };
-            on_entry(buffer);
+            on_buffer(buffer);
             return 1;
         }
 
         let mut detached = Vec::with_capacity(max);
+        let start = self.home_stripe();
         for offset in 0..self.stripes.len() {
             let stripe = &self.stripes[(start + offset) & self.stripe_mask];
             if !stripe.available.load(Ordering::Acquire) {
                 continue;
             }
-            let mut free = lock(&stripe.free);
+            let mut free = stripe.lock();
             while detached.len() < max {
-                let Some(owner_index) = Self::pop_locked(stripe, &mut free) else {
+                let Some(slot) = stripe.pop(&mut free) else {
                     break;
                 };
-                detached.push(owner_index);
+                detached.push(slot);
             }
             if detached.len() == max {
                 break;
@@ -383,31 +495,33 @@ impl Freelist {
             return 0;
         }
         let count = detached.len();
-        for owner_index in detached {
-            on_entry(self.claim(owner_index));
+        for slot in detached {
+            on_buffer(self.claim(slot));
         }
         count
     }
 
-    /// Deallocates every buffer currently parked in the global freelist.
+    /// Deallocates every buffer currently parked in this freelist.
     ///
-    /// Creation permits remain consumed. Each stripe receives an empty vector
-    /// with the same reserved capacity before detached buffers are deallocated.
+    /// Each stripe receives an empty vector with the same reserved capacity
+    /// while locked. Detached buffers are deallocated after unlocking. Creation
+    /// permits remain consumed, so a later return can reuse the reserved room
+    /// but draining never permits a second allocation for an existing slot.
     pub fn drain(&self) -> usize {
         let mut drained = 0;
 
         for stripe in &self.stripes {
             let detached = {
-                let mut free = lock(&stripe.free);
+                let mut free = stripe.lock();
                 let detached = std::mem::replace(&mut *free, Vec::with_capacity(stripe.limit));
                 stripe.available.store(false, Ordering::Release);
                 detached
             };
 
-            for owner_index in detached {
-                let buffer = self.claim(owner_index);
+            for slot in detached {
+                let buffer = self.claim(slot);
                 // SAFETY: this freelist created the detached buffer with this
-                // exact layout and removed its owner index under lock.
+                // exact layout and removed its slot under lock.
                 unsafe { buffer.deallocate(self.layout) };
                 drained += 1;
             }
@@ -416,55 +530,60 @@ impl Freelist {
         drained
     }
 
+    /// Returns the stable owner pointer for one slot id.
     #[inline(always)]
-    fn owner(&self, owner_index: u32) -> ptr::NonNull<PooledOwner> {
+    fn slot(&self, slot: u32) -> ptr::NonNull<PooledOwner> {
         let owner = self
-            .owners
-            .get(owner_index as usize)
-            .expect("owner index must belong to this freelist");
-        owner_ptr(owner)
+            .slots
+            .get(slot as usize)
+            .expect("slot must belong to this freelist");
+        Self::cell_ptr(owner)
     }
 
-    /// Returns one stable home stripe for the current thread.
+    /// Obtains the stable pointer stored by one platform-specific cell.
+    #[inline(always)]
+    #[allow(clippy::missing_const_for_fn)]
+    fn cell_ptr(owner: &UnsafeCell<PooledOwner>) -> ptr::NonNull<PooledOwner> {
+        cfg_if::cfg_if! {
+            if #[cfg(not(feature = "loom"))] {
+                ptr::NonNull::new(owner.get()).expect("slot pointers are non-null")
+            } else {
+                owner.with(|owner| {
+                    ptr::NonNull::new(owner.cast_mut()).expect("slot pointers are non-null")
+                })
+            }
+        }
+    }
+
+    /// Returns the current thread's stable home stripe in this freelist.
     #[inline(always)]
     fn home_stripe(&self) -> usize {
         if self.stripe_mask == 0 {
             return 0;
         }
-        take_thread_id() & self.stripe_mask
+        current_thread_id() & self.stripe_mask
     }
 
-    /// Removes one owner index and maintains the stripe's availability hint.
+    /// Reconstructs unique ownership after removing a slot from a stripe.
     #[inline(always)]
-    fn pop_locked(stripe: &Stripe, free: &mut MutexGuard<'_, Vec<u32>>) -> Option<u32> {
-        let Some(owner_index) = free.pop() else {
-            stripe.available.store(false, Ordering::Release);
-            return None;
-        };
-        if free.is_empty() {
-            stripe.available.store(false, Ordering::Release);
-        }
-        Some(owner_index)
-    }
-
-    /// Reconstructs unique ownership after removing an index from a stripe.
-    #[inline(always)]
-    fn claim(&self, owner_index: u32) -> PooledBuffer {
-        // SAFETY: the buffer-pool contract makes a globally stored owner index
-        // unique, and the caller removed this index from its stripe.
-        let buffer = unsafe { PooledBuffer::from_owner(self.owner(owner_index)) };
+    fn claim(&self, slot: u32) -> PooledBuffer {
+        // SAFETY: the buffer-pool contract makes a globally stored slot unique,
+        // and the caller removed this slot from its stripe.
+        let buffer = unsafe { PooledBuffer::from_owner(self.slot(slot)) };
         #[cfg(feature = "loom")]
-        buffer.assert_unique_sentinel();
+        buffer.assert_parked_sentinel();
         buffer
     }
 }
 
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "loom"))] {
-        static NEXT_TAKE_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+        /// Next process-local id assigned to a thread that touches a freelist.
+        static NEXT_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
     } else {
         loom::lazy_static! {
-            static ref NEXT_TAKE_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+            /// Next model-local id assigned to a thread that touches a freelist.
+            static ref NEXT_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
         }
     }
 }
@@ -472,24 +591,28 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "loom"))] {
         thread_local! {
-            static TAKE_THREAD_ID: Cell<Option<usize>> = const { Cell::new(None) };
+            /// Stable id used to select this thread's home in every freelist.
+            static THREAD_ID: Cell<Option<usize>> = const { Cell::new(None) };
         }
     } else {
         loom::thread_local! {
-            static TAKE_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
+            /// Stable id used to select this modeled thread's freelist home.
+            static THREAD_ID: Cell<Option<usize>> = Cell::new(None);
         }
     }
 }
 
 /// Returns one stable process-local id for the current thread.
 #[inline(always)]
-fn take_thread_id() -> usize {
-    TAKE_THREAD_ID.with(|thread_id| {
+fn current_thread_id() -> usize {
+    THREAD_ID.with(|thread_id| {
         if let Some(id) = thread_id.get() {
             return id;
         }
 
-        let id = NEXT_TAKE_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+        // The id is used only for load distribution, so wraparound and ordering
+        // relative to freelist contents have no correctness significance.
+        let id = NEXT_THREAD_ID.fetch_add(1, Ordering::Relaxed);
         thread_id.set(Some(id));
         id
     })
@@ -497,10 +620,13 @@ fn take_thread_id() -> usize {
 
 impl Drop for Freelist {
     fn drop(&mut self) {
+        // Outstanding slots keep the size class alive, so only globally parked
+        // buffers can remain when the final freelist reference is dropped.
         self.drain();
     }
 }
 
+/// Native unit tests and helpers shared with buffer-pool tests.
 #[cfg(all(test, not(feature = "loom")))]
 pub(super) mod tests {
     use super::*;
@@ -514,27 +640,32 @@ pub(super) mod tests {
         time::Duration,
     };
 
+    /// Allocation layout shared by native freelist tests.
     const TEST_LAYOUT: Layout = match Layout::from_size_align(64, 64) {
         Ok(layout) => layout,
         Err(_) => panic!("valid test layout"),
     };
 
+    /// Returns the number of permanent creation permits consumed.
     pub fn created(freelist: &Freelist) -> usize {
         freelist.created.load(Ordering::Relaxed)
     }
 
+    /// Returns the number of slots currently parked across all stripes.
     pub fn len(freelist: &Freelist) -> usize {
         freelist
             .stripes
             .iter()
-            .map(|stripe| lock(&stripe.free).len())
+            .map(|stripe| stripe.lock().len())
             .sum()
     }
 
+    /// Returns the number of stripes selected during construction.
     pub fn num_stripes(freelist: &Freelist) -> usize {
         freelist.stripes.len()
     }
 
+    /// Creates an empty freelist whose slots are allocated lazily.
     fn lazy(capacity: u32, parallelism: usize) -> Freelist {
         Freelist::new(
             NonZeroU32::new(capacity).expect("positive capacity"),
@@ -544,6 +675,7 @@ pub(super) mod tests {
         )
     }
 
+    /// Creates a freelist with every slot allocated and globally available.
     fn prefilled(capacity: u32, parallelism: usize) -> Freelist {
         Freelist::new(
             NonZeroU32::new(capacity).expect("positive capacity"),
@@ -553,6 +685,7 @@ pub(super) mod tests {
         )
     }
 
+    /// Takes every slot visible through repeated bounded batch scans.
     fn take_all(freelist: &Freelist) -> Vec<PooledBuffer> {
         let mut buffers = Vec::new();
         loop {
@@ -563,6 +696,16 @@ pub(super) mod tests {
         }
     }
 
+    /// Parks one test buffer in a chosen stripe without exercising routing.
+    fn park_in_stripe(freelist: &Freelist, stripe: usize, buffer: PooledBuffer) {
+        let stripe = &freelist.stripes[stripe];
+        let mut free = stripe.lock();
+        assert!(free.len() < stripe.limit);
+        free.push(buffer.into_slot());
+        stripe.available.store(true, Ordering::Release);
+    }
+
+    /// Verifies lazy creation, prefill, fixed permits, and explicit draining.
     #[test]
     fn test_creation_prefill_and_drain() {
         let set = lazy(3, 2);
@@ -570,13 +713,10 @@ pub(super) mod tests {
             .map(|_| set.try_create(false).expect("creation permit"))
             .collect::<Vec<_>>();
         assert_eq!(
-            buffers
-                .iter()
-                .map(PooledBuffer::owner_index)
-                .collect::<Vec<_>>(),
+            buffers.iter().map(PooledBuffer::slot).collect::<Vec<_>>(),
             vec![0, 1, 2]
         );
-        assert!(format!("{:?}", buffers[0]).contains("owner_index"));
+        assert!(format!("{:?}", buffers[0]).contains("slot"));
         assert!(set.try_create(false).is_none());
         assert_eq!(created(&set), 3);
 
@@ -592,6 +732,7 @@ pub(super) mod tests {
         assert!(set.try_create(false).is_none());
     }
 
+    /// Verifies that zeroed lazy creation initializes every data byte.
     #[test]
     fn test_zeroed_creation() {
         let set = lazy(1, 1);
@@ -602,6 +743,7 @@ pub(super) mod tests {
         set.put(buffer);
     }
 
+    /// Verifies stripe-count bounds, exact limits, and preallocated capacity.
     #[test]
     fn test_stripe_geometry_is_bounded_and_preallocated() {
         assert_eq!(Freelist::stripe_count(1, usize::MAX), 1);
@@ -613,18 +755,19 @@ pub(super) mod tests {
         let set = prefilled(19, 8);
         assert_eq!(num_stripes(&set), 8);
         for (index, stripe) in set.stripes.iter().enumerate() {
-            let free = lock(&stripe.free);
+            let free = stripe.lock();
             let expected = Freelist::stripe_capacity(19, 8, index);
             assert_eq!(stripe.limit, expected);
             assert_eq!(free.len(), expected);
             assert!(free.capacity() >= expected);
             assert!(
                 free.iter()
-                    .all(|owner_index| *owner_index as usize & set.stripe_mask == index)
+                    .all(|slot| *slot as usize & set.stripe_mask == index)
             );
         }
     }
 
+    /// Verifies that a batch spills past its home stripe's hard limit.
     #[test]
     fn test_returner_home_batch_spills_past_hard_limit() {
         let set = lazy(19, 8);
@@ -635,98 +778,91 @@ pub(super) mod tests {
             .collect::<Vec<_>>();
 
         set.put_batch(buffers);
-        assert_eq!(lock(&set.stripes[home].free).len(), set.stripes[home].limit);
+        assert_eq!(set.stripes[home].lock().len(), set.stripes[home].limit);
         assert_eq!(len(&set), count);
         assert_eq!(set.drain(), count);
     }
 
+    /// Verifies that `put` waits for its locked full home before scanning on.
     #[test]
     fn test_put_waits_for_locked_full_home() {
         let set = Arc::new(lazy(2, 2));
         let first = set.try_create(false).expect("first creation permit");
         let second = set.try_create(false).expect("second creation permit");
-        set.put_from(first, 0);
-
-        let guard = lock(&set.stripes[0].free);
+        let (home_tx, home_rx) = mpsc::channel();
+        let (go_tx, go_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
         let worker = {
             let set = Arc::clone(&set);
             std::thread::spawn(move || {
-                set.put_from(second, 0);
+                home_tx.send(set.home_stripe()).expect("send worker home");
+                go_rx.recv().expect("start return");
+                set.put(second);
                 done_tx.send(()).expect("signal completion");
             })
         };
 
+        let home = home_rx.recv().expect("receive worker home");
+        park_in_stripe(&set, home, first);
+        let guard = set.stripes[home].lock();
+        go_tx.send(()).expect("start worker");
         assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
         drop(guard);
         done_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("return must finish after home unlocks");
         worker.join().expect("worker must not panic");
-        assert_eq!(lock(&set.stripes[1].free).len(), 1);
+        assert_eq!(len(&set), 2);
     }
 
+    /// Verifies that `put_batch` waits for its full locked home, then spills.
     #[test]
     fn test_put_batch_waits_for_locked_full_home() {
-        let set = Arc::new(lazy(4, 2));
+        let set = Arc::new(lazy(4, 4));
         let mut buffers = (0..4).map(|_| set.try_create(false).expect("creation permit"));
         let first = buffers.next().expect("first buffer");
         let second = buffers.next().expect("second buffer");
         let third = buffers.next().expect("third buffer");
         let fourth = buffers.next().expect("fourth buffer");
-        set.put_from(first, 0);
-
-        let guard = lock(&set.stripes[0].free);
+        let (home_tx, home_rx) = mpsc::channel();
+        let (go_tx, go_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
         let worker = {
             let set = Arc::clone(&set);
             std::thread::spawn(move || {
-                set.put_batch_from([second, third, fourth], 0);
+                home_tx.send(set.home_stripe()).expect("send worker home");
+                go_rx.recv().expect("start batch return");
+                set.put_batch([second, third, fourth]);
                 done_tx.send(()).expect("signal completion");
             })
         };
 
+        let home = home_rx.recv().expect("receive worker home");
+        park_in_stripe(&set, home, first);
+        let guard = set.stripes[home].lock();
+        go_tx.send(()).expect("start worker");
         assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
         drop(guard);
         done_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("batch return must finish after home unlocks");
         worker.join().expect("worker must not panic");
-        assert_eq!(
-            set.stripes[1..]
-                .iter()
-                .map(|stripe| lock(&stripe.free).len())
-                .sum::<usize>(),
-            3
-        );
+        assert_eq!(set.stripes[home].lock().len(), 1);
+        assert_eq!(len(&set), 4);
     }
 
+    /// Verifies that one thread keeps a stable, in-range home stripe.
     #[test]
-    fn test_returner_homes_redistribute_fixed_owner_skew() {
+    fn test_thread_home_is_stable_and_bounded() {
         let set = lazy(64, 8);
-        let mut outside = (0..57)
-            .map(|_| set.try_create(false).expect("creation permit"))
-            .collect::<Vec<_>>();
-        let mut skewed = Vec::new();
-        for owner_index in (0..57).step_by(8) {
-            let index = outside
-                .iter()
-                .position(|buffer| buffer.owner_index() == owner_index)
-                .expect("created skewed owner");
-            skewed.push(outside.swap_remove(index));
+        let home = set.home_stripe();
+        assert!(home < set.stripes.len());
+        for _ in 0..32 {
+            assert_eq!(set.home_stripe(), home);
         }
-
-        for (home, buffer) in skewed.into_iter().enumerate() {
-            set.put_from(buffer, home);
-        }
-
-        for stripe in &set.stripes {
-            assert_eq!(lock(&stripe.free).len(), 1);
-        }
-        set.put_batch(outside);
-        assert_eq!(set.drain(), 57);
     }
 
+    /// Verifies multi-stripe batch scans and callbacks after all unlocks.
     #[test]
     fn test_take_batch_scans_stripes_and_calls_back_after_unlock() {
         let set = prefilled(8, 4);
@@ -736,10 +872,26 @@ pub(super) mod tests {
         assert_eq!(set.take_batch(0, |_| unreachable!()), 0);
     }
 
+    /// Verifies empty and singleton put and take batch paths.
+    #[test]
+    fn test_empty_and_singleton_batches() {
+        let set = lazy(1, 1);
+        set.put_batch(std::iter::empty());
+        assert_eq!(set.take_batch(1, |_| unreachable!()), 0);
+
+        let buffer = set.try_create(false).expect("creation permit");
+        set.put_batch([buffer]);
+
+        let mut taken = None;
+        assert_eq!(set.take_batch(1, |buffer| taken = Some(buffer)), 1);
+        set.put(taken.expect("singleton callback receives the buffer"));
+    }
+
+    /// Verifies that a positive stripe remains authoritative while locked.
     #[test]
     fn test_take_waits_for_locked_stripe() {
         let set = Arc::new(prefilled(1, 1));
-        let guard = lock(&set.stripes[0].free);
+        let guard = set.stripes[0].lock();
         let (started_tx, started_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
         let worker = {
@@ -761,23 +913,25 @@ pub(super) mod tests {
         set.put(buffer);
     }
 
+    /// Verifies that `take` waits for its positive home before later stripes.
     #[test]
     fn test_take_waits_for_home_before_later_stripe() {
         let set = Arc::new(prefilled(2, 2));
-        let first_guard = lock(&set.stripes[0].free);
-        let (started_tx, started_rx) = mpsc::channel();
+        let (home_tx, home_rx) = mpsc::channel();
+        let (go_tx, go_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
         let worker = {
             let set = Arc::clone(&set);
             std::thread::spawn(move || {
-                started_tx.send(()).expect("signal start");
-                done_tx
-                    .send(set.take_from(0))
-                    .expect("send take result");
+                home_tx.send(set.home_stripe()).expect("send worker home");
+                go_rx.recv().expect("start take");
+                done_tx.send(set.take()).expect("send take result");
             })
         };
 
-        started_rx.recv().expect("worker started");
+        let home = home_rx.recv().expect("receive worker home");
+        let first_guard = set.stripes[home].lock();
+        go_tx.send(()).expect("start worker");
         assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
         drop(first_guard);
         let result = done_rx.recv_timeout(Duration::from_secs(1));
@@ -786,29 +940,31 @@ pub(super) mod tests {
         let buffer = result
             .expect("take must finish after the home stripe unlocks")
             .expect("home stripe must remain productive");
-        assert_eq!(buffer.owner_index(), 0);
+        assert_eq!(buffer.slot(), home as u32);
         set.put(buffer);
     }
 
+    /// Verifies that `take_batch` waits for its home before scanning onward.
     #[test]
     fn test_take_batch_waits_for_home_before_later_stripe() {
         let set = Arc::new(prefilled(2, 2));
-        let first_guard = lock(&set.stripes[0].free);
-        let (started_tx, started_rx) = mpsc::channel();
+        let (home_tx, home_rx) = mpsc::channel();
+        let (go_tx, go_rx) = mpsc::channel();
         let (done_tx, done_rx) = mpsc::channel();
         let worker = {
             let set = Arc::clone(&set);
             std::thread::spawn(move || {
-                started_tx.send(()).expect("signal start");
+                home_tx.send(set.home_stripe()).expect("send worker home");
+                go_rx.recv().expect("start batch take");
                 let mut buffers = Vec::new();
-                let count = set.take_batch_from(2, 0, |buffer| buffers.push(buffer));
-                done_tx
-                    .send((count, buffers))
-                    .expect("send batch result");
+                let count = set.take_batch(2, |buffer| buffers.push(buffer));
+                done_tx.send((count, buffers)).expect("send batch result");
             })
         };
 
-        started_rx.recv().expect("worker started");
+        let home = home_rx.recv().expect("receive worker home");
+        let first_guard = set.stripes[home].lock();
+        go_tx.send(()).expect("start worker");
         assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
         drop(first_guard);
         let result = done_rx.recv_timeout(Duration::from_secs(1));
@@ -816,12 +972,13 @@ pub(super) mod tests {
 
         let (count, mut buffers) = result.expect("batch take must finish after home unlocks");
         assert_eq!(count, 2);
-        buffers.sort_by_key(PooledBuffer::owner_index);
-        assert_eq!(buffers[0].owner_index(), 0);
-        assert_eq!(buffers[1].owner_index(), 1);
+        buffers.sort_by_key(PooledBuffer::slot);
+        assert_eq!(buffers[0].slot(), 0);
+        assert_eq!(buffers[1].slot(), 1);
         set.put_batch(buffers);
     }
 
+    /// Verifies unique ownership across contended scalar take and put cycles.
     #[test]
     fn test_concurrent_take_and_put_preserve_unique_ownership() {
         const CAPACITY: usize = 64;
@@ -850,9 +1007,9 @@ pub(super) mod tests {
                         }
                         std::thread::yield_now();
                     };
-                    let owner_index = buffer.owner_index() as usize;
-                    assert!(!outside[owner_index].swap(true, StdOrdering::Relaxed));
-                    assert!(outside[owner_index].swap(false, StdOrdering::Relaxed));
+                    let slot = buffer.slot() as usize;
+                    assert!(!outside[slot].swap(true, StdOrdering::Relaxed));
+                    assert!(outside[slot].swap(false, StdOrdering::Relaxed));
                     set.put(buffer);
                 }
             }));
@@ -865,6 +1022,7 @@ pub(super) mod tests {
         assert_eq!(set.drain(), CAPACITY);
     }
 
+    /// Verifies concurrent batch publication respects every hard stripe limit.
     #[test]
     fn test_concurrent_batches_respect_hard_stripe_limits() {
         const CAPACITY: usize = 64;
@@ -895,39 +1053,41 @@ pub(super) mod tests {
         }
         assert_eq!(len(&set), CAPACITY);
         for stripe in &set.stripes {
-            let free = lock(&stripe.free);
+            let free = stripe.lock();
             assert_eq!(free.len(), stripe.limit);
             assert!(free.len() <= free.capacity());
         }
         assert_eq!(set.drain(), CAPACITY);
     }
 
+    /// Verifies concurrent lazy creation assigns each slot exactly once.
     #[test]
-    fn test_concurrent_creation_assigns_unique_owners() {
+    fn test_concurrent_creation_assigns_unique_slots() {
         const CAPACITY: usize = 64;
         let set = Arc::new(lazy(CAPACITY as u32, 8));
         let mut workers = Vec::new();
         for _ in 0..8 {
             let set = Arc::clone(&set);
             workers.push(std::thread::spawn(move || {
-                let mut owner_indices = Vec::new();
+                let mut slots = Vec::new();
                 while let Some(buffer) = set.try_create(false) {
-                    owner_indices.push(buffer.owner_index());
+                    slots.push(buffer.slot());
                     set.put(buffer);
                 }
-                owner_indices
+                slots
             }));
         }
 
-        let owner_indices = workers
+        let slots = workers
             .into_iter()
             .flat_map(|worker| worker.join().expect("worker must not panic"))
             .collect::<HashSet<_>>();
-        assert_eq!(owner_indices.len(), CAPACITY);
+        assert_eq!(slots.len(), CAPACITY);
         assert_eq!(created(&set), CAPACITY);
         assert_eq!(len(&set), CAPACITY);
     }
 
+    /// Verifies drain preserves reserved room for an outstanding late return.
     #[test]
     fn test_drain_leaves_room_for_late_return() {
         let set = prefilled(4, 2);
@@ -937,15 +1097,16 @@ pub(super) mod tests {
         assert_eq!(set.drain(), 1);
     }
 
+    /// Verifies repeated maximum batches return every slot exactly once.
     #[test]
-    fn test_take_all_covers_every_owner_once() {
+    fn test_take_all_covers_every_slot_once() {
         let set = prefilled(19, 8);
         let buffers = take_all(&set);
         assert_eq!(buffers.len(), 19);
         assert_eq!(
             buffers
                 .iter()
-                .map(PooledBuffer::owner_index)
+                .map(PooledBuffer::slot)
                 .collect::<HashSet<_>>()
                 .len(),
             19
@@ -953,6 +1114,7 @@ pub(super) mod tests {
         set.put_batch(buffers);
     }
 
+    /// Verifies the final removal clears and the next put restores the hint.
     #[test]
     fn test_last_take_clears_nonempty_hint() {
         let set = prefilled(1, 1);
@@ -963,23 +1125,39 @@ pub(super) mod tests {
         set.put(buffer);
         assert!(set.stripes[0].available.load(Ordering::Acquire));
     }
+
+    /// Verifies that the vector corrects a stale positive availability hint.
+    #[test]
+    fn test_stale_positive_hint_is_reconfirmed() {
+        let set = lazy(1, 1);
+
+        // This reproduces the state seen by a taker that loaded `true` before
+        // another taker removed the final slot and acquired the mutex later.
+        set.stripes[0].available.store(true, Ordering::Release);
+        assert!(set.take().is_none());
+        assert!(!set.stripes[0].available.load(Ordering::Acquire));
+    }
 }
 
+/// Exhaustive concurrency models for freelist ownership transfers.
 #[cfg(all(test, feature = "loom"))]
 mod loom_tests {
     use super::*;
     use commonware_utils::{NZU32, NZUsize};
     use loom::{sync::Arc, thread};
 
+    /// Small allocation layout used to keep model state compact.
     const TEST_LAYOUT: Layout = match Layout::from_size_align(8, 8) {
         Ok(layout) => layout,
         Err(_) => panic!("valid test layout"),
     };
 
+    /// Creates a fully available freelist for one Loom model.
     fn prefilled(capacity: u32) -> Freelist {
         Freelist::new(NZU32!(capacity), NZUsize!(1), TEST_LAYOUT, true)
     }
 
+    /// Verifies that a completed return is discoverable by a later take.
     #[test]
     fn completed_put_is_discoverable() {
         loom::model(|| {
@@ -1005,8 +1183,9 @@ mod loom_tests {
         });
     }
 
+    /// Verifies that two concurrent takers cannot claim one slot twice.
     #[test]
-    fn two_takers_cannot_claim_one_owner() {
+    fn two_takers_cannot_claim_one_slot() {
         loom::model(|| {
             let set = Arc::new(prefilled(1));
             let first = {
@@ -1025,8 +1204,9 @@ mod loom_tests {
         });
     }
 
+    /// Verifies that concurrent returns preserve both distinct slots.
     #[test]
-    fn concurrent_puts_preserve_both_owners() {
+    fn concurrent_puts_preserve_both_slots() {
         loom::model(|| {
             let set = Arc::new(Freelist::new(NZU32!(2), NZUsize!(1), TEST_LAYOUT, false));
             let first = set.try_create(false).expect("first permit");
@@ -1043,18 +1223,19 @@ mod loom_tests {
             first_put.join().expect("first put must not panic");
             second_put.join().expect("second put must not panic");
 
-            let first = set.take().expect("first owner");
-            let second = set.take().expect("second owner");
-            assert_ne!(first.owner_index(), second.owner_index());
+            let first = set.take().expect("first slot");
+            let second = set.take().expect("second slot");
+            assert_ne!(first.slot(), second.slot());
             set.put_batch([first, second]);
         });
     }
 
+    /// Verifies that a positive locked stripe is waited on, not skipped.
     #[test]
     fn locked_stripe_is_not_reported_empty() {
         loom::model(|| {
             let set = Arc::new(prefilled(1));
-            let guard = lock(&set.stripes[0].free);
+            let guard = set.stripes[0].lock();
             let taker = {
                 let set = Arc::clone(&set);
                 thread::spawn(move || set.take())
@@ -1070,36 +1251,30 @@ mod loom_tests {
         });
     }
 
+    /// Verifies that a return waits for the only stripe's lock.
     #[test]
-    fn return_waits_for_locked_full_home() {
+    fn return_waits_for_locked_stripe() {
         loom::model(|| {
-            let set = Arc::new(Freelist::new(
-                NZU32!(2),
-                NZUsize!(2),
-                TEST_LAYOUT,
-                false,
-            ));
-            let first = set.try_create(false).expect("first creation permit");
-            let second = set.try_create(false).expect("second creation permit");
-            set.put_from(first, 0);
+            let set = Arc::new(Freelist::new(NZU32!(1), NZUsize!(1), TEST_LAYOUT, false));
+            let buffer = set.try_create(false).expect("creation permit");
 
-            let guard = lock(&set.stripes[0].free);
+            let guard = set.stripes[0].lock();
             let returner = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.put_from(second, 0))
+                thread::spawn(move || set.put(buffer))
             };
             thread::yield_now();
             drop(guard);
             returner.join().expect("returner must not panic");
 
-            let first = set.take().expect("first returned buffer");
-            let second = set.take().expect("second returned buffer");
-            set.put_batch([first, second]);
+            let buffer = set.take().expect("returned buffer");
+            set.put(buffer);
         });
     }
 
+    /// Verifies that concurrent take and drain partition all parked slots.
     #[test]
-    fn take_and_drain_partition_owners() {
+    fn take_and_drain_partition_slots() {
         loom::model(|| {
             let set = Arc::new(prefilled(2));
             let taker = {

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -310,6 +310,9 @@ impl Freelist {
     #[inline(always)]
     pub(super) fn try_create(&self, zeroed: bool) -> Option<PooledBuffer> {
         let capacity = self.slots.len();
+
+        // The successful old counter value is a unique permanent slot id. This
+        // admission does not publish slot state, so relaxed ordering is enough.
         #[allow(deprecated)]
         let slot = self
             .created
@@ -364,6 +367,8 @@ impl Freelist {
     /// The iterator must contain distinct buffers created by this freelist. It
     /// should not panic because buffers yielded before a panic may leak.
     pub fn put_batch(&self, buffers: impl IntoIterator<Item = PooledBuffer>) {
+        // Keep empty and singleton batches off the staging path. Internal
+        // slot-id scratch is needed only when publishing multiple buffers.
         let mut buffers = buffers.into_iter();
         let Some(first) = buffers.next() else {
             return;
@@ -503,6 +508,8 @@ impl Freelist {
     pub fn drain(&self) -> usize {
         let mut drained = 0;
 
+        // Visit stripes directly so Drop can run during thread-local cache
+        // teardown without consulting this thread's routing state.
         for stripe in &self.stripes {
             // Allocate before locking so late returns never wait for allocator
             // work that is independent of the protected vector swap.
@@ -885,32 +892,6 @@ pub(super) mod tests {
         set.put(taken.expect("singleton callback receives the buffer"));
     }
 
-    /// Verifies that a positive stripe remains authoritative while locked.
-    #[test]
-    fn test_take_waits_for_locked_stripe() {
-        let set = Arc::new(prefilled(1, 1));
-        let guard = set.stripes[0].lock();
-        let (started_tx, started_rx) = mpsc::channel();
-        let (done_tx, done_rx) = mpsc::channel();
-        let worker = {
-            let set = Arc::clone(&set);
-            std::thread::spawn(move || {
-                started_tx.send(()).expect("signal start");
-                done_tx.send(set.take()).expect("send take result");
-            })
-        };
-
-        started_rx.recv().expect("worker started");
-        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
-        drop(guard);
-        let buffer = done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("take must finish after unlock")
-            .expect("locked stripe must preserve its buffer");
-        worker.join().expect("worker must not panic");
-        set.put(buffer);
-    }
-
     /// Verifies that `take` waits for its positive home before later stripes.
     #[test]
     fn test_take_waits_for_home_before_later_stripe() {
@@ -1196,6 +1177,8 @@ pub(super) mod tests {
         let mut registry = crate::telemetry::metrics::Registry::default();
         let pool = BufferPool::new(config, &mut registry);
 
+        // Exhaust the class before tracking allocations. Measuring only the
+        // repeated miss excludes pool setup and lazy buffer creation.
         let _held: [IoBufMut; CAPACITY] = std::array::from_fn(|_| {
             pool.try_alloc(BUFFER_SIZE)
                 .expect("lazy allocation within capacity")
@@ -1248,6 +1231,8 @@ mod loom_tests {
                 })
             };
 
+            // This flag orders the take after the put completes, so a miss
+            // would violate completed-operation discoverability.
             while !returned.load(Ordering::Acquire) {
                 thread::yield_now();
             }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -1,138 +1,33 @@
 //! Striped global freelist for one buffer-pool size class.
 //!
-//! A [`Freelist`] owns the allocation layout for one [`super::pool::BufferPool`]
-//! size class and is responsible for deallocating every tracked buffer created
-//! with that layout. Buffers that are not owned by pooled views and not held in
-//! a thread-local cache are parked in the freelist, making them available for
-//! reuse by any thread in the pool. Each tracked buffer has a stable slot id
-//! within its size class.
+//! A [Freelist] owns one stable [PooledOwner] record for every possible buffer
+//! in a size class. Globally free buffers are represented by owner indices in
+//! cache-isolated, mutex-protected vectors.
 //!
-//! A [`PooledBuffer`] does not carry its allocation layout. Any buffer created
-//! by this freelist, or taken from it, must eventually be returned to the same
-//! freelist before the freelist is finally dropped. [`Freelist::drain`] and
-//! [`Drop`] only release buffers currently parked here. **An outstanding buffer
-//! that is never returned will leak**.
+//! Each thread has one stable home stripe. Returns lock stripes from that home
+//! and spill past stripes at their exact preallocated limit. Those limits sum
+//! to the freelist capacity, so valid returns do not allocate while holding a
+//! lock. Takes skip stripes known to be empty, then lock and scan from the same
+//! home. The first insertion and last removal update one exact nonempty hint
+//! while holding the stripe lock, so empty probes avoid mutex traffic.
+//! Stripe locks are blocking. An operation can wait for a lock holder even
+//! when another stripe could otherwise satisfy it.
 //!
-//! The buffer pool keeps this requirement by storing a live size-class lease in
-//! every pooled buffer outside the freelist, including buffers held in a
-//! thread-local cache. Those leases keep the owning size class, and therefore
-//! this freelist, alive until the buffer returns here.
+//! The freelist does not track global membership separately. Its caller must
+//! return only uniquely owned buffers created by this freelist, return each
+//! buffer exactly once, and provide distinct entries in every batch.
 //!
-//! This is intentionally narrower than a general multi-producer, multi-consumer
-//! queue:
-//!
-//! - Capacity is fixed when the size class is created.
-//! - Callers only need to take any free slot, not preserve order.
-//! - Slot ownership is managed by the buffer pool.
-//! - Refill and spill paths naturally move buffers in batches.
-//!
-//! Each slot has three pieces of freelist state: a reservation bit, a
-//! side-table entry, and a free bit. The reservation bit records whether a
-//! stable slot id has been assigned to a created buffer. The side-table entry
-//! is stable for the lifetime of the size class and stores the data pointer,
-//! capacity, routing fields, refcount, and any live size-class lease. The free
-//! bit records whether that slot is globally available. Returning a buffer
-//! consumes its lease and sets the bit. Taking a buffer clears a set bit and
-//! then rebuilds a [`PooledBuffer`] handle from the side-table entry.
-//!
-//! Reservation and free bits are split across cache-line-padded atomic words.
-//! The pool passes its expected parallelism so the freelist can size these
-//! bitmaps for the expected contention level. The freelist rounds that target
-//! up to a power of two, caps it so every word can contain at least one slot,
-//! and grows it when needed so no bitmap word tracks more than 64 slots.
-//!
-//! Consecutive slot ids are not packed into the same word. Instead low slot-id
-//! bits choose the word and high slot-id bits choose the bit inside that word.
-//! With a power-of-two word count, the mapping is:
-//!
-//! - `word_mask = word_count - 1`
-//! - `word_shift = log2(word_count)`
-//! - `word_index = slot & word_mask`
-//! - `bit_index = slot >> word_shift`
-//! - `bit_mask = 1 << bit_index`
-//!
-//! For an eight-word freelist, slots are arranged like this:
-//!
-//! ```text
-//!            word 0   word 1   word 2   word 3   word 4   word 5   word 6   word 7
-//! bit 0:     slot 0   slot 1   slot 2   slot 3   slot 4   slot 5   slot 6   slot 7
-//! bit 1:     slot 8   slot 9   slot 10  slot 11  slot 12  slot 13  slot 14  slot 15
-//! bit 2:     slot 16  slot 17  slot 18  slot 19  slot 20  slot 21  slot 22  slot 23
-//! ...
-//! ```
-//!
-//! This gives concurrent threads more independent atomic words to target
-//! without changing the slot ids handed back to the pool.
-//!
-//! Lazy creation uses the same striped mapping. The slot id assigned at
-//! creation determines the word where that buffer will later be parked. If a
-//! single global counter assigns slot ids, a worker can create buffers that
-//! later publish on another worker's home word, then miss them when it starts a
-//! future take from its own home word. Reserving created slots with the same
-//! probe order keeps lazy growth aligned with later global reuse.
-//!
-//! Each thread also gets a stable probe id. The probe id uses the same
-//! power-of-two split as slot ids:
-//!
-//! - low id bits choose the thread's home word
-//! - higher id bits identify the home-word collision group
-//! - the low six bits of that group are reversed to choose the starting bit
-//!
-//! The first `word_count` long-lived workers therefore start on different
-//! bitmap words. Workers that already start on different words do not need
-//! distinct bit offsets. When more workers share the same home word, their bit
-//! offsets spread by halves, quarters, and so on.
-//!
-//! ```text
-//! word_count = 8
-//!
-//! thread id:       0  1  2  3  4  5  6  7 |  8  9 10 11 12 13 14 15
-//! home word:       0  1  2  3  4  5  6  7 |  0  1  2  3  4  5  6  7
-//! group:           0  0  0  0  0  0  0  0 |  1  1  1  1  1  1  1  1
-//! bit offset:      0  0  0  0  0  0  0  0 | 32 32 32 32 32 32 32 32
-//!
-//! home_word = thread_id & word_mask
-//! group     = thread_id >> word_shift
-//! offset    = reverse_low_6(group)
-//!
-//! home-word collision sequence:
-//!
-//! thread id:   0   8  16  24  32  40  48  56
-//! group:       0   1   2   3   4   5   6   7
-//! bit offset:  0  32  16  48   8  40  24  56
-//! ```
-//!
-//! The hot paths are fast for a few concrete reasons:
-//!
-//! - `try_create` starts from the same stable per-thread home word as `take`,
-//!   so lazy-created buffers tend to park where their creating thread will look
-//!   first when those buffers later return to the global freelist.
-//! - `put` is just one `fetch_or`, plus a double-return assert on the value
-//!   it returns.
-//! - `take` uses a stable per-thread home word before scanning others, so
-//!   threads tend to start from different stripes.
-//! - `take` and `take_batch` rotate bit selection inside each word, so threads
-//!   that share a word do not all probe bit 0 first.
-//! - `take` claims bits with `fetch_and` instead of a compare-and-swap loop.
-//!   Two threads removing different bits from the same word can both succeed
-//!   without one having to restart from scratch.
-//! - `put_batch` coalesces returned slots per word, turning many logical
-//!   inserts into one atomic `fetch_or` per touched stripe.
-//! - `take_batch` claims several bits from one word with one atomic operation,
-//!   which matches the refill behavior of the thread-local caches.
-//!
-//! The shared bitmap operations are lock-free, but the structure is not a
-//! standalone general-purpose container. It relies on the buffer pool's
-//! ownership discipline: a slot is either owned by a pooled backing, parked in a
-//! thread-local cache, or available in this freelist. Only the thread that owns
-//! a slot outside the freelist may mutate that slot's side-table entry.
+//! A [PooledBuffer] does not carry its allocation layout. Every created or
+//! claimed buffer must eventually return to this freelist before the freelist
+//! is dropped. An outstanding buffer that never returns leaks. Buffer-pool
+//! leases keep the owning size class and this freelist alive until valid
+//! returns complete.
 
 use super::owner::{PooledBuffer, PooledOwner};
 use crossbeam_utils::CachePadded;
 use std::{
     alloc::Layout,
     cell::Cell,
-    mem::MaybeUninit,
     num::{NonZeroU32, NonZeroUsize},
     ptr,
     sync::atomic::Ordering,
@@ -142,90 +37,87 @@ cfg_if::cfg_if! {
     if #[cfg(feature = "loom")] {
         use loom::{
             cell::UnsafeCell,
-            sync::atomic::{AtomicU64, AtomicUsize},
+            sync::{
+                Mutex,
+                MutexGuard,
+                atomic::{AtomicBool, AtomicUsize},
+            },
+            thread,
         };
     } else {
+        use commonware_utils::sync::{Mutex, MutexGuard};
         use std::{
             cell::UnsafeCell,
-            sync::atomic::{AtomicU64, AtomicUsize},
+            sync::atomic::{AtomicBool, AtomicUsize},
+            thread,
         };
     }
 }
 
-/// Number of slot bits tracked in each bitmap word.
-const SLOT_BITMAP_WORD_BITS: usize = u64::BITS as usize;
-/// Number of low-order bits needed to address bits within one bitmap word.
-const SLOT_BITMAP_WORD_SHIFT: u32 = SLOT_BITMAP_WORD_BITS.trailing_zeros();
-/// Number of word masks stored on the stack before falling back to heap scratch.
-const INLINE_PUT_BATCH_MASKS: usize = 128;
+/// Maximum number of cache-isolated lock stripes in one freelist.
+const MAX_STRIPES: usize = 4_096;
+/// Minimum stripe target when capacity permits.
+const MIN_STRIPES: usize = 8;
 
-/// Bounded lock-free freelist of tracked buffers for one size class.
-///
-/// The freelist owns the [`Layout`] shared by every tracked buffer in the size
-/// class. Pooled backing values and thread-local caches may temporarily hold
-/// [`PooledBuffer`] handles, but those handles must eventually return here so
-/// they can be released with the correct layout. The buffer pool keeps the
-/// freelist alive for those outstanding handles with live leases stored in
-/// pooled slot entries. Draining or dropping the freelist only deallocates buffers
-/// currently parked in it.
-///
-/// The bitmap is intentionally striped over a power-of-two number of words.
-/// That makes the slot-to-word mapping cheap and keeps small freelists from
-/// degenerating into a single hot atomic word.
-pub struct Freelist {
-    /// Allocation layout shared by every tracked buffer.
-    layout: Layout,
-    /// Number of creation permits claimed.
-    ///
-    /// This is a monotonic capacity-admission counter. Winning an increment
-    /// gives a creator one permit to reserve a slot id from the reservation
-    /// bitmap. Draining globally-free buffers does not decrement it because
-    /// created slot ids may still be owned by a pooled backing or parked in
-    /// thread-local caches.
-    created: AtomicUsize,
-    /// Cache-line-padded striped bitmap of reserved slot ids.
-    ///
-    /// Creation uses the same striped slot mapping and per-thread probe order as
-    /// the free bitmap. This preserves probe affinity during lazy growth: the
-    /// slot chosen for a newly-created buffer determines the global word where
-    /// that buffer will later be parked.
-    reserved: Box<[CachePadded<AtomicU64>]>,
-    /// Cache-line-padded striped bitmap of free slots.
-    ///
-    /// Padding matters here because threads often target different words in
-    /// steady state. Without padding, different bitmap words could still share
-    /// a cache line even when they represent disjoint slot stripes.
-    words: Box<[CachePadded<AtomicU64>]>,
-    /// Per-slot pooled owner state.
-    ///
-    /// A slot is mutated only while its free bit is clear and the slot is owned
-    /// by exactly one buffer/cache path. Publishing a slot to the global
-    /// freelist is the bitmap bit's Release transition. Taking it is the
-    /// matching Acquire transition.
-    slots: Box<[CachePadded<UnsafeCell<PooledOwner>>]>,
-    /// Mask used to map a slot id to its striped bitmap word.
-    word_mask: usize,
-    /// Number of low slot-id bits consumed by the word index.
-    word_shift: u32,
+#[cfg(not(feature = "loom"))]
+#[inline(always)]
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock()
 }
 
-// SAFETY: side-table entries are mutated only by the thread that currently owns
-// their slot id. Publication and removal from the global free set are
-// synchronized via bitmap bit transitions.
+#[cfg(feature = "loom")]
+#[inline(always)]
+fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
+    mutex.lock().expect("freelist mutex must not be poisoned")
+}
+
+#[inline(always)]
+#[allow(clippy::missing_const_for_fn)]
+fn owner_ptr(owner: &UnsafeCell<PooledOwner>) -> ptr::NonNull<PooledOwner> {
+    cfg_if::cfg_if! {
+        if #[cfg(not(feature = "loom"))] {
+            ptr::NonNull::new(owner.get()).expect("owner pointers are non-null")
+        } else {
+            owner.with(|owner| {
+                ptr::NonNull::new(owner.cast_mut()).expect("owner pointers are non-null")
+            })
+        }
+    }
+}
+
+/// One hard-bounded free vector and its lock.
+struct Stripe {
+    /// Exact nonempty hint, changed only while holding `free`.
+    available: AtomicBool,
+    free: Mutex<Vec<u32>>,
+    limit: usize,
+}
+
+/// Bounded striped freelist of tracked buffers for one size class.
+pub struct Freelist {
+    layout: Layout,
+    created: CachePadded<AtomicUsize>,
+    owners: Box<[CachePadded<UnsafeCell<PooledOwner>>]>,
+    stripes: Box<[CachePadded<Stripe>]>,
+    stripe_mask: usize,
+}
+
+// SAFETY: owner storage is stable for the lifetime of the freelist. The buffer
+// pool contract places each created owner either outside the global freelist or
+// in exactly one mutex-protected stripe.
 unsafe impl Send for Freelist {}
-// SAFETY: Same slot-ownership and bit-transition synchronization as above.
+// SAFETY: same ownership and locking discipline as the Send implementation.
 unsafe impl Sync for Freelist {}
 
 impl Freelist {
     /// Creates a new fixed-capacity freelist.
     ///
-    /// `parallelism` is the expected number of threads contending for the
-    /// freelist. The actual word count is the parallelism target rounded to a
-    /// power of two, capped so every word can contain at least one slot, and
-    /// grown when needed so no word tracks more than 64 slots.
+    /// Parallelism selects a power-of-two stripe target with a floor of up to
+    /// [MIN_STRIPES] and a cap of [MAX_STRIPES]. Each stripe preallocates its
+    /// exact share of the total capacity.
     ///
-    /// If `prefill` is true, creates `capacity` buffers and makes them
-    /// immediately available in the freelist.
+    /// If prefill is true, all buffers are created and parked before this
+    /// method returns.
     pub fn new(
         capacity: NonZeroU32,
         parallelism: NonZeroUsize,
@@ -233,482 +125,290 @@ impl Freelist {
         prefill: bool,
     ) -> Self {
         assert!(layout.size() > 0, "layout size must be non-zero");
-        let slot_count = capacity.get();
-        let capacity = slot_count as usize;
+        let capacity = capacity.get() as usize;
+        let stripe_count = Self::stripe_count(capacity, parallelism.get());
+        let stripe_mask = stripe_count - 1;
 
-        // Keep the caller-facing knob as expected parallelism, then derive an
-        // implementation-friendly stripe count here. Capping at capacity avoids
-        // permanently empty stripes when a small pool is used with a large
-        // parallelism setting.
-        let max_stripes = 1usize << capacity.ilog2();
-        let target_stripes = parallelism
-            .get()
-            .checked_next_power_of_two()
-            .unwrap_or(max_stripes)
-            .min(max_stripes);
-
-        // Small freelists reserve the target number of striped words when
-        // capacity allows it, so different threads can start from different
-        // cache lines. Large freelists are constrained by the number of bits
-        // required to represent all slots.
-        let word_count = target_stripes
-            .max(capacity.div_ceil(SLOT_BITMAP_WORD_BITS))
-            .next_power_of_two();
-        // `word_count` is always a power of two, so slot mapping can use the
-        // low bits as a word index and the remaining high bits as the bit
-        // index inside that word.
-        let word_shift = word_count.trailing_zeros();
-        let word_mask = word_count - 1;
-
-        let words = (0..word_count)
-            .map(|_| CachePadded::new(AtomicU64::new(0)))
-            .collect::<Vec<_>>()
-            .into_boxed_slice();
-
-        // Constructor-exclusive prefill can reserve every valid slot without
-        // running the concurrent affinity probe.
-        let reserved = (0..word_count)
-            .map(|word_index| {
-                let bits = if prefill {
-                    Self::valid_bits(capacity, word_shift, word_index)
-                } else {
-                    0
-                };
-                CachePadded::new(AtomicU64::new(bits))
+        let owners = (0..capacity)
+            .map(|owner_index| {
+                CachePadded::new(UnsafeCell::new(PooledOwner::new(
+                    u32::try_from(owner_index).expect("owner index must fit in u32"),
+                    layout.size(),
+                )))
             })
             .collect::<Vec<_>>()
             .into_boxed_slice();
-        let slots = (0..slot_count)
-            .map(|slot| CachePadded::new(UnsafeCell::new(PooledOwner::new(slot, layout.size()))))
+
+        let mut free = (0..stripe_count)
+            .map(|stripe| {
+                Vec::with_capacity(Self::stripe_capacity(capacity, stripe_count, stripe))
+            })
+            .collect::<Vec<_>>();
+
+        if prefill {
+            for owner_index in 0..capacity {
+                // SAFETY: construction exclusively initializes this stable owner.
+                let buffer = unsafe {
+                    PooledBuffer::new(owner_ptr(&owners[owner_index]), layout, false)
+                };
+                free[owner_index & stripe_mask].push(buffer.into_owner_index());
+            }
+        }
+
+        let stripes = free
+            .into_iter()
+            .enumerate()
+            .map(|(stripe, free)| {
+                CachePadded::new(Stripe {
+                    available: AtomicBool::new(!free.is_empty()),
+                    free: Mutex::new(free),
+                    limit: Self::stripe_capacity(capacity, stripe_count, stripe),
+                })
+            })
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
-        let freelist = Self {
+        Self {
             layout,
-            created: AtomicUsize::new(if prefill { capacity } else { 0 }),
-            reserved,
-            words,
-            slots,
-            word_mask,
-            word_shift,
-        };
-
-        if prefill {
-            freelist.put_batch((0..slot_count).map(|slot| {
-                // SAFETY: construction exclusively owns this reserved
-                // side-table entry. `put_batch` publishes it after initialization.
-                unsafe { PooledBuffer::new(freelist.slot_ptr(slot), layout, false) }
-            }));
+            created: CachePadded::new(AtomicUsize::new(if prefill { capacity } else { 0 })),
+            owners,
+            stripes,
+            stripe_mask,
         }
-
-        freelist
     }
 
-    /// Creates a new buffer and reserves a stable slot id for it.
+    #[inline]
+    fn stripe_count(capacity: usize, parallelism: usize) -> usize {
+        let capacity_ceiling = 1usize << capacity.ilog2();
+        parallelism
+            .checked_next_power_of_two()
+            .unwrap_or(MAX_STRIPES)
+            .max(MIN_STRIPES.min(capacity_ceiling))
+            .min(MAX_STRIPES)
+            .min(capacity_ceiling)
+    }
+
+    #[inline(always)]
+    const fn stripe_capacity(capacity: usize, stripes: usize, stripe: usize) -> usize {
+        ((capacity - 1 - stripe) / stripes) + 1
+    }
+
+    /// Creates a new tracked buffer and assigns its permanent owner index.
     ///
-    /// Creation has two steps. First, `created` claims one capacity permit.
-    /// Then the reservation bitmap assigns an actual slot id using the same
-    /// per-thread probe order as [`Self::take`]. This keeps newly-created
-    /// buffers mapped to the words their creating thread will probe first after
-    /// those buffers are returned to the global freelist.
-    ///
-    /// Returns `None` once every creation permit in the fixed-capacity
-    /// freelist has been claimed.
-    ///
-    /// The returned buffer does not deallocate itself. It must be returned to
-    /// this same freelist before the freelist is finally dropped, otherwise
-    /// its allocation leaks and its owner pointer dangles.
+    /// Returns None after all creation permits have been claimed. Draining
+    /// does not reopen permits.
     #[inline(always)]
     pub(super) fn try_create(&self, zeroed: bool) -> Option<PooledBuffer> {
-        let capacity = self.slots.len();
-
-        // `created` admits exactly `capacity` creators. It does not publish a
-        // buffer or a slot id, so relaxed ordering is enough.
-        //
-        // Loom's atomic implementation does not provide `try_update`.
+        let capacity = self.owners.len();
         #[allow(deprecated)]
-        self.created
+        let owner_index = self
+            .created
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |created| {
                 (created < capacity).then_some(created + 1)
             })
             .ok()?;
 
-        // Capture this thread's probe state once so the inner loop does not
-        // repeatedly touch thread-local storage.
-        let probe = SlotBitmapProbe::new(self.word_mask, self.word_shift);
-
-        // The capacity permit guarantees that some valid reservation bit is
-        // still clear. The bitmap RMW below chooses which slot id this creator
-        // owns.
-        let slot = 'reserve: {
-            for scanned in 0..self.reserved.len() {
-                let word_index = probe.word_index(scanned);
-                let word_ref = &self.reserved[word_index];
-                // Creation searches for zero bits, so unused high bits would
-                // look available without this mask.
-                let valid = Self::valid_bits(capacity, self.word_shift, word_index);
-                // The relaxed load only chooses candidates. The following RMW
-                // decides ownership.
-                let mut available = !word_ref.load(Ordering::Relaxed) & valid;
-
-                while available != 0 {
-                    // Probe a thread-specific bit order inside the chosen word so
-                    // colliding threads do not all stampede bit 0 first.
-                    let bit = probe.select_set_bit(available);
-                    let mask = 1u64 << bit;
-                    // This needs atomic uniqueness, not memory publication: no
-                    // parked buffer is made visible by reserving a slot id.
-                    let observed = word_ref.fetch_or(mask, Ordering::Relaxed);
-                    if observed & mask == 0 {
-                        break 'reserve self.slot_index(word_index, bit);
-                    }
-
-                    // Another creator reserved that candidate first. Continue
-                    // from the word state returned by the RMW instead of
-                    // restarting the whole scan.
-                    available = !observed & valid;
-                }
-            }
-
-            unreachable!("creation permit guarantees one reservable slot");
-        };
-
-        // SAFETY: the reservation RMW assigned `slot` exactly once, so no other
-        // thread can initialize or publish this side-table entry.
-        let buffer = unsafe { PooledBuffer::new(self.slot_ptr(slot), self.layout, zeroed) };
-
-        Some(buffer)
+        // SAFETY: creation admission assigns this owner exactly once. Its
+        // address remains stable for the freelist lifetime.
+        Some(unsafe { PooledBuffer::new(self.owner(owner_index as u32), self.layout, zeroed) })
     }
 
-    /// Returns the bitmap word index and bit mask for a slot id.
-    ///
-    /// Low slot-id bits choose the cache-line-padded word. High slot-id bits
-    /// choose the bit inside that word, spreading consecutive slots across
-    /// stripes instead of packing them into one atomic word.
-    #[inline(always)]
-    const fn slot_word(&self, slot: u32) -> (usize, u64) {
-        let slot = slot as usize;
-        let word_index = slot & self.word_mask;
-        let bit = slot >> self.word_shift;
-        (word_index, 1u64 << bit)
-    }
-
-    /// Returns the slot id represented by a bitmap word index and bit index.
-    ///
-    /// This is the inverse of [`Self::slot_word`] and is used after a bit has
-    /// been claimed from the bitmap.
-    #[inline(always)]
-    const fn slot_index(&self, word_index: usize, bit: usize) -> u32 {
-        let slot = (bit << self.word_shift) | word_index;
-        slot as u32
-    }
-
-    /// Returns the mask of valid slot bits for a bitmap word.
-    ///
-    /// Some words have unused high bits when capacity does not fill a complete
-    /// final logical row. For example, with capacity 10 and 4 words, words 0
-    /// and 1 have three valid bits (slots 0/4/8 and 1/5/9), while words 2 and 3
-    /// have only two.
-    #[inline(always)]
-    const fn valid_bits(capacity: usize, word_shift: u32, word_index: usize) -> u64 {
-        let bits = ((capacity - 1 - word_index) >> word_shift) + 1;
-        if bits == SLOT_BITMAP_WORD_BITS {
-            u64::MAX
-        } else {
-            (1u64 << bits) - 1
-        }
-    }
-
-    /// Puts one tracked buffer into the global freelist.
-    ///
-    /// The buffer's slot id is read from its side-table entry, then that slot's
-    /// free bit is set with `Release` ordering. A successful `take` performs
-    /// the matching `Acquire` operation before rebuilding a buffer handle from
-    /// the same side-table entry.
-    ///
-    /// The caller must own `buffer`, its slot must not already be available in
-    /// this freelist, and the buffer must have been created by this freelist.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the slot is already free in this freelist.
+    /// Returns one tracked buffer, starting from this thread's home stripe.
     #[inline]
     pub fn put(&self, buffer: PooledBuffer) {
-        let slot = buffer.slot();
-
-        // Setting the slot bit makes the slot available. `Release` pairs with
-        // the taker's `Acquire` clear before it reuses the side-table entry.
-        let (word_index, mask) = self.slot_word(slot);
-        let previous = self.words[word_index].fetch_or(mask, Ordering::Release);
-        assert_eq!(
-            previous & mask,
-            0,
-            "returned slot must not already be marked free"
-        );
+        self.put_from(buffer, self.home_stripe());
     }
 
-    /// Puts several tracked buffers into the global freelist.
-    ///
-    /// Batch insertion groups returned slots by bitmap word so each touched
-    /// stripe needs only one atomic `fetch_or`, regardless of how many entries
-    /// in the batch map to that word.
-    ///
-    /// `BufferPool` callers pass simple non-panicking iterators over entries
-    /// they already own. Avoiding per-entry guards keeps this path
-    /// allocation-free for ordinary batches.
-    ///
-    /// The caller must own every buffer in the batch. Slots must be unique
-    /// within the batch (staging asserts this) and must not already be
-    /// available in this freelist (asserted per word on insert). Each buffer
-    /// must have been created by this freelist. If this method panics after
-    /// accepting one or more buffers, accepted-but-unpublished buffers may
-    /// leak.
-    #[inline]
-    pub fn put_batch(&self, entries: impl IntoIterator<Item = PooledBuffer>) {
-        let mut entries = entries.into_iter();
-
-        // Keep empty and single-entry batches on the cheapest path. The mask
-        // scratch space is only needed once there are multiple slots to
-        // coalesce.
-        let Some(buffer) = entries.next() else {
-            return;
-        };
-        let Some(next_buffer) = entries.next() else {
-            self.put(buffer);
-            return;
-        };
-
-        let word_count = self.words.len();
-        if word_count <= INLINE_PUT_BATCH_MASKS {
-            let mut masks = MaybeUninit::<[u64; INLINE_PUT_BATCH_MASKS]>::uninit();
-            // Only the active bitmap words need scratch space. Avoid clearing
-            // the whole inline array for small freelists.
-            //
-            // SAFETY: `word_count <= INLINE_PUT_BATCH_MASKS`, so the
-            // initialized prefix is in bounds. `u64` has no drop glue, and the
-            // uninitialized tail is never exposed.
-            let masks = unsafe {
-                let ptr = masks.as_mut_ptr().cast::<u64>();
-                ptr.write_bytes(0, word_count);
-                std::slice::from_raw_parts_mut(ptr, word_count)
-            };
-            self.put_entries(masks, buffer, next_buffer, entries);
-        } else {
-            // Very large freelists are uncommon, so keep the common case on the
-            // stack and fall back to heap scratch only when the bitmap is wider
-            // than the fixed inline staging area.
-            let mut masks = vec![0u64; word_count];
-            self.put_entries(masks.as_mut_slice(), buffer, next_buffer, entries);
-        }
-    }
-
-    /// Inserts a multi-entry batch using per-word scratch masks.
-    ///
-    /// `put_batch` peels the first two entries before calling this helper, so
-    /// this path only handles batches large enough to benefit from coalescing.
-    /// `masks` must contain exactly one zeroed entry per bitmap word. Each slot
-    /// is ORed into its word's scratch mask. Once all entries are
-    /// staged, one `Release` `fetch_or` per non-empty mask makes the
-    /// corresponding slots available.
-    ///
-    /// The iterator must not panic after yielding an entry, because
-    /// staged-but-not-inserted buffers would no longer be owned by the caller
-    /// and would not yet be reachable through the bitmap.
-    #[inline(always)]
-    fn put_entries(
-        &self,
-        masks: &mut [u64],
-        buffer: PooledBuffer,
-        next_buffer: PooledBuffer,
-        entries: impl Iterator<Item = PooledBuffer>,
-    ) {
-        // Masks are staged by word before the later Release `fetch_or` makes
-        // every staged slot in that word available.
-        self.stage_put(masks, buffer);
-        self.stage_put(masks, next_buffer);
-        for buffer in entries {
-            self.stage_put(masks, buffer);
-        }
-
-        for (word_index, &mask) in masks.iter().enumerate() {
-            if mask == 0 {
-                continue;
-            }
-
-            // One Release operation makes every returned slot represented by
-            // this word mask available.
-            let previous = self.words[word_index].fetch_or(mask, Ordering::Release);
-            assert_eq!(
-                previous & mask,
-                0,
-                "returned slot batch must not already contain a free slot"
-            );
-        }
-    }
-
-    /// Records one returned buffer's slot in the batch scratch mask.
-    ///
-    /// This helper intentionally does not touch the atomic bitmap. The caller
-    /// later inserts the accumulated mask for each word, so multiple slots that
-    /// map to the same bitmap word share a single `Release` operation.
-    ///
-    /// `masks` must contain the scratch word for `buffer`'s slot.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the batch already staged this slot: a duplicate would OR
-    /// into the mask idempotently and silently alias the slot, where the
-    /// equivalent sequential `put` calls panic on the second return.
-    #[inline(always)]
-    fn stage_put(&self, masks: &mut [u64], buffer: PooledBuffer) {
-        let slot = buffer.slot();
-        let (word_index, mask) = self.slot_word(slot);
-        assert_eq!(masks[word_index] & mask, 0, "duplicate slot in put_batch");
-        masks[word_index] |= mask;
-    }
-
-    /// Takes any one available slot from the global freelist.
-    ///
-    /// On success, ownership of the returned buffer is transferred to the
-    /// caller. The buffer must be returned to this same freelist before the
-    /// freelist is finally dropped, otherwise it leaks.
-    ///
-    /// The search starts from a stable per-thread home word and scans the other
-    /// stripes only on miss. Within a word, `fetch_and` claims one bit. That is
-    /// important: unlike a full-word CAS loop, two threads removing different
-    /// bits from the same word can both succeed.
-    #[inline]
-    pub fn take(&self) -> Option<PooledBuffer> {
-        // Capture this thread's probe state once so the inner loop does not
-        // repeatedly touch thread-local storage.
-        let probe = SlotBitmapProbe::new(self.word_mask, self.word_shift);
-
-        for scanned in 0..self.words.len() {
-            let word_index = probe.word_index(scanned);
-            let word_ref = &self.words[word_index];
-            // This relaxed load only chooses candidate bits. The Acquire
-            // `fetch_and` below claims the bit if it is still present.
-            let mut word = word_ref.load(Ordering::Relaxed);
-
-            while word != 0 {
-                // Probe a thread-specific bit order inside the chosen word so
-                // colliding threads do not all stampede bit 0 first.
-                let bit = probe.select_set_bit(word);
-                let mask = 1u64 << bit;
-                let observed = word_ref.fetch_and(!mask, Ordering::Acquire);
-                if observed & mask != 0 {
-                    let slot = self.slot_index(word_index, bit);
-                    // The Acquire `fetch_and` above synchronizes with the
-                    // put-side Release operation.
-                    return Some(self.buffer(slot));
+    /// Returns one buffer starting from an already-resolved home stripe.
+    fn put_from(&self, buffer: PooledBuffer, start: usize) {
+        let mut owner_index = Some(buffer.into_owner_index());
+        loop {
+            for offset in 0..self.stripes.len() {
+                let stripe = &self.stripes[(start + offset) & self.stripe_mask];
+                let mut free = lock(&stripe.free);
+                if free.len() == stripe.limit {
+                    continue;
                 }
 
-                // Another thread removed that bit first. Reuse the returned
-                // word value instead of restarting the whole scan from the
-                // beginning.
-                word = observed & !mask;
+                let was_empty = free.is_empty();
+                debug_assert!(free.len() < free.capacity());
+                free.push(owner_index.take().expect("owner index is published once"));
+                if was_empty {
+                    stripe.available.store(true, Ordering::Release);
+                }
+                return;
+            }
+
+            // Aggregate room exists for every valid outside buffer, but racing
+            // operations can move that room during one scan.
+            thread::yield_now();
+        }
+    }
+
+    /// Returns several tracked buffers, starting from this thread's home.
+    ///
+    /// The complete batch is collected before any buffer is published.
+    /// Publication fills one hard-bounded stripe at a time.
+    ///
+    /// The iterator should not panic. Buffers yielded before a panic may leak.
+    #[inline]
+    pub fn put_batch(&self, entries: impl IntoIterator<Item = PooledBuffer>) {
+        self.put_batch_from(entries, self.home_stripe());
+    }
+
+    /// Returns several buffers using an already-resolved home stripe.
+    fn put_batch_from(
+        &self,
+        entries: impl IntoIterator<Item = PooledBuffer>,
+        start: usize,
+    ) {
+        let mut entries = entries.into_iter();
+        let Some(first) = entries.next() else {
+            return;
+        };
+        let Some(second) = entries.next() else {
+            self.put_from(first, start);
+            return;
+        };
+
+        let reserve = entries
+            .size_hint()
+            .0
+            .saturating_add(2)
+            .min(self.owners.len());
+        let mut owner_indices = Vec::with_capacity(reserve);
+        owner_indices.push(first.into_owner_index());
+        owner_indices.push(second.into_owner_index());
+        owner_indices.extend(entries.map(PooledBuffer::into_owner_index));
+
+        while !owner_indices.is_empty() {
+            let before = owner_indices.len();
+            for offset in 0..self.stripes.len() {
+                let stripe = &self.stripes[(start + offset) & self.stripe_mask];
+                let mut free = lock(&stripe.free);
+                let count = (stripe.limit - free.len()).min(owner_indices.len());
+                let was_empty = free.is_empty();
+                for _ in 0..count {
+                    debug_assert!(free.len() < free.capacity());
+                    free.push(owner_indices.pop().expect("count is bounded by length"));
+                }
+                if was_empty && count != 0 {
+                    stripe.available.store(true, Ordering::Release);
+                }
+                if owner_indices.is_empty() {
+                    return;
+                }
+            }
+
+            if owner_indices.len() == before {
+                thread::yield_now();
             }
         }
+    }
 
+    /// Takes any one globally available buffer.
+    ///
+    /// The scan reports empty only after every stripe is either known empty or
+    /// observed empty under its mutex.
+    #[inline]
+    pub fn take(&self) -> Option<PooledBuffer> {
+        self.take_from(self.home_stripe())
+    }
+
+    /// Takes one buffer using an already-resolved home stripe.
+    #[inline(always)]
+    fn take_from(&self, start: usize) -> Option<PooledBuffer> {
+        for offset in 0..self.stripes.len() {
+            let stripe = &self.stripes[(start + offset) & self.stripe_mask];
+            if !stripe.available.load(Ordering::Acquire) {
+                continue;
+            }
+            let mut free = lock(&stripe.free);
+            if let Some(owner_index) = Self::pop_locked(stripe, &mut free) {
+                drop(free);
+                return Some(self.claim(owner_index));
+            }
+        }
         None
     }
 
-    /// Takes up to `max` available slots from the global freelist.
+    /// Takes up to max globally available buffers.
     ///
-    /// Ownership of each claimed buffer is transferred to `on_entry`. Each
-    /// buffer must be returned to this same freelist before the freelist is
-    /// finally dropped, otherwise it leaks.
-    ///
-    /// `on_entry` receives each claimed buffer. This avoids internal
-    /// allocation and lets callers fill an existing spill/refill buffer
-    /// directly. `on_entry` **must not panic**: for batch claims, bits are
-    /// cleared before buffers are handed to the callback, so a panic could
-    /// strand already-claimed slots outside the freelist.
-    ///
-    /// For `max > 1`, the implementation tries to claim several bits from the
-    /// same word in a single atomic `fetch_and`, which amortizes the shared
-    /// synchronization cost across the batch.
+    /// Claimed buffers are detached while their stripe is locked. All callback
+    /// invocations happen after every lock has been released. The callback must
+    /// not panic because remaining detached buffers would be stranded.
     #[inline]
     pub fn take_batch(&self, max: usize, mut on_entry: impl FnMut(PooledBuffer)) -> usize {
+        self.take_batch_from(max, self.home_stripe(), &mut on_entry)
+    }
+
+    /// Takes a batch using an already-resolved home stripe.
+    fn take_batch_from(
+        &self,
+        max: usize,
+        start: usize,
+        mut on_entry: impl FnMut(PooledBuffer),
+    ) -> usize {
+        let max = max.min(self.owners.len());
+        if max == 0 {
+            return 0;
+        }
         if max == 1 {
-            // Keep single-slot takes on the cheaper path.
-            let Some(buffer) = self.take() else {
+            let Some(buffer) = self.take_from(start) else {
                 return 0;
             };
             on_entry(buffer);
             return 1;
         }
 
-        // Capture this thread's probe state once so the inner loop does not
-        // repeatedly touch thread-local storage.
-        let probe = SlotBitmapProbe::new(self.word_mask, self.word_shift);
-        let mut filled = 0;
-
-        for scanned in 0..self.words.len() {
-            if filled == max {
-                break;
+        let mut detached = Vec::with_capacity(max);
+        for offset in 0..self.stripes.len() {
+            let stripe = &self.stripes[(start + offset) & self.stripe_mask];
+            if !stripe.available.load(Ordering::Acquire) {
+                continue;
             }
-
-            let word_index = probe.word_index(scanned);
-            let word_ref = &self.words[word_index];
-            // This relaxed load only chooses candidate bits. The Acquire
-            // `fetch_and` below claims whichever candidates are still present.
-            let mut word = word_ref.load(Ordering::Relaxed);
-
-            while word != 0 && filled < max {
-                // Stage several candidate bits from the current word, then try
-                // to clear all of them with one atomic operation.
-                let claim = probe.select_set_bits(word, max - filled);
-                let observed = word_ref.fetch_and(!claim, Ordering::Acquire);
-                // `claim` is speculative. Intersect it with the observed word
-                // to keep only the bits this thread actually cleared.
-                let mut claimed = observed & claim;
-
-                while claimed != 0 {
-                    let bit = claimed.trailing_zeros() as usize;
-                    let slot = self.slot_index(word_index, bit);
-                    // These bits were cleared by the Acquire `fetch_and` above,
-                    // so each corresponding slot is now owned by this caller.
-                    on_entry(self.buffer(slot));
-                    claimed &= claimed - 1;
-                    filled += 1;
-                }
-
-                // Continue from the word snapshot returned by `fetch_and`.
-                word = observed & !claim;
+            let mut free = lock(&stripe.free);
+            while detached.len() < max {
+                let Some(owner_index) = Self::pop_locked(stripe, &mut free) else {
+                    break;
+                };
+                detached.push(owner_index);
+            }
+            if detached.len() == max {
+                break;
             }
         }
 
-        filled
+        if detached.is_empty() {
+            return 0;
+        }
+        let count = detached.len();
+        for owner_index in detached {
+            on_entry(self.claim(owner_index));
+        }
+        count
     }
 
-    /// Drops every currently available buffer from the global freelist.
+    /// Deallocates every buffer currently parked in the global freelist.
     ///
-    /// This is a teardown operation. Drained slot ids are not made available for
-    /// new creations. Buffers currently owned by a pooled backing or parked in
-    /// thread-local caches are not visible to this method and remain the
-    /// responsibility of their current owner until they are returned.
-    ///
-    /// Returns the number of drained slots.
-    #[inline]
+    /// Creation permits remain consumed. Each stripe receives an empty vector
+    /// with the same reserved capacity before detached buffers are deallocated.
     pub fn drain(&self) -> usize {
         let mut drained = 0;
 
-        for (word_index, word) in self.words.iter().enumerate() {
-            // Drain clears each whole word directly instead of using the
-            // probe-based take path. That keeps destruction independent from
-            // thread-local probe state, which may already be unavailable while
-            // TLS caches are being destroyed.
-            let mut claimed = word.swap(0, Ordering::Acquire);
+        for stripe in &self.stripes {
+            let detached = {
+                let mut free = lock(&stripe.free);
+                let detached = std::mem::replace(&mut *free, Vec::with_capacity(stripe.limit));
+                stripe.available.store(false, Ordering::Release);
+                detached
+            };
 
-            while claimed != 0 {
-                let bit = claimed.trailing_zeros() as usize;
-                let slot = self.slot_index(word_index, bit);
-                let buffer = self.buffer(slot);
-                // SAFETY: this freelist created the buffer for this slot,
-                // allocated with this freelist's layout.
+            for owner_index in detached {
+                let buffer = self.claim(owner_index);
+                // SAFETY: this freelist created the detached buffer with this
+                // exact layout and removed its owner index under lock.
                 unsafe { buffer.deallocate(self.layout) };
-                claimed &= claimed - 1;
                 drained += 1;
             }
         }
@@ -716,68 +416,55 @@ impl Freelist {
         drained
     }
 
-    /// Returns the side-table pointer for a slot id.
     #[inline(always)]
-    fn slot_ptr(&self, slot: u32) -> ptr::NonNull<PooledOwner> {
-        let cell = self
-            .slots
-            .get(slot as usize)
-            .expect("slot id must refer to an allocated slot");
-
-        cfg_if::cfg_if! {
-            if #[cfg(not(feature = "loom"))] {
-                ptr::NonNull::new(cell.get()).expect("slot pointers are non-null")
-            } else {
-                cell.with(|ptr| {
-                    ptr::NonNull::new(ptr.cast_mut()).expect("slot pointers are non-null")
-                })
-            }
-        }
+    fn owner(&self, owner_index: u32) -> ptr::NonNull<PooledOwner> {
+        let owner = self
+            .owners
+            .get(owner_index as usize)
+            .expect("owner index must belong to this freelist");
+        owner_ptr(owner)
     }
 
-    /// Rebuilds a pooled buffer handle for a claimed slot.
-    ///
-    /// The caller must have cleared the slot's free bit or freshly reserved
-    /// the slot before calling this method.
+    /// Returns one stable home stripe for the current thread.
     #[inline(always)]
-    fn buffer(&self, slot: u32) -> PooledBuffer {
-        // SAFETY: the caller owns the slot and its data allocation is live.
-        let buffer = unsafe { PooledBuffer::from_owner(self.slot_ptr(slot)) };
-        // Under loom, every claim validates that the parked slot's refcount
-        // sentinel was restored before the bitmap publication.
+    fn home_stripe(&self) -> usize {
+        if self.stripe_mask == 0 {
+            return 0;
+        }
+        take_thread_id() & self.stripe_mask
+    }
+
+    /// Removes one owner index and maintains the stripe's availability hint.
+    #[inline(always)]
+    fn pop_locked(stripe: &Stripe, free: &mut MutexGuard<'_, Vec<u32>>) -> Option<u32> {
+        let Some(owner_index) = free.pop() else {
+            stripe.available.store(false, Ordering::Release);
+            return None;
+        };
+        if free.is_empty() {
+            stripe.available.store(false, Ordering::Release);
+        }
+        Some(owner_index)
+    }
+
+    /// Reconstructs unique ownership after removing an index from a stripe.
+    #[inline(always)]
+    fn claim(&self, owner_index: u32) -> PooledBuffer {
+        // SAFETY: the buffer-pool contract makes a globally stored owner index
+        // unique, and the caller removed this index from its stripe.
+        let buffer = unsafe { PooledBuffer::from_owner(self.owner(owner_index)) };
         #[cfg(feature = "loom")]
-        buffer.assert_parked_sentinel();
+        buffer.assert_unique_sentinel();
         buffer
     }
 }
 
-impl Drop for Freelist {
-    fn drop(&mut self) {
-        // Any slot still free in the freelist owns a live pooled allocation.
-        // Drain it explicitly before the side-table storage goes away.
-        self.drain();
-    }
-}
-
-/// Per-call probe state for choosing bitmap words and bits.
-///
-/// Keeping this logic in one place makes the claim path easier to read and
-/// keeps the freelist API focused on putting and taking slots.
-struct SlotBitmapProbe {
-    start_word: usize,
-    word_mask: usize,
-    bit_offset: u32,
-}
-
-// Monotonic source for per-thread probe ids.
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "loom"))] {
-        static NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+        static NEXT_TAKE_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
     } else {
         loom::lazy_static! {
-            // Loom's `AtomicUsize::new` is not const, so the modeled global
-            // counter has to be initialized through `lazy_static!`.
-            static ref NEXT_SLOT_BITMAP_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
+            static ref NEXT_TAKE_THREAD_ID: AtomicUsize = AtomicUsize::new(0);
         }
     }
 }
@@ -785,116 +472,51 @@ cfg_if::cfg_if! {
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "loom"))] {
         thread_local! {
-            // The per-thread probe id gives each thread a stable starting point for
-            // bitmap scans.
-            //
-            // Keep this const-initialized so the TLS value has no destructor. The
-            // cold path initializes the id explicitly instead of using a lazy TLS
-            // initializer.
-            static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = const { Cell::new(None) };
+            static TAKE_THREAD_ID: Cell<Option<usize>> = const { Cell::new(None) };
         }
     } else {
         loom::thread_local! {
-            // Loom's `thread_local!` macro does not accept const initializers.
-            static TLS_SLOT_BITMAP_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
+            static TAKE_THREAD_ID: Cell<Option<usize>> = Cell::new(None);
         }
     }
 }
 
-impl SlotBitmapProbe {
-    /// Builds probe state for the current thread and freelist layout.
-    ///
-    /// The thread's stable id chooses both its home word and its preferred bit
-    /// offset inside each word.
-    #[inline(always)]
-    fn new(word_mask: usize, word_shift: u32) -> Self {
-        let thread_id = TLS_SLOT_BITMAP_THREAD_ID.with(|thread_id| {
-            if let Some(id) = thread_id.get() {
-                return id;
-            }
-
-            // Relaxed ordering is enough because probe ids only spread starting
-            // points across bitmap words, they do not synchronize buffer
-            // ownership.
-            let id = NEXT_SLOT_BITMAP_THREAD_ID.fetch_add(1, Ordering::Relaxed);
-            thread_id.set(Some(id));
-            id
-        });
-
-        Self {
-            // Low id bits choose the first bitmap word this thread probes.
-            // With a power-of-two word count, masking is equivalent to modulo
-            // but avoids a division on the hot path.
-            start_word: thread_id & word_mask,
-            word_mask,
-            // Threads that share a home word should start from well-separated
-            // bits within that word.
-            bit_offset: Self::bit_offset(thread_id, word_shift),
-        }
-    }
-
-    /// Returns the bit offset for this thread's home-word collision group.
-    #[inline(always)]
-    const fn bit_offset(thread_id: usize, word_shift: u32) -> u32 {
-        // `word_shift` is `log2(word_count)`, so shifting drops the id bits
-        // used to choose the home word. Bit-reversing the low six group bits
-        // gives offsets `0, 32, 16, 48, ...`, spreading home-word collisions
-        // across the 64-bit word for power-of-two batch sizes.
-        let group = thread_id >> word_shift;
-        (group.reverse_bits() >> (usize::BITS - SLOT_BITMAP_WORD_SHIFT)) as u32
-    }
-
-    /// Returns the word index to inspect after `scanned` words.
-    #[inline(always)]
-    const fn word_index(&self, scanned: usize) -> usize {
-        (self.start_word + scanned) & self.word_mask
-    }
-
-    /// Selects one set bit from `word` using a rotated probe order.
-    ///
-    /// This probe's bit offset becomes the first position checked. The returned
-    /// index is in the original, unrotated word.
-    #[inline(always)]
-    const fn select_set_bit(&self, word: u64) -> usize {
-        // Rotate the word so the thread's preferred probe offset becomes bit 0,
-        // select the first set bit in that rotated view, then rotate the answer
-        // back into the original word numbering.
-        let rotated = word.rotate_right(self.bit_offset);
-        ((rotated.trailing_zeros() + self.bit_offset) & (SLOT_BITMAP_WORD_BITS as u32 - 1)) as usize
-    }
-
-    /// Selects up to `limit` set bits from `word` using a rotated probe order.
-    ///
-    /// The returned mask is in the original, unrotated word and can be used
-    /// directly in a `fetch_and`.
-    #[inline]
-    const fn select_set_bits(&self, word: u64, limit: usize) -> u64 {
-        // Gather up to `limit` set bits using the same rotated probe order as
-        // `select_set_bit`. The result is rotated back so callers can apply it
-        // directly as a mask against the original word.
-        let mut remaining = word.rotate_right(self.bit_offset);
-        let mut selected = 0u64;
-        let mut taken = 0;
-
-        while remaining != 0 && taken < limit {
-            let bit = remaining.trailing_zeros();
-            let mask = 1u64 << bit;
-            selected |= mask;
-            remaining &= !mask;
-            taken += 1;
+/// Returns one stable process-local id for the current thread.
+#[inline(always)]
+fn take_thread_id() -> usize {
+    TAKE_THREAD_ID.with(|thread_id| {
+        if let Some(id) = thread_id.get() {
+            return id;
         }
 
-        selected.rotate_left(self.bit_offset)
+        let id = NEXT_TAKE_THREAD_ID.fetch_add(1, Ordering::Relaxed);
+        thread_id.set(Some(id));
+        id
+    })
+}
+
+impl Drop for Freelist {
+    fn drop(&mut self) {
+        self.drain();
     }
 }
 
 #[cfg(all(test, not(feature = "loom")))]
 pub(super) mod tests {
     use super::*;
-    use commonware_utils::{NZU32, NZUsize};
-    use std::sync::{
-        Arc, Barrier,
-        atomic::{AtomicUsize as StdAtomicUsize, Ordering as AtomicOrdering},
+    use std::{
+        collections::HashSet,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicBool as StdAtomicBool, Ordering as StdOrdering},
+            mpsc,
+        },
+        time::Duration,
+    };
+
+    const TEST_LAYOUT: Layout = match Layout::from_size_align(64, 64) {
+        Ok(layout) => layout,
+        Err(_) => panic!("valid test layout"),
     };
 
     pub fn created(freelist: &Freelist) -> usize {
@@ -903,1774 +525,599 @@ pub(super) mod tests {
 
     pub fn len(freelist: &Freelist) -> usize {
         freelist
-            .words
+            .stripes
             .iter()
-            .map(|word| word.load(Ordering::Acquire).count_ones() as usize)
+            .map(|stripe| lock(&stripe.free).len())
             .sum()
     }
 
-    pub fn num_words(freelist: &Freelist) -> usize {
-        freelist.words.len()
+    pub fn num_stripes(freelist: &Freelist) -> usize {
+        freelist.stripes.len()
     }
 
-    fn reserve_by_slot(freelist: &Freelist, capacity: usize) -> Vec<Option<PooledBuffer>> {
-        let mut entries = (0..capacity).map(|_| None).collect::<Vec<_>>();
-        for _ in 0..capacity {
-            let buffer = freelist.try_create(false).expect("slot");
-            let slot = buffer.slot() as usize;
-            assert!(slot < capacity);
-            assert!(entries[slot].replace(buffer).is_none());
-        }
-        entries
+    fn lazy(capacity: u32, parallelism: usize) -> Freelist {
+        Freelist::new(
+            NonZeroU32::new(capacity).expect("positive capacity"),
+            NonZeroUsize::new(parallelism).expect("positive parallelism"),
+            TEST_LAYOUT,
+            false,
+        )
     }
 
-    const TEST_LAYOUT: Layout = match Layout::from_size_align(64, 64) {
-        Ok(layout) => layout,
-        Err(_) => unreachable!(),
-    };
-
-    #[test]
-    fn test_freelist_try_create_tracks_capacity_and_prefill() {
-        // Creation should reserve exactly the configured capacity, whether
-        // slots are created lazily or during prefill.
-        let set = Freelist::new(NZU32!(2), NZUsize!(1), TEST_LAYOUT, false);
-        assert_eq!(created(&set), 0);
-
-        // Without prefill, slots are reserved lazily as buffers are created.
-        let buffer0 = set.try_create(false).expect("first creation");
-        let buffer1 = set.try_create(false).expect("second creation");
-        let slot0 = buffer0.slot();
-        let slot1 = buffer1.slot();
-        assert_ne!(slot0, slot1);
-        assert!(slot0 < 2);
-        assert!(slot1 < 2);
-        assert_eq!(created(&set), 2);
-        let debug = format!("{buffer0:?}");
-        assert!(debug.contains("PooledBuffer"));
-        assert!(debug.contains(&format!("slot: {slot0}")));
-
-        // Slot reservation is bounded by capacity, even if the created
-        // buffers have not yet been returned to the freelist.
-        assert!(set.try_create(false).is_none());
-
-        // Returning created buffers makes them available for reuse, but does
-        // not reopen slot creation beyond the fixed capacity.
-        set.put(buffer0);
-        set.put(buffer1);
-        assert_eq!(len(&set), 2);
-
-        assert_eq!(created(&set), 2);
-        assert!(set.try_create(false).is_none());
-
-        // Prefill reserves and publishes every slot during construction. Use a
-        // partial final logical row so unused high bits would show up as extra
-        // free slots if the initialization mask were wrong.
-        let prefilled = Freelist::new(NZU32!(10), NZUsize!(4), TEST_LAYOUT, true);
-        assert_eq!(created(&prefilled), 10);
-        assert_eq!(len(&prefilled), 10);
-        assert!(prefilled.try_create(false).is_none());
-
-        let mut seen = [false; 10];
-        let mut taken = Vec::new();
-        for _ in 0..10 {
-            let buffer = prefilled.take().expect("prefilled slot");
-            let slot = buffer.slot() as usize;
-            assert!(slot < 10);
-            assert!(!seen[slot]);
-            seen[slot] = true;
-            taken.push(buffer);
-        }
-        assert!(seen.into_iter().all(|seen| seen));
-        assert!(prefilled.take().is_none());
-
-        // Return taken test buffers so the freelist owns deallocation.
-        for buffer in taken {
-            prefilled.put(buffer);
-        }
+    fn prefilled(capacity: u32, parallelism: usize) -> Freelist {
+        Freelist::new(
+            NonZeroU32::new(capacity).expect("positive capacity"),
+            NonZeroUsize::new(parallelism).expect("positive parallelism"),
+            TEST_LAYOUT,
+            true,
+        )
     }
 
-    #[test]
-    #[should_panic(expected = "returned slot must not already be marked free")]
-    fn test_freelist_put_rejects_double_return() {
-        let set = Freelist::new(NZU32!(1), NZUsize!(1), TEST_LAYOUT, false);
-        let buffer = set.try_create(false).expect("slot available");
-        // SAFETY: the duplicate handle exists only to drive the double-return
-        // assert. The second put panics before it is used further, and drain
-        // deallocates the slot exactly once afterwards.
-        let duplicate = unsafe { PooledBuffer::from_owner(set.slot_ptr(0)) };
-        set.put(buffer);
-        set.put(duplicate);
-    }
-
-    #[test]
-    #[should_panic(expected = "returned slot batch must not already contain a free slot")]
-    fn test_freelist_put_batch_rejects_double_return() {
-        // Two entries force the multi-entry `put_entries` path, whose per-word
-        // assert is separate from the single-buffer `put` assert.
-        let set = Freelist::new(NZU32!(2), NZUsize!(1), TEST_LAYOUT, false);
-        let returned = set.try_create(false).expect("returned slot");
-        let returned_slot = returned.slot();
-        let other = set.try_create(false).expect("other slot");
-
-        // SAFETY: the duplicate handle exists only to drive the batch
-        // double-return assert. put_batch panics before it is used further,
-        // and drain deallocates each slot exactly once afterwards.
-        let duplicate = unsafe { PooledBuffer::from_owner(set.slot_ptr(returned_slot)) };
-        set.put(returned);
-        set.put_batch([other, duplicate]);
-    }
-
-    #[test]
-    fn test_freelist_put_batch_rejects_duplicate_within_batch() {
-        // A duplicate inside one batch trips the staging assert before any
-        // bit is published. The panic is caught (instead of should_panic) so
-        // the staged-but-unpublished slot can be republished afterwards:
-        // leaking it is the documented panic behavior, but it would trip
-        // miri's leak check.
-        let set = Freelist::new(NZU32!(2), NZUsize!(1), TEST_LAYOUT, false);
-        let buffer = set.try_create(false).expect("slot available");
-        let slot = buffer.slot();
-
-        // SAFETY: the duplicate handle exists only to drive the staging
-        // assert. put_batch panics before publishing either handle.
-        let duplicate = unsafe { PooledBuffer::from_owner(set.slot_ptr(slot)) };
-        let panic = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            set.put_batch([buffer, duplicate]);
-        }))
-        .expect_err("duplicate slot must panic");
-        let message = panic
-            .downcast_ref::<String>()
-            .map(String::as_str)
-            .or_else(|| panic.downcast_ref::<&str>().copied())
-            .unwrap_or_default();
-        assert!(
-            message.contains("duplicate slot in put_batch"),
-            "unexpected panic: {message}"
-        );
-
-        // Republish the slot so teardown reclaims its allocation.
-        // SAFETY: `slot` was created by this freelist and is not available
-        // (the staging panic happened before its bit was inserted).
-        set.put(unsafe { PooledBuffer::from_owner(set.slot_ptr(slot)) });
-    }
-
-    #[test]
-    fn test_freelist_returns_each_slot_once() {
-        // Use a non-power-of-two capacity to cover partial final words while
-        // keeping the expected slot set easy to inspect.
-        let set = Freelist::new(NZU32!(3), NZUsize!(1), TEST_LAYOUT, false);
-
-        let buffer0 = set.try_create(false).unwrap();
-        let buffer1 = set.try_create(false).unwrap();
-        let buffer2 = set.try_create(false).unwrap();
-        let mut created = [buffer0.slot(), buffer1.slot(), buffer2.slot()];
-        created.sort_unstable();
-        assert_eq!(created, [0, 1, 2]);
-        set.put(buffer0);
-        set.put(buffer1);
-        set.put(buffer2);
-
-        // Every free slot should be returned exactly once, and the
-        // freelist should report empty afterward.
-        let mut seen = [false; 3];
-        let mut taken = Vec::new();
-        for _ in 0..3 {
-            let buffer = set.take().expect("slot should be available");
-            let slot = buffer.slot();
-            assert!(!seen[slot as usize]);
-            seen[slot as usize] = true;
-            taken.push(buffer);
-        }
-
-        assert_eq!(len(&set), 0);
-        assert!(seen.into_iter().all(|seen| seen));
-        assert!(set.take().is_none());
-
-        // Return taken test buffers so the freelist owns deallocation.
-        for buffer in taken {
-            set.put(buffer);
-        }
-    }
-
-    #[test]
-    fn test_freelist_try_create_uses_thread_probe_order() {
-        // Lazy creation should choose the same first word and bit order that
-        // this thread will later use when taking from the global freelist.
-        // Capacity 512 with parallelism 8 gives each word 64 valid bits, so
-        // the second reservation should stay in the home word instead of
-        // falling through to another stripe because of mask limits.
-        let set = Freelist::new(NZU32!(512), NZUsize!(8), TEST_LAYOUT, false);
-        let probe = SlotBitmapProbe::new(set.word_mask, set.word_shift);
-
-        // Derive the expected slot ids from this thread's stable probe state.
-        let expected0 = set.slot_index(probe.word_index(0), probe.bit_offset as usize);
-        let expected1 = set.slot_index(
-            probe.word_index(0),
-            ((probe.bit_offset + 1) & (SLOT_BITMAP_WORD_BITS as u32 - 1)) as usize,
-        );
-
-        // The first two lazy reservations should follow this thread's rotated
-        // bit order within its home word.
-        let buffer0 = set.try_create(false).expect("first probed slot");
-        let buffer1 = set.try_create(false).expect("second probed slot");
-        let slot0 = buffer0.slot();
-        let slot1 = buffer1.slot();
-        assert_eq!(slot0, expected0);
-        assert_eq!(slot1, expected1);
-
-        // Return the created buffers so the freelist owns deallocation.
-        set.put(buffer0);
-        set.put(buffer1);
-    }
-
-    #[test]
-    fn test_freelist_concurrent_try_create_reserves_unique_slots() {
-        // Multiple creators racing to grow the same size class must reserve
-        // every slot at most once and stop exactly at capacity.
-        const CAPACITY: usize = 128;
-
-        // Cover capacity-wide creation with real threads. The Loom sibling
-        // exhaustively covers same-candidate reservation races.
-        let set = Arc::new(Freelist::new(NZU32!(128), NZUsize!(16), TEST_LAYOUT, false));
-        let barrier = Arc::new(Barrier::new(16));
-        let (tx, rx) = std::sync::mpsc::channel();
-        let mut handles = Vec::new();
-
-        for _ in 0..16 {
-            let set = Arc::clone(&set);
-            let barrier = Arc::clone(&barrier);
-            let tx = tx.clone();
-            handles.push(std::thread::spawn(move || {
-                // Align creators so the reservation bitmap sees real RMW
-                // contention instead of serial thread startup.
-                barrier.wait();
-                let mut entries = Vec::new();
-                while let Some(entry) = set.try_create(false) {
-                    entries.push(entry);
-                }
-                tx.send(entries).expect("send created entries");
-            }));
-        }
-        drop(tx);
-
-        let mut entries = Vec::new();
-        let mut seen = vec![false; CAPACITY];
-        for thread_entries in rx {
-            for buffer in thread_entries {
-                // Each successful reservation must be within capacity and must
-                // be observed exactly once across all racing creators.
-                let slot = buffer.slot() as usize;
-                assert!(slot < CAPACITY);
-                assert!(!seen[slot]);
-                seen[slot] = true;
-                entries.push(buffer);
-            }
-        }
-
-        for handle in handles {
-            handle.join().expect("creator should not panic");
-        }
-
-        // Capacity should be exhausted exactly once: no missing slots, no
-        // duplicate reservations, and the created counter reflects the total.
-        assert_eq!(entries.len(), CAPACITY);
-        assert!(seen.into_iter().all(|seen| seen));
-        assert_eq!(created(&set), CAPACITY);
-
-        // Return every created buffer so the freelist owns deallocation.
-        for buffer in entries {
-            set.put(buffer);
-        }
-    }
-
-    #[test]
-    fn test_freelist_uses_striped_power_of_two_words() {
-        // Covers target parallelism, capping when capacity is too small, and
-        // capacity-driven word growth for large slot counts.
-        let cases = [
-            (1, 1, 1),
-            (2, 2, 2),
-            (3, 4, 2),
-            (4, 4, 4),
-            (12, 9, 8),
-            (16, 8, 8),
-            (64, 8, 8),
-            (512, 8, 8),
-            (513, 8, 16),
-            (4097, 8, 128),
-        ];
-
-        for (capacity, parallelism, expected_words) in cases {
-            let set = Freelist::new(NZU32!(capacity), NZUsize!(parallelism), TEST_LAYOUT, false);
-            assert_eq!(num_words(&set), expected_words);
-            assert!(num_words(&set).is_power_of_two());
-
-            // Validate the striped mapping and its inverse for every slot that
-            // can actually be handed out by this freelist.
-            for slot in 0..capacity {
-                let (word_index, mask) = set.slot_word(slot);
-                let bit = mask.trailing_zeros() as usize;
-                assert!(word_index < expected_words);
-                assert_eq!(set.slot_index(word_index, bit), slot);
+    fn take_all(freelist: &Freelist) -> Vec<PooledBuffer> {
+        let mut buffers = Vec::new();
+        loop {
+            let taken = freelist.take_batch(usize::MAX, |buffer| buffers.push(buffer));
+            if taken == 0 {
+                return buffers;
             }
         }
     }
 
     #[test]
-    fn test_freelist_put_batch_handles_empty_single_and_multi_entry_paths() {
-        // Exercise all batch insertion paths while keeping ownership explicit:
-        // empty no-op, single-entry delegation, and multi-entry coalescing.
-        let set = Freelist::new(NZU32!(8), NZUsize!(8), TEST_LAYOUT, false);
-
-        // Empty batches are a no-op and must not make anything available.
-        set.put_batch(Vec::new());
-        assert_eq!(len(&set), 0);
-
-        // Reserve the full slot range.
-        let mut created = reserve_by_slot(&set, 8);
-
-        // A single-entry batch delegates to `put`, preserving the cheaper
-        // one-buffer path.
-        let buffer = created[3].take().unwrap();
-        set.put_batch(vec![buffer]);
-        assert_eq!(len(&set), 1);
-
-        let mut taken = Vec::new();
-        assert_eq!(set.take_batch(1, |buffer| taken.push(buffer)), 1);
-        assert_eq!(taken.len(), 1);
-        assert_eq!(taken[0].slot(), 3);
-        let single = taken.pop().expect("single entry was taken");
-
-        // Multi-entry batches should make every slot available and preserve
-        // ownership of each returned buffer until it is taken.
-        let mut batch = Vec::new();
-        for slot in [1, 5, 7] {
-            let buffer = created[slot as usize].take().unwrap();
-            batch.push(buffer);
-        }
-        set.put_batch(batch);
-        assert_eq!(len(&set), 3);
-
-        assert_eq!(set.take_batch(3, |buffer| taken.push(buffer)), 3);
-        let mut slots = taken.iter().map(PooledBuffer::slot).collect::<Vec<_>>();
-        slots.sort_unstable();
-        assert_eq!(slots, vec![1, 5, 7]);
-        assert_eq!(len(&set), 0);
-
-        // Return taken test buffers so the freelist owns deallocation.
-        set.put(single);
-        for buffer in taken {
-            set.put(buffer);
-        }
-        for buffer in created.into_iter().flatten() {
-            set.put(buffer);
-        }
-    }
-
-    #[test]
-    fn test_freelist_put_batch_uses_heap_masks_when_word_count_exceeds_inline_capacity() {
-        // A capacity of 8193 requires more than 128 bitmap words after rounding,
-        // forcing `put_batch` to use heap scratch for its per-word masks.
-        let set = Freelist::new(NZU32!(8193), NZUsize!(65), TEST_LAYOUT, false);
-        assert!(num_words(&set) > INLINE_PUT_BATCH_MASKS);
-
-        // Reserve all slots so the sparse test slots are valid while only
-        // those slots are published to the freelist.
-        let mut created = reserve_by_slot(&set, 8193);
-
-        let mut batch = Vec::new();
-        for slot in [0, 1, 64, 8192] {
-            let buffer = created[slot as usize].take().expect("slot buffer");
-            batch.push(buffer);
-        }
-        set.put_batch(batch);
-        assert_eq!(len(&set), 4);
-
-        let mut taken = Vec::new();
-        assert_eq!(set.take_batch(8, |buffer| taken.push(buffer)), 4);
-        let mut slots = taken.iter().map(PooledBuffer::slot).collect::<Vec<_>>();
-        slots.sort_unstable();
-        assert_eq!(slots, vec![0, 1, 64, 8192]);
-        assert_eq!(len(&set), 0);
-
-        // Return taken test buffers so the freelist owns deallocation.
-        for buffer in taken {
-            set.put(buffer);
-        }
-        for buffer in created.into_iter().flatten() {
-            set.put(buffer);
-        }
-    }
-
-    #[test]
-    fn test_freelist_drain_returns_all_available_slots() {
-        // Drain should drop every globally available buffer while leaving
-        // outstanding created buffers owned by the caller.
-        let set = Freelist::new(NZU32!(4), NZUsize!(4), TEST_LAYOUT, false);
-        let mut entries = (0..4)
-            .map(|_| set.try_create(false).expect("slot"))
+    fn test_creation_prefill_and_drain() {
+        let set = lazy(3, 2);
+        let buffers = (0..3)
+            .map(|_| set.try_create(false).expect("creation permit"))
             .collect::<Vec<_>>();
-        assert_eq!(entries.len(), 4);
-        let held = entries.pop().expect("held entry");
-        for buffer in entries {
-            set.put(buffer);
-        }
+        assert_eq!(
+            buffers
+                .iter()
+                .map(PooledBuffer::owner_index)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert!(format!("{:?}", buffers[0]).contains("owner_index"));
+        assert!(set.try_create(false).is_none());
+        assert_eq!(created(&set), 3);
 
+        set.put_batch(buffers);
+        assert_eq!(len(&set), 3);
         assert_eq!(set.drain(), 3);
         assert_eq!(len(&set), 0);
+        assert!(set.try_create(false).is_none());
 
-        // Return taken test buffer so the freelist owns deallocation.
-        set.put(held);
+        let set = prefilled(3, 2);
+        assert_eq!(created(&set), 3);
+        assert_eq!(len(&set), 3);
+        assert!(set.try_create(false).is_none());
     }
 
     #[test]
-    fn test_freelist_take_batch_handles_zero_single_and_partial_fill() {
-        // Put fewer slots than the largest requested batch to cover exact,
-        // partial, and empty refill behavior in one setup.
-        let set = Freelist::new(NZU32!(4), NZUsize!(4), TEST_LAYOUT, false);
-        for _ in [0, 1, 2] {
-            let buffer = set.try_create(false).expect("slot");
-            set.put(buffer);
-        }
+    fn test_zeroed_creation() {
+        let set = lazy(1, 1);
+        let buffer = set.try_create(true).expect("creation permit");
+        // SAFETY: the buffer owns a live allocation with TEST_LAYOUT bytes.
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.as_ptr(), TEST_LAYOUT.size()) };
+        assert!(bytes.iter().all(|&byte| byte == 0));
+        set.put(buffer);
+    }
 
-        let mut taken = Vec::new();
-        let mut record = |buffer| taken.push(buffer);
+    #[test]
+    fn test_stripe_geometry_is_bounded_and_preallocated() {
+        assert_eq!(Freelist::stripe_count(1, usize::MAX), 1);
+        assert_eq!(Freelist::stripe_count(3, 1), 2);
+        assert_eq!(Freelist::stripe_count(12, 1), MIN_STRIPES);
+        assert_eq!(Freelist::stripe_count(12, 9), 8);
+        assert_eq!(Freelist::stripe_count(65_536, usize::MAX), MAX_STRIPES);
 
-        // `max == 0` must return immediately and must not call the callback.
-        assert_eq!(set.take_batch(0, &mut record), 0);
-
-        // `max == 1` should still claim exactly one slot.
-        assert_eq!(set.take_batch(1, &mut record), 1);
-
-        // A request larger than the remaining occupancy should return only
-        // the slots that were actually available.
-        assert_eq!(set.take_batch(8, &mut record), 2);
-
-        // Once empty, neither the batch nor single path may invoke the callback.
-        assert_eq!(set.take_batch(8, &mut record), 0);
-        assert_eq!(set.take_batch(1, &mut record), 0);
-        assert_eq!(taken.len(), 3);
-
-        let mut slots = taken.iter().map(PooledBuffer::slot).collect::<Vec<_>>();
-        slots.sort_unstable();
-        assert_eq!(slots.len(), 3);
-        assert!(slots.iter().all(|&slot| slot < 4));
-        slots.dedup();
-        assert_eq!(slots.len(), 3);
-
-        // Return taken test buffers so the freelist owns deallocation.
-        for buffer in taken {
-            set.put(buffer);
+        let set = prefilled(19, 8);
+        assert_eq!(num_stripes(&set), 8);
+        for (index, stripe) in set.stripes.iter().enumerate() {
+            let free = lock(&stripe.free);
+            let expected = Freelist::stripe_capacity(19, 8, index);
+            assert_eq!(stripe.limit, expected);
+            assert_eq!(free.len(), expected);
+            assert!(free.capacity() >= expected);
+            assert!(
+                free.iter()
+                    .all(|owner_index| *owner_index as usize & set.stripe_mask == index)
+            );
         }
     }
 
     #[test]
-    fn test_freelist_take_batch_breaks_after_filling_target_in_home_word() {
-        let set = Freelist::new(NZU32!(16), NZUsize!(8), TEST_LAYOUT, true);
-        let start_word = SlotBitmapProbe::new(set.word_mask, set.word_shift).word_index(0);
-        let slot0 = set.slot_index(start_word, 0);
-        let slot1 = set.slot_index(start_word, 1);
+    fn test_returner_home_batch_spills_past_hard_limit() {
+        let set = lazy(19, 8);
+        let home = set.home_stripe();
+        let count = set.stripes[home].limit + 1;
+        let buffers = (0..count)
+            .map(|_| set.try_create(false).expect("creation permit"))
+            .collect::<Vec<_>>();
 
-        // A two-slot batch should fill from this thread's first probed word
-        // and stop immediately.
-        let mut taken = Vec::new();
-        assert_eq!(set.take_batch(2, |buffer| taken.push(buffer)), 2);
-
-        let mut slots = taken.iter().map(PooledBuffer::slot).collect::<Vec<_>>();
-        slots.sort_unstable();
-        assert_eq!(slots, vec![slot0, slot1]);
-        assert_eq!(len(&set), 14);
-
-        // Return taken test buffers so the freelist owns deallocation.
-        for buffer in taken {
-            set.put(buffer);
-        }
+        set.put_batch(buffers);
+        assert_eq!(lock(&set.stripes[home].free).len(), set.stripes[home].limit);
+        assert_eq!(len(&set), count);
+        assert_eq!(set.drain(), count);
     }
 
     #[test]
-    fn test_freelist_take_batch_stops_mid_word_when_limit_is_reached() {
-        let set = Freelist::new(NZU32!(24), NZUsize!(8), TEST_LAYOUT, true);
-        let start_word = SlotBitmapProbe::new(set.word_mask, set.word_shift).word_index(0);
-        // This thread's first probed word contains three slots, so the batch
-        // claim has to stop after clearing only the requested number of bits.
-        let slots = [
-            set.slot_index(start_word, 0),
-            set.slot_index(start_word, 1),
-            set.slot_index(start_word, 2),
-        ];
+    fn test_put_waits_for_locked_full_home() {
+        let set = Arc::new(lazy(2, 2));
+        let first = set.try_create(false).expect("first creation permit");
+        let second = set.try_create(false).expect("second creation permit");
+        set.put_from(first, 0);
 
-        let mut taken = Vec::new();
-        assert_eq!(set.take_batch(2, |buffer| taken.push(buffer)), 2);
-        assert_eq!(len(&set), 22);
-
-        // The third slot should remain free and be retrievable normally.
-        let remaining = set.take().expect("one slot should remain free");
-        let mut seen = taken.iter().map(PooledBuffer::slot).collect::<Vec<_>>();
-        seen.push(remaining.slot());
-        seen.sort_unstable();
-        assert_eq!(seen, slots);
-
-        // Return taken test buffers so the freelist owns deallocation.
-        for buffer in taken {
-            set.put(buffer);
-        }
-        set.put(remaining);
-    }
-
-    #[test]
-    fn test_slot_bitmap_probe_selectors_respect_offset_and_limit() {
-        // The probe offset should rotate priority without selecting bits that
-        // are not present in the original word.
-        let word = (1u64 << 1) | (1u64 << 5) | (1u64 << 9) | (1u64 << 20);
-
-        let probe_0 = SlotBitmapProbe {
-            start_word: 0,
-            word_mask: 0,
-            bit_offset: 0,
-        };
-        let probe_6 = SlotBitmapProbe {
-            start_word: 0,
-            word_mask: 0,
-            bit_offset: 6,
+        let guard = lock(&set.stripes[0].free);
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker = {
+            let set = Arc::clone(&set);
+            std::thread::spawn(move || {
+                set.put_from(second, 0);
+                done_tx.send(()).expect("signal completion");
+            })
         };
 
-        assert_eq!(probe_0.select_set_bit(word), 1);
-        assert_eq!(probe_6.select_set_bit(word), 9);
-
-        let selected = probe_6.select_set_bits(word, 2);
-        // Starting after bit 6, the first two set bits are 9 and 20.
-        assert_eq!(selected.count_ones(), 2);
-        assert_eq!(selected & !word, 0);
-        assert_eq!(selected, (1u64 << 9) | (1u64 << 20));
-
-        let probe_32 = SlotBitmapProbe {
-            start_word: 0,
-            word_mask: 0,
-            bit_offset: 32,
-        };
-        let wrap_word = (1u64 << 4) | (1u64 << 40);
-        let selected = probe_32.select_set_bits(wrap_word, 2);
-        // Starting after bit 32, selection should wrap after taking bit 40.
-        assert_eq!(selected, wrap_word);
+        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(guard);
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("return must finish after home unlocks");
+        worker.join().expect("worker must not panic");
+        assert_eq!(lock(&set.stripes[1].free).len(), 1);
     }
 
     #[test]
-    fn test_slot_bitmap_probe_offsets_spread_home_word_collisions() {
-        // For an 8-word freelist, thread ids spaced by 8 share home word 0.
-        // Spread their bit offsets across the word instead of assigning
-        // adjacent offsets.
+    fn test_put_batch_waits_for_locked_full_home() {
+        let set = Arc::new(lazy(4, 2));
+        let mut buffers = (0..4).map(|_| set.try_create(false).expect("creation permit"));
+        let first = buffers.next().expect("first buffer");
+        let second = buffers.next().expect("second buffer");
+        let third = buffers.next().expect("third buffer");
+        let fourth = buffers.next().expect("fourth buffer");
+        set.put_from(first, 0);
+
+        let guard = lock(&set.stripes[0].free);
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker = {
+            let set = Arc::clone(&set);
+            std::thread::spawn(move || {
+                set.put_batch_from([second, third, fourth], 0);
+                done_tx.send(()).expect("signal completion");
+            })
+        };
+
+        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(guard);
+        done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("batch return must finish after home unlocks");
+        worker.join().expect("worker must not panic");
         assert_eq!(
-            [
-                SlotBitmapProbe::bit_offset(0, 3),
-                SlotBitmapProbe::bit_offset(8, 3),
-                SlotBitmapProbe::bit_offset(16, 3),
-                SlotBitmapProbe::bit_offset(24, 3),
-                SlotBitmapProbe::bit_offset(32, 3),
-                SlotBitmapProbe::bit_offset(40, 3),
-                SlotBitmapProbe::bit_offset(48, 3),
-                SlotBitmapProbe::bit_offset(56, 3),
-            ],
-            [0, 32, 16, 48, 8, 40, 24, 56]
-        );
-
-        // The same collision groups should spread for the 64-word network
-        // geometry.
-        assert_eq!(
-            [
-                SlotBitmapProbe::bit_offset(0, 6),
-                SlotBitmapProbe::bit_offset(64, 6),
-                SlotBitmapProbe::bit_offset(128, 6),
-                SlotBitmapProbe::bit_offset(192, 6),
-                SlotBitmapProbe::bit_offset(256, 6),
-                SlotBitmapProbe::bit_offset(320, 6),
-                SlotBitmapProbe::bit_offset(384, 6),
-                SlotBitmapProbe::bit_offset(448, 6),
-            ],
-            [0, 32, 16, 48, 8, 40, 24, 56]
+            set.stripes[1..]
+                .iter()
+                .map(|stripe| lock(&stripe.free).len())
+                .sum::<usize>(),
+            3
         );
     }
 
     #[test]
-    fn test_freelist_take_retries_after_losing_a_same_bit_race() {
-        // Force repeated same-word contention on a single free slot. Some
-        // contenders should observe a stale non-zero word and follow the retry
-        // path before discovering that another thread already claimed the slot.
-        for _ in 0..32 {
-            let set = Arc::new(Freelist::new(NZU32!(1), NZUsize!(1), TEST_LAYOUT, false));
-            let buffer = set.try_create(false).unwrap();
-            assert_eq!(buffer.slot(), 0);
-            set.put(buffer);
-
-            // Align the contenders so several can race on the same observed
-            // word instead of serializing before `take`.
-            let barrier = Arc::new(Barrier::new(16));
-            let successes = Arc::new(StdAtomicUsize::new(0));
-            let (claimed_tx, claimed_rx) = std::sync::mpsc::channel();
-            let mut handles = Vec::new();
-
-            for _ in 0..16 {
-                let set = Arc::clone(&set);
-                let barrier = Arc::clone(&barrier);
-                let successes = Arc::clone(&successes);
-                let claimed_tx = claimed_tx.clone();
-                handles.push(std::thread::spawn(move || {
-                    barrier.wait();
-                    if let Some(entry) = set.take() {
-                        successes.fetch_add(1, AtomicOrdering::Relaxed);
-                        claimed_tx.send(entry).expect("send claimed entry");
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().expect("worker should not panic");
-            }
-
-            assert_eq!(successes.load(AtomicOrdering::Relaxed), 1);
-            assert_eq!(len(&set), 0);
-
-            let claimed = claimed_rx.recv().expect("one thread claimed the slot");
-            assert!(claimed_rx.try_recv().is_err());
-            // Return the claimed buffer so the freelist owns deallocation.
-            set.put(claimed);
+    fn test_returner_homes_redistribute_fixed_owner_skew() {
+        let set = lazy(64, 8);
+        let mut outside = (0..57)
+            .map(|_| set.try_create(false).expect("creation permit"))
+            .collect::<Vec<_>>();
+        let mut skewed = Vec::new();
+        for owner_index in (0..57).step_by(8) {
+            let index = outside
+                .iter()
+                .position(|buffer| buffer.owner_index() == owner_index)
+                .expect("created skewed owner");
+            skewed.push(outside.swap_remove(index));
         }
+
+        for (home, buffer) in skewed.into_iter().enumerate() {
+            set.put_from(buffer, home);
+        }
+
+        for stripe in &set.stripes {
+            assert_eq!(lock(&stripe.free).len(), 1);
+        }
+        set.put_batch(outside);
+        assert_eq!(set.drain(), 57);
     }
 
     #[test]
-    fn test_freelist_drop_drains_remaining_buffers() {
-        // Dropping a non-empty freelist must drop any buffers still parked in
-        // globally free slots.
-        let set = Freelist::new(NZU32!(2), NZUsize!(2), TEST_LAYOUT, false);
-        for _ in [0, 1] {
-            let buffer = set.try_create(false).expect("slot");
-            set.put(buffer);
+    fn test_take_batch_scans_stripes_and_calls_back_after_unlock() {
+        let set = prefilled(8, 4);
+        let count = set.take_batch(8, |buffer| set.put(buffer));
+        assert_eq!(count, 8);
+        assert_eq!(len(&set), 8);
+        assert_eq!(set.take_batch(0, |_| unreachable!()), 0);
+    }
+
+    #[test]
+    fn test_take_waits_for_locked_stripe() {
+        let set = Arc::new(prefilled(1, 1));
+        let guard = lock(&set.stripes[0].free);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker = {
+            let set = Arc::clone(&set);
+            std::thread::spawn(move || {
+                started_tx.send(()).expect("signal start");
+                done_tx.send(set.take()).expect("send take result");
+            })
+        };
+
+        started_rx.recv().expect("worker started");
+        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(guard);
+        let buffer = done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("take must finish after unlock")
+            .expect("locked stripe must preserve its buffer");
+        worker.join().expect("worker must not panic");
+        set.put(buffer);
+    }
+
+    #[test]
+    fn test_take_waits_for_home_before_later_stripe() {
+        let set = Arc::new(prefilled(2, 2));
+        let first_guard = lock(&set.stripes[0].free);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker = {
+            let set = Arc::clone(&set);
+            std::thread::spawn(move || {
+                started_tx.send(()).expect("signal start");
+                done_tx
+                    .send(set.take_from(0))
+                    .expect("send take result");
+            })
+        };
+
+        started_rx.recv().expect("worker started");
+        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(first_guard);
+        let result = done_rx.recv_timeout(Duration::from_secs(1));
+        worker.join().expect("worker must not panic");
+
+        let buffer = result
+            .expect("take must finish after the home stripe unlocks")
+            .expect("home stripe must remain productive");
+        assert_eq!(buffer.owner_index(), 0);
+        set.put(buffer);
+    }
+
+    #[test]
+    fn test_take_batch_waits_for_home_before_later_stripe() {
+        let set = Arc::new(prefilled(2, 2));
+        let first_guard = lock(&set.stripes[0].free);
+        let (started_tx, started_rx) = mpsc::channel();
+        let (done_tx, done_rx) = mpsc::channel();
+        let worker = {
+            let set = Arc::clone(&set);
+            std::thread::spawn(move || {
+                started_tx.send(()).expect("signal start");
+                let mut buffers = Vec::new();
+                let count = set.take_batch_from(2, 0, |buffer| buffers.push(buffer));
+                done_tx
+                    .send((count, buffers))
+                    .expect("send batch result");
+            })
+        };
+
+        started_rx.recv().expect("worker started");
+        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
+        drop(first_guard);
+        let result = done_rx.recv_timeout(Duration::from_secs(1));
+        worker.join().expect("worker must not panic");
+
+        let (count, mut buffers) = result.expect("batch take must finish after home unlocks");
+        assert_eq!(count, 2);
+        buffers.sort_by_key(PooledBuffer::owner_index);
+        assert_eq!(buffers[0].owner_index(), 0);
+        assert_eq!(buffers[1].owner_index(), 1);
+        set.put_batch(buffers);
+    }
+
+    #[test]
+    fn test_concurrent_take_and_put_preserve_unique_ownership() {
+        const CAPACITY: usize = 64;
+        const THREADS: usize = 8;
+        const ROUNDS: usize = 1_000;
+
+        let set = Arc::new(prefilled(CAPACITY as u32, THREADS));
+        let outside = Arc::new(
+            (0..CAPACITY)
+                .map(|_| StdAtomicBool::new(false))
+                .collect::<Vec<_>>(),
+        );
+        let start = Arc::new(Barrier::new(THREADS));
+        let mut workers = Vec::new();
+
+        for _ in 0..THREADS {
+            let set = Arc::clone(&set);
+            let outside = Arc::clone(&outside);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                for _ in 0..ROUNDS {
+                    let buffer = loop {
+                        if let Some(buffer) = set.take() {
+                            break buffer;
+                        }
+                        std::thread::yield_now();
+                    };
+                    let owner_index = buffer.owner_index() as usize;
+                    assert!(!outside[owner_index].swap(true, StdOrdering::Relaxed));
+                    assert!(outside[owner_index].swap(false, StdOrdering::Relaxed));
+                    set.put(buffer);
+                }
+            }));
         }
-        drop(set);
+
+        for worker in workers {
+            worker.join().expect("worker must not panic");
+        }
+        assert_eq!(len(&set), CAPACITY);
+        assert_eq!(set.drain(), CAPACITY);
+    }
+
+    #[test]
+    fn test_concurrent_batches_respect_hard_stripe_limits() {
+        const CAPACITY: usize = 64;
+        const THREADS: usize = 8;
+
+        let set = Arc::new(lazy(CAPACITY as u32, THREADS));
+        let buffers = (0..CAPACITY)
+            .map(|_| set.try_create(false).expect("creation permit"))
+            .collect::<Vec<_>>();
+        let mut batches = (0..THREADS).map(|_| Vec::new()).collect::<Vec<_>>();
+        for (index, buffer) in buffers.into_iter().enumerate() {
+            batches[index % THREADS].push(buffer);
+        }
+        let start = Arc::new(Barrier::new(THREADS));
+        let mut workers = Vec::new();
+
+        for batch in batches {
+            let set = Arc::clone(&set);
+            let start = Arc::clone(&start);
+            workers.push(std::thread::spawn(move || {
+                start.wait();
+                set.put_batch(batch);
+            }));
+        }
+
+        for worker in workers {
+            worker.join().expect("worker must not panic");
+        }
+        assert_eq!(len(&set), CAPACITY);
+        for stripe in &set.stripes {
+            let free = lock(&stripe.free);
+            assert_eq!(free.len(), stripe.limit);
+            assert!(free.len() <= free.capacity());
+        }
+        assert_eq!(set.drain(), CAPACITY);
+    }
+
+    #[test]
+    fn test_concurrent_creation_assigns_unique_owners() {
+        const CAPACITY: usize = 64;
+        let set = Arc::new(lazy(CAPACITY as u32, 8));
+        let mut workers = Vec::new();
+        for _ in 0..8 {
+            let set = Arc::clone(&set);
+            workers.push(std::thread::spawn(move || {
+                let mut owner_indices = Vec::new();
+                while let Some(buffer) = set.try_create(false) {
+                    owner_indices.push(buffer.owner_index());
+                    set.put(buffer);
+                }
+                owner_indices
+            }));
+        }
+
+        let owner_indices = workers
+            .into_iter()
+            .flat_map(|worker| worker.join().expect("worker must not panic"))
+            .collect::<HashSet<_>>();
+        assert_eq!(owner_indices.len(), CAPACITY);
+        assert_eq!(created(&set), CAPACITY);
+        assert_eq!(len(&set), CAPACITY);
+    }
+
+    #[test]
+    fn test_drain_leaves_room_for_late_return() {
+        let set = prefilled(4, 2);
+        let outside = set.take().expect("one outside buffer");
+        assert_eq!(set.drain(), 3);
+        set.put(outside);
+        assert_eq!(set.drain(), 1);
+    }
+
+    #[test]
+    fn test_take_all_covers_every_owner_once() {
+        let set = prefilled(19, 8);
+        let buffers = take_all(&set);
+        assert_eq!(buffers.len(), 19);
+        assert_eq!(
+            buffers
+                .iter()
+                .map(PooledBuffer::owner_index)
+                .collect::<HashSet<_>>()
+                .len(),
+            19
+        );
+        set.put_batch(buffers);
+    }
+
+    #[test]
+    fn test_last_take_clears_nonempty_hint() {
+        let set = prefilled(1, 1);
+        let buffer = set.take().expect("prefilled buffer");
+        assert!(!set.stripes[0].available.load(Ordering::Relaxed));
+        assert!(set.take().is_none());
+
+        set.put(buffer);
+        assert!(set.stripes[0].available.load(Ordering::Acquire));
     }
 }
 
 #[cfg(all(test, feature = "loom"))]
 mod loom_tests {
     use super::*;
-    use commonware_utils::{NZU32, NZUsize, sync::Mutex};
-    use loom::{
-        sync::{
-            Arc,
-            atomic::{AtomicUsize, Ordering},
-        },
-        thread,
+    use commonware_utils::{NZU32, NZUsize};
+    use loom::{sync::Arc, thread};
+
+    const TEST_LAYOUT: Layout = match Layout::from_size_align(8, 8) {
+        Ok(layout) => layout,
+        Err(_) => panic!("valid test layout"),
     };
 
-    /// Tracked stand-ins for the non-atomic side-table state that bitmap
-    /// publication transfers between threads.
-    ///
-    /// The real side-table accesses escape loom's tracking (they go through
-    /// raw pointers extracted from the slot cells), so the publication models
-    /// write these cells before `put` and read them after a claim: weakening
-    /// the put-Release or take-Acquire edge makes loom report a data race
-    /// here, which the slot-accounting assertions alone cannot detect.
-    struct SlotStamps {
-        cells: Vec<UnsafeCell<usize>>,
-    }
-
-    // SAFETY: cross-thread access is what the stamps exist to check. Loom
-    // tracks every access made through `UnsafeCell::with`/`with_mut`.
-    unsafe impl Send for SlotStamps {}
-    // SAFETY: as above.
-    unsafe impl Sync for SlotStamps {}
-
-    impl SlotStamps {
-        fn new(slots: usize) -> Arc<Self> {
-            Arc::new(Self {
-                cells: (0..slots).map(|_| UnsafeCell::new(0)).collect(),
-            })
-        }
-
-        /// Stamps a slot before its owner publishes it.
-        fn write(&self, slot: u32) {
-            // SAFETY: the slot is owned by the stamping thread until `put`
-            // publishes it. Loom flags any racing access.
-            self.cells[slot as usize].with_mut(|cell| unsafe { *cell = 1 });
-        }
-
-        /// Asserts a claimed slot's stamp is visible to the claimant.
-        fn assert_visible(&self, slot: u32) {
-            // SAFETY: claiming the bit transfers slot ownership. Loom flags
-            // the read as racing if the publication edge is too weak.
-            self.cells[slot as usize].with(|cell| assert_eq!(unsafe { *cell }, 1));
-        }
-    }
-
-    // This module uses loom to model the freelist's ownership protocol between
-    // bitmap bits and side-table slots: a producer publishes a returned slot,
-    // and exactly one consumer clears that bit before rebuilding a buffer
-    // handle from the slot.
-    // The models keep capacities small so loom can exhaustively explore the
-    // interleavings that stress this protocol: same-word RMW composition,
-    // striped scans across independent bitmap words, stale relaxed candidate
-    // loads, and the Release/Acquire edge that transfers slot ownership after
-    // its bit is claimed. Geometry-matrix tests cover single-word/single-bit,
-    // single-word/multi-bit, multi-word/single-bit, and multi-word/multi-bit
-    // layouts so both degenerate and striped cases stay exercised.
-
-    fn single_word_freelist(capacity: u32) -> Freelist {
-        let layout = Layout::from_size_align(64, 64).unwrap();
-        Freelist::new(NZU32!(capacity), NZUsize!(1), layout, false)
-    }
-
-    // Each geometry gives a model a small bitmap layout: one or more active
-    // bitmap words, with either one or multiple free bits per active word.
-    // The names spell out that words-by-bits matrix.
-    #[allow(clippy::enum_variant_names)]
-    #[derive(Clone, Copy, Debug)]
-    enum Geometry {
-        SingleWordSingleBit,
-        SingleWordMultiBit,
-        MultiWordSingleBit,
-        MultiWordMultiBit,
-    }
-
-    impl Geometry {
-        // Builds a freelist with this geometry's bitmap shape.
-        fn freelist(self) -> Freelist {
-            match self {
-                Self::SingleWordSingleBit => single_word_freelist(1),
-                Self::SingleWordMultiBit => single_word_freelist(2),
-                Self::MultiWordSingleBit => {
-                    let layout = Layout::from_size_align(64, 64).unwrap();
-                    Freelist::new(NZU32!(4), NZUsize!(4), layout, false)
-                }
-                Self::MultiWordMultiBit => {
-                    let layout = Layout::from_size_align(64, 64).unwrap();
-                    Freelist::new(NZU32!(4), NZUsize!(2), layout, false)
-                }
-            }
-        }
-
-        // Returns the slot ids that are active in this geometry. Models use
-        // only the first id and the id set. The order is not significant.
-        const fn slots(self) -> &'static [u32] {
-            match self {
-                Self::SingleWordSingleBit => &[0],
-                Self::SingleWordMultiBit => &[0, 1],
-                Self::MultiWordSingleBit => &[0, 1, 2, 3],
-                Self::MultiWordMultiBit => &[0, 2, 1, 3],
-            }
-        }
-
-        // Returns a bit mask of active slot ids for duplicate and completeness
-        // checks in the models.
-        fn slot_mask(self) -> usize {
-            self.slots()
-                .iter()
-                .fold(0usize, |mask, &slot| mask | (1usize << slot))
-        }
-    }
-
-    const ALL_GEOMETRIES: [Geometry; 4] = [
-        Geometry::SingleWordSingleBit,
-        Geometry::SingleWordMultiBit,
-        Geometry::MultiWordSingleBit,
-        Geometry::MultiWordMultiBit,
-    ];
-
-    const BATCH_GEOMETRIES: [Geometry; 3] = [
-        Geometry::SingleWordMultiBit,
-        Geometry::MultiWordSingleBit,
-        Geometry::MultiWordMultiBit,
-    ];
-
-    const STRIPED_GEOMETRIES: [Geometry; 2] =
-        [Geometry::MultiWordSingleBit, Geometry::MultiWordMultiBit];
-
-    const MULTI_BIT_GEOMETRIES: [Geometry; 2] =
-        [Geometry::SingleWordMultiBit, Geometry::MultiWordMultiBit];
-
-    fn model<F>(geometries: &[Geometry], test: F)
-    where
-        F: Fn(Geometry, Arc<Freelist>) + Clone + Send + Sync + 'static,
-    {
-        for &geometry in geometries {
-            let test = test.clone();
-            loom::model(move || {
-                test(geometry, Arc::new(geometry.freelist()));
-            });
-        }
-    }
-
-    // Owns buffers that a loom model has taken from the freelist. This
-    // keeps the test-side ownership rule in one place: every created buffer
-    // must be returned to the same freelist before that freelist is dropped.
-    struct Leases {
-        freelist: Arc<Freelist>,
-        buffers: Mutex<Vec<PooledBuffer>>,
-    }
-
-    impl Leases {
-        fn new(freelist: Arc<Freelist>) -> Arc<Self> {
-            Arc::new(Self {
-                freelist,
-                buffers: Mutex::new(Vec::new()),
-            })
-        }
-
-        fn reserve(freelist: Arc<Freelist>) -> (Arc<Self>, Vec<PooledBuffer>) {
-            let entries = Self::entries(&freelist);
-            (Self::new(freelist), entries)
-        }
-
-        fn entries(freelist: &Freelist) -> Vec<PooledBuffer> {
-            let mut entries = Vec::new();
-            while let Some(entry) = freelist.try_create(false) {
-                entries.push(entry);
-            }
-            entries
-        }
-
-        fn push(&self, buffer: PooledBuffer) {
-            self.buffers.lock().push(buffer);
-        }
-
-        fn push_expected(&self, seen: &AtomicUsize, expected: usize, buffer: PooledBuffer) {
-            let slot = buffer.slot();
-            let mask = 1usize << slot;
-            assert_ne!(expected & mask, 0);
-            let previous = seen.fetch_or(mask, Ordering::Relaxed);
-            assert_eq!(previous & mask, 0);
-            self.push(buffer);
-        }
-    }
-
-    impl Drop for Leases {
-        fn drop(&mut self) {
-            for buffer in self.buffers.lock().drain(..) {
-                self.freelist.put(buffer);
-            }
-        }
+    fn prefilled(capacity: u32) -> Freelist {
+        Freelist::new(NZU32!(capacity), NZUsize!(1), TEST_LAYOUT, true)
     }
 
     #[test]
-    fn concurrent_creates_do_not_duplicate_slots() {
-        // `created` admits the two creators, then the relaxed reservation
-        // bitmap chooses their slot ids. Parallelism 1 places both slots in
-        // one word and models the smallest same-word race, where both creators
-        // may choose the same first candidate and one must continue to the
-        // remaining bit. Parallelism 2 gives each slot its own word, so a
-        // creator that claims both permits must fall through its full home
-        // word and reserve the remaining slot in the other stripe.
-        for parallelism in [1, 2] {
-            loom::model(move || {
-                let freelist = Arc::new(Freelist::new(
-                    NZU32!(2),
-                    NZUsize!(parallelism),
-                    Layout::from_size_align(64, 64).unwrap(),
-                    false,
-                ));
-                let seen = Arc::new(AtomicUsize::new(0));
-                let expected = 0b11;
-                let leases = Leases::new(freelist.clone());
-                let mut handles = Vec::new();
-
-                for _ in 0..2 {
-                    handles.push(thread::spawn({
-                        let freelist = freelist.clone();
-                        let seen = seen.clone();
-                        let leases = leases.clone();
-                        move || {
-                            while let Some(buffer) = freelist.try_create(false) {
-                                leases.push_expected(&seen, expected, buffer);
-                            }
-                        }
-                    }));
-                }
-
-                for handle in handles {
-                    handle.join().unwrap();
-                }
-
-                assert_eq!(seen.load(Ordering::Relaxed), expected);
-                assert_eq!(freelist.created.load(Ordering::Relaxed), 2);
-            });
-        }
-    }
-
-    #[test]
-    fn put_publishes_before_take() {
-        // `put` publishes the returned slot with a Release RMW. The taker
-        // spins until it can clear that bit with an Acquire RMW, then rebuilds
-        // a buffer handle from the same side-table slot. The stamp pins the
-        // publication edge itself: the producer's pre-put write must be
-        // visible and race-free to the claimant.
-        model(&ALL_GEOMETRIES, |_, freelist| {
-            let buffer = freelist.try_create(false).unwrap();
-            let slot = buffer.slot();
-            let leases = Leases::new(freelist.clone());
-            let stamps = SlotStamps::new(4);
-
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                let stamps = stamps.clone();
-                move || {
-                    stamps.write(slot);
-                    freelist.put(buffer)
-                }
-            });
-
-            let reader = thread::spawn({
-                let leases = leases.clone();
-                move || loop {
-                    if let Some(buffer) = freelist.take() {
-                        assert_eq!(buffer.slot(), slot);
-                        stamps.assert_visible(slot);
-                        leases.push(buffer);
-                        break;
-                    }
-                    thread::yield_now();
-                }
-            });
-
-            writer.join().unwrap();
-            reader.join().unwrap();
-
-            // Keep the taken buffers checked out until the model is done:
-            // Leases returns them to the freelist on drop.
-            drop(leases);
-        });
-    }
-
-    #[test]
-    fn concurrent_puts_merge_disjoint_bits() {
-        // Two producers return different slots that live in the same bitmap
-        // word. Their atomic `fetch_or` operations must merge the bits: neither
-        // producer may overwrite the other's publication.
-        //
-        // The consumer runs after both producers finish so this test isolates
-        // lost producer updates from consumer-side claim races and from the
-        // publish/claim visibility tests below.
+    fn completed_put_is_discoverable() {
         loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(2));
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = 0b11;
-            let (leases, mut entries) = Leases::reserve(freelist.clone());
-            let buffer0 = entries.pop().unwrap();
-            let buffer1 = entries.pop().unwrap();
+            let set = Arc::new(Freelist::new(NZU32!(1), NZUsize!(1), TEST_LAYOUT, false));
+            let buffer = set.try_create(false).expect("creation permit");
+            let returned = Arc::new(AtomicBool::new(false));
 
-            let first = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put(buffer0)
-            });
+            let worker = {
+                let set = Arc::clone(&set);
+                let returned = Arc::clone(&returned);
+                thread::spawn(move || {
+                    set.put(buffer);
+                    returned.store(true, Ordering::Release);
+                })
+            };
 
-            let second = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put(buffer1)
-            });
-
-            first.join().unwrap();
-            second.join().unwrap();
-
-            assert_eq!(
-                freelist.take_batch(2, |buffer| {
-                    leases.push_expected(&seen, expected, buffer)
-                }),
-                2
-            );
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
+            while !returned.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            let buffer = set.take().expect("completed put must be found");
+            worker.join().expect("worker must not panic");
+            set.put(buffer);
         });
     }
 
     #[test]
-    fn concurrent_put_batches_merge_disjoint_bits() {
-        // Each producer stages two slots and then publishes its per-word mask
-        // with one Release `fetch_or`. Because all four slots share a word,
-        // this specifically checks that two batch producers merge their masks
-        // instead of losing either batch.
+    fn two_takers_cannot_claim_one_owner() {
         loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(4));
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = 0b1111;
-            let (leases, mut entries) = Leases::reserve(freelist.clone());
-            let second_entries = entries.split_off(2);
+            let set = Arc::new(prefilled(1));
+            let first = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.take())
+            };
+            let second = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.take())
+            };
 
-            let first = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put_batch(entries)
-            });
-
-            let second = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put_batch(second_entries)
-            });
-
-            first.join().unwrap();
-            second.join().unwrap();
-
-            assert_eq!(
-                freelist.take_batch(4, |buffer| {
-                    leases.push_expected(&seen, expected, buffer)
-                }),
-                4
-            );
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
+            let first = first.join().expect("first taker must not panic");
+            let second = second.join().expect("second taker must not panic");
+            assert_ne!(first.is_some(), second.is_some());
+            set.put(first.or(second).expect("one taker must succeed"));
         });
     }
 
     #[test]
-    fn put_and_take_compose_on_partially_free_word() {
-        // One slot starts free, then a producer returns another slot while
-        // `take` races on the same bitmap word. The producer's `fetch_or` must
-        // compose with the consumer's `fetch_and`: clearing the existing bit
-        // must not lose the newly published bit, and publishing the new bit
-        // must not resurrect a claimed bit.
+    fn concurrent_puts_preserve_both_owners() {
         loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(2));
-            let (leases, mut entries) = Leases::reserve(freelist.clone());
-            let initial_entry = entries.pop().unwrap();
-            let writer_entry = entries.pop().unwrap();
-            assert!(entries.pop().is_none());
-            freelist.put(initial_entry);
+            let set = Arc::new(Freelist::new(NZU32!(2), NZUsize!(1), TEST_LAYOUT, false));
+            let first = set.try_create(false).expect("first permit");
+            let second = set.try_create(false).expect("second permit");
 
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = 0b11;
+            let first_put = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(first))
+            };
+            let second_put = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put(second))
+            };
+            first_put.join().expect("first put must not panic");
+            second_put.join().expect("second put must not panic");
 
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put(writer_entry)
-            });
-
-            let taker = thread::spawn({
-                let freelist = freelist.clone();
-                let seen = seen.clone();
-                let leases = leases.clone();
-                move || {
-                    let buffer = freelist.take().expect("slot 0 starts free");
-                    leases.push_expected(&seen, expected, buffer);
-                }
-            });
-
-            writer.join().unwrap();
-            taker.join().unwrap();
-
-            // The taker may run before slot 1 is published. After the writer
-            // has joined, any slot not claimed during the race must still be
-            // available exactly once.
-            while let Some(buffer) = freelist.take() {
-                leases.push_expected(&seen, expected, buffer);
-            }
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
+            let first = set.take().expect("first owner");
+            let second = set.take().expect("second owner");
+            assert_ne!(first.owner_index(), second.owner_index());
+            set.put_batch([first, second]);
         });
     }
 
     #[test]
-    fn put_and_take_batch_compose_on_partially_free_word() {
-        // This is the batch-claim version of the partially-free word race:
-        // `take_batch` may speculatively choose candidates from a stale relaxed
-        // load while a producer publishes a different bit in the same word.
-        // Only bits actually cleared by the batch taker may drive callbacks,
-        // and missed bits must remain available.
+    fn locked_stripe_is_not_reported_empty() {
         loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(2));
-            let (leases, mut entries) = Leases::reserve(freelist.clone());
-            let initial_entry = entries.pop().unwrap();
-            let writer_entry = entries.pop().unwrap();
-            assert!(entries.pop().is_none());
-            freelist.put(initial_entry);
+            let set = Arc::new(prefilled(1));
+            let guard = lock(&set.stripes[0].free);
+            let taker = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.take())
+            };
+            thread::yield_now();
+            drop(guard);
 
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = 0b11;
-
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put(writer_entry)
-            });
-
-            let batch_taker = thread::spawn({
-                let freelist = freelist.clone();
-                let seen = seen.clone();
-                let leases = leases.clone();
-                move || {
-                    let count = freelist.take_batch(2, |buffer| {
-                        leases.push_expected(&seen, expected, buffer);
-                    });
-                    assert!((1..=2).contains(&count));
-                }
-            });
-
-            writer.join().unwrap();
-            batch_taker.join().unwrap();
-
-            // If the batch taker ran before slot 1 was published, the slot must
-            // still be visible after the writer completes.
-            while let Some(buffer) = freelist.take() {
-                leases.push_expected(&seen, expected, buffer);
-            }
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
+            let buffer = taker
+                .join()
+                .expect("taker must not panic")
+                .expect("locked stripe must not be missed");
+            set.put(buffer);
         });
     }
 
     #[test]
-    fn put_batch_and_drain_compose_on_partially_free_word() {
-        // One slot starts free, then a batch producer stages two more slots and
-        // publishes them with one `fetch_or`. A concurrent `drain` clears the
-        // whole word with `swap(0)`. The two RMWs must compose: the drainer may
-        // get only the initial slot or all three slots, but the slots it misses
-        // must remain available after the writer completes.
+    fn return_waits_for_locked_full_home() {
         loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(3));
-            let mut entries = Leases::entries(&freelist);
-            let writer_entry0 = entries.pop().unwrap();
-            let writer_entry1 = entries.pop().unwrap();
-            let initial_entry = entries.pop().unwrap();
-            assert!(entries.pop().is_none());
-            freelist.put(initial_entry);
+            let set = Arc::new(Freelist::new(
+                NZU32!(2),
+                NZUsize!(2),
+                TEST_LAYOUT,
+                false,
+            ));
+            let first = set.try_create(false).expect("first creation permit");
+            let second = set.try_create(false).expect("second creation permit");
+            set.put_from(first, 0);
 
-            let drained = Arc::new(AtomicUsize::new(0));
+            let guard = lock(&set.stripes[0].free);
+            let returner = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.put_from(second, 0))
+            };
+            thread::yield_now();
+            drop(guard);
+            returner.join().expect("returner must not panic");
 
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put_batch([writer_entry0, writer_entry1])
-            });
-
-            let drainer = thread::spawn({
-                let freelist = freelist.clone();
-                let drained = drained.clone();
-                move || {
-                    let count = freelist.drain();
-                    assert!(matches!(count, 1 | 3));
-                    drained.store(count, Ordering::Relaxed);
-                }
-            });
-
-            writer.join().unwrap();
-            drainer.join().unwrap();
-
-            let total = drained.load(Ordering::Relaxed) + freelist.drain();
-            assert_eq!(total, 3);
-            assert_eq!(freelist.drain(), 0);
+            let first = set.take().expect("first returned buffer");
+            let second = set.take().expect("second returned buffer");
+            set.put_batch([first, second]);
         });
     }
 
     #[test]
-    fn two_takers_cannot_claim_one_slot() {
-        // Both takers may observe the same relaxed non-zero candidate word.
-        // Only one may win the later `fetch_and` claim.
-        //
-        // This is the minimal stale-candidate case: the relaxed load is allowed
-        // to be old, but the returned value from `fetch_and` must decide
-        // ownership.
+    fn take_and_drain_partition_owners() {
         loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(2));
-            let buffer = freelist.try_create(false).unwrap();
-            let created_slot = buffer.slot();
-            freelist.put(buffer);
+            let set = Arc::new(prefilled(2));
+            let taker = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.take())
+            };
+            let drainer = {
+                let set = Arc::clone(&set);
+                thread::spawn(move || set.drain())
+            };
 
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = 1usize << created_slot;
-            let mut handles = Vec::new();
-            let leases = Leases::new(freelist.clone());
-
-            for _ in 0..2 {
-                handles.push(thread::spawn({
-                    let freelist = freelist.clone();
-                    let seen = seen.clone();
-                    let leases = leases.clone();
-                    move || {
-                        if let Some(buffer) = freelist.take() {
-                            leases.push_expected(&seen, expected, buffer);
-                        }
-                    }
-                }));
+            let taken = taker.join().expect("taker must not panic");
+            let drained = drainer.join().expect("drainer must not panic");
+            assert_eq!(usize::from(taken.is_some()) + drained, 2);
+            if let Some(buffer) = taken {
+                set.put(buffer);
+                assert_eq!(set.drain(), 1);
             }
-
-            for handle in handles {
-                handle.join().unwrap();
-            }
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-        });
-    }
-
-    #[test]
-    fn stale_candidate_can_claim_republished_same_slot() {
-        // A relaxed candidate load is not a reservation. One taker may observe
-        // slot 0 as free, lose the first claim race, and later clear a
-        // re-published bit for the same slot. The valid outcome is two
-        // sequential ownership transfers of slot 0, each synchronized by the
-        // Acquire claim that actually cleared the bit it returns.
-        loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(1));
-            let (leases, mut entries) = Leases::reserve(freelist.clone());
-            let entry = entries.pop().unwrap();
-            assert!(entries.pop().is_none());
-            freelist.put(entry);
-
-            let transfers = Arc::new(AtomicUsize::new(0));
-            let mut handles = Vec::new();
-
-            for _ in 0..2 {
-                handles.push(thread::spawn({
-                    let freelist = freelist.clone();
-                    let transfers = transfers.clone();
-                    let leases = leases.clone();
-                    move || loop {
-                        if let Some(buffer) = freelist.take() {
-                            let slot = buffer.slot();
-                            assert_eq!(slot, 0);
-                            let transfer = transfers.fetch_add(1, Ordering::Relaxed) + 1;
-                            if transfer == 1 {
-                                freelist.put(buffer);
-                            } else {
-                                leases.push(buffer);
-                            }
-                            break;
-                        }
-                        thread::yield_now();
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().unwrap();
-            }
-
-            assert_eq!(transfers.load(Ordering::Relaxed), 2);
-            assert_eq!(freelist.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn batch_claims_survive_intervening_rmw_sequence() {
-        // `put_batch` publishes both bits with one Release RMW. This model
-        // starts takers after publication to keep the state space small. The
-        // writer/reader visibility edge for batch publication is covered by
-        // `put_batch_publishes_to_take_batch`.
-        //
-        // What this case isolates is the two-taker claim sequence on the same
-        // word: one taker may clear one bit, then the other taker reads the
-        // word through that intervening RMW. Both slots must still be
-        // transferred exactly once.
-        loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(2));
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            freelist.put_batch(entries);
-
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = 0b11;
-            let mut handles = Vec::new();
-
-            for _ in 0..2 {
-                handles.push(thread::spawn({
-                    let freelist = freelist.clone();
-                    let seen = seen.clone();
-                    let leases = leases.clone();
-                    move || {
-                        if let Some(buffer) = freelist.take() {
-                            leases.push_expected(&seen, expected, buffer);
-                        }
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().unwrap();
-            }
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-        });
-    }
-
-    #[test]
-    fn take_and_take_batch_do_not_duplicate_slots() {
-        // A single-slot claim and a batch claim race over the same free set.
-        // Each claimed slot is recorded once, any duplicate ownership transfer
-        // trips the `previous & mask == 0` assertion.
-        //
-        // This covers the speculative batch claim path, where `take_batch`
-        // first chooses candidate bits and then intersects them with the word
-        // value returned by `fetch_and`.
-        model(&BATCH_GEOMETRIES, |geometry, freelist| {
-            let slots = geometry.slots();
-            let expected = geometry.slot_mask();
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            freelist.put_batch(entries);
-
-            let seen = Arc::new(AtomicUsize::new(0));
-            let batch_count = Arc::new(AtomicUsize::new(0));
-            let batch_callbacks = Arc::new(AtomicUsize::new(0));
-
-            let batch_taker = thread::spawn({
-                let freelist = freelist.clone();
-                let seen = seen.clone();
-                let batch_count = batch_count.clone();
-                let batch_callbacks = batch_callbacks.clone();
-                let leases = leases.clone();
-                move || {
-                    let count = freelist.take_batch(slots.len(), |buffer| {
-                        batch_callbacks.fetch_add(1, Ordering::Relaxed);
-                        leases.push_expected(&seen, expected, buffer);
-                    });
-                    batch_count.store(count, Ordering::Relaxed);
-                }
-            });
-
-            let single_taker = thread::spawn({
-                let seen = seen.clone();
-                let leases = leases.clone();
-                move || {
-                    if let Some(buffer) = freelist.take() {
-                        leases.push_expected(&seen, expected, buffer);
-                    }
-                }
-            });
-
-            batch_taker.join().unwrap();
-            single_taker.join().unwrap();
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert!(batch_count.load(Ordering::Relaxed) <= slots.len());
-            assert_eq!(
-                batch_count.load(Ordering::Relaxed),
-                batch_callbacks.load(Ordering::Relaxed)
-            );
-
-            // Keep the taken buffers checked out until the model is done:
-            // Leases returns them to the freelist on drop.
-            drop(leases);
-        });
-    }
-
-    #[test]
-    fn two_take_batches_do_not_duplicate_slots() {
-        // Two batch refill paths can speculatively choose stale candidate bits
-        // from relaxed word loads. Each callback must still be driven only by
-        // bits that caller actually cleared with `fetch_and`.
-        model(&MULTI_BIT_GEOMETRIES, |geometry, freelist| {
-            let slots = geometry.slots();
-            let expected = geometry.slot_mask();
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            freelist.put_batch(entries);
-
-            let seen = Arc::new(AtomicUsize::new(0));
-            let total = Arc::new(AtomicUsize::new(0));
-            let mut handles = Vec::new();
-
-            for _ in 0..2 {
-                handles.push(thread::spawn({
-                    let freelist = freelist.clone();
-                    let seen = seen.clone();
-                    let total = total.clone();
-                    let leases = leases.clone();
-                    move || {
-                        let count = freelist.take_batch(slots.len(), |buffer| {
-                            leases.push_expected(&seen, expected, buffer);
-                        });
-                        total.fetch_add(count, Ordering::Relaxed);
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().unwrap();
-            }
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(total.load(Ordering::Relaxed), slots.len());
-        });
-    }
-
-    #[test]
-    fn two_take_batches_continue_after_losing_selected_bits() {
-        // Both batch takers can speculatively select the same first two bits
-        // from a stale relaxed word load. If one taker clears those bits first,
-        // the other must use the word value returned by `fetch_and` and
-        // continue on to the still-set third bit instead of stopping after a
-        // zero-sized successful claim.
-        loom::model(|| {
-            let freelist = Arc::new(single_word_freelist(3));
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            freelist.put_batch(entries);
-
-            let seen = Arc::new(AtomicUsize::new(0));
-            let total = Arc::new(AtomicUsize::new(0));
-            let expected = 0b111;
-            let mut handles = Vec::new();
-
-            for _ in 0..2 {
-                handles.push(thread::spawn({
-                    let freelist = freelist.clone();
-                    let seen = seen.clone();
-                    let total = total.clone();
-                    let leases = leases.clone();
-                    move || {
-                        let count = freelist.take_batch(2, |buffer| {
-                            leases.push_expected(&seen, expected, buffer);
-                        });
-                        total.fetch_add(count, Ordering::Relaxed);
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().unwrap();
-            }
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(total.load(Ordering::Relaxed), 3);
-            assert_eq!(freelist.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn put_batch_publishes_to_take_batch() {
-        // This exercises the batch-specific publish and claim path end to end
-        // across selected bitmap geometries: Release `fetch_or` publications
-        // make returned slots visible, and Acquire `fetch_and` claims may
-        // transfer one or more bits per word.
-        //
-        // The reader loops because loom may run it before the writer has
-        // published anything. A zero-sized claim is just a retry, not an
-        // observable failure.
-        //
-        // Per-slot stamps pin the batch publication edge: every staged slot's
-        // pre-publish write must be visible and race-free to whichever
-        // claimant ends up with that slot.
-        model(&BATCH_GEOMETRIES, |geometry, freelist| {
-            let seen = Arc::new(AtomicUsize::new(0));
-            let slots = geometry.slots();
-            let expected = geometry.slot_mask();
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            let stamps = SlotStamps::new(4);
-
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                let stamps = stamps.clone();
-                move || {
-                    for entry in &entries {
-                        stamps.write(entry.slot());
-                    }
-                    freelist.put_batch(entries)
-                }
-            });
-
-            let reader = thread::spawn({
-                let seen = seen.clone();
-                let leases = leases.clone();
-                move || {
-                    while seen.load(Ordering::Relaxed) != expected {
-                        let claimed = freelist.take_batch(slots.len(), |buffer| {
-                            stamps.assert_visible(buffer.slot());
-                            leases.push_expected(&seen, expected, buffer);
-                        });
-
-                        if claimed == 0 {
-                            thread::yield_now();
-                        }
-                    }
-                }
-            });
-
-            writer.join().unwrap();
-            reader.join().unwrap();
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-
-            // Keep the taken buffers checked out until the model is done:
-            // Leases returns them to the freelist on drop.
-            drop(leases);
-        });
-    }
-
-    #[test]
-    fn put_publishes_to_drain() {
-        // `drain` uses an Acquire whole-word swap. Run it concurrently with
-        // publication so this model checks the put-side Release edge rather
-        // than relying on thread-spawn visibility from pre-populated state.
-        //
-        // If the swap does not compose with the successful put, the model can
-        // lose or duplicate the returned slot.
-        model(&ALL_GEOMETRIES, |_, freelist| {
-            let drained = Arc::new(AtomicUsize::new(0));
-            let buffer = freelist.try_create(false).unwrap();
-            let slot = buffer.slot();
-            let stamps = SlotStamps::new(4);
-
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                let stamps = stamps.clone();
-                move || {
-                    stamps.write(slot);
-                    freelist.put(buffer)
-                }
-            });
-
-            let drainer = thread::spawn({
-                let freelist = freelist.clone();
-                let drained = drained.clone();
-                move || {
-                    while drained.load(Ordering::Relaxed) == 0 {
-                        let count = freelist.drain();
-                        if count == 0 {
-                            // The drainer may run before the writer publishes.
-                            // A zero drain is a retry, not a failed assertion.
-                            thread::yield_now();
-                        } else {
-                            assert_eq!(count, 1);
-                            // The Acquire swap must make the producer's
-                            // pre-put write visible to the draining thread.
-                            stamps.assert_visible(slot);
-                            drained.store(count, Ordering::Relaxed);
-                        }
-                    }
-                }
-            });
-
-            writer.join().unwrap();
-            drainer.join().unwrap();
-
-            assert_eq!(drained.load(Ordering::Relaxed), 1);
-            assert_eq!(freelist.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn put_batch_publishes_to_drain() {
-        // A batch publish stages multiple returned slots before publishing the
-        // touched bitmap word masks. The drainer loops until its Acquire swaps
-        // have observed every publication and dropped every returned buffer.
-        //
-        // This is the drain analogue of `put_batch_publishes_to_take_batch`:
-        // each whole-word swap must claim all slots represented by the returned
-        // word exactly once before they are dropped.
-        model(&BATCH_GEOMETRIES, |geometry, freelist| {
-            let drained = Arc::new(AtomicUsize::new(0));
-            let slots = geometry.slots();
-            let expected = slots.len();
-            let entries = Leases::entries(&freelist);
-
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                move || freelist.put_batch(entries)
-            });
-
-            let drainer = thread::spawn({
-                let freelist = freelist.clone();
-                let drained = drained.clone();
-                move || {
-                    while drained.load(Ordering::Relaxed) < expected {
-                        let count = freelist.drain();
-                        if count == 0 {
-                            // The drainer may run before the batch is published.
-                            thread::yield_now();
-                        } else {
-                            let previous = drained.fetch_add(count, Ordering::Relaxed);
-                            assert!(previous + count <= expected);
-                        }
-                    }
-                }
-            });
-
-            writer.join().unwrap();
-            drainer.join().unwrap();
-
-            assert_eq!(drained.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn puts_and_take_scan_across_stripes() {
-        // Publish slots across multiple bitmap words using the single-entry
-        // `put` path. The reader uses repeated `take` calls, not `take_batch`,
-        // so this checks that the single-slot scan path reaches every occupied
-        // stripe and that each independent Release publication synchronizes
-        // with the later Acquire claim.
-        model(&STRIPED_GEOMETRIES, |geometry, freelist| {
-            let seen = Arc::new(AtomicUsize::new(0));
-            let expected = geometry.slot_mask();
-            let (leases, entries) = Leases::reserve(freelist.clone());
-
-            let writer = thread::spawn({
-                let freelist = freelist.clone();
-                move || {
-                    for buffer in entries {
-                        freelist.put(buffer);
-                    }
-                }
-            });
-
-            let reader = thread::spawn({
-                let freelist = freelist.clone();
-                let seen = seen.clone();
-                let leases = leases.clone();
-                move || {
-                    while seen.load(Ordering::Relaxed) != expected {
-                        if let Some(buffer) = freelist.take() {
-                            leases.push_expected(&seen, expected, buffer);
-                        } else {
-                            thread::yield_now();
-                        }
-                    }
-                }
-            });
-
-            writer.join().unwrap();
-            reader.join().unwrap();
-
-            assert_eq!(seen.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
-
-            // Keep the taken buffers checked out until the model is done:
-            // Leases returns them to the freelist on drop.
-            drop(leases);
-        });
-    }
-
-    #[test]
-    fn drain_and_take_do_not_duplicate_or_lose_slots() {
-        // `drain` clears a whole word with `swap(0)` while `take` clears one
-        // bit with `fetch_and`. Racing them should transfer ownership of each
-        // globally free buffer exactly once and leave no free bits behind.
-        //
-        // This also covers the synchronization shape used by `Drop`, which
-        // drains any buffers that remain globally free.
-        model(&BATCH_GEOMETRIES, |geometry, freelist| {
-            let slots = geometry.slots();
-            let expected = slots.len();
-            let expected_mask = geometry.slot_mask();
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            freelist.put_batch(entries);
-
-            let drained = Arc::new(AtomicUsize::new(0));
-            let taken = Arc::new(AtomicUsize::new(0));
-
-            let drainer = thread::spawn({
-                let freelist = freelist.clone();
-                let drained = drained.clone();
-                move || {
-                    drained.store(freelist.drain(), Ordering::Relaxed);
-                }
-            });
-
-            let taker = thread::spawn({
-                let freelist = freelist.clone();
-                let taken = taken.clone();
-                let leases = leases.clone();
-                move || {
-                    if let Some(buffer) = freelist.take() {
-                        leases.push_expected(&taken, expected_mask, buffer);
-                    }
-                }
-            });
-
-            drainer.join().unwrap();
-            taker.join().unwrap();
-
-            assert_eq!(freelist.drain(), 0);
-            assert_eq!(
-                drained.load(Ordering::Relaxed)
-                    + taken.load(Ordering::Relaxed).count_ones() as usize,
-                expected
-            );
-
-            // Keep the taken buffers checked out until the model is done:
-            // Leases returns them to the freelist on drop.
-            drop(leases);
-        });
-    }
-
-    #[test]
-    fn two_drains_do_not_duplicate_or_lose_slots() {
-        // `drain` is a public whole-word `swap(0)` operation over every bitmap
-        // word. Two drainers racing over the same free set must split ownership
-        // according to the values returned by their swaps, and the total must
-        // be exactly the original occupancy.
-        model(&BATCH_GEOMETRIES, |geometry, freelist| {
-            let slots = geometry.slots();
-            let expected = slots.len();
-            let entries = Leases::entries(&freelist);
-            freelist.put_batch(entries);
-
-            let total = Arc::new(AtomicUsize::new(0));
-            let mut handles = Vec::new();
-
-            for _ in 0..2 {
-                handles.push(thread::spawn({
-                    let freelist = freelist.clone();
-                    let total = total.clone();
-                    move || {
-                        total.fetch_add(freelist.drain(), Ordering::Relaxed);
-                    }
-                }));
-            }
-
-            for handle in handles {
-                handle.join().unwrap();
-            }
-
-            assert_eq!(total.load(Ordering::Relaxed), expected);
-            assert_eq!(freelist.drain(), 0);
-        });
-    }
-
-    #[test]
-    fn drain_and_take_batch_do_not_duplicate_or_lose_slots() {
-        // This is the same whole-word `swap(0)` race as the single-slot drain
-        // test, but the competing operation clears a speculative multi-bit
-        // claim. It makes sure `take_batch` uses the word value returned by
-        // `fetch_and`, not just the earlier relaxed load.
-        model(&BATCH_GEOMETRIES, |geometry, freelist| {
-            let slots = geometry.slots();
-            let expected = slots.len();
-            let expected_mask = geometry.slot_mask();
-            let (leases, entries) = Leases::reserve(freelist.clone());
-            freelist.put_batch(entries);
-
-            let drained = Arc::new(AtomicUsize::new(0));
-            let taken = Arc::new(AtomicUsize::new(0));
-            let taken_slots = Arc::new(AtomicUsize::new(0));
-
-            let drainer = thread::spawn({
-                let freelist = freelist.clone();
-                let drained = drained.clone();
-                move || {
-                    drained.store(freelist.drain(), Ordering::Relaxed);
-                }
-            });
-
-            let batch_taker = thread::spawn({
-                let freelist = freelist.clone();
-                let taken = taken.clone();
-                let taken_slots = taken_slots.clone();
-                let leases = leases.clone();
-                move || {
-                    let count = freelist.take_batch(expected, |buffer| {
-                        leases.push_expected(&taken_slots, expected_mask, buffer);
-                    });
-                    taken.store(count, Ordering::Relaxed);
-                }
-            });
-
-            drainer.join().unwrap();
-            batch_taker.join().unwrap();
-
-            assert_eq!(freelist.drain(), 0);
-            assert_eq!(
-                taken.load(Ordering::Relaxed),
-                taken_slots.load(Ordering::Relaxed).count_ones() as usize
-            );
-            assert_eq!(
-                drained.load(Ordering::Relaxed) + taken.load(Ordering::Relaxed),
-                expected
-            );
-
-            // Keep the taken buffers checked out until the model is done:
-            // Leases returns them to the freelist on drop.
-            drop(leases);
         });
     }
 }

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -570,6 +570,14 @@ impl Freelist {
     }
 }
 
+impl Drop for Freelist {
+    fn drop(&mut self) {
+        // Outstanding slots keep the size class alive, so only globally parked
+        // buffers can remain when the final freelist reference is dropped.
+        self.drain();
+    }
+}
+
 cfg_if::cfg_if! {
     if #[cfg(not(feature = "loom"))] {
         /// Next process-local id assigned to a thread that touches a freelist.
@@ -612,15 +620,6 @@ fn current_thread_id() -> usize {
     })
 }
 
-impl Drop for Freelist {
-    fn drop(&mut self) {
-        // Outstanding slots keep the size class alive, so only globally parked
-        // buffers can remain when the final freelist reference is dropped.
-        self.drain();
-    }
-}
-
-/// Native unit tests and helpers shared with buffer-pool tests.
 #[cfg(all(test, not(feature = "loom")))]
 pub(super) mod tests {
     use super::*;
@@ -1133,7 +1132,6 @@ pub(super) mod tests {
     }
 }
 
-/// Exhaustive concurrency models for freelist ownership transfers.
 #[cfg(all(test, feature = "loom"))]
 mod loom_tests {
     use super::*;

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -162,15 +162,12 @@ impl Stripe {
     /// `free` must be the guard obtained from [`Self::lock`] for this stripe.
     #[inline(always)]
     fn pop(&self, free: &mut MutexGuard<'_, Vec<u32>>) -> Option<u32> {
-        let Some(slot) = free.pop() else {
-            // A taker can load `true` before another taker removes the final
-            // slot. Reconfirm the now-authoritative empty state for later scans.
-            self.available.store(false, Ordering::Release);
-            return None;
-        };
+        // A taker can load `true` before another taker removes the final slot,
+        // so the locked vector may already be empty.
+        let slot = free.pop()?;
 
+        // Publish the last removal before releasing the stripe lock.
         if free.is_empty() {
-            // Publish the last removal before releasing the stripe lock.
             self.available.store(false, Ordering::Release);
         }
         Some(slot)
@@ -463,12 +460,17 @@ impl Freelist {
             return 1;
         }
 
-        let mut detached = Vec::with_capacity(max);
+        let mut detached = Vec::new();
         let start = self.home_stripe();
         for offset in 0..self.stripes.len() {
             let stripe = &self.stripes[(start + offset) & self.stripe_mask];
             if !stripe.available.load(Ordering::Acquire) {
                 continue;
+            }
+            if detached.capacity() == 0 {
+                // Reserve only after a potentially productive hint, while
+                // keeping allocator work outside the critical section.
+                detached = Vec::with_capacity(max);
             }
             let mut free = stripe.lock();
             while detached.len() < max {
@@ -623,7 +625,10 @@ fn current_thread_id() -> usize {
 #[cfg(all(test, not(feature = "loom")))]
 pub(super) mod tests {
     use super::*;
+    use crate::{BufferPool, BufferPoolConfig, IoBufMut, iobuf::PoolError};
     use std::{
+        alloc::{GlobalAlloc, System},
+        cell::Cell,
         collections::HashSet,
         sync::{
             Arc, Barrier,
@@ -1119,16 +1124,93 @@ pub(super) mod tests {
         assert!(set.stripes[0].available.load(Ordering::Acquire));
     }
 
-    /// Verifies that the vector corrects a stale positive availability hint.
-    #[test]
-    fn test_stale_positive_hint_is_reconfirmed() {
-        let set = lazy(1, 1);
+    struct TrackingAllocator;
 
-        // This reproduces the state seen by a taker that loaded `true` before
-        // another taker removed the final slot and acquired the mutex later.
-        set.stripes[0].available.store(true, Ordering::Release);
-        assert!(set.take().is_none());
-        assert!(!set.stripes[0].available.load(Ordering::Acquire));
+    std::thread_local! {
+        static ALLOCATION_CALLS: Cell<Option<usize>> = const { Cell::new(None) };
+    }
+
+    #[global_allocator]
+    static ALLOCATOR: TrackingAllocator = TrackingAllocator;
+
+    fn record_allocation() {
+        ALLOCATION_CALLS.with(|calls| {
+            if let Some(count) = calls.get() {
+                calls.set(Some(count + 1));
+            }
+        });
+    }
+
+    // SAFETY: Every operation delegates to the system allocator with unchanged
+    // arguments. Recording an allocation only updates a thread-local cell.
+    unsafe impl GlobalAlloc for TrackingAllocator {
+        unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+            record_allocation();
+            // SAFETY: The caller supplies the layout required by GlobalAlloc.
+            unsafe { System.alloc(layout) }
+        }
+
+        unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+            record_allocation();
+            // SAFETY: The caller supplies the layout required by GlobalAlloc.
+            unsafe { System.alloc_zeroed(layout) }
+        }
+
+        unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+            // SAFETY: The pointer was allocated through this wrapper, which
+            // delegates every allocation to System with the same layout.
+            unsafe { System.dealloc(ptr, layout) }
+        }
+
+        unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+            record_allocation();
+            // SAFETY: The pointer and layout came from System through this wrapper,
+            // and the caller supplies the new size required by GlobalAlloc.
+            unsafe { System.realloc(ptr, layout, new_size) }
+        }
+    }
+
+    fn allocation_calls_during<T>(f: impl FnOnce() -> T) -> (T, usize) {
+        ALLOCATION_CALLS.with(|calls| assert!(calls.replace(Some(0)).is_none()));
+        let result = f();
+        let calls = ALLOCATION_CALLS.with(|calls| calls.replace(None).expect("tracking enabled"));
+        (result, calls)
+    }
+
+    /// Verifies an exhausted TLS batch probe does not allocate result scratch.
+    #[test]
+    fn test_exhausted_batched_tls_miss_is_allocation_free() {
+        const BUFFER_SIZE: usize = 64;
+        const CAPACITY: usize = 4;
+
+        let size = NonZeroUsize::new(BUFFER_SIZE).expect("positive buffer size");
+        let config = BufferPoolConfig::for_network()
+            .with_size_class_range(
+                size,
+                size,
+                NonZeroU32::new(CAPACITY as u32).expect("positive capacity"),
+            )
+            .with_max_thread_cache_capacity(
+                NonZeroUsize::new(CAPACITY).expect("positive cache capacity"),
+            );
+        let mut registry = crate::telemetry::metrics::Registry::default();
+        let pool = BufferPool::new(config, &mut registry);
+
+        let _held: [IoBufMut; CAPACITY] = std::array::from_fn(|_| {
+            pool.try_alloc(BUFFER_SIZE)
+                .expect("lazy allocation within capacity")
+        });
+        assert!(matches!(
+            pool.try_alloc(BUFFER_SIZE),
+            Err(PoolError::Exhausted)
+        ));
+
+        let (result, allocation_calls) = allocation_calls_during(|| pool.try_alloc(BUFFER_SIZE));
+        assert!(matches!(result, Err(PoolError::Exhausted)));
+        assert_eq!(
+            allocation_calls, 0,
+            "an exhausted TLS batch probe must not allocate scratch"
+        );
     }
 }
 

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -521,15 +521,16 @@ impl Freelist {
 
     /// Deallocates every buffer currently parked in this freelist.
     ///
-    /// Each stripe receives a preallocated empty vector while locked. Detached
-    /// buffers are deallocated after unlocking. Creation permits remain
-    /// consumed, so a later return can reuse the reserved room but draining
-    /// never permits a second allocation for an existing slot.
+    /// Buffers still checked out or held in a thread-local cache may return during
+    /// or after this call. Each stripe is therefore replaced under lock with an
+    /// empty vector reserved to its original limit, so a return never grows the
+    /// vector while holding the stripe lock. Detached buffers are deallocated
+    /// after the lock is released.
+    ///
+    /// Draining does not restore creation permits, so deallocated buffers cannot
+    /// be recreated through this freelist.
     pub fn drain(&self) -> usize {
         let mut drained = 0;
-
-        // Visit stripes directly so Drop can run during thread-local cache
-        // teardown without consulting this thread's routing state.
         for stripe in &self.stripes {
             // Allocate before locking so late returns never wait for allocator
             // work that is independent of the protected vector swap.
@@ -541,16 +542,21 @@ impl Freelist {
                 detached
             };
 
-            for slot in detached {
-                let buffer = self.claim(slot);
-                // SAFETY: this freelist created the detached buffer with this
-                // exact layout and removed its slot under lock.
-                unsafe { buffer.deallocate(self.layout) };
-                drained += 1;
-            }
+            drained += self.deallocate_detached(detached);
         }
 
         drained
+    }
+
+    /// Deallocates buffers whose slots are no longer owned by a stripe.
+    fn deallocate_detached(&self, detached: Vec<u32>) -> usize {
+        let count = detached.len();
+        for slot in detached {
+            // SAFETY: detachment gives this method unique ownership of the buffer,
+            // which this freelist allocated with `self.layout`.
+            unsafe { self.claim(slot).deallocate(self.layout) };
+        }
+        count
     }
 
     /// Returns the stable owner pointer for one slot id.
@@ -601,9 +607,22 @@ impl Freelist {
 
 impl Drop for Freelist {
     fn drop(&mut self) {
-        // Outstanding slots keep the size class alive, so only globally parked
-        // buffers can remain when the final freelist reference is dropped.
-        self.drain();
+        // Every checked-out or TLS-cached slot keeps the size class alive until it
+        // returns. Final destruction therefore owns every live allocation and
+        // needs no replacement capacity for a later return.
+        for index in 0..self.stripes.len() {
+            #[cfg(feature = "loom")]
+            let detached = std::mem::take(
+                self.stripes[index]
+                    .free
+                    .get_mut()
+                    .expect("freelist mutex must not be poisoned"),
+            );
+            #[cfg(not(feature = "loom"))]
+            let detached = std::mem::take(self.stripes[index].free.get_mut());
+
+            self.deallocate_detached(detached);
+        }
     }
 }
 
@@ -660,9 +679,7 @@ pub(super) mod tests {
         sync::{
             Arc, Barrier,
             atomic::{AtomicBool as StdAtomicBool, Ordering as StdOrdering},
-            mpsc,
         },
-        time::Duration,
     };
 
     /// Allocation layout shared by native freelist tests.
@@ -719,15 +736,6 @@ pub(super) mod tests {
                 return buffers;
             }
         }
-    }
-
-    /// Parks one test buffer in a chosen stripe without exercising routing.
-    fn park_in_stripe(freelist: &Freelist, stripe: usize, buffer: PooledBuffer) {
-        let stripe = &freelist.stripes[stripe];
-        let mut free = stripe.lock();
-        assert!(free.len() < stripe.limit);
-        free.push(buffer.into_slot());
-        stripe.available.store(true, Ordering::Release);
     }
 
     /// Verifies lazy creation, prefill, fixed permits, and explicit draining.
@@ -808,74 +816,6 @@ pub(super) mod tests {
         assert_eq!(set.drain(), count);
     }
 
-    /// Verifies that `put` waits for its locked full home before scanning on.
-    #[test]
-    fn test_put_waits_for_locked_full_home() {
-        let set = Arc::new(lazy(2, 2));
-        let first = set.try_create(false).expect("first creation permit");
-        let second = set.try_create(false).expect("second creation permit");
-        let (home_tx, home_rx) = mpsc::channel();
-        let (go_tx, go_rx) = mpsc::channel();
-        let (done_tx, done_rx) = mpsc::channel();
-        let worker = {
-            let set = Arc::clone(&set);
-            std::thread::spawn(move || {
-                home_tx.send(set.home_stripe()).expect("send worker home");
-                go_rx.recv().expect("start return");
-                set.put(second);
-                done_tx.send(()).expect("signal completion");
-            })
-        };
-
-        let home = home_rx.recv().expect("receive worker home");
-        park_in_stripe(&set, home, first);
-        let guard = set.stripes[home].lock();
-        go_tx.send(()).expect("start worker");
-        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
-        drop(guard);
-        done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("return must finish after home unlocks");
-        worker.join().expect("worker must not panic");
-        assert_eq!(len(&set), 2);
-    }
-
-    /// Verifies that `put_batch` waits for its full locked home, then spills.
-    #[test]
-    fn test_put_batch_waits_for_locked_full_home() {
-        let set = Arc::new(lazy(4, 4));
-        let mut buffers = (0..4).map(|_| set.try_create(false).expect("creation permit"));
-        let first = buffers.next().expect("first buffer");
-        let second = buffers.next().expect("second buffer");
-        let third = buffers.next().expect("third buffer");
-        let fourth = buffers.next().expect("fourth buffer");
-        let (home_tx, home_rx) = mpsc::channel();
-        let (go_tx, go_rx) = mpsc::channel();
-        let (done_tx, done_rx) = mpsc::channel();
-        let worker = {
-            let set = Arc::clone(&set);
-            std::thread::spawn(move || {
-                home_tx.send(set.home_stripe()).expect("send worker home");
-                go_rx.recv().expect("start batch return");
-                set.put_batch([second, third, fourth]);
-                done_tx.send(()).expect("signal completion");
-            })
-        };
-
-        let home = home_rx.recv().expect("receive worker home");
-        park_in_stripe(&set, home, first);
-        let guard = set.stripes[home].lock();
-        go_tx.send(()).expect("start worker");
-        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
-        drop(guard);
-        done_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("batch return must finish after home unlocks");
-        worker.join().expect("worker must not panic");
-        assert_eq!(set.stripes[home].lock().len(), 1);
-        assert_eq!(len(&set), 4);
-    }
-
     /// Verifies that one thread keeps a stable, in-range home stripe.
     #[test]
     fn test_thread_home_is_stable_and_bounded() {
@@ -910,71 +850,6 @@ pub(super) mod tests {
         let mut taken = None;
         assert_eq!(set.take_batch(1, |buffer| taken = Some(buffer)), 1);
         set.put(taken.expect("singleton callback receives the buffer"));
-    }
-
-    /// Verifies that `take` waits for its positive home before later stripes.
-    #[test]
-    fn test_take_waits_for_home_before_later_stripe() {
-        let set = Arc::new(prefilled(2, 2));
-        let (home_tx, home_rx) = mpsc::channel();
-        let (go_tx, go_rx) = mpsc::channel();
-        let (done_tx, done_rx) = mpsc::channel();
-        let worker = {
-            let set = Arc::clone(&set);
-            std::thread::spawn(move || {
-                home_tx.send(set.home_stripe()).expect("send worker home");
-                go_rx.recv().expect("start take");
-                done_tx.send(set.take()).expect("send take result");
-            })
-        };
-
-        let home = home_rx.recv().expect("receive worker home");
-        let first_guard = set.stripes[home].lock();
-        go_tx.send(()).expect("start worker");
-        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
-        drop(first_guard);
-        let result = done_rx.recv_timeout(Duration::from_secs(1));
-        worker.join().expect("worker must not panic");
-
-        let buffer = result
-            .expect("take must finish after the home stripe unlocks")
-            .expect("home stripe must remain productive");
-        assert_eq!(buffer.slot(), home as u32);
-        set.put(buffer);
-    }
-
-    /// Verifies that `take_batch` waits for its home before scanning onward.
-    #[test]
-    fn test_take_batch_waits_for_home_before_later_stripe() {
-        let set = Arc::new(prefilled(2, 2));
-        let (home_tx, home_rx) = mpsc::channel();
-        let (go_tx, go_rx) = mpsc::channel();
-        let (done_tx, done_rx) = mpsc::channel();
-        let worker = {
-            let set = Arc::clone(&set);
-            std::thread::spawn(move || {
-                home_tx.send(set.home_stripe()).expect("send worker home");
-                go_rx.recv().expect("start batch take");
-                let mut buffers = Vec::new();
-                let count = set.take_batch(2, |buffer| buffers.push(buffer));
-                done_tx.send((count, buffers)).expect("send batch result");
-            })
-        };
-
-        let home = home_rx.recv().expect("receive worker home");
-        let first_guard = set.stripes[home].lock();
-        go_tx.send(()).expect("start worker");
-        assert!(done_rx.recv_timeout(Duration::from_millis(10)).is_err());
-        drop(first_guard);
-        let result = done_rx.recv_timeout(Duration::from_secs(1));
-        worker.join().expect("worker must not panic");
-
-        let (count, mut buffers) = result.expect("batch take must finish after home unlocks");
-        assert_eq!(count, 2);
-        buffers.sort_by_key(PooledBuffer::slot);
-        assert_eq!(buffers[0].slot(), 0);
-        assert_eq!(buffers[1].slot(), 1);
-        set.put_batch(buffers);
     }
 
     /// Verifies unique ownership across contended scalar take and put cycles.
@@ -1178,6 +1053,18 @@ pub(super) mod tests {
         (result, calls)
     }
 
+    /// Verifies populated final destruction does not reserve replacement capacity.
+    #[test]
+    fn test_populated_final_drop_is_allocation_free() {
+        let set = prefilled(19, 8);
+
+        let ((), allocation_calls) = allocation_calls_during(|| drop(set));
+        assert_eq!(
+            allocation_calls, 0,
+            "final destruction must not allocate replacement capacity"
+        );
+    }
+
     /// Verifies an exhausted TLS batch probe does not allocate result scratch.
     #[test]
     fn test_exhausted_batched_tls_miss_is_allocation_free() {
@@ -1229,16 +1116,46 @@ mod loom_tests {
         Err(_) => panic!("valid test layout"),
     };
 
+    const OPERATION_STARTED: usize = 1;
+    const OPERATION_FINISHED: usize = 2;
+
+    /// Creates an empty freelist for one Loom model.
+    fn empty(capacity: u32) -> Freelist {
+        Freelist::new(NZU32!(capacity), NZUsize!(1), TEST_LAYOUT, false)
+    }
+
     /// Creates a fully available freelist for one Loom model.
     fn prefilled(capacity: u32) -> Freelist {
         Freelist::new(NZU32!(capacity), NZUsize!(1), TEST_LAYOUT, true)
+    }
+
+    /// Parks one test buffer in a chosen stripe without exercising routing.
+    fn park_in_stripe(set: &Freelist, index: usize, buffer: PooledBuffer) {
+        let stripe = &set.stripes[index];
+        let mut free = stripe.lock();
+        assert!(free.len() < stripe.limit);
+        free.push(buffer.into_slot());
+        stripe.available.store(true, Ordering::Release);
+    }
+
+    /// Requires a modeled operation to remain incomplete while its home guard is held.
+    fn assert_waiting(phase: &AtomicUsize) {
+        while phase.load(Ordering::Acquire) == 0 {
+            thread::yield_now();
+        }
+        thread::yield_now();
+        assert_eq!(
+            phase.load(Ordering::Acquire),
+            OPERATION_STARTED,
+            "operation skipped its locked home stripe"
+        );
     }
 
     /// Verifies that a completed return is discoverable by a later take.
     #[test]
     fn completed_put_is_discoverable() {
         loom::model(|| {
-            let set = Arc::new(Freelist::new(NZU32!(1), NZUsize!(1), TEST_LAYOUT, false));
+            let set = Arc::new(empty(1));
             let buffer = set.try_create(false).expect("creation permit");
             let returned = Arc::new(AtomicBool::new(false));
 
@@ -1287,7 +1204,7 @@ mod loom_tests {
     #[test]
     fn concurrent_puts_preserve_both_slots() {
         loom::model(|| {
-            let set = Arc::new(Freelist::new(NZU32!(2), NZUsize!(1), TEST_LAYOUT, false));
+            let set = Arc::new(empty(2));
             let first = set.try_create(false).expect("first permit");
             let second = set.try_create(false).expect("second permit");
 
@@ -1309,45 +1226,132 @@ mod loom_tests {
         });
     }
 
-    /// Verifies that a positive locked stripe is waited on, not skipped.
+    /// Verifies that a take waits for its positive home before a later stripe.
     #[test]
-    fn locked_stripe_is_not_reported_empty() {
+    fn take_waits_for_home_before_later_stripe() {
         loom::model(|| {
-            let set = Arc::new(prefilled(1));
+            let set = Arc::new(prefilled(2));
+            let phase = Arc::new(AtomicUsize::new(0));
             let guard = set.stripes[0].lock();
             let taker = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.take())
+                let phase = Arc::clone(&phase);
+                thread::spawn(move || {
+                    assert_eq!(set.home_stripe(), 0);
+                    phase.store(OPERATION_STARTED, Ordering::Release);
+                    let buffer = set.take();
+                    phase.store(OPERATION_FINISHED, Ordering::Release);
+                    buffer
+                })
             };
-            thread::yield_now();
+
+            assert_waiting(&phase);
             drop(guard);
 
             let buffer = taker
                 .join()
                 .expect("taker must not panic")
-                .expect("locked stripe must not be missed");
+                .expect("home stripe must remain productive");
+            assert_eq!(phase.load(Ordering::Acquire), OPERATION_FINISHED);
+            assert_eq!(buffer.slot(), 0);
             set.put(buffer);
         });
     }
 
-    /// Verifies that a return waits for the only stripe's lock.
+    /// Verifies that a return waits for its full home before a later stripe.
     #[test]
-    fn return_waits_for_locked_stripe() {
+    fn put_waits_for_full_home_before_later_stripe() {
         loom::model(|| {
-            let set = Arc::new(Freelist::new(NZU32!(1), NZUsize!(1), TEST_LAYOUT, false));
-            let buffer = set.try_create(false).expect("creation permit");
+            let set = Arc::new(empty(2));
+            let parked = set.try_create(false).expect("first creation permit");
+            let returning = set.try_create(false).expect("second creation permit");
+            park_in_stripe(&set, 0, parked);
 
+            let phase = Arc::new(AtomicUsize::new(0));
             let guard = set.stripes[0].lock();
             let returner = {
                 let set = Arc::clone(&set);
-                thread::spawn(move || set.put(buffer))
+                let phase = Arc::clone(&phase);
+                thread::spawn(move || {
+                    assert_eq!(set.home_stripe(), 0);
+                    phase.store(OPERATION_STARTED, Ordering::Release);
+                    set.put(returning);
+                    phase.store(OPERATION_FINISHED, Ordering::Release);
+                })
             };
-            thread::yield_now();
+
+            assert_waiting(&phase);
             drop(guard);
             returner.join().expect("returner must not panic");
+            assert_eq!(phase.load(Ordering::Acquire), OPERATION_FINISHED);
+            assert_eq!(set.stripes[0].lock().len(), 1);
+            assert_eq!(set.stripes[1].lock().len(), 1);
+        });
+    }
 
-            let buffer = set.take().expect("returned buffer");
-            set.put(buffer);
+    /// Verifies that a batch return waits for its full home before spilling.
+    #[test]
+    fn put_batch_waits_for_full_home_before_later_stripes() {
+        loom::model(|| {
+            let set = Arc::new(empty(4));
+            let first = set.try_create(false).expect("first creation permit");
+            let second = set.try_create(false).expect("second creation permit");
+            let third = set.try_create(false).expect("third creation permit");
+            let fourth = set.try_create(false).expect("fourth creation permit");
+            park_in_stripe(&set, 0, first);
+
+            let phase = Arc::new(AtomicUsize::new(0));
+            let guard = set.stripes[0].lock();
+            let returner = {
+                let set = Arc::clone(&set);
+                let phase = Arc::clone(&phase);
+                thread::spawn(move || {
+                    assert_eq!(set.home_stripe(), 0);
+                    phase.store(OPERATION_STARTED, Ordering::Release);
+                    set.put_batch([second, third, fourth]);
+                    phase.store(OPERATION_FINISHED, Ordering::Release);
+                })
+            };
+
+            assert_waiting(&phase);
+            drop(guard);
+            returner.join().expect("returner must not panic");
+            assert_eq!(phase.load(Ordering::Acquire), OPERATION_FINISHED);
+            for stripe in &set.stripes {
+                assert_eq!(stripe.lock().len(), 1);
+            }
+        });
+    }
+
+    /// Verifies that a batch take waits for its home before scanning onward.
+    #[test]
+    fn take_batch_waits_for_home_before_later_stripe() {
+        loom::model(|| {
+            let set = Arc::new(prefilled(2));
+            let phase = Arc::new(AtomicUsize::new(0));
+            let guard = set.stripes[0].lock();
+            let taker = {
+                let set = Arc::clone(&set);
+                let phase = Arc::clone(&phase);
+                thread::spawn(move || {
+                    assert_eq!(set.home_stripe(), 0);
+                    phase.store(OPERATION_STARTED, Ordering::Release);
+                    let mut buffers = Vec::new();
+                    let count = set.take_batch(2, |buffer| buffers.push(buffer));
+                    phase.store(OPERATION_FINISHED, Ordering::Release);
+                    (count, buffers)
+                })
+            };
+
+            assert_waiting(&phase);
+            drop(guard);
+            let (count, mut buffers) = taker.join().expect("taker must not panic");
+            assert_eq!(phase.load(Ordering::Acquire), OPERATION_FINISHED);
+            assert_eq!(count, 2);
+            buffers.sort_by_key(PooledBuffer::slot);
+            assert_eq!(buffers[0].slot(), 0);
+            assert_eq!(buffers[1].slot(), 1);
+            set.put_batch(buffers);
         });
     }
 

--- a/runtime/src/iobuf/freelist.rs
+++ b/runtime/src/iobuf/freelist.rs
@@ -139,8 +139,8 @@ struct Stripe {
 impl Stripe {
     /// Creates a stripe from its preallocated initial free-slot vector.
     fn new(free: Vec<u32>, limit: usize) -> Self {
-        debug_assert!(free.len() <= limit);
-        debug_assert!(free.capacity() >= limit);
+        assert!(free.len() <= limit);
+        assert!(free.capacity() >= limit);
         Self {
             available: AtomicBool::new(!free.is_empty()),
             free: Mutex::new(free),
@@ -351,7 +351,6 @@ impl Freelist {
                 }
 
                 let was_empty = free.is_empty();
-                debug_assert!(free.len() < free.capacity());
                 free.push(slot);
                 if was_empty {
                     // Publish the first insertion before releasing the lock.
@@ -403,7 +402,6 @@ impl Freelist {
                 let count = (stripe.limit - free.len()).min(slots.len());
                 let was_empty = free.is_empty();
                 for _ in 0..count {
-                    debug_assert!(free.len() < free.capacity());
                     free.push(slots.pop().expect("count is bounded by length"));
                 }
                 if was_empty && count != 0 {
@@ -503,17 +501,20 @@ impl Freelist {
 
     /// Deallocates every buffer currently parked in this freelist.
     ///
-    /// Each stripe receives an empty vector with the same reserved capacity
-    /// while locked. Detached buffers are deallocated after unlocking. Creation
-    /// permits remain consumed, so a later return can reuse the reserved room
-    /// but draining never permits a second allocation for an existing slot.
+    /// Each stripe receives a preallocated empty vector while locked. Detached
+    /// buffers are deallocated after unlocking. Creation permits remain
+    /// consumed, so a later return can reuse the reserved room but draining
+    /// never permits a second allocation for an existing slot.
     pub fn drain(&self) -> usize {
         let mut drained = 0;
 
         for stripe in &self.stripes {
+            // Allocate before locking so late returns never wait for allocator
+            // work that is independent of the protected vector swap.
+            let replacement = Vec::with_capacity(stripe.limit);
             let detached = {
                 let mut free = stripe.lock();
-                let detached = std::mem::replace(&mut *free, Vec::with_capacity(stripe.limit));
+                let detached = std::mem::replace(&mut *free, replacement);
                 stripe.available.store(false, Ordering::Release);
                 detached
             };

--- a/runtime/src/iobuf/mod.rs
+++ b/runtime/src/iobuf/mod.rs
@@ -5,7 +5,7 @@
 //! reference: runtime-owned heap buffers keep a header inside their own
 //! allocation (in front of the data for low-alignment mutable buffers, at the
 //! tail for high-alignment ones and adopted vecs), pooled buffers keep their
-//! owner record in a side table owned by the size class,
+//! owner record in a per-slot side table owned by the size class,
 //! caller-supplied `Vec<u8>` values converted to immutable buffers are adopted
 //! into the native heap form when their spare capacity allows (mutable
 //! conversions copy to preserve the caller's capacity), and caller-supplied
@@ -208,8 +208,8 @@ pub mod bench {
         ///
         /// # Safety
         ///
-        /// `buffer` must have been taken from this freelist and must not already
-        /// be available here.
+        /// `buffer` must have been taken from this freelist, and its slot must
+        /// not already be available here.
         #[inline]
         pub unsafe fn put(&self, buffer: PooledBuffer) {
             self.0.put(buffer);
@@ -222,8 +222,8 @@ pub mod bench {
         ///
         /// # Safety
         ///
-        /// Every buffer must have been taken from this freelist. Their owner
-        /// indices must be distinct and unavailable in the freelist.
+        /// Every buffer must have been taken from this freelist. Their slots
+        /// must be unique within the batch and unavailable in the freelist.
         #[inline]
         pub unsafe fn put_batch(&self, buffers: impl IntoIterator<Item = PooledBuffer>) {
             self.0.put_batch(buffers);
@@ -917,7 +917,7 @@ impl IoBufMut {
     ///
     /// # Safety
     ///
-    /// `buffer` must have an initialized live lease in its pooled owner.
+    /// `buffer` must have an initialized live lease in its pooled slot.
     #[inline]
     pub(crate) unsafe fn from_pooled_parts(buffer: PooledBuffer) -> Self {
         let cap = buffer.capacity();

--- a/runtime/src/iobuf/mod.rs
+++ b/runtime/src/iobuf/mod.rs
@@ -5,7 +5,7 @@
 //! reference: runtime-owned heap buffers keep a header inside their own
 //! allocation (in front of the data for low-alignment mutable buffers, at the
 //! tail for high-alignment ones and adopted vecs), pooled buffers keep their
-//! owner record in a per-slot side table owned by the size class,
+//! owner record in a side table owned by the size class,
 //! caller-supplied `Vec<u8>` values converted to immutable buffers are adopted
 //! into the native heap form when their spare capacity allows (mutable
 //! conversions copy to preserve the caller's capacity), and caller-supplied
@@ -208,8 +208,8 @@ pub mod bench {
         ///
         /// # Safety
         ///
-        /// `buffer` must have been taken from this freelist, and its slot must
-        /// not already be available here.
+        /// `buffer` must have been taken from this freelist and must not already
+        /// be available here.
         #[inline]
         pub unsafe fn put(&self, buffer: PooledBuffer) {
             self.0.put(buffer);
@@ -222,8 +222,8 @@ pub mod bench {
         ///
         /// # Safety
         ///
-        /// Every buffer must have been taken from this freelist. Their slots
-        /// must be unique within the batch and unavailable in the freelist.
+        /// Every buffer must have been taken from this freelist. Their owner
+        /// indices must be distinct and unavailable in the freelist.
         #[inline]
         pub unsafe fn put_batch(&self, buffers: impl IntoIterator<Item = PooledBuffer>) {
             self.0.put_batch(buffers);
@@ -917,7 +917,7 @@ impl IoBufMut {
     ///
     /// # Safety
     ///
-    /// `buffer` must have an initialized live lease in its pooled slot.
+    /// `buffer` must have an initialized live lease in its pooled owner.
     #[inline]
     pub(crate) unsafe fn from_pooled_parts(buffer: PooledBuffer) -> Self {
         let cap = buffer.capacity();

--- a/runtime/src/iobuf/owner.rs
+++ b/runtime/src/iobuf/owner.rs
@@ -28,7 +28,7 @@
 //! header ptr | 0b01       HEAP      HeapOwner: tail-header aligned
 //!                                   allocations, adopted vecs, and
 //!                                   front-block mutables
-//! owner ptr  | 0b10       POOLED    PooledOwner side-table entry
+//! slot ptr   | 0b10       POOLED    PooledOwner side-table entry
 //! owner ptr  | 0b11       EXTERNAL  boxed ExternalOwner holding a Bytes
 //! ```
 //!
@@ -57,18 +57,18 @@
 //! per possible tracked buffer:
 //!
 //! ```text
-//! SizeClass owners: [ refs | lease | data_base | capacity | owner_index ]
-//!                     ^
-//!                     OwnerRef target
+//! SizeClass slots: [ refs | lease | data_base | capacity | slot ]
+//!                    ^
+//!                    OwnerRef target
 //!
 //! data allocation:  [ usable data bytes ............ ]
 //!                    ^
 //!                    data base
 //! ```
 //!
-//! The freelist stores owner indices for globally available buffers in striped
-//! vectors. Each side-table entry is the single record for refcounting, class
-//! liveness, the data pointer, and stable identity.
+//! The freelist stores slot ids for globally available buffers in striped
+//! vectors. The slot entry is the single state record for refcounting, class
+//! liveness, the data pointer, and return routing.
 //!
 //! Returning to heap allocations: low-alignment mutable buffers use the
 //! front-block layout instead of the tail layout above:
@@ -253,7 +253,7 @@ impl OwnerRef {
             .with_addr(self.0.addr() & !OWNER_TAG_MASK)
             .cast::<T>();
         // SAFETY: non-empty owner refs are built from non-null pointers, and
-        // masking the tag bits cannot zero a heap, box, or owner address.
+        // masking the tag bits cannot zero a heap/box/slot address.
         unsafe { NonNull::new_unchecked(ptr) }
     }
 
@@ -279,15 +279,15 @@ impl OwnerRef {
         Self::from_tagged(header, OWNER_HEAP)
     }
 
-    /// Creates a pooled owner ref from a side-table owner pointer.
+    /// Creates a pooled owner ref from a side-table slot pointer.
     ///
     /// # Safety
     ///
-    /// `owner` must point to a live [`PooledOwner`] whose low tag bits are zero
+    /// `slot` must point to a live [`PooledOwner`] whose low tag bits are zero
     /// and whose lease is initialized.
     #[inline(always)]
-    pub(crate) unsafe fn from_pooled(owner: NonNull<PooledOwner>) -> Self {
-        Self::from_tagged(owner, OWNER_POOLED)
+    pub(crate) unsafe fn from_pooled(slot: NonNull<PooledOwner>) -> Self {
+        Self::from_tagged(slot, OWNER_POOLED)
     }
 
     /// Creates an external owner ref.
@@ -342,7 +342,7 @@ impl OwnerRef {
         unsafe { self.untag() }
     }
 
-    /// Returns the side-table entry for a pooled owner.
+    /// Returns the side-table slot for a pooled owner.
     ///
     /// # Safety
     ///
@@ -1017,12 +1017,12 @@ impl HeapOwner {
     }
 }
 
-/// Owner record for one pooled allocation.
+/// Owner record for one pooled slot.
 ///
-/// The owning freelist stores one cache-line-padded entry per possible pooled
-/// buffer. Stable fields (`refs` sentinel, `data_base`, `capacity`, and
-/// `owner_index`) are written when the buffer is created and remain associated
-/// with it until the size class drops. The lease is live only while the buffer
+/// The owning freelist stores one cache-line-padded slot entry per possible
+/// pooled buffer. Stable fields (`refs` sentinel, `data_base`, `capacity`,
+/// `slot`) are written when the slot is created and remain associated with
+/// that slot until the size class drops. The lease is live only while the slot
 /// is outside the global freelist.
 #[repr(C)]
 pub struct PooledOwner {
@@ -1035,25 +1035,25 @@ pub struct PooledOwner {
     data_base: NonNull<u8>,
     /// Usable data capacity for the size class.
     capacity: usize,
-    /// Stable index within the owning freelist's owner table.
-    owner_index: u32,
+    /// Stable slot id within the owning freelist.
+    slot: u32,
 }
 
 impl PooledOwner {
-    /// Creates an empty side-table entry for a stable owner index.
+    /// Creates an empty side-table entry for a stable slot id.
     ///
     /// The data pointer is filled when the freelist first creates the pooled
-    /// allocation for this owner. Until then, its index cannot appear in a
+    /// allocation for this slot. Until then, its id cannot appear in a
     /// freelist stripe and no [`PooledBuffer`] may be built from it.
     #[inline]
     #[allow(clippy::missing_const_for_fn)]
-    pub fn new(owner_index: u32, capacity: usize) -> Self {
+    pub fn new(slot: u32, capacity: usize) -> Self {
         Self {
             refs: AtomicUsize::new(1),
             lease: MaybeUninit::uninit(),
             data_base: NonNull::dangling(),
             capacity,
-            owner_index,
+            slot,
         }
     }
 
@@ -1076,7 +1076,7 @@ impl PooledOwner {
     /// be initialized.
     #[inline(always)]
     unsafe fn release_to_thread_cache(owner: NonNull<Self>) {
-        // SAFETY: this unique owner proves its data allocation is live.
+        // SAFETY: this unique owner proves the slot's data allocation is live.
         let buffer = unsafe { PooledBuffer::from_owner(owner) };
         BufferPoolThreadCache::push(buffer);
     }
@@ -1084,11 +1084,10 @@ impl PooledOwner {
 
 /// A raw pooled allocation handle whose layout is stored by its size class.
 ///
-/// This handle points to the owning side-table entry. The entry stores the data
-/// pointer, stable owner index, capacity, refcount sentinel, and optional live
+/// This handle is a pointer to the owning side-table slot. The slot stores the
+/// data pointer, stable slot id, capacity, refcount sentinel, and optional live
 /// lease. Checkout initializes only the lease field in place and returns an
-/// owner reference to that entry. Return to the global freelist consumes the
-/// lease.
+/// owner reference to that slot. Return to the global freelist consumes the lease.
 ///
 /// `PooledBuffer` has no `Drop`: callers must return it to the originating
 /// freelist or deallocate it with the exact layout used for allocation.
@@ -1109,7 +1108,7 @@ impl std::fmt::Debug for PooledBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PooledBuffer")
             .field("owner", &self.owner)
-            .field("owner_index", &self.owner_index())
+            .field("slot", &self.slot())
             .field("ptr", &self.data_ptr())
             .finish()
     }
@@ -1143,7 +1142,7 @@ impl PooledBuffer {
             unsafe { alloc(layout) }
         };
         let ptr = NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(layout));
-        // SAFETY: guaranteed by the caller. The owner is unique and not
+        // SAFETY: guaranteed by the caller. The slot is unique and not
         // concurrently visible while its data pointer is initialized.
         unsafe {
             assert_eq!((*owner.as_ptr()).refs.load(Ordering::Relaxed), 1);
@@ -1173,33 +1172,34 @@ impl PooledBuffer {
     /// Returns the usable data base pointer without discarding non-nullness.
     #[inline(always)]
     pub(crate) const fn data_ptr(&self) -> NonNull<u8> {
-        // SAFETY: pooled buffers are built only for created owners.
+        // SAFETY: pooled buffers are built only for created slots.
         unsafe { self.owner.as_ref().data_base }
     }
 
     /// Returns the usable data capacity for this size-class buffer.
     #[inline(always)]
     pub(crate) const fn capacity(&self) -> usize {
-        // SAFETY: `PooledBuffer` is constructed only for created owners, whose
+        // SAFETY: `PooledBuffer` is constructed only for created slots, whose
         // stable side-table fields are initialized.
         unsafe { self.owner.as_ref().capacity }
     }
 
-    /// Returns the stable owner index for this size-class buffer.
+    /// Returns the stable slot id for this size-class buffer.
     ///
-    /// The index is initialized once when the owning freelist creates this
-    /// buffer. It is the compact representation stored by the global freelist.
+    /// The slot is initialized once when the owning freelist creates this
+    /// buffer and is needed only when the buffer returns to the global
+    /// freelist.
     #[inline(always)]
-    pub(crate) const fn owner_index(&self) -> u32 {
-        // SAFETY: `PooledBuffer` is constructed only for created owners, whose
+    pub(crate) const fn slot(&self) -> u32 {
+        // SAFETY: `PooledBuffer` is constructed only for created slots, whose
         // stable side-table fields are initialized.
-        unsafe { self.owner.as_ref().owner_index }
+        unsafe { self.owner.as_ref().slot }
     }
 
-    /// Consumes this unique handle and returns its compact global index.
+    /// Consumes this unique handle and returns its compact slot id.
     #[inline(always)]
-    pub(crate) const fn into_owner_index(self) -> u32 {
-        self.owner_index()
+    pub(crate) const fn into_slot(self) -> u32 {
+        self.slot()
     }
 
     /// Initializes the pooled lease for a buffer leaving global state.
@@ -1207,7 +1207,7 @@ impl PooledBuffer {
     /// # Safety
     ///
     /// This buffer must be checked out from the size class represented by
-    /// `lease`, and the owner must not currently contain a live lease.
+    /// `lease`, and the slot must not currently contain a live lease.
     #[inline(always)]
     pub(crate) unsafe fn init_lease(&mut self, lease: SizeClassLease) {
         // SAFETY: owner is a live side-table entry.
@@ -1228,7 +1228,7 @@ impl PooledBuffer {
         unsafe { &*self.owner.as_ref().lease.as_ptr() }
     }
 
-    /// Consumes the live lease from this owner.
+    /// Consumes the live lease from this slot.
     ///
     /// # Safety
     ///
@@ -1264,7 +1264,7 @@ impl PooledBuffer {
         unsafe { dealloc(self.data_ptr().as_ptr(), layout) };
     }
 
-    /// Asserts the refcount sentinel on a freshly claimed global buffer.
+    /// Asserts the parked-slot sentinel invariant on a freshly claimed buffer.
     ///
     /// A buffer leaving the global freelist must observe the refcount sentinel
     /// of 1. The final release restores the sentinel before the return unlocks
@@ -1272,8 +1272,8 @@ impl PooledBuffer {
     /// buffer. A Relaxed load suffices because the assertion is on the value.
     /// Loom explores every interleaving that could expose a stale one.
     #[cfg(feature = "loom")]
-    pub(crate) fn assert_unique_sentinel(&self) {
-        // SAFETY: the caller just claimed the owner, so the side-table entry
+    pub(crate) fn assert_parked_sentinel(&self) {
+        // SAFETY: the caller just claimed the slot, so the side-table entry
         // is live and owned by this thread.
         let refs = unsafe { &self.owner.as_ref().refs };
         assert_eq!(refs.load(Ordering::Relaxed), 1);

--- a/runtime/src/iobuf/owner.rs
+++ b/runtime/src/iobuf/owner.rs
@@ -28,7 +28,7 @@
 //! header ptr | 0b01       HEAP      HeapOwner: tail-header aligned
 //!                                   allocations, adopted vecs, and
 //!                                   front-block mutables
-//! slot ptr   | 0b10       POOLED    PooledOwner side-table entry
+//! owner ptr  | 0b10       POOLED    PooledOwner side-table entry
 //! owner ptr  | 0b11       EXTERNAL  boxed ExternalOwner holding a Bytes
 //! ```
 //!
@@ -57,18 +57,18 @@
 //! per possible tracked buffer:
 //!
 //! ```text
-//! SizeClass slots: [ refs | lease | data_base | capacity | slot ]
-//!                    ^
-//!                    OwnerRef target
+//! SizeClass owners: [ refs | lease | data_base | capacity | owner_index ]
+//!                     ^
+//!                     OwnerRef target
 //!
 //! data allocation:  [ usable data bytes ............ ]
 //!                    ^
 //!                    data base
 //! ```
 //!
-//! The freelist bitmap records which slots are globally available. The slot
-//! entry is the single state record for refcounting, class liveness, data
-//! pointer, and return routing.
+//! The freelist stores owner indices for globally available buffers in striped
+//! vectors. Each side-table entry is the single record for refcounting, class
+//! liveness, the data pointer, and stable identity.
 //!
 //! Returning to heap allocations: low-alignment mutable buffers use the
 //! front-block layout instead of the tail layout above:
@@ -253,7 +253,7 @@ impl OwnerRef {
             .with_addr(self.0.addr() & !OWNER_TAG_MASK)
             .cast::<T>();
         // SAFETY: non-empty owner refs are built from non-null pointers, and
-        // masking the tag bits cannot zero a heap/box/slot address.
+        // masking the tag bits cannot zero a heap, box, or owner address.
         unsafe { NonNull::new_unchecked(ptr) }
     }
 
@@ -279,15 +279,15 @@ impl OwnerRef {
         Self::from_tagged(header, OWNER_HEAP)
     }
 
-    /// Creates a pooled owner ref from a side-table slot pointer.
+    /// Creates a pooled owner ref from a side-table owner pointer.
     ///
     /// # Safety
     ///
-    /// `slot` must point to a live [`PooledOwner`] whose low tag bits are zero
+    /// `owner` must point to a live [`PooledOwner`] whose low tag bits are zero
     /// and whose lease is initialized.
     #[inline(always)]
-    pub(crate) unsafe fn from_pooled(slot: NonNull<PooledOwner>) -> Self {
-        Self::from_tagged(slot, OWNER_POOLED)
+    pub(crate) unsafe fn from_pooled(owner: NonNull<PooledOwner>) -> Self {
+        Self::from_tagged(owner, OWNER_POOLED)
     }
 
     /// Creates an external owner ref.
@@ -342,7 +342,7 @@ impl OwnerRef {
         unsafe { self.untag() }
     }
 
-    /// Returns the side-table slot for a pooled owner.
+    /// Returns the side-table entry for a pooled owner.
     ///
     /// # Safety
     ///
@@ -495,8 +495,8 @@ impl OwnerRef {
         // handles, ordering their payload accesses before the release.
         fence(Ordering::Acquire);
         // Restore the sentinel before releasing. No other handle exists, so
-        // Relaxed is sufficient. Pooled reuse synchronizes through the
-        // freelist's own Release/Acquire bit transitions.
+        // Relaxed is sufficient. Pooled reuse has exclusive ownership in a
+        // thread-local cache or synchronizes through a freelist stripe mutex.
         refs.store(1, Ordering::Relaxed);
         // SAFETY: guaranteed by the caller.
         unsafe { self.release_unique() };
@@ -1017,12 +1017,12 @@ impl HeapOwner {
     }
 }
 
-/// Owner record for one pooled slot.
+/// Owner record for one pooled allocation.
 ///
-/// The owning freelist stores one cache-line-padded slot entry per possible
-/// pooled buffer. Stable fields (`refs` sentinel, `data_base`, `capacity`,
-/// `slot`) are written when the slot is created and remain associated with
-/// that slot until the size class drops. The lease is live only while the slot
+/// The owning freelist stores one cache-line-padded entry per possible pooled
+/// buffer. Stable fields (`refs` sentinel, `data_base`, `capacity`, and
+/// `owner_index`) are written when the buffer is created and remain associated
+/// with it until the size class drops. The lease is live only while the buffer
 /// is outside the global freelist.
 #[repr(C)]
 pub struct PooledOwner {
@@ -1035,25 +1035,25 @@ pub struct PooledOwner {
     data_base: NonNull<u8>,
     /// Usable data capacity for the size class.
     capacity: usize,
-    /// Stable slot id within the owning freelist.
-    slot: u32,
+    /// Stable index within the owning freelist's owner table.
+    owner_index: u32,
 }
 
 impl PooledOwner {
-    /// Creates an empty side-table entry for a stable slot id.
+    /// Creates an empty side-table entry for a stable owner index.
     ///
     /// The data pointer is filled when the freelist first creates the pooled
-    /// allocation for this slot. Until the slot is created, no free bit points
-    /// at it and no [`PooledBuffer`] may be built from it.
+    /// allocation for this owner. Until then, its index cannot appear in a
+    /// freelist stripe and no [`PooledBuffer`] may be built from it.
     #[inline]
     #[allow(clippy::missing_const_for_fn)]
-    pub fn new(slot: u32, capacity: usize) -> Self {
+    pub fn new(owner_index: u32, capacity: usize) -> Self {
         Self {
             refs: AtomicUsize::new(1),
             lease: MaybeUninit::uninit(),
             data_base: NonNull::dangling(),
             capacity,
-            slot,
+            owner_index,
         }
     }
 
@@ -1076,7 +1076,7 @@ impl PooledOwner {
     /// be initialized.
     #[inline(always)]
     unsafe fn release_to_thread_cache(owner: NonNull<Self>) {
-        // SAFETY: this unique owner proves the slot's data allocation is live.
+        // SAFETY: this unique owner proves its data allocation is live.
         let buffer = unsafe { PooledBuffer::from_owner(owner) };
         BufferPoolThreadCache::push(buffer);
     }
@@ -1084,10 +1084,11 @@ impl PooledOwner {
 
 /// A raw pooled allocation handle whose layout is stored by its size class.
 ///
-/// This handle is a pointer to the owning side-table slot. The slot stores the
-/// data pointer, stable slot id, capacity, refcount sentinel, and optional live
+/// This handle points to the owning side-table entry. The entry stores the data
+/// pointer, stable owner index, capacity, refcount sentinel, and optional live
 /// lease. Checkout initializes only the lease field in place and returns an
-/// owner reference to that slot. Return to the global freelist consumes the lease.
+/// owner reference to that entry. Return to the global freelist consumes the
+/// lease.
 ///
 /// `PooledBuffer` has no `Drop`: callers must return it to the originating
 /// freelist or deallocate it with the exact layout used for allocation.
@@ -1108,7 +1109,7 @@ impl std::fmt::Debug for PooledBuffer {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PooledBuffer")
             .field("owner", &self.owner)
-            .field("slot", &self.slot())
+            .field("owner_index", &self.owner_index())
             .field("ptr", &self.data_ptr())
             .finish()
     }
@@ -1129,7 +1130,7 @@ impl PooledBuffer {
     ///
     /// The caller must own `owner` initialization for this size class. No other
     /// thread may read it until the returned buffer is published through the
-    /// freelist bitmap or handed to a checked-out owner. The side-table entry
+    /// freelist or handed to a checked-out owner. The side-table entry
     /// must outlive the returned buffer and every operation on it.
     #[inline]
     pub unsafe fn new(owner: NonNull<PooledOwner>, layout: Layout, zeroed: bool) -> Self {
@@ -1142,7 +1143,7 @@ impl PooledBuffer {
             unsafe { alloc(layout) }
         };
         let ptr = NonNull::new(ptr).unwrap_or_else(|| handle_alloc_error(layout));
-        // SAFETY: guaranteed by the caller. The slot is unique and not
+        // SAFETY: guaranteed by the caller. The owner is unique and not
         // concurrently visible while its data pointer is initialized.
         unsafe {
             assert_eq!((*owner.as_ptr()).refs.load(Ordering::Relaxed), 1);
@@ -1172,28 +1173,33 @@ impl PooledBuffer {
     /// Returns the usable data base pointer without discarding non-nullness.
     #[inline(always)]
     pub(crate) const fn data_ptr(&self) -> NonNull<u8> {
-        // SAFETY: pooled buffers are built only for created slots.
+        // SAFETY: pooled buffers are built only for created owners.
         unsafe { self.owner.as_ref().data_base }
     }
 
     /// Returns the usable data capacity for this size-class buffer.
     #[inline(always)]
     pub(crate) const fn capacity(&self) -> usize {
-        // SAFETY: `PooledBuffer` is constructed only for created slots, whose
+        // SAFETY: `PooledBuffer` is constructed only for created owners, whose
         // stable side-table fields are initialized.
         unsafe { self.owner.as_ref().capacity }
     }
 
-    /// Returns the stable slot id for this size-class buffer.
+    /// Returns the stable owner index for this size-class buffer.
     ///
-    /// The slot is initialized once when the owning freelist creates this
-    /// buffer and is needed only when the buffer returns to the global
-    /// freelist.
+    /// The index is initialized once when the owning freelist creates this
+    /// buffer. It is the compact representation stored by the global freelist.
     #[inline(always)]
-    pub(crate) const fn slot(&self) -> u32 {
-        // SAFETY: `PooledBuffer` is constructed only for created slots, whose
+    pub(crate) const fn owner_index(&self) -> u32 {
+        // SAFETY: `PooledBuffer` is constructed only for created owners, whose
         // stable side-table fields are initialized.
-        unsafe { self.owner.as_ref().slot }
+        unsafe { self.owner.as_ref().owner_index }
+    }
+
+    /// Consumes this unique handle and returns its compact global index.
+    #[inline(always)]
+    pub(crate) const fn into_owner_index(self) -> u32 {
+        self.owner_index()
     }
 
     /// Initializes the pooled lease for a buffer leaving global state.
@@ -1201,7 +1207,7 @@ impl PooledBuffer {
     /// # Safety
     ///
     /// This buffer must be checked out from the size class represented by
-    /// `lease`, and the slot must not currently contain a live lease.
+    /// `lease`, and the owner must not currently contain a live lease.
     #[inline(always)]
     pub(crate) unsafe fn init_lease(&mut self, lease: SizeClassLease) {
         // SAFETY: owner is a live side-table entry.
@@ -1222,7 +1228,7 @@ impl PooledBuffer {
         unsafe { &*self.owner.as_ref().lease.as_ptr() }
     }
 
-    /// Consumes the live lease from this slot.
+    /// Consumes the live lease from this owner.
     ///
     /// # Safety
     ///
@@ -1258,16 +1264,16 @@ impl PooledBuffer {
         unsafe { dealloc(self.data_ptr().as_ptr(), layout) };
     }
 
-    /// Asserts the parked-slot sentinel invariant on a freshly claimed buffer.
+    /// Asserts the refcount sentinel on a freshly claimed global buffer.
     ///
-    /// A buffer leaving the global freelist must observe the refcount
-    /// sentinel of 1: the final release restores the sentinel before the
-    /// bitmap bit's Release publication, and the claimant's Acquire clear
-    /// pairs with it. A Relaxed load suffices because the assertion is on the
-    /// value. Loom explores every interleaving that could expose a stale one.
+    /// A buffer leaving the global freelist must observe the refcount sentinel
+    /// of 1. The final release restores the sentinel before the return unlocks
+    /// its stripe mutex, and the claimant acquires that mutex before taking the
+    /// buffer. A Relaxed load suffices because the assertion is on the value.
+    /// Loom explores every interleaving that could expose a stale one.
     #[cfg(feature = "loom")]
-    pub(crate) fn assert_parked_sentinel(&self) {
-        // SAFETY: the caller just claimed the slot, so the side-table entry
+    pub(crate) fn assert_unique_sentinel(&self) {
+        // SAFETY: the caller just claimed the owner, so the side-table entry
         // is live and owned by this thread.
         let refs = unsafe { &self.owner.as_ref().refs };
         assert_eq!(refs.load(Ordering::Relaxed), 1);

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -8,8 +8,9 @@
 //! # Thread Safety
 //!
 //! [`BufferPool`] is `Send + Sync` and can be safely shared across threads.
-//! Allocation and deallocation use atomic counters together with a bounded
-//! lock-free global freelist plus per-thread caches.
+//! Allocation and deallocation use atomic counters together with a global
+//! freelist made of hard-bounded mutex-protected stripes, plus per-thread
+//! caches.
 //!
 //! # Pool Lifecycle
 //!
@@ -38,8 +39,10 @@
 //! 16000-byte request above is served by the 32768-byte class. Requests larger
 //! than the largest enabled class return [`PoolError::Oversized`] from
 //! [`BufferPool::try_alloc`], or fall back to an untracked aligned heap
-//! allocation from [`BufferPool::alloc`]. A request routed to an exhausted
-//! class returns [`PoolError::Exhausted`] without trying larger classes.
+//! allocation from [`BufferPool::alloc`]. A request that misses its required
+//! class returns [`PoolError::Exhausted`] without trying larger classes. The
+//! freelist scan is a bounded concurrent observation, not a linearizable empty
+//! snapshot, so a retry can succeed after a concurrent return.
 //!
 //! # Cache Structure
 //!
@@ -89,8 +92,11 @@ pub enum PoolError {
     /// The requested capacity exceeds the maximum buffer size.
     #[error("requested capacity exceeds maximum buffer size")]
     Oversized,
-    /// The pool is exhausted for the required size class.
-    #[error("pool exhausted for required size class")]
+    /// A bounded allocation attempt missed the required size class.
+    ///
+    /// This is not a linearizable empty snapshot. A retry can succeed after a
+    /// concurrent return.
+    #[error("pool allocation missed required size class")]
     Exhausted,
 }
 
@@ -119,7 +125,7 @@ pub struct BufferPoolClassConfig {
     pub size: NonZeroUsize,
     /// Maximum number of tracked buffers in this class.
     ///
-    /// Size-class slots are identified by `u32`, so the per-class limit is
+    /// Size-class owners are indexed by `u32`, so the per-class limit is
     /// capped by this type.
     pub max_buffers: NonZeroU32,
 }
@@ -166,9 +172,11 @@ pub struct BufferPoolConfig {
     alignment: NonZeroUsize,
     /// Expected number of threads concurrently accessing the pool.
     ///
-    /// This sizes the shared global freelist stripes. It is also used to derive
-    /// thread-cache capacity when the thread-cache policy is automatic, using
-    /// approximately half of each class limit divided across expected threads.
+    /// This selects the shared global freelist stripe target, which is rounded
+    /// to a power of two, floored at up to eight stripes, and capped at the
+    /// class capacity and 4,096. It is also used to derive thread-cache capacity
+    /// when the thread-cache policy is automatic, using approximately half of
+    /// each class limit divided across expected threads.
     parallelism: NonZeroUsize,
     /// Policy for sizing the per-thread local cache in each size class.
     ///
@@ -367,10 +375,12 @@ impl BufferPoolConfig {
 
     /// Returns a copy of this config with a new expected parallelism.
     ///
-    /// This controls the minimum global-freelist stripe count, and controls
-    /// thread-cache capacity when the thread-cache policy is automatic. The
-    /// automatic policy reserves about half of each class for the global
-    /// freelist and divides the remaining capacity across expected threads.
+    /// The global freelist rounds this target up to a power of two, uses at
+    /// least eight stripes when capacity permits, and caps it at both the class
+    /// capacity and 4,096 stripes. This value also controls thread-cache
+    /// capacity when the thread-cache policy is automatic. The automatic policy
+    /// reserves about half of each class for the global freelist and divides
+    /// the remaining capacity across expected threads.
     pub const fn with_parallelism(mut self, parallelism: NonZeroUsize) -> Self {
         self.parallelism = parallelism;
         self
@@ -463,7 +473,7 @@ impl BufferPoolConfig {
         // optimal count vector.
         const FRACTION_BITS: u32 = 64;
 
-        // Scaled limit for one class. The u32 slot-identifier bound is
+        // Scaled limit for one class. The u32 owner-index bound is
         // enforced by `evaluate` and the post-search assert below. Saturating
         // math keeps the evaluation monotonic for scales beyond that bound
         // instead of overflowing.
@@ -471,7 +481,7 @@ impl BufferPoolConfig {
             ((limit.get() as u128).saturating_mul(scale) >> FRACTION_BITS).max(1)
         };
         // Saturating total tracked bytes at a scale, and whether every scaled
-        // limit still fits u32 slot identifiers. Both constraints are
+        // limit still fits u32 owner indices. Both constraints are
         // monotonically violated as the scale grows, so feasibility is a
         // prefix of the scale axis and binary search applies.
         let evaluate = |scale: u128| -> (u128, bool) {
@@ -652,7 +662,7 @@ struct SizeClassLabel {
 struct PoolMetrics {
     /// Number of tracked buffers created for the size class.
     created: GaugeFamily<SizeClassLabel>,
-    /// Total number of failed allocations (pool exhausted).
+    /// Total number of bounded allocation attempts that missed their class.
     exhausted_total: CounterFamily<SizeClassLabel>,
     /// Total number of oversized allocation requests.
     oversized_total: Counter,
@@ -670,7 +680,7 @@ impl PoolMetrics {
             // prometheus encoder appends it to counter names.
             exhausted_total: registry.register(
                 "buffer_pool_exhausted",
-                "Total number of failed allocations due to pool exhaustion",
+                "Total number of bounded allocation attempts that missed the required size class",
                 raw::Family::default(),
             ),
             oversized_total: registry.register(
@@ -688,21 +698,21 @@ impl PoolMetrics {
 /// - a shared global freelist for tracked buffers visible to all threads
 /// - a per-thread local cache for same-thread reuse
 ///
-/// The global freelist owns the allocation layout, slot reservation counter,
-/// and side-table slots for this class. A tracked buffer can be globally parked,
+/// The global freelist owns the allocation layout, creation counter, and
+/// side-table owners for this class. A tracked buffer can be globally parked,
 /// owned by a pooled backing, or parked in one thread's local cache, but the
-/// slot always belongs to this `SizeClass`.
+/// owner always belongs to this `SizeClass`.
 ///
 /// Liveness follows the buffer ownership state. Global freelist entries carry
 /// no per-buffer strong reference and rely on the pool's [`SizeClassHandle`]
 /// while the pool is alive. Pooled backing values and thread-local cache
-/// entries carry a live [`SizeClassLease`] in the pooled slot. Those
+/// entries carry a live [`SizeClassLease`] in the pooled owner. Those
 /// non-global states are what allow a buffer to outlive the public
 /// [`BufferPool`] handle and still return to the correct freelist.
 ///
 /// The freelist is the only place that deallocates tracked buffers. Returning a
 /// buffer to the freelist transfers buffer ownership back to that freelist and
-/// releases the slot lease that kept the class alive while the buffer was
+/// releases the owner lease that kept the class alive while the buffer was
 /// outside the global freelist.
 ///
 /// Allocation prefers the local cache, then refills from the global freelist,
@@ -747,7 +757,7 @@ unsafe impl Sync for SizeClass {}
 ///   and carries one [`SizeClassLease`], which is one strong reference to the
 ///   class.
 /// - Thread-local cache: each initialized [`TlsSizeClassCacheEntry`] owns a
-///   [`PooledBuffer`] whose side-table slot contains a live
+///   [`PooledBuffer`] whose side-table owner contains a live
 ///   [`SizeClassLease`]. Increasing or decreasing the cache `len` moves entries
 ///   into or out of the initialized prefix, but does not touch the `Arc` strong
 ///   count.
@@ -758,7 +768,7 @@ unsafe impl Sync for SizeClass {}
 /// reference without touching the refcount:
 ///
 /// ```text
-///                      lease_into: retain class ref into slot lease
+///                     lease_into: retain class ref into owner lease
 /// +-------------------+                             +-----------------+
 /// | parked in global  | --------------------------> | checked out     |
 /// | freelist          |                             | (pooled view)   |
@@ -779,7 +789,7 @@ unsafe impl Sync for SizeClass {}
 /// drops its `SizeClassHandle`s. Pooled views and non-empty TLS caches may keep
 /// the `SizeClass` alive after that point. Empty TLS caches keep no size-class
 /// reference. A later return of an outstanding buffer can recreate the cache
-/// from the live lease in that buffer's slot.
+/// from the live lease in that buffer's owner.
 ///
 /// This is the one raw pointer shape used by all pool-owned, pooled view, and
 /// thread-local references to a [`SizeClass`]. The pointer is always derived
@@ -789,14 +799,14 @@ unsafe impl Sync for SizeClass {}
 /// pointer accepted by the `Arc` refcount APIs:
 /// - [`SizeClassHandle`] pairs a token with ownership of one strong reference.
 /// - [`SizeClassLease`] pairs a token with ownership of one strong reference.
-/// - [`TlsSizeClassCache`] stores entries whose pooled slots own strong
+/// - [`TlsSizeClassCache`] stores entries whose pooled owners hold strong
 ///   references through live leases.
 ///
 /// Because the token is non-owning, code may dereference it or adjust the
 /// strong count only when another invariant proves the allocation is still
 /// live. [`SizeClassHandle`] and [`SizeClassLease`] prove liveness through
 /// owned strong references. A non-empty [`TlsSizeClassCache`] proves liveness
-/// through the live leases stored in its entries' pooled slots.
+/// through the live leases stored in its entries' pooled owners.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 struct SizeClassToken {
@@ -858,11 +868,11 @@ impl SizeClassToken {
 /// while the [`BufferPoolInner`] exists. Dropping the handle releases that
 /// pool-owned strong reference. A class may still outlive the handle if pooled
 /// backing values or thread-local cache entries own additional references
-/// through live [`SizeClassLease`] values in pooled slots.
+/// through live [`SizeClassLease`] values in pooled owners.
 ///
 /// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
 /// to keep the pool-owned reference alive and to provide a live token for
-/// allocation paths that need to retain pooled-slot lease references. The raw
+/// allocation paths that need to retain pooled-owner lease references. The raw
 /// form keeps the already-loaded class pointer usable for
 /// explicit refcount operations without calling [`Arc::as_ptr`] or storing a
 /// second token alongside an `Arc`.
@@ -973,7 +983,7 @@ impl std::ops::Deref for SizeClassHandle {
 /// both own exactly one strong reference for a token. The types are separate
 /// because they live in different state machines. `SizeClassHandle` is ordinary
 /// RAII ownership for the pool's class vector. `SizeClassLease` is hot-path
-/// pooled ownership that lives in the pooled slot while a buffer is
+/// pooled ownership that lives in the pooled owner while a buffer is
 /// checked out or parked in a thread-local cache. It must be explicitly
 /// returned to the global freelist when the buffer leaves local ownership.
 ///
@@ -984,16 +994,16 @@ impl std::ops::Deref for SizeClassHandle {
 /// through pooled buffer and cache-entry structs makes the compiler preserve
 /// destructor paths for those structs. `SizeClassLease` has no automatic drop:
 /// moving between checked-out view and local-cache state is just moving the
-/// pooled buffer whose slot contains the lease. Only explicit calls such as
+/// pooled buffer whose owner contains the lease. Only explicit calls such as
 /// [`Self::return_global`] adjust the strong count.
 ///
 /// A lease must be consumed when a buffer returns to the global freelist.
 /// Because this type intentionally has no `Drop` implementation, simply
 /// dropping a lease value would leak the strong reference. The hot local
-/// alloc/drop loop therefore keeps the lease in the slot and avoids moving a
+/// alloc/drop loop therefore keeps the lease in the owner and avoids moving a
 /// separate lease value at all.
 ///
-/// Thread-local cache entries store a [`PooledBuffer`] whose slot lease stays
+/// Thread-local cache entries store a [`PooledBuffer`] whose owner lease stays
 /// live. Popping from the local cache hands that same live lease back to the
 /// caller without touching the strong count.
 ///
@@ -1060,7 +1070,7 @@ impl SizeClassLease {
     #[inline(always)]
     fn return_global(self, buffer: PooledBuffer) {
         // The lease proves this buffer was checked out from this class's
-        // freelist, and checked-out slots are not available in the freelist.
+        // freelist, and checked-out owners are not available in the freelist.
         self.class().global.put(buffer);
         // SAFETY: this lease owns one strong reference.
         unsafe { self.token.release() };
@@ -1084,10 +1094,10 @@ impl SizeClassLease {
 /// entry is held here, the buffer is owned by the current thread and is not
 /// visible to the class-global freelist.
 ///
-/// The buffer's side-table slot identifies the stable slot within its
+/// The buffer's side-table entry identifies its stable owner within the
 /// [`SizeClass`] and contains the live lease that keeps that class alive. The
-/// entry itself intentionally stores only the buffer so local pop/push does
-/// not move separate slot or class metadata per buffer.
+/// cache entry stores only the buffer, so local pop and push do not move
+/// separate owner or class metadata.
 struct TlsSizeClassCacheEntry {
     buffer: PooledBuffer,
 }
@@ -1096,7 +1106,7 @@ impl TlsSizeClassCacheEntry {
     /// Returns this entry to its class-global freelist.
     #[inline(always)]
     fn return_global(mut self) {
-        // SAFETY: local cache entries keep a live lease in the pooled slot.
+        // SAFETY: local cache entries keep a live lease in the pooled owner.
         let lease = unsafe { self.buffer.take_lease() };
         lease.return_global(self.buffer);
     }
@@ -1111,7 +1121,7 @@ impl TlsSizeClassCacheEntry {
 /// overflow spill, explicit flush, or thread exit (return).
 ///
 /// When `len > 0`, each initialized entry in `entries[..len]` owns one live
-/// slot lease, which keeps the pointed-to class alive. An empty cache owns no
+/// owner lease, which keeps the pointed-to class alive. An empty cache owns no
 /// class reference. It is only an allocated local stack for a class id.
 ///
 /// The hot steady-state allocation path pops an entry from `entries`, and the
@@ -1143,7 +1153,7 @@ impl TlsSizeClassCache {
     /// batch-take from the global freelist, return the first claimed buffer,
     /// and retain the rest locally for future allocations.
     ///
-    /// The returned entry carries a live lease in its pooled slot.
+    /// The returned entry carries a live lease in its pooled owner.
     #[inline(always)]
     fn pop(&mut self, class: &SizeClassHandle) -> Option<TlsSizeClassCacheEntry> {
         if let Some(entry) = self.pop_local() {
@@ -1173,7 +1183,7 @@ impl TlsSizeClassCache {
     /// Takes from the class-global freelist after the local stack misses.
     ///
     /// Every claimed global entry gets one retained class reference installed
-    /// as a live slot lease. The first claimed entry is returned to the
+    /// as a live owner lease. The first claimed entry is returned to the
     /// caller, and additional claimed entries are parked in this cache and
     /// counted by `len`.
     ///
@@ -1192,14 +1202,14 @@ impl TlsSizeClassCache {
         }
 
         // Refill larger caches to half capacity. That leaves room for future
-        // same-thread returns while still amortizing the global atomic scan
+        // same-thread returns while still amortizing the global stripe locks
         // over several future local pops.
         let mut entry = None;
         let take = self.capacity / 2;
         class.global.take_batch(take, |buffer| {
             // Each claimed global entry becomes either the returned allocation
             // or a local cache entry, so each needs one retained class
-            // reference stored in its slot lease.
+            // reference stored in its owner lease.
             let buffer = class.lease_into(buffer);
             let cache_entry = TlsSizeClassCacheEntry { buffer };
             if entry.is_none() {
@@ -1275,7 +1285,7 @@ impl TlsSizeClassCache {
         let spill = self.len.min(self.capacity / 2).max(1);
         let end = self.len;
         let start = end - spill;
-        // Stop tracking slots before moving them out.
+        // Stop tracking owners before moving them out.
         self.len = start;
         self.return_global_batch(start, end);
 
@@ -1286,15 +1296,14 @@ impl TlsSizeClassCache {
     /// Returns the initialized entries in `start..end` to their class-global
     /// freelist as one batch.
     ///
-    /// All entries in one cache belong to the same size class, so their slot
+    /// All entries in one cache belong to the same size class, so their owner
     /// leases own strong references represented by one shared token. Each
-    /// lease is consumed without being released, the whole batch parks with
-    /// one coalesced [`Freelist::put_batch`] (one atomic `fetch_or` per
-    /// touched bitmap word instead of one per entry), and the strong
-    /// references are released only after every buffer is parked. Parking
-    /// before releasing matters: if the public pool is already gone and these
-    /// leases are the last references, releasing first would drop the
-    /// freelist before the buffers returned to it.
+    /// lease is consumed without being released, then the whole batch parks
+    /// under its freelist stripe locks. The strong references are released
+    /// only after every buffer is parked. Parking before releasing matters: if
+    /// the public pool is already gone and these leases are the last
+    /// references, releasing first would drop the freelist before the buffers
+    /// returned to it.
     ///
     /// The caller must have already lowered `len` to at most `start`,
     /// transferring ownership of the entries in `start..end` to this function.
@@ -1320,7 +1329,7 @@ impl TlsSizeClassCache {
             // Reading moves each entry out and leaves the slot uninitialized.
             let mut entry = unsafe { entries.add(index).read().assume_init() };
             // SAFETY: local cache entries keep a live lease in the pooled
-            // slot. The strong reference it owns is intentionally not
+            // owner. The strong reference it owns is intentionally not
             // released here (leases have no drop glue). The token releases
             // below settle it.
             let _ = unsafe { entry.buffer.take_lease() }.into_token();
@@ -1348,7 +1357,7 @@ impl Drop for TlsSizeClassCache {
         // Flush remaining entries (thread exit or explicit flush) with one
         // coalesced batch insert.
         let end = self.len;
-        // Stop tracking slots before moving them out.
+        // Stop tracking owners before moving them out.
         self.len = 0;
         self.return_global_batch(0, end);
     }
@@ -1369,7 +1378,7 @@ impl Drop for TlsSizeClassCache {
 /// Empty initialized caches can also remain after their pool has been dropped.
 /// They own no class reference while empty. If the class is still live because
 /// a pooled buffer is outstanding, a later return of that buffer to this same
-/// thread can use the buffer's live slot lease to make the cache usable
+/// thread can use the buffer's live owner lease to make the cache usable
 /// again.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
@@ -1391,7 +1400,7 @@ impl TlsSizeClassCaches {
     /// The caller must provide a live class id from a [`SizeClassHandle`] or
     /// [`SizeClassLease`]. A missing cache starts empty and owns no class
     /// reference. The first local push or global refill stores entries whose
-    /// pooled slots contain live leases.
+    /// pooled owners contain live leases.
     #[inline(always)]
     fn get_or_init(&mut self, class_id: usize, capacity: usize) -> &mut TlsSizeClassCache {
         // The initialized arm is defensively kept but not reachable today:
@@ -1504,13 +1513,13 @@ impl BufferPoolThreadCache {
     /// The hot path uses only an already-initialized cache from the fast TLS
     /// pointer. If the fast pointer is missing, or this thread has not
     /// initialized the size class yet, [`Self::push_slow`] performs the checked
-    /// TLS access and creates the local cache. The buffer's live slot lease
+    /// TLS access and creates the local cache. The buffer's live owner lease
     /// proves that initialization is safe. During thread-local teardown,
     /// checked TLS access can fail, in that case the buffer falls back to the
     /// global freelist.
     ///
     /// Cache routing reads `class_id` and `thread_cache_capacity` from the
-    /// live slot lease (on the slot line the release path has already loaded)
+    /// live owner lease, on the cache line the release path already loaded,
     /// instead of dereferencing the class object, keeping the dependent-load
     /// chain on the return fast path one level shorter.
     #[inline(always)]
@@ -1693,9 +1702,9 @@ impl BufferPoolInner {
     ///
     /// Uses a three-tier strategy:
     /// 1. **Thread-local cache** (fast path): no atomics, no contention.
-    /// 2. **Global freelist**: atomic pop, then batch-refill the local cache
+    /// 2. **Global freelist**: striped pop, then batch-refill the local cache
     ///    when the local bin is large enough to amortize shared-queue traffic.
-    /// 3. **New allocation**: reserve a slot in the global freelist, then
+    /// 3. **New allocation**: reserve an owner in the global freelist, then
     ///    allocate from the heap.
     ///
     /// If `zero_on_new` is true, newly-created buffers are allocated with
@@ -1720,7 +1729,7 @@ impl BufferPoolInner {
     /// Creates a new tracked buffer after the reuse path fails.
     ///
     /// This is separate from [`Self::try_alloc`] so the steady-state allocation
-    /// path can inline the TLS hit without also carrying slot reservation,
+    /// path can inline the TLS hit without also carrying owner reservation,
     /// metrics, and heap-allocation code.
     #[inline(never)]
     fn try_alloc_new(&self, class: &SizeClassHandle, zeroed: bool) -> Option<Allocation> {
@@ -1893,9 +1902,9 @@ impl BufferPool {
     /// Attempts to allocate a buffer without falling back on pool miss.
     ///
     /// Unlike [`Self::alloc`], this method does not fall back to untracked
-    /// allocation on exhaustion or oversized requests. Requests smaller than
-    /// [`BufferPoolConfig::pool_min_size`] intentionally bypass pooling and
-    /// return an untracked aligned allocation instead.
+    /// allocation on a bounded pool miss or oversized request. Requests
+    /// smaller than [`BufferPoolConfig::pool_min_size`] intentionally bypass
+    /// pooling and return an untracked aligned allocation instead.
     ///
     /// The returned buffer has `len() == 0` and `capacity() >= capacity`.
     ///
@@ -1910,7 +1919,8 @@ impl BufferPool {
     /// # Errors
     ///
     /// - [`PoolError::Oversized`]: `capacity` exceeds `max_size`
-    /// - [`PoolError::Exhausted`]: pool exhausted for the required size class
+    /// - [`PoolError::Exhausted`]: this bounded attempt missed the required
+    ///   size class. A retry can succeed after a concurrent return
     #[inline(always)]
     pub fn try_alloc(&self, capacity: usize) -> Result<IoBufMut, PoolError> {
         if capacity == 0 {
@@ -1949,12 +1959,12 @@ impl BufferPool {
     /// Zero-capacity requests return a detached empty buffer without touching
     /// the pool.
     ///
-    /// If the pool can provide a buffer (capacity within limits and pool not
-    /// exhausted), this returns a pooled buffer that will be returned to the
-    /// pool when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
-    /// bypass pooling and return an untracked aligned allocation. Oversized or
-    /// exhausted requests also fall back to an untracked aligned heap allocation
-    /// that is deallocated when dropped.
+    /// If the pool can provide a buffer on this attempt, this returns a pooled
+    /// buffer that will be returned to the pool when dropped. Requests smaller
+    /// than [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
+    /// untracked aligned allocation. Oversized requests and bounded pool misses
+    /// also fall back to an untracked aligned heap allocation that is
+    /// deallocated when dropped.
     ///
     /// Use [`Self::try_alloc`] if eligible requests must fail instead of falling
     /// back to direct allocation.
@@ -1990,9 +2000,9 @@ impl BufferPool {
     /// pool miss.
     ///
     /// Unlike [`Self::alloc_zeroed`], this method does not fall back to
-    /// untracked allocation on exhaustion or oversized requests. Requests
-    /// smaller than [`BufferPoolConfig::pool_min_size`] intentionally bypass
-    /// pooling and return an untracked aligned allocation instead.
+    /// untracked allocation on a bounded pool miss or oversized request.
+    /// Requests smaller than [`BufferPoolConfig::pool_min_size`] intentionally
+    /// bypass pooling and return an untracked aligned allocation instead.
     ///
     /// The returned buffer has `len() == len` and `capacity() >= len`.
     /// Zero-length requests return a detached empty buffer without touching
@@ -2006,7 +2016,8 @@ impl BufferPool {
     /// # Errors
     ///
     /// - [`PoolError::Oversized`]: `len` exceeds `max_size`
-    /// - [`PoolError::Exhausted`]: pool exhausted for the required size class
+    /// - [`PoolError::Exhausted`]: this bounded attempt missed the required
+    ///   size class. A retry can succeed after a concurrent return
     pub fn try_alloc_zeroed(&self, len: usize) -> Result<IoBufMut, PoolError> {
         if len == 0 {
             return Ok(IoBufMut::default());
@@ -2049,12 +2060,12 @@ impl BufferPool {
     /// Zero-length requests return a detached empty buffer without touching
     /// the pool.
     ///
-    /// If the pool can provide a buffer (len within limits and pool not
-    /// exhausted), this returns a pooled buffer that will be returned to the
-    /// pool when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
-    /// bypass pooling and return an untracked aligned allocation. Oversized or
-    /// exhausted requests also fall back to an untracked aligned heap allocation
-    /// that is deallocated when dropped.
+    /// If the pool can provide a buffer on this attempt, this returns a pooled
+    /// buffer that will be returned to the pool when dropped. Requests smaller
+    /// than [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
+    /// untracked aligned allocation. Oversized requests and bounded pool misses
+    /// also fall back to an untracked aligned heap allocation that is
+    /// deallocated when dropped.
     ///
     /// Use this for read APIs that require an initialized `&mut [u8]`. This
     /// avoids `unsafe set_len` at callsites.
@@ -2068,7 +2079,7 @@ impl BufferPool {
     /// may be uninitialized.
     pub fn alloc_zeroed(&self, len: usize) -> IoBufMut {
         self.try_alloc_zeroed(len).unwrap_or_else(|_| {
-            // Pool exhausted or oversized: allocate untracked zeroed memory.
+            // Pool miss or oversized request: allocate untracked zeroed memory.
             let size = len.max(1);
             let mut buf = IoBufMut::zeroed_with_alignment(size, self.inner.config.alignment);
             buf.truncate(len);
@@ -2747,7 +2758,7 @@ mod tests {
 
     #[test]
     fn test_zero_capacity_requests_bypass_pool() {
-        // A single-slot pool: if a zero-capacity request claimed a buffer,
+        // A single-buffer pool: if a zero-capacity request claimed a buffer,
         // the follow-up real allocation would fail with Exhausted.
         let page = page_size();
         let pool = test_pool(test_config(page, page, 1));
@@ -2906,7 +2917,7 @@ mod tests {
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(pool.inner.classes[class_index].thread_cache_capacity, 4);
 
-        // Large classes scale past the previous eight-slot cap.
+        // Large classes scale past the previous eight-buffer cap.
         let pool = test_pool(test_config(page, page, 4096).with_parallelism(NZUsize!(8)));
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(pool.inner.classes[class_index].thread_cache_capacity, 256);
@@ -2960,21 +2971,29 @@ mod tests {
     #[test]
     fn test_parallelism_policy_resolves_freelist_stripes() {
         let page = page_size();
+        let pool = test_pool(test_config(page, page, 64).with_parallelism(NZUsize!(1)));
+
+        let class_index = pool.class_index(page).unwrap();
+        assert_eq!(
+            freelist::tests::num_stripes(&pool.inner.classes[class_index].global),
+            8
+        );
+
         let pool = test_pool(test_config(page, page, 64).with_parallelism(NZUsize!(16)));
 
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(
-            freelist::tests::num_words(&pool.inner.classes[class_index].global),
+            freelist::tests::num_stripes(&pool.inner.classes[class_index].global),
             16
         );
 
         // When expected parallelism rounds above capacity, the freelist caps
-        // stripes so every word can contain at least one slot.
+        // stripes so every stripe can contain at least one owner index.
         let pool = test_pool(test_config(page, page, 12).with_parallelism(NZUsize!(9)));
 
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(
-            freelist::tests::num_words(&pool.inner.classes[class_index].global),
+            freelist::tests::num_stripes(&pool.inner.classes[class_index].global),
             8
         );
 
@@ -2987,7 +3006,7 @@ mod tests {
 
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(
-            freelist::tests::num_words(&pool.inner.classes[class_index].global),
+            freelist::tests::num_stripes(&pool.inner.classes[class_index].global),
             16
         );
     }
@@ -3005,7 +3024,7 @@ mod tests {
         // Fixed capacity should bypass the derived parallelism heuristic.
         assert_eq!(pool.inner.classes[class_index].thread_cache_capacity, 7);
         assert_eq!(
-            freelist::tests::num_words(&pool.inner.classes[class_index].global),
+            freelist::tests::num_stripes(&pool.inner.classes[class_index].global),
             8
         );
     }
@@ -3230,7 +3249,7 @@ mod tests {
         );
         assert_eq!(
             PoolError::Exhausted.to_string(),
-            "pool exhausted for required size class"
+            "pool allocation missed required size class"
         );
     }
 
@@ -3298,7 +3317,7 @@ mod tests {
         let page = page_size();
         let threads = std::thread::available_parallelism().map_or(1, NonZeroUsize::get);
         let max_per_class =
-            u32::try_from(threads * 8).expect("test capacity must fit in u32 slot ids");
+            u32::try_from(threads * 8).expect("test capacity must fit in u32 owner indices");
         let pool = test_pool(test_config(page, page, max_per_class));
         let class_index = pool
             .class_index(page)
@@ -3338,7 +3357,7 @@ mod tests {
     #[test]
     fn test_global_batch_alloc_stops_when_global_runs_empty() {
         let class = test_size_class(64, 64);
-        let buffer = class.global.try_create(false).expect("slot reservation");
+        let buffer = class.global.try_create(false).expect("owner reservation");
 
         // A short global freelist should return the allocation and stop
         // without filling the local cache to its batch target.
@@ -3359,7 +3378,7 @@ mod tests {
         let mut cache = TlsSizeClassCache::new(MIN_TLS_BATCH_CAPACITY);
         assert_eq!(size_class_strong_count(&class), 1);
 
-        let mut buffer = class.global.try_create(false).expect("slot reservation");
+        let mut buffer = class.global.try_create(false).expect("owner reservation");
         let lease = SizeClassLease::retain(&class);
         // SAFETY: this buffer was just created and has no live lease.
         unsafe { buffer.init_lease(lease) };
@@ -3376,7 +3395,7 @@ mod tests {
         assert_eq!(size_class_strong_count(&class), 1);
 
         for _ in 0..2 {
-            let buffer = class.global.try_create(false).expect("slot reservation");
+            let buffer = class.global.try_create(false).expect("owner reservation");
             class.global.put(buffer);
         }
 
@@ -3395,7 +3414,7 @@ mod tests {
     #[test]
     fn test_tls_size_class_cache_push_tolerates_empty_spill() {
         let class = test_size_class(64, 64);
-        let mut buffer = class.global.try_create(false).expect("slot reservation");
+        let mut buffer = class.global.try_create(false).expect("owner reservation");
         let lease = SizeClassLease::retain(&class);
         // SAFETY: this buffer was just created and has no live lease.
         unsafe { buffer.init_lease(lease) };
@@ -3403,15 +3422,15 @@ mod tests {
 
         // Small local capacities should bypass batching and push straight to
         // global. The retained reference above is represented by the live
-        // slot lease and transferred into `cache.push`.
+        // owner lease and transferred into `cache.push`.
         cache.push(buffer);
         assert_eq!(cache.len, 0);
         drop(cache);
     }
 
     #[test]
-    fn test_global_freelist_returns_each_slot_once() {
-        // Use a two-slot class with TLS capacity one so this test can exercise
+    fn test_global_freelist_returns_each_owner_once() {
+        // Use a two-buffer class with TLS capacity one so this test can exercise
         // the class-global freelist directly without involving local-cache
         // refill or spill behavior.
         let class = SizeClassHandle::new(
@@ -3424,35 +3443,35 @@ mod tests {
             false,
         );
 
-        // Create both slot ids and keep each allocation's pointer so we can
-        // verify that the freelist returns the same buffer parked for that slot.
-        let buffer0 = class.global.try_create(false).expect("first slot");
-        let slot0 = buffer0.slot();
+        // Create both owner indices and keep each allocation's pointer so we can
+        // verify that the freelist returns the same buffer for that owner.
+        let buffer0 = class.global.try_create(false).expect("first owner");
+        let owner_index0 = buffer0.owner_index();
         let ptr0 = buffer0.as_ptr();
-        let buffer1 = class.global.try_create(false).expect("second slot");
-        let slot1 = buffer1.slot();
+        let buffer1 = class.global.try_create(false).expect("second owner");
+        let owner_index1 = buffer1.owner_index();
         let ptr1 = buffer1.as_ptr();
-        let mut expected = [(slot0, ptr0), (slot1, ptr1)];
-        expected.sort_by_key(|(slot, _)| *slot);
+        let mut expected = [(owner_index0, ptr0), (owner_index1, ptr1)];
+        expected.sort_by_key(|(owner_index, _)| *owner_index);
 
         class.global.put(buffer0);
         class.global.put(buffer1);
 
-        // The freelist does not preserve insertion order, so normalize by slot
-        // before asserting identity. The important property is that each slot is
-        // returned exactly once with its original parked buffer.
+        // The freelist does not preserve insertion order, so normalize by owner
+        // index before asserting identity. Each owner must be returned once with
+        // its original buffer.
         let mut popped = [
             class.global.take().expect("first pop"),
             class.global.take().expect("second pop"),
         ];
-        popped.sort_by_key(PooledBuffer::slot);
+        popped.sort_by_key(PooledBuffer::owner_index);
 
-        assert_eq!(popped[0].slot(), expected[0].0);
+        assert_eq!(popped[0].owner_index(), expected[0].0);
         assert_eq!(popped[0].as_ptr(), expected[0].1);
-        assert_eq!(popped[1].slot(), expected[1].0);
+        assert_eq!(popped[1].owner_index(), expected[1].0);
         assert_eq!(popped[1].as_ptr(), expected[1].1);
 
-        // Both slots were claimed above, so the global freelist is empty.
+        // Both owners were claimed above, so the global freelist is empty.
         assert!(class.global.take().is_none());
 
         // Return the buffers so the freelist owns and deallocates them when the
@@ -4267,12 +4286,12 @@ mod loom_tests {
     // drop (which drains the global freelist and then releases the pool-owned
     // class reference). Whichever release is last drops the SizeClass and its
     // freelist. Parking strictly before releasing is what keeps the freelist
-    // alive for the return-path fetch_or. Loom performs no liveness check
-    // when tracked state is dropped, so swapping that order manifests as a
-    // use-after-free of the freed bitmap that corrupts loom's internal object
-    // state (caught by its internal asserts in practice, not by a designed
-    // race report). The loom-tracked class strong count still verifies the
-    // release accounting itself.
+    // alive until the return finishes publishing under its stripe lock. Loom
+    // performs no liveness check when tracked state is dropped, so swapping
+    // that order manifests as a use-after-free of the freed freelist state.
+    // This corrupts Loom's internal object state and is caught by its internal
+    // assertions in practice. The Loom-tracked class strong count still
+    // verifies the release accounting itself.
     #[test]
     fn final_drop_races_pool_teardown() {
         loom::model(|| {
@@ -4296,7 +4315,7 @@ mod loom_tests {
     // Models the multi-entry TLS teardown edge without using OS thread-local
     // state, which loom cannot reset between model executions. Dropping the
     // production cache takes each real pooled-owner lease, batch-parks both
-    // slots, and only then releases the lease references. The final class-handle
+    // owners, and only then releases the lease references. The final class-handle
     // release races that batch return, so either side may perform the final
     // SizeClass drop and reclaim the parked buffers.
     #[test]
@@ -4306,7 +4325,7 @@ mod loom_tests {
             let mut cache = TlsSizeClassCache::new(2);
 
             for _ in 0..2 {
-                let buffer = class.try_create(false).expect("tracked slot");
+                let buffer = class.try_create(false).expect("tracked buffer");
                 cache.push(buffer);
             }
             assert_eq!(cache.len, 2);
@@ -4322,7 +4341,7 @@ mod loom_tests {
     // Release decrement lands on 1, or the race-final path re-stores it with
     // a Relaxed store) before the freelist's Release publication. A
     // successful concurrent take must observe that sentinel (asserted in
-    // Freelist::buffer under loom) before handing the slot to a new mutable
+    // Freelist::claim under loom) before handing the owner to a new mutable
     // handle.
     #[test]
     fn final_drop_races_recheckout() {
@@ -4342,7 +4361,7 @@ mod loom_tests {
             let t = thread::spawn(move || drop(clone));
             drop(frozen);
 
-            // The single slot may still be checked out (Exhausted) or already
+            // The single owner may still be checked out (Exhausted) or already
             // returned by whichever drop was final. A successful claim must
             // expose a writable buffer with the sentinel restored.
             if let Ok(mut again) = pool.try_alloc(64) {

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -12,6 +12,11 @@
 //! freelist made of hard-bounded mutex-protected stripes, plus per-thread
 //! caches.
 //!
+//! Global freelist operations use blocking mutexes. After a local cache miss or
+//! spill, an operation can wait for a stripe lock. A preempted lock holder can
+//! therefore delay the operation even when another stripe could provide or
+//! accept a buffer.
+//!
 //! # Pool Lifecycle
 //!
 //! Tracked buffers held by pooled views or cached in thread-local bins keep a

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -695,8 +695,8 @@ impl PoolMetrics {
 /// - a shared global freelist for tracked buffers visible to all threads
 /// - a per-thread local cache for same-thread reuse
 ///
-/// The global freelist owns the allocation layout, slot reservation counter, and
-/// side-table slots for this class. A tracked buffer can be globally parked,
+/// The global freelist owns the allocation layout, slot reservation counter,
+/// and side-table slots for this class. A tracked buffer can be globally parked,
 /// owned by a pooled backing, or parked in one thread's local cache, but the
 /// slot always belongs to this `SizeClass`.
 ///
@@ -1093,7 +1093,7 @@ impl SizeClassLease {
 ///
 /// The buffer's side-table slot identifies the stable slot within its
 /// [`SizeClass`] and contains the live lease that keeps that class alive. The
-/// entry itself intentionally stores only the buffer so local pop and push do
+/// entry itself intentionally stores only the buffer so local pop/push does
 /// not move separate slot or class metadata per buffer.
 struct TlsSizeClassCacheEntry {
     buffer: PooledBuffer,
@@ -2966,14 +2966,6 @@ mod tests {
     #[test]
     fn test_parallelism_policy_resolves_freelist_stripes() {
         let page = page_size();
-        let pool = test_pool(test_config(page, page, 64).with_parallelism(NZUsize!(1)));
-
-        let class_index = pool.class_index(page).unwrap();
-        assert_eq!(
-            freelist::tests::num_stripes(&pool.inner.classes[class_index].global),
-            8
-        );
-
         let pool = test_pool(test_config(page, page, 64).with_parallelism(NZUsize!(16)));
 
         let class_index = pool.class_index(page).unwrap();

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -9,8 +9,8 @@
 //!
 //! [`BufferPool`] is `Send + Sync` and can be safely shared across threads.
 //! Allocation and deallocation use atomic counters together with a global
-//! freelist made of hard-bounded mutex-protected stripes, plus per-thread
-//! caches.
+//! freelist split across mutex-protected stripes, each with a fixed slot limit,
+//! plus per-thread caches.
 //!
 //! Global freelist operations use blocking mutexes. After a local cache miss or
 //! spill, an operation can wait for a stripe lock. A preempted lock holder can

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -125,7 +125,7 @@ pub struct BufferPoolClassConfig {
     pub size: NonZeroUsize,
     /// Maximum number of tracked buffers in this class.
     ///
-    /// Size-class owners are indexed by `u32`, so the per-class limit is
+    /// Size-class slots are identified by `u32`, so the per-class limit is
     /// capped by this type.
     pub max_buffers: NonZeroU32,
 }
@@ -473,7 +473,7 @@ impl BufferPoolConfig {
         // optimal count vector.
         const FRACTION_BITS: u32 = 64;
 
-        // Scaled limit for one class. The u32 owner-index bound is
+        // Scaled limit for one class. The u32 slot-identifier bound is
         // enforced by `evaluate` and the post-search assert below. Saturating
         // math keeps the evaluation monotonic for scales beyond that bound
         // instead of overflowing.
@@ -481,7 +481,7 @@ impl BufferPoolConfig {
             ((limit.get() as u128).saturating_mul(scale) >> FRACTION_BITS).max(1)
         };
         // Saturating total tracked bytes at a scale, and whether every scaled
-        // limit still fits u32 owner indices. Both constraints are
+        // limit still fits u32 slot identifiers. Both constraints are
         // monotonically violated as the scale grows, so feasibility is a
         // prefix of the scale axis and binary search applies.
         let evaluate = |scale: u128| -> (u128, bool) {
@@ -698,21 +698,21 @@ impl PoolMetrics {
 /// - a shared global freelist for tracked buffers visible to all threads
 /// - a per-thread local cache for same-thread reuse
 ///
-/// The global freelist owns the allocation layout, creation counter, and
-/// side-table owners for this class. A tracked buffer can be globally parked,
+/// The global freelist owns the allocation layout, slot reservation counter, and
+/// side-table slots for this class. A tracked buffer can be globally parked,
 /// owned by a pooled backing, or parked in one thread's local cache, but the
-/// owner always belongs to this `SizeClass`.
+/// slot always belongs to this `SizeClass`.
 ///
 /// Liveness follows the buffer ownership state. Global freelist entries carry
 /// no per-buffer strong reference and rely on the pool's [`SizeClassHandle`]
 /// while the pool is alive. Pooled backing values and thread-local cache
-/// entries carry a live [`SizeClassLease`] in the pooled owner. Those
+/// entries carry a live [`SizeClassLease`] in the pooled slot. Those
 /// non-global states are what allow a buffer to outlive the public
 /// [`BufferPool`] handle and still return to the correct freelist.
 ///
 /// The freelist is the only place that deallocates tracked buffers. Returning a
 /// buffer to the freelist transfers buffer ownership back to that freelist and
-/// releases the owner lease that kept the class alive while the buffer was
+/// releases the slot lease that kept the class alive while the buffer was
 /// outside the global freelist.
 ///
 /// Allocation prefers the local cache, then refills from the global freelist,
@@ -757,7 +757,7 @@ unsafe impl Sync for SizeClass {}
 ///   and carries one [`SizeClassLease`], which is one strong reference to the
 ///   class.
 /// - Thread-local cache: each initialized [`TlsSizeClassCacheEntry`] owns a
-///   [`PooledBuffer`] whose side-table owner contains a live
+///   [`PooledBuffer`] whose side-table slot contains a live
 ///   [`SizeClassLease`]. Increasing or decreasing the cache `len` moves entries
 ///   into or out of the initialized prefix, but does not touch the `Arc` strong
 ///   count.
@@ -768,7 +768,7 @@ unsafe impl Sync for SizeClass {}
 /// reference without touching the refcount:
 ///
 /// ```text
-///                     lease_into: retain class ref into owner lease
+///                      lease_into: retain class ref into slot lease
 /// +-------------------+                             +-----------------+
 /// | parked in global  | --------------------------> | checked out     |
 /// | freelist          |                             | (pooled view)   |
@@ -789,7 +789,7 @@ unsafe impl Sync for SizeClass {}
 /// drops its `SizeClassHandle`s. Pooled views and non-empty TLS caches may keep
 /// the `SizeClass` alive after that point. Empty TLS caches keep no size-class
 /// reference. A later return of an outstanding buffer can recreate the cache
-/// from the live lease in that buffer's owner.
+/// from the live lease in that buffer's slot.
 ///
 /// This is the one raw pointer shape used by all pool-owned, pooled view, and
 /// thread-local references to a [`SizeClass`]. The pointer is always derived
@@ -799,14 +799,14 @@ unsafe impl Sync for SizeClass {}
 /// pointer accepted by the `Arc` refcount APIs:
 /// - [`SizeClassHandle`] pairs a token with ownership of one strong reference.
 /// - [`SizeClassLease`] pairs a token with ownership of one strong reference.
-/// - [`TlsSizeClassCache`] stores entries whose pooled owners hold strong
+/// - [`TlsSizeClassCache`] stores entries whose pooled slots own strong
 ///   references through live leases.
 ///
 /// Because the token is non-owning, code may dereference it or adjust the
 /// strong count only when another invariant proves the allocation is still
 /// live. [`SizeClassHandle`] and [`SizeClassLease`] prove liveness through
 /// owned strong references. A non-empty [`TlsSizeClassCache`] proves liveness
-/// through the live leases stored in its entries' pooled owners.
+/// through the live leases stored in its entries' pooled slots.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(transparent)]
 struct SizeClassToken {
@@ -868,11 +868,11 @@ impl SizeClassToken {
 /// while the [`BufferPoolInner`] exists. Dropping the handle releases that
 /// pool-owned strong reference. A class may still outlive the handle if pooled
 /// backing values or thread-local cache entries own additional references
-/// through live [`SizeClassLease`] values in pooled owners.
+/// through live [`SizeClassLease`] values in pooled slots.
 ///
 /// Functionally this is an `Arc<SizeClass>` stored in raw-token form. It exists
 /// to keep the pool-owned reference alive and to provide a live token for
-/// allocation paths that need to retain pooled-owner lease references. The raw
+/// allocation paths that need to retain pooled-slot lease references. The raw
 /// form keeps the already-loaded class pointer usable for
 /// explicit refcount operations without calling [`Arc::as_ptr`] or storing a
 /// second token alongside an `Arc`.
@@ -983,7 +983,7 @@ impl std::ops::Deref for SizeClassHandle {
 /// both own exactly one strong reference for a token. The types are separate
 /// because they live in different state machines. `SizeClassHandle` is ordinary
 /// RAII ownership for the pool's class vector. `SizeClassLease` is hot-path
-/// pooled ownership that lives in the pooled owner while a buffer is
+/// pooled ownership that lives in the pooled slot while a buffer is
 /// checked out or parked in a thread-local cache. It must be explicitly
 /// returned to the global freelist when the buffer leaves local ownership.
 ///
@@ -994,16 +994,16 @@ impl std::ops::Deref for SizeClassHandle {
 /// through pooled buffer and cache-entry structs makes the compiler preserve
 /// destructor paths for those structs. `SizeClassLease` has no automatic drop:
 /// moving between checked-out view and local-cache state is just moving the
-/// pooled buffer whose owner contains the lease. Only explicit calls such as
+/// pooled buffer whose slot contains the lease. Only explicit calls such as
 /// [`Self::return_global`] adjust the strong count.
 ///
 /// A lease must be consumed when a buffer returns to the global freelist.
 /// Because this type intentionally has no `Drop` implementation, simply
 /// dropping a lease value would leak the strong reference. The hot local
-/// alloc/drop loop therefore keeps the lease in the owner and avoids moving a
+/// alloc/drop loop therefore keeps the lease in the slot and avoids moving a
 /// separate lease value at all.
 ///
-/// Thread-local cache entries store a [`PooledBuffer`] whose owner lease stays
+/// Thread-local cache entries store a [`PooledBuffer`] whose slot lease stays
 /// live. Popping from the local cache hands that same live lease back to the
 /// caller without touching the strong count.
 ///
@@ -1070,7 +1070,7 @@ impl SizeClassLease {
     #[inline(always)]
     fn return_global(self, buffer: PooledBuffer) {
         // The lease proves this buffer was checked out from this class's
-        // freelist, and checked-out owners are not available in the freelist.
+        // freelist, and checked-out slots are not available in the freelist.
         self.class().global.put(buffer);
         // SAFETY: this lease owns one strong reference.
         unsafe { self.token.release() };
@@ -1094,10 +1094,10 @@ impl SizeClassLease {
 /// entry is held here, the buffer is owned by the current thread and is not
 /// visible to the class-global freelist.
 ///
-/// The buffer's side-table entry identifies its stable owner within the
+/// The buffer's side-table slot identifies the stable slot within its
 /// [`SizeClass`] and contains the live lease that keeps that class alive. The
-/// cache entry stores only the buffer, so local pop and push do not move
-/// separate owner or class metadata.
+/// entry itself intentionally stores only the buffer so local pop and push do
+/// not move separate slot or class metadata per buffer.
 struct TlsSizeClassCacheEntry {
     buffer: PooledBuffer,
 }
@@ -1106,7 +1106,7 @@ impl TlsSizeClassCacheEntry {
     /// Returns this entry to its class-global freelist.
     #[inline(always)]
     fn return_global(mut self) {
-        // SAFETY: local cache entries keep a live lease in the pooled owner.
+        // SAFETY: local cache entries keep a live lease in the pooled slot.
         let lease = unsafe { self.buffer.take_lease() };
         lease.return_global(self.buffer);
     }
@@ -1121,7 +1121,7 @@ impl TlsSizeClassCacheEntry {
 /// overflow spill, explicit flush, or thread exit (return).
 ///
 /// When `len > 0`, each initialized entry in `entries[..len]` owns one live
-/// owner lease, which keeps the pointed-to class alive. An empty cache owns no
+/// slot lease, which keeps the pointed-to class alive. An empty cache owns no
 /// class reference. It is only an allocated local stack for a class id.
 ///
 /// The hot steady-state allocation path pops an entry from `entries`, and the
@@ -1153,7 +1153,7 @@ impl TlsSizeClassCache {
     /// batch-take from the global freelist, return the first claimed buffer,
     /// and retain the rest locally for future allocations.
     ///
-    /// The returned entry carries a live lease in its pooled owner.
+    /// The returned entry carries a live lease in its pooled slot.
     #[inline(always)]
     fn pop(&mut self, class: &SizeClassHandle) -> Option<TlsSizeClassCacheEntry> {
         if let Some(entry) = self.pop_local() {
@@ -1183,7 +1183,7 @@ impl TlsSizeClassCache {
     /// Takes from the class-global freelist after the local stack misses.
     ///
     /// Every claimed global entry gets one retained class reference installed
-    /// as a live owner lease. The first claimed entry is returned to the
+    /// as a live slot lease. The first claimed entry is returned to the
     /// caller, and additional claimed entries are parked in this cache and
     /// counted by `len`.
     ///
@@ -1209,7 +1209,7 @@ impl TlsSizeClassCache {
         class.global.take_batch(take, |buffer| {
             // Each claimed global entry becomes either the returned allocation
             // or a local cache entry, so each needs one retained class
-            // reference stored in its owner lease.
+            // reference stored in its slot lease.
             let buffer = class.lease_into(buffer);
             let cache_entry = TlsSizeClassCacheEntry { buffer };
             if entry.is_none() {
@@ -1285,7 +1285,7 @@ impl TlsSizeClassCache {
         let spill = self.len.min(self.capacity / 2).max(1);
         let end = self.len;
         let start = end - spill;
-        // Stop tracking owners before moving them out.
+        // Stop tracking slots before moving them out.
         self.len = start;
         self.return_global_batch(start, end);
 
@@ -1296,7 +1296,7 @@ impl TlsSizeClassCache {
     /// Returns the initialized entries in `start..end` to their class-global
     /// freelist as one batch.
     ///
-    /// All entries in one cache belong to the same size class, so their owner
+    /// All entries in one cache belong to the same size class, so their slot
     /// leases own strong references represented by one shared token. Each
     /// lease is consumed without being released, then the whole batch parks
     /// under its freelist stripe locks. The strong references are released
@@ -1329,7 +1329,7 @@ impl TlsSizeClassCache {
             // Reading moves each entry out and leaves the slot uninitialized.
             let mut entry = unsafe { entries.add(index).read().assume_init() };
             // SAFETY: local cache entries keep a live lease in the pooled
-            // owner. The strong reference it owns is intentionally not
+            // slot. The strong reference it owns is intentionally not
             // released here (leases have no drop glue). The token releases
             // below settle it.
             let _ = unsafe { entry.buffer.take_lease() }.into_token();
@@ -1357,7 +1357,7 @@ impl Drop for TlsSizeClassCache {
         // Flush remaining entries (thread exit or explicit flush) with one
         // coalesced batch insert.
         let end = self.len;
-        // Stop tracking owners before moving them out.
+        // Stop tracking slots before moving them out.
         self.len = 0;
         self.return_global_batch(0, end);
     }
@@ -1378,7 +1378,7 @@ impl Drop for TlsSizeClassCache {
 /// Empty initialized caches can also remain after their pool has been dropped.
 /// They own no class reference while empty. If the class is still live because
 /// a pooled buffer is outstanding, a later return of that buffer to this same
-/// thread can use the buffer's live owner lease to make the cache usable
+/// thread can use the buffer's live slot lease to make the cache usable
 /// again.
 ///
 /// We intentionally use `Vec<Option<...>>` because class ids are dense enough
@@ -1400,7 +1400,7 @@ impl TlsSizeClassCaches {
     /// The caller must provide a live class id from a [`SizeClassHandle`] or
     /// [`SizeClassLease`]. A missing cache starts empty and owns no class
     /// reference. The first local push or global refill stores entries whose
-    /// pooled owners contain live leases.
+    /// pooled slots contain live leases.
     #[inline(always)]
     fn get_or_init(&mut self, class_id: usize, capacity: usize) -> &mut TlsSizeClassCache {
         // The initialized arm is defensively kept but not reachable today:
@@ -1513,13 +1513,13 @@ impl BufferPoolThreadCache {
     /// The hot path uses only an already-initialized cache from the fast TLS
     /// pointer. If the fast pointer is missing, or this thread has not
     /// initialized the size class yet, [`Self::push_slow`] performs the checked
-    /// TLS access and creates the local cache. The buffer's live owner lease
+    /// TLS access and creates the local cache. The buffer's live slot lease
     /// proves that initialization is safe. During thread-local teardown,
     /// checked TLS access can fail, in that case the buffer falls back to the
     /// global freelist.
     ///
     /// Cache routing reads `class_id` and `thread_cache_capacity` from the
-    /// live owner lease, on the cache line the release path already loaded,
+    /// live slot lease, on the slot line the release path already loaded,
     /// instead of dereferencing the class object, keeping the dependent-load
     /// chain on the return fast path one level shorter.
     #[inline(always)]
@@ -1704,7 +1704,7 @@ impl BufferPoolInner {
     /// 1. **Thread-local cache** (fast path): no atomics, no contention.
     /// 2. **Global freelist**: striped pop, then batch-refill the local cache
     ///    when the local bin is large enough to amortize shared-queue traffic.
-    /// 3. **New allocation**: reserve an owner in the global freelist, then
+    /// 3. **New allocation**: reserve a slot in the global freelist, then
     ///    allocate from the heap.
     ///
     /// If `zero_on_new` is true, newly-created buffers are allocated with
@@ -1729,7 +1729,7 @@ impl BufferPoolInner {
     /// Creates a new tracked buffer after the reuse path fails.
     ///
     /// This is separate from [`Self::try_alloc`] so the steady-state allocation
-    /// path can inline the TLS hit without also carrying owner reservation,
+    /// path can inline the TLS hit without also carrying slot reservation,
     /// metrics, and heap-allocation code.
     #[inline(never)]
     fn try_alloc_new(&self, class: &SizeClassHandle, zeroed: bool) -> Option<Allocation> {
@@ -2758,7 +2758,7 @@ mod tests {
 
     #[test]
     fn test_zero_capacity_requests_bypass_pool() {
-        // A single-buffer pool: if a zero-capacity request claimed a buffer,
+        // A single-slot pool: if a zero-capacity request claimed a buffer,
         // the follow-up real allocation would fail with Exhausted.
         let page = page_size();
         let pool = test_pool(test_config(page, page, 1));
@@ -2917,7 +2917,7 @@ mod tests {
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(pool.inner.classes[class_index].thread_cache_capacity, 4);
 
-        // Large classes scale past the previous eight-buffer cap.
+        // Large classes scale past the previous eight-slot cap.
         let pool = test_pool(test_config(page, page, 4096).with_parallelism(NZUsize!(8)));
         let class_index = pool.class_index(page).unwrap();
         assert_eq!(pool.inner.classes[class_index].thread_cache_capacity, 256);
@@ -2988,7 +2988,7 @@ mod tests {
         );
 
         // When expected parallelism rounds above capacity, the freelist caps
-        // stripes so every stripe can contain at least one owner index.
+        // stripes so every stripe can contain at least one slot.
         let pool = test_pool(test_config(page, page, 12).with_parallelism(NZUsize!(9)));
 
         let class_index = pool.class_index(page).unwrap();
@@ -3317,7 +3317,7 @@ mod tests {
         let page = page_size();
         let threads = std::thread::available_parallelism().map_or(1, NonZeroUsize::get);
         let max_per_class =
-            u32::try_from(threads * 8).expect("test capacity must fit in u32 owner indices");
+            u32::try_from(threads * 8).expect("test capacity must fit in u32 slot ids");
         let pool = test_pool(test_config(page, page, max_per_class));
         let class_index = pool
             .class_index(page)
@@ -3357,7 +3357,7 @@ mod tests {
     #[test]
     fn test_global_batch_alloc_stops_when_global_runs_empty() {
         let class = test_size_class(64, 64);
-        let buffer = class.global.try_create(false).expect("owner reservation");
+        let buffer = class.global.try_create(false).expect("slot reservation");
 
         // A short global freelist should return the allocation and stop
         // without filling the local cache to its batch target.
@@ -3378,7 +3378,7 @@ mod tests {
         let mut cache = TlsSizeClassCache::new(MIN_TLS_BATCH_CAPACITY);
         assert_eq!(size_class_strong_count(&class), 1);
 
-        let mut buffer = class.global.try_create(false).expect("owner reservation");
+        let mut buffer = class.global.try_create(false).expect("slot reservation");
         let lease = SizeClassLease::retain(&class);
         // SAFETY: this buffer was just created and has no live lease.
         unsafe { buffer.init_lease(lease) };
@@ -3395,7 +3395,7 @@ mod tests {
         assert_eq!(size_class_strong_count(&class), 1);
 
         for _ in 0..2 {
-            let buffer = class.global.try_create(false).expect("owner reservation");
+            let buffer = class.global.try_create(false).expect("slot reservation");
             class.global.put(buffer);
         }
 
@@ -3414,7 +3414,7 @@ mod tests {
     #[test]
     fn test_tls_size_class_cache_push_tolerates_empty_spill() {
         let class = test_size_class(64, 64);
-        let mut buffer = class.global.try_create(false).expect("owner reservation");
+        let mut buffer = class.global.try_create(false).expect("slot reservation");
         let lease = SizeClassLease::retain(&class);
         // SAFETY: this buffer was just created and has no live lease.
         unsafe { buffer.init_lease(lease) };
@@ -3422,15 +3422,15 @@ mod tests {
 
         // Small local capacities should bypass batching and push straight to
         // global. The retained reference above is represented by the live
-        // owner lease and transferred into `cache.push`.
+        // slot lease and transferred into `cache.push`.
         cache.push(buffer);
         assert_eq!(cache.len, 0);
         drop(cache);
     }
 
     #[test]
-    fn test_global_freelist_returns_each_owner_once() {
-        // Use a two-buffer class with TLS capacity one so this test can exercise
+    fn test_global_freelist_returns_each_slot_once() {
+        // Use a two-slot class with TLS capacity one so this test can exercise
         // the class-global freelist directly without involving local-cache
         // refill or spill behavior.
         let class = SizeClassHandle::new(
@@ -3443,35 +3443,35 @@ mod tests {
             false,
         );
 
-        // Create both owner indices and keep each allocation's pointer so we can
-        // verify that the freelist returns the same buffer for that owner.
-        let buffer0 = class.global.try_create(false).expect("first owner");
-        let owner_index0 = buffer0.owner_index();
+        // Create both slot ids and keep each allocation's pointer so we can
+        // verify that the freelist returns the same buffer parked for that slot.
+        let buffer0 = class.global.try_create(false).expect("first slot");
+        let slot0 = buffer0.slot();
         let ptr0 = buffer0.as_ptr();
-        let buffer1 = class.global.try_create(false).expect("second owner");
-        let owner_index1 = buffer1.owner_index();
+        let buffer1 = class.global.try_create(false).expect("second slot");
+        let slot1 = buffer1.slot();
         let ptr1 = buffer1.as_ptr();
-        let mut expected = [(owner_index0, ptr0), (owner_index1, ptr1)];
-        expected.sort_by_key(|(owner_index, _)| *owner_index);
+        let mut expected = [(slot0, ptr0), (slot1, ptr1)];
+        expected.sort_by_key(|(slot, _)| *slot);
 
         class.global.put(buffer0);
         class.global.put(buffer1);
 
-        // The freelist does not preserve insertion order, so normalize by owner
-        // index before asserting identity. Each owner must be returned once with
-        // its original buffer.
+        // The freelist does not preserve insertion order, so normalize by slot
+        // before asserting identity. Each slot must be returned once with its
+        // original buffer.
         let mut popped = [
             class.global.take().expect("first pop"),
             class.global.take().expect("second pop"),
         ];
-        popped.sort_by_key(PooledBuffer::owner_index);
+        popped.sort_by_key(PooledBuffer::slot);
 
-        assert_eq!(popped[0].owner_index(), expected[0].0);
+        assert_eq!(popped[0].slot(), expected[0].0);
         assert_eq!(popped[0].as_ptr(), expected[0].1);
-        assert_eq!(popped[1].owner_index(), expected[1].0);
+        assert_eq!(popped[1].slot(), expected[1].0);
         assert_eq!(popped[1].as_ptr(), expected[1].1);
 
-        // Both owners were claimed above, so the global freelist is empty.
+        // Both slots were claimed above, so the global freelist is empty.
         assert!(class.global.take().is_none());
 
         // Return the buffers so the freelist owns and deallocates them when the
@@ -4314,8 +4314,8 @@ mod loom_tests {
 
     // Models the multi-entry TLS teardown edge without using OS thread-local
     // state, which loom cannot reset between model executions. Dropping the
-    // production cache takes each real pooled-owner lease, batch-parks both
-    // owners, and only then releases the lease references. The final class-handle
+    // production cache takes each real pooled-slot lease, batch-parks both
+    // slots, and only then releases the lease references. The final class-handle
     // release races that batch return, so either side may perform the final
     // SizeClass drop and reclaim the parked buffers.
     #[test]
@@ -4325,7 +4325,7 @@ mod loom_tests {
             let mut cache = TlsSizeClassCache::new(2);
 
             for _ in 0..2 {
-                let buffer = class.try_create(false).expect("tracked buffer");
+                let buffer = class.try_create(false).expect("tracked slot");
                 cache.push(buffer);
             }
             assert_eq!(cache.len, 2);
@@ -4341,7 +4341,7 @@ mod loom_tests {
     // Release decrement lands on 1, or the race-final path re-stores it with
     // a Relaxed store) before the freelist's Release publication. A
     // successful concurrent take must observe that sentinel (asserted in
-    // Freelist::claim under loom) before handing the owner to a new mutable
+    // Freelist::claim under loom) before handing the slot to a new mutable
     // handle.
     #[test]
     fn final_drop_races_recheckout() {
@@ -4361,7 +4361,7 @@ mod loom_tests {
             let t = thread::spawn(move || drop(clone));
             drop(frozen);
 
-            // The single owner may still be checked out (Exhausted) or already
+            // The single slot may still be checked out (Exhausted) or already
             // returned by whichever drop was final. A successful claim must
             // expose a writable buffer with the sentinel restored.
             if let Ok(mut again) = pool.try_alloc(64) {

--- a/runtime/src/iobuf/pool.rs
+++ b/runtime/src/iobuf/pool.rs
@@ -44,10 +44,8 @@
 //! 16000-byte request above is served by the 32768-byte class. Requests larger
 //! than the largest enabled class return [`PoolError::Oversized`] from
 //! [`BufferPool::try_alloc`], or fall back to an untracked aligned heap
-//! allocation from [`BufferPool::alloc`]. A request that misses its required
-//! class returns [`PoolError::Exhausted`] without trying larger classes. The
-//! freelist scan is a bounded concurrent observation, not a linearizable empty
-//! snapshot, so a retry can succeed after a concurrent return.
+//! allocation from [`BufferPool::alloc`]. A request routed to an exhausted
+//! class returns [`PoolError::Exhausted`] without trying larger classes.
 //!
 //! # Cache Structure
 //!
@@ -97,11 +95,8 @@ pub enum PoolError {
     /// The requested capacity exceeds the maximum buffer size.
     #[error("requested capacity exceeds maximum buffer size")]
     Oversized,
-    /// A bounded allocation attempt missed the required size class.
-    ///
-    /// This is not a linearizable empty snapshot. A retry can succeed after a
-    /// concurrent return.
-    #[error("pool allocation missed required size class")]
+    /// The pool is exhausted for the required size class.
+    #[error("pool exhausted for required size class")]
     Exhausted,
 }
 
@@ -177,11 +172,9 @@ pub struct BufferPoolConfig {
     alignment: NonZeroUsize,
     /// Expected number of threads concurrently accessing the pool.
     ///
-    /// This selects the shared global freelist stripe target, which is rounded
-    /// to a power of two, floored at up to eight stripes, and capped at the
-    /// class capacity and 4,096. It is also used to derive thread-cache capacity
-    /// when the thread-cache policy is automatic, using approximately half of
-    /// each class limit divided across expected threads.
+    /// This sizes the shared global freelist stripes. It is also used to derive
+    /// thread-cache capacity when the thread-cache policy is automatic, using
+    /// approximately half of each class limit divided across expected threads.
     parallelism: NonZeroUsize,
     /// Policy for sizing the per-thread local cache in each size class.
     ///
@@ -380,12 +373,11 @@ impl BufferPoolConfig {
 
     /// Returns a copy of this config with a new expected parallelism.
     ///
-    /// The global freelist rounds this target up to a power of two, uses at
-    /// least eight stripes when capacity permits, and caps it at both the class
-    /// capacity and 4,096 stripes. This value also controls thread-cache
-    /// capacity when the thread-cache policy is automatic. The automatic policy
-    /// reserves about half of each class for the global freelist and divides
-    /// the remaining capacity across expected threads.
+    /// The global freelist derives its stripe count from this target and the
+    /// class capacity. This value also controls thread-cache capacity when the
+    /// thread-cache policy is automatic. The automatic policy reserves about
+    /// half of each class for the global freelist and divides the remaining
+    /// capacity across expected threads.
     pub const fn with_parallelism(mut self, parallelism: NonZeroUsize) -> Self {
         self.parallelism = parallelism;
         self
@@ -667,7 +659,7 @@ struct SizeClassLabel {
 struct PoolMetrics {
     /// Number of tracked buffers created for the size class.
     created: GaugeFamily<SizeClassLabel>,
-    /// Total number of bounded allocation attempts that missed their class.
+    /// Total number of failed allocations (pool exhausted).
     exhausted_total: CounterFamily<SizeClassLabel>,
     /// Total number of oversized allocation requests.
     oversized_total: Counter,
@@ -685,7 +677,7 @@ impl PoolMetrics {
             // prometheus encoder appends it to counter names.
             exhausted_total: registry.register(
                 "buffer_pool_exhausted",
-                "Total number of bounded allocation attempts that missed the required size class",
+                "Total number of failed allocations due to pool exhaustion",
                 raw::Family::default(),
             ),
             oversized_total: registry.register(
@@ -1524,7 +1516,7 @@ impl BufferPoolThreadCache {
     /// global freelist.
     ///
     /// Cache routing reads `class_id` and `thread_cache_capacity` from the
-    /// live slot lease, on the slot line the release path already loaded,
+    /// live slot lease (on the slot line the release path has already loaded)
     /// instead of dereferencing the class object, keeping the dependent-load
     /// chain on the return fast path one level shorter.
     #[inline(always)]
@@ -1907,9 +1899,9 @@ impl BufferPool {
     /// Attempts to allocate a buffer without falling back on pool miss.
     ///
     /// Unlike [`Self::alloc`], this method does not fall back to untracked
-    /// allocation on a bounded pool miss or oversized request. Requests
-    /// smaller than [`BufferPoolConfig::pool_min_size`] intentionally bypass
-    /// pooling and return an untracked aligned allocation instead.
+    /// allocation on exhaustion or oversized requests. Requests smaller than
+    /// [`BufferPoolConfig::pool_min_size`] intentionally bypass pooling and
+    /// return an untracked aligned allocation instead.
     ///
     /// The returned buffer has `len() == 0` and `capacity() >= capacity`.
     ///
@@ -1924,8 +1916,7 @@ impl BufferPool {
     /// # Errors
     ///
     /// - [`PoolError::Oversized`]: `capacity` exceeds `max_size`
-    /// - [`PoolError::Exhausted`]: this bounded attempt missed the required
-    ///   size class. A retry can succeed after a concurrent return
+    /// - [`PoolError::Exhausted`]: pool exhausted for the required size class
     #[inline(always)]
     pub fn try_alloc(&self, capacity: usize) -> Result<IoBufMut, PoolError> {
         if capacity == 0 {
@@ -1964,12 +1955,12 @@ impl BufferPool {
     /// Zero-capacity requests return a detached empty buffer without touching
     /// the pool.
     ///
-    /// If the pool can provide a buffer on this attempt, this returns a pooled
-    /// buffer that will be returned to the pool when dropped. Requests smaller
-    /// than [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
-    /// untracked aligned allocation. Oversized requests and bounded pool misses
-    /// also fall back to an untracked aligned heap allocation that is
-    /// deallocated when dropped.
+    /// If the pool can provide a buffer (capacity within limits and pool not
+    /// exhausted), this returns a pooled buffer that will be returned to the
+    /// pool when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
+    /// bypass pooling and return an untracked aligned allocation. Oversized or
+    /// exhausted requests also fall back to an untracked aligned heap allocation
+    /// that is deallocated when dropped.
     ///
     /// Use [`Self::try_alloc`] if eligible requests must fail instead of falling
     /// back to direct allocation.
@@ -2005,9 +1996,9 @@ impl BufferPool {
     /// pool miss.
     ///
     /// Unlike [`Self::alloc_zeroed`], this method does not fall back to
-    /// untracked allocation on a bounded pool miss or oversized request.
-    /// Requests smaller than [`BufferPoolConfig::pool_min_size`] intentionally
-    /// bypass pooling and return an untracked aligned allocation instead.
+    /// untracked allocation on exhaustion or oversized requests. Requests
+    /// smaller than [`BufferPoolConfig::pool_min_size`] intentionally bypass
+    /// pooling and return an untracked aligned allocation instead.
     ///
     /// The returned buffer has `len() == len` and `capacity() >= len`.
     /// Zero-length requests return a detached empty buffer without touching
@@ -2021,8 +2012,7 @@ impl BufferPool {
     /// # Errors
     ///
     /// - [`PoolError::Oversized`]: `len` exceeds `max_size`
-    /// - [`PoolError::Exhausted`]: this bounded attempt missed the required
-    ///   size class. A retry can succeed after a concurrent return
+    /// - [`PoolError::Exhausted`]: pool exhausted for the required size class
     pub fn try_alloc_zeroed(&self, len: usize) -> Result<IoBufMut, PoolError> {
         if len == 0 {
             return Ok(IoBufMut::default());
@@ -2065,12 +2055,12 @@ impl BufferPool {
     /// Zero-length requests return a detached empty buffer without touching
     /// the pool.
     ///
-    /// If the pool can provide a buffer on this attempt, this returns a pooled
-    /// buffer that will be returned to the pool when dropped. Requests smaller
-    /// than [`BufferPoolConfig::pool_min_size`] bypass pooling and return an
-    /// untracked aligned allocation. Oversized requests and bounded pool misses
-    /// also fall back to an untracked aligned heap allocation that is
-    /// deallocated when dropped.
+    /// If the pool can provide a buffer (len within limits and pool not
+    /// exhausted), this returns a pooled buffer that will be returned to the
+    /// pool when dropped. Requests smaller than [`BufferPoolConfig::pool_min_size`]
+    /// bypass pooling and return an untracked aligned allocation. Oversized or
+    /// exhausted requests also fall back to an untracked aligned heap allocation
+    /// that is deallocated when dropped.
     ///
     /// Use this for read APIs that require an initialized `&mut [u8]`. This
     /// avoids `unsafe set_len` at callsites.
@@ -2084,7 +2074,7 @@ impl BufferPool {
     /// may be uninitialized.
     pub fn alloc_zeroed(&self, len: usize) -> IoBufMut {
         self.try_alloc_zeroed(len).unwrap_or_else(|_| {
-            // Pool miss or oversized request: allocate untracked zeroed memory.
+            // Pool exhausted or oversized: allocate untracked zeroed memory.
             let size = len.max(1);
             let mut buf = IoBufMut::zeroed_with_alignment(size, self.inner.config.alignment);
             buf.truncate(len);
@@ -3254,7 +3244,7 @@ mod tests {
         );
         assert_eq!(
             PoolError::Exhausted.to_string(),
-            "pool allocation missed required size class"
+            "pool exhausted for required size class"
         );
     }
 
@@ -3463,8 +3453,8 @@ mod tests {
         class.global.put(buffer1);
 
         // The freelist does not preserve insertion order, so normalize by slot
-        // before asserting identity. Each slot must be returned once with its
-        // original buffer.
+        // before asserting identity. The important property is that each slot is
+        // returned exactly once with its original parked buffer.
         let mut popped = [
             class.global.take().expect("first pop"),
             class.global.take().expect("second pop"),


### PR DESCRIPTION
This is an alternative to #4479. It's a complete redesign that is focused on code simplicity. The freelist is backed by striped mutex vec, where each thread gets its own stripe and therefore the lock should be mostly uncontended. It's slightly slower than the existing bitmap freelist in the worst case (ie. TLS-cache disabled, so there's no batching), and slightly faster when operations to/from the global freelist are batched (ie. when TLS-cache is enabled). This is expected because the current implementation is lock-free, but when batching the locks in this implementation are amortized instead of paying for atomics for every `put` / `take`. It's also faster on the degenerate case that #4479 tried to solve.

## Results

### Direct global freelist

| Threads | Batch | Simple | Bitmap | Simple relative to bitmap |
|---:|---:|---:|---:|---:|
| 1 | 1 | 17.97 ns | 14.44 ns | 24.4% slower |
| 1 | 8 | 36.07 ns | 54.22 ns | 32.9% faster |
| 1 | 32 | 79.68 ns | 111.78 ns | 29.0% faster |
| 8, lockstep | 1 | 19.13 ns | 16.55 ns | 15.6% slower |
| 8, lockstep | 8 | 40.53 ns | 58.95 ns | 30.6% faster |
| 8, lockstep | 32 | 88.82 ns | 125.37 ns | 29.4% faster |

### BufferPool reuse and empty probes

| Scenario | Simple | Bitmap | Simple relative to bitmap |
|---|---:|---:|---:|
| TLS disabled, batch 1 | 270.66 ns | 234.69 ns | 16.1% slower |
| TLS disabled, batch 8 | 1.879 us | 1.666 us | 12.8% slower |
| Empty, parallelism 8 | 3.92 ns | 139.11 ns | 97.2% faster, about 35.5x |
| Empty, parallelism 4,096 | 1.950 us | 2.936 us | 34.3% faster |

