### PR TITLE
[runtime] Model atomic blob crash recovery

### DIFF
--- a/runtime/src/atomic.rs
+++ b/runtime/src/atomic.rs
@@ -294,6 +294,10 @@ use std::{
 };
 
 mod batch;
+#[cfg(test)]
+mod model_tests;
+#[cfg(test)]
+mod scheduled_tests;
 
 const ROOT_MAGIC: &[u8; 7] = b"CWUNO15";
 const ROOT_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_LOG_ROOT";

--- a/runtime/src/atomic/model_tests.rs
+++ b/runtime/src/atomic/model_tests.rs
@@ -1,0 +1,1505 @@
+//! Independent bounded semantic specification for coordinator-free atomic publication.
+//!
+//! This module models protocol authority rather than production decoding. A complete prepared
+//! vector stands for an already validated bound candidate ring, a torn prepare is never authority,
+//! and a successful durability outcome guarantees the complete local prepare. Production-linked
+//! scheduled tests exercise decoding and recovery. The ordinal shape checked here only keeps
+//! bounded vectors internally well formed.
+
+const MAX_PARTICIPANTS: usize = 3;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Operation {
+    Publish,
+    Rewind,
+    Remove,
+}
+
+impl Operation {
+    const ALL: [Self; 3] = [Self::Publish, Self::Rewind, Self::Remove];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum World {
+    Predecessor,
+    Candidate,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PrepareState {
+    Absent,
+    Torn,
+    Complete,
+}
+
+impl PrepareState {
+    const ALL: [Self; 3] = [Self::Absent, Self::Torn, Self::Complete];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DurabilityOutcome {
+    NotAttempted,
+    Failed,
+    Succeeded,
+}
+
+impl DurabilityOutcome {
+    const ALL: [Self; 3] = [Self::NotAttempted, Self::Failed, Self::Succeeded];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PayloadProof {
+    Invalid,
+    Valid,
+    NotRequired,
+}
+
+impl PayloadProof {
+    fn authorizes(self, operation: Operation) -> bool {
+        match operation {
+            Operation::Publish => self == Self::Valid,
+            Operation::Rewind | Operation::Remove => self == Self::NotRequired,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FinalState {
+    Absent,
+    Torn,
+    Complete,
+}
+
+impl FinalState {
+    const ALL: [Self; 3] = [Self::Absent, Self::Torn, Self::Complete];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Participant {
+    ordinal: usize,
+    operation: Operation,
+    prepare: PrepareState,
+    publication_sync: DurabilityOutcome,
+    proof: PayloadProof,
+    final_state: FinalState,
+    final_durable: bool,
+    recovery_sync: DurabilityOutcome,
+    resized: bool,
+    unlinked: bool,
+}
+
+impl Participant {
+    const PLACEHOLDER: Self = Self {
+        ordinal: MAX_PARTICIPANTS,
+        operation: Operation::Publish,
+        prepare: PrepareState::Absent,
+        publication_sync: DurabilityOutcome::NotAttempted,
+        proof: PayloadProof::Invalid,
+        final_state: FinalState::Absent,
+        final_durable: false,
+        recovery_sync: DurabilityOutcome::NotAttempted,
+        resized: false,
+        unlinked: false,
+    };
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Image {
+    count: usize,
+    participants: [Participant; MAX_PARTICIPANTS],
+    decision_without_authority: bool,
+    live_cleanup_without_completed_cut: bool,
+    unlink_before_completed_final_cut: bool,
+}
+
+impl Image {
+    fn participants(&self) -> &[Participant] {
+        &self.participants[..self.count]
+    }
+
+    fn participants_mut(&mut self) -> &mut [Participant] {
+        &mut self.participants[..self.count]
+    }
+
+    fn ordinal_shape(&self) -> bool {
+        (1..=MAX_PARTICIPANTS).contains(&self.count)
+            && self
+                .participants()
+                .iter()
+                .enumerate()
+                .all(|(ordinal, participant)| participant.ordinal == ordinal)
+    }
+
+    fn complete_prepared_vector(&self, require_payload_proofs: bool) -> bool {
+        self.ordinal_shape()
+            && self.participants().iter().all(|participant| {
+                !participant.unlinked
+                    && participant.prepare == PrepareState::Complete
+                    && (!require_payload_proofs
+                        || participant.proof.authorizes(participant.operation))
+            })
+    }
+
+    fn retained_final_vector(&self) -> bool {
+        self.ordinal_shape()
+            && self
+                .participants()
+                .iter()
+                .all(|participant| participant.final_state == FinalState::Complete)
+    }
+
+    fn completed_final_cut(&self) -> bool {
+        self.retained_final_vector()
+            && self
+                .participants()
+                .iter()
+                .all(|participant| participant.final_durable)
+    }
+
+    fn candidate_authority(&self) -> bool {
+        self.complete_prepared_vector(true) || self.retained_final_vector()
+    }
+
+    fn completed_publication_cut(&self) -> bool {
+        self.participants()
+            .iter()
+            .all(|participant| participant.publication_sync == DurabilityOutcome::Succeeded)
+    }
+
+    fn selected_worlds(&self, variant: Variant) -> [World; MAX_PARTICIPANTS] {
+        let mut worlds = [World::Predecessor; MAX_PARTICIPANTS];
+        let independent = self.retained_final_vector();
+        let complete_vector = match variant {
+            Variant::IgnorePayloadProof => self.complete_prepared_vector(false),
+            _ => self.complete_prepared_vector(true),
+        };
+
+        for (world, participant) in worlds.iter_mut().zip(self.participants()) {
+            let local_final = participant.final_state == FinalState::Complete
+                || (participant.operation == Operation::Remove && participant.unlinked);
+            let local_prepare = participant.prepare == PrepareState::Complete
+                && participant.proof.authorizes(participant.operation);
+            let candidate = match variant {
+                Variant::LocalPrepareDecides => independent || local_final || local_prepare,
+                _ => independent || complete_vector || local_final,
+            };
+            if candidate {
+                *world = World::Candidate;
+            }
+        }
+        worlds
+    }
+
+    fn uniform_world(&self, variant: Variant) -> Option<World> {
+        let worlds = self.selected_worlds(variant);
+        let first = worlds[0];
+        worlds[..self.count]
+            .iter()
+            .all(|world| *world == first)
+            .then_some(first)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Variant {
+    Reference,
+    LocalPrepareDecides,
+    FailedSyncIsCut,
+    IgnorePayloadProof,
+    FinalizeBeforeCompletedCut,
+    UnlinkBeforeCompletedFinalCut,
+}
+
+impl Variant {
+    const MUTANTS: [Self; 5] = [
+        Self::LocalPrepareDecides,
+        Self::FailedSyncIsCut,
+        Self::IgnorePayloadProof,
+        Self::FinalizeBeforeCompletedCut,
+        Self::UnlinkBeforeCompletedFinalCut,
+    ];
+
+    fn permits_live_cleanup(self, image: &Image) -> bool {
+        match self {
+            Self::FailedSyncIsCut => image
+                .participants()
+                .iter()
+                .all(|participant| participant.publication_sync != DurabilityOutcome::NotAttempted),
+            Self::FinalizeBeforeCompletedCut => image
+                .participants()
+                .iter()
+                .any(|participant| participant.prepare != PrepareState::Absent),
+            _ => image.completed_publication_cut(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InvariantViolation {
+    InvalidOrdinalShape,
+    MixedWorld,
+    CandidateWithoutAuthority,
+    LiveCleanupWithoutCompletedCut,
+    CleanupWithoutDiskAuthority,
+    UnlinkBeforeCompletedFinalCut,
+    InvalidCleanupTarget,
+    DurableTornFinal,
+}
+
+fn first_violation(image: &Image, variant: Variant) -> Option<InvariantViolation> {
+    if !image.ordinal_shape() {
+        return Some(InvariantViolation::InvalidOrdinalShape);
+    }
+    if image.unlink_before_completed_final_cut {
+        return Some(InvariantViolation::UnlinkBeforeCompletedFinalCut);
+    }
+    if image.live_cleanup_without_completed_cut {
+        return Some(InvariantViolation::LiveCleanupWithoutCompletedCut);
+    }
+    if image.decision_without_authority {
+        return Some(InvariantViolation::CandidateWithoutAuthority);
+    }
+
+    let worlds = image.selected_worlds(variant);
+    if worlds[..image.count]
+        .iter()
+        .any(|world| *world != worlds[0])
+    {
+        return Some(InvariantViolation::MixedWorld);
+    }
+    if worlds[0] == World::Candidate && !image.candidate_authority() {
+        return Some(InvariantViolation::CandidateWithoutAuthority);
+    }
+
+    let completed_final_cut = image.completed_final_cut();
+    for participant in image.participants() {
+        if participant.final_durable && participant.final_state != FinalState::Complete {
+            return Some(InvariantViolation::DurableTornFinal);
+        }
+        if (participant.final_state != FinalState::Absent || participant.resized)
+            && !image.candidate_authority()
+        {
+            return Some(InvariantViolation::CleanupWithoutDiskAuthority);
+        }
+        if participant.unlinked && participant.operation != Operation::Remove {
+            return Some(InvariantViolation::InvalidCleanupTarget);
+        }
+        if participant.unlinked && !completed_final_cut {
+            return Some(InvariantViolation::UnlinkBeforeCompletedFinalCut);
+        }
+    }
+    None
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+struct RecoveryWork {
+    final_writes: usize,
+    barriers: usize,
+    clears: usize,
+    resizes: usize,
+    unlinks: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct RecoveryResult {
+    image: Image,
+    decision: Option<World>,
+    work: RecoveryWork,
+}
+
+fn recover_fault_free(mut image: Image, variant: Variant) -> RecoveryResult {
+    let Some(decision) = image.uniform_world(variant) else {
+        return RecoveryResult {
+            image,
+            decision: None,
+            work: RecoveryWork::default(),
+        };
+    };
+    let mut work = RecoveryWork::default();
+
+    match decision {
+        World::Predecessor => {
+            for participant in image.participants_mut() {
+                if participant.prepare != PrepareState::Absent
+                    || participant.final_state != FinalState::Absent
+                {
+                    participant.prepare = PrepareState::Absent;
+                    participant.final_state = FinalState::Absent;
+                    participant.final_durable = false;
+                    participant.recovery_sync = DurabilityOutcome::Succeeded;
+                    work.clears += 1;
+                }
+            }
+        }
+        World::Candidate => {
+            let authority = image.candidate_authority();
+            if !authority {
+                image.decision_without_authority = true;
+            }
+            for participant in image.participants_mut() {
+                if participant.unlinked || participant.final_state == FinalState::Complete {
+                    continue;
+                }
+                participant.final_state = FinalState::Complete;
+                work.final_writes += 1;
+            }
+
+            if variant == Variant::UnlinkBeforeCompletedFinalCut {
+                let completed_final_cut = image.completed_final_cut();
+                let unlinking = image.participants().iter().any(|participant| {
+                    participant.operation == Operation::Remove && !participant.unlinked
+                });
+                image.unlink_before_completed_final_cut |= !completed_final_cut && unlinking;
+                for participant in image.participants_mut() {
+                    if participant.operation == Operation::Remove && !participant.unlinked {
+                        participant.unlinked = true;
+                        work.unlinks += 1;
+                    }
+                }
+            }
+
+            for participant in image.participants_mut() {
+                if participant.unlinked {
+                    continue;
+                }
+                participant.final_state = FinalState::Complete;
+                participant.final_durable = true;
+                participant.recovery_sync = DurabilityOutcome::Succeeded;
+                work.barriers += 1;
+            }
+
+            if image.completed_final_cut() {
+                for participant in image.participants_mut() {
+                    match participant.operation {
+                        Operation::Publish => {}
+                        Operation::Rewind if !participant.resized => {
+                            participant.resized = true;
+                            work.resizes += 1;
+                        }
+                        Operation::Remove if !participant.unlinked => {
+                            participant.unlinked = true;
+                            work.unlinks += 1;
+                        }
+                        Operation::Rewind | Operation::Remove => {}
+                    }
+                }
+            }
+        }
+    }
+
+    RecoveryResult {
+        image,
+        decision: Some(decision),
+        work,
+    }
+}
+
+fn quiescent(image: &Image) -> bool {
+    if first_violation(image, Variant::Reference).is_some() {
+        return false;
+    }
+    let Some(world) = image.uniform_world(Variant::Reference) else {
+        return false;
+    };
+    image.participants().iter().all(|participant| match world {
+        World::Predecessor => {
+            participant.prepare == PrepareState::Absent
+                && participant.final_state == FinalState::Absent
+                && !participant.final_durable
+                && !participant.resized
+                && !participant.unlinked
+        }
+        World::Candidate => {
+            participant.final_state == FinalState::Complete
+                && participant.final_durable
+                && match participant.operation {
+                    Operation::Publish => !participant.resized && !participant.unlinked,
+                    Operation::Rewind => participant.resized && !participant.unlinked,
+                    Operation::Remove => participant.unlinked,
+                }
+        }
+    })
+}
+
+fn choice_vectors<T: Copy>(choices: &[T], count: usize) -> Vec<[T; MAX_PARTICIPANTS]> {
+    assert!(!choices.is_empty());
+    assert!((1..=MAX_PARTICIPANTS).contains(&count));
+    let combinations = choices.len().pow(count as u32);
+    let mut vectors = Vec::with_capacity(combinations);
+    for encoded in 0..combinations {
+        let mut encoded = encoded;
+        let mut vector = [choices[0]; MAX_PARTICIPANTS];
+        for value in &mut vector[..count] {
+            *value = choices[encoded % choices.len()];
+            encoded /= choices.len();
+        }
+        vectors.push(vector);
+    }
+    vectors
+}
+
+fn proof_vectors(
+    operations: &[Operation; MAX_PARTICIPANTS],
+    count: usize,
+) -> Vec<[PayloadProof; MAX_PARTICIPANTS]> {
+    let publishes = operations[..count]
+        .iter()
+        .filter(|operation| **operation == Operation::Publish)
+        .count();
+    let mut vectors = Vec::with_capacity(1 << publishes);
+    for mask in 0..1usize << publishes {
+        let mut vector = [PayloadProof::NotRequired; MAX_PARTICIPANTS];
+        let mut publish = 0;
+        for (proof, operation) in vector.iter_mut().zip(&operations[..count]) {
+            if *operation == Operation::Publish {
+                *proof = if mask & (1 << publish) == 0 {
+                    PayloadProof::Invalid
+                } else {
+                    PayloadProof::Valid
+                };
+                publish += 1;
+            }
+        }
+        vectors.push(vector);
+    }
+    vectors
+}
+
+fn publication_image(
+    count: usize,
+    operations: [Operation; MAX_PARTICIPANTS],
+    prepares: [PrepareState; MAX_PARTICIPANTS],
+    proofs: [PayloadProof; MAX_PARTICIPANTS],
+    outcomes: [DurabilityOutcome; MAX_PARTICIPANTS],
+) -> Option<Image> {
+    let mut participants = [Participant::PLACEHOLDER; MAX_PARTICIPANTS];
+    for ordinal in 0..count {
+        let operation = operations[ordinal];
+        let prepare = prepares[ordinal];
+        let proof = proofs[ordinal];
+        let outcome = outcomes[ordinal];
+        if outcome == DurabilityOutcome::Succeeded
+            && (prepare != PrepareState::Complete || !proof.authorizes(operation))
+        {
+            return None;
+        }
+        participants[ordinal] = Participant {
+            ordinal,
+            operation,
+            prepare,
+            publication_sync: outcome,
+            proof,
+            final_state: FinalState::Absent,
+            final_durable: false,
+            recovery_sync: DurabilityOutcome::NotAttempted,
+            resized: false,
+            unlinked: false,
+        };
+    }
+    Some(Image {
+        count,
+        participants,
+        decision_without_authority: false,
+        live_cleanup_without_completed_cut: false,
+        unlink_before_completed_final_cut: false,
+    })
+}
+
+fn live_cleanup_image(
+    mut image: Image,
+    final_states: [FinalState; MAX_PARTICIPANTS],
+    resize_mask: usize,
+    variant: Variant,
+) -> Image {
+    let completed_cut = image.completed_publication_cut();
+    let retained_cleanup = final_states[..image.count]
+        .iter()
+        .any(|state| *state != FinalState::Absent)
+        || resize_mask != 0;
+    image.live_cleanup_without_completed_cut |= retained_cleanup && !completed_cut;
+    for (ordinal, participant) in image.participants_mut().iter_mut().enumerate() {
+        participant.final_state = final_states[ordinal];
+        if participant.operation == Operation::Rewind && resize_mask & (1 << ordinal) != 0 {
+            participant.resized = true;
+        }
+    }
+    debug_assert!(variant.permits_live_cleanup(&image));
+    image
+}
+
+fn cleanup_positions(image: &Image, include_remove: bool) -> usize {
+    image
+        .participants()
+        .iter()
+        .enumerate()
+        .fold(0, |mask, (ordinal, participant)| {
+            let cleanup = participant.operation == Operation::Rewind
+                || (include_remove && participant.operation == Operation::Remove);
+            if cleanup { mask | (1 << ordinal) } else { mask }
+        })
+}
+
+fn assert_reference_contract(image: Image) {
+    assert_eq!(
+        first_violation(&image, Variant::Reference),
+        None,
+        "invalid reference image: {image:?}"
+    );
+    let expected = if image.candidate_authority() {
+        World::Candidate
+    } else {
+        World::Predecessor
+    };
+    assert_eq!(image.uniform_world(Variant::Reference), Some(expected));
+
+    let first = recover_fault_free(image, Variant::Reference);
+    assert_eq!(first.decision, Some(expected));
+    assert_eq!(
+        first_violation(&first.image, Variant::Reference),
+        None,
+        "recovery violated the model: {first:?}"
+    );
+    assert!(
+        quiescent(&first.image),
+        "recovery did not converge: {first:?}"
+    );
+
+    let second = recover_fault_free(first.image, Variant::Reference);
+    assert_eq!(second.decision, first.decision);
+    assert_eq!(
+        second.image, first.image,
+        "second recovery changed the image"
+    );
+    // Reopen may repeat durability barriers, but settled metadata and namespace mutations do not.
+    assert_eq!(
+        second.work,
+        RecoveryWork {
+            barriers: second.work.barriers,
+            ..RecoveryWork::default()
+        }
+    );
+}
+
+fn for_each_candidate_recovery_crash(mut seed: Image, mut check: impl FnMut(Image)) {
+    assert!(seed.candidate_authority());
+    for participant in seed.participants_mut() {
+        participant.final_state = FinalState::Absent;
+        participant.final_durable = false;
+    }
+    let outcomes = choice_vectors(&DurabilityOutcome::ALL, seed.count);
+    let final_states = choice_vectors(&FinalState::ALL, seed.count);
+    for outcome in outcomes {
+        for retained in &final_states {
+            let mut crash = seed;
+            let mut reachable = true;
+            for ordinal in 0..crash.count {
+                if outcome[ordinal] == DurabilityOutcome::Succeeded
+                    && retained[ordinal] != FinalState::Complete
+                {
+                    reachable = false;
+                    break;
+                }
+                let participant = &mut crash.participants[ordinal];
+                participant.final_state = retained[ordinal];
+                participant.final_durable = outcome[ordinal] == DurabilityOutcome::Succeeded;
+                participant.recovery_sync = outcome[ordinal];
+            }
+            if !reachable {
+                continue;
+            }
+            check(crash);
+
+            if crash.completed_final_cut() {
+                let positions = cleanup_positions(&crash, true);
+                for cleanup_mask in 0..1usize << crash.count {
+                    if cleanup_mask & !positions != 0 {
+                        continue;
+                    }
+                    let mut cleanup_crash = crash;
+                    for ordinal in 0..cleanup_crash.count {
+                        if cleanup_mask & (1 << ordinal) == 0 {
+                            continue;
+                        }
+                        let participant = &mut cleanup_crash.participants[ordinal];
+                        match participant.operation {
+                            Operation::Publish => unreachable!("publish has no physical cleanup"),
+                            Operation::Rewind => participant.resized = true,
+                            Operation::Remove => participant.unlinked = true,
+                        }
+                    }
+                    check(cleanup_crash);
+                }
+            }
+        }
+    }
+}
+
+fn clear_retention_reachable(
+    before: PrepareState,
+    outcome: DurabilityOutcome,
+    after: PrepareState,
+) -> bool {
+    match (before, outcome) {
+        (PrepareState::Absent, _) | (_, DurabilityOutcome::Succeeded) => {
+            after == PrepareState::Absent
+        }
+        (PrepareState::Torn, _) => after != PrepareState::Complete,
+        (PrepareState::Complete, _) => true,
+    }
+}
+
+fn for_each_predecessor_recovery_crash(seed: Image, mut check: impl FnMut(Image)) {
+    assert!(!seed.candidate_authority());
+    let outcomes = choice_vectors(&DurabilityOutcome::ALL, seed.count);
+    let retained = choice_vectors(&PrepareState::ALL, seed.count);
+    for outcome in outcomes {
+        for after in &retained {
+            if (0..seed.count).any(|ordinal| {
+                !clear_retention_reachable(
+                    seed.participants[ordinal].prepare,
+                    outcome[ordinal],
+                    after[ordinal],
+                )
+            }) {
+                continue;
+            }
+            let mut crash = seed;
+            for ordinal in 0..crash.count {
+                let participant = &mut crash.participants[ordinal];
+                participant.prepare = after[ordinal];
+                participant.recovery_sync = outcome[ordinal];
+            }
+            assert!(!crash.candidate_authority());
+            check(crash);
+        }
+    }
+}
+
+const SLOT_CLASS_COUNT: usize = 3;
+const HEADER_CLASS: u8 = 1;
+const ALL_SLOT_CLASSES: u8 = (1u8 << SLOT_CLASS_COUNT) - 1;
+
+// Root header, witness frame, and witness body are the only byte-equivalence classes. Retention
+// chooses the old or program-issued value for each whole class; it never fabricates slot bytes.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SlotCandidate {
+    generation: u8,
+    attempt: u8,
+}
+
+impl SlotCandidate {
+    fn slot(self) -> usize {
+        usize::from(self.generation & 1)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SlotAtom {
+    Zero,
+    PreparedHeader(SlotCandidate),
+    FinalHeader(SlotCandidate),
+    WitnessFrame(SlotCandidate),
+    WitnessBody(SlotCandidate),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SemanticSlot {
+    atoms: [SlotAtom; SLOT_CLASS_COUNT],
+}
+
+impl SemanticSlot {
+    const ZERO: Self = Self {
+        atoms: [SlotAtom::Zero; SLOT_CLASS_COUNT],
+    };
+
+    fn apply(&mut self, write: CanonicalSlotWrite, retained: u8) {
+        assert_eq!(retained & !write.touched, 0);
+        for (class, atom) in self.atoms.iter_mut().enumerate() {
+            if retained & (1u8 << class) != 0 {
+                *atom = write.atoms[class];
+            }
+        }
+    }
+
+    fn meaning(self) -> SlotMeaning {
+        match self.atoms {
+            [SlotAtom::Zero, SlotAtom::Zero, SlotAtom::Zero] => SlotMeaning::Zero,
+            [
+                SlotAtom::PreparedHeader(candidate),
+                SlotAtom::WitnessFrame(frame),
+                SlotAtom::WitnessBody(body),
+            ] if candidate == frame && candidate == body => SlotMeaning::Prepared(candidate),
+            [
+                SlotAtom::FinalHeader(candidate),
+                SlotAtom::WitnessFrame(frame),
+                SlotAtom::WitnessBody(body),
+            ] if candidate == frame && candidate == body => SlotMeaning::Final(candidate),
+            _ => SlotMeaning::Torn,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CanonicalSlotWrite {
+    touched: u8,
+    atoms: [SlotAtom; SLOT_CLASS_COUNT],
+}
+
+impl CanonicalSlotWrite {
+    fn prepared(candidate: SlotCandidate) -> Self {
+        Self {
+            touched: ALL_SLOT_CLASSES,
+            atoms: [
+                SlotAtom::PreparedHeader(candidate),
+                SlotAtom::WitnessFrame(candidate),
+                SlotAtom::WitnessBody(candidate),
+            ],
+        }
+    }
+
+    fn final_root(candidate: SlotCandidate) -> Self {
+        Self {
+            touched: HEADER_CLASS,
+            atoms: [
+                SlotAtom::FinalHeader(candidate),
+                SlotAtom::Zero,
+                SlotAtom::Zero,
+            ],
+        }
+    }
+
+    const fn clear() -> Self {
+        Self {
+            touched: ALL_SLOT_CLASSES,
+            atoms: [SlotAtom::Zero; SLOT_CLASS_COUNT],
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SlotMeaning {
+    Zero,
+    Prepared(SlotCandidate),
+    Final(SlotCandidate),
+    Torn,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct TwoSlotHistory {
+    slots: [SemanticSlot; 2],
+}
+
+impl TwoSlotHistory {
+    fn new() -> Self {
+        Self {
+            slots: [SemanticSlot::ZERO; 2],
+        }
+    }
+
+    fn apply(&mut self, candidate: SlotCandidate, write: CanonicalSlotWrite, retained: u8) {
+        self.slots[candidate.slot()].apply(write, retained);
+    }
+
+    /// Establish a generation after a completed recovery barrier.
+    fn install_durable_final(&mut self, candidate: SlotCandidate) {
+        self.apply(
+            candidate,
+            CanonicalSlotWrite::prepared(candidate),
+            ALL_SLOT_CLASSES,
+        );
+        self.apply(
+            candidate,
+            CanonicalSlotWrite::final_root(candidate),
+            HEADER_CLASS,
+        );
+        assert_eq!(
+            self.slots[candidate.slot()].meaning(),
+            SlotMeaning::Final(candidate)
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RejectedSlotAction {
+    Clear {
+        outcome: DurabilityOutcome,
+        retained: u8,
+    },
+    Skip,
+}
+
+fn synced_clear_retention_reachable(outcome: DurabilityOutcome, retained: u8) -> bool {
+    match outcome {
+        DurabilityOutcome::Failed => true,
+        DurabilityOutcome::Succeeded => retained == ALL_SLOT_CLASSES,
+        DurabilityOutcome::NotAttempted => false,
+    }
+}
+
+fn consume_rejected_slot(
+    history: &mut TwoSlotHistory,
+    rejected: SlotCandidate,
+    action: RejectedSlotAction,
+) -> usize {
+    let RejectedSlotAction::Clear { outcome, retained } = action else {
+        return 0;
+    };
+    assert!(synced_clear_retention_reachable(outcome, retained));
+    history.apply(rejected, CanonicalSlotWrite::clear(), retained);
+    if outcome == DurabilityOutcome::Failed {
+        history.apply(rejected, CanonicalSlotWrite::clear(), ALL_SLOT_CLASSES);
+    }
+    assert_eq!(history.slots[rejected.slot()].meaning(), SlotMeaning::Zero);
+    1 + usize::from(outcome == DurabilityOutcome::Failed)
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct SlotReuseObservation {
+    retained: SlotMeaning,
+    clear_writes: usize,
+}
+
+fn three_generation_slot_reuse(
+    rejected_prepared_retained: u8,
+    retry_retained: u8,
+    retry_final_retained: u8,
+    rejected_slot_action: RejectedSlotAction,
+) -> SlotReuseObservation {
+    let generation_one = SlotCandidate {
+        generation: 1,
+        attempt: 0,
+    };
+    let generation_two = SlotCandidate {
+        generation: 2,
+        attempt: 0,
+    };
+    let rejected = SlotCandidate {
+        generation: 3,
+        attempt: 0,
+    };
+    let retry = SlotCandidate {
+        generation: 3,
+        attempt: 1,
+    };
+    let mut history = TwoSlotHistory::new();
+    history.install_durable_final(generation_one);
+    history.install_durable_final(generation_two);
+    assert_eq!(generation_one.slot(), rejected.slot());
+    assert_ne!(generation_two.slot(), rejected.slot());
+
+    history.apply(
+        rejected,
+        CanonicalSlotWrite::prepared(rejected),
+        rejected_prepared_retained,
+    );
+    assert!(
+        rejected_prepared_retained != 0
+            && matches!(
+                history.slots[rejected.slot()].meaning(),
+                SlotMeaning::Prepared(candidate) if candidate == rejected
+            )
+            || matches!(history.slots[rejected.slot()].meaning(), SlotMeaning::Torn)
+    );
+    let clear_writes = consume_rejected_slot(&mut history, rejected, rejected_slot_action);
+    history.apply(retry, CanonicalSlotWrite::prepared(retry), retry_retained);
+    assert!(retry_retained == ALL_SLOT_CLASSES || retry_final_retained == 0);
+    if retry_retained == ALL_SLOT_CLASSES {
+        history.apply(
+            retry,
+            CanonicalSlotWrite::final_root(retry),
+            retry_final_retained,
+        );
+    }
+    SlotReuseObservation {
+        retained: history.slots[retry.slot()].meaning(),
+        clear_writes,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlapVariant {
+    Reference,
+    SkipHiddenDebt,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OpenOrder {
+    SuccessorFirst,
+    PredecessorFirst,
+}
+
+impl OpenOrder {
+    const ALL: [Self; 2] = [Self::SuccessorFirst, Self::PredecessorFirst];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PostSuccessor {
+    CrashBeforeReuse,
+    ConsumePredecessorEdges,
+}
+
+impl PostSuccessor {
+    const ALL: [Self; 2] = [Self::CrashBeforeReuse, Self::ConsumePredecessorEdges];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct OverlapCase {
+    count: usize,
+    successor_mask: usize,
+    // A set bit still depends on the predecessor ring rather than an independent durable final.
+    predecessor_final_debt: usize,
+    barrier_outcomes: [DurabilityOutcome; MAX_PARTICIPANTS],
+    retained_successor_evidence: usize,
+}
+
+impl OverlapCase {
+    fn participant_mask(&self) -> usize {
+        (1usize << self.count) - 1
+    }
+
+    fn omitted_mask(&self) -> usize {
+        self.participant_mask() & !self.successor_mask
+    }
+
+    fn reachable(&self, variant: OverlapVariant) -> bool {
+        if !(2..=MAX_PARTICIPANTS).contains(&self.count)
+            || self.successor_mask == 0
+            || self.successor_mask & !self.participant_mask() != 0
+            || self.predecessor_final_debt & !self.participant_mask() != 0
+            || self.retained_successor_evidence & !self.successor_mask != 0
+        {
+            return false;
+        }
+
+        for ordinal in 0..self.count {
+            let bit = 1usize << ordinal;
+            let successor_participant = self.successor_mask & bit != 0;
+            let hidden_debt = self.predecessor_final_debt & self.omitted_mask() & bit != 0;
+            let barrier_is_issued =
+                successor_participant || (variant == OverlapVariant::Reference && hidden_debt);
+            let outcome = self.barrier_outcomes[ordinal];
+            if !barrier_is_issued && outcome != DurabilityOutcome::NotAttempted {
+                return false;
+            }
+            if successor_participant
+                && outcome == DurabilityOutcome::Succeeded
+                && self.retained_successor_evidence & bit == 0
+            {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn successor_authority(&self) -> bool {
+        self.retained_successor_evidence & self.successor_mask == self.successor_mask
+    }
+
+    fn completed_successor_cut(&self, variant: OverlapVariant) -> bool {
+        let participant_barriers_succeeded = (0..self.count).all(|ordinal| {
+            let bit = 1usize << ordinal;
+            self.successor_mask & bit == 0
+                || self.barrier_outcomes[ordinal] == DurabilityOutcome::Succeeded
+        });
+        let hidden_barriers_succeeded = match variant {
+            OverlapVariant::Reference => (0..self.count).all(|ordinal| {
+                let bit = 1usize << ordinal;
+                self.predecessor_final_debt & self.omitted_mask() & bit == 0
+                    || self.barrier_outcomes[ordinal] == DurabilityOutcome::Succeeded
+            }),
+            OverlapVariant::SkipHiddenDebt => true,
+        };
+        participant_barriers_succeeded && hidden_barriers_succeeded
+    }
+
+    fn remaining_predecessor_debt(&self) -> usize {
+        (0..self.count).fold(self.predecessor_final_debt, |debt, ordinal| {
+            if self.barrier_outcomes[ordinal] == DurabilityOutcome::Succeeded {
+                debt & !(1usize << ordinal)
+            } else {
+                debt
+            }
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlapRecovery {
+    Recovered { world: World, remaining_debt: usize },
+    Stranded { omitted_member: usize },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum RecoveryStep {
+    Predecessor,
+    Successor,
+}
+
+fn recover_overlap(
+    case: OverlapCase,
+    variant: OverlapVariant,
+    order: OpenOrder,
+    post_successor: PostSuccessor,
+) -> OverlapRecovery {
+    let remaining_debt = case.remaining_predecessor_debt();
+    let predecessor_edges_consumed = post_successor == PostSuccessor::ConsumePredecessorEdges
+        && case.completed_successor_cut(variant)
+        && case.successor_authority();
+    let steps = match order {
+        OpenOrder::SuccessorFirst => [RecoveryStep::Successor, RecoveryStep::Predecessor],
+        OpenOrder::PredecessorFirst => [RecoveryStep::Predecessor, RecoveryStep::Successor],
+    };
+    let mut predecessor_closed = remaining_debt == 0;
+    let mut world = World::Predecessor;
+
+    for step in steps {
+        let needs_predecessor = step == RecoveryStep::Predecessor
+            || (step == RecoveryStep::Successor && case.successor_authority());
+        if needs_predecessor && !predecessor_closed {
+            if predecessor_edges_consumed {
+                let hidden_debt = remaining_debt & case.omitted_mask();
+                return OverlapRecovery::Stranded {
+                    omitted_member: hidden_debt.trailing_zeros() as usize,
+                };
+            }
+            predecessor_closed = true;
+        }
+        if step == RecoveryStep::Successor && case.successor_authority() {
+            world = World::Candidate;
+        }
+    }
+
+    OverlapRecovery::Recovered {
+        world,
+        remaining_debt: usize::from(!predecessor_closed) * remaining_debt,
+    }
+}
+
+fn for_each_overlap_case(variant: OverlapVariant, mut check: impl FnMut(OverlapCase)) {
+    for count in 2..=MAX_PARTICIPANTS {
+        let outcomes = choice_vectors(&DurabilityOutcome::ALL, count);
+        let participant_mask = (1usize << count) - 1;
+        for successor_mask in 1..=participant_mask {
+            for predecessor_final_debt in 0..=participant_mask {
+                for retained_successor_evidence in 0..=participant_mask {
+                    if retained_successor_evidence & !successor_mask != 0 {
+                        continue;
+                    }
+                    for barrier_outcomes in &outcomes {
+                        let case = OverlapCase {
+                            count,
+                            successor_mask,
+                            predecessor_final_debt,
+                            barrier_outcomes: *barrier_outcomes,
+                            retained_successor_evidence,
+                        };
+                        if case.reachable(variant) {
+                            check(case);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn publication_crashes_select_one_complete_world() {
+    let mut images = 0usize;
+    let mut participant_counts = [false; MAX_PARTICIPANTS + 1];
+    let mut operations_seen = [false; Operation::ALL.len()];
+    let mut prepares_seen = [false; PrepareState::ALL.len()];
+    let mut outcomes_seen = [false; DurabilityOutcome::ALL.len()];
+    let mut retained_candidate_after_failed_sync = false;
+    let mut failed_sync_without_candidate = false;
+
+    for (count, covered) in participant_counts.iter_mut().enumerate().skip(1) {
+        *covered = true;
+        let operations = choice_vectors(&Operation::ALL, count);
+        let prepares = choice_vectors(&PrepareState::ALL, count);
+        let outcomes = choice_vectors(&DurabilityOutcome::ALL, count);
+        for operation in operations {
+            for prepare in &prepares {
+                for proof in proof_vectors(&operation, count) {
+                    for outcome in &outcomes {
+                        let Some(image) =
+                            publication_image(count, operation, *prepare, proof, *outcome)
+                        else {
+                            continue;
+                        };
+                        images += 1;
+                        for participant in image.participants() {
+                            operations_seen[participant.operation as usize] = true;
+                            prepares_seen[participant.prepare as usize] = true;
+                            outcomes_seen[participant.publication_sync as usize] = true;
+                        }
+                        let any_failed = image.participants().iter().any(|participant| {
+                            participant.publication_sync == DurabilityOutcome::Failed
+                        });
+                        retained_candidate_after_failed_sync |=
+                            any_failed && image.candidate_authority();
+                        failed_sync_without_candidate |= any_failed && !image.candidate_authority();
+                        assert_reference_contract(image);
+
+                        if !Variant::Reference.permits_live_cleanup(&image) {
+                            continue;
+                        }
+                        let final_states = choice_vectors(&FinalState::ALL, count);
+                        let resize_positions = cleanup_positions(&image, false);
+                        for retained in final_states {
+                            for resize_mask in 0..1usize << count {
+                                if resize_mask & !resize_positions != 0 {
+                                    continue;
+                                }
+                                images += 1;
+                                assert_reference_contract(live_cleanup_image(
+                                    image,
+                                    retained,
+                                    resize_mask,
+                                    Variant::Reference,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(images > 20_000, "bounded exploration unexpectedly shrank");
+    assert!(participant_counts[1..].iter().all(|covered| *covered));
+    assert!(operations_seen.iter().all(|covered| *covered));
+    assert!(prepares_seen.iter().all(|covered| *covered));
+    assert!(outcomes_seen.iter().all(|covered| *covered));
+    assert!(retained_candidate_after_failed_sync);
+    assert!(failed_sync_without_candidate);
+}
+
+#[test]
+fn crashes_during_recovery_converge_idempotently() {
+    let mut crash_images = 0usize;
+    for count in 1..=MAX_PARTICIPANTS {
+        let operations = choice_vectors(&Operation::ALL, count);
+        let prepares = choice_vectors(&PrepareState::ALL, count);
+        for operation in operations {
+            let proofs = proof_vectors(&operation, count);
+
+            let candidate = publication_image(
+                count,
+                operation,
+                [PrepareState::Complete; MAX_PARTICIPANTS],
+                proofs
+                    .iter()
+                    .copied()
+                    .find(|proof| {
+                        (0..count).all(|ordinal| proof[ordinal].authorizes(operation[ordinal]))
+                    })
+                    .expect("every operation vector has valid proofs"),
+                [DurabilityOutcome::Succeeded; MAX_PARTICIPANTS],
+            )
+            .expect("successful durability has complete local evidence");
+            for_each_candidate_recovery_crash(candidate, |crash| {
+                crash_images += 1;
+                assert_reference_contract(crash);
+            });
+
+            for prepare in &prepares {
+                for proof in &proofs {
+                    let seed = publication_image(
+                        count,
+                        operation,
+                        *prepare,
+                        *proof,
+                        [DurabilityOutcome::NotAttempted; MAX_PARTICIPANTS],
+                    )
+                    .expect("an unattempted durability operation imposes no retained state");
+                    if seed.candidate_authority() {
+                        continue;
+                    }
+                    for_each_predecessor_recovery_crash(seed, |crash| {
+                        crash_images += 1;
+                        assert_reference_contract(crash);
+                    });
+                }
+            }
+        }
+    }
+    assert!(
+        crash_images > 200_000,
+        "recovery-cut exploration unexpectedly shrank: {crash_images}"
+    );
+}
+
+#[test]
+fn rejected_slot_is_consumed_before_three_generation_reuse() {
+    let retry = SlotCandidate {
+        generation: 3,
+        attempt: 1,
+    };
+    let mut explored = 0usize;
+    for rejected_retained in 1..=ALL_SLOT_CLASSES {
+        for clear_outcome in [DurabilityOutcome::Failed, DurabilityOutcome::Succeeded] {
+            for clear_retained in 0..=ALL_SLOT_CLASSES {
+                if !synced_clear_retention_reachable(clear_outcome, clear_retained) {
+                    continue;
+                }
+                for retry_retained in 0..=ALL_SLOT_CLASSES {
+                    let final_retentions: &[u8] = if retry_retained == ALL_SLOT_CLASSES {
+                        &[0, HEADER_CLASS]
+                    } else {
+                        &[0]
+                    };
+                    for retry_final_retained in final_retentions {
+                        explored += 1;
+                        let observation = three_generation_slot_reuse(
+                            rejected_retained,
+                            retry_retained,
+                            *retry_final_retained,
+                            RejectedSlotAction::Clear {
+                                outcome: clear_outcome,
+                                retained: clear_retained,
+                            },
+                        );
+                        let expected = match (retry_retained, *retry_final_retained) {
+                            (0, _) => SlotMeaning::Zero,
+                            (ALL_SLOT_CLASSES, HEADER_CLASS) => SlotMeaning::Final(retry),
+                            (ALL_SLOT_CLASSES, _) => SlotMeaning::Prepared(retry),
+                            _ => SlotMeaning::Torn,
+                        };
+                        assert_eq!(observation.retained, expected);
+                        assert_eq!(
+                            observation.clear_writes,
+                            if clear_outcome == DurabilityOutcome::Failed {
+                                2
+                            } else {
+                                1
+                            }
+                        );
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(explored, 567);
+}
+
+#[test]
+fn skipping_durable_slot_clear_resurrects_rejected_generation() {
+    let rejected = SlotCandidate {
+        generation: 3,
+        attempt: 0,
+    };
+    let counterexample =
+        three_generation_slot_reuse(ALL_SLOT_CLASSES, 0, 0, RejectedSlotAction::Skip);
+    assert_eq!(counterexample.clear_writes, 0);
+    assert_eq!(counterexample.retained, SlotMeaning::Prepared(rejected));
+}
+
+#[test]
+fn overlapping_successors_pay_every_predecessor_member() {
+    let mut explored = 0usize;
+    let mut memberships_seen = [[false; 1 << MAX_PARTICIPANTS]; MAX_PARTICIPANTS + 1];
+    let mut debt_masks_seen = [[false; 1 << MAX_PARTICIPANTS]; MAX_PARTICIPANTS + 1];
+    let mut participant_outcomes_seen = [false; DurabilityOutcome::ALL.len()];
+    let mut hidden_outcomes_seen = [false; DurabilityOutcome::ALL.len()];
+    let mut retained_full_successor = false;
+    let mut retained_partial_successor = false;
+
+    for_each_overlap_case(OverlapVariant::Reference, |case| {
+        explored += 1;
+        memberships_seen[case.count][case.successor_mask] = true;
+        debt_masks_seen[case.count][case.predecessor_final_debt] = true;
+        retained_full_successor |= case.successor_authority();
+        retained_partial_successor |= !case.successor_authority();
+        for ordinal in 0..case.count {
+            let bit = 1usize << ordinal;
+            let outcome = case.barrier_outcomes[ordinal] as usize;
+            if case.successor_mask & bit != 0 {
+                participant_outcomes_seen[outcome] = true;
+            } else if case.predecessor_final_debt & bit != 0 {
+                hidden_outcomes_seen[outcome] = true;
+            }
+        }
+
+        for post_successor in PostSuccessor::ALL {
+            let successor_first = recover_overlap(
+                case,
+                OverlapVariant::Reference,
+                OpenOrder::SuccessorFirst,
+                post_successor,
+            );
+            let predecessor_first = recover_overlap(
+                case,
+                OverlapVariant::Reference,
+                OpenOrder::PredecessorFirst,
+                post_successor,
+            );
+            assert_eq!(successor_first, predecessor_first, "order changed {case:?}");
+            assert!(matches!(
+                successor_first,
+                OverlapRecovery::Recovered {
+                    remaining_debt: 0,
+                    ..
+                }
+            ));
+        }
+        if case.completed_successor_cut(OverlapVariant::Reference) {
+            assert_eq!(
+                case.remaining_predecessor_debt() & case.omitted_mask(),
+                0,
+                "completed successor stranded predecessor debt: {case:?}"
+            );
+        }
+    });
+
+    assert!(explored > 2_500, "overlap exploration unexpectedly shrank");
+    for count in 2..=MAX_PARTICIPANTS {
+        assert!(
+            memberships_seen[count][1..1 << count]
+                .iter()
+                .all(|seen| *seen)
+        );
+        assert!(
+            debt_masks_seen[count][..1 << count]
+                .iter()
+                .all(|seen| *seen)
+        );
+    }
+    assert!(participant_outcomes_seen.iter().all(|seen| *seen));
+    assert!(hidden_outcomes_seen.iter().all(|seen| *seen));
+    assert!(retained_full_successor);
+    assert!(retained_partial_successor);
+}
+
+#[test]
+fn skipping_hidden_debt_has_a_stranded_peer_counterexample() {
+    let mut counterexample = None;
+    for_each_overlap_case(OverlapVariant::SkipHiddenDebt, |case| {
+        if counterexample.is_some() {
+            return;
+        }
+        if let OverlapRecovery::Stranded { omitted_member } = recover_overlap(
+            case,
+            OverlapVariant::SkipHiddenDebt,
+            OpenOrder::SuccessorFirst,
+            PostSuccessor::ConsumePredecessorEdges,
+        ) {
+            counterexample = Some((case, omitted_member));
+        }
+    });
+
+    let (case, omitted_member) = counterexample.expect("skip-hidden-debt mutant survived");
+    assert!(case.completed_successor_cut(OverlapVariant::SkipHiddenDebt));
+    assert!(case.successor_authority());
+    assert_eq!(case.successor_mask & (1usize << omitted_member), 0);
+    assert_ne!(
+        case.remaining_predecessor_debt() & (1usize << omitted_member),
+        0
+    );
+    assert!(matches!(
+        recover_overlap(
+            case,
+            OverlapVariant::SkipHiddenDebt,
+            OpenOrder::SuccessorFirst,
+            PostSuccessor::CrashBeforeReuse,
+        ),
+        OverlapRecovery::Recovered {
+            remaining_debt: 0,
+            ..
+        }
+    ));
+    for order in OpenOrder::ALL {
+        assert_eq!(
+            recover_overlap(
+                case,
+                OverlapVariant::SkipHiddenDebt,
+                order,
+                PostSuccessor::ConsumePredecessorEdges,
+            ),
+            OverlapRecovery::Stranded { omitted_member }
+        );
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Counterexample {
+    variant: Variant,
+    violation: InvariantViolation,
+    image: Image,
+}
+
+fn find_counterexample(variant: Variant) -> Option<Counterexample> {
+    for count in 1..=MAX_PARTICIPANTS {
+        let operations = choice_vectors(&Operation::ALL, count);
+        let prepares = choice_vectors(&PrepareState::ALL, count);
+        let outcomes = choice_vectors(&DurabilityOutcome::ALL, count);
+        let final_states = choice_vectors(&FinalState::ALL, count);
+        for operation in operations {
+            for prepare in &prepares {
+                for proof in proof_vectors(&operation, count) {
+                    for outcome in &outcomes {
+                        let Some(image) =
+                            publication_image(count, operation, *prepare, proof, *outcome)
+                        else {
+                            continue;
+                        };
+                        if let Some(violation) = first_violation(&image, variant) {
+                            return Some(Counterexample {
+                                variant,
+                                violation,
+                                image,
+                            });
+                        }
+
+                        let recovered = recover_fault_free(image, variant);
+                        if let Some(violation) = first_violation(&recovered.image, variant) {
+                            return Some(Counterexample {
+                                variant,
+                                violation,
+                                image: recovered.image,
+                            });
+                        }
+                        if !variant.permits_live_cleanup(&image) {
+                            continue;
+                        }
+                        for retained in &final_states {
+                            let cleanup = live_cleanup_image(image, *retained, 0, variant);
+                            if let Some(violation) = first_violation(&cleanup, variant) {
+                                return Some(Counterexample {
+                                    variant,
+                                    violation,
+                                    image: cleanup,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn every_critical_semantic_mutant_has_a_counterexample() {
+    for variant in Variant::MUTANTS {
+        let counterexample = find_counterexample(variant)
+            .unwrap_or_else(|| panic!("semantic mutant survived bounded exploration: {variant:?}"));
+        let expected = match variant {
+            Variant::LocalPrepareDecides => InvariantViolation::MixedWorld,
+            Variant::FailedSyncIsCut | Variant::FinalizeBeforeCompletedCut => {
+                InvariantViolation::LiveCleanupWithoutCompletedCut
+            }
+            Variant::IgnorePayloadProof => InvariantViolation::CandidateWithoutAuthority,
+            Variant::UnlinkBeforeCompletedFinalCut => {
+                InvariantViolation::UnlinkBeforeCompletedFinalCut
+            }
+            Variant::Reference => unreachable!("the reference is not a semantic mutant"),
+        };
+        assert_eq!(
+            counterexample.violation, expected,
+            "unexpected counterexample for {variant:?}: {counterexample:?}"
+        );
+    }
+}

--- a/runtime/src/atomic/scheduled_tests.rs
+++ b/runtime/src/atomic/scheduled_tests.rs
@@ -1,0 +1,1711 @@
+//! Deterministic post-identity crash schedules for atomic publication and recovery.
+//!
+//! The schedules cover canonical program-issued writes, resizes, full and range syncs, and
+//! removals against the in-memory backend. Container creation, migration replacement, task
+//! cancellation, and filesystem durability are outside this gate. Migration crash behavior has a
+//! dedicated fuzz target.
+
+use super::*;
+use crate::{
+    BufferPool, BufferPoolConfig, Handle, IoBufs, IoBufsMut, Runner as _, WriteOptions,
+    deterministic, storage::memory, telemetry::metrics::Registry,
+};
+use commonware_utils::sync::Mutex as SyncMutex;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    io,
+    ops::RangeInclusive,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+const PARTITION: &str = "atomic_scheduled";
+const DIRECT_NAMES: [&[u8]; 1] = [b"a"];
+const PAIR_NAMES: [&[u8]; 2] = [b"a", b"b"];
+const TRIPLE_NAMES: [&[u8]; 3] = [b"a", b"b", b"c"];
+const SUFFIX: &[u8] = b"-new";
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct Location {
+    partition: String,
+    name: Vec<u8>,
+}
+
+impl Location {
+    fn new(partition: &str, name: &[u8]) -> Self {
+        Self {
+            partition: partition.to_string(),
+            name: name.to_vec(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum EventKind {
+    Write { offset: u64, len: usize, sync: bool },
+    Sync,
+    Resize { len: u64 },
+    Remove,
+}
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+struct CallIdentity {
+    location: Location,
+    ordinal: u64,
+    kind: EventKind,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct PrimitiveEvent {
+    issue: u64,
+    call: CallIdentity,
+    failed: bool,
+}
+
+enum PendingMutation {
+    Write {
+        issue: u64,
+        event_len: usize,
+        source_start: usize,
+        location: Location,
+        blob: memory::Blob,
+        offset: u64,
+        bytes: Vec<u8>,
+        durable: bool,
+    },
+    Resize {
+        issue: u64,
+        location: Location,
+        blob: memory::Blob,
+        len: u64,
+    },
+}
+
+impl PendingMutation {
+    fn location(&self) -> &Location {
+        match self {
+            Self::Write { location, .. } | Self::Resize { location, .. } => location,
+        }
+    }
+}
+
+#[derive(Default)]
+struct ScheduleState {
+    events: Vec<PrimitiveEvent>,
+    failures: BTreeSet<CallIdentity>,
+    remove_then_errors: BTreeSet<CallIdentity>,
+    ordinals: BTreeMap<Location, u64>,
+    next_issue: u64,
+    pending: Vec<PendingMutation>,
+}
+
+impl ScheduleState {
+    fn record(&mut self, location: Location, kind: EventKind) -> (u64, bool) {
+        let ordinal = self.ordinals.entry(location.clone()).or_default();
+        let call = CallIdentity {
+            location,
+            ordinal: *ordinal,
+            kind,
+        };
+        *ordinal = ordinal
+            .checked_add(1)
+            .expect("one location cannot exhaust call ordinals");
+        let issue = self.next_issue;
+        self.next_issue = self
+            .next_issue
+            .checked_add(1)
+            .expect("one storage cannot exhaust issue identifiers");
+        let failed = self.failures.remove(&call);
+        self.events.push(PrimitiveEvent {
+            issue,
+            call,
+            failed,
+        });
+        (issue, failed)
+    }
+}
+
+#[derive(Default)]
+struct CrashPlan {
+    writes: BTreeMap<u64, Vec<bool>>,
+    resizes: BTreeMap<u64, bool>,
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Retention {
+    Discard,
+    Keep,
+    Stripe,
+}
+
+impl Retention {
+    fn mask(self, issue: u64, len: usize) -> Vec<bool> {
+        match self {
+            Self::Discard => vec![false; len],
+            Self::Keep => vec![true; len],
+            Self::Stripe => (0..len)
+                .map(|index| (issue + index as u64).is_multiple_of(2))
+                .collect(),
+        }
+    }
+
+    fn retain_resize(self, issue: u64) -> bool {
+        match self {
+            Self::Discard => false,
+            Self::Keep => true,
+            Self::Stripe => issue.is_multiple_of(2),
+        }
+    }
+}
+
+#[derive(Clone)]
+struct ScheduledStorage {
+    inner: memory::Storage,
+    state: Arc<SyncMutex<ScheduleState>>,
+    identifiers: Arc<AtomicU64>,
+}
+
+impl ScheduledStorage {
+    fn new(pool: BufferPool) -> Self {
+        Self {
+            inner: memory::Storage::new(pool),
+            state: Arc::new(SyncMutex::new(ScheduleState::default())),
+            identifiers: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    fn wrap(&self, partition: &str, name: &[u8], inner: memory::Blob) -> ScheduledBlob {
+        ScheduledBlob {
+            inner,
+            location: Location::new(partition, name),
+            state: self.state.clone(),
+        }
+    }
+
+    fn arm(&self, failures: impl IntoIterator<Item = CallIdentity>) {
+        self.arm_with_mode(failures, false);
+    }
+
+    fn arm_clean(&self, failures: impl IntoIterator<Item = CallIdentity>) {
+        self.arm_with_mode(failures, true);
+    }
+
+    fn arm_clean_remove_then_error(&self, failure: CallIdentity) {
+        self.arm_with_mode([], true);
+        self.state.lock().remove_then_errors.insert(failure);
+    }
+
+    fn arm_with_mode(&self, failures: impl IntoIterator<Item = CallIdentity>, require_clean: bool) {
+        let mut state = self.state.lock();
+        assert!(
+            state.failures.is_empty() && state.remove_then_errors.is_empty(),
+            "the previous schedule did not consume every fault"
+        );
+        if require_clean {
+            assert!(
+                state.pending.is_empty(),
+                "a clean schedule began with mutation debt"
+            );
+        }
+        state.events.clear();
+        state.ordinals.clear();
+        state.failures = failures.into_iter().collect();
+    }
+
+    fn events(&self) -> Vec<PrimitiveEvent> {
+        self.state.lock().events.clone()
+    }
+
+    fn pending_issues(&self) -> BTreeSet<u64> {
+        self.state
+            .lock()
+            .pending
+            .iter()
+            .map(|mutation| match mutation {
+                PendingMutation::Write { issue, .. } | PendingMutation::Resize { issue, .. } => {
+                    *issue
+                }
+            })
+            .collect()
+    }
+
+    fn assert_unsynchronized_finals(&self, names: &[&[u8]]) {
+        let state = self.state.lock();
+        for name in names {
+            let location = Location::new(PARTITION, name);
+            assert!(
+                state.pending.iter().any(|mutation| matches!(
+                    mutation,
+                    PendingMutation::Write {
+                        location: candidate,
+                        offset,
+                        bytes,
+                        durable: false,
+                        ..
+                    } if candidate == &location
+                        && ROOT_OFFSETS.contains(offset)
+                        && bytes.len() == ROOT_LEN
+                )),
+                "the first publication did not leave final-root debt for {location:?}"
+            );
+        }
+    }
+
+    fn assert_failures_consumed(&self) {
+        let state = self.state.lock();
+        assert!(
+            state.failures.is_empty() && state.remove_then_errors.is_empty(),
+            "the scheduled primitive call was not reached"
+        );
+    }
+
+    fn crash_plan(&self, retention: Retention) -> CrashPlan {
+        let state = self.state.lock();
+        let mut plan = CrashPlan::default();
+        for mutation in &state.pending {
+            match mutation {
+                PendingMutation::Write {
+                    issue,
+                    event_len,
+                    durable,
+                    ..
+                } => {
+                    let mask = if *durable {
+                        vec![true; *event_len]
+                    } else {
+                        retention.mask(*issue, *event_len)
+                    };
+                    if let Some(existing) = plan.writes.insert(*issue, mask.clone()) {
+                        assert_eq!(existing, mask, "one write issue has one exact byte mask");
+                    }
+                }
+                PendingMutation::Resize { issue, .. } => {
+                    plan.resizes.insert(*issue, retention.retain_resize(*issue));
+                }
+            }
+        }
+        plan
+    }
+
+    fn crash(&self, plan: CrashPlan) -> Result<(), Error> {
+        let pending = {
+            let mut state = self.state.lock();
+            state.failures.clear();
+            state.remove_then_errors.clear();
+            std::mem::take(&mut state.pending)
+        };
+
+        for mutation in pending {
+            match mutation {
+                PendingMutation::Write {
+                    issue,
+                    event_len,
+                    source_start,
+                    blob,
+                    offset,
+                    bytes,
+                    ..
+                } => {
+                    let mask = plan
+                        .writes
+                        .get(&issue)
+                        .unwrap_or_else(|| panic!("missing byte mask for write issue {issue}"));
+                    assert_eq!(mask.len(), event_len, "write masks have exact widths");
+                    let mut retained = mask[source_start..source_start + bytes.len()]
+                        .iter()
+                        .copied();
+                    blob.retain_crash_write(offset, IoBufs::from(bytes), || {
+                        retained.next().expect("one decision exists for every byte")
+                    })?;
+                    assert!(retained.next().is_none());
+                }
+                PendingMutation::Resize {
+                    issue, blob, len, ..
+                } => {
+                    let retain = plan
+                        .resizes
+                        .get(&issue)
+                        .unwrap_or_else(|| panic!("missing outcome for resize issue {issue}"));
+                    if *retain {
+                        blob.retain_crash_resize(len)?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn clear_pending(&self, location: &Location) {
+        self.state
+            .lock()
+            .pending
+            .retain(|mutation| mutation.location() != location);
+    }
+
+    fn clear_removed(&self, partition: &str, name: Option<&[u8]>) {
+        self.state.lock().pending.retain(|mutation| {
+            let location = mutation.location();
+            location.partition != partition
+                || name.is_some_and(|name| location.name.as_slice() != name)
+        });
+    }
+}
+
+#[derive(Clone)]
+struct ScheduledBlob {
+    inner: memory::Blob,
+    location: Location,
+    state: Arc<SyncMutex<ScheduleState>>,
+}
+
+impl ScheduledBlob {
+    fn record(&self, kind: EventKind) -> (u64, bool) {
+        self.state.lock().record(self.location.clone(), kind)
+    }
+
+    fn record_pending_write(&self, issue: u64, offset: u64, bytes: Vec<u8>) {
+        if bytes.is_empty() {
+            return;
+        }
+        let event_len = bytes.len();
+        self.state.lock().pending.push(PendingMutation::Write {
+            issue,
+            event_len,
+            source_start: 0,
+            location: self.location.clone(),
+            blob: self.inner.clone(),
+            offset,
+            bytes,
+            durable: false,
+        });
+    }
+
+    fn retire_range(&self, issue: u64, offset: u64, bytes: &[u8]) {
+        let len = bytes.len();
+        let end = offset
+            .checked_add(len as u64)
+            .expect("the submitted write range was validated");
+        let mut state = self.state.lock();
+        let mutations = std::mem::take(&mut state.pending);
+        let mut retained = Vec::with_capacity(mutations.len() + 1);
+        let mut follows_resize = false;
+        for mutation in mutations {
+            let PendingMutation::Write {
+                issue: pending_issue,
+                event_len,
+                source_start,
+                location,
+                blob,
+                offset: write_offset,
+                bytes,
+                durable,
+            } = mutation
+            else {
+                if matches!(
+                    &mutation,
+                    PendingMutation::Resize { location, .. } if location == &self.location
+                ) {
+                    follows_resize = true;
+                }
+                retained.push(mutation);
+                continue;
+            };
+            if location != self.location {
+                retained.push(PendingMutation::Write {
+                    issue: pending_issue,
+                    event_len,
+                    source_start,
+                    location,
+                    blob,
+                    offset: write_offset,
+                    bytes,
+                    durable,
+                });
+                continue;
+            }
+            let write_end = write_offset + bytes.len() as u64;
+            let overlap_start = write_offset.max(offset);
+            let overlap_end = write_end.min(end);
+            if overlap_start >= overlap_end {
+                retained.push(PendingMutation::Write {
+                    issue: pending_issue,
+                    event_len,
+                    source_start,
+                    location,
+                    blob,
+                    offset: write_offset,
+                    bytes,
+                    durable,
+                });
+                continue;
+            }
+
+            let prefix_len = usize::try_from(overlap_start - write_offset).unwrap();
+            let suffix_start = usize::try_from(overlap_end - write_offset).unwrap();
+            if prefix_len != 0 {
+                retained.push(PendingMutation::Write {
+                    issue: pending_issue,
+                    event_len,
+                    source_start,
+                    location: location.clone(),
+                    blob: blob.clone(),
+                    offset: write_offset,
+                    bytes: bytes[..prefix_len].to_vec(),
+                    durable,
+                });
+            }
+            if suffix_start != bytes.len() {
+                retained.push(PendingMutation::Write {
+                    issue: pending_issue,
+                    event_len,
+                    source_start: source_start + suffix_start,
+                    location,
+                    blob,
+                    offset: overlap_end,
+                    bytes: bytes[suffix_start..].to_vec(),
+                    durable,
+                });
+            }
+        }
+        if follows_resize && !bytes.is_empty() {
+            retained.push(PendingMutation::Write {
+                issue,
+                event_len: bytes.len(),
+                source_start: 0,
+                location: self.location.clone(),
+                blob: self.inner.clone(),
+                offset,
+                bytes: bytes.to_vec(),
+                durable: true,
+            });
+        }
+        state.pending = retained;
+    }
+
+    async fn sync_inner(&self) -> Result<(), Error> {
+        let (_, failed) = self.record(EventKind::Sync);
+        if failed {
+            return Err(injected_error());
+        }
+        self.inner.sync().await?;
+        self.state
+            .lock()
+            .pending
+            .retain(|mutation| mutation.location() != &self.location);
+        Ok(())
+    }
+}
+
+fn injected_error() -> Error {
+    io::Error::other("scheduled storage fault").into()
+}
+
+impl crate::Blob for ScheduledBlob {
+    async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+        self.inner.read_at(offset, len).await
+    }
+
+    async fn read_at_buf(
+        &self,
+        offset: u64,
+        len: usize,
+        bufs: impl Into<IoBufsMut> + Send,
+    ) -> Result<IoBufsMut, Error> {
+        self.inner.read_at_buf(offset, len, bufs).await
+    }
+
+    async fn write_at(
+        &self,
+        offset: u64,
+        bufs: impl Into<IoBufs> + Send,
+        options: WriteOptions,
+    ) -> Result<(), Error> {
+        let bufs = bufs.into();
+        let bytes = bufs.clone().coalesce().as_ref().to_vec();
+        let sync = options.contains(WriteOptions::SYNC);
+        let (issue, failed) = self.record(EventKind::Write {
+            offset,
+            len: bytes.len(),
+            sync,
+        });
+
+        if failed {
+            self.inner
+                .write_at(offset, bufs, options.without(WriteOptions::SYNC))
+                .await?;
+            self.record_pending_write(issue, offset, bytes);
+            return Err(injected_error());
+        }
+
+        self.inner.write_at(offset, bufs, options).await?;
+        if sync {
+            self.retire_range(issue, offset, &bytes);
+        } else {
+            self.record_pending_write(issue, offset, bytes);
+        }
+        Ok(())
+    }
+
+    async fn resize(&self, len: u64) -> Result<(), Error> {
+        let (issue, failed) = self.record(EventKind::Resize { len });
+        self.inner.resize(len).await?;
+        self.state.lock().pending.push(PendingMutation::Resize {
+            issue,
+            location: self.location.clone(),
+            blob: self.inner.clone(),
+            len,
+        });
+        if failed {
+            Err(injected_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn sync(&self) -> Result<(), Error> {
+        self.sync_inner().await
+    }
+
+    async fn start_sync(&self) -> Handle<()> {
+        Handle::ready(self.sync_inner().await)
+    }
+}
+
+impl crate::Storage for ScheduledStorage {
+    type Blob = ScheduledBlob;
+
+    async fn open_versioned(
+        &self,
+        partition: &str,
+        name: &[u8],
+        versions: RangeInclusive<u16>,
+    ) -> Result<(Self::Blob, u64, u16), Error> {
+        let (blob, len, version) = self.inner.open_versioned(partition, name, versions).await?;
+        Ok((self.wrap(partition, name, blob), len, version))
+    }
+
+    async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
+        let location = Location::new(partition, name.unwrap_or_default());
+        let (failed, remove_then_error, call) = {
+            let mut state = self.state.lock();
+            let (_, failed) = state.record(location, EventKind::Remove);
+            let call = state.events.last().unwrap().call.clone();
+            let remove_then_error = state.remove_then_errors.contains(&call);
+            if remove_then_error {
+                state.events.last_mut().unwrap().failed = true;
+            }
+            (failed, remove_then_error, call)
+        };
+        if failed {
+            return Err(injected_error());
+        }
+        self.inner.remove(partition, name).await?;
+        self.clear_removed(partition, name);
+        if remove_then_error {
+            assert!(self.state.lock().remove_then_errors.remove(&call));
+            Err(injected_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
+        self.inner.scan(partition).await
+    }
+}
+
+impl Backend for ScheduledStorage {
+    type Worker = Self;
+
+    fn atomic_worker(&self) -> Self::Worker {
+        self.clone()
+    }
+
+    fn atomic_resources(&self) -> AtomicResources {
+        <memory::Storage as Backend>::atomic_resources(&self.inner)
+    }
+
+    fn new_atomic_identifier(&self) -> [u8; INCARNATION_LEN] {
+        let ordinal = self.identifiers.fetch_add(1, Ordering::Relaxed);
+        let mut identifier = [0x5c; INCARNATION_LEN];
+        identifier[INCARNATION_LEN - std::mem::size_of::<u64>()..]
+            .copy_from_slice(&ordinal.to_be_bytes());
+        identifier
+    }
+
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; INCARNATION_LEN],
+    ) -> Result<(), Error> {
+        let location = blob.location.clone();
+        <memory::Storage as Backend>::migrate_atomic_backing(&self.inner, blob.inner, incarnation)
+            .await?;
+        self.clear_pending(&location);
+        Ok(())
+    }
+
+    async fn open_atomic_existing(
+        &self,
+        partition: &str,
+        name: &[u8],
+    ) -> Result<Option<(Self::Blob, u64)>, Error> {
+        Ok(
+            <memory::Storage as Backend>::open_atomic_existing(&self.inner, partition, name)
+                .await?
+                .map(|(blob, len)| (self.wrap(partition, name, blob), len)),
+        )
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+enum Scenario {
+    Direct,
+    Pair,
+    Triple,
+}
+
+impl Scenario {
+    fn names(self) -> &'static [&'static [u8]] {
+        match self {
+            Self::Direct => &DIRECT_NAMES,
+            Self::Pair => &PAIR_NAMES,
+            Self::Triple => &TRIPLE_NAMES,
+        }
+    }
+
+    fn initial(self, index: usize) -> &'static [u8] {
+        match (self, index) {
+            (Self::Direct, 0) => b"old",
+            (_, 0) => b"old-a",
+            (_, 1) => b"abcdef",
+            (Self::Triple, 2) => b"victim",
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct Value {
+    data: Vec<u8>,
+    tag: [u8; ATOMIC_BLOB_TAG_LEN],
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct World(Vec<Option<Value>>);
+
+#[derive(Clone, Copy)]
+enum RecoveryEntry {
+    Open(usize),
+    Scan,
+}
+
+fn old_tag(index: usize) -> [u8; ATOMIC_BLOB_TAG_LEN] {
+    [0x10 + index as u8; ATOMIC_BLOB_TAG_LEN]
+}
+
+fn new_tag(index: usize) -> [u8; ATOMIC_BLOB_TAG_LEN] {
+    [0x20 + index as u8; ATOMIC_BLOB_TAG_LEN]
+}
+
+fn successor_tag() -> [u8; ATOMIC_BLOB_TAG_LEN] {
+    [0x30; ATOMIC_BLOB_TAG_LEN]
+}
+
+fn test_pool() -> BufferPool {
+    let mut registry = Registry::default();
+    BufferPool::new(BufferPoolConfig::for_storage(), &mut registry)
+}
+
+fn expected_worlds(scenario: Scenario) -> (World, World) {
+    let predecessor = World(
+        scenario
+            .names()
+            .iter()
+            .enumerate()
+            .map(|(index, _)| {
+                Some(Value {
+                    data: scenario.initial(index).to_vec(),
+                    tag: old_tag(index),
+                })
+            })
+            .collect(),
+    );
+    let candidate = match scenario {
+        Scenario::Direct => World(vec![Some(Value {
+            data: b"old-new".to_vec(),
+            tag: new_tag(0),
+        })]),
+        Scenario::Pair => World(vec![
+            Some(Value {
+                data: b"old-a-new".to_vec(),
+                tag: new_tag(0),
+            }),
+            Some(Value {
+                data: b"abc".to_vec(),
+                tag: new_tag(1),
+            }),
+        ]),
+        Scenario::Triple => World(vec![
+            Some(Value {
+                data: b"old-a-new".to_vec(),
+                tag: new_tag(0),
+            }),
+            Some(Value {
+                data: b"abc".to_vec(),
+                tag: new_tag(1),
+            }),
+            None,
+        ]),
+    };
+    (predecessor, candidate)
+}
+
+async fn initialize(scenario: Scenario) -> (ScheduledStorage, Vec<Blob<ScheduledBlob>>) {
+    let storage = ScheduledStorage::new(test_pool());
+    let mut blobs = Vec::new();
+    for (index, name) in scenario.names().iter().enumerate() {
+        let (blob, _) = storage.open_atomic(PARTITION, name).await.unwrap();
+        blob.append_tagged(scenario.initial(index), old_tag(index))
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+        blob.backing.sync().await.unwrap();
+        blobs.push(blob);
+    }
+    storage.arm_clean([]);
+    (storage, blobs)
+}
+
+async fn publish(
+    scenario: Scenario,
+    storage: &ScheduledStorage,
+    blobs: &[Blob<ScheduledBlob>],
+) -> Result<(), Error> {
+    blobs[0].append_tagged(SUFFIX, new_tag(0)).await?;
+    if matches!(scenario, Scenario::Direct) {
+        return blobs[0].sync().await;
+    }
+
+    blobs[1].set_tag(new_tag(1)).await?;
+    let mut operations = vec![
+        BatchOperation::Publish(blobs[0].clone()),
+        BatchOperation::Rewind {
+            blob: blobs[1].clone(),
+            len: 3,
+        },
+    ];
+    if matches!(scenario, Scenario::Triple) {
+        operations.insert(0, BatchOperation::Remove(blobs[2].clone()));
+    }
+    storage.apply(operations).await
+}
+
+async fn read_value(storage: &ScheduledStorage, name: &[u8]) -> Result<Value, Error> {
+    let (blob, len) = storage.open_atomic(PARTITION, name).await?;
+    let data = blob
+        .read_at(0, len as usize)
+        .await?
+        .coalesce()
+        .as_ref()
+        .to_vec();
+    Ok(Value {
+        data,
+        tag: blob.tag().await?,
+    })
+}
+
+async fn observe_names(
+    storage: &ScheduledStorage,
+    scenario: Scenario,
+    names: &[Vec<u8>],
+) -> Result<World, Error> {
+    let mut world = Vec::new();
+    for name in scenario.names() {
+        if !names.iter().any(|candidate| candidate.as_slice() == *name) {
+            world.push(None);
+            continue;
+        }
+        world.push(Some(read_value(storage, name).await?));
+    }
+    Ok(World(world))
+}
+
+async fn observe(storage: &ScheduledStorage, scenario: Scenario) -> Result<World, Error> {
+    let names = storage.scan_atomic(PARTITION).await?;
+    observe_names(storage, scenario, &names).await
+}
+
+async fn recover_via(
+    storage: &ScheduledStorage,
+    scenario: Scenario,
+    expected: &World,
+    entry: RecoveryEntry,
+) -> Result<Vec<PrimitiveEvent>, Error> {
+    match entry {
+        RecoveryEntry::Open(index) => {
+            let value = read_value(storage, scenario.names()[index]).await?;
+            assert_eq!(Some(&value), expected.0[index].as_ref());
+            let trace = storage.events();
+            assert_eq!(observe(storage, scenario).await?, *expected);
+            Ok(trace)
+        }
+        RecoveryEntry::Scan => {
+            let names = storage.scan_atomic(PARTITION).await?;
+            let trace = storage.events();
+            let world = observe_names(storage, scenario, &names).await?;
+            assert_eq!(world, *expected);
+            Ok(trace)
+        }
+    }
+}
+
+async fn observe_in_order(
+    storage: &ScheduledStorage,
+    scenario: Scenario,
+    order: &[usize],
+) -> Result<World, Error> {
+    assert_eq!(order.len(), scenario.names().len());
+    let mut world = vec![None; order.len()];
+    for &index in order {
+        world[index] = Some(read_value(storage, scenario.names()[index]).await?);
+    }
+    Ok(World(world))
+}
+
+fn prepared_write_index(events: &[PrimitiveEvent], location: &Location) -> Option<usize> {
+    events.iter().position(|event| {
+        event.call.location == *location
+            && matches!(
+                event.call.kind,
+                EventKind::Write {
+                    offset,
+                    len: ROOT_SLOT_SIZE,
+                    sync: false,
+                } if ROOT_OFFSETS.contains(&offset)
+            )
+    })
+}
+
+fn participant_barriers_completed(scenario: Scenario, events: &[PrimitiveEvent]) -> bool {
+    scenario.names().iter().all(|name| {
+        let location = Location::new(PARTITION, name);
+        let Some(prepared) = prepared_write_index(events, &location) else {
+            return false;
+        };
+        events[prepared + 1..].iter().any(|event| {
+            event.call.location == location
+                && matches!(event.call.kind, EventKind::Sync)
+                && !event.failed
+        })
+    })
+}
+
+fn complete_prepared_publication_retained(
+    scenario: Scenario,
+    events: &[PrimitiveEvent],
+    plan: &CrashPlan,
+) -> bool {
+    scenario.names().iter().all(|name| {
+        let location = Location::new(PARTITION, name);
+        let Some(prepared) = prepared_write_index(events, &location) else {
+            return false;
+        };
+        if events[prepared + 1..].iter().any(|event| {
+            event.call.location == location
+                && matches!(event.call.kind, EventKind::Sync)
+                && !event.failed
+        }) {
+            return true;
+        }
+
+        events[..=prepared]
+            .iter()
+            .filter(|event| {
+                event.call.location == location
+                    && matches!(event.call.kind, EventKind::Write { .. })
+            })
+            .all(|event| {
+                plan.writes
+                    .get(&event.issue)
+                    .is_some_and(|mask| mask.iter().all(|retained| *retained))
+            })
+    })
+}
+
+fn publication_candidate_authoritative(
+    scenario: Scenario,
+    events: &[PrimitiveEvent],
+    plan: &CrashPlan,
+) -> bool {
+    participant_barriers_completed(scenario, events)
+        || complete_prepared_publication_retained(scenario, events, plan)
+}
+
+fn assert_complete_world(actual: &World, predecessor: &World, candidate: &World) {
+    assert!(
+        actual == predecessor || actual == candidate,
+        "recovery selected a mixed world: {actual:?}"
+    );
+}
+
+async fn assert_idempotent_and_usable(
+    storage: &ScheduledStorage,
+    scenario: Scenario,
+    recovered: &World,
+) {
+    let plan = storage.crash_plan(Retention::Discard);
+    storage.crash(plan).unwrap();
+    storage.arm_clean([]);
+    let repeated = observe(storage, scenario).await.unwrap();
+    assert_eq!(&repeated, recovered);
+
+    let plan = storage.crash_plan(Retention::Discard);
+    storage.crash(plan).unwrap();
+    storage.arm_clean([]);
+    let original = recovered.0[0].as_ref().unwrap();
+    let (blob, len) = storage.open_atomic(PARTITION, b"a").await.unwrap();
+    assert_eq!(len as usize, original.data.len());
+    blob.append_tagged(b"!", [0x70; ATOMIC_BLOB_TAG_LEN])
+        .await
+        .unwrap();
+    blob.sync().await.unwrap();
+    drop(blob);
+    let plan = storage.crash_plan(Retention::Discard);
+    storage.crash(plan).unwrap();
+    storage.arm_clean([]);
+    let (blob, len) = storage.open_atomic(PARTITION, b"a").await.unwrap();
+    let mut expected = original.data.clone();
+    expected.push(b'!');
+    assert_eq!(len as usize, expected.len());
+    assert_eq!(
+        blob.read_at(0, expected.len())
+            .await
+            .unwrap()
+            .coalesce()
+            .as_ref(),
+        expected
+    );
+    assert_eq!(blob.tag().await.unwrap(), [0x70; ATOMIC_BLOB_TAG_LEN]);
+}
+
+async fn publication_trace(scenario: Scenario) -> Vec<PrimitiveEvent> {
+    let (storage, blobs) = initialize(scenario).await;
+    publish(scenario, &storage, &blobs).await.unwrap();
+    storage.events()
+}
+
+fn overlap_worlds() -> (World, World) {
+    let first = expected_worlds(Scenario::Pair).1;
+    let mut successor = first.clone();
+    let value = successor.0[0].as_mut().unwrap();
+    value.data.extend_from_slice(b"-next");
+    value.tag = successor_tag();
+    (first, successor)
+}
+
+async fn initialize_overlap() -> (ScheduledStorage, Vec<Blob<ScheduledBlob>>, BTreeSet<u64>) {
+    let (storage, blobs) = initialize(Scenario::Pair).await;
+    publish(Scenario::Pair, &storage, &blobs).await.unwrap();
+    storage.assert_unsynchronized_finals(Scenario::Pair.names());
+    let prior_debt = storage.pending_issues();
+    assert!(!prior_debt.is_empty());
+    storage.arm([]);
+    (storage, blobs, prior_debt)
+}
+
+async fn publish_overlap_successor(blobs: &[Blob<ScheduledBlob>]) -> Result<(), Error> {
+    blobs[0].append_tagged(b"-next", successor_tag()).await?;
+    blobs[0].sync().await
+}
+
+async fn overlap_sync_trace() -> Vec<PrimitiveEvent> {
+    let (storage, blobs, prior_debt) = initialize_overlap().await;
+    publish_overlap_successor(&blobs).await.unwrap();
+    let events = storage.events();
+    let last_prior_issue = prior_debt.last().copied().unwrap();
+    assert!(events.iter().all(|event| event.issue > last_prior_issue));
+    events
+        .into_iter()
+        .filter(|event| matches!(event.call.kind, EventKind::Sync))
+        .collect()
+}
+
+fn reincarnation_worlds() -> (World, World) {
+    let predecessor = World(vec![
+        Some(Value {
+            data: b"old-a-kept".to_vec(),
+            tag: [0x41; ATOMIC_BLOB_TAG_LEN],
+        }),
+        Some(Value {
+            data: b"new-b".to_vec(),
+            tag: [0x42; ATOMIC_BLOB_TAG_LEN],
+        }),
+    ]);
+    let mut candidate = predecessor.clone();
+    for (index, value) in candidate.0.iter_mut().enumerate() {
+        let value = value.as_mut().unwrap();
+        value.data.extend_from_slice(b"-later");
+        value.tag = [0x51 + index as u8; ATOMIC_BLOB_TAG_LEN];
+    }
+    (predecessor, candidate)
+}
+
+async fn initialize_reincarnation_history() -> (
+    ScheduledStorage,
+    Blob<ScheduledBlob>,
+    Blob<ScheduledBlob>,
+    [u8; INCARNATION_LEN],
+) {
+    let (storage, blobs) = initialize(Scenario::Pair).await;
+    let old_incarnation = blobs[1].incarnation;
+    blobs[0]
+        .append_tagged(b"-kept", [0x41; ATOMIC_BLOB_TAG_LEN])
+        .await
+        .unwrap();
+    storage
+        .apply(vec![
+            BatchOperation::Remove(blobs[1].clone()),
+            BatchOperation::Publish(blobs[0].clone()),
+        ])
+        .await
+        .unwrap();
+    drop(blobs);
+
+    let plan = storage.crash_plan(Retention::Discard);
+    storage.crash(plan).unwrap();
+    storage.arm_clean([]);
+    let (replacement, len) = storage.open_atomic(PARTITION, b"b").await.unwrap();
+    assert_eq!(len, 0);
+    let new_incarnation = replacement.incarnation;
+    assert_ne!(new_incarnation, old_incarnation);
+    replacement
+        .append_tagged(b"new-b", [0x42; ATOMIC_BLOB_TAG_LEN])
+        .await
+        .unwrap();
+    replacement.sync().await.unwrap();
+    replacement.backing.sync().await.unwrap();
+
+    let (survivor, len) = storage.open_atomic(PARTITION, b"a").await.unwrap();
+    assert_eq!(len, b"old-a-kept".len() as u64);
+    storage.arm_clean([]);
+    (storage, survivor, replacement, new_incarnation)
+}
+
+async fn publish_reincarnation_successor(
+    storage: &ScheduledStorage,
+    survivor: &Blob<ScheduledBlob>,
+    replacement: &Blob<ScheduledBlob>,
+) -> Result<(), Error> {
+    survivor
+        .append_tagged(b"-later", [0x51; ATOMIC_BLOB_TAG_LEN])
+        .await?;
+    replacement
+        .append_tagged(b"-later", [0x52; ATOMIC_BLOB_TAG_LEN])
+        .await?;
+    storage
+        .apply(vec![
+            BatchOperation::Publish(survivor.clone()),
+            BatchOperation::Publish(replacement.clone()),
+        ])
+        .await
+}
+
+async fn reincarnation_successor_trace() -> Vec<PrimitiveEvent> {
+    let (storage, survivor, replacement, _) = initialize_reincarnation_history().await;
+    publish_reincarnation_successor(&storage, &survivor, &replacement)
+        .await
+        .unwrap();
+    storage.events()
+}
+
+fn call_identity(name: &[u8], ordinal: u64, kind: EventKind) -> CallIdentity {
+    CallIdentity {
+        location: Location::new(PARTITION, name),
+        ordinal,
+        kind,
+    }
+}
+
+async fn initialize_raw(name: &[u8], bytes: &[u8]) -> (ScheduledStorage, ScheduledBlob) {
+    let storage = ScheduledStorage::new(test_pool());
+    let (blob, _) = storage.open(PARTITION, name).await.unwrap();
+    blob.write_at(0, bytes.to_vec(), WriteOptions::SYNC)
+        .await
+        .unwrap();
+    storage.arm_clean([]);
+    (storage, blob)
+}
+
+async fn raw_image(storage: &ScheduledStorage, name: &[u8]) -> Vec<u8> {
+    let (blob, len) = storage.open(PARTITION, name).await.unwrap();
+    blob.read_at(0, len as usize)
+        .await
+        .unwrap()
+        .coalesce()
+        .as_ref()
+        .to_vec()
+}
+
+async fn publication_fault_case(
+    scenario: Scenario,
+    failed_call: CallIdentity,
+    retention: Retention,
+) {
+    let (storage, blobs) = initialize(scenario).await;
+    storage.arm_clean([failed_call]);
+    assert!(publish(scenario, &storage, &blobs).await.is_err());
+    storage.assert_failures_consumed();
+    drop(blobs);
+
+    let plan = storage.crash_plan(retention);
+    let events = storage.events();
+    let candidate_authoritative = publication_candidate_authoritative(scenario, &events, &plan);
+    storage.crash(plan).unwrap();
+    storage.arm_clean([]);
+    let actual = observe(&storage, scenario).await.unwrap();
+    let (predecessor, candidate) = expected_worlds(scenario);
+    assert_complete_world(&actual, &predecessor, &candidate);
+    let expected = if candidate_authoritative {
+        &candidate
+    } else {
+        &predecessor
+    };
+    assert_eq!(&actual, expected);
+    assert_idempotent_and_usable(&storage, scenario, &actual).await;
+}
+
+#[test]
+fn exact_publication_faults_never_mix_worlds() {
+    deterministic::Runner::seeded(0x5c4e_d001).start(|_| async move {
+        for scenario in [Scenario::Direct, Scenario::Pair, Scenario::Triple] {
+            let trace = publication_trace(scenario).await;
+            assert!(!trace.is_empty());
+            for event in trace {
+                for retention in [Retention::Discard, Retention::Keep, Retention::Stripe] {
+                    publication_fault_case(scenario, event.call.clone(), retention).await;
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn participant_sync_outcomes_have_exact_oracles() {
+    deterministic::Runner::seeded(0x5c4e_d002).start(|_| async move {
+        for scenario in [Scenario::Direct, Scenario::Pair, Scenario::Triple] {
+            let trace = publication_trace(scenario).await;
+            let syncs = trace
+                .iter()
+                .filter(|event| matches!(event.call.kind, EventKind::Sync))
+                .map(|event| event.call.clone())
+                .collect::<Vec<_>>();
+            assert_eq!(syncs.len(), scenario.names().len());
+
+            for failed in 0..1usize << syncs.len() {
+                for retention in [Retention::Discard, Retention::Keep] {
+                    let (storage, blobs) = initialize(scenario).await;
+                    let failures = syncs
+                        .iter()
+                        .enumerate()
+                        .filter_map(|(index, call)| {
+                            (failed & (1 << index) != 0).then_some(call.clone())
+                        })
+                        .collect::<Vec<_>>();
+                    storage.arm_clean(failures);
+                    let result = publish(scenario, &storage, &blobs).await;
+                    assert_eq!(result.is_err(), failed != 0);
+                    storage.assert_failures_consumed();
+                    drop(blobs);
+                    let plan = storage.crash_plan(retention);
+                    let events = storage.events();
+                    let candidate_authoritative =
+                        publication_candidate_authoritative(scenario, &events, &plan);
+                    storage.crash(plan).unwrap();
+                    storage.arm_clean([]);
+                    let actual = observe(&storage, scenario).await.unwrap();
+                    let (predecessor, candidate) = expected_worlds(scenario);
+                    let expected = if candidate_authoritative {
+                        &candidate
+                    } else {
+                        &predecessor
+                    };
+                    assert_eq!(&actual, expected);
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn overlapping_publications_pay_hidden_debt_exactly() {
+    deterministic::Runner::seeded(0x5c4e_d004).start(|_| async move {
+        let syncs = overlap_sync_trace().await;
+        assert_eq!(syncs.len(), 2);
+        assert_eq!(
+            syncs
+                .iter()
+                .map(|event| event.call.location.clone())
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                Location::new(PARTITION, b"a"),
+                Location::new(PARTITION, b"b"),
+            ])
+        );
+
+        for failed in 0..1usize << syncs.len() {
+            for retention in [Retention::Discard, Retention::Keep] {
+                for order in [[0, 1], [1, 0]] {
+                    let (storage, blobs, prior_debt) = initialize_overlap().await;
+                    let failures = syncs.iter().enumerate().filter_map(|(index, event)| {
+                        (failed & (1 << index) != 0).then_some(event.call.clone())
+                    });
+                    storage.arm(failures);
+                    let result = publish_overlap_successor(&blobs).await;
+                    assert_eq!(result.is_err(), failed != 0);
+                    storage.assert_failures_consumed();
+                    let events = storage.events();
+                    let last_prior_issue = prior_debt.last().copied().unwrap();
+                    assert!(events.iter().all(|event| event.issue > last_prior_issue));
+                    drop(blobs);
+
+                    let plan = storage.crash_plan(retention);
+                    // The first ring is already durable. The strict-subset successor is selected
+                    // exactly when A's complete self-linked preparation is durable; recovery
+                    // independently closes any retained first-ring debt on B.
+                    let successor_authoritative =
+                        publication_candidate_authoritative(Scenario::Direct, &events, &plan);
+                    storage.crash(plan).unwrap();
+                    storage.arm_clean([]);
+
+                    let actual = observe_in_order(&storage, Scenario::Pair, &order)
+                        .await
+                        .unwrap();
+                    let (first, successor) = overlap_worlds();
+                    assert_complete_world(&actual, &first, &successor);
+                    let expected = if successor_authoritative {
+                        &successor
+                    } else {
+                        &first
+                    };
+                    assert_eq!(&actual, expected);
+                    assert_idempotent_and_usable(&storage, Scenario::Pair, &actual).await;
+                }
+            }
+        }
+    });
+}
+
+#[test]
+fn recreated_participant_joins_a_later_ring_exactly() {
+    deterministic::Runner::seeded(0x5c4e_d009).start(|_| async move {
+        let failed_sync = reincarnation_successor_trace()
+            .await
+            .into_iter()
+            .find(|event| {
+                event.call.location == Location::new(PARTITION, b"b")
+                    && matches!(event.call.kind, EventKind::Sync)
+            })
+            .expect("the replacement participates in the group durability barrier")
+            .call;
+
+        for retention in [Retention::Discard, Retention::Keep] {
+            let (storage, survivor, replacement, new_incarnation) =
+                initialize_reincarnation_history().await;
+            storage.arm_clean([failed_sync.clone()]);
+            assert!(
+                publish_reincarnation_successor(&storage, &survivor, &replacement)
+                    .await
+                    .is_err()
+            );
+            storage.assert_failures_consumed();
+            drop(survivor);
+            drop(replacement);
+
+            let plan = storage.crash_plan(retention);
+            let events = storage.events();
+            let candidate_authoritative =
+                publication_candidate_authoritative(Scenario::Pair, &events, &plan);
+            assert_eq!(
+                candidate_authoritative,
+                matches!(retention, Retention::Keep)
+            );
+            storage.crash(plan).unwrap();
+            storage.arm_clean([]);
+
+            let (predecessor, candidate) = reincarnation_worlds();
+            let expected = if matches!(retention, Retention::Keep) {
+                &candidate
+            } else {
+                &predecessor
+            };
+            let actual = observe_in_order(&storage, Scenario::Pair, &[0, 1])
+                .await
+                .unwrap();
+            assert_eq!(&actual, expected);
+            let (opened, _) = storage.open_atomic(PARTITION, b"b").await.unwrap();
+            assert_eq!(opened.incarnation, new_incarnation);
+            drop(opened);
+            assert_idempotent_and_usable(&storage, Scenario::Pair, &actual).await;
+        }
+    });
+}
+
+#[test]
+fn backend_explicit_masks_replay_overlapping_writes_in_issue_order() {
+    deterministic::Runner::seeded(0x5c4e_d005).start(|_| async move {
+        let name = b"mechanics-overlap";
+        let (storage, blob) = initialize_raw(name, b"........").await;
+        blob.write_at(0, b"ABCDEFGH".to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+        blob.write_at(2, b"wxyz".to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+
+        let events = storage.events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].call,
+            call_identity(
+                name,
+                0,
+                EventKind::Write {
+                    offset: 0,
+                    len: 8,
+                    sync: false,
+                },
+            )
+        );
+        assert_eq!(
+            events[1].call,
+            call_identity(
+                name,
+                1,
+                EventKind::Write {
+                    offset: 2,
+                    len: 4,
+                    sync: false,
+                },
+            )
+        );
+        let mut plan = storage.crash_plan(Retention::Discard);
+        plan.writes.insert(
+            events[0].issue,
+            vec![true, false, true, false, true, false, true, false],
+        );
+        plan.writes
+            .insert(events[1].issue, vec![false, true, true, false]);
+        drop(blob);
+        storage.crash(plan).unwrap();
+        storage.arm_clean([]);
+
+        assert_eq!(raw_image(&storage, name).await, b"A.Cxy.G.");
+    });
+}
+
+#[test]
+fn backend_range_sync_replays_after_retained_resize() {
+    deterministic::Runner::seeded(0x5c4e_d006).start(|_| async move {
+        let name = b"mechanics-range";
+        let (storage, blob) = initialize_raw(name, b"abcdefghij").await;
+        blob.write_at(0, b"ABCDEFGHIJ".to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+        blob.resize(3).await.unwrap();
+        blob.write_at(6, b"WXYZ".to_vec(), WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let events = storage.events();
+        assert_eq!(events.len(), 3);
+        let write_issue = events
+            .iter()
+            .find(|event| {
+                event.call.kind
+                    == (EventKind::Write {
+                        offset: 0,
+                        len: 10,
+                        sync: false,
+                    })
+            })
+            .unwrap()
+            .issue;
+        let resize_issue = events
+            .iter()
+            .find(|event| event.call.kind == EventKind::Resize { len: 3 })
+            .unwrap()
+            .issue;
+        assert!(events.iter().any(|event| {
+            event.call.kind
+                == (EventKind::Write {
+                    offset: 6,
+                    len: 4,
+                    sync: true,
+                })
+        }));
+
+        let mut plan = storage.crash_plan(Retention::Discard);
+        plan.writes.insert(write_issue, vec![true; 10]);
+        plan.resizes.insert(resize_issue, true);
+        drop(blob);
+        storage.crash(plan).unwrap();
+        storage.arm_clean([]);
+
+        assert_eq!(raw_image(&storage, name).await, b"ABC\0\0\0WXYZ".to_vec());
+    });
+}
+
+#[test]
+fn backend_range_sync_retires_overlap_and_preserves_mask_alignment() {
+    deterministic::Runner::seeded(0x5c4e_d007).start(|_| async move {
+        let name = b"mechanics-range-overlap";
+        let (storage, blob) = initialize_raw(name, b"........").await;
+        blob.write_at(0, b"ABCDEFGH".to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+        blob.write_at(3, b"xy".to_vec(), WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let events = storage.events();
+        assert_eq!(events.len(), 2);
+        let write_issue = events
+            .iter()
+            .find(|event| {
+                event.call.kind
+                    == (EventKind::Write {
+                        offset: 0,
+                        len: 8,
+                        sync: false,
+                    })
+            })
+            .unwrap()
+            .issue;
+        assert!(events.iter().any(|event| {
+            event.call.kind
+                == (EventKind::Write {
+                    offset: 3,
+                    len: 2,
+                    sync: true,
+                })
+        }));
+
+        let mut plan = storage.crash_plan(Retention::Discard);
+        plan.writes.insert(
+            write_issue,
+            vec![true, false, false, true, true, false, true, true],
+        );
+        drop(blob);
+        storage.crash(plan).unwrap();
+        storage.arm_clean([]);
+
+        assert_eq!(raw_image(&storage, name).await, b"A..xy.GH");
+    });
+}
+
+#[test]
+fn backend_failed_full_sync_leaves_mutation_debt() {
+    deterministic::Runner::seeded(0x5c4e_d008).start(|_| async move {
+        let name = b"mechanics-full-sync";
+        let (storage, blob) = initialize_raw(name, b"........").await;
+        let failed_sync = call_identity(name, 1, EventKind::Sync);
+        storage.arm_clean([failed_sync.clone()]);
+        blob.write_at(0, b"ABCDEFGH".to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+        assert!(blob.sync().await.is_err());
+        storage.assert_failures_consumed();
+
+        let events = storage.events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[1].call, failed_sync);
+        assert!(events[1].failed);
+        let mut plan = storage.crash_plan(Retention::Discard);
+        plan.writes.insert(
+            events[0].issue,
+            vec![false, true, false, false, true, false, false, true],
+        );
+        drop(blob);
+        storage.crash(plan).unwrap();
+        storage.arm_clean([]);
+
+        assert_eq!(raw_image(&storage, name).await, b".B..E..H");
+    });
+}
+
+#[derive(Clone, Copy)]
+enum RecoveryFixture {
+    CandidateGroup,
+    RejectedSlot,
+    ShortIdentity,
+}
+
+impl RecoveryFixture {
+    fn scenario(self) -> Scenario {
+        match self {
+            Self::CandidateGroup => Scenario::Triple,
+            Self::RejectedSlot | Self::ShortIdentity => Scenario::Direct,
+        }
+    }
+
+    fn expected(self) -> World {
+        match self {
+            Self::CandidateGroup => expected_worlds(Scenario::Triple).1,
+            Self::RejectedSlot => expected_worlds(Scenario::Direct).0,
+            Self::ShortIdentity => World(vec![Some(Value {
+                data: Vec::new(),
+                tag: [0; ATOMIC_BLOB_TAG_LEN],
+            })]),
+        }
+    }
+}
+
+async fn recovery_image(
+    fixture: RecoveryFixture,
+    rejected_write: &CallIdentity,
+) -> ScheduledStorage {
+    match fixture {
+        RecoveryFixture::CandidateGroup => {
+            let scenario = fixture.scenario();
+            let (storage, blobs) = initialize(scenario).await;
+            publish(scenario, &storage, &blobs).await.unwrap();
+            drop(blobs);
+            let plan = storage.crash_plan(Retention::Discard);
+            storage.crash(plan).unwrap();
+            storage.arm_clean([]);
+            storage
+        }
+        RecoveryFixture::RejectedSlot => {
+            let scenario = fixture.scenario();
+            let (storage, blobs) = initialize(scenario).await;
+            storage.arm_clean([rejected_write.clone()]);
+            assert!(publish(scenario, &storage, &blobs).await.is_err());
+            storage.assert_failures_consumed();
+            drop(blobs);
+            let plan = storage.crash_plan(Retention::Stripe);
+            storage.crash(plan).unwrap();
+            storage.arm_clean([]);
+            storage
+        }
+        RecoveryFixture::ShortIdentity => {
+            let (storage, blob) = initialize_raw(b"a", &encode_identity([0x3C; 16])).await;
+            drop(blob);
+            storage
+        }
+    }
+}
+
+async fn retry_recovery_after_fault(
+    storage: &ScheduledStorage,
+    scenario: Scenario,
+    expected: &World,
+    entry: RecoveryEntry,
+    retention: Retention,
+) {
+    storage.assert_failures_consumed();
+    let plan = storage.crash_plan(retention);
+    storage.crash(plan).unwrap();
+    storage.arm_clean([]);
+    recover_via(storage, scenario, expected, entry)
+        .await
+        .unwrap();
+    assert_idempotent_and_usable(storage, scenario, expected).await;
+}
+
+#[test]
+fn recovery_primitive_failures_are_retryable() {
+    deterministic::Runner::seeded(0x5c4e_d003).start(|_| async move {
+        let rejected_write = publication_trace(Scenario::Direct)
+            .await
+            .into_iter()
+            .find(|event| {
+                matches!(
+                    event.call.kind,
+                    EventKind::Write {
+                        len: ROOT_SLOT_SIZE,
+                        sync: false,
+                        ..
+                    }
+                )
+            })
+            .unwrap()
+            .call;
+
+        for (fixture, entry) in [
+            (RecoveryFixture::CandidateGroup, RecoveryEntry::Open(1)),
+            (RecoveryFixture::CandidateGroup, RecoveryEntry::Scan),
+            (RecoveryFixture::RejectedSlot, RecoveryEntry::Open(0)),
+            (RecoveryFixture::ShortIdentity, RecoveryEntry::Open(0)),
+        ] {
+            let scenario = fixture.scenario();
+            let expected = fixture.expected();
+            let storage = recovery_image(fixture, &rejected_write).await;
+            let recovery_trace = recover_via(&storage, scenario, &expected, entry)
+                .await
+                .unwrap();
+            match fixture {
+                RecoveryFixture::CandidateGroup => assert!(
+                    recovery_trace
+                        .iter()
+                        .any(|event| matches!(event.call.kind, EventKind::Remove))
+                ),
+                RecoveryFixture::RejectedSlot => assert!(recovery_trace.iter().any(|event| {
+                    matches!(
+                        event.call.kind,
+                        EventKind::Write {
+                            len: ROOT_SLOT_SIZE,
+                            sync: true,
+                            ..
+                        }
+                    )
+                })),
+                RecoveryFixture::ShortIdentity => {
+                    assert!(recovery_trace.iter().any(|event| {
+                        event.call.kind == (EventKind::Resize { len: DATA_OFFSET })
+                    }));
+                    assert!(
+                        recovery_trace
+                            .iter()
+                            .any(|event| matches!(event.call.kind, EventKind::Sync))
+                    );
+                }
+            }
+
+            for event in &recovery_trace {
+                for retention in [Retention::Discard, Retention::Keep] {
+                    let storage = recovery_image(fixture, &rejected_write).await;
+                    storage.arm_clean([event.call.clone()]);
+                    assert!(
+                        recover_via(&storage, scenario, &expected, entry)
+                            .await
+                            .is_err()
+                    );
+                    retry_recovery_after_fault(&storage, scenario, &expected, entry, retention)
+                        .await;
+                }
+            }
+
+            let Some(remove_call) = recovery_trace
+                .iter()
+                .find(|event| matches!(event.call.kind, EventKind::Remove))
+                .map(|event| event.call.clone())
+            else {
+                continue;
+            };
+            // The injected error follows the unlink, after earlier recovery writes are
+            // durable, so there is no remaining mutation whose retention can vary.
+            let storage = recovery_image(fixture, &rejected_write).await;
+            storage.arm_clean_remove_then_error(remove_call);
+            assert!(
+                recover_via(&storage, scenario, &expected, entry)
+                    .await
+                    .is_err()
+            );
+            retry_recovery_after_fault(&storage, scenario, &expected, entry, Retention::Discard)
+                .await;
+        }
+    });
+}


### PR DESCRIPTION
## Summary

Adds two complementary bounded crash oracles above the production and unit-test layers:

- `model_tests.rs` exhausts semantic publication and recovery histories, including three-generation slot reuse and overlapping successor groups.
- `scheduled_tests.rs` drives the production encoder and recovery path with exact operation identities, retained-write masks, and independent recovery orders.

This is layer 5 of 6 in the atomic blob stack. It changes no production behavior and keeps model failures separate from the broader behavioral suite in #4491.

## Review focus

- Every accepted state is derived from a complete predecessor or candidate vector; the model never invents or contracts a ring.
- Prepared-ring durability, hidden cleanup debt, rejected-slot consumption, and generation reuse are exercised as explicit state transitions.
- Open-first and scan-first recovery evidence is derived independently before either path can repair the backing.

## Diff size

- Production code: `+0 / -0 LOC`
- Tests and test infrastructure: `+3220 / -0 LOC`
- Total: `+3220 / -0 LOC`

Counts are physical diff lines, including comments and blank lines. Test-only files, hooks, and lines inside `#[cfg(test)]` modules are counted as tests; everything else is counted as production code.
