### PR TITLE
[cryptography] Add resumable CRC32C hashing

### DIFF
--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -403,6 +403,8 @@ mod tests {
         assert_eq!(hash.as_u32(), expected);
     }
 
+    /// Verify a resumed hasher continues the original stream and that finalize returns
+    /// a hasher reset to the default state, not the resumed state.
     #[test]
     fn resumed_hasher_resets_after_finalize() {
         let prefix = b"durable prefix";

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -70,10 +70,6 @@ impl Crc32 {
     }
 
     /// Resume a CRC32C stream from a previously finalized checksum.
-    ///
-    /// This is useful when a durable checkpoint stores only the four-byte checksum of an
-    /// append-only prefix. Updating the returned hasher with a suffix produces the same checksum as
-    /// hashing the prefix and suffix together.
     pub fn resume(checksum: u32) -> Self {
         // CRC32C finalization XORs the running state with all ones. Undo that transform before
         // asking crc-fast to continue from the recovered state.

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -425,14 +425,14 @@ mod tests {
 
     /// Verify a resumed stream matches the one-shot checksum for every split point.
     ///
-    /// Suffix lengths sweep 0..=4097, so resumed states enter every SIMD code path,
-    /// including the empty-prefix and empty-suffix edges.
+    /// Suffix lengths sweep 0..=4097, including both empty-prefix and
+    /// empty-suffix edges.
     #[test]
     fn resume_split_independence() {
         let data = sequential_data(4097);
         let expected = CRC32C_REF.checksum(&data);
         for split in 0..=data.len() {
-            let mut hasher = Crc32::resume(Crc32::checksum(&data[..split]));
+            let mut hasher = Crc32::resume(CRC32C_REF.checksum(&data[..split]));
             hasher.update(&data[split..]);
             assert_eq!(hasher.finalize().1.as_u32(), expected);
         }

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -72,7 +72,7 @@ impl Crc32 {
     /// Resume a CRC32C stream from a previously finalized checksum.
     pub fn resume(checksum: u32) -> Self {
         // CRC32C finalization XORs the running state with all ones. Undo that transform before
-        // asking crc-fast to continue from the recovered state.
+        // resuming the checksum stream.
         Self {
             inner: crc_fast::Digest::new_with_init_state(ALGORITHM, u64::from(checksum ^ u32::MAX)),
         }

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -421,6 +421,35 @@ mod tests {
         assert_eq!(digest.as_u32(), Crc32::checksum(suffix));
     }
 
+    /// Verify a resumed stream matches the one-shot checksum for every split point.
+    ///
+    /// Suffix lengths sweep 0..=4097, so resumed states enter every SIMD code path,
+    /// including the empty-prefix and empty-suffix edges.
+    #[test]
+    fn resume_split_independence() {
+        let data = sequential_data(4097);
+        let expected = CRC32C_REF.checksum(&data);
+        for split in 0..=data.len() {
+            let mut hasher = Crc32::resume(Crc32::checksum(&data[..split]));
+            hasher.update(&data[split..]);
+            assert_eq!(hasher.finalize().1.as_u32(), expected);
+        }
+    }
+
+    /// Verify finalizing a resumed hasher without updates returns the resumed checksum,
+    /// including values that never came from hashing data.
+    #[test]
+    fn resume_finalize_round_trip() {
+        for checksum in [
+            0x00000000,
+            0xFFFFFFFF,
+            0xDEADBEEF,
+            Crc32::checksum(b"resume"),
+        ] {
+            assert_eq!(Crc32::resume(checksum).finalize().1.as_u32(), checksum);
+        }
+    }
+
     #[test]
     fn test_crc32_len() {
         assert_eq!(Digest::SIZE, SIZE);

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -47,7 +47,7 @@ const ALGORITHM: crc_fast::CrcAlgorithm = crc_fast::CrcAlgorithm::Crc32Iscsi;
 /// CRC32C hasher.
 ///
 /// Uses the iSCSI polynomial (0x1EDC6F41) as specified in RFC 3720.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Crc32 {
     inner: crc_fast::Digest,
 }

--- a/cryptography/src/crc32/mod.rs
+++ b/cryptography/src/crc32/mod.rs
@@ -47,7 +47,7 @@ const ALGORITHM: crc_fast::CrcAlgorithm = crc_fast::CrcAlgorithm::Crc32Iscsi;
 /// CRC32C hasher.
 ///
 /// Uses the iSCSI polynomial (0x1EDC6F41) as specified in RFC 3720.
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct Crc32 {
     inner: crc_fast::Digest,
 }
@@ -67,6 +67,19 @@ impl Crc32 {
     #[inline]
     pub fn checksum(data: &[u8]) -> u32 {
         crc_fast::checksum(ALGORITHM, data) as u32
+    }
+
+    /// Resume a CRC32C stream from a previously finalized checksum.
+    ///
+    /// This is useful when a durable checkpoint stores only the four-byte checksum of an
+    /// append-only prefix. Updating the returned hasher with a suffix produces the same checksum as
+    /// hashing the prefix and suffix together.
+    pub fn resume(checksum: u32) -> Self {
+        // CRC32C finalization XORs the running state with all ones. Undo that transform before
+        // asking crc-fast to continue from the recovered state.
+        Self {
+            inner: crc_fast::Digest::new_with_init_state(ALGORITHM, u64::from(checksum ^ u32::MAX)),
+        }
     }
 }
 
@@ -392,6 +405,24 @@ mod tests {
         // Test multi-part one-shot
         let hash = Crc32::hash(&[b"hello", b" world"]);
         assert_eq!(hash.as_u32(), expected);
+    }
+
+    #[test]
+    fn resumed_hasher_resets_after_finalize() {
+        let prefix = b"durable prefix";
+        let suffix = b"new suffix";
+        let mut hasher = Crc32::resume(Crc32::checksum(prefix));
+        hasher.update(suffix);
+
+        let (mut hasher, digest) = hasher.finalize();
+        assert_eq!(
+            digest.as_u32(),
+            Crc32::hash(&[prefix.as_slice(), suffix.as_slice()]).as_u32()
+        );
+
+        hasher.update(suffix);
+        let (_, digest) = hasher.finalize();
+        assert_eq!(digest.as_u32(), Crc32::checksum(suffix));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `Crc32::resume` so append-only callers can continue CRC32C from a persisted finalized checksum without rereading the durable prefix. `Crc32` remains non-cloneable; callers explicitly reconstruct a transient stream when continuation is needed.

This PR is self-contained and targets `main`. Atomic blob storage consumes this API in #4490.

## Review focus

- The finalized checksum representation is converted back into the running CRC32C state before resuming.
- Finalization still returns a hasher reset to the default state, matching the existing `Hasher` contract.
- Split-point and round-trip coverage exercise empty prefix/suffix boundaries and arbitrary finalized states.

## Diff size

- Production code: `+9 / -0 LOC`
- Tests and test infrastructure: `+49 / -0 LOC`
- Total: `+58 / -0 LOC`

Counts are physical diff lines, including comments and blank lines. Test-only files, hooks, and lines inside `#[cfg(test)]` modules are counted as tests; everything else is counted as production code.