### PR TITLE
[runtime] Add atomic blob storage

### DIFF
--- a/runtime/src/atomic.rs
+++ b/runtime/src/atomic.rs
@@ -1,0 +1,4648 @@
+//! Coordinator-free atomic publication over ordinary blobs.
+//!
+//! Atomic blobs narrow [`Storage`] to append, rewind, tag, and exact removal operations. New bytes
+//! are written directly at their encoded offsets. Publication does not copy them. A published
+//! rewind can shrink the backing, after which later appends reuse the discarded tail. Alternating
+//! roots publish the visible length and integrity state without a coordinator record.
+//!
+//! # Backing layout
+//!
+//! [`BackingBlob`] exposes logical contents after a backend-owned container header. Creation is
+//! delegated to [`Storage::open`], so this module neither encodes nor recovers that header. Atomic
+//! identification begins at logical offset zero, where this module owns the following fixed prefix:
+//!
+//! ```text
+//! logical offset     0              4096       6144       8192
+//!                    +--------------+----------+----------+-------------------+
+//! atomic contents    | identity     | root 0   | root 1   | encoded payload   |
+//!                    | page (4 KiB) | even     | odd      |                   |
+//!                    +--------------+----------+----------+-------------------+
+//! ```
+//!
+//! Generation parity selects a root slot. Generation zero is a synthetic all-zero predecessor and
+//! is never encoded. Writing generation `g` leaves the other slot's bytes untouched. A decided
+//! shrink can later make the older root's payload extent out of bounds, so that root is not always
+//! a valid fallback.
+//!
+//! The ordinary container has no persistent incarnation. The identity page supplies one so
+//! recovery can distinguish an unlinked blob from a later same-name replacement:
+//!
+//! ```text
+//! byte       0       7 8                 24   28                         4096
+//!            +-------+-+------------------+----+----------------------------+
+//! identity   | magic |G| incarnation      | crc| zero padding               |
+//!            +-------+-+------------------+----+----------------------------+
+//! width          7   1        16             4             4068
+//! ```
+//!
+//! The magic is `CWUNOID`. The CRC32C covers the identity domain and bytes 0 through 23. Fresh
+//! creation writes the complete page and synchronizes the backing once.
+//!
+//! A fresh identity is written only when the serialized open observed the name missing and created
+//! its backing. A pre-existing name must contain a complete identity; an invalid or incomplete page
+//! is rejected without mutation.
+//!
+//! # R15 root slots
+//!
+//! The first 132 bytes of each slot contain one root. Its magic is `CWUNO15`. Multi-byte integers
+//! are big endian. The CRC32C covers the root domain and the preceding 128 bytes. It detects
+//! malformed and torn state but is not authentication. The 20-byte binding is zero for roots
+//! without a batch witness and is a truncated SHA-256 binding to the witness otherwise.
+//!
+//! ```text
+//! byte    0      7 8      16     24     32  36  40  44       64       128 132
+//!         +------+-+-------+------+------+---+---+---+---------+----------+---+
+//! root    | magic|G| gen   | len  | tail |crc|fmt|wid| binding | tag      |crc|
+//!         +------+-+-------+------+------+---+---+---+---------+----------+---+
+//! width      7   1    8       8      8    4   4   4     20        64       4
+//! ```
+//!
+//! `tail` and its CRC32C describe the only unfinished integrity unit. `fmt` is 0 for unbound, 1 for
+//! variable, and 2 for chunked integrity. `wid` is nonzero only for chunked integrity. The
+//! application owns all 64 tag bytes.
+//!
+//! A witness-bound slot uses the remaining bytes for a length frame, one local successor
+//! link, and canonical zero padding:
+//!
+//! ```text
+//! byte       0             132 136                         2048
+//!            +-------------+---+---------------------------+
+//! batch slot | root        |len| local link | zero padding |
+//!            +-------------+---+---------------------------+
+//! ```
+//!
+//! The fixed frame and variable link have this grammar:
+//!
+//! ```text
+//! frame    [link length:4]
+//!
+//! link     [CWUNOL15:8][group id:16][removed:4]
+//!          [incarnation:16][candidate template:132][payload descriptor:40]
+//!          [next partition length + bytes][next name length + bytes][next incarnation:16]
+//! ```
+//!
+//! The root binding covers this exact link under the truncated SHA-256 collision-resistance
+//! assumption. All integer fields are big endian.
+//!
+//! Root spellings separate local authority from group evidence:
+//!
+//! - `BatchPrepared` is a candidate and requires complete ring evidence.
+//! - `Finalized` is a locally selectable group result whose retained witness says whether it is
+//!   present or removed.
+//!
+//! Locally selectable means recovery can choose the complete slot without following a peer. It
+//! does not mean the issued bytes have crossed a durability operation. Live `Finalized` roots can
+//! still carry durability debt.
+//!
+//! Each spelling has an exact suffix rule:
+//!
+//! ```text
+//! BatchPrepared           exact framed witness and matching witness binding
+//! Finalized                exact retained witness and matching witness binding
+//! ```
+//!
+//! The guard encodes the root spelling:
+//!
+//! ```text
+//! BatchPrepared = 1
+//! Finalized     = 3 + ((generation / 2) mod 2)
+//! ```
+//!
+//! Finalized guards alternate whenever one parity slot is reused. Before the final write is
+//! issued, neither the previous same-slot root nor the prepared write contains the target guard.
+//! Guard zero and generation zero are invalid. The generation is protected by the root checksum,
+//! and generation parity selects the slot.
+//!
+//! # Direct publication
+//!
+//! A direct sync is encoded as a one-participant group whose successor is itself:
+//!
+//! ```text
+//! write any new payload at encoded offsets
+//!          |
+//!          v
+//! write complete BatchPrepared root + self witness
+//!          |
+//!          v
+//! sync the backing blob                         durable decision
+//!          |
+//!          v
+//! write Finalized root                          cleanup only
+//! ```
+//!
+//! The candidate slot and any described payload suffix share one full-file durability operation.
+//! The finalized spelling is not synchronized separately. If an earlier group left cleanup
+//! debt on peer files, those files join this same concurrent durability layer.
+//!
+//! Large append epochs may finish detached payload preflushes before publication. These do not
+//! publish a root. They establish an invisible durable prefix so the final publication still has
+//! one bounded suffix to prove.
+//!
+//! # Multi-blob publication
+//!
+//! Canonical participant order forms a closed ring. Each local link binds its participant,
+//! candidate, payload proof, and exact successor incarnation:
+//!
+//! ```text
+//! A: [candidate A | next B] ---> B: [candidate B | next C]
+//!           ^                                  |
+//!           |                                  v
+//!           +---------------- C: [candidate C | next A]
+//!
+//! write slot A    write slot B    write slot C
+//! sync file A     sync file B     sync file C      one concurrent layer
+//!          \____________ complete ring __________/
+//!                           |
+//!                           v
+//!                    durable group decision
+//! ```
+//!
+//! Every participant slot and every carried-debt barrier starts in that one concurrent set. There
+//! are no fixed-size waves and no second final-root durability round. When at least one operation
+//! participates, returning from [`AtomicStorage::start_apply`] with `Ok` proves the complete ring
+//! is durable. Its completion handle waits for final-root writes, truncation, and in-memory
+//! activation.
+//!
+//! # Recovery
+//!
+//! Once atomic identity initialization has completed, each issued write after the last successful
+//! full-file durability cut may retain any subset of its addressed positions, including the empty
+//! and complete subsets. An unretained position falls back to its earlier durable or retained
+//! value. Recovery never assumes a prefix. A failed sync establishes no cut.
+//! [`WriteOptions::SYNC`] covers only the bytes in its own write, not earlier writes. Resize and
+//! unlink are ordered behind durable roots and have separate retry rules.
+//!
+//! Recovery reads the two fixed root slots first and follows only exact successor links from a
+//! candidate found there.
+//!
+//! A group is accepted only when exact successor traversal closes at its starting participant,
+//! locations are unique and in canonical cyclic order, incarnations are distinct, every candidate
+//! transition is compatible, and every payload proof validates.
+//! The outcome is therefore the complete predecessor vector or the complete candidate vector.
+//!
+//! ```text
+//! local candidate
+//!       |
+//!       +-- complete closed ring + valid payload proofs --> finish whole group
+//!       |
+//!       `-- missing or invalid evidence -----------------> keep prior authority
+//!
+//! finish whole group
+//!       |
+//!       +-- finish every immediate unpaid witness predecessor
+//!       +-- write missing locally selectable final spellings
+//!       +-- barrier every readable participant
+//!       `-- remove tombstoned names only after every final is durable
+//! ```
+//!
+//! A rejected generation cannot be ignored because its bytes remain in a slot that will be reused.
+//! Recovery first materializes a complete singleton `BatchPrepared` ring. Otherwise it durably
+//! clears the rejected slot before returning mutable access, allowing the same generation to be
+//! retried.
+//!
+//! # Bounded payload validation
+//!
+//! Each candidate describes only the suffix not covered by an earlier durability operation. The
+//! descriptor binds its start and final logical endpoint inside the exact witness; its length is
+//! derived from the candidate root. Its digest is SHA-256 over the payload domain followed by the
+//! suffix bytes. The aggregate described suffix for a group is at most 64 MiB. Reopen therefore
+//! reads fixed metadata plus a bounded payload suffix and never scans historical payload.
+//!
+//! # Integrity units
+//!
+//! Integrity-aware operations divide the encoded payload into application-selected units:
+//!
+//! ```text
+//! completed units                         unfinished unit
+//! +----------+--------+----------+--------+------------------+
+//! | data     | CRC32C | data     | CRC32C | data             |
+//! +----------+--------+----------+--------+------------------+
+//!                                             ^
+//!                                             root stores start + rolling CRC32C
+//! ```
+//!
+//! Completed-unit footers are part of encoded offsets. The unfinished unit has no footer. Its root
+//! metadata lets reopen validate or resume it without trusting caller-supplied checksum state.
+//!
+//! # Namespace ownership
+//!
+//! The backend owns its ordinary blob header and physical namespace. Atomic names are opt-in and
+//! must not be opened through ordinary [`Storage`] while atomic handles exist. A new atomic blob
+//! starts from R15's all-zero generation-zero predecessor. There is no compatibility path for
+//! older experimental roots.
+//!
+//! Logical removal publishes a tombstone before physical unlink. Recovery makes every group final
+//! independently durable before removing any member. The exclusive storage-lineage contract lets
+//! recovery keep each verified name current through its durable removal.
+//!
+//! # Correctness invariants and assumptions
+//!
+//! - One storage value and its clones and wrappers form a storage lineage. Live operations share
+//!   its exclusion lock; namespace recovery holds it exclusively. No independent storage instance,
+//!   process, path alias, or ordinary handle mutates that lineage's names while atomic handles
+//!   exist, and scans run only after every handle in their partition has been dropped.
+//! - One handle operation, every overlapping batch, and every publication carrying the same prior
+//!   group remain serialized until their I/O and cleanup have quiesced. Disjoint handles and debt
+//!   groups may progress concurrently. Dropping an observer does not shorten ownership. Payload
+//!   preflushes grant no authority and are drained before that handle can rewind or publish.
+//! - Only a complete canonical root or bound ring grants payload authority. Bytes beyond the
+//!   selected logical end have none. A published shrink reclaims them after the root is durable;
+//!   recovery repeats a lost resize. Rewinding unpublished bytes first drains that handle's
+//!   preflush, and a later append overwrites reused offsets before exposing them.
+//! - A successful full-file sync is a truthful durability cut. Before the next cut, a crash may
+//!   retain the old or issued value independently at every written byte. A failed sync establishes
+//!   no cut, and range-sync covers only its own write.
+//! - Fresh identifiers do not collide with retained token epochs, incarnations, or group
+//!   identifiers, and the truncated SHA-256 witness binding is collision-resistant for reachable
+//!   records. Correctness assumes no reachable torn or corrupt image has an accepted CRC32C
+//!   collision; CRC32C is not authentication.
+
+use crate::{
+    ATOMIC_BLOB_TAG_LEN, AtomicBlob, AtomicStorage, BatchOperation, Blob as BackingBlob, Buf,
+    Error, Handle, IntegrityAppend, IntegrityBoundary, IntegrityScheme, IntegritySnapshot,
+    IntegrityToken, IntegrityUnit, IoBuf, IoBufs, IoBufsMut, Storage, WriteOptions,
+    signal::{Signal, Signaler},
+};
+use commonware_cryptography::{Crc32, Hasher as _, Sha256};
+use commonware_formatting::hex;
+use commonware_utils::{
+    channel::oneshot,
+    sync::{
+        AsyncMutex as Mutex, AsyncMutexGuard as MutexGuard, AsyncRwLock as RwLock,
+        Mutex as BlockingMutex,
+    },
+    sys_rng,
+};
+use futures::future::join_all;
+use rand::Rng as _;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::OnceLock;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    future::Future,
+    io,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    sync::{
+        Arc, Weak,
+        atomic::{AtomicBool, AtomicU64, Ordering as AtomicOrdering},
+    },
+};
+
+mod batch;
+
+const ROOT_MAGIC: &[u8; 7] = b"CWUNO15";
+const ROOT_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_LOG_ROOT";
+const PAYLOAD_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_BATCH_PAYLOAD";
+const DIRECT_GROUP_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_DIRECT_GROUP";
+const ROOT_GUARD_OFFSET: usize = 7;
+const ROOT_INTEGRITY_START_OFFSET: usize = 24;
+const ROOT_INTEGRITY_CHECKSUM_OFFSET: usize = 32;
+const ROOT_INTEGRITY_SCHEME_OFFSET: usize = 36;
+const ROOT_INTEGRITY_CHUNK_OFFSET: usize = 40;
+const ROOT_BINDING_OFFSET: usize = 44;
+const ROOT_PREFIX_LEN: usize = 64;
+const ROOT_BINDING_LEN: usize = ROOT_PREFIX_LEN - ROOT_BINDING_OFFSET;
+const ROOT_BODY_LEN: usize = ROOT_PREFIX_LEN + ATOMIC_BLOB_TAG_LEN;
+const ROOT_CHECKSUM_LEN: usize = size_of::<u32>();
+const ROOT_LEN: usize = ROOT_BODY_LEN + ROOT_CHECKSUM_LEN;
+const ROOT_SLOT_LEN: u64 = 2 * 1024;
+const ROOT_SLOT_SIZE: usize = ROOT_SLOT_LEN as usize;
+pub(crate) const IDENTITY_PAGE_LEN: u64 = 4 * 1024;
+const IDENTITY_MAGIC: &[u8; 7] = b"CWUNOID";
+const IDENTITY_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_INCARNATION";
+const IDENTITY_GUARD_OFFSET: usize = 7;
+const IDENTITY_GUARD: u8 = 1;
+const IDENTITY_LEN: usize = 28;
+const INCARNATION_LEN: usize = 16;
+const ROOT_OFFSETS: [u64; 2] = [IDENTITY_PAGE_LEN, IDENTITY_PAGE_LEN + ROOT_SLOT_LEN];
+pub(crate) const DATA_OFFSET: u64 = IDENTITY_PAGE_LEN + 2 * ROOT_SLOT_LEN;
+const MAX_UNSYNCED_PAYLOAD_LEN: u64 = 64 * 1024 * 1024;
+const PAYLOAD_CHECKSUM_CHUNK_LEN: u64 = 1024 * 1024;
+type RootSlot = [u8; ROOT_SLOT_SIZE];
+type RootBinding = [u8; ROOT_BINDING_LEN];
+type PayloadDigest = [u8; 32];
+type ParticipantOperation<'a> = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
+
+fn validate_atomic_location(partition: &str, name: &[u8]) -> Result<(), Error> {
+    batch::validate_location(partition, name).map_err(Into::into)
+}
+
+/// Storage-lineage-wide accounting for payload durability and live carried-group payments.
+///
+/// `total` is the sum reported by every live [`PayloadAccount`]. Registered rounds remain here
+/// until their detached worker finishes, so namespace recovery can drain work whose original
+/// observer was dropped. Weak carried-payment entries let recovery notify live group holders
+/// without retaining their backing handles.
+#[derive(Default)]
+struct PayloadBudgetState {
+    total: u128,
+    next_round: u128,
+    rounds: BTreeMap<u128, Signal>,
+    carried_payments: BTreeMap<[u8; batch::GROUP_ID_LEN], Weak<CarriedPayment>>,
+}
+
+#[derive(Default)]
+pub(crate) struct PayloadBudget {
+    state: BlockingMutex<PayloadBudgetState>,
+}
+
+impl PayloadBudget {
+    /// Register one detached preflush and return its lineage-unique identifier.
+    fn register(&self, completion: Signal) -> u128 {
+        let mut state = self.state.lock();
+        let id = state.next_round;
+        state.next_round = state
+            .next_round
+            .checked_add(1)
+            .expect("atomic payload preflush round identifiers are not exhausted");
+        assert!(state.rounds.insert(id, completion).is_none());
+        id
+    }
+
+    /// Retire a successful preflush from lineage accounting.
+    fn finish(&self, id: u128) {
+        self.state.lock().rounds.remove(&id);
+    }
+
+    fn register_carried(
+        self: &Arc<Self>,
+        group_id: [u8; batch::GROUP_ID_LEN],
+    ) -> Arc<CarriedPayment> {
+        let payment = Arc::new(CarriedPayment {
+            group_id,
+            paid: AtomicBool::new(false),
+            budget: Arc::downgrade(self),
+        });
+        let mut state = self.state.lock();
+        assert!(
+            state
+                .carried_payments
+                .get(&group_id)
+                .and_then(Weak::upgrade)
+                .is_none(),
+            "atomic group identifiers are unique within one storage lineage"
+        );
+        state
+            .carried_payments
+            .insert(group_id, Arc::downgrade(&payment));
+        payment
+    }
+
+    fn mark_carried_paid(&self, group_id: [u8; batch::GROUP_ID_LEN]) {
+        let payment = {
+            let mut state = self.state.lock();
+            let payment = state
+                .carried_payments
+                .get(&group_id)
+                .and_then(Weak::upgrade);
+            if payment.is_none() {
+                state.carried_payments.remove(&group_id);
+            }
+            payment
+        };
+        if let Some(payment) = payment {
+            payment.paid.store(true, AtomicOrdering::Release);
+        }
+    }
+
+    /// Wait for every registered round after the caller has excluded new lineage mutations.
+    async fn drain(&self) -> Result<(), Error> {
+        let rounds = self
+            .state
+            .lock()
+            .rounds
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+        let results = join_all(rounds).await;
+        if results.iter().any(Result::is_err) {
+            Err(Error::Closed)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+/// One blob's contribution to the aggregate unsynchronized payload budget.
+///
+/// The account is shared by all handle clones. Dropping the last clone removes its contribution
+/// even when the blob never publishes again.
+struct PayloadAccount {
+    budget: Arc<PayloadBudget>,
+    amount: AtomicU64,
+}
+
+impl PayloadAccount {
+    fn new(budget: Arc<PayloadBudget>) -> Arc<Self> {
+        Arc::new(Self {
+            budget,
+            amount: AtomicU64::new(0),
+        })
+    }
+
+    /// Replace this blob's contribution and return the new lineage aggregate.
+    fn set(&self, amount: u64) -> u128 {
+        let mut state = self.budget.state.lock();
+        let previous = self.amount.swap(amount, AtomicOrdering::Relaxed);
+        state.total = state
+            .total
+            .checked_sub(u128::from(previous))
+            .expect("atomic payload accounting contains every live account")
+            .checked_add(u128::from(amount))
+            .expect("live atomic payload accounting fits u128");
+        state.total
+    }
+}
+
+impl Drop for PayloadAccount {
+    fn drop(&mut self) {
+        let mut state = self.budget.state.lock();
+        let amount = self.amount.load(AtomicOrdering::Relaxed);
+        state.total = state
+            .total
+            .checked_sub(u128::from(amount))
+            .expect("dropped atomic payload accounts remain in the aggregate");
+    }
+}
+
+/// Coalesced preflush state for one blob.
+///
+/// Only one round runs at a time. Later requests raise that round's target rather than creating a
+/// second concurrent durability operation for the same backing file. The sync gate also excludes
+/// a peer publication paying carried cleanup debt for this backing.
+#[derive(Default)]
+struct PayloadPreflushState {
+    current: Option<Arc<PayloadPreflushRound>>,
+    failure: Option<Error>,
+}
+
+#[derive(Default)]
+struct PayloadPreflush {
+    state: BlockingMutex<PayloadPreflushState>,
+    sync_gate: Arc<Mutex<()>>,
+}
+
+/// A detached full-file durability round whose target can advance while it runs.
+struct PayloadPreflushRound {
+    id: u128,
+    requested: AtomicU64,
+    completion: Signal,
+}
+
+/// Durable and transitional spellings encoded by the root guard.
+///
+/// Finalized roots are locally selectable after their full slot grammar validates. This is a
+/// recovery classification, not proof that the installed bytes are durable. Finalized roots retain
+/// their local witness. Batch-prepared roots require a complete witness ring.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RootState {
+    BatchPrepared,
+    Finalized,
+}
+
+impl RootState {
+    const fn guard(self, generation: u64) -> u8 {
+        match self {
+            Self::BatchPrepared => 1,
+            Self::Finalized => {
+                if (generation & 2) == 0 {
+                    3
+                } else {
+                    4
+                }
+            }
+        }
+    }
+}
+
+fn checksum(parts: &[&[u8]]) -> u32 {
+    let mut hasher = Crc32::default();
+    for part in parts {
+        hasher.update(part);
+    }
+    hasher.finalize().1.as_u32()
+}
+
+fn update_payload_checksum(hasher: &mut Sha256, payload: &mut impl Buf) {
+    while payload.remaining() != 0 {
+        let chunk = payload.chunk();
+        let len = chunk.len();
+        hasher.update(chunk);
+        payload.advance(len);
+    }
+}
+
+/// Hash one bounded encoded payload suffix without materializing it as a contiguous allocation.
+async fn payload_checksum_at<B: BackingBlob>(
+    backing: &B,
+    start: u64,
+    len: u64,
+) -> Result<PayloadDigest, Error> {
+    let mut hasher = Sha256::default();
+    hasher.update(PAYLOAD_DOMAIN);
+    let mut offset = raw_len(start)?;
+    let mut remaining = len;
+    while remaining != 0 {
+        let chunk_len = remaining.min(PAYLOAD_CHECKSUM_CHUNK_LEN) as usize;
+        let mut payload = backing.read_at(offset, chunk_len).await?;
+        update_payload_checksum(&mut hasher, &mut payload);
+        offset = offset
+            .checked_add(chunk_len as u64)
+            .ok_or(Error::OffsetOverflow)?;
+        remaining -= chunk_len as u64;
+    }
+    Ok(hasher.finalize().1.as_ref().try_into().unwrap())
+}
+
+/// Derive the stable group identifier for a one-member publication.
+///
+/// The domain-separated input includes the path, incarnation, and generation. Correctness relies
+/// on collisions in the 128-bit truncated SHA-256 result being infeasible.
+fn direct_group_id(
+    partition: &str,
+    name: &[u8],
+    incarnation: &[u8; INCARNATION_LEN],
+    generation: u64,
+) -> [u8; INCARNATION_LEN] {
+    let partition_len = (partition.len() as u64).to_be_bytes();
+    let name_len = (name.len() as u64).to_be_bytes();
+    let generation = generation.to_be_bytes();
+    let digest = Sha256::hash(&[
+        DIRECT_GROUP_DOMAIN,
+        &partition_len,
+        partition.as_bytes(),
+        &name_len,
+        name,
+        incarnation,
+        &generation,
+    ]);
+    digest.as_ref()[..INCARNATION_LEN].try_into().unwrap()
+}
+
+/// Encode the complete canonical identity page for one namespace incarnation.
+///
+/// Fresh creation writes this complete page before its durability barrier.
+fn encode_identity(identity: [u8; INCARNATION_LEN]) -> [u8; IDENTITY_PAGE_LEN as usize] {
+    let mut page = [0u8; IDENTITY_PAGE_LEN as usize];
+    page[..7].copy_from_slice(IDENTITY_MAGIC);
+    page[IDENTITY_GUARD_OFFSET] = IDENTITY_GUARD;
+    page[8..24].copy_from_slice(&identity);
+    let crc = checksum(&[IDENTITY_DOMAIN, &page[..24]]);
+    page[24..IDENTITY_LEN].copy_from_slice(&crc.to_be_bytes());
+    page
+}
+
+/// Decode a complete canonical identity page.
+pub(crate) fn decode_identity(
+    page: &[u8; IDENTITY_PAGE_LEN as usize],
+) -> Option<[u8; INCARNATION_LEN]> {
+    if &page[..7] != IDENTITY_MAGIC
+        || page[IDENTITY_GUARD_OFFSET] != IDENTITY_GUARD
+        || page[IDENTITY_LEN..].iter().any(|byte| *byte != 0)
+    {
+        return None;
+    }
+    let stored = u32::from_be_bytes(page[24..IDENTITY_LEN].try_into().unwrap());
+    (stored == checksum(&[IDENTITY_DOMAIN, &page[..24]])).then(|| page[8..24].try_into().unwrap())
+}
+
+/// Encode a root with a zero witness binding.
+///
+/// A `BatchPrepared` result is only a template. `Candidate::bind` replaces its binding after the
+/// exact local witness has been encoded.
+fn encode_root_value(state: RootState, root: Root) -> [u8; ROOT_LEN] {
+    encode_root_with_binding(state, root, [0; ROOT_BINDING_LEN])
+}
+
+/// Encode one complete root header with an explicit witness binding.
+fn encode_root_with_binding(state: RootState, value: Root, binding: RootBinding) -> [u8; ROOT_LEN] {
+    let mut root = [0u8; ROOT_LEN];
+    root[..7].copy_from_slice(ROOT_MAGIC);
+    root[ROOT_GUARD_OFFSET] = state.guard(value.generation);
+    root[8..16].copy_from_slice(&value.generation.to_be_bytes());
+    root[16..24].copy_from_slice(&value.logical_len.to_be_bytes());
+    root[ROOT_INTEGRITY_START_OFFSET..ROOT_INTEGRITY_CHECKSUM_OFFSET]
+        .copy_from_slice(&value.integrity_start.to_be_bytes());
+    root[ROOT_INTEGRITY_CHECKSUM_OFFSET..ROOT_INTEGRITY_SCHEME_OFFSET]
+        .copy_from_slice(&value.integrity_checksum.to_be_bytes());
+    let (scheme, chunk) = match value.integrity_scheme {
+        IntegrityScheme::Unbound => (0u32, 0u32),
+        IntegrityScheme::Variable => (1, 0),
+        IntegrityScheme::Chunked(size) => (2, size.get()),
+    };
+    root[ROOT_INTEGRITY_SCHEME_OFFSET..ROOT_INTEGRITY_CHUNK_OFFSET]
+        .copy_from_slice(&scheme.to_be_bytes());
+    root[ROOT_INTEGRITY_CHUNK_OFFSET..ROOT_BINDING_OFFSET].copy_from_slice(&chunk.to_be_bytes());
+    root[ROOT_BINDING_OFFSET..ROOT_PREFIX_LEN].copy_from_slice(&binding);
+    root[ROOT_PREFIX_LEN..ROOT_BODY_LEN].copy_from_slice(&value.tag);
+    let checksum = checksum(&[ROOT_DOMAIN, &root[..ROOT_BODY_LEN]]);
+    root[ROOT_BODY_LEN..].copy_from_slice(&checksum.to_be_bytes());
+    root
+}
+
+fn root_binding(encoded: &[u8; ROOT_LEN]) -> RootBinding {
+    encoded[ROOT_BINDING_OFFSET..ROOT_PREFIX_LEN]
+        .try_into()
+        .expect("the root binding has a fixed width")
+}
+
+/// Logical value carried by every root spelling.
+///
+/// The root does not store a separate payload map. `logical_len` selects one contiguous prefix,
+/// while the integrity fields describe the only unfinished checksum unit in that prefix.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Root {
+    generation: u64,
+    logical_len: u64,
+    integrity_start: u64,
+    integrity_checksum: u32,
+    integrity_scheme: IntegrityScheme,
+    tag: [u8; ATOMIC_BLOB_TAG_LEN],
+}
+
+#[cfg(test)]
+impl Root {
+    const fn unbound(generation: u64, logical_len: u64, tag: [u8; ATOMIC_BLOB_TAG_LEN]) -> Self {
+        Self {
+            generation,
+            logical_len,
+            integrity_start: 0,
+            integrity_checksum: 0,
+            integrity_scheme: IntegrityScheme::Unbound,
+            tag,
+        }
+    }
+}
+
+/// Decode the value fields without assigning local authority to their guard or checksum.
+///
+/// Transition repair uses this weaker parse only after independent evidence constrains every byte
+/// to one of two canonical root spellings.
+fn decode_root_fields(encoded: &[u8; ROOT_LEN]) -> Option<Root> {
+    if &encoded[..7] != ROOT_MAGIC {
+        return None;
+    }
+    let generation = u64::from_be_bytes(encoded[8..16].try_into().unwrap());
+    let scheme = u32::from_be_bytes(
+        encoded[ROOT_INTEGRITY_SCHEME_OFFSET..ROOT_INTEGRITY_CHUNK_OFFSET]
+            .try_into()
+            .unwrap(),
+    );
+    let chunk = u32::from_be_bytes(
+        encoded[ROOT_INTEGRITY_CHUNK_OFFSET..ROOT_BINDING_OFFSET]
+            .try_into()
+            .unwrap(),
+    );
+    let integrity_scheme = match (scheme, chunk) {
+        (0, 0) => IntegrityScheme::Unbound,
+        (1, 0) => IntegrityScheme::Variable,
+        (2, chunk) => IntegrityScheme::Chunked(std::num::NonZeroU32::new(chunk)?),
+        _ => return None,
+    };
+    (generation != 0).then(|| Root {
+        generation,
+        logical_len: u64::from_be_bytes(encoded[16..24].try_into().unwrap()),
+        integrity_start: u64::from_be_bytes(
+            encoded[ROOT_INTEGRITY_START_OFFSET..ROOT_INTEGRITY_CHECKSUM_OFFSET]
+                .try_into()
+                .unwrap(),
+        ),
+        integrity_checksum: u32::from_be_bytes(
+            encoded[ROOT_INTEGRITY_CHECKSUM_OFFSET..ROOT_INTEGRITY_SCHEME_OFFSET]
+                .try_into()
+                .unwrap(),
+        ),
+        integrity_scheme,
+        tag: encoded[ROOT_PREFIX_LEN..ROOT_BODY_LEN].try_into().unwrap(),
+    })
+}
+
+/// Decode one exact spelling and validate its guard, binding rule, and CRC32C.
+///
+/// This does not validate slot parity, payload extent, integrity geometry, or the slot suffix.
+fn decode_root(encoded: &[u8; ROOT_LEN], state: RootState) -> Option<Root> {
+    let root = decode_root_fields(encoded)?;
+    if encoded[ROOT_GUARD_OFFSET] != state.guard(root.generation) {
+        return None;
+    }
+    let stored = u32::from_be_bytes(encoded[ROOT_BODY_LEN..].try_into().unwrap());
+    if stored != checksum(&[ROOT_DOMAIN, &encoded[..ROOT_BODY_LEN]]) {
+        return None;
+    }
+    Some(root)
+}
+
+/// Decode the first root spelling whose complete header grammar matches.
+fn decode_any_root(encoded: &[u8; ROOT_LEN]) -> Option<(RootState, Root)> {
+    [RootState::BatchPrepared, RootState::Finalized]
+        .into_iter()
+        .find_map(|state| decode_root(encoded, state).map(|root| (state, root)))
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn invalid_input(message: impl Into<String>) -> Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into()).into()
+}
+
+fn raw_len(logical_len: u64) -> Result<u64, Error> {
+    DATA_OFFSET
+        .checked_add(logical_len)
+        .ok_or(Error::OffsetOverflow)
+}
+
+fn next_generation(generation: u64) -> Result<u64, Error> {
+    generation.checked_add(1).map_or_else(
+        || Err(invalid_data("atomic generation overflow").into()),
+        Ok,
+    )
+}
+
+/// Validate slot parity, checked payload extent, and canonical integrity geometry.
+///
+/// Guard, header CRC32C, witness binding, and suffix validation belong to the root and slot
+/// decoders. The returned value is the raw backing extent selected by this root.
+fn validate_root(root: Root, root_offset: u64, backing_len: u64) -> io::Result<u64> {
+    if ROOT_OFFSETS[(root.generation as usize) & 1] != root_offset {
+        return Err(invalid_data("atomic root generation is in the wrong slot"));
+    }
+    let end = DATA_OFFSET
+        .checked_add(root.logical_len)
+        .ok_or_else(|| invalid_data("atomic payload length overflows"))?;
+    if end > backing_len {
+        return Err(invalid_data("atomic root exceeds the backing blob"));
+    }
+    if root.integrity_start > root.logical_len {
+        return Err(invalid_data(
+            "atomic integrity tail starts beyond the payload",
+        ));
+    }
+    let tail_len = root.logical_len - root.integrity_start;
+    if tail_len == 0 && root.integrity_checksum != 0 {
+        return Err(invalid_data("empty atomic integrity tail has a checksum"));
+    }
+    match root.integrity_scheme {
+        IntegrityScheme::Unbound if root.integrity_start != 0 => {
+            return Err(invalid_data(
+                "unbound atomic integrity tail has a nonzero start",
+            ));
+        }
+        IntegrityScheme::Chunked(size) => {
+            let data_len = u64::from(size.get());
+            let encoded_len = data_len
+                .checked_add(size_of::<u32>() as u64)
+                .ok_or_else(|| invalid_data("atomic integrity geometry overflows"))?;
+            if !root.integrity_start.is_multiple_of(encoded_len) || tail_len >= data_len {
+                return Err(invalid_data(
+                    "atomic chunked integrity tail is noncanonical",
+                ));
+            }
+        }
+        IntegrityScheme::Unbound | IntegrityScheme::Variable => {}
+    }
+    Ok(end)
+}
+
+/// Classify a complete root slot before lineage or payload validation.
+///
+/// `Raw` includes corrupt roots and allowed torn transitions. Recovery interprets those bytes only
+/// when a predecessor or bound witness supplies the missing authority.
+#[derive(Clone, Copy, Debug)]
+enum Slot {
+    Zero,
+    Root(RootState, Root),
+    Finalized { root: Root, removed: bool },
+    Raw,
+}
+
+impl Slot {
+    const fn root(self) -> Option<Root> {
+        match self {
+            Self::Root(_, root) | Self::Finalized { root, .. } => Some(root),
+            Self::Zero | Self::Raw => None,
+        }
+    }
+
+    const fn independent(self) -> Option<(Root, bool)> {
+        match self {
+            Self::Finalized { root, removed } => Some((root, removed)),
+            Self::Zero | Self::Root(_, _) | Self::Raw => None,
+        }
+    }
+}
+
+/// Decode a slot and enforce the suffix grammar for its root spelling.
+fn decode_slot(
+    encoded: &RootSlot,
+    root_offset: u64,
+    expected_incarnation: Option<&[u8; INCARNATION_LEN]>,
+) -> Slot {
+    if encoded.iter().all(|byte| *byte == 0) {
+        Slot::Zero
+    } else {
+        let header: &[u8; ROOT_LEN] = encoded[..ROOT_LEN]
+            .try_into()
+            .expect("root slots contain a complete header");
+        let Some((state, root)) = decode_any_root(header) else {
+            return Slot::Raw;
+        };
+        let suffix_valid = match state {
+            RootState::BatchPrepared => {
+                let Some(link) = batch::link_at(encoded, "", &[], root_offset) else {
+                    return Slot::Raw;
+                };
+                expected_incarnation
+                    .is_none_or(|expected| link.participant.incarnation == *expected)
+                    && header == &link.participant.candidate.prepared_root
+            }
+            RootState::Finalized => {
+                let Some(link) = batch::link_at(encoded, "", &[], root_offset).filter(|link| {
+                    expected_incarnation
+                        .is_none_or(|expected| link.participant.incarnation == *expected)
+                }) else {
+                    return Slot::Raw;
+                };
+                let Some(final_root) = link.participant.candidate.final_root() else {
+                    return Slot::Raw;
+                };
+                if header != &final_root {
+                    return Slot::Raw;
+                }
+                return Slot::Finalized {
+                    root,
+                    removed: link.participant.removed,
+                };
+            }
+        };
+        if !suffix_valid {
+            return Slot::Raw;
+        }
+        Slot::Root(state, root)
+    }
+}
+
+/// Non-authoritative parity slot that must be durably cleared before reuse.
+struct RejectionPlan {
+    root_offset: u64,
+}
+
+const INTEGRITY_CHECKSUM_LEN: usize = size_of::<u32>();
+
+fn validate_integrity(data: &[u8], expected: u32) -> io::Result<()> {
+    let mut checksum = Crc32::default();
+    checksum.update(data);
+    if checksum.finalize().1.as_u32() == expected {
+        Ok(())
+    } else {
+        Err(invalid_data("atomic integrity checksum mismatch"))
+    }
+}
+
+/// Select the repair needed before the non-authoritative parity slot can be reused.
+///
+/// The newest valid locally selectable root is the authority. Its opposite slot must be zero, the
+/// exact predecessor, or the next attempted generation. Clearing an attempted generation preserves
+/// the authority's generation so the same next generation can be retried from a durable zero slot.
+///
+/// ```text
+/// authority or slot condition                       result
+/// ------------------------------------------------  -----------------------------------
+/// removed Finalized h                              no local plan
+/// exact canonical predecessor h - 1                no plan
+/// durable zero slot                                no plan
+/// BatchPrepared h + 1, Raw, older mosaic           clear the complete slot
+/// bad gap or unresolved newer local authority      corruption
+/// ```
+fn rejection_plan_for(
+    backing_len: u64,
+    encoded: &[RootSlot; ROOT_OFFSETS.len()],
+    expected_incarnation: Option<&[u8; INCARNATION_LEN]>,
+) -> io::Result<Option<RejectionPlan>> {
+    if backing_len < DATA_OFFSET {
+        return Err(invalid_data("atomic blob is shorter than its root region"));
+    }
+
+    let slots: [Slot; ROOT_OFFSETS.len()] = std::array::from_fn(|index| {
+        decode_slot(&encoded[index], ROOT_OFFSETS[index], expected_incarnation)
+    });
+    for (slot, offset) in slots.iter().zip(ROOT_OFFSETS) {
+        if let Some(root) = slot.root()
+            && ROOT_OFFSETS[(root.generation as usize) & 1] != offset
+        {
+            return Err(invalid_data("atomic root generation is in the wrong slot"));
+        }
+    }
+
+    let mut authority: Option<(usize, bool, Root)> = None;
+    let mut recovery_error = None;
+    for (index, slot) in slots.iter().enumerate() {
+        let Some((root, removed)) = slot.independent() else {
+            continue;
+        };
+        match validate_root(root, ROOT_OFFSETS[index], backing_len) {
+            Ok(_) => {}
+            Err(error) => {
+                recovery_error.get_or_insert(error);
+                continue;
+            }
+        }
+        if authority
+            .as_ref()
+            .is_none_or(|(_, _, selected)| root.generation > selected.generation)
+        {
+            authority = Some((index, removed, root));
+        }
+    }
+
+    let (authority_index, authority_removed, authority) = match authority {
+        Some(authority) => authority,
+        None if matches!(slots[0], Slot::Zero) => (
+            0,
+            false,
+            Root {
+                generation: 0,
+                logical_len: 0,
+                integrity_start: 0,
+                integrity_checksum: 0,
+                integrity_scheme: IntegrityScheme::Unbound,
+                tag: [0; ATOMIC_BLOB_TAG_LEN],
+            },
+        ),
+        None => {
+            return Err(recovery_error
+                .unwrap_or_else(|| invalid_data("atomic blob has no recoverable root")));
+        }
+    };
+    if authority_removed {
+        return Ok(None);
+    }
+    let target_index = 1 - authority_index;
+    let target = slots[target_index];
+    if matches!(target, Slot::Zero) {
+        return Ok(None);
+    }
+    if let Some((root, _)) = target.independent() {
+        if root.generation < authority.generation {
+            if validate_root(root, ROOT_OFFSETS[target_index], backing_len).is_ok()
+                && root.generation.checked_add(1) == Some(authority.generation)
+            {
+                return Ok(None);
+            }
+            // A torn prepared-slot rewrite can turn the older slot into a checksum-valid
+            // independent mosaic. The hybrid may have an unrelated generation, or retain the
+            // predecessor generation while changing its value. Neither can supersede the newer
+            // authority, but both must be consumed before this slot is reused.
+        } else {
+            return Err(invalid_data(format!(
+                "atomic recovery left generation {} unresolved",
+                root.generation
+            )));
+        }
+    } else if let Some(root) = target.root()
+        && authority.generation.checked_add(1) != Some(root.generation)
+    {
+        return Err(invalid_data(
+            "atomic rejected candidate does not follow its predecessor",
+        ));
+    }
+
+    authority
+        .generation
+        .checked_add(1)
+        .ok_or_else(|| invalid_data("atomic generation overflow"))?;
+    Ok(Some(RejectionPlan {
+        root_offset: ROOT_OFFSETS[target_index],
+    }))
+}
+
+/// Mutable view of one opened incarnation.
+///
+/// Three lengths separate visibility, publication, and earlier durability:
+///
+/// ```text
+/// durable_len <= logical_len
+/// committed.logical_len has no fixed ordering with durable_len or logical_len
+/// logical_len is the encoded length visible through this handle
+/// ```
+///
+/// Appends can move `logical_len` ahead of both baselines. Preflush can move `durable_len` past the
+/// published end, while rewind can clamp it below that end. A pending rewind can also move
+/// `logical_len` below the committed length. Dirtiness compares visible and published state, not
+/// payload durability. Any admitted mutable I/O failure poisons the complete clone set until
+/// reopen reconstructs this state.
+#[derive(Clone, Debug)]
+struct State {
+    /// Fresh compare-token epoch shared by one opened handle and its clones.
+    token_epoch: [u8; INCARNATION_LEN],
+    /// Encoded payload length visible through this handle.
+    logical_len: u64,
+    /// Visible prefix covered by a completed full-file durability operation.
+    durable_len: u64,
+    /// Complete value selected by the current root.
+    committed: Root,
+    /// Start of the unfinished integrity unit in the visible payload.
+    integrity_start: u64,
+    /// Finalized checksum of the unfinished visible unit.
+    integrity_checksum: u32,
+    /// Integrity geometry bound to visible offsets.
+    integrity_scheme: IntegrityScheme,
+    /// Immediately visible application tag.
+    tag: [u8; ATOMIC_BLOB_TAG_LEN],
+    /// In-memory compare-token component advanced by coherent mutations.
+    revision: u64,
+    /// Whether an admitted mutable operation ended without a known in-memory result.
+    poisoned: bool,
+    /// Whether a completed group selected logical absence for this incarnation.
+    removed: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            token_epoch: [0; INCARNATION_LEN],
+            logical_len: 0,
+            durable_len: 0,
+            committed: Root {
+                generation: 0,
+                logical_len: 0,
+                integrity_start: 0,
+                integrity_checksum: 0,
+                integrity_scheme: IntegrityScheme::Unbound,
+                tag: [0; ATOMIC_BLOB_TAG_LEN],
+            },
+            integrity_start: 0,
+            integrity_checksum: 0,
+            integrity_scheme: IntegrityScheme::Unbound,
+            tag: [0; ATOMIC_BLOB_TAG_LEN],
+            revision: 0,
+            poisoned: false,
+            removed: false,
+        }
+    }
+}
+
+impl State {
+    /// Reconstruct visible state from the newest valid independent root.
+    ///
+    /// Group recovery and rejection consumption run before this selector. Batch-prepared roots and
+    /// raw transitions are therefore ignored here. The returned length requests a
+    /// repeated physical shrink when the selected logical end is shorter than the backing blob.
+    fn recover_for(
+        backing_len: u64,
+        encoded: &[RootSlot; ROOT_OFFSETS.len()],
+        expected_incarnation: Option<&[u8; INCARNATION_LEN]>,
+        token_epoch: [u8; INCARNATION_LEN],
+    ) -> io::Result<(Self, Option<u64>)> {
+        let mut roots = Vec::new();
+        let mut recovery_error = None;
+        for (slot, offset) in encoded.iter().zip(ROOT_OFFSETS) {
+            let Some((root, _)) = decode_slot(slot, offset, expected_incarnation).independent()
+            else {
+                continue;
+            };
+            match validate_root(root, offset, backing_len) {
+                Ok(end) => roots.push((root, end)),
+                Err(error) => {
+                    recovery_error.get_or_insert(error);
+                }
+            }
+        }
+        roots.sort_by_key(|(root, _)| std::cmp::Reverse(root.generation));
+        let (root, selected_len) = match roots.into_iter().next() {
+            Some(selected) => selected,
+            None if matches!(
+                decode_slot(&encoded[0], ROOT_OFFSETS[0], expected_incarnation),
+                Slot::Zero
+            ) =>
+            {
+                (
+                    Root {
+                        generation: 0,
+                        logical_len: 0,
+                        integrity_start: 0,
+                        integrity_checksum: 0,
+                        integrity_scheme: IntegrityScheme::Unbound,
+                        tag: [0; ATOMIC_BLOB_TAG_LEN],
+                    },
+                    DATA_OFFSET,
+                )
+            }
+            None => {
+                return Err(recovery_error
+                    .unwrap_or_else(|| invalid_data("atomic blob has no recoverable root")));
+            }
+        };
+        Ok((
+            Self {
+                token_epoch,
+                logical_len: root.logical_len,
+                durable_len: root.logical_len,
+                committed: root,
+                integrity_start: root.integrity_start,
+                integrity_checksum: root.integrity_checksum,
+                integrity_scheme: root.integrity_scheme,
+                tag: root.tag,
+                revision: 0,
+                poisoned: false,
+                removed: false,
+            },
+            (selected_len != backing_len).then_some(selected_len),
+        ))
+    }
+
+    fn ensure_healthy(&self) -> Result<(), Error> {
+        if self.poisoned {
+            return Err(invalid_data("atomic blob generation is poisoned").into());
+        }
+        Ok(())
+    }
+
+    fn ensure_mutable(&self) -> Result<(), Error> {
+        if self.removed {
+            return Err(invalid_data("atomic blob incarnation was removed").into());
+        }
+        if self.committed.generation == u64::MAX {
+            return Err(invalid_data("atomic generation exhausted").into());
+        }
+        Ok(())
+    }
+
+    fn set_tag(&mut self, tag: [u8; ATOMIC_BLOB_TAG_LEN]) -> Result<(), Error> {
+        if tag == self.tag {
+            return Ok(());
+        }
+        self.ensure_mutable()?;
+        self.tag = tag;
+        self.advance_revision();
+        Ok(())
+    }
+
+    fn integrity_tail(&self) -> Option<IntegrityUnit> {
+        (self.integrity_start < self.logical_len).then_some(IntegrityUnit {
+            offset: self.integrity_start,
+            len: self.logical_len - self.integrity_start,
+        })
+    }
+
+    const fn integrity_token(&self) -> IntegrityToken {
+        IntegrityToken {
+            epoch: self.token_epoch,
+            revision: self.revision,
+        }
+    }
+
+    fn expect_integrity_token(&self, expected: IntegrityToken) -> Result<(), Error> {
+        if self.integrity_token() == expected {
+            Ok(())
+        } else {
+            Err(invalid_input("atomic integrity state is stale"))
+        }
+    }
+
+    const fn advance_revision(&mut self) {
+        self.revision = self
+            .revision
+            .checked_add(1)
+            .expect("atomic in-memory mutation revision exhausted");
+    }
+
+    /// Return whether visible state differs from its published baseline.
+    fn is_dirty(&self) -> bool {
+        self.logical_len != self.committed.logical_len
+            || self.integrity_start != self.committed.integrity_start
+            || self.integrity_checksum != self.committed.integrity_checksum
+            || self.integrity_scheme != self.committed.integrity_scheme
+            || self.tag != self.committed.tag
+    }
+
+    fn validate_integrity_tail(&self, data: &[u8]) -> Result<(), Error> {
+        let Some(unit) = self.integrity_tail() else {
+            return if data.is_empty() {
+                Ok(())
+            } else {
+                Err(invalid_input(
+                    "closed atomic integrity state has tail bytes",
+                ))
+            };
+        };
+        if usize::try_from(unit.len).ok() != Some(data.len()) {
+            return Err(invalid_input("atomic integrity tail has an invalid length"));
+        }
+        validate_integrity(data, self.integrity_checksum).map_err(Into::into)
+    }
+
+    /// Preflight an integrity append and return its write plan when bytes must be written.
+    ///
+    /// The result interleaves caller bytes with protocol-owned CRC32C footers. Chunked mode can
+    /// close several units in one append. Variable mode closes at most the caller-selected current
+    /// unit. A returned [`PreparedAppend`] leaves state unchanged until `finish_append`. Empty
+    /// scheme binding is the exception. It updates integrity metadata without backing I/O.
+    ///
+    /// ```text
+    /// visible tail + caller bytes
+    ///          |
+    ///          +-- Continue --------> keep one unfinished unit
+    ///          +-- Complete --------> append one footer and close it
+    ///          `-- Chunked(width) --> append a footer at every full boundary
+    /// ```
+    fn prepare_integrity_append(
+        &mut self,
+        mut data: IoBufs,
+        boundary: IntegrityBoundary,
+    ) -> Result<Option<PreparedAppend>, Error> {
+        if data.is_empty() && matches!(boundary, IntegrityBoundary::Continue) {
+            return Ok(None);
+        }
+        if self.logical_len < self.committed.logical_len {
+            return Err(invalid_input(
+                "atomic append requires synchronizing the committed rewind first",
+            ));
+        }
+        self.ensure_mutable()?;
+        let requested_scheme = match boundary {
+            IntegrityBoundary::Continue => None,
+            IntegrityBoundary::Complete => Some(IntegrityScheme::Variable),
+            IntegrityBoundary::Chunked(size) => Some(IntegrityScheme::Chunked(size)),
+        };
+        let integrity_scheme = match (self.integrity_scheme, requested_scheme) {
+            (scheme, None) | (IntegrityScheme::Unbound, Some(scheme)) => scheme,
+            (scheme, Some(requested)) if scheme == requested => scheme,
+            _ => {
+                return Err(invalid_input(
+                    "atomic blob is already bound to a different integrity scheme",
+                ));
+            }
+        };
+        let logical_start = self.logical_len;
+        let mut logical_cursor = logical_start;
+        let mut integrity_start = self.integrity_start;
+        let mut integrity_checksum = Crc32::resume(self.integrity_checksum);
+        let mut result_offset = None;
+        let mut parts = Vec::new();
+        let mut footer_bytes = Vec::new();
+        let chunk_size = match integrity_scheme {
+            IntegrityScheme::Chunked(size) => Some(u64::from(size.get())),
+            IntegrityScheme::Unbound | IntegrityScheme::Variable => None,
+        };
+        if let Some(chunk_size) = chunk_size
+            && logical_cursor - integrity_start > chunk_size
+        {
+            return Err(invalid_input(
+                "current atomic integrity unit exceeds the requested chunk size",
+            ));
+        }
+        let closes_existing = matches!(boundary, IntegrityBoundary::Complete)
+            && self.integrity_start != self.logical_len
+            || chunk_size.is_some_and(|size| self.logical_len - self.integrity_start == size);
+        if data.is_empty() && !closes_existing {
+            if self.integrity_scheme != integrity_scheme {
+                self.integrity_scheme = integrity_scheme;
+                self.advance_revision();
+            }
+            return Ok(None);
+        }
+
+        let data_len = u64::try_from(data.len()).map_err(|_| Error::OffsetOverflow)?;
+        let seal_count = if let Some(chunk_size) = chunk_size {
+            let tail_len = logical_cursor - integrity_start;
+            u64::try_from((u128::from(tail_len) + u128::from(data_len)) / u128::from(chunk_size))
+                .map_err(|_| Error::OffsetOverflow)?
+        } else if matches!(boundary, IntegrityBoundary::Complete) {
+            1
+        } else {
+            0
+        };
+        let logical_end = logical_start
+            .checked_add(data_len)
+            .and_then(|end| {
+                seal_count
+                    .checked_mul(INTEGRITY_CHECKSUM_LEN as u64)
+                    .and_then(|footer_len| end.checked_add(footer_len))
+            })
+            .ok_or(Error::OffsetOverflow)?;
+        raw_len(logical_end)?;
+        let mut packed = (seal_count > MAX_SCATTER_INTEGRITY_UNITS).then(PackedAppend::new);
+
+        let seal = |parts: &mut Vec<(IoBufs, Option<usize>)>,
+                    footer_bytes: &mut Vec<u8>,
+                    packed: &mut Option<PackedAppend>,
+                    integrity_start: &mut u64,
+                    integrity_checksum: &mut Crc32,
+                    logical_cursor: &mut u64|
+         -> Result<(), Error> {
+            debug_assert_ne!(*integrity_start, *logical_cursor);
+            let footer = std::mem::take(integrity_checksum)
+                .finalize()
+                .1
+                .as_u32()
+                .to_be_bytes();
+            if let Some(packed) = packed.as_mut() {
+                packed.push(&footer);
+            } else {
+                let footer_offset = footer_bytes.len();
+                footer_bytes.extend_from_slice(&footer);
+                parts.push((IoBufs::default(), Some(footer_offset)));
+            }
+            *logical_cursor = logical_cursor
+                .checked_add(INTEGRITY_CHECKSUM_LEN as u64)
+                .ok_or(Error::OffsetOverflow)?;
+            *integrity_start = *logical_cursor;
+            Ok(())
+        };
+
+        if chunk_size.is_some_and(|size| logical_cursor - integrity_start == size) {
+            seal(
+                &mut parts,
+                &mut footer_bytes,
+                &mut packed,
+                &mut integrity_start,
+                &mut integrity_checksum,
+                &mut logical_cursor,
+            )?;
+        }
+
+        while !data.is_empty() {
+            let available = chunk_size
+                .map(|size| size - (logical_cursor - integrity_start))
+                .unwrap_or(u64::MAX);
+            let take = data
+                .len()
+                .min(usize::try_from(available).unwrap_or(usize::MAX));
+            debug_assert_ne!(take, 0);
+            let part = data.split_to(take);
+            part.for_each_chunk(|chunk| {
+                integrity_checksum.update(chunk);
+            });
+            result_offset.get_or_insert(logical_cursor);
+            logical_cursor = logical_cursor
+                .checked_add(take as u64)
+                .ok_or(Error::OffsetOverflow)?;
+            if let Some(packed) = packed.as_mut() {
+                part.for_each_chunk(|chunk| packed.push(chunk));
+            } else {
+                parts.push((part, None));
+            }
+            if chunk_size.is_some_and(|size| logical_cursor - integrity_start == size) {
+                seal(
+                    &mut parts,
+                    &mut footer_bytes,
+                    &mut packed,
+                    &mut integrity_start,
+                    &mut integrity_checksum,
+                    &mut logical_cursor,
+                )?;
+            }
+        }
+        if matches!(boundary, IntegrityBoundary::Complete) {
+            seal(
+                &mut parts,
+                &mut footer_bytes,
+                &mut packed,
+                &mut integrity_start,
+                &mut integrity_checksum,
+                &mut logical_cursor,
+            )?;
+        }
+        debug_assert_eq!(logical_cursor, logical_end);
+        let encoded = packed.map_or_else(
+            || {
+                let footers = IoBuf::from(footer_bytes);
+                let mut encoded = IoBufs::default();
+                for (part, footer_offset) in parts {
+                    encoded.append(part.coalesce());
+                    if let Some(offset) = footer_offset {
+                        encoded.append(footers.slice(offset..offset + INTEGRITY_CHECKSUM_LEN));
+                    }
+                }
+                encoded
+            },
+            PackedAppend::finish,
+        );
+        let integrity_checksum = integrity_checksum.finalize().1.as_u32();
+        Ok(Some(PreparedAppend {
+            result_offset: result_offset.unwrap_or(logical_start),
+            logical_start,
+            logical_end: logical_cursor,
+            encoded,
+            integrity_start,
+            integrity_checksum,
+            integrity_scheme,
+        }))
+    }
+
+    /// Install a successfully written append into the immediately visible state.
+    ///
+    /// Reusing an offset at or before the prior durable frontier conservatively moves the frontier
+    /// back to the start of this write.
+    fn finish_append(&mut self, prepared: PreparedAppend) {
+        self.durable_len = if self.durable_len < prepared.logical_start {
+            self.durable_len
+        } else {
+            prepared.logical_start
+        };
+        self.logical_len = prepared.logical_end;
+        self.integrity_start = prepared.integrity_start;
+        self.integrity_checksum = prepared.integrity_checksum;
+        self.integrity_scheme = prepared.integrity_scheme;
+        self.advance_revision();
+    }
+
+    const fn speculative_payload_len(&self) -> u64 {
+        self.logical_len.saturating_sub(self.durable_len)
+    }
+
+    fn finish_payload_preflush(&mut self, target: u64) {
+        assert!(target <= self.logical_len);
+        self.durable_len = self.durable_len.max(target);
+    }
+
+    fn validate_rewind(&self, len: u64) -> Result<(), Error> {
+        if len > self.logical_len {
+            return Err(invalid_input("atomic rewind cannot extend a blob"));
+        }
+        if len == self.logical_len {
+            return Ok(());
+        }
+        self.ensure_mutable()?;
+        Ok(())
+    }
+
+    /// Build the read plan needed to prove a rewind target.
+    ///
+    /// An internally known unit boundary needs no read. Rewinding into a unit requires the complete
+    /// current unit or one completed unit whose footer can be validated before rebuilding the
+    /// retained prefix checksum.
+    fn rewind_integrity_source(
+        &self,
+        len: u64,
+        unit: Option<IntegrityUnit>,
+    ) -> Result<Option<RewindIntegritySource>, Error> {
+        self.validate_rewind(len)?;
+        if len == self.logical_len || len == self.committed.logical_len {
+            return Ok(None);
+        }
+        let current = self.integrity_tail();
+        let unit = unit.or_else(|| {
+            current.filter(|unit| {
+                unit.offset < len
+                    && unit
+                        .offset
+                        .checked_add(unit.len)
+                        .is_some_and(|end| len <= end)
+            })
+        });
+        let Some(unit) = unit else {
+            let known_boundary = len == 0
+                || current.is_some_and(|unit| len == unit.offset)
+                || match self.integrity_scheme {
+                    IntegrityScheme::Chunked(size) => {
+                        let encoded_unit = u64::from(size.get())
+                            .checked_add(INTEGRITY_CHECKSUM_LEN as u64)
+                            .ok_or(Error::OffsetOverflow)?;
+                        len.is_multiple_of(encoded_unit)
+                    }
+                    IntegrityScheme::Unbound | IntegrityScheme::Variable => false,
+                };
+            return if known_boundary {
+                Ok(None)
+            } else {
+                Err(invalid_input(
+                    "atomic rewind target is not a proven integrity-unit boundary",
+                ))
+            };
+        };
+        let is_current = current == Some(unit);
+        if !is_current {
+            self.integrity_scheme.validate_completed_unit(unit)?;
+        }
+        let data_end = unit
+            .offset
+            .checked_add(unit.len)
+            .ok_or(Error::OffsetOverflow)?;
+        if !is_current
+            && matches!(self.integrity_scheme, IntegrityScheme::Chunked(_))
+            && len == data_end
+        {
+            return Err(invalid_input(
+                "atomic rewind cannot leave a full fixed-width integrity tail",
+            ));
+        }
+        let encoded_end = if is_current {
+            data_end
+        } else {
+            let encoded_end = data_end
+                .checked_add(INTEGRITY_CHECKSUM_LEN as u64)
+                .ok_or(Error::OffsetOverflow)?;
+            if encoded_end > self.integrity_start {
+                return Err(invalid_input(
+                    "completed atomic integrity unit exceeds the completed payload prefix",
+                ));
+            }
+            encoded_end
+        };
+        let retain_prefix = unit.offset < len && len <= data_end;
+        let boundary = len == unit.offset || (!is_current && len == encoded_end);
+        if !retain_prefix && !boundary {
+            return Err(invalid_input(
+                "atomic rewind integrity unit does not contain or border the new end",
+            ));
+        }
+        if is_current && boundary {
+            return Ok(None);
+        }
+        Ok(Some(RewindIntegritySource {
+            unit,
+            current: is_current,
+            retain_prefix,
+        }))
+    }
+
+    /// Apply a validated rewind and rebuild the unfinished integrity baseline.
+    ///
+    /// This changes logical authority only in memory. Publication selects the shorter root before
+    /// any physical truncation is attempted.
+    fn apply_rewind(
+        &mut self,
+        len: u64,
+        source: Option<(IntegrityUnit, &[u8])>,
+    ) -> Result<(), Error> {
+        self.validate_rewind(len)?;
+        if len == self.logical_len {
+            return Ok(());
+        }
+        let integrity_scheme = if len == self.committed.logical_len {
+            self.committed.integrity_scheme
+        } else {
+            self.integrity_scheme
+        };
+        let (integrity_start, integrity_checksum) = if len == self.committed.logical_len {
+            (
+                self.committed.integrity_start,
+                self.committed.integrity_checksum,
+            )
+        } else if let Some((unit, data)) = source {
+            if usize::try_from(unit.len).ok() != Some(data.len()) {
+                return Err(invalid_input(
+                    "atomic rewind integrity source has an invalid length",
+                ));
+            }
+            let retained = usize::try_from(len - unit.offset).map_err(|_| Error::OffsetOverflow)?;
+            let mut checksum = Crc32::default();
+            checksum.update(&data[..retained]);
+            (unit.offset, checksum.finalize().1.as_u32())
+        } else {
+            (len, 0)
+        };
+        self.logical_len = len;
+        self.durable_len = self.durable_len.min(len);
+        self.integrity_start = integrity_start;
+        self.integrity_checksum = integrity_checksum;
+        self.integrity_scheme = integrity_scheme;
+        self.advance_revision();
+        Ok(())
+    }
+
+    /// Snapshot the next root without changing visible or committed state.
+    fn prepare_commit(&self) -> Result<Option<PreparedCommit>, Error> {
+        if !self.is_dirty() {
+            return Ok(None);
+        }
+        self.ensure_mutable()?;
+        let generation = next_generation(self.committed.generation)?;
+        let root_offset = ROOT_OFFSETS[(generation as usize) & 1];
+        Ok(Some(PreparedCommit {
+            generation,
+            logical_len: self.logical_len,
+            integrity_start: self.integrity_start,
+            integrity_checksum: self.integrity_checksum,
+            integrity_scheme: self.integrity_scheme,
+            tag: self.tag,
+            root_offset,
+            truncate: self.logical_len < self.committed.logical_len,
+        }))
+    }
+
+    /// Advance the in-memory published baseline after its durable decision and cleanup write.
+    const fn finish_commit(&mut self, prepared: &PreparedCommit) {
+        self.durable_len = prepared.logical_len;
+        self.committed = Root {
+            generation: prepared.generation,
+            logical_len: prepared.logical_len,
+            integrity_start: prepared.integrity_start,
+            integrity_checksum: prepared.integrity_checksum,
+            integrity_scheme: prepared.integrity_scheme,
+            tag: prepared.tag,
+        };
+    }
+}
+
+/// Immutable root fields and cleanup requirements captured before direct publication starts.
+struct PreparedCommit {
+    generation: u64,
+    logical_len: u64,
+    integrity_start: u64,
+    integrity_checksum: u32,
+    integrity_scheme: IntegrityScheme,
+    tag: [u8; ATOMIC_BLOB_TAG_LEN],
+    root_offset: u64,
+    truncate: bool,
+}
+
+/// Encoded append and the visible integrity state it establishes after a successful write.
+struct PreparedAppend {
+    result_offset: u64,
+    logical_start: u64,
+    logical_end: u64,
+    encoded: IoBufs,
+    integrity_start: u64,
+    integrity_checksum: u32,
+    integrity_scheme: IntegrityScheme,
+}
+
+const INTEGRITY_ENCODING_BLOCK_LEN: usize = 64 * 1024;
+// Scatter encoding contributes one payload and one footer descriptor per completed unit.
+const MAX_SCATTER_INTEGRITY_UNITS: u64 = 512;
+
+/// Packs highly fragmented integrity encodings into bounded contiguous write chunks.
+struct PackedAppend {
+    encoded: IoBufs,
+    block: Vec<u8>,
+}
+
+impl PackedAppend {
+    fn new() -> Self {
+        Self {
+            encoded: IoBufs::default(),
+            block: Vec::with_capacity(INTEGRITY_ENCODING_BLOCK_LEN),
+        }
+    }
+
+    fn push(&mut self, mut bytes: &[u8]) {
+        while !bytes.is_empty() {
+            let available = INTEGRITY_ENCODING_BLOCK_LEN - self.block.len();
+            if available == 0 {
+                let block = std::mem::replace(
+                    &mut self.block,
+                    Vec::with_capacity(INTEGRITY_ENCODING_BLOCK_LEN),
+                );
+                self.encoded.append(IoBuf::from(block));
+                continue;
+            }
+            let take = available.min(bytes.len());
+            self.block.extend_from_slice(&bytes[..take]);
+            bytes = &bytes[take..];
+        }
+    }
+
+    fn finish(mut self) -> IoBufs {
+        if !self.block.is_empty() {
+            self.encoded.append(IoBuf::from(self.block));
+        }
+        self.encoded
+    }
+}
+
+/// Read plan for the integrity proof around a rewind target.
+///
+/// `current` selects the root-carried checksum with no footer. Otherwise the following footer must
+/// be read. `retain_prefix` means data is also needed to rebuild the new rolling checksum.
+#[derive(Clone, Copy)]
+struct RewindIntegritySource {
+    unit: IntegrityUnit,
+    current: bool,
+    retain_prefix: bool,
+}
+
+/// Poison-on-drop boundary for state-coupled mutable I/O.
+///
+/// Any exit while armed poisons shared state. Issued bytes or a decision may already be durable, so
+/// reopen decides the outcome. Background observer drop does not drop the retained task. Detached
+/// preflush failures poison explicitly. Validation and no-op paths remain unarmed. Successful
+/// mutation paths disarm only after in-memory state reflects all I/O.
+struct Operation<'a> {
+    state: MutexGuard<'a, State>,
+    armed: bool,
+}
+
+type CarriedSlot<B> = Arc<Mutex<Option<Arc<CarriedGroup<B>>>>>;
+
+/// Participant file whose issued final root still needs a durability barrier.
+struct CarriedMember<B> {
+    partition: Arc<str>,
+    name: Arc<[u8]>,
+    incarnation: [u8; INCARNATION_LEN],
+    backing: B,
+    sync_gate: Arc<Mutex<()>>,
+    slot: Weak<Mutex<Option<Arc<CarriedGroup<B>>>>>,
+}
+
+/// Process-local notification that recovery made one group's final roots independent.
+struct CarriedPayment {
+    group_id: [u8; batch::GROUP_ID_LEN],
+    paid: AtomicBool,
+    budget: Weak<PayloadBudget>,
+}
+
+impl CarriedPayment {
+    fn is_paid(&self) -> bool {
+        self.paid.load(AtomicOrdering::Acquire)
+    }
+}
+
+impl Drop for CarriedPayment {
+    fn drop(&mut self) {
+        let Some(budget) = self.budget.upgrade() else {
+            return;
+        };
+        let mut state = budget.state.lock();
+        if state
+            .carried_payments
+            .get(&self.group_id)
+            .is_some_and(|payment| std::ptr::eq(payment.as_ptr(), self))
+        {
+            state.carried_payments.remove(&self.group_id);
+        }
+    }
+}
+
+/// Live certificate and final-root durability debt for one decided group.
+///
+/// ```text
+/// participant carried slots --Arc--> shared group --> participant backing handles
+/// shared group ----------------Weak-----------------------> participant carried slots
+/// ```
+///
+/// The bound ring is durable. Its identity and exact candidate fields certify the selected
+/// predecessor while final roots remain unsynchronized. A later decision synchronizes every prior
+/// member file before clearing pointer-matching slots. Weak back-references avoid a retention cycle
+/// and let dropped participant handles disappear. If all handles disappear, the disk ring remains
+/// recovery authority. This tracks final-root durability, not physical deletion.
+struct CarriedGroup<B> {
+    group_id: [u8; batch::GROUP_ID_LEN],
+    members: Vec<CarriedMember<B>>,
+    payment: Arc<CarriedPayment>,
+    coordination: Mutex<()>,
+}
+
+/// Clear this group without disturbing a newer certificate already installed in a member slot.
+async fn clear_carried_group<B>(group: &Arc<CarriedGroup<B>>) {
+    for member in &group.members {
+        let Some(slot) = member.slot.upgrade() else {
+            continue;
+        };
+        let mut slot = slot.lock().await;
+        if slot
+            .as_ref()
+            .is_some_and(|installed| Arc::ptr_eq(installed, group))
+        {
+            *slot = None;
+        }
+    }
+}
+
+async fn sync_carried_member<B: BackingBlob>(member: &CarriedMember<B>) -> Result<(), Error> {
+    let _sync = member.sync_gate.lock().await;
+    member.backing.sync().await
+}
+
+impl<'a> Operation<'a> {
+    const fn new(state: MutexGuard<'a, State>) -> Self {
+        Self {
+            state,
+            armed: false,
+        }
+    }
+
+    const fn arm(&mut self) {
+        self.armed = true;
+    }
+
+    fn finish(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Deref for Operation<'_> {
+    type Target = State;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl DerefMut for Operation<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
+}
+
+impl Drop for Operation<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            self.state.poisoned = true;
+        }
+    }
+}
+
+/// Cloneable atomic view over one exact backing incarnation.
+///
+/// Clones share mutation state, payload accounting, preflush work, carried cleanup debt, and
+/// operation ownership. The public ownership contract forbids independently opened handles, so
+/// this type does not coordinate with them. The lineage exclusion lock separates live operations
+/// from namespace recovery, while the operation mutex serializes conflicting clones and groups.
+/// `driver` owns the cancellation policy for admitted work.
+pub struct Blob<B> {
+    backing: B,
+    partition: Arc<str>,
+    name: Arc<[u8]>,
+    incarnation: [u8; INCARNATION_LEN],
+    state: Arc<Mutex<State>>,
+    payload: Arc<PayloadAccount>,
+    preflush: Arc<PayloadPreflush>,
+    carried: CarriedSlot<B>,
+    driver: Driver,
+    exclusion: Arc<RwLock<()>>,
+    operation: Arc<Mutex<()>>,
+}
+
+/// Storage-lineage resources attached to each newly opened atomic blob.
+pub(crate) struct AtomicResources {
+    pub(crate) driver: Driver,
+    pub(crate) exclusion: Arc<RwLock<()>>,
+    pub(crate) namespace: Arc<Mutex<()>>,
+    pub(crate) payload_budget: Arc<PayloadBudget>,
+}
+
+impl Clone for AtomicResources {
+    fn clone(&self) -> Self {
+        Self {
+            driver: self.driver.clone(),
+            exclusion: self.exclusion.clone(),
+            namespace: self.namespace.clone(),
+            payload_budget: self.payload_budget.clone(),
+        }
+    }
+}
+
+impl<B: Clone> Clone for Blob<B> {
+    fn clone(&self) -> Self {
+        Self {
+            backing: self.backing.clone(),
+            partition: self.partition.clone(),
+            name: self.name.clone(),
+            incarnation: self.incarnation,
+            state: self.state.clone(),
+            payload: self.payload.clone(),
+            preflush: self.preflush.clone(),
+            carried: self.carried.clone(),
+            driver: self.driver.clone(),
+            exclusion: self.exclusion.clone(),
+            operation: self.operation.clone(),
+        }
+    }
+}
+
+impl<B: BackingBlob> Blob<B> {
+    /// Normalize rejected local slot states before exposing a mutable handle.
+    ///
+    /// Namespace-aware recovery resolves every complete group before entering this function. The
+    /// remaining local work consumes an incomplete candidate or repeats a lost truncate:
+    ///
+    /// ```text
+    /// read both root slots
+    ///          |
+    ///          +-- rejected generation --> clear its slot --+
+    ///          `-- stable frontier --------------------------+--> select root
+    /// ```
+    async fn open_named(
+        backing: B,
+        partition: &str,
+        name: &[u8],
+        backing_len: u64,
+        incarnation: [u8; INCARNATION_LEN],
+        token_epoch: [u8; INCARNATION_LEN],
+        resources: AtomicResources,
+    ) -> Result<(Self, u64), Error> {
+        debug_assert!(backing_len >= DATA_OFFSET);
+
+        let mut slots = Self::read_roots(&backing).await?;
+        while let Some(plan) = rejection_plan_for(backing_len, &slots, Some(&incarnation))? {
+            Self::clear_rejected_slot(&backing, &plan).await?;
+            let index = ROOT_OFFSETS
+                .iter()
+                .position(|offset| *offset == plan.root_offset)
+                .expect("rejection plans target a root slot");
+            slots[index].fill(0);
+        }
+        let (state, truncate_to) =
+            State::recover_for(backing_len, &slots, Some(&incarnation), token_epoch)?;
+        if let Some(len) = truncate_to {
+            // The selected root is already authority. Repeating a lost shrink before returning a
+            // mutable handle prevents discarded physical offsets from being reused prematurely.
+            backing.resize(len).await?;
+        }
+        let logical_len = state.logical_len;
+        let AtomicResources {
+            driver,
+            exclusion,
+            namespace: _,
+            payload_budget,
+        } = resources;
+        Ok((
+            Self {
+                backing,
+                partition: Arc::from(partition),
+                name: Arc::from(name),
+                incarnation,
+                state: Arc::new(Mutex::new(state)),
+                payload: PayloadAccount::new(payload_budget),
+                preflush: Arc::new(PayloadPreflush::default()),
+                carried: Arc::new(Mutex::new(None)),
+                driver,
+                exclusion,
+                operation: Arc::new(Mutex::new(())),
+            },
+            logical_len,
+        ))
+    }
+
+    /// Read the complete identity of an existing backing.
+    async fn read_identity(backing: &B, backing_len: u64) -> Result<[u8; INCARNATION_LEN], Error> {
+        if backing_len < IDENTITY_PAGE_LEN {
+            return Err(invalid_data("ordinary blob cannot be opened as atomic").into());
+        }
+        let page = backing
+            .read_at(0, IDENTITY_PAGE_LEN as usize)
+            .await?
+            .coalesce();
+        let page = page
+            .as_ref()
+            .try_into()
+            .expect("identity reads have a fixed length");
+        decode_identity(page)
+            .ok_or_else(|| invalid_data("ordinary blob cannot be opened as atomic").into())
+    }
+
+    /// Install an identity into a fresh ordinary backing.
+    async fn initialize_identity(
+        backing: &B,
+        backing_len: u64,
+        fresh_identity: impl FnOnce() -> [u8; INCARNATION_LEN] + Send,
+    ) -> Result<[u8; INCARNATION_LEN], Error> {
+        if backing_len != 0 {
+            return Err(invalid_data("ordinary blob cannot be opened as atomic").into());
+        }
+        let incarnation = fresh_identity();
+        let canonical = encode_identity(incarnation);
+        backing.resize(DATA_OFFSET).await?;
+        backing
+            .write_at(0, canonical.to_vec(), WriteOptions::default())
+            .await?;
+        backing.sync().await?;
+        Ok(incarnation)
+    }
+
+    /// Read the complete fixed recovery region for both alternating roots.
+    async fn read_roots(backing: &B) -> Result<[RootSlot; ROOT_OFFSETS.len()], Error> {
+        // Direct recovery is bounded: read both complete slots and never scan application payload.
+        let mut slots = [[0u8; ROOT_SLOT_SIZE]; ROOT_OFFSETS.len()];
+        for (slot, offset) in slots.iter_mut().zip(ROOT_OFFSETS) {
+            let data = backing.read_at(offset, ROOT_SLOT_SIZE).await?.coalesce();
+            slot.copy_from_slice(data.as_ref());
+        }
+        Ok(slots)
+    }
+
+    /// Durably erase every byte from a rejected non-authoritative slot before it can be reused.
+    async fn clear_rejected_slot(backing: &B, plan: &RejectionPlan) -> Result<(), Error> {
+        backing
+            .write_at(
+                plan.root_offset,
+                vec![0; ROOT_SLOT_SIZE],
+                WriteOptions::SYNC,
+            )
+            .await
+    }
+
+    async fn lock_state(&self) -> Result<MutexGuard<'_, State>, Error> {
+        let state = self.state.lock().await;
+        state.ensure_healthy()?;
+        Ok(state)
+    }
+
+    fn key(&self) -> (&str, &[u8]) {
+        (&self.partition, &self.name)
+    }
+
+    fn same_handle(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+
+    /// Drive one coalesced payload preflush until it reaches the latest requested target.
+    ///
+    /// A request that arrives during `sync` raises `requested`. The worker loops so completion
+    /// covers every target admitted to this round before it retires lineage accounting. A
+    /// successful barrier credits only the sampled target to `durable_len`, even if later writes
+    /// also persisted. Requests raised during the barrier force another iteration. Preflush never
+    /// changes generation, published state, or `dirty`.
+    async fn run_payload_preflush(
+        backing: B,
+        state: Arc<Mutex<State>>,
+        payload: Arc<PayloadAccount>,
+        preflush: Arc<PayloadPreflush>,
+        round: Arc<PayloadPreflushRound>,
+        signaler: Signaler,
+    ) {
+        let _sync = preflush.sync_gate.lock().await;
+        loop {
+            let target = {
+                let preflush_state = preflush.state.lock();
+                let current = preflush_state
+                    .current
+                    .as_ref()
+                    .expect("an admitted payload preflush remains current until completion");
+                assert!(Arc::ptr_eq(current, &round));
+                round.requested.load(AtomicOrdering::Relaxed)
+            };
+            if let Err(error) = backing.sync().await {
+                state.lock().await.poisoned = true;
+                payload.set(0);
+                let mut preflush_state = preflush.state.lock();
+                preflush_state.failure = Some(error);
+                let current = preflush_state
+                    .current
+                    .take()
+                    .expect("a failed payload preflush remains current");
+                assert!(Arc::ptr_eq(&current, &round));
+                drop(preflush_state);
+                // A mutable storage failure consumes the lineage even when the last handle drops.
+                // Retaining the closed completion makes every later namespace drain fail closed.
+                return;
+            }
+
+            let mut blob_state = state.lock().await;
+            blob_state.finish_payload_preflush(target);
+            payload.set(blob_state.speculative_payload_len());
+            drop(blob_state);
+
+            let complete = {
+                let mut preflush_state = preflush.state.lock();
+                let current = preflush_state
+                    .current
+                    .as_ref()
+                    .expect("a successful payload preflush remains current");
+                assert!(Arc::ptr_eq(current, &round));
+                if round.requested.load(AtomicOrdering::Relaxed) > target {
+                    false
+                } else {
+                    preflush_state.current = None;
+                    true
+                }
+            };
+            if complete {
+                payload.budget.finish(round.id);
+                drop(signaler.signal(0));
+                return;
+            }
+        }
+    }
+
+    /// Start or extend this blob's current detached payload durability round.
+    async fn request_payload_preflush(&self, target: u64) -> Result<(), Error> {
+        let (round, signaler) = {
+            let mut preflush_state = self.preflush.state.lock();
+            Self::take_payload_preflush_failure(&mut preflush_state)?;
+            if let Some(round) = &preflush_state.current {
+                round.requested.fetch_max(target, AtomicOrdering::Relaxed);
+                return Ok(());
+            }
+
+            let (signaler, completion) = Signaler::new();
+            let round = Arc::new(PayloadPreflushRound {
+                id: self.payload.budget.register(completion.clone()),
+                requested: AtomicU64::new(target),
+                completion,
+            });
+            preflush_state.current = Some(round.clone());
+            (round, signaler)
+        };
+
+        let backing = self.backing.clone();
+        let state = self.state.clone();
+        let payload = self.payload.clone();
+        let preflush = self.preflush.clone();
+        self.driver
+            .drive_detached(async move {
+                Self::run_payload_preflush(backing, state, payload, preflush, round, signaler)
+                    .await;
+            })
+            .await;
+        Self::take_payload_preflush_failure(&mut self.preflush.state.lock())
+    }
+
+    /// Wait for this blob's current preflush, then consume its recorded detached failure.
+    async fn drain_payload_preflush(&self) -> Result<(), Error> {
+        loop {
+            let completion = {
+                let mut state = self.preflush.state.lock();
+                Self::take_payload_preflush_failure(&mut state)?;
+                let Some(round) = &state.current else {
+                    return Ok(());
+                };
+                round.completion.clone()
+            };
+            if completion.await.is_err() {
+                let mut state = self.preflush.state.lock();
+                Self::take_payload_preflush_failure(&mut state)?;
+                return Err(Error::Closed);
+            }
+        }
+    }
+
+    fn take_payload_preflush_failure(state: &mut PayloadPreflushState) -> Result<(), Error> {
+        state.failure.take().map_or(Ok(()), Err)
+    }
+
+    /// Serialize one append, write its final payload offsets, and then expose the new state.
+    ///
+    /// Validation and offset arithmetic complete before the operation is armed. Once backing I/O
+    /// starts, cancellation or error poisons the handle because the visible write result is no
+    /// longer known.
+    async fn append_inner(
+        &self,
+        data: IoBufs,
+        boundary: IntegrityBoundary,
+        tag: Option<[u8; ATOMIC_BLOB_TAG_LEN]>,
+        expected: Option<IntegrityToken>,
+    ) -> Result<IntegrityAppend, Error> {
+        let state = self.lock_state().await?;
+        let mut operation = Operation::new(state);
+        if let Some(expected) = expected {
+            operation.expect_integrity_token(expected)?;
+        }
+        let fallback_offset = operation.logical_len;
+        let prepared = operation.prepare_integrity_append(data, boundary)?;
+        let result_offset = prepared
+            .as_ref()
+            .map_or(fallback_offset, |prepared| prepared.result_offset);
+        let mut preflush_target = None;
+        if let Some(mut prepared) = prepared {
+            let backing_offset = raw_len(prepared.logical_start)?;
+            let encoded = std::mem::take(&mut prepared.encoded);
+            operation.arm();
+            self.backing
+                .write_at(backing_offset, encoded, WriteOptions::default())
+                .await?;
+            operation.finish_append(prepared);
+            let aggregate = self.payload.set(operation.speculative_payload_len());
+            if aggregate > u128::from(MAX_UNSYNCED_PAYLOAD_LEN) {
+                let target = operation.logical_len;
+                if matches!(&self.driver, Driver::Inline) {
+                    let result = {
+                        let _sync = self.preflush.sync_gate.lock().await;
+                        self.backing.sync().await
+                    };
+                    if let Err(error) = result {
+                        self.payload.set(0);
+                        return Err(error);
+                    }
+                    operation.finish_payload_preflush(target);
+                    self.payload.set(operation.speculative_payload_len());
+                } else {
+                    preflush_target = Some(target);
+                }
+            }
+        }
+        if let Some(tag) = tag {
+            operation.set_tag(tag)?;
+        }
+        let token = operation.integrity_token();
+        operation.finish();
+        if let Some(target) = preflush_target {
+            self.request_payload_preflush(target).await?;
+        }
+        Ok(IntegrityAppend {
+            offset: result_offset,
+            token,
+        })
+    }
+
+    /// Validate and apply one logical rewind after all payload preflushes have quiesced.
+    async fn rewind_inner(
+        &self,
+        expected: Option<IntegrityToken>,
+        len: u64,
+        unit: Option<IntegrityUnit>,
+        tag: Option<[u8; ATOMIC_BLOB_TAG_LEN]>,
+    ) -> Result<IntegrityToken, Error> {
+        // Rewind may reclaim and reuse bytes covered by this handle's running full-file preflush.
+        // Operation ownership prevents a new round from being admitted after this drain.
+        self.drain_payload_preflush().await?;
+        let mut state = self.lock_state().await?;
+        if let Some(expected) = expected {
+            state.expect_integrity_token(expected)?;
+        }
+        let source_data = self.validated_rewind_source(&state, len, unit).await?;
+        state
+            .apply_rewind(
+                len,
+                source_data
+                    .as_ref()
+                    .map(|(unit, data)| (*unit, data.as_slice())),
+            )
+            .expect("validated rewind sources are internally consistent");
+        self.payload.set(state.speculative_payload_len());
+        if let Some(tag) = tag {
+            state.set_tag(tag)?;
+        }
+        Ok(state.integrity_token())
+    }
+
+    /// Read and verify the integrity source needed to rewind into a unit.
+    async fn validated_rewind_source(
+        &self,
+        state: &State,
+        len: u64,
+        unit: Option<IntegrityUnit>,
+    ) -> Result<Option<(IntegrityUnit, Vec<u8>)>, Error> {
+        let Some(source) = state.rewind_integrity_source(len, unit)? else {
+            return Ok(None);
+        };
+        let data_len = usize::try_from(source.unit.len).map_err(|_| Error::OffsetOverflow)?;
+        let read_len = if source.current {
+            data_len
+        } else {
+            data_len
+                .checked_add(INTEGRITY_CHECKSUM_LEN)
+                .ok_or(Error::OffsetOverflow)?
+        };
+        let offset = raw_len(source.unit.offset)?;
+        let encoded = self.backing.read_at(offset, read_len).await?.coalesce();
+        if source.current {
+            state.validate_integrity_tail(encoded.as_ref())?;
+        } else {
+            let expected = u32::from_be_bytes(
+                encoded.as_ref()[data_len..]
+                    .try_into()
+                    .expect("integrity checksum footers have a fixed length"),
+            );
+            validate_integrity(&encoded.as_ref()[..data_len], expected)?;
+        }
+        Ok(source
+            .retain_prefix
+            .then(|| (source.unit, encoded.as_ref()[..data_len].to_vec())))
+    }
+
+    /// Publish the current dirty state as a durable one-member decision.
+    ///
+    /// ```text
+    /// build payload proof and self witness
+    ///                 |
+    ///                 v
+    /// write candidate + sync this file and carried peers
+    ///                 |
+    ///                 v
+    /// write final root + repeat truncate + activate state
+    /// ```
+    ///
+    /// The concurrent barrier set is the publication's only durability layer. `Finalized` is
+    /// ordinary cleanup. A later publication's barrier covers the same file, while recovery
+    /// reconstructs the obligation from the durable self-link.
+    async fn publish_locked(&self, state: MutexGuard<'_, State>) -> Result<(), Error> {
+        let mut operation = Operation::new(state);
+        let Some(prepared) = operation.prepare_commit()? else {
+            operation.finish();
+            return Ok(());
+        };
+
+        let root = Root {
+            generation: prepared.generation,
+            logical_len: prepared.logical_len,
+            integrity_start: prepared.integrity_start,
+            integrity_checksum: prepared.integrity_checksum,
+            integrity_scheme: prepared.integrity_scheme,
+            tag: prepared.tag,
+        };
+        let payload = if prepared.logical_len <= operation.durable_len {
+            batch::PayloadDescriptor::empty(prepared.logical_len)
+        } else {
+            let len = prepared.logical_len - operation.durable_len;
+            assert!(
+                len <= MAX_UNSYNCED_PAYLOAD_LEN,
+                "direct payload preflush bounds the recovery suffix"
+            );
+            batch::PayloadDescriptor {
+                start: operation.durable_len,
+                checksum: payload_checksum_at(&self.backing, operation.durable_len, len).await?,
+            }
+        };
+        let group_id = direct_group_id(
+            &self.partition,
+            &self.name,
+            &self.incarnation,
+            prepared.generation,
+        );
+        let group = batch::prepare_with_group_id(
+            vec![batch::Participant {
+                partition: self.partition.to_string(),
+                name: self.name.to_vec(),
+                incarnation: self.incarnation,
+                candidate: batch::Candidate::with_payload(root, payload)?,
+                removed: false,
+            }],
+            group_id,
+        )?;
+        let participant = &group.participants[0];
+        let final_root = participant
+            .candidate
+            .final_root()
+            .expect("prepared direct candidates have a final root");
+        let previous = self.carried.lock().await.clone();
+        let _previous_guard = match &previous {
+            Some(group) => Some(group.coordination.lock().await),
+            None => None,
+        };
+        let previous_installed = match &previous {
+            Some(group) => self
+                .carried
+                .lock()
+                .await
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, group)),
+            None => false,
+        };
+        let previous_requires_sync = previous_installed
+            && previous
+                .as_ref()
+                .is_some_and(|group| !group.payment.is_paid());
+
+        operation.arm();
+        // The complete self-linked candidate and its payload obligation are the sole durable
+        // decision. The finalized spelling is cleanup and deliberately has no second barrier.
+        let mut preparations: Vec<ParticipantOperation<'_>> = vec![Box::pin(async {
+            self.backing
+                .write_at(
+                    prepared.root_offset,
+                    group.slots[0].to_vec(),
+                    WriteOptions::default(),
+                )
+                .await?;
+            self.backing.sync().await
+        })];
+        if let Some(previous) = &previous
+            && previous_requires_sync
+        {
+            for member in &previous.members {
+                if member.partition.as_ref() == self.partition.as_ref()
+                    && member.name.as_ref() == self.name.as_ref()
+                    && member.incarnation == self.incarnation
+                {
+                    continue;
+                }
+                preparations.push(Box::pin(sync_carried_member(member)));
+            }
+        }
+        join_participant_io(preparations).await?;
+        if let Some(previous) = &previous
+            && previous_installed
+        {
+            clear_carried_group(previous).await;
+        }
+        self.backing
+            .write_at(
+                prepared.root_offset,
+                final_root.to_vec(),
+                WriteOptions::default(),
+            )
+            .await?;
+        if prepared.truncate {
+            // The selected root is authority before discarded offsets are reclaimed. If this
+            // resize is lost, reopening repeats it before those offsets can be reused.
+            self.backing.resize(raw_len(prepared.logical_len)?).await?;
+        }
+        operation.finish_commit(&prepared);
+        self.payload.set(0);
+        operation.finish();
+        Ok(())
+    }
+}
+
+/// Exact backing snapshot used while validating namespace and group recovery.
+struct Existing<B> {
+    backing: B,
+    backing_len: u64,
+    incarnation: [u8; INCARNATION_LEN],
+    slots: [RootSlot; ROOT_OFFSETS.len()],
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+type DriverFuture = Pin<Box<dyn Future<Output = ()> + Send + 'static>>;
+#[cfg(not(target_arch = "wasm32"))]
+const DRIVER_ADMISSION_CAPACITY: usize = 64;
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Admission ownership shared by every clone in one filesystem storage lineage.
+///
+/// Foreground work can await a detached payload-preflush handoff while retaining its own permit.
+/// Independent bounds let that handoff make progress while limiting all queued and running work.
+pub(crate) struct BackgroundDriver {
+    sender: OnceLock<tokio::sync::mpsc::UnboundedSender<DriverFuture>>,
+    foreground: Arc<tokio::sync::Semaphore>,
+    detached: Arc<tokio::sync::Semaphore>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl BackgroundDriver {
+    fn new() -> Self {
+        Self {
+            sender: OnceLock::new(),
+            foreground: Arc::new(tokio::sync::Semaphore::new(DRIVER_ADMISSION_CAPACITY)),
+            detached: Arc::new(tokio::sync::Semaphore::new(DRIVER_ADMISSION_CAPACITY)),
+        }
+    }
+}
+
+/// Runtime ownership for admitted atomic work.
+///
+/// Backends whose physical I/O is cancellation-synchronous use the inline mode. Filesystem
+/// backends use one lazily started worker per storage lineage so accepted work is independent of
+/// the Tokio runtime polling its completion observer.
+#[derive(Clone)]
+pub(crate) enum Driver {
+    #[cfg_attr(commonware_stability_BETA, allow(dead_code))]
+    Inline,
+    #[cfg(not(target_arch = "wasm32"))]
+    Background(Arc<BackgroundDriver>),
+}
+
+/// Reserved foreground capacity that can synchronously accept one task.
+///
+/// Capacity is reserved before lineage ownership so every foreground path uses the same lock
+/// order. Once lineage ownership is acquired, moving it into [`Self::drive`] has no cancellation
+/// point before a background worker accepts the task.
+enum ForegroundPermit {
+    Inline,
+    #[cfg(not(target_arch = "wasm32"))]
+    Background {
+        driver: Arc<BackgroundDriver>,
+        admission: tokio::sync::OwnedSemaphorePermit,
+    },
+}
+
+impl ForegroundPermit {
+    fn drive<T, F>(self, task: F) -> Handle<T>
+    where
+        T: Send + 'static,
+        F: Future<Output = Result<T, Error>> + Send + 'static,
+    {
+        match self {
+            Self::Inline => Handle::from_future(task),
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Background { driver, admission } => {
+                Driver::enqueue(Driver::Background(driver.clone()), &driver, task, admission)
+            }
+        }
+    }
+}
+
+impl Driver {
+    #[cfg_attr(commonware_stability_BETA, allow(dead_code))]
+    pub(crate) const fn inline() -> Self {
+        Self::Inline
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn background() -> Self {
+        Self::Background(Arc::new(BackgroundDriver::new()))
+    }
+
+    /// Reserve foreground capacity before acquiring resources the driven task will own.
+    async fn reserve(&self) -> Result<ForegroundPermit, Error> {
+        match self {
+            Self::Inline => Ok(ForegroundPermit::Inline),
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Background(driver) => {
+                let admission = driver
+                    .foreground
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .map_err(|_| Error::Closed)?;
+                Ok(ForegroundPermit::Background {
+                    driver: driver.clone(),
+                    admission,
+                })
+            }
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn enqueue<T, F>(
+        retention: Self,
+        driver: &BackgroundDriver,
+        task: F,
+        admission: tokio::sync::OwnedSemaphorePermit,
+    ) -> Handle<T>
+    where
+        T: Send + 'static,
+        F: Future<Output = Result<T, Error>> + Send + 'static,
+    {
+        let sender = driver.sender.get_or_init(start_driver);
+        let (result_sender, result_receiver) = commonware_utils::channel::oneshot::channel();
+        let task: DriverFuture = Box::pin(async move {
+            let _retention = retention;
+            let _admission = admission;
+            let _ = result_sender.send(task.await);
+        });
+        if sender.send(task).is_err() {
+            return Handle::ready(Err(Error::Closed));
+        }
+        Handle::from_receiver(result_receiver)
+    }
+
+    /// Run admitted work independently of a completion observer.
+    ///
+    /// Inline backends complete the future before returning. Background backends transfer it to
+    /// their worker; if that worker has stopped, the caller completes the already-owned task.
+    pub(crate) async fn drive_detached<F>(&self, task: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        match self {
+            Self::Inline => task.await,
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Background(driver) => {
+                let Ok(admission) = driver.detached.clone().acquire_owned().await else {
+                    task.await;
+                    return;
+                };
+                let sender = driver.sender.get_or_init(start_driver);
+                let retention = self.clone();
+                let task: DriverFuture = Box::pin(async move {
+                    let _retention = retention;
+                    let _admission = admission;
+                    task.await;
+                });
+                if let Err(error) = sender.send(task) {
+                    error.0.await;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn start_driver() -> tokio::sync::mpsc::UnboundedSender<DriverFuture> {
+    let (sender, mut receiver) = tokio::sync::mpsc::unbounded_channel::<DriverFuture>();
+    drop(crate::utils::thread::spawn(
+        crate::utils::thread::system_thread_stack_size(),
+        move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("failed to create atomic storage runtime");
+            runtime.block_on(async move {
+                while let Some(task) = receiver.recv().await {
+                    drop(tokio::spawn(task));
+                }
+            });
+        },
+    ));
+    sender
+}
+
+/// Namespace operations that ordinary [`Storage`] deliberately does not promise.
+///
+/// The trait is crate-private so the public atomic interfaces are implemented only for runtimes
+/// whose direct-entry open semantics are known under their public namespace
+/// ownership contract. Protocol decoding and incarnation checks remain in this module; backends
+/// only provide serialized namespace steps.
+///
+/// Every returned resource must belong to the same storage lineage and remain shared across its
+/// clones and wrappers:
+///
+/// ```text
+/// Storage lineage and clones
+///   |-- AtomicResources -----------> opened Blob clones
+///   `-- atomic_worker() -----------> owned namespace and publication tasks
+/// ```
+///
+/// This coherence lets namespace recovery take exclusive ownership while live operations on
+/// disjoint handles share the lineage. The budget accounts every live blob's speculative payload
+/// contribution and retains detached rounds for exclusive recovery.
+pub(crate) trait Backend: Storage {
+    /// Owned backend used by detached atomic operations.
+    ///
+    /// This value may outlive the runtime polling its observer, so it must not retain resources
+    /// whose destruction requires that runtime's execution context.
+    type Worker: Backend<Blob = Self::Blob>;
+
+    /// Create the owned backend used by a detached atomic operation.
+    fn atomic_worker(&self) -> Self::Worker;
+
+    /// Return the shared namespace, exclusion, payload accounting, and task driver for this
+    /// lineage.
+    ///
+    /// Live operations hold shared exclusion through their I/O and cleanup. Namespace operations
+    /// hold exclusive exclusion and drain detached payload preflushes before inspecting backings.
+    fn atomic_resources(&self) -> AtomicResources;
+
+    /// Generate a fresh identifier for an incarnation, opened token epoch, or multi-blob group.
+    fn new_atomic_identifier(&self) -> [u8; INCARNATION_LEN] {
+        let mut identifier = [0; INCARNATION_LEN];
+        sys_rng().fill_bytes(&mut identifier);
+        identifier
+    }
+
+    /// Open the current exact name without creating or repairing it.
+    ///
+    /// An incomplete ordinary container is reported as absent. A complete legacy container is
+    /// rejected so its payload cannot be reinterpreted as atomic state.
+    /// [`Storage::open`] owns any container-level recovery before atomic identity initialization.
+    fn open_atomic_existing(
+        &self,
+        partition: &str,
+        name: &[u8],
+    ) -> impl std::future::Future<Output = Result<Option<(Self::Blob, u64)>, Error>> + Send;
+}
+
+/// Open an existing name only when its complete atomic identity is readable.
+///
+/// Missing, short, or torn identities return `None`. Recovery callers decide whether that image is
+/// absent, ordinary, or corrupt; they never initialize it as a new atomic incarnation.
+async fn open_existing<S: Backend>(
+    storage: &S,
+    partition: &str,
+    name: &[u8],
+) -> Result<Option<Existing<S::Blob>>, Error> {
+    let Some((backing, backing_len)) = storage.open_atomic_existing(partition, name).await? else {
+        return Ok(None);
+    };
+    if backing_len < DATA_OFFSET {
+        return Ok(None);
+    }
+    let page = backing
+        .read_at(0, IDENTITY_PAGE_LEN as usize)
+        .await?
+        .coalesce();
+    let page: &[u8; IDENTITY_PAGE_LEN as usize] = page
+        .as_ref()
+        .try_into()
+        .expect("identity reads have a fixed length");
+    let Some(incarnation) = decode_identity(page) else {
+        return Ok(None);
+    };
+    let slots = Blob::<S::Blob>::read_roots(&backing).await?;
+    Ok(Some(Existing {
+        backing,
+        backing_len,
+        incarnation,
+        slots,
+    }))
+}
+
+/// Durably remove a tombstoned name while exclusive lineage ownership is held.
+///
+/// Absence means cleanup already completed. Other failures leave the storage instance unusable and
+/// must remain visible to the caller.
+async fn remove_atomic_name<S: Storage>(
+    storage: &S,
+    partition: &str,
+    name: &[u8],
+) -> Result<(), Error> {
+    match storage.remove(partition, Some(name)).await {
+        Ok(()) | Err(Error::BlobMissing(_, _) | Error::PartitionMissing(_)) => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+/// One discovered ring participant together with the bytes needed to validate its local frontier.
+#[derive(Clone)]
+struct GroupMember<B> {
+    link: batch::Link,
+    backing: B,
+    backing_len: u64,
+    slots: [RootSlot; ROOT_OFFSETS.len()],
+}
+
+fn root_index(root_offset: u64) -> Option<usize> {
+    ROOT_OFFSETS
+        .iter()
+        .position(|offset| *offset == root_offset)
+}
+
+/// Find the unique local witness for one group and incarnation.
+fn matching_link<B>(
+    existing: &Existing<B>,
+    partition: &str,
+    name: &[u8],
+    group_id: &[u8; 16],
+) -> Option<batch::Link> {
+    let mut matches = existing
+        .slots
+        .iter()
+        .zip(ROOT_OFFSETS)
+        .filter_map(|(slot, offset)| {
+            let link = batch::link_at(slot, partition, name, offset)?;
+            (link.group_id == *group_id && link.participant.incarnation == existing.incarnation)
+                .then_some(link)
+        });
+    let link = matches.next()?;
+    matches.next().is_none().then_some(link)
+}
+
+/// Validate the predecessor evidence that keeps a candidate on the current recovery frontier.
+///
+/// `allow_successor` permits an older complete ring to remain usable behind one later incomplete
+/// attempt. This is needed when that later attempt overwrote local predecessor bytes but never
+/// formed its own durable decision.
+///
+/// ```text
+/// local evidence                                      usable
+/// candidate slot is newer                              no
+/// exact Finalized root                                 yes
+/// genesis candidate with a zero predecessor slot       yes
+/// exact base-generation root                            yes
+/// next BatchPrepared or raw predecessor                 only with fallback
+/// anything else                                         no
+/// ```
+fn candidate_frontier_is_current(
+    link: &batch::Link,
+    slots: &[RootSlot; ROOT_OFFSETS.len()],
+    allow_successor: bool,
+) -> bool {
+    let Some(root) = link.participant.candidate.root() else {
+        return false;
+    };
+    let candidate_offset = link
+        .participant
+        .candidate
+        .root_offset()
+        .expect("decoded batch candidates have a root slot");
+    let candidate_index =
+        root_index(candidate_offset).expect("validated batch candidates target one root slot");
+    if decode_slot(
+        &slots[candidate_index],
+        candidate_offset,
+        Some(&link.participant.incarnation),
+    )
+    .root()
+    .is_some_and(|installed| installed.generation > root.generation)
+    {
+        return false;
+    }
+    // An exact finalized root is locally selectable evidence for this participant. A later
+    // publication may have consumed the opposite predecessor slot after its barrier also made
+    // this final durable.
+    // The older group must remain traversable. A peer whose concurrent debt barrier failed can use
+    // this certificate to complete the same decision after a crash.
+    if exact_final(link, slots) {
+        return true;
+    }
+
+    let predecessor_index = 1 - candidate_index;
+    let predecessor_slot = decode_slot(
+        &slots[predecessor_index],
+        ROOT_OFFSETS[predecessor_index],
+        Some(&link.participant.incarnation),
+    );
+    let base_generation = link
+        .participant
+        .candidate
+        .base_generation()
+        .expect("decoded batch candidates have a predecessor generation");
+    if base_generation == 0 && matches!(predecessor_slot, Slot::Zero) {
+        return true;
+    }
+    match predecessor_slot {
+        slot if slot.root().is_some_and(|predecessor| {
+            predecessor.generation == base_generation
+                && ROOT_OFFSETS[(predecessor.generation as usize) & 1]
+                    == ROOT_OFFSETS[predecessor_index]
+        }) =>
+        {
+            true
+        }
+        // A failed next publication may leave its complete candidate root while losing
+        // both payload bytes and this group's ordinary final spelling. Newer candidates are
+        // considered first; if they cannot decide, the still-complete prior ring remains the
+        // fallback authority. Materializing it does not overwrite the newer candidate's slot.
+        Slot::Root(RootState::BatchPrepared, successor)
+            if allow_successor && root.generation.checked_add(1) == Some(successor.generation) =>
+        {
+            true
+        }
+        Slot::Raw if allow_successor => true,
+        Slot::Zero | Slot::Root(_, _) | Slot::Finalized { .. } | Slot::Raw => false,
+    }
+}
+
+/// Reject any root frontier that continues one incarnation after a tombstone.
+///
+/// Removal is terminal. A tombstone cannot be the predecessor of another candidate, and no
+/// geometrically valid newer root can follow it. The incarnation remains linked for corruption
+/// handling when either contradiction is present.
+fn validate_terminal_frontier(
+    link: &batch::Link,
+    backing_len: u64,
+    slots: &[RootSlot; ROOT_OFFSETS.len()],
+) -> io::Result<()> {
+    let candidate = link
+        .participant
+        .candidate
+        .root()
+        .expect("decoded batch links contain matching candidate roots");
+    for (slot, offset) in slots.iter().zip(ROOT_OFFSETS) {
+        let slot = decode_slot(slot, offset, Some(&link.participant.incarnation));
+        let Some(root) = slot.root() else {
+            continue;
+        };
+        if matches!(slot, Slot::Finalized { removed: true, .. })
+            && root.generation < candidate.generation
+        {
+            return Err(invalid_data("atomic tombstone has a successor"));
+        }
+        if link.participant.removed
+            && root.generation > candidate.generation
+            && validate_root(root, offset, backing_len).is_ok()
+        {
+            return Err(invalid_data("atomic tombstone precedes a newer root"));
+        }
+    }
+    Ok(())
+}
+
+/// Classify a candidate while optionally retaining a complete predecessor ring as fallback.
+fn candidate_status(
+    link: &batch::Link,
+    backing_len: u64,
+    slots: &[RootSlot; ROOT_OFFSETS.len()],
+    allow_successor: bool,
+) -> io::Result<Option<batch::CandidateStatus>> {
+    let candidate = &link.participant.candidate;
+    let root = candidate
+        .root()
+        .ok_or_else(|| invalid_data("batch candidate roots do not match"))?;
+    validate_terminal_frontier(link, backing_len, slots)?;
+    let payload_end = DATA_OFFSET
+        .checked_add(root.logical_len)
+        .ok_or_else(|| invalid_data("batch candidate payload length overflows"))?;
+    let validation_len = if link.participant.removed {
+        payload_end
+    } else {
+        if payload_end > backing_len {
+            return Ok(None);
+        }
+        backing_len
+    };
+    if !candidate_frontier_is_current(link, slots, allow_successor) {
+        return Ok(None);
+    }
+    let root_offset = candidate
+        .root_offset()
+        .expect("decoded batch candidates have a root slot");
+    validate_root(root, root_offset, validation_len)?;
+    let index = root_index(root_offset).expect("validated batch candidates target one root slot");
+    let slot = &slots[index];
+    let installed: &[u8; ROOT_LEN] = slot[..ROOT_LEN]
+        .try_into()
+        .expect("root slots contain a complete header");
+    Ok(candidate.status(installed))
+}
+
+/// Verify the exact speculative suffix named by one participant's bound payload descriptor.
+///
+/// Removed participants and candidates whose complete payload is already durable have no suffix.
+/// All other descriptors must end at the candidate root and fit inside the observed backing blob.
+async fn candidate_payload_valid<B: BackingBlob>(member: &GroupMember<B>) -> Result<bool, Error> {
+    let participant = &member.link.participant;
+    let descriptor = participant.candidate.payload;
+    let Some(root) = participant.candidate.root() else {
+        return Ok(false);
+    };
+    let Some(len) = descriptor.len(root.logical_len) else {
+        return Ok(false);
+    };
+    if participant.removed || len == 0 {
+        return Ok(true);
+    }
+    let Some(backing_end) = DATA_OFFSET.checked_add(root.logical_len) else {
+        return Ok(false);
+    };
+    if backing_end > member.backing_len {
+        return Ok(false);
+    }
+    Ok(payload_checksum_at(&member.backing, descriptor.start, len).await? == descriptor.checksum)
+}
+
+/// Enforce the aggregate crash-time payload validation budget for one recovered group.
+fn group_payload_within_recovery_bound<'a>(
+    participants: impl IntoIterator<Item = &'a batch::Participant>,
+) -> bool {
+    participants
+        .into_iter()
+        .filter(|participant| !participant.removed)
+        .try_fold(0u64, |total, participant| {
+            total.checked_add(participant.candidate.payload_len()?)
+        })
+        .is_some_and(|total| total <= MAX_UNSYNCED_PAYLOAD_LEN)
+}
+
+/// Return whether this candidate's exact independent final spelling is installed.
+fn exact_final(link: &batch::Link, slots: &[RootSlot; ROOT_OFFSETS.len()]) -> bool {
+    let candidate = &link.participant.candidate;
+    let Some(index) = candidate.root_offset().and_then(root_index) else {
+        return false;
+    };
+    candidate
+        .final_root()
+        .is_some_and(|final_root| slots[index][..ROOT_LEN] == final_root)
+}
+
+/// Validate membership properties that are not implied by following successor links.
+///
+/// Successors must cover one canonical ordering of unique paths and incarnations. Sorting is
+/// limited to borrowed links and does not change the returned traversal order.
+fn canonical_ring(links: &[&batch::Link]) -> bool {
+    if links.is_empty() {
+        return false;
+    }
+
+    let mut canonical = links.to_vec();
+    canonical.sort_by(|left, right| left.participant.key().cmp(&right.participant.key()));
+    if canonical
+        .windows(2)
+        .any(|pair| pair[0].participant.key() == pair[1].participant.key())
+    {
+        return false;
+    }
+    let mut incarnations = canonical
+        .iter()
+        .map(|link| link.participant.incarnation)
+        .collect::<Vec<_>>();
+    incarnations.sort_unstable();
+    if incarnations.windows(2).any(|pair| pair[0] == pair[1]) {
+        return false;
+    }
+
+    canonical.iter().enumerate().all(|(index, link)| {
+        let next = &canonical[(index + 1) % canonical.len()].participant;
+        link.next.partition == next.partition
+            && link.next.name == next.name
+            && link.next.incarnation == next.incarnation
+    })
+}
+
+/// Follow exact successor locations until the ring closes or evidence becomes incomplete.
+///
+/// Traversal opens only names embedded in validated links and allocates one member at a time. The
+/// returned vector remains in successor order:
+///
+/// ```text
+/// start k -> (k + 1) % n -> ... -> (k - 1) % n -> start k
+/// ```
+async fn traverse_group<S: Backend>(
+    storage: &S,
+    start: GroupMember<S::Blob>,
+    allow_successor: bool,
+) -> Result<Option<Vec<GroupMember<S::Blob>>>, Error> {
+    if !candidate_frontier_is_current(&start.link, &start.slots, allow_successor) {
+        return Ok(None);
+    }
+    let first_location = batch::Location {
+        partition: start.link.participant.partition.clone(),
+        name: start.link.participant.name.clone(),
+        incarnation: start.link.participant.incarnation,
+    };
+    let group_id = start.link.group_id;
+    let mut members = Vec::new();
+    let mut locations = BTreeSet::new();
+    let mut incarnations = BTreeSet::new();
+    locations.insert((
+        first_location.partition.clone(),
+        first_location.name.clone(),
+    ));
+    incarnations.insert(first_location.incarnation);
+    members.push(start);
+    loop {
+        let previous = members.last().expect("a group has a starting participant");
+        if previous.link.next == first_location {
+            break;
+        }
+        let location = previous.link.next.clone();
+        if !locations.insert((location.partition.clone(), location.name.clone()))
+            || !incarnations.insert(location.incarnation)
+        {
+            return Ok(None);
+        }
+        let Some(existing) = open_existing(storage, &location.partition, &location.name).await?
+        else {
+            return Ok(None);
+        };
+        if existing.incarnation != location.incarnation {
+            return Ok(None);
+        }
+        let Some(link) = matching_link(&existing, &location.partition, &location.name, &group_id)
+        else {
+            return Ok(None);
+        };
+        if !candidate_frontier_is_current(&link, &existing.slots, allow_successor) {
+            return Ok(None);
+        }
+        members.push(GroupMember {
+            link,
+            backing: existing.backing,
+            backing_len: existing.backing_len,
+            slots: existing.slots,
+        });
+    }
+
+    let links = members
+        .iter()
+        .map(|member| &member.link)
+        .collect::<Vec<_>>();
+    Ok(canonical_ring(&links).then_some(members))
+}
+
+fn recovery_group_metadata_complete<B: BackingBlob>(
+    members: &[GroupMember<B>],
+    allow_successor: bool,
+) -> io::Result<bool> {
+    if !group_payload_within_recovery_bound(members.iter().map(|member| &member.link.participant)) {
+        return Ok(false);
+    }
+    for member in members {
+        if candidate_status(
+            &member.link,
+            member.backing_len,
+            &member.slots,
+            allow_successor,
+        )?
+        .is_none()
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+async fn recovery_group_complete<B: BackingBlob>(
+    members: &[GroupMember<B>],
+    allow_successor: bool,
+) -> Result<bool, Error> {
+    if !recovery_group_metadata_complete(members, allow_successor)? {
+        return Ok(false);
+    }
+    for member in members {
+        if !candidate_payload_valid(member).await? {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+async fn materialize_group_roots<B: BackingBlob>(members: &[GroupMember<B>]) -> Result<(), Error> {
+    let mut finalizations = Vec::new();
+    for member in members {
+        if exact_final(&member.link, &member.slots) {
+            continue;
+        }
+        let participant = &member.link.participant;
+        let Some(final_root) = participant.candidate.final_root() else {
+            return Err(invalid_data("batch candidate cannot be finalized").into());
+        };
+        finalizations.push(
+            member.backing.write_at(
+                participant
+                    .candidate
+                    .root_offset()
+                    .expect("decoded batch candidates have a root slot"),
+                final_root.to_vec(),
+                WriteOptions::default(),
+            ),
+        );
+    }
+    join_participant_io(finalizations).await?;
+
+    let barriers = members.iter().map(|member| member.backing.sync()).collect();
+    join_participant_io(barriers).await
+}
+
+fn immediate_shorter_successor(
+    older: &batch::Participant,
+    older_root: Root,
+    newer: &batch::Participant,
+    backing_len: u64,
+) -> bool {
+    if newer.removed
+        || newer.key() != older.key()
+        || newer.incarnation != older.incarnation
+        || newer.candidate.base_generation() != Some(older_root.generation)
+    {
+        return false;
+    }
+    let Some(newer_root) = newer.candidate.root() else {
+        return false;
+    };
+    newer_root.logical_len < older_root.logical_len
+        && DATA_OFFSET
+            .checked_add(newer_root.logical_len)
+            .is_some_and(|newer_end| newer_end <= backing_len)
+}
+
+fn predecessor_payload_is_obsolete<B: BackingBlob>(
+    older: &GroupMember<B>,
+    older_root: Root,
+    accepted_members: &[GroupMember<B>],
+) -> bool {
+    let older_participant = &older.link.participant;
+    if accepted_members.iter().any(|newer| {
+        immediate_shorter_successor(
+            older_participant,
+            older_root,
+            &newer.link.participant,
+            older.backing_len,
+        )
+    }) {
+        return true;
+    }
+    let Some(older_end) = DATA_OFFSET.checked_add(older_root.logical_len) else {
+        return false;
+    };
+    older_end > older.backing_len
+        && older.slots.iter().zip(ROOT_OFFSETS).any(|(slot, offset)| {
+            let Some(newer) = batch::link_at(
+                slot,
+                &older_participant.partition,
+                &older_participant.name,
+                offset,
+            ) else {
+                return false;
+            };
+            immediate_shorter_successor(
+                older_participant,
+                older_root,
+                &newer.participant,
+                older.backing_len,
+            )
+        })
+}
+
+/// Return whether a later durable decision already paid a predecessor's cleanup debt.
+///
+/// A successor publication barrier synchronizes every carried predecessor member before its
+/// decision can become authoritative. A shorter immediate successor therefore makes the older
+/// payload obsolete even when a later speculative write regrows the discarded physical extent.
+/// Predecessor roots must still have exact final spellings, and every non-obsolete extent and
+/// frontier remains validated.
+fn predecessor_debt_is_paid<B: BackingBlob>(
+    predecessor: &[GroupMember<B>],
+    accepted_members: &[GroupMember<B>],
+) -> io::Result<bool> {
+    if !predecessor
+        .iter()
+        .all(|member| exact_final(&member.link, &member.slots))
+        || !group_payload_within_recovery_bound(
+            predecessor.iter().map(|member| &member.link.participant),
+        )
+    {
+        return Ok(false);
+    }
+
+    let any_obsolete = predecessor.iter().any(|older| {
+        older
+            .link
+            .participant
+            .candidate
+            .root()
+            .is_some_and(|older_root| {
+                predecessor_payload_is_obsolete(older, older_root, accepted_members)
+            })
+    });
+    if !any_obsolete {
+        return Ok(false);
+    }
+
+    for older in predecessor {
+        let Some(older_root) = older.link.participant.candidate.root() else {
+            return Ok(false);
+        };
+        let Some(older_end) = DATA_OFFSET.checked_add(older_root.logical_len) else {
+            return Ok(false);
+        };
+        let obsolete = predecessor_payload_is_obsolete(older, older_root, accepted_members);
+        if older_end > older.backing_len && !obsolete {
+            return Ok(false);
+        }
+        let validation_len = if obsolete {
+            older_end
+        } else {
+            older.backing_len
+        };
+        if candidate_status(&older.link, validation_len, &older.slots, true)?.is_none() {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
+async fn predecessor_groups<S: Backend>(
+    storage: &S,
+    members: &[GroupMember<S::Blob>],
+) -> Result<Vec<Vec<GroupMember<S::Blob>>>, Error> {
+    let mut groups = Vec::new();
+    let mut group_ids = BTreeSet::new();
+    let mut backings = members
+        .iter()
+        .map(|member| {
+            let participant = &member.link.participant;
+            (
+                batch::Location {
+                    partition: participant.partition.clone(),
+                    name: participant.name.clone(),
+                    incarnation: participant.incarnation,
+                },
+                member.backing.clone(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for member in members {
+        let participant = &member.link.participant;
+        let predecessor_generation = participant
+            .candidate
+            .base_generation()
+            .ok_or_else(|| invalid_data("batch predecessor candidate is invalid"))?;
+        if predecessor_generation == 0 {
+            continue;
+        }
+        let predecessor = member
+            .slots
+            .iter()
+            .zip(ROOT_OFFSETS)
+            .find_map(|(slot, offset)| {
+                let link = batch::link_at(slot, &participant.partition, &participant.name, offset)?;
+                let root = link.participant.candidate.root()?;
+                (link.participant.incarnation == participant.incarnation
+                    && root.generation == predecessor_generation)
+                    .then_some(link)
+            });
+        let Some(link) = predecessor else {
+            continue;
+        };
+        if !group_ids.insert(link.group_id) {
+            continue;
+        }
+        let start = GroupMember {
+            link,
+            backing: member.backing.clone(),
+            backing_len: member.backing_len,
+            slots: member.slots,
+        };
+        let Some(mut predecessor) = traverse_group(storage, start, true).await? else {
+            // Under exclusive lineage ownership, an unavailable predecessor edge can only be
+            // cleanup performed after that predecessor's final roots became independent.
+            continue;
+        };
+        if predecessor_debt_is_paid(&predecessor, members)? {
+            continue;
+        }
+        // The accepted successor could only be issued after this immediate predecessor's payload
+        // decision completed. Recovery still validates and materializes its metadata and cleanup
+        // debt, but rehashing historical payload cannot distinguish a reachable crash outcome.
+        if !recovery_group_metadata_complete(&predecessor, true)? {
+            return Err(invalid_data("atomic group predecessor is incomplete").into());
+        }
+        // One path can occur in several predecessor rings. Use one live backing image so a later
+        // full-file barrier cannot publish an independently opened stale snapshot.
+        for member in &mut predecessor {
+            let participant = &member.link.participant;
+            let location = batch::Location {
+                partition: participant.partition.clone(),
+                name: participant.name.clone(),
+                incarnation: participant.incarnation,
+            };
+            let backing = member.backing.clone();
+            member.backing = backings.entry(location).or_insert(backing).clone();
+        }
+        groups.push(predecessor);
+    }
+    Ok(groups)
+}
+
+/// Transfer a proven group decision into independent final roots and namespace state.
+///
+/// Recovery first closes every immediate witness-bound predecessor, so accepting a successor
+/// cannot strand a peer whose predecessor final is still only prepared. It then writes missing
+/// independent final spellings and joins one durability operation on every participant. Every root
+/// in the closure is durable before any tombstone is unlinked.
+/// A successfully activated predecessor paid its carried ancestors in its decision barrier. If a
+/// barrier fails, poisoning prevents another successor, so only the immediate predecessors can
+/// remain unpaid.
+///
+/// This recovery barrier is the explicit payment of cleanup debt after reopen no longer has the
+/// in-memory [`CarriedGroup`].
+async fn finish_group<S: Backend>(
+    storage: &S,
+    members: &[GroupMember<S::Blob>],
+) -> Result<(), Error> {
+    let predecessors = predecessor_groups(storage, members).await?;
+    for group in predecessors
+        .iter()
+        .map(Vec::as_slice)
+        .chain(std::iter::once(members))
+    {
+        materialize_group_roots(group).await?;
+    }
+
+    for group in predecessors
+        .iter()
+        .map(Vec::as_slice)
+        .chain(std::iter::once(members))
+    {
+        // A peer may already carry a later incomplete generation. Its own open resolves that
+        // local frontier; an older group snapshot must never resize it.
+        for member in group.iter().rev() {
+            let participant = &member.link.participant;
+            if participant.removed {
+                remove_atomic_name(storage, &participant.partition, &participant.name).await?;
+            }
+        }
+    }
+
+    for group in predecessors
+        .iter()
+        .map(Vec::as_slice)
+        .chain(std::iter::once(members))
+    {
+        let group_id = group
+            .first()
+            .expect("recovered groups are nonempty")
+            .link
+            .group_id;
+        storage
+            .atomic_resources()
+            .payload_budget
+            .mark_carried_paid(group_id);
+    }
+    Ok(())
+}
+
+/// Logical state selected for the name from which group recovery started.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GroupRecovery {
+    Present,
+    Removed,
+}
+
+fn compare_link_generations_desc(left: &batch::Link, right: &batch::Link) -> std::cmp::Ordering {
+    right
+        .participant
+        .candidate
+        .base_generation()
+        .cmp(&left.participant.candidate.base_generation())
+}
+
+/// Resolve the newest complete group reachable from one local backing snapshot.
+///
+/// Links are tried newest first. An incomplete newer attempt enables predecessor fallback for the
+/// next older ring. A locally exact final remains authoritative when later cleanup has already
+/// removed an edge after all participant finals became independent. A raw local slot enables
+/// fallback before the first traversal because it may be a retained subset of a newer attempt.
+async fn recover_groups<S: Backend>(
+    storage: &S,
+    partition: &str,
+    name: &[u8],
+    local: &Existing<S::Blob>,
+    mut recovered: Option<&mut BTreeSet<[u8; batch::GROUP_ID_LEN]>>,
+) -> Result<GroupRecovery, Error> {
+    let mut links = local
+        .slots
+        .iter()
+        .zip(ROOT_OFFSETS)
+        .filter_map(|(slot, offset)| {
+            let link = batch::link_at(slot, partition, name, offset)?;
+            (link.participant.incarnation == local.incarnation).then_some(link)
+        })
+        .collect::<Vec<_>>();
+    links.sort_by(compare_link_generations_desc);
+    let mut allow_successor = local.slots.iter().zip(ROOT_OFFSETS).any(|(slot, offset)| {
+        matches!(
+            decode_slot(slot, offset, Some(&local.incarnation)),
+            Slot::Raw
+        )
+    });
+    for link in links {
+        let local_outcome = if link.participant.removed {
+            GroupRecovery::Removed
+        } else {
+            GroupRecovery::Present
+        };
+        let start = GroupMember {
+            link,
+            backing: local.backing.clone(),
+            backing_len: local.backing_len,
+            slots: local.slots,
+        };
+        let local_final = exact_final(&start.link, &start.slots);
+        if local_final {
+            let candidate = &start.link.participant.candidate;
+            let root = candidate
+                .root()
+                .expect("decoded batch links contain matching candidate roots");
+            let validation_len = if start.link.participant.removed {
+                DATA_OFFSET
+                    .checked_add(root.logical_len)
+                    .ok_or_else(|| invalid_data("atomic payload length overflows"))?
+            } else {
+                start.backing_len
+            };
+            validate_root(
+                root,
+                candidate
+                    .root_offset()
+                    .expect("decoded batch candidates have a root slot"),
+                validation_len,
+            )?;
+            validate_terminal_frontier(&start.link, start.backing_len, &start.slots)?;
+            if recovered
+                .as_deref()
+                .is_some_and(|groups| groups.contains(&start.link.group_id))
+            {
+                return Ok(local_outcome);
+            }
+        }
+        let retry_peer_successor =
+            !allow_successor && candidate_frontier_is_current(&start.link, &start.slots, false);
+        let mut traversal = traverse_group(storage, start.clone(), allow_successor).await?;
+        let mut traversal_allow_successor = allow_successor;
+        if traversal.is_none() && retry_peer_successor {
+            // An intact local frontier remains usable when only a peer carries the next attempt.
+            traversal = traverse_group(storage, start, true).await?;
+            traversal_allow_successor = true;
+        }
+        if let Some(members) = traversal
+            && recovery_group_complete(&members, traversal_allow_successor).await?
+        {
+            finish_group(storage, &members).await?;
+            if let Some(recovered) = recovered.as_deref_mut() {
+                let group_id = members
+                    .first()
+                    .expect("recovered groups are nonempty")
+                    .link
+                    .group_id;
+                recovered.insert(group_id);
+            }
+            return Ok(local_outcome);
+        }
+        // An exact Finalized root and its retained witness are local authority for this
+        // participant. Under exclusive namespace ownership, a missing successor can only be
+        // cleanup after every participant's final root became independently durable.
+        if local_final {
+            return Ok(local_outcome);
+        }
+        allow_successor = true;
+    }
+    Ok(GroupRecovery::Present)
+}
+
+/// Requested mutation after duplicate handles have been canonicalized by path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BatchKind {
+    Publish,
+    Rewind(u64),
+    Remove,
+}
+
+/// One canonical batch path and the exact handle authorized to mutate it.
+struct BatchEntry<B> {
+    blob: Blob<B>,
+    kind: BatchKind,
+}
+
+/// Candidate root derived during read-only batch validation.
+#[derive(Clone, Copy)]
+struct BatchParticipantPlan {
+    index: usize,
+    root: Root,
+    removed: bool,
+}
+
+/// Mutation guards held across the complete group decision and activation sequence.
+///
+/// Once armed, an error or canceled admitted operation poisons every selected state, including
+/// clean selections. Selected handles cannot be reused after an indeterminate mutable-storage
+/// outcome.
+struct BatchMutation<'a> {
+    states: Vec<MutexGuard<'a, State>>,
+    armed: bool,
+}
+
+impl BatchMutation<'_> {
+    const fn arm(&mut self) {
+        self.armed = true;
+    }
+
+    fn finish(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for BatchMutation<'_> {
+    fn drop(&mut self) {
+        if self.armed {
+            for state in &mut self.states {
+                state.poisoned = true;
+            }
+        }
+    }
+}
+
+/// Sort operations by canonical path and collapse only identical repeats of the same handle.
+///
+/// Distinct handles for one name are rejected even when they request the same mutation because
+/// their in-memory visible states may differ.
+fn canonicalize_batch<B: BackingBlob>(
+    operations: Vec<BatchOperation<Blob<B>>>,
+) -> Result<Vec<BatchEntry<B>>, Error> {
+    let mut entries = BTreeMap::<(String, Vec<u8>), BatchEntry<B>>::new();
+    for operation in operations {
+        let (blob, kind) = match operation {
+            BatchOperation::Publish(blob) => (blob, BatchKind::Publish),
+            BatchOperation::Rewind { blob, len } => (blob, BatchKind::Rewind(len)),
+            BatchOperation::Remove(blob) => (blob, BatchKind::Remove),
+        };
+        let key = (blob.partition.to_string(), blob.name.to_vec());
+        match entries.entry(key) {
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(BatchEntry { blob, kind });
+            }
+            std::collections::btree_map::Entry::Occupied(entry)
+                if entry.get().kind == kind && entry.get().blob.same_handle(&blob) => {}
+            std::collections::btree_map::Entry::Occupied(_) => {
+                return Err(invalid_input(
+                    "atomic batch contains conflicting or independently opened handles",
+                ));
+            }
+        }
+    }
+    Ok(entries.into_values().collect())
+}
+
+/// Describe the exact non-durable suffix that recovery must hash for one candidate.
+///
+/// ```text
+/// logical payload  [0 ........ durable_len) [durable_len ........ logical_len)
+///                   already covered          SHA-256 descriptor suffix
+/// descriptor       start = durable_len, len = logical_len - durable_len
+/// backing bytes     DATA_OFFSET + start .. DATA_OFFSET + logical_len
+/// ```
+///
+/// Removal and roots at or before `durable_len` use the canonical empty descriptor.
+async fn candidate_payload_descriptor<B: BackingBlob>(
+    blob: &Blob<B>,
+    state: &State,
+    logical_len: u64,
+    removed: bool,
+) -> Result<batch::PayloadDescriptor, Error> {
+    if removed || logical_len <= state.durable_len {
+        return Ok(batch::PayloadDescriptor::empty(logical_len));
+    }
+    let len = logical_len - state.durable_len;
+    assert!(
+        len <= MAX_UNSYNCED_PAYLOAD_LEN,
+        "batch payload preflush bounds each recovery suffix"
+    );
+    Ok(batch::PayloadDescriptor {
+        start: state.durable_len,
+        checksum: payload_checksum_at(&blob.backing, state.durable_len, len).await?,
+    })
+}
+
+/// Poll a complete participant I/O set to completion and report its first ordered error.
+///
+/// Draining every admitted future prevents a peer write from escaping group-wide exclusion after
+/// another participant fails.
+async fn join_participant_io<F>(operations: Vec<F>) -> Result<(), Error>
+where
+    F: Future<Output = Result<(), Error>> + Send,
+{
+    // Poll the complete participant set together. Even when one operation fails, join every
+    // admitted peer before releasing group-wide exclusion.
+    for result in join_all(operations).await {
+        result?;
+    }
+    Ok(())
+}
+
+/// Return whether in-memory carried debt certifies the handle's selected predecessor.
+///
+/// A live group can have durable bound candidates while its independent final spellings remain
+/// unsynchronized. The shared [`CarriedGroup`] is the authority that lets the next publication
+/// accept that state without forcing recovery first.
+async fn carried_predecessor_matches<B: BackingBlob>(
+    blob: &Blob<B>,
+    current: &Existing<B>,
+    state: &State,
+) -> bool {
+    let Some(group) = blob.carried.lock().await.clone() else {
+        return false;
+    };
+    debug_assert!(group.members.iter().any(|member| {
+        member.slot.upgrade().is_some_and(|slot| {
+            Arc::ptr_eq(&slot, &blob.carried)
+                && member.partition.as_ref() == blob.partition.as_ref()
+                && member.name.as_ref() == blob.name.as_ref()
+                && member.incarnation == blob.incarnation
+        })
+    }));
+
+    current
+        .slots
+        .iter()
+        .zip(ROOT_OFFSETS)
+        .filter_map(|(slot, offset)| {
+            batch::link_at(slot, &blob.partition, &blob.name, offset).map(|link| (link, offset))
+        })
+        .any(|(link, offset)| {
+            let root = link
+                .participant
+                .candidate
+                .root()
+                .expect("decoded batch links contain valid candidates");
+            link.group_id == group.group_id
+                && link.participant.incarnation == blob.incarnation
+                && !link.participant.removed
+                && validate_root(root, offset, current.backing_len).is_ok()
+                && root == state.committed
+        })
+}
+
+/// Return whether an exact durable self-link certifies the live singleton predecessor.
+fn singleton_predecessor_matches<B: BackingBlob>(
+    blob: &Blob<B>,
+    current: &Existing<B>,
+    state: &State,
+) -> bool {
+    current
+        .slots
+        .iter()
+        .zip(ROOT_OFFSETS)
+        .filter_map(|(slot, offset)| {
+            batch::link_at(slot, &blob.partition, &blob.name, offset)
+                .map(|link| (slot, link, offset))
+        })
+        .any(|(slot, link, offset)| {
+            let candidate = &link.participant.candidate;
+            let root = candidate
+                .root()
+                .expect("decoded batch links contain valid candidates");
+            let installed: &[u8; ROOT_LEN] = slot[..ROOT_LEN]
+                .try_into()
+                .expect("root slots contain a complete header");
+            installed == &candidate.prepared_root
+                && link.participant.incarnation == blob.incarnation
+                && !link.participant.removed
+                && link.next.partition == blob.partition.as_ref()
+                && link.next.name == blob.name.as_ref()
+                && link.next.incarnation == blob.incarnation
+                && validate_root(root, offset, current.backing_len).is_ok()
+                && root == state.committed
+        })
+}
+
+/// Validate, decide, and activate one coordinator-free multi-blob publication.
+///
+/// No candidate root is written until all operations, handles, incarnations, predecessor state,
+/// witness sizes, rewind proofs, and payload bounds have been validated.
+///
+/// ```text
+/// canonicalize operations
+///          |
+/// lock every participant and drain its payload preflush
+///          |
+/// reopen names and validate exact predecessor incarnations
+///          |
+/// preview mutations, hash bounded payload suffixes, encode and validate witnesses
+///          |
+/// write every candidate slot + sync every participant and carried-debt file
+///          |                                                   one durability layer
+///          v
+/// signal durable decision
+///          |
+/// write final roots, resize, activate state, attach multi-member cleanup debt
+/// ```
+///
+/// Errors before admission leave selected state unchanged. Errors after `mutation.arm()` poison
+/// every selected state so callers must reopen and recover the old or complete new vector.
+async fn apply_batch<S: Backend>(
+    storage: &S,
+    operations: Vec<BatchOperation<Blob<S::Blob>>>,
+    decision: oneshot::Sender<()>,
+) -> Result<(), Error> {
+    let entries = canonicalize_batch(operations)?;
+    if entries.is_empty() {
+        let _ = decision.send(());
+        return Ok(());
+    }
+
+    // Operation ownership closes the gap between an append's payload write and detached preflush
+    // registration. Acquire every participant in canonical path order, then drain only those
+    // participants before freezing their states.
+    let mut _operation_guards = Vec::with_capacity(entries.len());
+    for entry in &entries {
+        _operation_guards.push(entry.blob.operation.clone().lock_owned().await);
+    }
+    for result in join_all(
+        entries
+            .iter()
+            .map(|entry| entry.blob.drain_payload_preflush()),
+    )
+    .await
+    {
+        result?;
+    }
+    // Hold every participant mutation lock in canonical key order through validation, the decision
+    // join, activation writes, and in-memory activation.
+    let cores = entries
+        .iter()
+        .map(|entry| entry.blob.state.clone())
+        .collect::<Vec<_>>();
+    let mut states = Vec::with_capacity(cores.len());
+    for core in &cores {
+        let state = core.lock().await;
+        state.ensure_healthy()?;
+        states.push(state);
+    }
+    let mut mutation = BatchMutation {
+        states,
+        armed: false,
+    };
+
+    let mut participant_plans = Vec::new();
+    let mut incarnations = BTreeSet::new();
+    let mut rewind_sources = vec![None; entries.len()];
+    for (index, entry) in entries.iter().enumerate() {
+        let current = open_existing(storage, &entry.blob.partition, &entry.blob.name)
+            .await?
+            .ok_or_else(|| {
+                Error::BlobMissing(entry.blob.partition.to_string(), hex(&entry.blob.name))
+            })?;
+        if current.incarnation != entry.blob.incarnation {
+            return Err(Error::BlobMissing(
+                entry.blob.partition.to_string(),
+                hex(&entry.blob.name),
+            ));
+        }
+        if !incarnations.insert(entry.blob.incarnation) {
+            return Err(invalid_input(
+                "atomic batch paths must name distinct blob incarnations",
+            ));
+        }
+        let state = &mutation.states[index];
+        let (durable, _) = State::recover_for(
+            current.backing_len,
+            &current.slots,
+            Some(&current.incarnation),
+            [0; INCARNATION_LEN],
+        )?;
+        let independent_predecessor = durable.committed == state.committed;
+        let newer_bound_candidate = current
+            .slots
+            .iter()
+            .zip(ROOT_OFFSETS)
+            .filter_map(|(slot, offset)| {
+                batch::link_at(slot, &entry.blob.partition, &entry.blob.name, offset)
+                    .map(|link| (link, offset))
+            })
+            .any(|(link, _)| {
+                link.participant.incarnation == current.incarnation
+                    && link
+                        .participant
+                        .candidate
+                        .root()
+                        .is_some_and(|root| root.generation > state.committed.generation)
+            });
+        if (!independent_predecessor || newer_bound_candidate)
+            && !singleton_predecessor_matches(&entry.blob, &current, state)
+            && !carried_predecessor_matches(&entry.blob, &current, state).await
+        {
+            return Err(invalid_input(
+                "atomic batch handle does not select the current durable predecessor",
+            ));
+        }
+        let (candidate_state, participates) = match entry.kind {
+            BatchKind::Publish => ((**state).clone(), state.is_dirty()),
+            BatchKind::Rewind(len) => {
+                let mut preview = (**state).clone();
+                let source = entry.blob.validated_rewind_source(state, len, None).await?;
+                preview
+                    .apply_rewind(
+                        len,
+                        source.as_ref().map(|(unit, data)| (*unit, data.as_slice())),
+                    )
+                    .expect("validated rewind sources are internally consistent");
+                rewind_sources[index] = source;
+                let participates = preview.is_dirty();
+                (preview, participates)
+            }
+            BatchKind::Remove => ((**state).clone(), true),
+        };
+        if !participates {
+            continue;
+        }
+        let generation = next_generation(state.committed.generation)?;
+        let root = Root {
+            generation,
+            logical_len: candidate_state.logical_len,
+            integrity_start: candidate_state.integrity_start,
+            integrity_checksum: candidate_state.integrity_checksum,
+            integrity_scheme: candidate_state.integrity_scheme,
+            tag: candidate_state.tag,
+        };
+        let removed = entry.kind == BatchKind::Remove;
+        participant_plans.push(BatchParticipantPlan {
+            index,
+            root,
+            removed,
+        });
+    }
+
+    let group_id = (!participant_plans.is_empty()).then(|| storage.new_atomic_identifier());
+    let mut participants = Vec::with_capacity(participant_plans.len());
+    let mut participant_indices = Vec::with_capacity(participant_plans.len());
+    for plan in &participant_plans {
+        let entry = &entries[plan.index];
+        let payload = candidate_payload_descriptor(
+            &entry.blob,
+            &mutation.states[plan.index],
+            plan.root.logical_len,
+            plan.removed,
+        )
+        .await?;
+        participants.push(batch::Participant {
+            partition: entry.blob.partition.to_string(),
+            name: entry.blob.name.to_vec(),
+            incarnation: entry.blob.incarnation,
+            candidate: batch::Candidate::with_payload(plan.root, payload)?,
+            removed: plan.removed,
+        });
+        participant_indices.push(plan.index);
+    }
+    debug_assert!(group_payload_within_recovery_bound(&participants));
+    let prepared = (!participants.is_empty())
+        .then(|| {
+            batch::prepare_with_group_id(
+                participants,
+                group_id.expect("nonempty batches have an identifier"),
+            )
+        })
+        .transpose()?;
+
+    // A prior decision can make an explicit participant responsible for synchronizing peer files.
+    // Serialize publications that share that hidden debt group, while leaving unrelated groups
+    // independent. Locks are ordered by stable group identity.
+    let mut previous_groups = Vec::new();
+    let mut previous_group_ids = BTreeSet::new();
+    for &index in &participant_indices {
+        if let Some(group) = entries[index].blob.carried.lock().await.clone()
+            && previous_group_ids.insert(group.group_id)
+        {
+            previous_groups.push(group);
+        }
+    }
+    previous_groups.sort_by_key(|group| group.group_id);
+    let mut _previous_group_guards = Vec::with_capacity(previous_groups.len());
+    for group in &previous_groups {
+        _previous_group_guards.push(group.coordination.lock().await);
+    }
+    let mut active_previous_group_ids = BTreeSet::new();
+    for &index in &participant_indices {
+        if let Some(group) = entries[index].blob.carried.lock().await.as_ref()
+            && previous_group_ids.contains(&group.group_id)
+        {
+            active_previous_group_ids.insert(group.group_id);
+        }
+    }
+
+    for (index, entry) in entries.iter().enumerate() {
+        if let BatchKind::Rewind(len) = entry.kind {
+            mutation.states[index]
+                .apply_rewind(
+                    len,
+                    rewind_sources[index]
+                        .as_ref()
+                        .map(|(unit, data)| (*unit, data.as_slice())),
+                )
+                .expect("the previewed rewind remains internally consistent");
+            entry
+                .blob
+                .payload
+                .set(mutation.states[index].speculative_payload_len());
+        }
+    }
+    let Some(prepared) = prepared else {
+        mutation.finish();
+        let _ = decision.send(());
+        return Ok(());
+    };
+    debug_assert_eq!(prepared.participants.len(), participant_indices.len());
+    for (&index, participant) in participant_indices.iter().zip(&prepared.participants) {
+        debug_assert_eq!(entries[index].blob.key(), participant.key());
+    }
+    mutation.arm();
+
+    // Every participant publishes its bound candidate slot and joins the same durability layer.
+    // Await every operation even after an error so no canceled backing write can outlive the
+    // group-wide exclusion held by this task.
+    let participant_keys = prepared
+        .participants
+        .iter()
+        .map(|participant| {
+            (
+                participant.partition.clone(),
+                participant.name.clone(),
+                participant.incarnation,
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    let mut preparations: Vec<ParticipantOperation<'_>> = participant_indices
+        .iter()
+        .zip(&prepared.participants)
+        .zip(&prepared.slots)
+        .map(|((&index, participant), slot)| {
+            let backing = &entries[index].blob.backing;
+            Box::pin(async move {
+                backing
+                    .write_at(
+                        participant
+                            .candidate
+                            .root_offset()
+                            .expect("prepared candidates have a root slot"),
+                        slot.to_vec(),
+                        WriteOptions::default(),
+                    )
+                    .await?;
+                backing.sync().await
+            }) as ParticipantOperation<'_>
+        })
+        .collect();
+    let mut debt_keys = BTreeSet::new();
+    for group in &previous_groups {
+        if !active_previous_group_ids.contains(&group.group_id) {
+            continue;
+        }
+        if group.payment.is_paid() {
+            continue;
+        }
+        for member in &group.members {
+            let key = (
+                member.partition.to_string(),
+                member.name.to_vec(),
+                member.incarnation,
+            );
+            if participant_keys.contains(&key) || !debt_keys.insert(key) {
+                continue;
+            }
+            preparations.push(Box::pin(sync_carried_member(member)));
+        }
+    }
+    join_participant_io(preparations).await?;
+    for group in &previous_groups {
+        if active_previous_group_ids.contains(&group.group_id) {
+            clear_carried_group(group).await;
+        }
+    }
+    // A complete bound ring and every candidate payload obligation are now durable. The remaining
+    // work only transfers that decision into independent final-root spellings and activates state.
+    let _ = decision.send(());
+
+    // Final roots are cleanup spellings, not a second durability decision. Install all of them
+    // concurrently without another barrier. A later publication folds them into its sole sync;
+    // recovery materializes them before namespace cleanup when no later publication occurs.
+    let finalizations = participant_indices
+        .iter()
+        .zip(&prepared.participants)
+        .map(|(&index, participant)| {
+            let backing = &entries[index].blob.backing;
+            let final_root = participant
+                .candidate
+                .final_root()
+                .expect("prepared groups contain valid candidates");
+            async move {
+                backing
+                    .write_at(
+                        participant
+                            .candidate
+                            .root_offset()
+                            .expect("prepared candidates have a root slot"),
+                        final_root.to_vec(),
+                        WriteOptions::default(),
+                    )
+                    .await
+            }
+        })
+        .collect();
+    join_participant_io(finalizations).await?;
+
+    for (&index, participant) in participant_indices.iter().zip(&prepared.participants) {
+        let root = participant
+            .candidate
+            .root()
+            .expect("prepared groups contain valid candidates");
+        entries[index].blob.payload.set(0);
+        if participant.removed {
+            mutation.states[index].removed = true;
+            continue;
+        }
+        let state = &mut mutation.states[index];
+        if root.logical_len < state.committed.logical_len {
+            entries[index]
+                .blob
+                .backing
+                .resize(raw_len(root.logical_len)?)
+                .await?;
+        }
+        state.logical_len = root.logical_len;
+        state.durable_len = root.logical_len;
+        state.integrity_start = root.integrity_start;
+        state.integrity_checksum = root.integrity_checksum;
+        state.integrity_scheme = root.integrity_scheme;
+        state.tag = root.tag;
+        state.committed = root;
+    }
+
+    if prepared.participants.len() > 1 {
+        let group_id = group_id.expect("nonempty batches have an identifier");
+        let carried = Arc::new(CarriedGroup {
+            group_id,
+            members: participant_indices
+                .iter()
+                .map(|&index| CarriedMember {
+                    partition: entries[index].blob.partition.clone(),
+                    name: entries[index].blob.name.clone(),
+                    incarnation: entries[index].blob.incarnation,
+                    backing: entries[index].blob.backing.clone(),
+                    sync_gate: entries[index].blob.preflush.sync_gate.clone(),
+                    slot: Arc::downgrade(&entries[index].blob.carried),
+                })
+                .collect(),
+            payment: storage
+                .atomic_resources()
+                .payload_budget
+                .register_carried(group_id),
+            coordination: Mutex::new(()),
+        });
+        for &index in &participant_indices {
+            *entries[index].blob.carried.lock().await = Some(carried.clone());
+        }
+    }
+
+    mutation.finish();
+    Ok(())
+}
+
+/// Map protocol parse failures to the path-aware corruption error used by public opens.
+fn map_open_error(partition: &str, name: &[u8], error: Error) -> Error {
+    match error {
+        Error::Io(source)
+            if matches!(
+                source.kind(),
+                io::ErrorKind::InvalidData | io::ErrorKind::UnexpectedEof
+            ) =>
+        {
+            Error::BlobCorrupt(partition.into(), hex(name), source.to_string())
+        }
+        error => error,
+    }
+}
+
+/// Recover one existing atomic name and return a mutable view when it remains logically present.
+///
+/// This path validates a complete identity, resolves a complete group, reclaims a tombstone,
+/// consumes a rejected local generation, and repeats a lost truncate before returning.
+async fn recover_existing_name<S: Backend>(
+    storage: &S,
+    resources: &AtomicResources,
+    partition: &str,
+    name: &[u8],
+    recovered: Option<&mut BTreeSet<[u8; batch::GROUP_ID_LEN]>>,
+) -> Result<Option<(Blob<S::Blob>, u64)>, Error> {
+    let Some((backing, mut backing_len)) = storage.open_atomic_existing(partition, name).await?
+    else {
+        return Ok(None);
+    };
+    let incarnation = Blob::<S::Blob>::read_identity(&backing, backing_len)
+        .await
+        .map_err(|error| map_open_error(partition, name, error))?;
+    if backing_len < DATA_OFFSET {
+        backing.resize(DATA_OFFSET).await?;
+        backing.sync().await?;
+        backing_len = DATA_OFFSET;
+    }
+    let slots = Blob::<S::Blob>::read_roots(&backing).await?;
+    let local = Existing {
+        backing: backing.clone(),
+        backing_len,
+        incarnation,
+        slots,
+    };
+    if recover_groups(storage, partition, name, &local, recovered)
+        .await
+        .map_err(|error| map_open_error(partition, name, error))?
+        == GroupRecovery::Removed
+    {
+        remove_atomic_name(storage, partition, name).await?;
+        return Ok(None);
+    }
+
+    let opened = Blob::open_named(
+        backing,
+        partition,
+        name,
+        backing_len,
+        incarnation,
+        storage.new_atomic_identifier(),
+        resources.clone(),
+    )
+    .await
+    .map_err(|error| map_open_error(partition, name, error))?;
+    Ok(Some(opened))
+}
+
+/// Return as soon as a batch decision is durable while preserving its completion observer.
+///
+/// If the task exits before signaling a decision, its error is returned instead of a handle. Empty
+/// and all-clean batches signal without creating a ring. For a participating batch:
+///
+/// ```text
+/// shared lineage + participant/debt ownership -> candidate barrier -> signal decision
+///                                                                       |
+/// start_apply returns Handle <-------------------------------------------+
+///          |
+///          `-> final-root cleanup and activation -> Handle completes
+/// ```
+async fn await_batch_decision(
+    mut completion: Handle<()>,
+    decision: oneshot::Receiver<()>,
+) -> Result<Handle<()>, Error> {
+    commonware_macros::select! {
+        decision = decision => match decision {
+            Ok(()) => Ok(completion),
+            Err(_) => match completion.await {
+                Ok(()) => Err(Error::Closed),
+                Err(error) => Err(error),
+            },
+        },
+        result = &mut completion => {
+            result?;
+            Ok(Handle::ready(Ok(())))
+        },
+    }
+}
+
+/// Return a direct sync handle only after its publication task reaches the locked start point.
+///
+/// ```text
+/// reserve capacity -> shared lineage -> admit task -> handle operation -> drain preflush -> lock State
+///                                                                          |
+///                                                           signal started |
+///                                                                          v
+/// start_sync returns Handle <-----------------------------------------------+
+///          |
+///          `-> candidate durability and cleanup -> Handle completes
+/// ```
+///
+/// The state lock fixes the publication snapshot before the outer future returns. An inline driver
+/// may complete the task before this handoff becomes observable.
+async fn await_publication_start(
+    mut completion: Handle<()>,
+    started: oneshot::Receiver<()>,
+) -> Handle<()> {
+    commonware_macros::select! {
+        started = started => match started {
+            Ok(()) => completion,
+            Err(_) => Handle::ready(completion.await),
+        },
+        result = &mut completion => Handle::ready(result),
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+struct AdmissionPause {
+    lineage: Weak<RwLock<()>>,
+    entered: oneshot::Sender<()>,
+    resume: oneshot::Receiver<()>,
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+static ADMISSION_PAUSES: BlockingMutex<Vec<AdmissionPause>> = BlockingMutex::new(Vec::new());
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+async fn pause_admitted_operation_if_requested(lineage: &Arc<RwLock<()>>) {
+    let target = Arc::downgrade(lineage);
+    let pause = {
+        let mut pauses = ADMISSION_PAUSES.lock();
+        pauses
+            .iter()
+            .position(|pause| Weak::ptr_eq(&pause.lineage, &target))
+            .map(|index| pauses.swap_remove(index))
+    };
+    let Some(pause) = pause else {
+        return;
+    };
+    let _ = pause.entered.send(());
+    let _ = pause.resume.await;
+}
+
+/// Shared namespace recovery pipeline for atomic open and scan operations.
+///
+/// ```text
+/// hold exclusive lineage ownership and drain payload preflushes
+///                                |
+/// recover identity and complete the fixed prefix
+///                    |
+/// recover_groups, which may open and finish peers
+///                    |
+/// tombstone? open retries after durable unlink, scan omits the name
+///                    |
+/// open_named: repair or reject local roots and repeat a lost truncate
+///                    |
+/// return a handle or report a live scanned name
+/// ```
+///
+/// Scan discards the temporary `open_named` handle after its repair and truncate side effects.
+#[commonware_macros::stability(BETA)]
+impl<S: Backend> AtomicStorage for S {
+    type AtomicBlob = Blob<S::Blob>;
+
+    fn open_atomic(
+        &self,
+        partition: &str,
+        name: &[u8],
+    ) -> impl std::future::Future<Output = Result<(Self::AtomicBlob, u64), Error>> + Send {
+        Box::pin(async move {
+            validate_atomic_location(partition, name)?;
+            let resources = self.atomic_resources();
+            let driver = resources.driver.clone();
+            let worker = self.atomic_worker();
+            let partition = partition.to_string();
+            let name = name.to_vec();
+            let permit = driver.reserve().await?;
+            let guard = resources.exclusion.clone().write_owned().await;
+            let task = async move {
+                let _guard = guard;
+                resources.payload_budget.drain().await?;
+                if let Some(opened) =
+                    recover_existing_name(&worker, &resources, &partition, &name, None).await?
+                {
+                    return Ok(opened);
+                }
+
+                let (backing, backing_len) = worker.open(&partition, &name).await?;
+                let incarnation =
+                    Blob::<S::Blob>::initialize_identity(&backing, backing_len, || {
+                        worker.new_atomic_identifier()
+                    })
+                    .await
+                    .map_err(|error| map_open_error(&partition, &name, error))?;
+                Blob::open_named(
+                    backing,
+                    &partition,
+                    &name,
+                    DATA_OFFSET,
+                    incarnation,
+                    worker.new_atomic_identifier(),
+                    resources.clone(),
+                )
+                .await
+                .map_err(|error| map_open_error(&partition, &name, error))
+            };
+            permit.drive(task).await
+        })
+    }
+
+    fn scan_atomic(
+        &self,
+        partition: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<Vec<u8>>, Error>> + Send {
+        Box::pin(async move {
+            let resources = self.atomic_resources();
+            let driver = resources.driver.clone();
+            let worker = self.atomic_worker();
+            let partition = partition.to_string();
+            let permit = driver.reserve().await?;
+            let guard = resources.exclusion.clone().write_owned().await;
+            let task = async move {
+                let _guard = guard;
+                resources.payload_budget.drain().await?;
+                let names = Storage::scan(&worker, &partition).await?;
+                let mut live = Vec::with_capacity(names.len());
+                let mut recovered = BTreeSet::new();
+                for name in names {
+                    if recover_existing_name(
+                        &worker,
+                        &resources,
+                        &partition,
+                        &name,
+                        Some(&mut recovered),
+                    )
+                    .await?
+                    .is_some()
+                    {
+                        live.push(name);
+                    }
+                }
+                live.sort();
+                Ok(live)
+            };
+            permit.drive(task).await
+        })
+    }
+
+    fn start_apply(
+        &self,
+        operations: Vec<BatchOperation<Self::AtomicBlob>>,
+    ) -> impl std::future::Future<Output = Result<Handle<()>, Error>> + Send {
+        Box::pin(async move {
+            let resources = self.atomic_resources();
+            if operations.iter().any(|operation| {
+                let blob = match operation {
+                    BatchOperation::Publish(blob) | BatchOperation::Remove(blob) => blob,
+                    BatchOperation::Rewind { blob, .. } => blob,
+                };
+                !Arc::ptr_eq(&resources.exclusion, &blob.exclusion)
+            }) {
+                return Err(invalid_input(
+                    "atomic batch contains a handle from another storage lineage",
+                ));
+            }
+            let driver = resources.driver.clone();
+            let worker = self.atomic_worker();
+            let (decision_sender, decision_receiver) = oneshot::channel();
+            let permit = driver.reserve().await?;
+            let guard = resources.exclusion.clone().read_owned().await;
+            let task = async move {
+                let _guard = guard;
+                #[cfg(all(test, not(target_arch = "wasm32")))]
+                pause_admitted_operation_if_requested(&resources.exclusion).await;
+                apply_batch(&worker, operations, decision_sender).await
+            };
+            let completion = match permit {
+                ForegroundPermit::Inline => Handle::ready(task.await),
+                #[cfg(not(target_arch = "wasm32"))]
+                permit @ ForegroundPermit::Background { .. } => permit.drive(task),
+            };
+            await_batch_decision(completion, decision_receiver).await
+        })
+    }
+}
+
+#[commonware_macros::stability(BETA)]
+impl<B: BackingBlob> AtomicBlob for Blob<B> {
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+        let state = self.lock_state().await?;
+        // Rust's supported targets have at most 64-bit `usize`, so this conversion is infallible.
+        let len_u64 = len as u64;
+        let end = offset.checked_add(len_u64).ok_or(Error::OffsetOverflow)?;
+        if end > state.logical_len {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "read exceeds atomic blob length",
+            )
+            .into());
+        }
+        let backing_offset = DATA_OFFSET
+            .checked_add(offset)
+            .ok_or(Error::OffsetOverflow)?;
+        self.backing.read_at(backing_offset, len).await
+    }
+
+    async fn tag(&self) -> Result<[u8; ATOMIC_BLOB_TAG_LEN], Error> {
+        Ok(self.lock_state().await?.tag)
+    }
+
+    async fn set_tag(&self, tag: [u8; ATOMIC_BLOB_TAG_LEN]) -> Result<(), Error> {
+        self.lock_state().await?.set_tag(tag)
+    }
+
+    async fn integrity_scheme(&self) -> Result<IntegrityScheme, Error> {
+        Ok(self.lock_state().await?.integrity_scheme)
+    }
+
+    async fn integrity_snapshot(&self) -> Result<IntegritySnapshot, Error> {
+        let state = self.lock_state().await?;
+        let encoded_len = state.logical_len;
+        let scheme = state.integrity_scheme;
+        let tag = state.tag;
+        let token = state.integrity_token();
+        let Some(unit) = state.integrity_tail() else {
+            return Ok(IntegritySnapshot {
+                encoded_len,
+                scheme,
+                tag,
+                tail: None,
+                token,
+            });
+        };
+        let len = usize::try_from(unit.len).map_err(|_| Error::OffsetOverflow)?;
+        let data = self
+            .backing
+            .read_at(raw_len(unit.offset)?, len)
+            .await?
+            .coalesce();
+        state.validate_integrity_tail(data.as_ref())?;
+        Ok(IntegritySnapshot {
+            encoded_len,
+            scheme,
+            tag,
+            tail: Some((unit, IoBufs::from(data.freeze()))),
+            token,
+        })
+    }
+
+    async fn compare_set_tag(
+        &self,
+        expected: IntegrityToken,
+        tag: [u8; ATOMIC_BLOB_TAG_LEN],
+    ) -> Result<IntegrityToken, Error> {
+        let mut state = self.lock_state().await?;
+        state.expect_integrity_token(expected)?;
+        state.set_tag(tag)?;
+        Ok(state.integrity_token())
+    }
+
+    async fn append(&self, data: impl Into<IoBufs> + Send) -> Result<u64, Error> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let data = data.into();
+        let permit = self.driver.reserve().await?;
+        let lineage = exclusion.read_owned().await;
+        permit
+            .drive(Box::pin(async move {
+                let _lineage = lineage;
+                let _operation = operation.lock_owned().await;
+                blob.append_inner(data, IntegrityBoundary::Continue, None, None)
+                    .await
+                    .map(|result| result.offset)
+            }))
+            .await
+    }
+
+    async fn append_tagged(
+        &self,
+        data: impl Into<IoBufs> + Send,
+        tag: [u8; ATOMIC_BLOB_TAG_LEN],
+    ) -> Result<u64, Error> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let data = data.into();
+        let permit = self.driver.reserve().await?;
+        let lineage = exclusion.read_owned().await;
+        permit
+            .drive(Box::pin(async move {
+                let _lineage = lineage;
+                let _operation = operation.lock_owned().await;
+                blob.append_inner(data, IntegrityBoundary::Continue, Some(tag), None)
+                    .await
+                    .map(|result| result.offset)
+            }))
+            .await
+    }
+
+    async fn append_integrity(
+        &self,
+        expected: IntegrityToken,
+        data: impl Into<IoBufs> + Send,
+        boundary: IntegrityBoundary,
+        tag: Option<[u8; ATOMIC_BLOB_TAG_LEN]>,
+    ) -> Result<IntegrityAppend, Error> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let data = data.into();
+        let permit = self.driver.reserve().await?;
+        let lineage = exclusion.read_owned().await;
+        permit
+            .drive(Box::pin(async move {
+                let _lineage = lineage;
+                let _operation = operation.lock_owned().await;
+                blob.append_inner(data, boundary, tag, Some(expected)).await
+            }))
+            .await
+    }
+
+    async fn read_integrity(&self, unit: IntegrityUnit) -> Result<IoBufs, Error> {
+        let state = self.lock_state().await?;
+        state.integrity_scheme.validate_completed_unit(unit)?;
+        let data_len = usize::try_from(unit.len).map_err(|_| Error::OffsetOverflow)?;
+        let encoded_len = data_len
+            .checked_add(INTEGRITY_CHECKSUM_LEN)
+            .ok_or(Error::OffsetOverflow)?;
+        let encoded_end = unit
+            .offset
+            .checked_add(encoded_len as u64)
+            .ok_or(Error::OffsetOverflow)?;
+        if encoded_end > state.integrity_start {
+            return Err(invalid_input(
+                "integrity unit is not within the completed payload prefix",
+            ));
+        }
+        let mut encoded = self
+            .backing
+            .read_at(raw_len(unit.offset)?, encoded_len)
+            .await?
+            .coalesce();
+        let expected = u32::from_be_bytes(
+            encoded.as_ref()[data_len..]
+                .try_into()
+                .expect("integrity checksum footers have a fixed length"),
+        );
+        validate_integrity(&encoded.as_ref()[..data_len], expected)?;
+        encoded.truncate(data_len);
+        Ok(IoBufs::from(encoded))
+    }
+
+    async fn rewind(&self, len: u64) -> Result<(), Error> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let permit = self.driver.reserve().await?;
+        let lineage = exclusion.read_owned().await;
+        permit
+            .drive(Box::pin(async move {
+                let _lineage = lineage;
+                let _operation = operation.lock_owned().await;
+                blob.rewind_inner(None, len, None, None).await.map(|_| ())
+            }))
+            .await
+    }
+
+    async fn rewind_tagged(&self, len: u64, tag: [u8; ATOMIC_BLOB_TAG_LEN]) -> Result<(), Error> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let permit = self.driver.reserve().await?;
+        let lineage = exclusion.read_owned().await;
+        permit
+            .drive(Box::pin(async move {
+                let _lineage = lineage;
+                let _operation = operation.lock_owned().await;
+                blob.rewind_inner(None, len, None, Some(tag))
+                    .await
+                    .map(|_| ())
+            }))
+            .await
+    }
+
+    async fn rewind_integrity(
+        &self,
+        expected: IntegrityToken,
+        len: u64,
+        unit: Option<IntegrityUnit>,
+        tag: Option<[u8; ATOMIC_BLOB_TAG_LEN]>,
+    ) -> Result<IntegrityToken, Error> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let permit = self.driver.reserve().await?;
+        let lineage = exclusion.read_owned().await;
+        permit
+            .drive(Box::pin(async move {
+                let _lineage = lineage;
+                let _operation = operation.lock_owned().await;
+                blob.rewind_inner(Some(expected), len, unit, tag).await
+            }))
+            .await
+    }
+
+    async fn start_sync(&self) -> Handle<()> {
+        let blob = self.clone();
+        let exclusion = self.exclusion.clone();
+        let operation = self.operation.clone();
+        let (started_sender, started_receiver) = oneshot::channel();
+        let permit = match self.driver.reserve().await {
+            Ok(permit) => permit,
+            Err(error) => return Handle::ready(Err(error)),
+        };
+        let lineage = exclusion.read_owned().await;
+        let task = Box::pin(async move {
+            let _lineage = lineage;
+            let _operation = operation.lock_owned().await;
+            blob.drain_payload_preflush().await?;
+            let state = blob.lock_state().await?;
+            let _ = started_sender.send(());
+            blob.publish_locked(state).await
+        });
+        let completion = match permit {
+            ForegroundPermit::Inline => Handle::ready(task.await),
+            #[cfg(not(target_arch = "wasm32"))]
+            permit @ ForegroundPermit::Background { .. } => permit.drive(task),
+        };
+        await_publication_start(completion, started_receiver).await
+    }
+}

--- a/runtime/src/atomic/batch.rs
+++ b/runtime/src/atomic/batch.rs
@@ -1,0 +1,809 @@
+//! Pure witness encoding, candidate binding, and transition classification.
+
+use super::*;
+
+const WITNESS_BINDING_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_BATCH_BINDING";
+const WITNESS_HEADER_LEN: usize = 4;
+const LINK_MAGIC: &[u8; 8] = b"CWUNOL15";
+pub(super) const GROUP_ID_LEN: usize = 16;
+const LINK_REMOVED: u32 = 1;
+const PAYLOAD_DESCRIPTOR_LEN: usize = 40;
+const LINK_FIXED_LEN: usize = 8
+    + GROUP_ID_LEN
+    + 4
+    + INCARNATION_LEN
+    + ROOT_LEN
+    + PAYLOAD_DESCRIPTOR_LEN
+    + 4
+    + 4
+    + INCARNATION_LEN;
+pub(super) const MAX_LINK_LEN: usize = ROOT_SLOT_SIZE - ROOT_LEN - WITNESS_HEADER_LEN;
+pub(super) const MAX_LOCATION_LEN: usize = 1_640;
+const _: () = assert!(MAX_LOCATION_LEN <= MAX_LINK_LEN - LINK_FIXED_LEN);
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct PayloadDescriptor {
+    pub(super) start: u64,
+    pub(super) checksum: PayloadDigest,
+}
+
+impl PayloadDescriptor {
+    pub(super) const fn empty(logical_len: u64) -> Self {
+        Self {
+            start: logical_len,
+            checksum: [0; 32],
+        }
+    }
+
+    fn decode(encoded: &[u8], logical_len: u64) -> io::Result<Self> {
+        let descriptor = Self {
+            start: u64::from_be_bytes(encoded[..8].try_into().unwrap()),
+            checksum: encoded[8..].try_into().unwrap(),
+        };
+        descriptor.validate(logical_len)?;
+        Ok(descriptor)
+    }
+
+    fn encode(self) -> [u8; PAYLOAD_DESCRIPTOR_LEN] {
+        let mut encoded = [0u8; PAYLOAD_DESCRIPTOR_LEN];
+        encoded[..8].copy_from_slice(&self.start.to_be_bytes());
+        encoded[8..].copy_from_slice(&self.checksum);
+        encoded
+    }
+
+    fn validate(self, logical_len: u64) -> io::Result<()> {
+        if self.len(logical_len).is_some() {
+            return Ok(());
+        }
+        Err(invalid_input_io("batch payload descriptor is invalid"))
+    }
+
+    pub(super) fn len(self, logical_len: u64) -> Option<u64> {
+        let len = logical_len.checked_sub(self.start)?;
+        if (len == 0 && self.checksum == [0; 32]) || (len != 0 && len <= MAX_UNSYNCED_PAYLOAD_LEN) {
+            Some(len)
+        } else {
+            None
+        }
+    }
+
+    pub(super) fn is_empty(self, logical_len: u64) -> bool {
+        self.len(logical_len) == Some(0)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct Candidate {
+    pub(super) prepared_root: [u8; ROOT_LEN],
+    pub(super) payload: PayloadDescriptor,
+}
+
+impl Candidate {
+    #[cfg(test)]
+    pub(super) fn new(root: Root) -> io::Result<Self> {
+        Self::with_payload(root, PayloadDescriptor::empty(root.logical_len))
+    }
+
+    pub(super) fn with_payload(root: Root, payload: PayloadDescriptor) -> io::Result<Self> {
+        root.generation
+            .checked_sub(1)
+            .ok_or_else(|| invalid_input_io("batch candidates require a nonzero generation"))?;
+        payload.validate(root.logical_len)?;
+        Ok(Self {
+            prepared_root: encode_root_value(RootState::BatchPrepared, root),
+            payload,
+        })
+    }
+
+    fn bind(&mut self, witness: &[u8]) {
+        let root = self
+            .root()
+            .expect("batch candidates are validated before witness binding");
+        self.prepared_root =
+            encode_root_with_binding(RootState::BatchPrepared, root, witness_binding(witness));
+    }
+
+    fn template_prepared_root(&self) -> Option<[u8; ROOT_LEN]> {
+        let root = self.root()?;
+        Some(encode_root_value(RootState::BatchPrepared, root))
+    }
+
+    pub(super) fn root(&self) -> Option<Root> {
+        let prepared = decode_root(&self.prepared_root, RootState::BatchPrepared)?;
+        self.payload
+            .validate(prepared.logical_len)
+            .is_ok()
+            .then_some(prepared)
+    }
+
+    pub(super) fn base_generation(&self) -> Option<u64> {
+        self.root()?.generation.checked_sub(1)
+    }
+
+    pub(super) fn root_offset(&self) -> Option<u64> {
+        let root = self.root()?;
+        Some(ROOT_OFFSETS[(root.generation as usize) & 1])
+    }
+
+    pub(super) fn payload_len(&self) -> Option<u64> {
+        let root = self.root()?;
+        self.payload.len(root.logical_len)
+    }
+
+    pub(super) fn final_root(&self) -> Option<[u8; ROOT_LEN]> {
+        let root = self.root()?;
+        Some(encode_root_with_binding(
+            RootState::Finalized,
+            root,
+            root_binding(&self.prepared_root),
+        ))
+    }
+
+    pub(super) fn status(&self, installed: &[u8; ROOT_LEN]) -> Option<CandidateStatus> {
+        let final_root = self.final_root()?;
+        if installed == &self.prepared_root {
+            return Some(CandidateStatus::Prepared);
+        }
+        for (actual, (prepared, final_value)) in installed
+            .iter()
+            .zip(self.prepared_root.iter().zip(final_root))
+        {
+            if actual != prepared && *actual != final_value {
+                return None;
+            }
+        }
+        // Exact prepared was handled above. A remaining compatible image may be a torn final write
+        // or a stale byte that happens to equal the final target. It has no local authority: group
+        // recovery still validates the complete bound ring and every payload obligation.
+        Some(CandidateStatus::Transition)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum CandidateStatus {
+    Prepared,
+    Transition,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct Participant {
+    pub(super) partition: String,
+    pub(super) name: Vec<u8>,
+    pub(super) incarnation: [u8; INCARNATION_LEN],
+    pub(super) candidate: Candidate,
+    pub(super) removed: bool,
+}
+
+impl Participant {
+    pub(super) fn key(&self) -> (&str, &[u8]) {
+        (&self.partition, &self.name)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct Location {
+    pub(super) partition: String,
+    pub(super) name: Vec<u8>,
+    pub(super) incarnation: [u8; INCARNATION_LEN],
+}
+
+#[cfg(test)]
+impl Location {
+    pub(super) fn key(&self) -> (&str, &[u8]) {
+        (&self.partition, &self.name)
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) struct Link {
+    pub(super) group_id: [u8; GROUP_ID_LEN],
+    pub(super) participant: Participant,
+    pub(super) next: Location,
+}
+
+#[derive(Clone)]
+pub(super) struct PreparedGroup {
+    pub(super) participants: Vec<Participant>,
+    pub(super) slots: Vec<RootSlot>,
+}
+
+fn invalid_input_io(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn encoded_u32(value: usize, field: &'static str) -> io::Result<u32> {
+    u32::try_from(value).map_err(|_| invalid_input_io(format!("batch {field} exceeds u32")))
+}
+
+fn push_len(encoded: &mut Vec<u8>, len: usize) -> io::Result<()> {
+    encoded.extend_from_slice(&encoded_u32(len, "path component length")?.to_be_bytes());
+    Ok(())
+}
+
+fn witness_binding(witness: &[u8]) -> RootBinding {
+    // Recovery treats a matching 160-bit prefix as equality of the reachable witness and relies on
+    // truncated SHA-256 collision resistance for distinct records and old/new mosaics.
+    let digest = Sha256::hash(&[WITNESS_BINDING_DOMAIN, witness]);
+    let mut binding = [0u8; ROOT_BINDING_LEN];
+    binding.copy_from_slice(&digest.as_ref()[..ROOT_BINDING_LEN]);
+    binding
+}
+
+fn link_len(partition_len: usize, name_len: usize) -> io::Result<usize> {
+    LINK_FIXED_LEN
+        .checked_add(partition_len)
+        .and_then(|len| len.checked_add(name_len))
+        .ok_or_else(|| invalid_input_io("batch link length overflow"))
+}
+
+pub(super) fn validate_location(partition: &str, name: &[u8]) -> io::Result<()> {
+    let len = partition
+        .len()
+        .checked_add(name.len())
+        .ok_or_else(|| invalid_input_io("atomic location length overflow"))?;
+    if len > MAX_LOCATION_LEN {
+        return Err(invalid_input_io("atomic location exceeds its root slot"));
+    }
+    Ok(())
+}
+
+fn encode_link(
+    group_id: [u8; GROUP_ID_LEN],
+    participants: &[Participant],
+    index: usize,
+) -> io::Result<Vec<u8>> {
+    let participant = participants
+        .get(index)
+        .ok_or_else(|| invalid_input_io("batch participant index is out of range"))?;
+    let participant_root = participant
+        .candidate
+        .root()
+        .ok_or_else(|| invalid_input_io("invalid batch candidate"))?;
+    if participant.removed
+        && !participant
+            .candidate
+            .payload
+            .is_empty(participant_root.logical_len)
+    {
+        return Err(invalid_input_io(
+            "removed batch participants cannot describe payload",
+        ));
+    }
+    let next = &participants[(index + 1) % participants.len()];
+    validate_location(&next.partition, &next.name)?;
+    let len = link_len(next.partition.len(), next.name.len())?;
+    debug_assert!(len <= MAX_LINK_LEN);
+    let mut encoded = Vec::with_capacity(len);
+    encoded.extend_from_slice(LINK_MAGIC);
+    encoded.extend_from_slice(&group_id);
+    encoded.extend_from_slice(&u32::from(participant.removed).to_be_bytes());
+    encoded.extend_from_slice(&participant.incarnation);
+    encoded.extend_from_slice(
+        &participant
+            .candidate
+            .template_prepared_root()
+            .ok_or(invalid_input_io("invalid batch candidate"))?,
+    );
+    encoded.extend_from_slice(&participant.candidate.payload.encode());
+    push_len(&mut encoded, next.partition.len())?;
+    encoded.extend_from_slice(next.partition.as_bytes());
+    push_len(&mut encoded, next.name.len())?;
+    encoded.extend_from_slice(&next.name);
+    encoded.extend_from_slice(&next.incarnation);
+    debug_assert_eq!(encoded.len(), len);
+    Ok(encoded)
+}
+
+pub(super) fn prepare_with_group_id(
+    mut participants: Vec<Participant>,
+    group_id: [u8; GROUP_ID_LEN],
+) -> io::Result<PreparedGroup> {
+    if participants.is_empty() {
+        return Err(invalid_input_io("batch requires at least one participant"));
+    }
+    participants.sort_by(|left, right| left.key().cmp(&right.key()));
+    if participants
+        .windows(2)
+        .any(|pair| pair[0].key() >= pair[1].key())
+    {
+        return Err(invalid_input_io("batch participants are not unique"));
+    }
+    let mut slots = Vec::with_capacity(participants.len());
+    for index in 0..participants.len() {
+        let link = encode_link(group_id, &participants, index)?;
+        let participant = &mut participants[index];
+        participant.candidate.bind(&link);
+        slots.push(encode_slot(&participant.candidate, &link)?);
+    }
+    Ok(PreparedGroup {
+        participants,
+        slots,
+    })
+}
+
+#[cfg(test)]
+pub(super) fn prepare(participants: Vec<Participant>) -> io::Result<PreparedGroup> {
+    prepare_with_group_id(participants, [0xa5; GROUP_ID_LEN])
+}
+
+fn encode_slot(candidate: &Candidate, witness: &[u8]) -> io::Result<RootSlot> {
+    if candidate.root().is_none()
+        || root_binding(&candidate.prepared_root) != witness_binding(witness)
+        || witness.len() > MAX_LINK_LEN
+    {
+        return Err(invalid_input_io("invalid batch candidate"));
+    }
+    let mut slot = [0u8; ROOT_SLOT_SIZE];
+    slot[..ROOT_LEN].copy_from_slice(&candidate.prepared_root);
+    let len = encoded_u32(witness.len(), "witness length")?.to_be_bytes();
+    slot[ROOT_LEN..ROOT_LEN + WITNESS_HEADER_LEN].copy_from_slice(&len);
+    slot[ROOT_LEN + WITNESS_HEADER_LEN..ROOT_LEN + WITNESS_HEADER_LEN + witness.len()]
+        .copy_from_slice(witness);
+    Ok(slot)
+}
+
+pub(super) fn witness(slot: &[u8]) -> Option<&[u8]> {
+    if slot.len() != ROOT_SLOT_SIZE {
+        return None;
+    }
+    let header = slot.get(ROOT_LEN..ROOT_LEN + WITNESS_HEADER_LEN)?;
+    let len = usize::try_from(u32::from_be_bytes(header.try_into().unwrap())).ok()?;
+    if len > MAX_LINK_LEN {
+        return None;
+    }
+    let end = ROOT_LEN + WITNESS_HEADER_LEN + len;
+    let witness = slot.get(ROOT_LEN + WITNESS_HEADER_LEN..end)?;
+    if slot.get(end..)?.iter().any(|byte| *byte != 0) {
+        return None;
+    }
+    Some(witness)
+}
+
+struct Cursor<'a> {
+    bytes: &'a [u8],
+    offset: usize,
+}
+
+impl<'a> Cursor<'a> {
+    fn take(&mut self, len: usize) -> io::Result<&'a [u8]> {
+        let end = self
+            .offset
+            .checked_add(len)
+            .ok_or_else(|| invalid_data("batch witness length overflow"))?;
+        let value = self
+            .bytes
+            .get(self.offset..end)
+            .ok_or_else(|| invalid_data("batch witness is truncated"))?;
+        self.offset = end;
+        Ok(value)
+    }
+
+    fn u32(&mut self) -> io::Result<u32> {
+        Ok(u32::from_be_bytes(self.take(4)?.try_into().unwrap()))
+    }
+
+    fn bytes(&mut self) -> io::Result<Vec<u8>> {
+        let len = self.u32()? as usize;
+        Ok(self.take(len)?.to_vec())
+    }
+}
+
+pub(super) fn decode_link_at(
+    encoded: &[u8],
+    partition: &str,
+    name: &[u8],
+    root_offset: u64,
+) -> io::Result<Link> {
+    if !(LINK_FIXED_LEN..=MAX_LINK_LEN).contains(&encoded.len()) {
+        return Err(invalid_data("batch link has an invalid length"));
+    }
+    let mut cursor = Cursor {
+        bytes: encoded,
+        offset: 0,
+    };
+    if cursor.take(8)? != LINK_MAGIC {
+        return Err(invalid_data("batch link magic mismatch"));
+    }
+    let group_id = cursor.take(GROUP_ID_LEN)?.try_into().unwrap();
+    let flags = cursor.u32()?;
+    if flags & !LINK_REMOVED != 0 {
+        return Err(invalid_data("batch link header is invalid"));
+    }
+    let incarnation = cursor.take(INCARNATION_LEN)?.try_into().unwrap();
+    let prepared_root = cursor.take(ROOT_LEN)?.try_into().unwrap();
+    let root = decode_root(&prepared_root, RootState::BatchPrepared)
+        .ok_or_else(|| invalid_data("batch participant candidate is invalid"))?;
+    if ROOT_OFFSETS[(root.generation as usize) & 1] != root_offset {
+        return Err(invalid_data(
+            "batch participant candidate is in the wrong slot",
+        ));
+    }
+    let payload = PayloadDescriptor::decode(cursor.take(PAYLOAD_DESCRIPTOR_LEN)?, root.logical_len)
+        .map_err(|_| invalid_data("batch participant payload descriptor is invalid"))?;
+    if flags & LINK_REMOVED != 0 && !payload.is_empty(root.logical_len) {
+        return Err(invalid_data("removed batch participant describes payload"));
+    }
+    let next_partition = String::from_utf8(cursor.bytes()?)
+        .map_err(|_| invalid_data("batch successor partition is not UTF-8"))?;
+    crate::storage::validate_partition_name(&next_partition)
+        .map_err(|_| invalid_data("batch successor partition is invalid"))?;
+    let next_name = cursor.bytes()?;
+    validate_location(&next_partition, &next_name)
+        .map_err(|_| invalid_data("batch successor location exceeds its root slot"))?;
+    let next_incarnation = cursor.take(INCARNATION_LEN)?.try_into().unwrap();
+    if cursor.offset != encoded.len() {
+        return Err(invalid_data("batch link has trailing bytes"));
+    }
+    let mut candidate = Candidate {
+        prepared_root,
+        payload,
+    };
+    candidate.bind(encoded);
+    Ok(Link {
+        group_id,
+        participant: Participant {
+            partition: partition.to_string(),
+            name: name.to_vec(),
+            incarnation,
+            candidate,
+            removed: flags & LINK_REMOVED != 0,
+        },
+        next: Location {
+            partition: next_partition,
+            name: next_name,
+            incarnation: next_incarnation,
+        },
+    })
+}
+
+pub(super) fn link_at(slot: &[u8], partition: &str, name: &[u8], root_offset: u64) -> Option<Link> {
+    let link = decode_link_at(witness(slot)?, partition, name, root_offset).ok()?;
+    let installed: &[u8; ROOT_LEN] = slot.get(..ROOT_LEN)?.try_into().ok()?;
+    link.participant.candidate.status(installed)?;
+    Some(link)
+}
+
+#[cfg(test)]
+pub(super) fn link(slot: &[u8], partition: &str, name: &[u8]) -> Option<Link> {
+    let link = decode_link(witness(slot)?, partition, name).ok()?;
+    let installed: &[u8; ROOT_LEN] = slot.get(..ROOT_LEN)?.try_into().ok()?;
+    link.participant.candidate.status(installed)?;
+    Some(link)
+}
+
+#[cfg(test)]
+fn decode_link(encoded: &[u8], partition: &str, name: &[u8]) -> io::Result<Link> {
+    let prepared_offset = 8 + GROUP_ID_LEN + 4 + INCARNATION_LEN;
+    let prepared: &[u8; ROOT_LEN] = encoded
+        .get(prepared_offset..prepared_offset + ROOT_LEN)
+        .ok_or_else(|| invalid_data("batch link is truncated"))?
+        .try_into()
+        .unwrap();
+    let root = decode_root(prepared, RootState::BatchPrepared)
+        .ok_or_else(|| invalid_data("batch participant candidate is invalid"))?;
+    decode_link_at(
+        encoded,
+        partition,
+        name,
+        ROOT_OFFSETS[(root.generation as usize) & 1],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const FLAGS_OFFSET: usize = 8 + GROUP_ID_LEN;
+    const CANDIDATE_OFFSET: usize = FLAGS_OFFSET + 4 + INCARNATION_LEN;
+    const PREPARED_OFFSET: usize = CANDIDATE_OFFSET;
+    const PAYLOAD_OFFSET: usize = PREPARED_OFFSET + ROOT_LEN;
+    const NEXT_PARTITION_LEN_OFFSET: usize = PAYLOAD_OFFSET + PAYLOAD_DESCRIPTOR_LEN;
+
+    fn participant(name: &[u8], incarnation: u8, generation: u64, removed: bool) -> Participant {
+        Participant {
+            partition: "partition".to_string(),
+            name: name.to_vec(),
+            incarnation: [incarnation; INCARNATION_LEN],
+            candidate: Candidate::new(Root::unbound(
+                generation,
+                generation,
+                [incarnation; ATOMIC_BLOB_TAG_LEN],
+            ))
+            .unwrap(),
+            removed,
+        }
+    }
+
+    fn valid_link_bytes() -> (Participant, Vec<u8>) {
+        let group = prepare(vec![
+            participant(b"b", 2, 2, true),
+            participant(b"a", 1, 2, false),
+        ])
+        .unwrap();
+        let participant = group.participants[0].clone();
+        let encoded = witness(&group.slots[0]).unwrap().to_vec();
+        (participant, encoded)
+    }
+
+    #[test]
+    fn candidates_validate_lineage_and_classify_every_reachable_transition() {
+        assert!(Candidate::new(Root::unbound(0, 0, [0; ATOMIC_BLOB_TAG_LEN])).is_err());
+
+        let candidate = participant(b"a", 1, 2, false).candidate;
+        let root = candidate.root().unwrap();
+        assert_eq!(root.generation, 2);
+        let finalized = candidate.final_root().unwrap();
+        assert!(decode_root(&finalized, RootState::Finalized).is_some());
+        assert_eq!(
+            candidate.status(&candidate.prepared_root),
+            Some(CandidateStatus::Prepared)
+        );
+        assert_eq!(
+            candidate.status(&finalized),
+            Some(CandidateStatus::Transition)
+        );
+
+        let changed = candidate
+            .prepared_root
+            .iter()
+            .zip(finalized)
+            .position(|(prepared, final_byte)| *prepared != final_byte)
+            .unwrap();
+        let mut torn = candidate.prepared_root;
+        torn[changed] = finalized[changed];
+        assert_eq!(candidate.status(&torn), Some(CandidateStatus::Transition));
+        torn[changed] = (0..=u8::MAX)
+            .find(|byte| *byte != candidate.prepared_root[changed] && *byte != finalized[changed])
+            .unwrap();
+        assert_eq!(candidate.status(&torn), None);
+
+        let mut bad_prepared = candidate.clone();
+        bad_prepared.prepared_root[0] ^= 1;
+        assert!(bad_prepared.root().is_none());
+        assert!(bad_prepared.final_root().is_none());
+        assert!(bad_prepared.status(&candidate.prepared_root).is_none());
+
+        assert_eq!(candidate.base_generation(), Some(1));
+        assert_eq!(candidate.root_offset(), Some(ROOT_OFFSETS[0]));
+    }
+
+    #[test]
+    fn payload_descriptors_derive_a_canonical_bounded_suffix() {
+        for logical_len in [0, 7] {
+            let empty = PayloadDescriptor::empty(logical_len);
+            assert_eq!(empty.len(logical_len), Some(0));
+            assert_eq!(
+                PayloadDescriptor::decode(&empty.encode(), logical_len).unwrap(),
+                empty
+            );
+        }
+
+        let full = PayloadDescriptor {
+            start: 0,
+            checksum: [1; 32],
+        };
+        assert_eq!(
+            full.len(MAX_UNSYNCED_PAYLOAD_LEN),
+            Some(MAX_UNSYNCED_PAYLOAD_LEN)
+        );
+        assert!(full.validate(MAX_UNSYNCED_PAYLOAD_LEN + 1).is_err());
+
+        let past_end = PayloadDescriptor {
+            start: 8,
+            checksum: [1; 32],
+        };
+        assert!(past_end.validate(7).is_err());
+
+        let noncanonical_empty = PayloadDescriptor {
+            start: 7,
+            checksum: [1; 32],
+        };
+        assert!(noncanonical_empty.validate(7).is_err());
+    }
+
+    #[test]
+    fn prepared_groups_are_canonical_closed_rings_and_reject_invalid_inputs() {
+        assert!(prepare(Vec::new()).is_err());
+        let duplicate = participant(b"same", 1, 1, false);
+        assert!(prepare(vec![duplicate.clone(), duplicate]).is_err());
+
+        let group = prepare(vec![
+            participant(b"c", 3, 1, false),
+            participant(b"a", 1, 1, false),
+            participant(b"b", 2, 1, true),
+        ])
+        .unwrap();
+        assert_eq!(
+            group
+                .participants
+                .iter()
+                .map(|participant| participant.name.as_slice())
+                .collect::<Vec<_>>(),
+            [b"a".as_slice(), b"b".as_slice(), b"c".as_slice()]
+        );
+        for (ordinal, slot) in group.slots.iter().enumerate() {
+            let link = link(
+                slot,
+                &group.participants[ordinal].partition,
+                &group.participants[ordinal].name,
+            )
+            .unwrap();
+            assert_eq!(link.participant.key(), group.participants[ordinal].key());
+            assert_eq!(link.next.key(), group.participants[(ordinal + 1) % 3].key());
+            assert_eq!(link.participant.removed, ordinal == 1);
+        }
+
+        let oversized = participant(&vec![b'x'; MAX_LINK_LEN], 1, 1, false);
+        assert!(prepare(vec![oversized]).is_err());
+        let mut removed_with_payload = participant(b"removed", 1, 1, true);
+        removed_with_payload.candidate.payload = PayloadDescriptor {
+            start: 0,
+            checksum: [0; 32],
+        };
+        assert!(prepare(vec![removed_with_payload]).is_err());
+        assert!(encode_link([0; GROUP_ID_LEN], &group.participants, 3).is_err());
+        assert!(link_len(usize::MAX, 1).is_err());
+        #[cfg(target_pointer_width = "64")]
+        assert!(encoded_u32(u32::MAX as usize + 1, "value").is_err());
+
+        let mut invalid_candidate = group.participants[0].candidate.clone();
+        invalid_candidate.prepared_root[0] ^= 1;
+        assert!(encode_slot(&invalid_candidate, b"witness").is_err());
+        assert!(
+            encode_slot(&group.participants[0].candidate, &vec![0; MAX_LINK_LEN + 1],).is_err()
+        );
+    }
+
+    #[test]
+    fn witness_frame_rejects_every_noncanonical_shape() {
+        let group = prepare(vec![participant(b"a", 1, 1, false)]).unwrap();
+        let valid = group.slots[0];
+        assert!(witness(&valid).is_some());
+        assert!(witness(&valid[..ROOT_SLOT_SIZE - 1]).is_none());
+
+        let mut oversized = valid;
+        oversized[ROOT_LEN..ROOT_LEN + WITNESS_HEADER_LEN]
+            .copy_from_slice(&(MAX_LINK_LEN as u32 + 1).to_be_bytes());
+        assert!(witness(&oversized).is_none());
+
+        let mut suffix = valid;
+        suffix[ROOT_SLOT_SIZE - 1] = 1;
+        assert!(witness(&suffix).is_none());
+
+        let mut malformed_link = valid;
+        let link_start = ROOT_LEN + WITNESS_HEADER_LEN;
+        malformed_link[link_start] ^= 1;
+        assert!(link(&malformed_link, "partition", b"a").is_none());
+    }
+
+    #[test]
+    fn prepared_root_binds_the_exact_local_witness() {
+        let old = prepare_with_group_id(
+            vec![
+                participant(b"a", 1, 2, false),
+                participant(b"c", 3, 2, false),
+            ],
+            [1; GROUP_ID_LEN],
+        )
+        .unwrap();
+        let new = prepare_with_group_id(
+            vec![
+                participant(b"a", 1, 4, false),
+                participant(b"b", 2, 4, false),
+                participant(b"c", 3, 4, false),
+            ],
+            [2; GROUP_ID_LEN],
+        )
+        .unwrap();
+
+        let mut retained_subset = new.slots[0];
+        let witness_start = ROOT_LEN + WITNESS_HEADER_LEN;
+        let old_witness = witness(&old.slots[0]).unwrap();
+        let new_witness = witness(&new.slots[0]).unwrap();
+        assert_eq!(old_witness.len(), new_witness.len());
+        retained_subset
+            [witness_start + NEXT_PARTITION_LEN_OFFSET..witness_start + new_witness.len()]
+            .copy_from_slice(&old_witness[NEXT_PARTITION_LEN_OFFSET..]);
+        assert!(
+            retained_subset
+                .iter()
+                .zip(old.slots[0].iter().zip(&new.slots[0]))
+                .all(|(actual, (old, new))| actual == old || actual == new)
+        );
+        let retained_witness = witness(&retained_subset).unwrap();
+        let retained_link = decode_link(retained_witness, "partition", b"a").unwrap();
+        assert_eq!(retained_link.next.name, b"c");
+        assert!(
+            link(&retained_subset, "partition", b"a").is_none(),
+            "a retained old successor must not match the newer root",
+        );
+    }
+
+    #[test]
+    fn link_decoder_rejects_malformed_and_adversarial_fields() {
+        let (expected_participant, valid) = valid_link_bytes();
+        let decoded = decode_link(
+            &valid,
+            &expected_participant.partition,
+            &expected_participant.name,
+        )
+        .unwrap();
+        assert_eq!(decoded.participant, expected_participant);
+        assert!(
+            decode_link_at(
+                &valid,
+                &expected_participant.partition,
+                &expected_participant.name,
+                ROOT_OFFSETS[1],
+            )
+            .is_err()
+        );
+        assert!(decode_link(&valid[..LINK_FIXED_LEN - 1], "partition", b"a").is_err());
+
+        let mut bad_magic = valid.clone();
+        bad_magic[0] ^= 1;
+        assert!(decode_link(&bad_magic, "partition", b"a").is_err());
+
+        let mut bad_flags = valid.clone();
+        bad_flags[FLAGS_OFFSET..FLAGS_OFFSET + 4].copy_from_slice(&2u32.to_be_bytes());
+        assert!(decode_link(&bad_flags, "partition", b"a").is_err());
+
+        let mut bad_candidate = valid.clone();
+        bad_candidate[PREPARED_OFFSET] ^= 1;
+        assert!(decode_link(&bad_candidate, "partition", b"a").is_err());
+
+        let mut bad_payload = valid.clone();
+        bad_payload[PAYLOAD_OFFSET] = 1;
+        assert!(decode_link(&bad_payload, "partition", b"a").is_err());
+
+        let removed = prepare(vec![participant(b"removed", 3, 1, true)]).unwrap();
+        let mut removed_with_payload = witness(&removed.slots[0]).unwrap().to_vec();
+        removed_with_payload[PAYLOAD_OFFSET + 8..PAYLOAD_OFFSET + 16]
+            .copy_from_slice(&1u64.to_be_bytes());
+        assert!(decode_link(&removed_with_payload, "partition", b"removed").is_err());
+
+        let partition_len = u32::from_be_bytes(
+            valid[NEXT_PARTITION_LEN_OFFSET..NEXT_PARTITION_LEN_OFFSET + 4]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let partition_start = NEXT_PARTITION_LEN_OFFSET + 4;
+        let mut non_utf8 = valid.clone();
+        non_utf8[partition_start] = 0xff;
+        assert!(decode_link(&non_utf8, "partition", b"a").is_err());
+
+        let mut invalid_partition = valid.clone();
+        invalid_partition[partition_start..partition_start + partition_len].fill(b'/');
+        assert!(decode_link(&invalid_partition, "partition", b"a").is_err());
+
+        let mut truncated_path = valid.clone();
+        truncated_path[NEXT_PARTITION_LEN_OFFSET..NEXT_PARTITION_LEN_OFFSET + 4]
+            .copy_from_slice(&u32::MAX.to_be_bytes());
+        assert!(decode_link(&truncated_path, "partition", b"a").is_err());
+
+        let name_len_offset = NEXT_PARTITION_LEN_OFFSET + 4 + partition_len;
+        let name_len = u32::from_be_bytes(
+            valid[name_len_offset..name_len_offset + 4]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let extra = MAX_LOCATION_LEN + 1 - partition_len - name_len;
+        let name_end = name_len_offset + 4 + name_len;
+        let mut oversized_location = valid.clone();
+        oversized_location[name_len_offset..name_len_offset + 4]
+            .copy_from_slice(&u32::try_from(name_len + extra).unwrap().to_be_bytes());
+        oversized_location.splice(name_end..name_end, std::iter::repeat_n(0, extra));
+        assert!(oversized_location.len() <= MAX_LINK_LEN);
+        assert!(decode_link(&oversized_location, "partition", b"a").is_err());
+
+        let mut trailing = valid;
+        trailing.push(0);
+        assert!(decode_link(&trailing, "partition", b"a").is_err());
+
+        let mut cursor = Cursor {
+            bytes: &[],
+            offset: usize::MAX,
+        };
+        assert!(cursor.take(1).is_err());
+    }
+}

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -42,7 +42,7 @@
 //! });
 //! ```
 
-pub use crate::storage::faulty::Config as FaultConfig;
+pub use crate::storage::faulty::{Config as FaultConfig, PartialWriteMode};
 #[cfg(feature = "external")]
 use crate::{Blocker, Pacer};
 use crate::{
@@ -54,8 +54,10 @@ use crate::{
     },
     prefixed_name,
     storage::{
-        audited::Storage as AuditedStorage, faulty::Storage as FaultyStorage,
-        memory::Storage as MemStorage, metered::Storage as MeteredStorage,
+        audited::Storage as AuditedStorage,
+        faulty::Storage as FaultyStorage,
+        memory::{Snapshot as MemStorageSnapshot, Storage as MemStorage},
+        metered::Storage as MeteredStorage,
     },
     telemetry::metrics::{
         Counter, CounterFamily, GaugeFamily, Metric, Register, Registered, Registry, add_attribute,
@@ -499,7 +501,8 @@ pub struct Checkpoint {
     auditor: Arc<Auditor>,
     rng: Arc<Mutex<BoxDynRng>>,
     time: Mutex<SystemTime>,
-    storage: Arc<Storage>,
+    storage: MemStorageSnapshot,
+    storage_fault_cfg: FaultConfig,
     dns: Mutex<HashMap<String, Vec<IpAddr>>>,
     catch_panics: bool,
     network_buffer_pool_cfg: BufferPoolConfig,
@@ -707,6 +710,15 @@ impl Runner {
         // root future is still Pending and holds captured variables with Context references.
         drop(root);
 
+        // No task can issue or make a write durable after this crash boundary.
+        storage
+            .inner()
+            .inner()
+            .crash()
+            .expect("retaining successful unsynced writes at crash should succeed");
+        let storage_fault_cfg = storage.inner().inner().config().read().clone();
+        let storage = storage.inner().inner().inner().take_snapshot();
+
         // Assert the context doesn't escape the start() function (behavior
         // is undefined in this case)
         assert!(
@@ -731,6 +743,7 @@ impl Runner {
             rng: executor.rng,
             time: executor.time,
             storage,
+            storage_fault_cfg,
             dns: executor.dns,
             catch_panics: executor.panicker.catch(),
             network_buffer_pool_cfg,
@@ -907,6 +920,22 @@ impl Tasks {
 type Network = MeteredNetwork<AuditedNetwork<DeterministicNetwork>>;
 type Storage = MeteredStorage<AuditedStorage<FaultyStorage<MemStorage>>>;
 
+fn build_storage(
+    inner: MemStorage,
+    rng: Arc<Mutex<BoxDynRng>>,
+    faults: FaultConfig,
+    auditor: Arc<Auditor>,
+    registry: &mut impl Register,
+) -> Storage {
+    MeteredStorage::new(
+        AuditedStorage::new(
+            FaultyStorage::new(inner, rng, Arc::new(RwLock::new(faults))),
+            auditor,
+        ),
+        registry,
+    )
+}
+
 /// Implementation of [crate::Spawner], [crate::Clock],
 /// [crate::Network], and [crate::Storage] for the `deterministic`
 /// runtime.
@@ -949,17 +978,11 @@ impl Context {
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
         );
 
-        // Create storage fault config (default to disabled if None)
-        let storage_fault_config = Arc::new(RwLock::new(cfg.storage_fault_cfg));
-        let storage = MeteredStorage::new(
-            AuditedStorage::new(
-                FaultyStorage::new(
-                    MemStorage::new(storage_buffer_pool.clone()),
-                    rng.clone(),
-                    storage_fault_config,
-                ),
-                auditor.clone(),
-            ),
+        let storage = build_storage(
+            MemStorage::new(storage_buffer_pool.clone()),
+            rng.clone(),
+            cfg.storage_fault_cfg,
+            auditor.clone(),
             &mut runtime_registry,
         );
 
@@ -1002,10 +1025,11 @@ impl Context {
         )
     }
 
-    /// Recover the inner state (deadline, metrics, auditor, rng, synced storage, etc.) from the
-    /// current runtime and use it to initialize a new instance of the runtime. A recovered runtime
-    /// does not inherit the current runtime's pending tasks, unsynced storage, network connections, nor
-    /// its shutdown signaler.
+    /// Recover the inner state (deadline, metrics, auditor, rng, storage, etc.) from the current
+    /// runtime and use it to initialize a new instance of the runtime. Storage recovery includes
+    /// durable state and any unsynchronized mutations retained by the configured crash policy. A
+    /// recovered runtime does not inherit pending tasks, network connections, or its shutdown
+    /// signaler.
     ///
     /// This is useful for performing a deterministic simulation that spans multiple runtime instantiations,
     /// like simulating unclean shutdown (which involves repeatedly halting the runtime at unexpected intervals).
@@ -1032,6 +1056,13 @@ impl Context {
         let storage_buffer_pool = BufferPool::new(
             checkpoint.storage_buffer_pool_cfg.clone(),
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
+        );
+        let storage = build_storage(
+            MemStorage::from_snapshot(checkpoint.storage, storage_buffer_pool.clone()),
+            checkpoint.rng.clone(),
+            checkpoint.storage_fault_cfg,
+            checkpoint.auditor.clone(),
+            &mut runtime_registry,
         );
 
         // Initialize panicker
@@ -1060,7 +1091,7 @@ impl Context {
                 attributes: Vec::new(),
                 executor: Arc::downgrade(&executor),
                 network: Arc::new(network),
-                storage: checkpoint.storage,
+                storage: Arc::new(storage),
                 network_buffer_pool,
                 storage_buffer_pool,
                 tree: Tree::root(),
@@ -1881,6 +1912,88 @@ mod tests {
             let (_, len) = context.open(partition, name).await.unwrap();
             assert_eq!(len, 0);
         });
+    }
+
+    #[test]
+    fn test_recover_snapshots_fault_configuration() {
+        let (stale_config, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let config = context.storage_fault_config();
+                *config.write() = FaultConfig::default().open(1.0);
+                config
+            });
+        *stale_config.write() = FaultConfig::default();
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            assert!(context.open("fault_config", b"blob").await.is_err());
+        });
+    }
+
+    #[test]
+    fn test_recover_retained_successful_resize() {
+        let cfg = deterministic::Config::default()
+            .with_storage_fault_config(FaultConfig::default().crash_resize(1.0));
+        let (_, checkpoint) =
+            deterministic::Runner::new(cfg).start_and_recover(|context| async move {
+                let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();
+                blob.write_at(0, b"abcdefgh", WriteOptions::SYNC)
+                    .await
+                    .unwrap();
+                blob.resize(3).await.unwrap();
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let (blob, len) = context.open("crash_resize", b"blob").await.unwrap();
+            assert_eq!(len, 3);
+            assert_eq!(blob.read_at(0, 3).await.unwrap().coalesce(), b"abc");
+        });
+    }
+
+    #[test]
+    fn test_recover_random_crash_writes_is_seeded_and_epoch_scoped() {
+        const STABLE_LEN: usize = 32;
+        const PENDING_LEN: usize = 256;
+
+        fn run(seed: u64) -> (Vec<u8>, Digest) {
+            let cfg = deterministic::Config::default()
+                .with_seed(seed)
+                .with_storage_fault_config(
+                    FaultConfig::default().write_retention(PartialWriteMode::Subset, 0.5),
+                );
+            let (_, checkpoint) =
+                deterministic::Runner::new(cfg).start_and_recover(|context| async move {
+                    let (blob, _) = context.open("crash_epoch", b"blob").await.unwrap();
+                    blob.write_at(0, vec![0xA5; STABLE_LEN], WriteOptions::default())
+                        .await
+                        .unwrap();
+                    blob.sync().await.unwrap();
+                    blob.write_at(
+                        STABLE_LEN as u64,
+                        vec![0x5A; PENDING_LEN],
+                        WriteOptions::default(),
+                    )
+                    .await
+                    .unwrap();
+                });
+
+            deterministic::Runner::from(checkpoint).start(|context| async move {
+                let (blob, len) = context.open("crash_epoch", b"blob").await.unwrap();
+                let mut bytes = vec![0; STABLE_LEN + PENDING_LEN];
+                let len = usize::try_from(len).unwrap();
+                let durable = blob.read_at(0, len).await.unwrap().coalesce();
+                bytes[..durable.len()].copy_from_slice(durable.as_ref());
+                (bytes, context.storage_audit())
+            })
+        }
+
+        let first = run(12345);
+        let second = run(12345);
+        let different = run(54321);
+        assert_eq!(first, second);
+        assert_ne!(first.0, different.0);
+        assert!(first.0[..STABLE_LEN].iter().all(|&byte| byte == 0xA5));
+        assert!(first.0[STABLE_LEN..].contains(&0));
+        assert!(first.0[STABLE_LEN..].contains(&0x5A));
     }
 
     #[test]

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -30,6 +30,429 @@ mod network;
 mod process;
 mod storage;
 
+stability_scope!(BETA {
+    mod atomic;
+
+    /// Number of application-owned bytes published with an atomic blob's length.
+    pub const ATOMIC_BLOB_TAG_LEN: usize = 64;
+
+    /// How an integrity-aware append closes checksum units.
+    ///
+    /// Unit boundaries are independent of write calls. A page cache can keep one unit open across
+    /// many small writes and close it at a page boundary, while a record store can complete one
+    /// unit after writing an entire value.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum IntegrityBoundary {
+        /// Leave the current unit open after appending the supplied bytes.
+        Continue,
+        /// Complete the current unit after appending the supplied bytes.
+        Complete,
+        /// Complete units whenever their payload reaches this many bytes.
+        ///
+        /// A final shorter unit remains open. The selected root carries its rolling checksum, so a
+        /// sync does not force a short unit to be closed.
+        Chunked(std::num::NonZeroU32),
+    }
+
+    /// Checksum-unit layout bound to an atomic blob's immediately visible state.
+    ///
+    /// A blob binds itself when a [`IntegrityBoundary::Complete`] or
+    /// [`IntegrityBoundary::Chunked`] operation first chooses a layout. A `Continue` append may
+    /// leave an unbound blob open. Reopening with a different fixed unit width is rejected before
+    /// any offsets are interpreted.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum IntegrityScheme {
+        /// No integrity-unit layout has been chosen yet.
+        Unbound,
+        /// Units end at explicit caller-selected boundaries.
+        Variable,
+        /// Units close automatically after a fixed number of data bytes.
+        Chunked(std::num::NonZeroU32),
+    }
+
+    impl IntegrityScheme {
+        pub(crate) fn validate_completed_unit(self, unit: IntegrityUnit) -> Result<(), Error> {
+            if unit.len == 0 {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "integrity units must contain data",
+                )
+                .into());
+            }
+            match self {
+                Self::Unbound => Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    "atomic blob has no completed integrity-unit layout",
+                )
+                .into()),
+                Self::Variable => Ok(()),
+                Self::Chunked(size) => {
+                    let data_len = u64::from(size.get());
+                    let encoded_len = data_len + std::mem::size_of::<u32>() as u64;
+                    if unit.len != data_len || !unit.offset.is_multiple_of(encoded_len) {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "fixed integrity unit does not match the blob's bound geometry",
+                        )
+                        .into());
+                    }
+                    Ok(())
+                }
+            }
+        }
+    }
+
+    /// One completed or in-progress integrity unit in the encoded atomic payload.
+    ///
+    /// `offset` addresses the first data byte and `len` excludes the four-byte checksum footer of
+    /// a completed unit. The footer immediately follows the data. An in-progress unit has no
+    /// footer; its checksum is carried by the selected root instead.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct IntegrityUnit {
+        /// Encoded payload offset of the first data byte.
+        pub offset: u64,
+        /// Number of data bytes in the unit, excluding its checksum footer.
+        pub len: u64,
+    }
+
+    /// Opaque version of one atomic blob's immediately visible integrity state.
+    ///
+    /// Integrity-aware mutations compare this token while holding the blob's mutation lock. A
+    /// stale token is rejected before payload I/O, preventing two cached writers from interpreting
+    /// the same bytes with different unit boundaries or lengths.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct IntegrityToken {
+        pub(crate) epoch: [u8; 16],
+        pub(crate) revision: u64,
+    }
+
+    /// One coherent view of an atomic blob's integrity metadata and unfinished unit.
+    pub struct IntegritySnapshot {
+        /// Encoded payload length, including completed-unit checksum footers.
+        pub encoded_len: u64,
+        /// Integrity-unit layout in this immediately visible snapshot.
+        pub scheme: IntegrityScheme,
+        /// Complete application-owned root tag.
+        pub tag: [u8; ATOMIC_BLOB_TAG_LEN],
+        /// Validated unfinished unit and its bytes, if one exists.
+        pub tail: Option<(IntegrityUnit, IoBufs)>,
+        /// Compare token for the next integrity-aware mutation.
+        pub token: IntegrityToken,
+    }
+
+    /// Result of one integrity-aware append.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub struct IntegrityAppend {
+        /// Encoded offset of the first newly supplied data byte.
+        pub offset: u64,
+        /// Compare token for the next integrity-aware mutation.
+        pub token: IntegrityToken,
+    }
+
+    /// One mutation in an atomic multi-blob publication.
+    ///
+    /// Every distinct dirty blob named by a batch becomes one participant in a canonical closed
+    /// ring. Identical operations may be repeated, but different operations for the same blob are
+    /// rejected before the batch is admitted.
+    #[derive(Clone, Debug)]
+    pub enum BatchOperation<B> {
+        /// Publish the blob's pending append, rewind, and tag state.
+        Publish(B),
+        /// Publish `len` as the blob's new length.
+        Rewind {
+            /// Blob to rewind.
+            blob: B,
+            /// New encoded length, which cannot exceed the blob's immediately visible length or
+            /// cut through protocol-owned integrity state.
+            len: u64,
+        },
+        /// Durably publish logical absence for the blob's current incarnation.
+        ///
+        /// Physical namespace reclamation is deferred until recovery, an atomic scan, or a later
+        /// same-name atomic open.
+        Remove(B),
+    }
+
+    /// Opt-in interface for opening append-only blobs with crash-atomic publication.
+    ///
+    /// Atomic blobs are stored inside ordinary default-version blobs, but expose a narrower
+    /// mutation interface. The backend owns the ordinary container layout; the atomic identity and
+    /// roots live in the blob's logical contents. A name belongs exclusively to either this
+    /// interface or ordinary [`Storage`]: it must not be populated or mutated through both.
+    /// Existing names require a complete atomic identity and are never implicitly converted. At
+    /// most one independently opened handle for a name may be live: drop that handle and all of
+    /// its clones before reopening the name. Use clones of one returned handle for coordinated
+    /// concurrent access. Atomic namespace
+    /// and recovery work is serialized across one storage value and its clones. Live operations on
+    /// disjoint handles and carried-debt groups may proceed concurrently; operations sharing either
+    /// are serialized. If a canceled observer leaves backing work in flight, including when the
+    /// runtime polling that observer is torn down, a later conflicting operation waits for that
+    /// work before examining any affected peer. Publication rings may span partitions, so recovery
+    /// started from one member may read, synchronize, finalize, or unlink peers in other
+    /// partitions. Observer-independent work may retain the lineage after every caller-held clone
+    /// is dropped. To transfer a filesystem directory to a new lineage in the same process, retain
+    /// a storage clone and establish quiescence through a known completion or a later conflicting
+    /// operation; dropping the last caller-held clone is not a quiescence barrier.
+    /// Filesystem-backed storage directories must be owned by exactly one independently constructed
+    /// storage lineage for that lineage's full lifetime. Clones are part of the same lineage;
+    /// another process, storage instance, path alias, or direct filesystem mutation must not access
+    /// the directory concurrently.
+    pub trait AtomicStorage: Storage {
+        /// Blob type returned by atomic opens.
+        type AtomicBlob: AtomicBlob;
+
+        /// Open an existing atomic blob or create a new one.
+        ///
+        /// The returned length addresses the encoded payload, including completed integrity-unit
+        /// checksum footers. The backing blob's fixed root region is hidden. The name must be
+        /// reserved for atomic use before its first open. The UTF-8 partition bytes and raw name
+        /// bytes must total at most 1,640 bytes so the location fits in the fixed-size witness. This
+        /// is the protocol limit; a storage backend may impose a smaller namespace limit. Crash
+        /// recovery requires a complete atomic identity page. If a machine crash preserves that
+        /// page but not the rest of the fixed root region, recovery completes and synchronizes the
+        /// region. A torn or invalid identity is rejected rather than overwritten on restart.
+        ///
+        /// Dropping this future after backing I/O begins does not expose a peer while admitted
+        /// initialization or recovery work remains in flight. A later atomic operation waits for
+        /// that work and then recovers from its durable result. Recovery may follow a publication
+        /// ring into other partitions, mutate those peers, and return an error from their backing
+        /// or namespace operations.
+        fn open_atomic(
+            &self,
+            partition: &str,
+            name: &[u8],
+        ) -> impl std::future::Future<Output = Result<(Self::AtomicBlob, u64), Error>> + Send;
+
+        /// Return every logically present atomic blob in a partition.
+        ///
+        /// Unlike [`Storage::scan`], this resolves interrupted atomic publications and omits and
+        /// reclaims durable tombstones before returning. A partition reserved for atomic names
+        /// must be enumerated through this method. Before scanning, callers must finish all
+        /// operations and drop every atomic handle and clone opened from the partition. No create,
+        /// remove, open, or publication may mutate the partition concurrently with the scan. The
+        /// returned names are limited to `partition`, but recovery may read, finalize, synchronize,
+        /// or unlink publication peers in other partitions and may surface their errors.
+        fn scan_atomic(
+            &self,
+            partition: &str,
+        ) -> impl std::future::Future<Output = Result<Vec<Vec<u8>>, Error>> + Send;
+
+        /// Start one atomic multi-blob publication.
+        ///
+        /// Every selected handle must have been opened from this storage lineage.
+        ///
+        /// Implementations store a framed local witness beside every prepared participant
+        /// root, and each root binds its exact witness. The witnesses form a closed successor ring,
+        /// allowing recovery that starts from any surviving participant to discover the whole
+        /// group without a coordinator record. A group is durable after every participant's
+        /// preparation has completed its durability operation; those operations may run
+        /// concurrently. All files needed by the new decision and any carried predecessor are
+        /// launched as one concurrent set, without fixed-size waves or a second final-root
+        /// durability round.
+        ///
+        /// When at least one operation participates, returning `Ok` proves the complete group is
+        /// durable. Empty and all-clean batches perform no publication. Awaiting the returned
+        /// handle waits for in-memory activation, ordinary final-root writes, and required
+        /// truncation. Final-root durability and physical removal are cleanup debt: a later
+        /// publication folds that debt into its single durability layer, while recovery initiated
+        /// by an atomic open or scan from any surviving member can pay it explicitly, including
+        /// across partitions. Dropping the handle stops waiting but does not revoke the committed
+        /// decision.
+        ///
+        /// A validation error before physical admission leaves every selected state unchanged.
+        /// Any other error or cancellation may have admitted the group; none of the selected
+        /// handles may be reused, and callers must reopen after outstanding backing work is
+        /// quiescent. Recovery returns either the complete preceding vector or the complete
+        /// candidate vector. Payload has no protocol batch cap: completed invisible preflushes keep
+        /// the aggregate suffix described by one group within the implementation's bounded-recovery
+        /// budget.
+        fn start_apply(
+            &self,
+            operations: Vec<BatchOperation<Self::AtomicBlob>>,
+        ) -> impl std::future::Future<Output = Result<Handle<()>, Error>> + Send;
+
+        /// Publish a multi-blob group and wait for its activation writes to finish.
+        fn apply(
+            &self,
+            operations: Vec<BatchOperation<Self::AtomicBlob>>,
+        ) -> impl std::future::Future<Output = Result<(), Error>> + Send {
+            async move { self.start_apply(operations).await?.await }
+        }
+    }
+
+    /// Append-only blob mutations with crash-atomic publication.
+    ///
+    /// Appends and rewinds are immediately visible through this handle and its clones.
+    /// [`Self::sync`] atomically publishes their encoded length, integrity state, and tag. The trait
+    /// deliberately does not extend [`Blob`], so positional writes and arbitrary resizes are not
+    /// available on an atomic handle.
+    ///
+    /// Integrity-aware appends extend a rolling CRC32C for the current unit. Completing a unit
+    /// appends one four-byte footer; publication stores the start and checksum of an unfinished
+    /// unit in the selected root. Callers choose only when units close and never calculate or
+    /// encode checksums. Raw offsets address the encoded stream, including completed-unit footers;
+    /// use [`Self::read_integrity`] to read and validate a complete unit.
+    ///
+    /// After a mutation or sync future has begun issuing backing I/O, dropping its completion
+    /// observer cannot release conflicting-operation exclusion early. Filesystem backends continue
+    /// accepted work independently; cancellation-synchronous backends poison the open handle and
+    /// clones when cancellation interrupts the operation. An error after mutable backing I/O has
+    /// been admitted also poisons the handle and every clone; validation errors before admission do
+    /// not. A caller that did not observe completion or receives an admitted mutable error must
+    /// stop using the handle and reopen after the backing work is quiescent.
+    pub trait AtomicBlob: Clone + Send + Sync + 'static {
+        /// Read exactly `len` encoded payload bytes at `offset`.
+        fn read_at(
+            &self,
+            offset: u64,
+            len: usize,
+        ) -> impl std::future::Future<Output = Result<IoBufsMut, Error>> + Send;
+
+        /// Return the application-owned tag in the immediately visible state.
+        fn tag(
+            &self,
+        ) -> impl std::future::Future<Output = Result<[u8; ATOMIC_BLOB_TAG_LEN], Error>> + Send;
+
+        /// Stage an application-owned tag for the next publication.
+        fn set_tag(
+            &self,
+            tag: [u8; ATOMIC_BLOB_TAG_LEN],
+        ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
+        /// Return the integrity-unit layout in this blob's immediately visible state.
+        fn integrity_scheme(
+            &self,
+        ) -> impl std::future::Future<Output = Result<IntegrityScheme, Error>> + Send;
+
+        /// Return length, scheme, tag, and validated unfinished bytes from one coherent state.
+        ///
+        /// This reads, retains, and validates the complete unfinished unit before returning.
+        /// Unbound and variable-width units can span the entire encoded payload and are not limited
+        /// by the publication-recovery suffix budget. Operations requiring the same coherent state
+        /// wait for this validation. Close units or use an appropriately bounded chunk width when
+        /// snapshot cost must be bounded.
+        fn integrity_snapshot(
+            &self,
+        ) -> impl std::future::Future<Output = Result<IntegritySnapshot, Error>> + Send;
+
+        /// Stage a tag only if `expected` still names the current immediately visible state.
+        fn compare_set_tag(
+            &self,
+            expected: IntegrityToken,
+            tag: [u8; ATOMIC_BLOB_TAG_LEN],
+        ) -> impl std::future::Future<Output = Result<IntegrityToken, Error>> + Send;
+
+        /// Append `data` and return its starting encoded payload offset.
+        ///
+        /// This continues the current integrity unit. On a blob already bound to a chunked scheme,
+        /// automatic unit boundaries can insert four-byte checksum footers between bytes from one
+        /// `data` argument. The returned offset names the first supplied byte, not necessarily a
+        /// contiguous `data.len()` range in the encoded stream.
+        ///
+        /// Empty appends succeed without changing the blob. After rewinding published bytes,
+        /// appends are rejected until the rewind is synchronized. Large epochs can start a
+        /// coalesced invisible payload preflush; filesystem append returns after that work is
+        /// admitted and publication waits for it before staging a root.
+        fn append(
+            &self,
+            data: impl Into<IoBufs> + Send,
+        ) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
+
+        /// Append `data` and stage `tag` as one in-memory mutation.
+        ///
+        /// The append has the same encoded-offset and integrity-unit behavior as [`Self::append`].
+        ///
+        /// The operation is linearized across this handle and its clones: a concurrent sync
+        /// observes both changes or neither change. A separate [`Self::set_tag`] and append does
+        /// not provide that compound guarantee.
+        fn append_tagged(
+            &self,
+            data: impl Into<IoBufs> + Send,
+            tag: [u8; ATOMIC_BLOB_TAG_LEN],
+        ) -> impl std::future::Future<Output = Result<u64, Error>> + Send;
+
+        /// Append bytes while maintaining protocol-owned integrity units.
+        ///
+        /// The returned offset addresses the first newly supplied byte in the encoded payload. The
+        /// protocol may insert four-byte checksum footers before later supplied bytes when
+        /// `boundary` closes one or more units. `tag`, when present, is staged atomically with the
+        /// append and integrity state. Empty data can still complete an existing non-empty unit. A
+        /// stale `expected` token is rejected before payload I/O. The returned token must name the
+        /// next coherent integrity or tag mutation.
+        fn append_integrity(
+            &self,
+            expected: IntegrityToken,
+            data: impl Into<IoBufs> + Send,
+            boundary: IntegrityBoundary,
+            tag: Option<[u8; ATOMIC_BLOB_TAG_LEN]>,
+        ) -> impl std::future::Future<Output = Result<IntegrityAppend, Error>> + Send;
+
+        /// Read and validate one complete integrity unit.
+        ///
+        /// The unit's checksum footer is consumed by the protocol and is not included in the
+        /// returned buffers.
+        fn read_integrity(
+            &self,
+            unit: IntegrityUnit,
+        ) -> impl std::future::Future<Output = Result<IoBufs, Error>> + Send;
+
+        /// Rewind to encoded payload length `len`, which cannot exceed the immediately visible
+        /// length or cut through protocol-owned integrity state. Use [`Self::rewind_integrity`]
+        /// when rewinding into an integrity unit requires a proof of its retained prefix.
+        fn rewind(
+            &self,
+            len: u64,
+        ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
+        /// Rewind to `len` and stage `tag` as one in-memory mutation.
+        ///
+        /// The operation is linearized across this handle and its clones: a concurrent sync
+        /// observes both changes or neither change. A separate [`Self::set_tag`] and rewind does
+        /// not provide that compound guarantee. The same integrity-boundary requirements as
+        /// [`Self::rewind`] apply.
+        fn rewind_tagged(
+            &self,
+            len: u64,
+            tag: [u8; ATOMIC_BLOB_TAG_LEN],
+        ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
+        /// Rewind the encoded payload while preserving protocol-owned integrity state.
+        ///
+        /// When `unit` is `Some`, it identifies the complete or current unit containing the new
+        /// end; the protocol validates that unit and stores the checksum of the retained prefix as
+        /// the new unfinished unit. Pass `None` only when `len` is already a completed-unit
+        /// boundary. `tag`, when present, is staged atomically with the rewind and rebuilt integrity
+        /// state. A stale `expected` token is rejected before payload I/O. The returned token must
+        /// name the next coherent integrity or tag mutation.
+        fn rewind_integrity(
+            &self,
+            expected: IntegrityToken,
+            len: u64,
+            unit: Option<IntegrityUnit>,
+            tag: Option<[u8; ATOMIC_BLOB_TAG_LEN]>,
+        ) -> impl std::future::Future<Output = Result<IntegrityToken, Error>> + Send;
+
+        /// Request atomic publication and durable persistence of all pending mutations.
+        ///
+        /// Awaiting this future waits until the task has acquired shared lineage and handle
+        /// ownership, drained this blob's payload preflush, and locked its state to freeze the
+        /// publication snapshot, or until the task has already completed. Mutations started after
+        /// this handoff are excluded from the snapshot. Awaiting the returned [`Handle`] waits for
+        /// the same durability guarantee as [`Self::sync`].
+        fn start_sync(&self) -> impl std::future::Future<Output = Handle<()>> + Send;
+
+        /// Atomically publish and durably persist all pending mutations.
+        ///
+        /// A pending suffix within the recovery bound uses one full-file durability operation; the
+        /// self-linked decision's independent final spelling is not synchronized separately.
+        /// Arbitrarily large append epochs establish earlier invisible durable prefixes, leaving
+        /// only a bounded suffix for publication recovery.
+        fn sync(&self) -> impl std::future::Future<Output = Result<(), Error>> + Send {
+            async move { self.start_sync().await.await }
+        }
+    }
+});
+
 stability_scope!(ALPHA {
     #[cfg(feature = "arbitrary")]
     pub mod conformance;

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -2,12 +2,13 @@
 
 use crate::{Error, Handle, IoBufs, IoBufsMut, WriteOptions, deterministic::BoxDynRng};
 use bytes::Buf;
-use commonware_utils::sync::{Mutex, RwLock};
+use commonware_utils::sync::{AsyncMutex, Mutex, RwLock};
 use rand::RngExt as _;
 use std::{
+    collections::BTreeMap,
     io::Error as IoError,
     sync::{
-        Arc,
+        Arc, OnceLock, Weak,
         atomic::{AtomicU64, Ordering},
     },
 };
@@ -24,6 +25,16 @@ enum Op {
     Scan,
 }
 
+/// Selects how retained bytes are arranged when a write is partially preserved.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PartialWriteMode {
+    /// Retain bytes from the beginning of the write until the first omitted byte.
+    Prefix,
+
+    /// Independently retain submitted byte positions.
+    Subset,
+}
+
 /// Configuration for deterministic storage fault injection.
 ///
 /// Each rate is a probability from 0.0 (never fail) to 1.0 (always fail).
@@ -38,11 +49,16 @@ pub struct Config {
     /// Failure rate for `write_at` operations.
     pub write_rate: Option<f64>,
 
-    /// Probability that a write failure is a partial write (some bytes written
-    /// before failure) rather than a complete failure (no bytes written).
-    /// Only applies when `write_rate` triggers a failure.
-    /// Value from 0.0 (always complete failure) to 1.0 (always partial write).
-    pub partial_write_rate: Option<f64>,
+    /// Byte-retention policy for failed writes and successful unsynchronized writes at a
+    /// simulated crash.
+    ///
+    /// The tuple contains the retention mode and frequency. `None`, `NaN`, and frequencies at or
+    /// below 0.0 retain no bytes, while frequencies at or above 1.0 retain every byte.
+    pub write_retention: Option<(PartialWriteMode, f64)>,
+
+    /// Probability that a successful unsynced resize survives a simulated crash.
+    /// Value from 0.0 (always lost) to 1.0 (always retained).
+    pub crash_resize_rate: Option<f64>,
 
     /// Failure rate for `sync` operations.
     pub sync_rate: Option<f64>,
@@ -96,9 +112,15 @@ impl Config {
         self
     }
 
-    /// Set the partial write rate (probability of partial vs complete write failure).
-    pub const fn partial_write(mut self, rate: f64) -> Self {
-        self.partial_write_rate = Some(rate);
+    /// Set the byte-retention policy for failed and unsynchronized writes.
+    pub const fn write_retention(mut self, mode: PartialWriteMode, frequency: f64) -> Self {
+        self.write_retention = Some((mode, frequency));
+        self
+    }
+
+    /// Set the probability that successful unsynced resizes survive a simulated crash.
+    pub const fn crash_resize(mut self, rate: f64) -> Self {
+        self.crash_resize_rate = Some(rate);
         self
     }
 
@@ -140,26 +162,199 @@ struct Oracle {
     config: Arc<RwLock<Config>>,
 }
 
+enum PendingMutation<B> {
+    Write {
+        generation: Arc<FileGeneration>,
+        blob: B,
+        offset: u64,
+        bufs: IoBufs,
+        retention: Arc<PendingWriteRetention>,
+        selection_offset: usize,
+    },
+    Resize {
+        generation: Arc<FileGeneration>,
+        blob: B,
+        len: u64,
+    },
+}
+
+/// Retention choices belong to the issued write and are shared by fragments created by later
+/// durability barriers.
+struct PendingWriteRetention {
+    policy: (PartialWriteMode, f64),
+    len: usize,
+    selected: OnceLock<Vec<bool>>,
+}
+
+impl PendingWriteRetention {
+    const fn new(policy: (PartialWriteMode, f64), len: usize) -> Self {
+        Self {
+            policy,
+            len,
+            selected: OnceLock::new(),
+        }
+    }
+}
+
+impl<B> PendingMutation<B> {
+    const fn generation(&self) -> &Arc<FileGeneration> {
+        match self {
+            Self::Write { generation, .. } | Self::Resize { generation, .. } => generation,
+        }
+    }
+}
+
+type PendingMutations<B> = Arc<Mutex<Vec<PendingMutation<B>>>>;
+type FileKey = (String, Vec<u8>);
+struct FileGeneration {
+    mutation: AsyncMutex<()>,
+}
+
+impl FileGeneration {
+    fn new() -> Self {
+        Self {
+            mutation: AsyncMutex::new(()),
+        }
+    }
+}
+
+// Every handle for one live file generation shares its durability cut and pending-mutation epoch.
+// Replacements receive a new generation object.
+type FileGenerations = Arc<Mutex<BTreeMap<FileKey, Weak<FileGeneration>>>>;
+
+fn clear_pending<B>(pending: &PendingMutations<B>, generation: &Arc<FileGeneration>) {
+    pending
+        .lock()
+        .retain(|mutation| !Arc::ptr_eq(mutation.generation(), generation));
+}
+
+/// Retire covered write debt and replay the durable range after any earlier resize debt.
+fn record_durable_range<B: Clone>(
+    pending: &PendingMutations<B>,
+    generation: &Arc<FileGeneration>,
+    blob: B,
+    offset: u64,
+    durable: IoBufs,
+) {
+    let len = durable.remaining() as u64;
+    if len == 0 {
+        return;
+    }
+    let end = offset
+        .checked_add(len)
+        .expect("submitted write range was validated before mutation");
+    let mut pending = pending.lock();
+    let mutations = std::mem::take(&mut *pending);
+    let mut retained = Vec::with_capacity(mutations.len() + 1);
+    let mut follows_resize = false;
+    for mutation in mutations {
+        if !Arc::ptr_eq(mutation.generation(), generation) {
+            retained.push(mutation);
+            continue;
+        }
+        let (write_generation, write_blob, write_offset, bufs, retention, selection_offset) =
+            match mutation {
+                PendingMutation::Write {
+                    generation,
+                    blob,
+                    offset,
+                    bufs,
+                    retention,
+                    selection_offset,
+                } => (generation, blob, offset, bufs, retention, selection_offset),
+                resize @ PendingMutation::Resize { .. } => {
+                    follows_resize = true;
+                    retained.push(resize);
+                    continue;
+                }
+            };
+        let write_len = bufs.remaining() as u64;
+        let write_end = write_offset
+            .checked_add(write_len)
+            .expect("pending write ranges are validated before recording");
+        let overlap_start = write_offset.max(offset);
+        let overlap_end = write_end.min(end);
+        if overlap_start >= overlap_end {
+            retained.push(PendingMutation::Write {
+                generation: write_generation,
+                blob: write_blob,
+                offset: write_offset,
+                bufs,
+                retention,
+                selection_offset,
+            });
+            continue;
+        }
+
+        let bytes = bufs.coalesce();
+        if write_offset < overlap_start {
+            let prefix_len = usize::try_from(overlap_start - write_offset)
+                .expect("a pending-write subrange fits its source buffer");
+            retained.push(PendingMutation::Write {
+                generation: write_generation.clone(),
+                blob: write_blob.clone(),
+                offset: write_offset,
+                bufs: bytes.slice(..prefix_len).into(),
+                retention: retention.clone(),
+                selection_offset,
+            });
+        }
+        if overlap_end < write_end {
+            let suffix_start = usize::try_from(overlap_end - write_offset)
+                .expect("a pending-write subrange fits its source buffer");
+            retained.push(PendingMutation::Write {
+                generation: write_generation,
+                blob: write_blob,
+                offset: overlap_end,
+                bufs: bytes.slice(suffix_start..).into(),
+                retention,
+                selection_offset: selection_offset
+                    .checked_add(suffix_start)
+                    .expect("a pending-write fragment stays within its selection"),
+            });
+        }
+    }
+    if follows_resize {
+        let retention = Arc::new(PendingWriteRetention::new(
+            (PartialWriteMode::Prefix, 1.0),
+            durable.remaining(),
+        ));
+        retained.push(PendingMutation::Write {
+            generation: generation.clone(),
+            blob,
+            offset,
+            bufs: durable,
+            retention,
+            selection_offset: 0,
+        });
+    }
+    *pending = retained;
+}
+
 impl Oracle {
     /// Check if a fault should be injected for the given operation.
     fn should_fail(&self, op: Op) -> bool {
         self.roll(Some(self.config.read().rate_for(op)))
     }
 
-    /// Check if a write fault should be injected. Returns (should_fail, partial_rate).
+    /// Check if a write fault should be injected.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_write_fault(&self) -> (bool, Option<f64>) {
+    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, f64)>) {
         let config = self.config.read();
         let fail = self.roll(Some(config.rate_for(Op::Write)));
-        (fail, config.partial_write_rate)
+        let retention = config
+            .write_retention
+            .filter(|(_, frequency)| *frequency > 0.0);
+        (fail, retention)
     }
 
-    /// Check if a resize fault should be injected. Returns (should_fail, partial_rate).
+    /// Check if a resize fault should be injected and snapshot its crash outcome.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_resize_fault(&self) -> (bool, Option<f64>) {
+    fn check_resize_fault(&self) -> (bool, Option<f64>, bool) {
         let config = self.config.read();
         let fail = self.roll(Some(config.rate_for(Op::Resize)));
-        (fail, config.partial_resize_rate)
+        let retain = !fail && self.roll(config.crash_resize_rate);
+        (fail, config.partial_resize_rate, retain)
     }
 
     /// Check if an event should occur based on a probability rate.
@@ -186,6 +381,25 @@ impl Oracle {
         Some(self.rng.lock().random_range(min + 1..max))
     }
 
+    /// Select retained byte positions according to a snapshotted write policy.
+    fn retained_bytes(&self, len: usize, (mode, frequency): (PartialWriteMode, f64)) -> Vec<bool> {
+        debug_assert!(frequency > 0.0);
+        if frequency >= 1.0 {
+            return vec![true; len];
+        }
+
+        let mut rng = self.rng.lock();
+        match mode {
+            PartialWriteMode::Prefix => {
+                let retained = (0..len).take_while(|_| rng.random_bool(frequency)).count();
+                let mut positions = vec![false; len];
+                positions[..retained].fill(true);
+                positions
+            }
+            PartialWriteMode::Subset => (0..len).map(|_| rng.random_bool(frequency)).collect(),
+        }
+    }
+
     /// Try to generate a partial operation target. Returns Some if both the rate
     /// check passes and an intermediate value exists between `from` and `to`.
     fn try_partial(&self, rate: Option<f64>, from: u64, to: u64) -> Option<u64> {
@@ -204,6 +418,8 @@ impl Oracle {
 pub struct Storage<S: crate::Storage> {
     inner: S,
     ctx: Oracle,
+    pending: PendingMutations<S::Blob>,
+    generations: FileGenerations,
 }
 
 impl<S: crate::Storage> Storage<S> {
@@ -212,6 +428,8 @@ impl<S: crate::Storage> Storage<S> {
         Self {
             inner,
             ctx: Oracle { rng, config },
+            pending: Arc::new(Mutex::new(Vec::new())),
+            generations: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
@@ -223,6 +441,90 @@ impl<S: crate::Storage> Storage<S> {
     /// Get access to the fault configuration for dynamic modification.
     pub fn config(&self) -> Arc<RwLock<Config>> {
         self.ctx.config.clone()
+    }
+
+    fn wrap_blob(&self, partition: &str, name: &[u8], inner: S::Blob, size: u64) -> Blob<S::Blob> {
+        let key = (partition.to_string(), name.to_vec());
+        let generation = {
+            let mut generations = self.generations.lock();
+            generations
+                .get(&key)
+                .and_then(Weak::upgrade)
+                .unwrap_or_else(|| {
+                    let generation = Arc::new(FileGeneration::new());
+                    generations.insert(key.clone(), Arc::downgrade(&generation));
+                    generation
+                })
+        };
+        Blob::new(
+            self.ctx.clone(),
+            self.pending.clone(),
+            generation,
+            inner,
+            size,
+        )
+    }
+
+    fn retire_names(&self, partition: &str, name: Option<&[u8]>) {
+        let retired = {
+            let mut generations = self.generations.lock();
+            match name {
+                Some(name) => generations
+                    .remove(&(partition.to_string(), name.to_vec()))
+                    .and_then(|generation| generation.upgrade())
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+                None => {
+                    let keys = generations
+                        .keys()
+                        .filter(|(candidate, _)| candidate == partition)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    keys.into_iter()
+                        .filter_map(|key| generations.remove(&key)?.upgrade())
+                        .collect()
+                }
+            }
+        };
+        for generation in retired {
+            clear_pending(&self.pending, &generation);
+        }
+    }
+}
+
+impl Storage<crate::storage::memory::Storage> {
+    /// Replay selected crash outcomes in issue order.
+    pub(crate) fn crash(&self) -> Result<(), Error> {
+        let pending = std::mem::take(&mut *self.pending.lock());
+        for mutation in pending {
+            match mutation {
+                PendingMutation::Write {
+                    blob,
+                    offset,
+                    bufs,
+                    retention,
+                    selection_offset,
+                    ..
+                } => {
+                    let selected = retention
+                        .selected
+                        .get_or_init(|| self.ctx.retained_bytes(retention.len, retention.policy));
+                    let selection_end = selection_offset
+                        .checked_add(bufs.remaining())
+                        .expect("a pending-write fragment stays within its selection");
+                    let mut retained = selected[selection_offset..selection_end].iter().copied();
+                    blob.retain_crash_write(offset, bufs, || {
+                        retained
+                            .next()
+                            .expect("the retention policy covers every submitted byte")
+                    })?;
+                }
+                PendingMutation::Resize { blob, len, .. } => {
+                    blob.retain_crash_resize(len)?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 
@@ -243,19 +545,22 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
         if self.ctx.should_fail(Op::Open) {
             return Err(injected_io_error().into());
         }
-        self.inner
-            .open_versioned(partition, name, versions)
-            .await
-            .map(|(blob, len, blob_version)| {
-                (Blob::new(self.ctx.clone(), blob, len), len, blob_version)
-            })
+        let (blob, len, blob_version) =
+            self.inner.open_versioned(partition, name, versions).await?;
+        Ok((
+            self.wrap_blob(partition, name, blob, len),
+            len,
+            blob_version,
+        ))
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         if self.ctx.should_fail(Op::Remove) {
             return Err(injected_io_error().into());
         }
-        self.inner.remove(partition, name).await
+        self.inner.remove(partition, name).await?;
+        self.retire_names(partition, name);
+        Ok(())
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
@@ -271,17 +576,64 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
 pub struct Blob<B: crate::Blob> {
     inner: B,
     ctx: Oracle,
+    pending: PendingMutations<B>,
+    generation: Arc<FileGeneration>,
     /// Tracked size for partial resize support.
     size: Arc<AtomicU64>,
 }
 
 impl<B: crate::Blob> Blob<B> {
-    fn new(ctx: Oracle, inner: B, size: u64) -> Self {
+    fn new(
+        ctx: Oracle,
+        pending: PendingMutations<B>,
+        generation: Arc<FileGeneration>,
+        inner: B,
+        size: u64,
+    ) -> Self {
         Self {
             inner,
             ctx,
+            pending,
+            generation,
             size: Arc::new(AtomicU64::new(size)),
         }
+    }
+
+    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: (PartialWriteMode, f64)) {
+        if bufs.is_empty() {
+            return;
+        }
+        let retention = Arc::new(PendingWriteRetention::new(retention, bufs.remaining()));
+        self.pending.lock().push(PendingMutation::Write {
+            generation: self.generation.clone(),
+            blob: self.inner.clone(),
+            offset,
+            bufs,
+            retention,
+            selection_offset: 0,
+        });
+    }
+
+    fn record_pending_resize(&self, len: u64) {
+        self.pending.lock().push(PendingMutation::Resize {
+            generation: self.generation.clone(),
+            blob: self.inner.clone(),
+            len,
+        });
+    }
+
+    fn clear_pending(&self) {
+        clear_pending(&self.pending, &self.generation);
+    }
+
+    fn record_durable_range(&self, offset: u64, bufs: IoBufs) {
+        record_durable_range(
+            &self.pending,
+            &self.generation,
+            self.inner.clone(),
+            offset,
+            bufs,
+        )
     }
 }
 
@@ -317,52 +669,92 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         if sync && total_bytes == 0 {
             return Ok(());
         }
-
-        let (should_fail, partial_rate) = self.ctx.check_write_fault();
+        offset
+            .checked_add(total_bytes)
+            .ok_or(Error::OffsetOverflow)?;
+        let (should_fail, write_retention) = self.ctx.check_write_fault();
+        let _mutation = self.generation.mutation.lock().await;
         if should_fail {
-            if let Some(bytes) = self.ctx.try_partial(partial_rate, 0, total_bytes) {
-                // Partial write: write some bytes, sync, then fail
-                let bufs = bufs.coalesce().slice(..bytes as usize);
-                self.inner.write_at(offset, bufs, options).await?;
-                if !sync {
-                    self.inner.sync().await?;
+            if let Some(retention) = write_retention {
+                let len = bufs.remaining();
+                let retained = self.ctx.retained_bytes(len, retention);
+                let bufs = bufs.coalesce();
+                let mut position = 0;
+                while position < len {
+                    if !retained[position] {
+                        position += 1;
+                        continue;
+                    }
+
+                    let start = position;
+                    while position < len && retained[position] {
+                        position += 1;
+                    }
+                    let end = position;
+                    let run_offset = offset
+                        .checked_add(start as u64)
+                        .ok_or(Error::OffsetOverflow)?;
+                    let run = bufs.slice(start..end);
+                    let durable = run.clone().into();
+                    self.inner
+                        .write_at(run_offset, run, options | WriteOptions::SYNC)
+                        .await?;
+                    self.record_durable_range(run_offset, durable);
+                    self.size.fetch_max(
+                        run_offset.saturating_add((end - start) as u64),
+                        Ordering::Relaxed,
+                    );
                 }
-                self.size
-                    .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
-                return Err(injected_io_error().into());
             }
             return Err(injected_io_error().into());
         }
 
         if sync && self.ctx.should_fail(Op::Sync) {
+            let pending = write_retention.map(|retention| (bufs.clone(), retention));
             self.inner
                 .write_at(offset, bufs, options.without(WriteOptions::SYNC))
                 .await?;
             self.size
                 .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
+            if let Some((bufs, retention)) = pending {
+                self.record_pending(offset, bufs, retention);
+            }
             return Err(injected_io_error().into());
         }
 
+        let pending = match (sync, write_retention) {
+            (false, Some(retention)) => Some((bufs.clone(), retention)),
+            _ => None,
+        };
+        let durable = sync.then(|| bufs.clone());
         self.inner.write_at(offset, bufs, options).await?;
         self.size
             .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
+        if let Some(durable) = durable {
+            self.record_durable_range(offset, durable);
+        } else if let Some((bufs, retention)) = pending {
+            self.record_pending(offset, bufs, retention);
+        }
         Ok(())
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {
-        let (should_fail, partial_rate) = self.ctx.check_resize_fault();
+        let (should_fail, partial_rate, retain) = self.ctx.check_resize_fault();
+        let _mutation = self.generation.mutation.lock().await;
         if should_fail {
             let current = self.size.load(Ordering::Relaxed);
             if let Some(len) = self.ctx.try_partial(partial_rate, current, len) {
-                // Partial resize: resize to an intermediate size, sync, then fail
                 self.inner.resize(len).await?;
-                self.inner.sync().await?;
+                self.record_pending_resize(len);
                 self.size.store(len, Ordering::Relaxed);
                 return Err(injected_io_error().into());
             }
             return Err(injected_io_error().into());
         }
         self.inner.resize(len).await?;
+        if retain {
+            self.record_pending_resize(len);
+        }
         self.size.store(len, Ordering::Relaxed);
         Ok(())
     }
@@ -371,14 +763,23 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         if self.ctx.should_fail(Op::Sync) {
             return Err(injected_io_error().into());
         }
-        self.inner.sync().await
+        let _mutation = self.generation.mutation.lock().await;
+        self.inner.sync().await?;
+        self.clear_pending();
+        Ok(())
     }
 
     async fn start_sync(&self) -> Handle<()> {
         if self.ctx.should_fail(Op::Sync) {
             return Handle::ready(Err(injected_io_error().into()));
         }
-        self.inner.start_sync().await
+        let _mutation = self.generation.mutation.lock().await;
+        // A completed backing sync ends the crash epoch even if its completion is never observed.
+        let result = self.inner.start_sync().await.await;
+        if result.is_ok() {
+            self.clear_pending();
+        }
+        Handle::ready(result)
     }
 }
 
@@ -390,7 +791,89 @@ mod tests {
         storage::{memory::Storage as MemStorage, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
+    use futures::task::noop_waker;
     use rand::{SeedableRng, rngs::StdRng};
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::atomic::AtomicBool,
+        task::{Context, Poll},
+    };
+
+    #[derive(Clone)]
+    struct OperationGate<B> {
+        inner: B,
+        pause_after_write: bool,
+        armed: Arc<AtomicBool>,
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl<B> OperationGate<B> {
+        async fn pause(&self, after_write: bool) {
+            if self.pause_after_write == after_write && self.armed.swap(false, Ordering::Relaxed) {
+                self.started.notify_one();
+                self.release.notified().await;
+            }
+        }
+    }
+
+    impl<B: crate::Blob> crate::Blob for OperationGate<B> {
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            bufs: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, bufs).await
+        }
+
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn write_at(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+            options: WriteOptions,
+        ) -> Result<(), Error> {
+            self.inner.write_at(offset, bufs, options).await?;
+            self.pause(true).await;
+            Ok(())
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await?;
+            self.pause(false).await;
+            Ok(())
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            let inner = self.inner.clone();
+            let pause_after_write = self.pause_after_write;
+            let armed = self.armed.clone();
+            let started = self.started.clone();
+            let release = self.release.clone();
+            Handle::from_future(async move {
+                inner.sync().await?;
+                if !pause_after_write && armed.swap(false, Ordering::Relaxed) {
+                    started.notify_one();
+                    release.notified().await;
+                }
+                Ok(())
+            })
+        }
+    }
+
+    fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+        let waker = noop_waker();
+        future.poll(&mut Context::from_waker(&waker))
+    }
 
     fn test_pool() -> BufferPool {
         let mut registry = Registry::default();
@@ -424,10 +907,568 @@ mod tests {
         }
     }
 
+    async fn run_overlapping_barrier(start: bool) {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
+        inner
+            .write_at(0, b"base", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let gated = OperationGate {
+            inner,
+            pause_after_write: false,
+            armed: Arc::new(AtomicBool::new(true)),
+            started: started.clone(),
+            release: release.clone(),
+        };
+        let pending = Arc::new(Mutex::new(Vec::new()));
+        let blob = Blob::new(
+            h.storage.ctx.clone(),
+            pending.clone(),
+            Arc::new(FileGeneration::new()),
+            gated,
+            4,
+        );
+
+        let barrier_blob = blob.clone();
+        let barrier = tokio::spawn(async move {
+            if start {
+                drop(barrier_blob.start_sync().await);
+            } else {
+                barrier_blob.sync().await.unwrap();
+            }
+        });
+        started.notified().await;
+
+        let mut late = Box::pin(blob.write_at(0, b"late", WriteOptions::default()));
+        assert!(poll_once(late.as_mut()).is_pending());
+        release.notify_one();
+        barrier.await.unwrap();
+        late.await.unwrap();
+
+        for mutation in std::mem::take(&mut *pending.lock()) {
+            let PendingMutation::Write {
+                blob,
+                offset,
+                bufs,
+                retention,
+                ..
+            } = mutation
+            else {
+                panic!("write test recorded a resize");
+            };
+            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+            blob.inner
+                .retain_crash_write(offset, bufs, || true)
+                .unwrap();
+        }
+        let (durable, len) = h.inner.open("partition", b"overlap").await.unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(durable.read_at(0, 4).await.unwrap().coalesce(), b"late");
+    }
+
+    #[tokio::test]
+    async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
+        inner
+            .write_at(0, b"base!", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let gated = OperationGate {
+            inner,
+            pause_after_write: true,
+            armed: Arc::new(AtomicBool::new(true)),
+            started: started.clone(),
+            release: release.clone(),
+        };
+        let pending = Arc::new(Mutex::new(Vec::new()));
+        let blob = Blob::new(
+            h.storage.ctx.clone(),
+            pending.clone(),
+            Arc::new(FileGeneration::new()),
+            gated,
+            5,
+        );
+
+        let mut stale = Box::pin(blob.write_at(0, b"stale", WriteOptions::default()));
+        assert!(poll_once(stale.as_mut()).is_pending());
+        started.notified().await;
+
+        *h.config.write() = Config::default();
+        let fresh_blob = blob.clone();
+        let mut fresh = Box::pin(async move {
+            fresh_blob
+                .write_at(0, b"fresh", WriteOptions::default())
+                .await?;
+            fresh_blob.sync().await
+        });
+        assert!(poll_once(fresh.as_mut()).is_pending());
+
+        release.notify_one();
+        stale.await.unwrap();
+        fresh.await.unwrap();
+
+        for mutation in std::mem::take(&mut *pending.lock()) {
+            let PendingMutation::Write {
+                blob,
+                offset,
+                bufs,
+                retention,
+                ..
+            } = mutation
+            else {
+                panic!("write test recorded a resize");
+            };
+            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+            blob.inner
+                .retain_crash_write(offset, bufs, || true)
+                .unwrap();
+        }
+        let (durable, len) = h.inner.open("partition", b"late-record").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(durable.read_at(0, 5).await.unwrap().coalesce(), b"fresh");
+    }
+
+    async fn run_subset_overwrite(seed: u64, original: &[u8], replacement: &[u8]) -> Vec<u8> {
+        assert_eq!(original.len(), replacement.len());
+
+        let h = Harness::with_seed(
+            seed,
+            Config::default().write_retention(PartialWriteMode::Subset, 0.5),
+        );
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, original.to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+
+        {
+            let mut config = h.config.write();
+            config.write_rate = Some(1.0);
+        }
+
+        let result = blob
+            .write_at(0, replacement.to_vec(), WriteOptions::default())
+            .await;
+        assert!(matches!(result, Err(Error::Io(_))));
+
+        let (inner_blob, size) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(size, original.len() as u64);
+        inner_blob
+            .read_at(0, original.len())
+            .await
+            .unwrap()
+            .coalesce()
+            .as_ref()
+            .to_vec()
+    }
+
+    async fn run_random_crash(seed: u64, len: usize) -> Vec<u8> {
+        let h = Harness::with_seed(
+            seed,
+            Config::default().write_retention(PartialWriteMode::Subset, 0.5),
+        );
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, vec![0; len], WriteOptions::SYNC)
+            .await
+            .unwrap();
+        blob.write_at(0, vec![1; len], WriteOptions::default())
+            .await
+            .unwrap();
+
+        // The retention policy is part of the completed write, not a global crash-time choice.
+        h.config.write().write_retention = None;
+        h.storage.crash().unwrap();
+
+        let (blob, durable_len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable_len, len as u64);
+        blob.read_at(0, len)
+            .await
+            .unwrap()
+            .coalesce()
+            .as_ref()
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn test_reopened_sync_clears_prior_handle_crash_writes() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"stale", WriteOptions::default())
+            .await
+            .unwrap();
+        drop(blob);
+
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"fresh", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+        drop(blob);
+
+        h.storage.crash().unwrap();
+        let (blob, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(
+            blob.read_at(0, 5).await.unwrap().coalesce().as_ref(),
+            b"fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"stale", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_retention = None;
+        blob.write_at(0, b"fresh", WriteOptions::default())
+            .await
+            .unwrap();
+
+        let completion = blob.start_sync().await;
+        drop(completion);
+        h.storage.crash().unwrap();
+
+        let (blob, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(
+            blob.read_at(0, 5).await.unwrap().coalesce().as_ref(),
+            b"fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"........", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        blob.write_at(0, b"A", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.write_at(7, b"Z", WriteOptions::SYNC).await.unwrap();
+        h.storage.crash().unwrap();
+
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 8);
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"A......Z");
+    }
+
+    #[tokio::test]
+    async fn test_sync_write_retires_only_overlapping_pending_bytes() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        let (other, _) = h.storage.open("partition", b"other").await.unwrap();
+        for candidate in [&blob, &other] {
+            candidate
+                .write_at(0, b"........", WriteOptions::SYNC)
+                .await
+                .unwrap();
+        }
+
+        blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+            .await
+            .unwrap();
+        other
+            .write_at(0, b"12345678", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.write_at(3, b"xy", WriteOptions::SYNC).await.unwrap();
+        h.storage.crash().unwrap();
+
+        let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"ABCxyFGH");
+        let (durable, _) = h.inner.open("partition", b"other").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"12345678");
+    }
+
+    #[tokio::test]
+    async fn test_range_sync_preserves_prefix_retention_across_pending_fragments() {
+        for seed in 0..64 {
+            let h = Harness::with_seed(
+                seed,
+                Config::default().write_retention(PartialWriteMode::Prefix, 0.5),
+            );
+            let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+            blob.write_at(0, b"........", WriteOptions::SYNC)
+                .await
+                .unwrap();
+            blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+                .await
+                .unwrap();
+            blob.write_at(3, b"xy", WriteOptions::SYNC).await.unwrap();
+
+            h.storage.crash().unwrap();
+            let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+            let durable = durable.read_at(0, 8).await.unwrap().coalesce();
+            if durable.as_ref()[..3].contains(&b'.') {
+                assert_eq!(&durable.as_ref()[5..], b"...");
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_crash_replays_writes_and_resizes_in_issue_order() {
+        let h = Harness::new(
+            Config::default()
+                .write_retention(PartialWriteMode::Prefix, 1.0)
+                .crash_resize(1.0),
+        );
+        let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
+        write_then_resize
+            .write_at(0, b"abcdef", WriteOptions::default())
+            .await
+            .unwrap();
+        write_then_resize.resize(3).await.unwrap();
+        write_then_resize.resize(5).await.unwrap();
+
+        let (resize_then_write, _) = h.storage.open("partition", b"second").await.unwrap();
+        resize_then_write
+            .write_at(0, b"abcdef", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        resize_then_write.resize(3).await.unwrap();
+        resize_then_write
+            .write_at(5, b"X", WriteOptions::default())
+            .await
+            .unwrap();
+
+        h.storage.crash().unwrap();
+
+        let (first, len) = h.inner.open("partition", b"first").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(first.read_at(0, 5).await.unwrap().coalesce(), b"abc\0\0");
+        let (second, len) = h.inner.open("partition", b"second").await.unwrap();
+        assert_eq!(len, 6);
+        assert_eq!(second.read_at(0, 6).await.unwrap().coalesce(), b"abc\0\0X");
+    }
+
+    #[tokio::test]
+    async fn test_partial_sync_write_replays_after_retained_resize() {
+        let h = Harness::new(Config::default().crash_resize(1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        blob.resize(3).await.unwrap();
+        {
+            let mut config = h.config.write();
+            config.write_rate = Some(1.0);
+            config.write_retention = Some((PartialWriteMode::Subset, 0.5));
+        }
+
+        assert!(blob.write_at(6, b"WXYZ", WriteOptions::SYNC).await.is_err());
+        let (before, _) = h.inner.open("partition", b"test").await.unwrap();
+        let before = before.read_at(0, 10).await.unwrap().coalesce();
+        let mut expected = b"abc".to_vec();
+        for (index, replacement) in b"WXYZ".iter().copied().enumerate() {
+            let index = index + 6;
+            if before.as_ref()[index] != replacement {
+                continue;
+            }
+            expected.resize(index + 1, 0);
+            expected[index] = replacement;
+        }
+        assert!(expected.len() > 3);
+
+        h.storage.crash().unwrap();
+
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, expected.len() as u64);
+        assert_eq!(
+            durable
+                .read_at(0, expected.len())
+                .await
+                .unwrap()
+                .coalesce()
+                .as_ref(),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn test_preissued_sync_write_survives_failed_partial_resize() {
+        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let resize_blob = blob.clone();
+        let (resize, write) = tokio::join!(biased;
+            resize_blob.resize(0),
+            blob.write_at(10, b"X", WriteOptions::SYNC),
+        );
+        assert!(resize.is_err());
+        write.unwrap();
+
+        let retained_len = h
+            .storage
+            .pending
+            .lock()
+            .iter()
+            .find_map(|mutation| match mutation {
+                PendingMutation::Resize { len, .. } => Some(*len),
+                PendingMutation::Write { .. } => None,
+            })
+            .unwrap();
+        h.storage.crash().unwrap();
+
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 11);
+        let mut expected = b"abcdefghij".to_vec();
+        expected.truncate(retained_len as usize);
+        expected.resize(10, 0);
+        expected.push(b'X');
+        assert_eq!(
+            durable.read_at(0, 11).await.unwrap().coalesce().as_ref(),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partial_sync_write_retires_each_persisted_range() {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+            let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+            blob.write_at(0, b"........", WriteOptions::SYNC)
+                .await
+                .unwrap();
+            blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+                .await
+                .unwrap();
+            {
+                let mut config = h.config.write();
+                config.write_rate = Some(1.0);
+                config.write_retention = Some((partial_write_mode, 0.5));
+            }
+
+            assert!(blob.write_at(2, b"wxyz", WriteOptions::SYNC).await.is_err());
+            let (before, _) = h.inner.open("partition", b"test").await.unwrap();
+            let before = before.read_at(0, 8).await.unwrap().coalesce();
+            h.storage.crash().unwrap();
+            let (after, _) = h.inner.open("partition", b"test").await.unwrap();
+            let after = after.read_at(0, 8).await.unwrap().coalesce();
+            for (index, (&before, &after)) in before
+                .as_ref()
+                .iter()
+                .zip(after.as_ref().iter())
+                .enumerate()
+            {
+                let expected = if before == b'.' {
+                    b'A' + index as u8
+                } else {
+                    before
+                };
+                assert_eq!(
+                    after, expected,
+                    "mode={partial_write_mode:?}, index={index}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_full_sync_epoch_is_linearized_with_overlapping_write() {
+        run_overlapping_barrier(false).await;
+    }
+
+    #[tokio::test]
+    async fn test_dropped_start_sync_epoch_is_linearized_with_overlapping_write() {
+        run_overlapping_barrier(true).await;
+    }
+
     #[tokio::test]
     async fn test_faulty_storage_no_faults() {
         let h = Harness::new(Config::default());
         run_storage_tests(h.storage).await;
+    }
+
+    #[test]
+    fn test_write_retention_frequency_upper_bound() {
+        let h = Harness::new(Config::default());
+        for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            for frequency in [1.0, 2.0, f64::INFINITY] {
+                assert_eq!(
+                    h.storage.ctx.retained_bytes(4, (mode, frequency)),
+                    [true; 4]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_prefix_retention_stops_after_the_first_omission() {
+        for seed in 0..64 {
+            let h = Harness::with_seed(seed, Config::default());
+            let retained = h
+                .storage
+                .ctx
+                .retained_bytes(64, (PartialWriteMode::Prefix, 0.5));
+            let mut omitted = false;
+            for keep in retained {
+                if omitted {
+                    assert!(!keep);
+                } else if !keep {
+                    omitted = true;
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_faulty_open_can_fail() {
+        let h = Harness::new(Config::default().open(1.0));
+        assert!(matches!(
+            h.storage.open("partition", b"blob").await,
+            Err(Error::Io(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_write_rejects_offset_overflow_before_retention() {
+        let h = Harness::new(
+            Config::default()
+                .write(1.0)
+                .write_retention(PartialWriteMode::Subset, 0.5),
+        );
+        let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
+        assert!(matches!(
+            blob.write_at(u64::MAX, vec![1, 2], WriteOptions::default())
+                .await,
+            Err(Error::OffsetOverflow)
+        ));
+        let (_, len) = h.inner.open("partition", b"blob").await.unwrap();
+        assert_eq!(len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_failed_write_can_retain_every_byte() {
+        let h = Harness::new(
+            Config::default()
+                .write(1.0)
+                .write_retention(PartialWriteMode::Prefix, 1.0),
+        );
+        let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
+
+        assert!(matches!(
+            blob.write_at(0, b"x", WriteOptions::default()).await,
+            Err(Error::Io(_))
+        ));
+        let (durable, len) = h.inner.open("partition", b"blob").await.unwrap();
+        assert_eq!(len, 1);
+        assert_eq!(durable.read_at(0, 1).await.unwrap().coalesce(), b"x");
     }
 
     #[tokio::test]
@@ -444,7 +1485,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_start_sync_always_fails() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(
+            Config::default()
+                .write_retention(PartialWriteMode::Prefix, 1.0)
+                .sync(1.0),
+        );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -453,6 +1498,7 @@ mod tests {
 
         let result = blob.start_sync().await.await;
         assert!(matches!(result, Err(Error::Io(_))));
+        assert_eq!(h.storage.pending.lock().len(), 1);
     }
 
     #[tokio::test]
@@ -510,6 +1556,16 @@ mod tests {
 
         let (_reopened, size) = h.inner.open("partition", b"test").await.unwrap();
         assert_eq!(size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_empty_unsynced_write_does_not_create_crash_debt() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, Vec::<u8>::new(), WriteOptions::default())
+            .await
+            .unwrap();
+        assert!(h.storage.pending.lock().is_empty());
     }
 
     #[tokio::test]
@@ -630,8 +1686,201 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_partial_write() {
-        let h = Harness::new(Config::default().write(1.0).partial_write(1.0));
+    async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"........", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        blob.write_at(0, b"AB", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_retention = None;
+        blob.write_at(2, b"CD", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_retention = Some((PartialWriteMode::Prefix, 1.0));
+        blob.write_at(1, b"XY", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_retention = None;
+
+        h.storage.crash().unwrap();
+        let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"AXY.....");
+
+        durable.write_at(0, b"Q", WriteOptions::SYNC).await.unwrap();
+        h.storage.crash().unwrap();
+        let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"QXY.....");
+    }
+
+    #[tokio::test]
+    async fn test_random_crash_write_is_deterministic_and_inclusive() {
+        let first = run_random_crash(12345, 64).await;
+        let second = run_random_crash(12345, 64).await;
+        let different = run_random_crash(54321, 64).await;
+        assert_eq!(first, second);
+        assert_ne!(first, different);
+        assert!(first.contains(&0));
+        assert!(first.contains(&1));
+
+        let mut saw_empty = false;
+        let mut saw_full = false;
+        for seed in 0..64 {
+            match run_random_crash(seed, 1).await.as_slice() {
+                [0] => saw_empty = true,
+                [1] => saw_full = true,
+                other => panic!("unexpected one-byte crash result: {other:?}"),
+            }
+        }
+        assert!(saw_empty && saw_full);
+    }
+
+    #[tokio::test]
+    async fn failed_partial_write_does_not_barrier_prior_crash_writes() {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            let mut saw_old = false;
+            let mut saw_new = false;
+            for seed in 0..64 {
+                let h = Harness::with_seed(
+                    seed,
+                    Config::default().write_retention(PartialWriteMode::Subset, 0.5),
+                );
+                let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+                blob.write_at(0, b"......", WriteOptions::SYNC)
+                    .await
+                    .unwrap();
+                blob.write_at(0, b"AAAA", WriteOptions::default())
+                    .await
+                    .unwrap();
+                {
+                    let mut config = h.config.write();
+                    config.write_rate = Some(1.0);
+                    config.write_retention = Some((partial_write_mode, 0.5));
+                }
+
+                assert!(
+                    blob.write_at(4, b"XY", WriteOptions::default())
+                        .await
+                        .is_err()
+                );
+                h.storage.crash().unwrap();
+
+                let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+                let durable = durable.read_at(0, 4).await.unwrap().coalesce();
+                saw_old |= durable.as_ref().contains(&b'.');
+                saw_new |= durable.as_ref().contains(&b'A');
+            }
+            assert!(saw_old && saw_new);
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_partial_resize_does_not_barrier_prior_crash_writes() {
+        let mut saw_old = false;
+        let mut saw_new = false;
+        for seed in 0..64 {
+            let h = Harness::with_seed(
+                seed,
+                Config::default().write_retention(PartialWriteMode::Subset, 0.5),
+            );
+            let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+            blob.write_at(0, b"......", WriteOptions::SYNC)
+                .await
+                .unwrap();
+            blob.write_at(0, b"AAAA", WriteOptions::default())
+                .await
+                .unwrap();
+            {
+                let mut config = h.config.write();
+                config.resize_rate = Some(1.0);
+                config.partial_resize_rate = Some(1.0);
+            }
+
+            assert!(blob.resize(8).await.is_err());
+            h.storage.crash().unwrap();
+
+            let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+            assert_eq!(len, 7);
+            let durable = durable.read_at(0, 4).await.unwrap().coalesce();
+            saw_old |= durable.as_ref().contains(&b'.');
+            saw_new |= durable.as_ref().contains(&b'A');
+        }
+        assert!(saw_old && saw_new);
+    }
+
+    #[tokio::test]
+    async fn test_crash_journal_clears_only_after_completed_durability() {
+        let h = Harness::new(Config::default().write_retention(PartialWriteMode::Prefix, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+
+        blob.write_at(0, b"a", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        h.config.write().sync_rate = Some(1.0);
+        assert!(matches!(blob.sync().await, Err(Error::Io(_))));
+        assert_eq!(h.storage.pending.lock().len(), 1);
+
+        h.config.write().sync_rate = None;
+        blob.sync().await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+
+        let (other, _) = h.storage.open("partition", b"other").await.unwrap();
+        blob.write_at(0, b"b", WriteOptions::default())
+            .await
+            .unwrap();
+        other
+            .write_at(0, b"x", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 2);
+        blob.sync().await.unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        other.sync().await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+
+        blob.write_at(0, b"b", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        blob.start_sync().await.await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+
+        blob.write_at(0, b"c", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        blob.write_at(0, b"d", WriteOptions::SYNC).await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_sync_failure_journals_the_successful_inner_write() {
+        let h = Harness::new(
+            Config::default()
+                .write_retention(PartialWriteMode::Prefix, 1.0)
+                .sync(1.0),
+        );
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        assert!(matches!(
+            blob.write_at(0, b"data", WriteOptions::SYNC).await,
+            Err(Error::Io(_))
+        ));
+        assert_eq!(h.storage.pending.lock().len(), 1);
+
+        h.storage.crash().unwrap();
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(durable.read_at(0, 4).await.unwrap().coalesce(), b"data");
+    }
+
+    #[tokio::test]
+    async fn test_faulty_storage_write_retention_defaults_to_none() {
+        let h = Harness::new(Config::default().write(1.0));
+        assert_eq!(h.config.read().write_retention, None);
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let data = b"hello world".to_vec();
@@ -641,49 +1890,90 @@ mod tests {
 
         assert!(matches!(result, Err(Error::Io(_))));
 
-        let (inner_blob, size) = h.inner.open("partition", b"test").await.unwrap();
-        let bytes_written = size as usize;
-        assert!(
-            bytes_written > 0 && bytes_written < data.len(),
-            "Expected partial write: {bytes_written} bytes out of {}",
-            data.len()
-        );
-
-        let read_result = inner_blob.read_at(0, bytes_written).await.unwrap();
-        assert_eq!(read_result.coalesce().as_ref(), &data[..bytes_written]);
+        let (_, size) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(size, 0);
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_partial_write_disabled() {
-        let h = Harness::new(Config::default().write(1.0).partial_write(0.0));
+    async fn test_faulty_storage_partial_write_subset_can_be_non_prefix() {
+        let original = b"abcdefghijklmnop";
+        let replacement = b"ABCDEFGHIJKLMNOP";
+        let observed = run_subset_overwrite(42, original, replacement).await;
 
-        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
-        let result = blob
-            .write_at(0, b"hello world".to_vec(), WriteOptions::default())
-            .await;
+        let retained: Vec<_> = observed
+            .iter()
+            .zip(original)
+            .zip(replacement)
+            .map(|((&actual, &old), &new)| {
+                assert!(actual == old || actual == new);
+                actual == new
+            })
+            .collect();
+        assert!(retained.iter().any(|&keep| keep));
+        assert!(retained.iter().any(|&keep| !keep));
 
-        assert!(matches!(result, Err(Error::Io(_))));
-
-        let (_, size) = h.inner.open("partition", b"test").await.unwrap();
-        assert_eq!(
-            size, 0,
-            "Expected no bytes written when partial_write_rate is 0"
-        );
+        let mut omitted = false;
+        let non_prefix = retained.into_iter().any(|keep| {
+            if keep {
+                omitted
+            } else {
+                omitted = true;
+                false
+            }
+        });
+        assert!(non_prefix, "expected a retained byte after an omitted byte");
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_partial_write_single_byte() {
-        let h = Harness::new(Config::default().write(1.0).partial_write(1.0));
+    async fn test_faulty_storage_write_retention_frequency_edges() {
+        for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            for (frequency, expected) in [
+                (0.0, b"old".as_slice()),
+                (f64::NAN, b"old".as_slice()),
+                (1.0, b"new".as_slice()),
+            ] {
+                let failed = Harness::new(
+                    Config::default()
+                        .write(1.0)
+                        .write_retention(mode, frequency),
+                );
+                let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
+                blob.write_at(0, b"new", WriteOptions::SYNC)
+                    .await
+                    .unwrap_err();
+                let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
+                if frequency >= 1.0 {
+                    assert_eq!(len, 3);
+                    assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
+                } else {
+                    assert_eq!(len, 0);
+                }
 
-        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
-        let result = blob
-            .write_at(0, b"x".to_vec(), WriteOptions::default())
-            .await;
+                let crashed = Harness::new(Config::default().write_retention(mode, frequency));
+                let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();
+                blob.write_at(0, b"old", WriteOptions::SYNC).await.unwrap();
+                blob.write_at(0, b"new", WriteOptions::default())
+                    .await
+                    .unwrap();
+                crashed.storage.crash().unwrap();
+                let (durable, len) = crashed.inner.open("partition", b"crashed").await.unwrap();
+                assert_eq!(len, 3);
+                assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
+            }
+        }
+    }
 
-        assert!(matches!(result, Err(Error::Io(_))));
+    #[tokio::test]
+    async fn test_faulty_storage_partial_write_subset_same_seed_is_deterministic() {
+        let original = vec![0x11; 64];
+        let replacement = vec![0xAA; 64];
 
-        let (_, size) = h.inner.open("partition", b"test").await.unwrap();
-        assert_eq!(size, 0, "No partial write possible for single byte");
+        let first = run_subset_overwrite(12345, &original, &replacement).await;
+        let second = run_subset_overwrite(12345, &original, &replacement).await;
+
+        assert_eq!(first, second);
+        assert!(first.contains(&0x11));
+        assert!(first.contains(&0xAA));
     }
 
     #[tokio::test]
@@ -697,6 +1987,7 @@ mod tests {
         let result = blob.resize(target_size).await;
 
         assert!(matches!(result, Err(Error::Io(_))));
+        h.storage.crash().unwrap();
 
         let (_, actual_size) = h.inner.open("partition", b"test").await.unwrap();
         assert!(
@@ -723,6 +2014,7 @@ mod tests {
         let result = blob.resize(target_size).await;
 
         assert!(matches!(result, Err(Error::Io(_))));
+        h.storage.crash().unwrap();
 
         let (_, actual_size) = h.inner.open("partition", b"test").await.unwrap();
         assert!(
@@ -782,6 +2074,7 @@ mod tests {
         let result = blob.resize(target_size).await;
 
         assert!(matches!(result, Err(Error::Io(_))));
+        h.storage.crash().unwrap();
 
         let (_, actual_size) = h.inner.open("partition", b"test").await.unwrap();
         assert!(

--- a/runtime/src/storage/header.rs
+++ b/runtime/src/storage/header.rs
@@ -462,6 +462,25 @@ stability_scope!(BETA {
 
         Err(err.into_error(partition, name))
     }
+
+    /// Reject a resolved ordinary container that cannot back atomic storage in place.
+    ///
+    /// Legacy layouts remain supported through ordinary [`crate::Storage`], but atomic recovery
+    /// must never reinterpret their logical payload as its own identity and root region.
+    pub(crate) fn require_atomic_layout(
+        data_offset: u64,
+        partition: &str,
+        name: &[u8],
+    ) -> Result<(), crate::Error> {
+        if data_offset != Layout::V1.data_offset() {
+            return Err(crate::Error::BlobCorrupt(
+                partition.into(),
+                hex(name),
+                "expected V1 header layout".into(),
+            ));
+        }
+        Ok(())
+    }
 });
 
 #[cfg(feature = "arbitrary")]
@@ -496,6 +515,27 @@ pub(crate) mod tests {
         let mut raw = v0_header(blob_version).encode().to_vec();
         raw.extend_from_slice(payload);
         raw
+    }
+
+    /// A V0 blob whose payload begins with a complete fresh atomic prefix.
+    pub(crate) fn v0_atomic_lookalike_bytes() -> Vec<u8> {
+        const INCARNATION: [u8; 16] = [0x11; 16];
+        const IDENTITY_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_INCARNATION";
+
+        let mut payload = vec![0; crate::atomic::DATA_OFFSET as usize];
+        payload[..7].copy_from_slice(b"CWUNOID");
+        payload[7] = 1;
+        payload[8..24].copy_from_slice(&INCARNATION);
+        let mut checksum_input = IDENTITY_DOMAIN.to_vec();
+        checksum_input.extend_from_slice(&payload[..24]);
+        let checksum = commonware_cryptography::Crc32::checksum(&checksum_input);
+        payload[24..28].copy_from_slice(&checksum.to_be_bytes());
+        let identity = payload[..crate::atomic::IDENTITY_PAGE_LEN as usize]
+            .try_into()
+            .unwrap();
+        assert_eq!(crate::atomic::decode_identity(identity), Some(INCARNATION));
+        payload.extend_from_slice(b"ordinary tail");
+        v0_blob_bytes(crate::DEFAULT_BLOB_VERSION, &payload)
     }
 
     /// Raw bytes of a V1 blob with the given version, followed by `payload`.

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -15,19 +15,71 @@ fn resolve_header(
     super::header::resolve(raw, content.len() as u64, versions, partition, name)
 }
 
+type BlobKey = (String, Vec<u8>);
+type Partition = BTreeMap<Vec<u8>, Vec<u8>>;
+
+/// Durable contents detached from all live storage and blob handles.
+pub(crate) struct Snapshot(BTreeMap<String, Partition>);
+
+#[derive(Default)]
+struct Generations {
+    next: u64,
+    current: BTreeMap<BlobKey, u64>,
+}
+
+impl Generations {
+    fn get_or_insert(&mut self, key: &BlobKey) -> u64 {
+        if let Some(generation) = self.current.get(key) {
+            return *generation;
+        }
+        self.rotate(key)
+    }
+
+    fn rotate(&mut self, key: &BlobKey) -> u64 {
+        let generation = self.next;
+        self.next = self.next.checked_add(1).expect("blob generation overflow");
+        self.current.insert(key.clone(), generation);
+        generation
+    }
+
+    fn remove_partition(&mut self, partition: &str) {
+        self.current
+            .retain(|(current_partition, _), _| current_partition != partition);
+    }
+}
+
 /// In-memory storage implementation for the commonware runtime.
 #[derive(Clone)]
 pub struct Storage {
     partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
+    generations: Arc<Mutex<Generations>>,
     pool: BufferPool,
 }
 
 impl Storage {
     pub fn new(pool: BufferPool) -> Self {
+        Self::with_partitions(BTreeMap::new(), pool)
+    }
+
+    fn with_partitions(partitions: BTreeMap<String, Partition>, pool: BufferPool) -> Self {
         Self {
-            partitions: Arc::new(Mutex::new(BTreeMap::new())),
+            partitions: Arc::new(Mutex::new(partitions)),
+            generations: Arc::new(Mutex::new(Generations::default())),
             pool,
         }
+    }
+
+    /// Transfer durable contents and retire every live blob generation.
+    pub(crate) fn take_snapshot(&self) -> Snapshot {
+        let mut generations = self.generations.lock();
+        generations.current.clear();
+        let mut partitions = self.partitions.lock();
+        Snapshot(std::mem::take(&mut *partitions))
+    }
+
+    /// Rebuild storage from detached durable contents.
+    pub(crate) fn from_snapshot(snapshot: Snapshot, pool: BufferPool) -> Self {
+        Self::with_partitions(snapshot.0, pool)
     }
 }
 
@@ -64,6 +116,8 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, u16), crate::Error> {
         super::validate_partition_name(partition)?;
 
+        let key = (partition.to_string(), name.to_vec());
+        let mut generations = self.generations.lock();
         let mut partitions = self.partitions.lock();
         let partition_entry = partitions.entry(partition.into()).or_default();
         let content = partition_entry.entry(name.into()).or_default();
@@ -71,22 +125,31 @@ impl crate::Storage for Storage {
         // Handle header: existing blobs have their header read; new blobs and blobs left torn
         // by an interrupted creation get a fresh header written.
         let existing = resolve_header(content, &versions, partition, name)?;
-        let (logical_size, blob_version, data_offset) = existing.unwrap_or_else(|| {
-            let (region, blob_version) = Header::create(&versions);
-            let data_offset = region.len() as u64;
-            content.clear();
-            content.extend_from_slice(&region);
-            (0, blob_version, data_offset)
-        });
+        let (logical_size, blob_version, data_offset, generation) = match existing {
+            Some((logical_size, blob_version, data_offset)) => (
+                logical_size,
+                blob_version,
+                data_offset,
+                generations.get_or_insert(&key),
+            ),
+            None => {
+                let (region, blob_version) = Header::create(&versions);
+                let data_offset = region.len() as u64;
+                content.clear();
+                content.extend_from_slice(&region);
+                (0, blob_version, data_offset, generations.rotate(&key))
+            }
+        };
 
         Ok((
             Blob::new(
                 self.partitions.clone(),
-                partition.into(),
-                name,
+                self.generations.clone(),
+                key,
                 content.clone(),
                 self.pool.clone(),
                 data_offset,
+                generation,
             ),
             logical_size,
             blob_version,
@@ -96,6 +159,7 @@ impl crate::Storage for Storage {
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), crate::Error> {
         super::validate_partition_name(partition)?;
 
+        let mut generations = self.generations.lock();
         let mut partitions = self.partitions.lock();
         match name {
             Some(name) => {
@@ -104,11 +168,15 @@ impl crate::Storage for Storage {
                     .ok_or(crate::Error::PartitionMissing(partition.into()))?
                     .remove(name)
                     .ok_or(crate::Error::BlobMissing(partition.into(), hex(name)))?;
+                generations
+                    .current
+                    .remove(&(partition.to_string(), name.to_vec()));
             }
             None => {
                 partitions
                     .remove(partition)
                     .ok_or(crate::Error::PartitionMissing(partition.into()))?;
+                generations.remove_partition(partition);
             }
         }
         Ok(())
@@ -130,36 +198,51 @@ impl crate::Storage for Storage {
     }
 }
 
-type Partition = BTreeMap<Vec<u8>, Vec<u8>>;
-
 #[derive(Clone)]
 pub struct Blob {
     partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
+    generations: Arc<Mutex<Generations>>,
     partition: String,
     name: Vec<u8>,
     content: Arc<RwLock<Vec<u8>>>,
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// Namespace generation captured when this handle was opened.
+    generation: u64,
 }
 
 impl Blob {
     fn new(
         partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
-        partition: String,
-        name: &[u8],
+        generations: Arc<Mutex<Generations>>,
+        (partition, name): BlobKey,
         content: Vec<u8>,
         pool: BufferPool,
         data_offset: u64,
+        generation: u64,
     ) -> Self {
         Self {
             partitions,
+            generations,
             partition,
-            name: name.into(),
+            name,
             content: Arc::new(RwLock::new(content)),
             pool,
             data_offset,
+            generation,
         }
+    }
+
+    fn ensure_current(&self, generations: &Generations) -> Result<(), crate::Error> {
+        let key = (self.partition.clone(), self.name.clone());
+        if generations.current.get(&key) == Some(&self.generation) {
+            return Ok(());
+        }
+        Err(crate::Error::BlobMissing(
+            self.partition.clone(),
+            hex(&self.name),
+        ))
     }
 
     fn sync_inner(&self) -> Result<(), crate::Error> {
@@ -167,6 +250,8 @@ impl Blob {
         let new_content = self.content.read().clone();
 
         // Update partition content
+        let generations = self.generations.lock();
+        self.ensure_current(&generations)?;
         let mut partitions = self.partitions.lock();
         let partition = partitions
             .get_mut(&self.partition)
@@ -178,6 +263,105 @@ impl Blob {
                 hex(&self.name),
             ))?;
         *content = new_content;
+        Ok(())
+    }
+
+    fn sync_range_inner(&self, offset: usize, buf: &[u8]) -> Result<(), crate::Error> {
+        let end = offset
+            .checked_add(buf.len())
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let generations = self.generations.lock();
+        self.ensure_current(&generations)?;
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&self.partition)
+            .and_then(|partition| partition.get_mut(&self.name))
+            .expect("a current blob generation has durable content");
+        if end > content.len() {
+            content.resize(end, 0);
+        }
+        content[offset..end].copy_from_slice(buf);
+        Ok(())
+    }
+
+    /// Merge selected bytes into durable storage without changing this handle's live contents.
+    pub(crate) fn retain_crash_write(
+        &self,
+        offset: u64,
+        mut bufs: IoBufs,
+        mut keep: impl FnMut() -> bool,
+    ) -> Result<(), crate::Error> {
+        let offset = offset
+            .checked_add(self.data_offset)
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let offset: usize = offset
+            .try_into()
+            .map_err(|_| crate::Error::OffsetOverflow)?;
+        offset
+            .checked_add(bufs.remaining())
+            .ok_or(crate::Error::OffsetOverflow)?;
+
+        let generations = self.generations.lock();
+        if self.ensure_current(&generations).is_err() {
+            return Ok(());
+        }
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&self.partition)
+            .and_then(|partition| partition.get_mut(&self.name))
+            .expect("a current blob generation has durable content");
+
+        let mut position = 0usize;
+        while bufs.has_remaining() {
+            let chunk = bufs.chunk();
+            let chunk_len = chunk.len();
+            let mut run_start = None;
+
+            let mut retain_run = |run_start: usize, run_end: usize| {
+                let physical_start = offset + position + run_start;
+                let physical_end = offset + position + run_end;
+                if physical_end > content.len() {
+                    content.resize(physical_end, 0);
+                }
+                content[physical_start..physical_end].copy_from_slice(&chunk[run_start..run_end]);
+            };
+
+            for index in 0..chunk_len {
+                if keep() {
+                    if run_start.is_none() {
+                        run_start = Some(index);
+                    }
+                } else if let Some(start) = run_start.take() {
+                    retain_run(start, index);
+                }
+            }
+            if let Some(start) = run_start {
+                retain_run(start, chunk_len);
+            }
+
+            position += chunk_len;
+            bufs.advance(chunk_len);
+        }
+        Ok(())
+    }
+
+    /// Apply a retained resize to durable storage without changing this handle's live contents.
+    pub(crate) fn retain_crash_resize(&self, len: u64) -> Result<(), crate::Error> {
+        let len = len
+            .checked_add(self.data_offset)
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let len: usize = len.try_into().map_err(|_| crate::Error::OffsetOverflow)?;
+
+        let generations = self.generations.lock();
+        if self.ensure_current(&generations).is_err() {
+            return Ok(());
+        }
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&self.partition)
+            .and_then(|partition| partition.get_mut(&self.name))
+            .expect("a current blob generation has durable content");
+        content.resize(len, 0);
         Ok(())
     }
 }
@@ -229,15 +413,21 @@ impl crate::Blob for Blob {
         let offset: usize = offset
             .try_into()
             .map_err(|_| crate::Error::OffsetOverflow)?;
+        let required = offset
+            .checked_add(buf.len())
+            .ok_or(crate::Error::OffsetOverflow)?;
         {
             let mut content = self.content.write();
-            let required = offset + buf.len();
             if required > content.len() {
                 content.resize(required, 0);
             }
             content[offset..offset + buf.len()].copy_from_slice(buf.as_ref());
         }
-        if sync { self.sync().await } else { Ok(()) }
+        if sync {
+            self.sync_range_inner(offset, buf.as_ref())
+        } else {
+            Ok(())
+        }
     }
 
     async fn resize(&self, len: u64) -> Result<(), crate::Error> {
@@ -300,6 +490,64 @@ mod tests {
         drop(sync);
         let (_, sync_len) = storage.open("partition", b"sync").await.unwrap();
         assert_eq!(sync_len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_crash_write_merges_durable_bytes_only() {
+        let storage = Storage::new(test_pool());
+        let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+        blob.write_at(0, b"abcdefgh", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+        blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+            .await
+            .unwrap();
+
+        let mut index = 0usize;
+        blob.retain_crash_write(0, IoBufs::from(&b"12345678"[..]), || {
+            let keep = index % 2 == 1;
+            index += 1;
+            keep
+        })
+        .unwrap();
+
+        let live = blob.read_at(0, 8).await.unwrap();
+        assert_eq!(live.coalesce(), b"ABCDEFGH");
+        let (reopened, len) = storage.open("partition", b"blob").await.unwrap();
+        assert_eq!(len, 8);
+        let durable = reopened.read_at(0, 8).await.unwrap();
+        assert_eq!(durable.coalesce(), b"a2c4e6g8");
+
+        let (sparse, _) = storage.open("partition", b"sparse").await.unwrap();
+        let mut index = 0usize;
+        sparse
+            .retain_crash_write(4, IoBufs::from(&b"xyz"[..]), || {
+                let keep = index == 1;
+                index += 1;
+                keep
+            })
+            .unwrap();
+        let (sparse, len) = storage.open("partition", b"sparse").await.unwrap();
+        assert_eq!(len, 6);
+        assert_eq!(
+            sparse.read_at(0, 6).await.unwrap().coalesce(),
+            b"\0\0\0\0\0y"
+        );
+
+        let (removed, _) = storage.open("partition", b"removed").await.unwrap();
+        storage.remove("partition", Some(b"removed")).await.unwrap();
+        let (replacement, _) = storage.open("partition", b"removed").await.unwrap();
+        replacement
+            .write_at(0, b"new!", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        removed
+            .retain_crash_write(0, IoBufs::from(&b"lost"[..]), || true)
+            .unwrap();
+        let (replacement, len) = storage.open("partition", b"removed").await.unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(replacement.read_at(0, 4).await.unwrap().coalesce(), b"new!");
     }
 
     #[tokio::test]

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,7 +1,7 @@
 use super::Header;
 use crate::{Buf, BufferPool, Handle, IoBufs, IoBufsMut, WriteOptions, deterministic::AuditHasher};
 use commonware_formatting::hex;
-use commonware_utils::sync::{Mutex, RwLock};
+use commonware_utils::sync::{AsyncMutex, AsyncRwLock, Mutex, RwLock};
 use std::{collections::BTreeMap, ops::RangeInclusive, sync::Arc};
 
 /// Resolves a blob's header from its full contents (see [super::header::resolve]).
@@ -53,6 +53,7 @@ impl Generations {
 pub struct Storage {
     partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
     generations: Arc<Mutex<Generations>>,
+    atomic_resources: crate::atomic::AtomicResources,
     pool: BufferPool,
 }
 
@@ -65,6 +66,12 @@ impl Storage {
         Self {
             partitions: Arc::new(Mutex::new(partitions)),
             generations: Arc::new(Mutex::new(Generations::default())),
+            atomic_resources: crate::atomic::AtomicResources {
+                driver: crate::atomic::Driver::inline(),
+                exclusion: Arc::new(AsyncRwLock::new(())),
+                namespace: Arc::new(AsyncMutex::new(())),
+                payload_budget: Arc::new(crate::atomic::PayloadBudget::default()),
+            },
             pool,
         }
     }
@@ -449,11 +456,60 @@ impl crate::Blob for Blob {
     }
 }
 
+impl crate::atomic::Backend for Storage {
+    type Worker = Self;
+
+    fn atomic_worker(&self) -> Self {
+        self.clone()
+    }
+
+    fn atomic_resources(&self) -> crate::atomic::AtomicResources {
+        self.atomic_resources.clone()
+    }
+
+    async fn open_atomic_existing(
+        &self,
+        partition: &str,
+        name: &[u8],
+    ) -> Result<Option<(Self::Blob, u64)>, crate::Error> {
+        super::validate_partition_name(partition)?;
+        let key = (partition.to_string(), name.to_vec());
+        let mut generations = self.generations.lock();
+        let mut partitions = self.partitions.lock();
+        let Some(blobs) = partitions.get_mut(partition) else {
+            return Ok(None);
+        };
+        let Some(content) = blobs.get(name) else {
+            return Ok(None);
+        };
+        let versions = crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION;
+        let Some((logical_size, _, data_offset)) =
+            resolve_header(content, &versions, partition, name)?
+        else {
+            return Ok(None);
+        };
+        super::header::require_atomic_layout(data_offset, partition, name)?;
+        let generation = generations.get_or_insert(&key);
+        Ok(Some((
+            Blob::new(
+                self.partitions.clone(),
+                self.generations.clone(),
+                key,
+                content.clone(),
+                self.pool.clone(),
+                data_offset,
+                generation,
+            ),
+            logical_size,
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Header, *};
     use crate::{
-        Blob, BufferPoolConfig, Storage as _,
+        AtomicStorage as _, Blob, BufferPoolConfig, Storage as _,
         storage::{Layout, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
@@ -467,6 +523,99 @@ mod tests {
     async fn test_memory_storage() {
         let storage = Storage::new(test_pool());
         run_storage_tests(storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_atomic_backing_matches_the_ordinary_default_container() {
+        let storage = Storage::new(test_pool());
+        let (ordinary, _) = storage.open("headers", b"ordinary").await.unwrap();
+        let (atomic, _) = storage.open_atomic("headers", b"atomic").await.unwrap();
+        drop(ordinary);
+        drop(atomic);
+
+        let partitions = storage.partitions.lock();
+        let partition = partitions.get("headers").unwrap();
+        let ordinary = partition.get(b"ordinary".as_slice()).unwrap();
+        let atomic = partition.get(b"atomic".as_slice()).unwrap();
+        let (header, version) =
+            Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION));
+        assert_eq!(version, crate::DEFAULT_BLOB_VERSION);
+        let header_len = header.len();
+        assert_eq!(&atomic[..header_len], &ordinary[..header_len]);
+        assert_eq!(&atomic[..header_len], header.as_slice());
+    }
+
+    #[tokio::test]
+    async fn test_atomic_exact_open_preserves_incomplete_container_and_generation() {
+        let storage = Storage::new(test_pool());
+        let partition = "atomic_container_recovery";
+        let name = b"blob".to_vec();
+        let key = (partition.to_string(), name.clone());
+        let interrupted =
+            Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION)).0
+                [..Header::PRELUDE_SIZE]
+                .to_vec();
+        storage
+            .partitions
+            .lock()
+            .entry(partition.to_string())
+            .or_default()
+            .insert(name.clone(), interrupted.clone());
+        let generation = storage.generations.lock().get_or_insert(&key);
+
+        assert!(
+            crate::atomic::Backend::open_atomic_existing(&storage, partition, &name)
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(storage.partitions.lock()[partition][&name], interrupted);
+        assert_eq!(
+            storage.generations.lock().current.get(&key),
+            Some(&generation)
+        );
+
+        let (_, len) = storage.open_atomic(partition, &name).await.unwrap();
+        assert_eq!(len, 0);
+        assert_ne!(
+            storage.generations.lock().current.get(&key),
+            Some(&generation)
+        );
+    }
+
+    #[tokio::test]
+    async fn test_atomic_rejects_v0_ordinary_lookalikes_without_mutation() {
+        let storage = Storage::new(test_pool());
+        let original = crate::storage::header::tests::v0_atomic_lookalike_bytes();
+
+        for (partition, name) in [("v0_atomic_open", b"open"), ("v0_atomic_scan", b"scan")] {
+            storage
+                .partitions
+                .lock()
+                .entry(partition.to_string())
+                .or_default()
+                .insert(name.to_vec(), original.clone());
+        }
+
+        let rejected_open = storage.open_atomic("v0_atomic_open", b"open").await;
+        let rejected_scan = storage.scan_atomic("v0_atomic_scan").await;
+        let partitions = storage.partitions.lock();
+        assert!(
+            partitions["v0_atomic_open"][b"open".as_slice()].as_slice() == original.as_slice(),
+            "atomic open mutated a legacy ordinary blob"
+        );
+        assert!(
+            partitions["v0_atomic_scan"][b"scan".as_slice()].as_slice() == original.as_slice(),
+            "atomic scan mutated a legacy ordinary blob"
+        );
+        assert!(matches!(
+            rejected_open,
+            Err(crate::Error::BlobCorrupt(_, _, reason)) if reason == "expected V1 header layout"
+        ));
+        assert!(matches!(
+            rejected_scan,
+            Err(crate::Error::BlobCorrupt(_, _, reason)) if reason == "expected V1 header layout"
+        ));
     }
 
     #[tokio::test]

--- a/runtime/src/storage/tokio/blob.rs
+++ b/runtime/src/storage/tokio/blob.rs
@@ -13,6 +13,40 @@ use std::{
 };
 use tokio::task;
 
+#[cfg(test)]
+struct WritePause {
+    partition: String,
+    name: Vec<u8>,
+    entered: oneshot::Sender<()>,
+    resume: std::sync::mpsc::Receiver<()>,
+    completed: oneshot::Sender<()>,
+}
+
+#[cfg(test)]
+struct WriteCompletion(Option<oneshot::Sender<()>>);
+
+#[cfg(test)]
+impl Drop for WriteCompletion {
+    fn drop(&mut self) {
+        if let Some(completed) = self.0.take() {
+            let _ = completed.send(());
+        }
+    }
+}
+
+#[cfg(test)]
+static WRITE_PAUSE: commonware_utils::sync::Mutex<Option<WritePause>> =
+    commonware_utils::sync::Mutex::new(None);
+
+#[cfg(test)]
+fn take_write_pause(partition: &str, name: &[u8]) -> Option<WritePause> {
+    let mut pause = WRITE_PAUSE.lock();
+    let matches = pause
+        .as_ref()
+        .is_some_and(|pause| pause.partition == partition && pause.name == name);
+    matches.then(|| pause.take().unwrap())
+}
+
 // Linux rejects more than IOV_MAX (1024) iovecs with EINVAL. Use the maximum so storage writes
 // span as few submissions as possible.
 const IOVEC_BATCH_SIZE: usize = 1024;
@@ -240,9 +274,22 @@ impl crate::Blob for Blob {
         } else {
             Cache::Enabled
         };
+        #[cfg(test)]
+        let pause_partition = self.partition.clone();
+        #[cfg(test)]
+        let pause_name = self.name.clone();
         let partition = sync.then(|| self.partition.clone());
         let name = sync.then(|| self.name.clone());
         task::spawn_blocking(move || {
+            #[cfg(test)]
+            let _completion = if let Some(pause) = take_write_pause(&pause_partition, &pause_name) {
+                let _ = pause.entered.send(());
+                let _ = pause.resume.recv();
+                Some(WriteCompletion(Some(pause.completed)))
+            } else {
+                None
+            };
+
             // Preserve the single-buffer fast path when no option requires per-write flags.
             let bufs = if !sync && !cache.is_disabled() {
                 match bufs.try_into_single() {

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -1,7 +1,9 @@
 use super::Header;
 use crate::{BufferPool, Error};
 use commonware_formatting::{from_hex, hex};
+use commonware_utils::sync::AsyncRwLock;
 use std::{
+    io::ErrorKind,
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::Arc,
@@ -34,9 +36,18 @@ async fn sync_dir(path: &Path) -> Result<(), Error> {
     })
 }
 
+/// Configuration for a [`Storage`].
+///
+/// `storage_directory` must be owned by exactly one independently constructed [`Storage`] lineage
+/// for its full lifetime. Clones belong to that lineage. Another process, storage instance, path
+/// alias, or direct filesystem mutation must not access the directory concurrently.
+/// Partition names and hex-encoded blob names each occupy one filesystem path component and must
+/// fit the filesystem's component-length limit.
 #[derive(Clone)]
 pub struct Config {
+    /// Directory exclusively owned by the resulting storage lineage.
     pub storage_directory: PathBuf,
+    /// Maximum buffered bytes for each blob.
     pub maximum_buffer_size: usize,
 }
 
@@ -51,7 +62,7 @@ impl Config {
 
 #[derive(Clone)]
 pub struct Storage {
-    lock: Arc<Mutex<()>>,
+    atomic_resources: crate::atomic::AtomicResources,
     cfg: Config,
     pool: BufferPool,
 }
@@ -72,9 +83,21 @@ async fn resolve_header(
 }
 
 impl Storage {
+    /// Create storage with exclusive authority over `cfg.storage_directory`.
+    ///
+    /// Cloning the returned value preserves the same authority. Independently constructing another
+    /// storage value for this directory, including through a path alias or another process, is not
+    /// supported while this lineage remains live. Before replacing an old lineage, callers must
+    /// establish quiescence through that lineage; dropping its last caller-held clone is not a
+    /// barrier for unobserved admitted atomic work.
     pub fn new(cfg: Config, pool: BufferPool) -> Self {
         Self {
-            lock: Arc::new(Mutex::new(())),
+            atomic_resources: crate::atomic::AtomicResources {
+                driver: crate::atomic::Driver::background(),
+                exclusion: Arc::new(AsyncRwLock::new(())),
+                namespace: Arc::new(Mutex::new(())),
+                payload_budget: Arc::new(crate::atomic::PayloadBudget::default()),
+            },
             cfg,
             pool,
         }
@@ -94,7 +117,7 @@ impl crate::Storage for Storage {
 
         // Acquire the filesystem lock. The guard is owned so the creation path can move it
         // into a task that outlives a dropped open future.
-        let guard = self.lock.clone().lock_owned().await;
+        let guard = self.atomic_resources.namespace.clone().lock_owned().await;
 
         // Construct the full path
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
@@ -185,15 +208,19 @@ impl crate::Storage for Storage {
         super::validate_partition_name(partition)?;
 
         // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        let _guard = self.atomic_resources.namespace.lock().await;
 
         // Remove all related files
         let path = self.cfg.storage_directory.join(partition);
         if let Some(name) = name {
             let blob_path = path.join(hex(name));
-            fs::remove_file(blob_path)
-                .await
-                .map_err(|_| Error::BlobMissing(partition.into(), hex(name)))?;
+            match fs::remove_file(blob_path).await {
+                Ok(()) => {}
+                Err(error) if error.kind() == ErrorKind::NotFound => {
+                    return Err(Error::BlobMissing(partition.into(), hex(name)));
+                }
+                Err(error) => return Err(Error::Io(error.into())),
+            }
 
             // Sync the partition directory to ensure the removal is durable.
             sync_dir(&path).await?;
@@ -212,11 +239,11 @@ impl crate::Storage for Storage {
         super::validate_partition_name(partition)?;
 
         // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        let _guard = self.atomic_resources.namespace.lock().await;
 
         // Scan the partition directory
         let path = self.cfg.storage_directory.join(partition);
-        let mut entries = fs::read_dir(path)
+        let mut entries = fs::read_dir(&path)
             .await
             .map_err(|_| Error::PartitionMissing(partition.into()))?;
         let mut blobs = Vec::new();
@@ -225,7 +252,8 @@ impl crate::Storage for Storage {
             if !file_type.is_file() {
                 return Err(Error::PartitionCorrupt(partition.into()));
             }
-            if let Some(name) = entry.file_name().to_str() {
+            let file_name = entry.file_name();
+            if let Some(name) = file_name.to_str() {
                 // Reject anything that isn't canonical lowercase hex (no `0x`
                 // prefix, no whitespace) since `from_hex` is lenient and
                 // storage only ever writes the canonical form via `hex()`.
@@ -241,17 +269,77 @@ impl crate::Storage for Storage {
     }
 }
 
+impl crate::atomic::Backend for Storage {
+    type Worker = Self;
+
+    fn atomic_worker(&self) -> Self {
+        self.clone()
+    }
+
+    fn atomic_resources(&self) -> crate::atomic::AtomicResources {
+        self.atomic_resources.clone()
+    }
+
+    async fn open_atomic_existing(
+        &self,
+        partition: &str,
+        name: &[u8],
+    ) -> Result<Option<(Self::Blob, u64)>, Error> {
+        super::validate_partition_name(partition)?;
+        let guard = self.atomic_resources.namespace.clone().lock_owned().await;
+        let path = self.cfg.storage_directory.join(partition).join(hex(name));
+        let mut file = match fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&path)
+            .await
+        {
+            Ok(file) => file,
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(Error::BlobOpenFailed(
+                    partition.into(),
+                    hex(name),
+                    error.into(),
+                ));
+            }
+        };
+
+        let raw_len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
+        file.set_max_buf_size(self.cfg.maximum_buffer_size);
+        let versions = crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION;
+        let Some((logical_len, _, data_offset)) =
+            resolve_header(&mut file, raw_len, &versions, partition, name).await?
+        else {
+            return Ok(None);
+        };
+        super::header::require_atomic_layout(data_offset, partition, name)?;
+        let file = file.into_std().await;
+        let opened = Some((
+            blob::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset),
+            logical_len,
+        ));
+        drop(guard);
+        Ok(opened)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Header, *};
     use crate::{
-        Blob, BufferPoolConfig, Storage as _, WriteOptions,
+        AtomicStorage as _, Blob, BufferPoolConfig, Storage as _, WriteOptions,
         storage::{Layout, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
     use commonware_utils::sys_rng;
     use rand::RngExt as _;
-    use std::env;
+    use std::{
+        env,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    static NEXT_ATOMIC_TEST_DIR: AtomicU64 = AtomicU64::new(0);
 
     fn test_pool() -> BufferPool {
         let mut registry = Registry::default();
@@ -263,6 +351,14 @@ mod tests {
         rng.random()
     }
 
+    fn atomic_test_directory(label: &str) -> PathBuf {
+        env::temp_dir().join(format!(
+            "{label}_{}_{}",
+            std::process::id(),
+            NEXT_ATOMIC_TEST_DIR.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
     #[tokio::test]
     async fn test_storage() {
         let mut rng = sys_rng();
@@ -271,6 +367,141 @@ mod tests {
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
         let storage = Storage::new(config, test_pool());
         run_storage_tests(storage).await;
+    }
+
+    #[tokio::test]
+    async fn test_remove_propagates_non_missing_file_errors() {
+        let storage_directory = atomic_test_directory("storage_tokio_remove_error");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+        let blob_path = storage_directory.join("partition").join(hex(b"directory"));
+        std::fs::create_dir_all(&blob_path).unwrap();
+
+        let error = storage
+            .remove("partition", Some(b"directory"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, Error::Io(_)));
+        assert!(blob_path.is_dir());
+
+        let _ = std::fs::remove_dir_all(storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_backend_existing_and_direct_open() {
+        let storage_directory = atomic_test_directory("storage_tokio_atomic");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+
+        let missing = crate::atomic::Backend::open_atomic_existing(&storage, "partition", b"blob")
+            .await
+            .unwrap();
+        assert!(missing.is_none());
+        assert!(!storage_directory.exists());
+
+        let (blob, len) = Box::pin(storage.open_atomic("partition", b"blob"))
+            .await
+            .unwrap();
+        assert_eq!(len, 0);
+        drop(blob);
+        let (blob, len) = Box::pin(storage.open_atomic("partition", b"blob"))
+            .await
+            .unwrap();
+        assert_eq!(len, 0);
+        drop(blob);
+        let (_, backing_len) =
+            crate::atomic::Backend::open_atomic_existing(&storage, "partition", b"blob")
+                .await
+                .unwrap()
+                .unwrap();
+        assert!(backing_len >= crate::atomic::IDENTITY_PAGE_LEN);
+        let (direct, direct_len) = storage.open("partition", b"blob").await.unwrap();
+        assert_eq!(direct_len, backing_len);
+        drop(direct);
+
+        let _ = std::fs::remove_dir_all(storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_rejects_v0_ordinary_lookalikes_without_mutation() {
+        let storage_directory = atomic_test_directory("storage_tokio_atomic_v0_lookalike");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let original = crate::storage::header::tests::v0_atomic_lookalike_bytes();
+        for (partition, name) in [("v0_atomic_open", b"open"), ("v0_atomic_scan", b"scan")] {
+            let partition_path = storage_directory.join(partition);
+            std::fs::create_dir_all(&partition_path).unwrap();
+            std::fs::write(partition_path.join(hex(name)), &original).unwrap();
+        }
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+
+        let rejected_open = storage.open_atomic("v0_atomic_open", b"open").await;
+        let rejected_scan = storage.scan_atomic("v0_atomic_scan").await;
+        assert!(
+            std::fs::read(storage_directory.join("v0_atomic_open").join(hex(b"open"))).unwrap()
+                == original,
+            "atomic open mutated a legacy ordinary blob"
+        );
+        assert!(
+            std::fs::read(storage_directory.join("v0_atomic_scan").join(hex(b"scan"))).unwrap()
+                == original,
+            "atomic scan mutated a legacy ordinary blob"
+        );
+        assert!(matches!(
+            rejected_open,
+            Err(crate::Error::BlobCorrupt(_, _, reason)) if reason == "expected V1 header layout"
+        ));
+        assert!(matches!(
+            rejected_scan,
+            Err(crate::Error::BlobCorrupt(_, _, reason)) if reason == "expected V1 header layout"
+        ));
+
+        drop(storage);
+        let _ = std::fs::remove_dir_all(storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_exact_open_leaves_container_recovery_to_ordinary_open() {
+        let storage_directory = atomic_test_directory("storage_tokio_atomic_container_recovery");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+        let path = partition_path.join(hex(b"blob"));
+        let interrupted =
+            Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION)).0
+                [..Header::PRELUDE_SIZE]
+                .to_vec();
+        std::fs::write(&path, &interrupted).unwrap();
+        std::fs::File::open(&path).unwrap().sync_all().unwrap();
+        std::fs::File::open(&partition_path)
+            .unwrap()
+            .sync_all()
+            .unwrap();
+
+        assert!(
+            crate::atomic::Backend::open_atomic_existing(&storage, "partition", b"blob")
+                .await
+                .unwrap()
+                .is_none()
+        );
+        assert_eq!(std::fs::read(&path).unwrap(), interrupted);
+
+        let (_, len) = storage.open_atomic("partition", b"blob").await.unwrap();
+        assert_eq!(len, 0);
+
+        let _ = std::fs::remove_dir_all(storage_directory);
     }
 
     /// Dropping the `start_sync` receiver must not break the blob: the handle stays

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -29,6 +29,7 @@ use commonware_macros::{select, stability};
 #[stability(BETA)]
 use commonware_parallel::Rayon;
 use commonware_utils::{NZUsize, sync::Mutex, sys_rng};
+use futures::FutureExt as _;
 use governor::clock::{Clock as GClock, ReasonablyRealtime};
 use rand_core::{Rng, TryCryptoRng, TryRng};
 #[stability(BETA)]
@@ -39,11 +40,15 @@ use std::{
     future::Future,
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime},
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::{
+    runtime::{Builder, Handle as RuntimeHandle},
+    sync::Notify,
+};
 
 #[cfg(feature = "iouring-network")]
 cfg_if::cfg_if! {
@@ -338,10 +343,63 @@ impl Default for Config {
 pub struct Executor {
     registry: Registry,
     metrics: Arc<Metrics>,
-    runtime: Runtime,
+    runtime: RuntimeHandle,
+    tasks: Arc<TaskTracker>,
     shutdown: Mutex<Stopper>,
     panicker: Panicker,
     thread_stack_size: usize,
+}
+
+/// Closes task admission and tracks wrappers through user-future drop and descendant cleanup.
+#[derive(Default)]
+struct TaskTracker {
+    state: Mutex<TaskTrackerState>,
+    idle: Notify,
+}
+
+#[derive(Default)]
+struct TaskTrackerState {
+    active: usize,
+    closed: bool,
+}
+
+impl TaskTracker {
+    fn admit(self: &Arc<Self>) -> Option<TaskGuard> {
+        let mut state = self.state.lock();
+        if state.closed {
+            return None;
+        }
+        state.active = state.active.checked_add(1).expect("active task overflow");
+        Some(TaskGuard(Arc::clone(self)))
+    }
+
+    fn close(&self) {
+        self.state.lock().closed = true;
+    }
+
+    async fn wait(&self) {
+        loop {
+            // Subscribe before checking so the final task cannot notify between the check and wait.
+            let idle = self.idle.notified();
+            if self.state.lock().active == 0 {
+                return;
+            }
+            idle.await;
+        }
+    }
+}
+
+struct TaskGuard(Arc<TaskTracker>);
+
+impl Drop for TaskGuard {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock();
+        state.active = state.active.checked_sub(1).expect("active task underflow");
+        if state.active == 0 {
+            drop(state);
+            self.0.idle.notify_one();
+        }
+    }
 }
 
 /// Implementation of [crate::Runner] for the `tokio` runtime.
@@ -492,7 +550,8 @@ impl crate::Runner for Runner {
         let executor = Arc::new(Executor {
             registry,
             metrics,
-            runtime,
+            runtime: runtime.handle().clone(),
+            tasks: Arc::new(TaskTracker::default()),
             shutdown: Mutex::new(Stopper::default()),
             panicker,
             thread_stack_size: self.cfg.thread_stack_size,
@@ -504,6 +563,7 @@ impl crate::Runner for Runner {
         let gauge = executor.metrics.tasks_running.get_or_create(&label).clone();
 
         // Run the future
+        let tree = Tree::root();
         let context = Context {
             storage,
             name: label.name(),
@@ -512,13 +572,23 @@ impl crate::Runner for Runner {
             network,
             network_buffer_pool,
             storage_buffer_pool,
-            tree: Tree::root(),
+            tree: Arc::clone(&tree),
             execution: Execution::default(),
         };
-        let output = executor.runtime.block_on(panicked.interrupt(f(context)));
+        let root = catch_unwind(AssertUnwindSafe(|| f(context)));
+        let output = match root {
+            Ok(root) => runtime.block_on(AssertUnwindSafe(panicked.interrupt(root)).catch_unwind()),
+            Err(panic) => Err(panic),
+        };
+        executor.tasks.close();
+        tree.abort();
+        runtime.block_on(executor.tasks.wait());
         gauge.dec();
 
-        output
+        match output {
+            Ok(output) => output,
+            Err(panic) => resume_unwind(panic),
+        }
     }
 }
 
@@ -592,6 +662,9 @@ impl crate::Spawner for Context {
 
         // Spawn the task
         let executor = self.executor.clone();
+        let Some(task_guard) = executor.tasks.admit() else {
+            return Handle::closed(metric);
+        };
         let future = f(self);
         let (f, handle) = Handle::init(
             future,
@@ -599,11 +672,15 @@ impl crate::Spawner for Context {
             executor.panicker.clone(),
             Arc::clone(&parent),
         );
+        let f = async move {
+            let _task_guard = task_guard;
+            f.await;
+        };
 
         if matches!(past, Execution::Dedicated) {
             utils::thread::spawn(executor.thread_stack_size, {
                 // Ensure the task can access the tokio runtime
-                let handle = executor.runtime.handle().clone();
+                let handle = executor.runtime.clone();
                 move || {
                     handle.block_on(f);
                 }
@@ -611,7 +688,7 @@ impl crate::Spawner for Context {
         } else if matches!(past, Execution::Shared(true)) {
             executor.runtime.spawn_blocking({
                 // Ensure the task can access the tokio runtime
-                let handle = executor.runtime.handle().clone();
+                let handle = executor.runtime.clone();
                 move || {
                     handle.block_on(f);
                 }
@@ -861,6 +938,106 @@ mod tests {
     };
     use tracing::{Level, error};
 
+    struct TaskDropGate {
+        entered: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    }
+
+    impl Drop for TaskDropGate {
+        fn drop(&mut self) {
+            let _ = self.entered.send(());
+            let _ = self.release.recv();
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum RootExit {
+        Return,
+        FuturePanic,
+        ConstructorPanic,
+    }
+
+    fn spawn_drop_gated_task(
+        context: Context,
+        execution: Execution,
+        drop_gate: TaskDropGate,
+        ready: Option<commonware_utils::channel::oneshot::Sender<()>>,
+    ) {
+        let child = match execution {
+            Execution::Dedicated => context.dedicated(),
+            Execution::Shared(blocking) => context.shared(blocking),
+        };
+        child.spawn(move |context| async move {
+            let _context = context;
+            let _drop_gate = drop_gate;
+            if let Some(ready) = ready {
+                ready.send(()).unwrap();
+            }
+            futures::future::pending::<()>().await;
+        });
+    }
+
+    fn assert_runner_drains_spawned_task(execution: Execution, root_exit: RootExit) {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (ready_tx, ready_rx) = commonware_utils::channel::oneshot::channel();
+        let (drop_entered_tx, drop_entered_rx) = std::sync::mpsc::channel();
+        let (drop_release_tx, drop_release_rx) = std::sync::mpsc::channel();
+        let (runner_done_tx, runner_done_rx) = std::sync::mpsc::channel();
+        let runner = std::thread::spawn(move || {
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                let drop_gate = TaskDropGate {
+                    entered: drop_entered_tx,
+                    release: drop_release_rx,
+                };
+                match root_exit {
+                    RootExit::ConstructorPanic => {
+                        Runner::new(cfg).start(move |context| -> futures::future::Pending<()> {
+                            spawn_drop_gated_task(context, execution, drop_gate, None);
+                            panic!("root constructor panic after spawning child");
+                        })
+                    }
+                    RootExit::Return | RootExit::FuturePanic => {
+                        Runner::new(cfg).start(move |context| async move {
+                            spawn_drop_gated_task(context, execution, drop_gate, Some(ready_tx));
+                            ready_rx.await.unwrap();
+                            assert!(
+                                matches!(root_exit, RootExit::Return),
+                                "root future panic after spawning child"
+                            );
+                        })
+                    }
+                }
+            }));
+            runner_done_tx.send(result.is_err()).unwrap();
+        });
+
+        drop_entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("spawned task was not canceled after the root returned");
+        let early = runner_done_rx.recv_timeout(Duration::from_millis(250));
+        let returned_before_cleanup = match early {
+            Ok(panicked) => Some(panicked),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => None,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("Runner::start exited without reporting its result")
+            }
+        };
+        drop_release_tx.send(()).unwrap();
+        let panicked = returned_before_cleanup.unwrap_or_else(|| {
+            runner_done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("Runner::start did not return after task cleanup completed")
+        });
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        assert!(
+            returned_before_cleanup.is_none(),
+            "Runner::start returned before {execution:?} task cleanup completed"
+        );
+        assert_eq!(panicked, !matches!(root_exit, RootExit::Return));
+    }
+
     #[test]
     fn test_worker_threads_updates_default_buffer_pool_parallelism() {
         let cfg = Config::new().with_worker_threads(8);
@@ -887,6 +1064,77 @@ mod tests {
         assert_eq!(
             cfg.thread_stack_size(),
             utils::thread::system_thread_stack_size()
+        );
+    }
+
+    #[test]
+    fn test_runner_waits_for_spawned_task_cancellation() {
+        for execution in [
+            Execution::Shared(false),
+            Execution::Shared(true),
+            Execution::Dedicated,
+        ] {
+            for root_exit in [
+                RootExit::Return,
+                RootExit::FuturePanic,
+                RootExit::ConstructorPanic,
+            ] {
+                assert_runner_drains_spawned_task(execution, root_exit);
+            }
+        }
+    }
+
+    #[test]
+    fn test_runner_owns_runtime_when_context_escapes() {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (ready_tx, ready_rx) = commonware_utils::channel::oneshot::channel();
+        let (drop_entered_tx, drop_entered_rx) = std::sync::mpsc::channel();
+        let (drop_release_tx, drop_release_rx) = std::sync::mpsc::channel();
+        let (runner_returned_tx, runner_returned_rx) = std::sync::mpsc::channel();
+        let (context_release_tx, context_release_rx) = std::sync::mpsc::channel();
+        let runner = std::thread::spawn(move || {
+            let context = Runner::new(cfg).start(move |context| async move {
+                context.executor.runtime.spawn(async move {
+                    let _drop_gate = TaskDropGate {
+                        entered: drop_entered_tx,
+                        release: drop_release_rx,
+                    };
+                    ready_tx.send(()).unwrap();
+                    futures::future::pending::<()>().await;
+                });
+                ready_rx.await.unwrap();
+                context
+            });
+            runner_returned_tx.send(()).unwrap();
+            context_release_rx.recv().unwrap();
+            drop(context);
+        });
+
+        let returned_early = runner_returned_rx
+            .recv_timeout(Duration::from_millis(500))
+            .is_ok();
+        if returned_early {
+            drop_release_tx.send(()).unwrap();
+            context_release_tx.send(()).unwrap();
+            drop_entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("escaped Context did not retain the raw runtime task");
+        } else {
+            drop_entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("Runner did not cancel its raw runtime task");
+            drop_release_tx.send(()).unwrap();
+            runner_returned_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("Runner did not return after raw task cleanup");
+            context_release_tx.send(()).unwrap();
+        }
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        assert!(
+            !returned_early,
+            "a returned Context kept the Tokio runtime alive after Runner::start"
         );
     }
 

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -2,10 +2,10 @@
 
 //! Fuzz target contiguous journal crash recovery.
 //!
-//! A journal is an append-only log of items. Appends are buffered; `sync` and `commit` push data
-//! to storage, and an unclean shutdown loses anything not yet durable. On the next `init()` the
-//! journal must rebuild a consistent state from whatever survived. This target tests recovering
-//! after storage faults.
+//! A journal is an append-only log of items. Appends are buffered; `sync` and `commit` establish
+//! durability, while the configured crash policy may retain unsynchronized storage mutations. On
+//! the next `init()` the journal must rebuild a consistent state from whatever survived. This
+//! target tests recovering after storage faults.
 //!
 //! # Cycles
 //!
@@ -14,7 +14,8 @@
 //!   1. `init()` recovers the journal left by the previous cycle's crash.
 //!   2. Check it against the `Expected` carried from that crash.
 //!   3. Append and query under fault injection (the cycle's `ops`).
-//!   4. Drop the journal without a clean shutdown: the crash. Unsynced data is lost.
+//!   4. Drop the journal without a clean shutdown: the crash. Unsynchronized bytes survive
+//!      according to the configured write-retention policy.
 //!
 //! `Crash` markers split the op list into one `ops` list per cycle. Driving recovery repeatedly on
 //! the same journal is the point: watermark, pruning-metadata, and section-layout bugs often need a
@@ -29,9 +30,9 @@
 //!
 //! # Faults
 //!
-//! The operation phase runs under write/sync/resize fault injection. The torn-write modes
-//! (`partial_write_rate`, `partial_resize_rate`) cut a write or truncation short, leaving the
-//! half-finished bytes a real crash would.
+//! The operation phase runs under write/sync/resize fault injection. The torn-write settings
+//! (`write_retention_frequency`, `partial_resize_rate`) cut a write or truncation short, leaving
+//! the half-finished bytes a real crash would.
 //!
 //! # Positions
 //!
@@ -166,9 +167,9 @@ struct FuzzInput {
     /// Failure rate for write operations.
     #[arbitrary(with = bounded_rate)]
     write_failure_rate: f64,
-    /// Probability that a write failure is a partial (torn) write.
+    /// Frequency with which bytes survive a failed or unsynchronized write.
     #[arbitrary(with = bounded_rate)]
-    partial_write_rate: f64,
+    write_retention_frequency: f64,
     /// Failure rate for sync operations.
     #[arbitrary(with = bounded_rate)]
     sync_failure_rate: f64,
@@ -191,7 +192,7 @@ struct Params {
     items_per_section: u64,
     write_buffer: NonZeroUsize,
     write_rate: f64,
-    partial_write_rate: f64,
+    write_retention_frequency: f64,
     sync_rate: f64,
     resize_rate: f64,
     partial_resize_rate: f64,
@@ -202,7 +203,10 @@ impl Params {
     fn fault_config(&self) -> deterministic::FaultConfig {
         deterministic::FaultConfig {
             write_rate: Some(self.write_rate),
-            partial_write_rate: Some(self.partial_write_rate),
+            write_retention: Some((
+                deterministic::PartialWriteMode::Prefix,
+                self.write_retention_frequency,
+            )),
             sync_rate: Some(self.sync_rate),
             resize_rate: Some(self.resize_rate),
             partial_resize_rate: Some(self.partial_resize_rate),
@@ -821,7 +825,7 @@ where
         items_per_section: input.items_per_section,
         write_buffer: NonZeroUsize::new(input.write_buffer).unwrap(),
         write_rate: input.write_failure_rate,
-        partial_write_rate: input.partial_write_rate,
+        write_retention_frequency: input.write_retention_frequency,
         sync_rate: input.sync_failure_rate,
         resize_rate: input.resize_failure_rate,
         partial_resize_rate: input.partial_resize_rate,


### PR DESCRIPTION
## Summary

Adds the cohesive BETA atomic blob storage contract and engine to the runtime. Atomic blobs are opt-in, append-only blobs whose payload is written once at its final offset. They support crash-atomic publication of appends, rewinds, application tags, integrity units, and exact removals, either for one blob or as a coordinator-free multi-blob group.

This is the bottom layer of the six-PR atomic blob stack and depends on the crash-faithful substrate in #4501. The remaining backend/runtime adapters follow in #4502, and explicit ordinary-to-atomic migration follows in #4495. These are separate review units but one atomic-storage release unit: merge them in order and do not release the engine by itself.

The BETA surface in this layer includes:

- `AtomicStorage::{open_atomic, scan_atomic}`;
- `AtomicBlob` append, rewind, tag, integrity, `start_sync`, and `sync` operations; and
- `AtomicStorage::{start_apply, apply}` for atomic publish, rewind, and remove groups.

The layer includes the two minimal raw storage adapters required by the engine itself: Memory consumes the inline driver and Tokio storage consumes the cross-platform background driver. Deterministic contexts, wrappers, Tokio runtime forwarding, and Linux io_uring remain isolated in #4502.

## Storage and identity

Atomic storage uses the existing canonical V1 container. Atomic identification starts at logical offset zero with a 4 KiB `CWUNOID` incarnation page and two alternating 2 KiB R15 root slots; payload begins at logical offset 8192.

A new identity is installed only after ordinary `Storage` reports the name absent and creates a fresh zero-length backing. Existing backings must contain a complete identity; incomplete identities and ordinary payloads are rejected without mutation. Scans never create names. The core root grammar contains only `BatchPrepared` and `Finalized`; the migration-only committed spelling lands with its producer in #4495.

## Publication and recovery

A direct publication is encoded as a singleton witness ring. Group publication writes one root-bound successor witness beside every candidate root, and the complete durable closed ring is the decision. Final-root materialization, tombstones, truncation, and physical namespace cleanup are recovery debt rather than a second decision round.

Recovery validates exact membership, canonical order, incarnations, generations, successor closure, root transitions, and bounded payload proofs. It selects either the complete predecessor vector or the complete candidate vector and never invents or contracts a ring. Foreground and detached work share the same owned driver future after admission, so dropping an admitted observer does not cancel the mutation.

## Review focus

- Direct and grouped publication intentionally stay together because they share the witness encoding and generic recovery path.
- The public API, batch grammar, state transitions, recovery, and apply path land as one final mechanism without a temporary trait or format.
- Memory and raw Tokio storage keep both final driver modes live at this compile boundary.
- `AtomicResources` explicitly clones every shared driver, lock, and accounting resource, preserving one lineage while keeping the WASM boundary warning-free.
- Remaining adapters and all migration mechanisms are deliberately absent and isolated in #4502 and #4495.

## Diff size

- Production code: `+5645 / -11 LOC`
- Tests and test infrastructure: `+716 / -3 LOC`
- Total: `+6361 / -14 LOC`

Counts are physical diff lines, including comments and blank lines. Test-only files, hooks, and lines inside `#[cfg(test)]` modules are counted as tests; everything else is counted as production code.
