### PR TITLE
[storage] Expose batched leaf digest append

### DIFF
--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -261,7 +261,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
 
     /// Add a run of pre-computed leaf digests, in order.
     #[cfg(feature = "std")]
-    pub(crate) fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
+    pub fn add_leaf_digests(mut self, digests: impl IntoIterator<Item = D>) -> Self {
         // Each leaf also appends its parent placeholders, so reserve for the full node count.
         let digests = digests.into_iter();
         let n = digests.size_hint().0 as u64;


### PR DESCRIPTION
Exposes `Batch::add_leaf_digests` for callers that already compute leaf digests and need to append them without re-encoding values. [Exoware uses it](https://github.com/exowarexyz/monorepo/blob/1952044494c07b69653f414c888175b9251a0509/qmdb/rs/src/core.rs#L593-L596) to feed operation digests directly into QMDB Merkle construction.