### PR TITLE
[runtime] Migrate ordinary blobs into atomic storage

### DIFF
--- a/runtime/src/atomic.rs
+++ b/runtime/src/atomic.rs
@@ -36,11 +36,12 @@
 //! ```
 //!
 //! The magic is `CWUNOID`. The CRC32C covers the identity domain and bytes 0 through 23. Fresh
-//! creation writes the complete page and synchronizes the backing once.
+//! creation writes the complete page and synchronizes the backing once. Migration places the same
+//! page in a staged replacement before synchronizing that replacement.
 //!
 //! A fresh identity is written only when the serialized open observed the name missing and created
 //! its backing. A pre-existing name must contain a complete identity; an invalid or incomplete page
-//! is rejected without mutation.
+//! is rejected without mutation and ordinary blobs require explicit migration.
 //!
 //! # R15 root slots
 //!
@@ -87,6 +88,7 @@
 //! Root spellings separate local authority from group evidence:
 //!
 //! - `BatchPrepared` is a candidate and requires complete ring evidence.
+//! - `Committed` is the generation-one migration root with a zero witness binding.
 //! - `Finalized` is a locally selectable group result whose retained witness says whether it is
 //!   present or removed.
 //!
@@ -97,6 +99,7 @@
 //! Each spelling has an exact suffix rule:
 //!
 //! ```text
+//! Committed               zero witness binding and zero slot suffix
 //! BatchPrepared           exact framed witness and matching witness binding
 //! Finalized                exact retained witness and matching witness binding
 //! ```
@@ -105,6 +108,7 @@
 //!
 //! ```text
 //! BatchPrepared = 1
+//! Committed     = 2
 //! Finalized     = 3 + ((generation / 2) mod 2)
 //! ```
 //!
@@ -227,9 +231,9 @@
 //! # Namespace ownership
 //!
 //! The backend owns its ordinary blob header and physical namespace. Atomic names are opt-in and
-//! must not be opened through ordinary [`Storage`] while atomic handles exist. A new atomic blob
-//! starts from R15's all-zero generation-zero predecessor. There is no compatibility path for
-//! older experimental roots.
+//! must not be opened through ordinary [`Storage`] while atomic handles exist. Ordinary blobs enter
+//! this layout only through explicit migration. A new atomic blob starts from R15's all-zero
+//! generation-zero predecessor. There is no compatibility path for older experimental roots.
 //!
 //! Logical removal publishes a tombstone before physical unlink. Recovery makes every group final
 //! independently durable before removing any member. The exclusive storage-lineage contract lets
@@ -314,7 +318,7 @@ const IDENTITY_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_INCARNATION";
 const IDENTITY_GUARD_OFFSET: usize = 7;
 const IDENTITY_GUARD: u8 = 1;
 const IDENTITY_LEN: usize = 28;
-const INCARNATION_LEN: usize = 16;
+pub(crate) const INCARNATION_LEN: usize = 16;
 const ROOT_OFFSETS: [u64; 2] = [IDENTITY_PAGE_LEN, IDENTITY_PAGE_LEN + ROOT_SLOT_LEN];
 pub(crate) const DATA_OFFSET: u64 = IDENTITY_PAGE_LEN + 2 * ROOT_SLOT_LEN;
 const MAX_UNSYNCED_PAYLOAD_LEN: u64 = 64 * 1024 * 1024;
@@ -324,7 +328,7 @@ type RootBinding = [u8; ROOT_BINDING_LEN];
 type PayloadDigest = [u8; 32];
 type ParticipantOperation<'a> = Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
 
-fn validate_atomic_location(partition: &str, name: &[u8]) -> Result<(), Error> {
+pub(crate) fn validate_atomic_location(partition: &str, name: &[u8]) -> Result<(), Error> {
     batch::validate_location(partition, name).map_err(Into::into)
 }
 
@@ -492,12 +496,13 @@ struct PayloadPreflushRound {
 
 /// Durable and transitional spellings encoded by the root guard.
 ///
-/// Finalized roots are locally selectable after their full slot grammar validates. This is a
-/// recovery classification, not proof that the installed bytes are durable. Finalized roots retain
-/// their local witness. Batch-prepared roots require a complete witness ring.
+/// Committed and finalized roots are locally selectable after their full slot grammar validates.
+/// This is a recovery classification, not proof that the installed bytes are durable. Finalized
+/// roots retain their local witness. Batch-prepared roots require a complete witness ring.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum RootState {
     BatchPrepared,
+    Committed,
     Finalized,
 }
 
@@ -505,6 +510,7 @@ impl RootState {
     const fn guard(self, generation: u64) -> u8 {
         match self {
             Self::BatchPrepared => 1,
+            Self::Committed => 2,
             Self::Finalized => {
                 if (generation & 2) == 0 {
                     3
@@ -582,7 +588,7 @@ fn direct_group_id(
 
 /// Encode the complete canonical identity page for one namespace incarnation.
 ///
-/// Fresh creation writes this complete page before its durability barrier.
+/// Fresh creation and migration write this complete page before their durability barrier.
 fn encode_identity(identity: [u8; INCARNATION_LEN]) -> [u8; IDENTITY_PAGE_LEN as usize] {
     let mut page = [0u8; IDENTITY_PAGE_LEN as usize];
     page[..7].copy_from_slice(IDENTITY_MAGIC);
@@ -605,6 +611,33 @@ pub(crate) fn decode_identity(
     }
     let stored = u32::from_be_bytes(page[24..IDENTITY_LEN].try_into().unwrap());
     (stored == checksum(&[IDENTITY_DOMAIN, &page[..24]])).then(|| page[8..24].try_into().unwrap())
+}
+
+/// Build the fixed atomic prefix used by ordinary-to-atomic migration.
+///
+/// Migration starts at generation one with an independently readable committed root. The copied
+/// payload follows this prefix at its final atomic offset.
+pub(crate) fn migration_prefix(
+    incarnation: [u8; INCARNATION_LEN],
+    logical_len: u64,
+    integrity_checksum: u32,
+) -> [u8; DATA_OFFSET as usize] {
+    let mut prefix = [0; DATA_OFFSET as usize];
+    prefix[..IDENTITY_PAGE_LEN as usize].copy_from_slice(&encode_identity(incarnation));
+    let root = encode_root_value(
+        RootState::Committed,
+        Root {
+            generation: 1,
+            logical_len,
+            integrity_start: 0,
+            integrity_checksum,
+            integrity_scheme: IntegrityScheme::Unbound,
+            tag: [0; ATOMIC_BLOB_TAG_LEN],
+        },
+    );
+    let offset = ROOT_OFFSETS[1] as usize;
+    prefix[offset..offset + ROOT_LEN].copy_from_slice(&root);
+    prefix
 }
 
 /// Encode a root with a zero witness binding.
@@ -723,7 +756,10 @@ fn decode_root_fields(encoded: &[u8; ROOT_LEN]) -> Option<Root> {
 /// This does not validate slot parity, payload extent, integrity geometry, or the slot suffix.
 fn decode_root(encoded: &[u8; ROOT_LEN], state: RootState) -> Option<Root> {
     let root = decode_root_fields(encoded)?;
-    if encoded[ROOT_GUARD_OFFSET] != state.guard(root.generation) {
+    if encoded[ROOT_GUARD_OFFSET] != state.guard(root.generation)
+        || (state == RootState::Committed
+            && (root.generation != 1 || root_binding(encoded) != [0; ROOT_BINDING_LEN]))
+    {
         return None;
     }
     let stored = u32::from_be_bytes(encoded[ROOT_BODY_LEN..].try_into().unwrap());
@@ -735,9 +771,13 @@ fn decode_root(encoded: &[u8; ROOT_LEN], state: RootState) -> Option<Root> {
 
 /// Decode the first root spelling whose complete header grammar matches.
 fn decode_any_root(encoded: &[u8; ROOT_LEN]) -> Option<(RootState, Root)> {
-    [RootState::BatchPrepared, RootState::Finalized]
-        .into_iter()
-        .find_map(|state| decode_root(encoded, state).map(|root| (state, root)))
+    [
+        RootState::BatchPrepared,
+        RootState::Committed,
+        RootState::Finalized,
+    ]
+    .into_iter()
+    .find_map(|state| decode_root(encoded, state).map(|root| (state, root)))
 }
 
 fn invalid_data(message: impl Into<String>) -> io::Error {
@@ -828,6 +868,7 @@ impl Slot {
 
     const fn independent(self) -> Option<(Root, bool)> {
         match self {
+            Self::Root(RootState::Committed, root) => Some((root, false)),
             Self::Finalized { root, removed } => Some((root, removed)),
             Self::Zero | Self::Root(_, _) | Self::Raw => None,
         }
@@ -850,6 +891,7 @@ fn decode_slot(
             return Slot::Raw;
         };
         let suffix_valid = match state {
+            RootState::Committed => encoded[ROOT_LEN..].iter().all(|byte| *byte == 0),
             RootState::BatchPrepared => {
                 let Some(link) = batch::link_at(encoded, "", &[], root_offset) else {
                     return Slot::Raw;
@@ -2648,6 +2690,8 @@ pub(crate) trait Backend: Storage {
     ///
     /// Live operations hold shared exclusion through their I/O and cleanup. Namespace operations
     /// hold exclusive exclusion and drain detached payload preflushes before inspecting backings.
+    /// Filesystem storage operations share the namespace lock so a migration can own it before
+    /// transferring work to the background driver.
     fn atomic_resources(&self) -> AtomicResources;
 
     /// Generate a fresh identifier for an incarnation, opened token epoch, or multi-blob group.
@@ -2657,10 +2701,18 @@ pub(crate) trait Backend: Storage {
         identifier
     }
 
+    /// Durably replace one exact ordinary backing with the atomic layout for `incarnation`.
+    /// The caller owns this lineage's namespace lock through completion.
+    fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; INCARNATION_LEN],
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
+
     /// Open the current exact name without creating or repairing it.
     ///
     /// An incomplete ordinary container is reported as absent. A complete legacy container is
-    /// rejected so its payload cannot be reinterpreted as atomic state.
+    /// rejected so its payload can only enter atomic storage through explicit migration.
     /// [`Storage::open`] owns any container-level recovery before atomic identity initialization.
     fn open_atomic_existing(
         &self,
@@ -4277,6 +4329,30 @@ async fn pause_admitted_operation_if_requested(lineage: &Arc<RwLock<()>>) {
 #[commonware_macros::stability(BETA)]
 impl<S: Backend> AtomicStorage for S {
     type AtomicBlob = Blob<S::Blob>;
+
+    fn migrate_atomic(
+        &self,
+        blob: Self::Blob,
+    ) -> impl std::future::Future<Output = Result<(), Error>> + Send {
+        Box::pin(async move {
+            let resources = self.atomic_resources();
+            let driver = resources.driver.clone();
+            let worker = self.atomic_worker();
+            let admission = driver.reserve().await?;
+            let guard = resources.exclusion.clone().write_owned().await;
+            let namespace = resources.namespace.clone().lock_owned().await;
+            let task = async move {
+                let _guard = guard;
+                let _namespace = namespace;
+                #[cfg(all(test, not(target_arch = "wasm32")))]
+                pause_admitted_operation_if_requested(&resources.exclusion).await;
+                resources.payload_budget.drain().await?;
+                let incarnation = worker.new_atomic_identifier();
+                worker.migrate_atomic_backing(blob, incarnation).await
+            };
+            admission.drive(task).await
+        })
+    }
 
     fn open_atomic(
         &self,

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1646,6 +1646,14 @@ impl crate::atomic::Backend for Context {
         identifier
     }
 
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        self.storage.migrate_atomic_backing(blob, incarnation).await
+    }
+
     async fn open_atomic_existing(
         &self,
         partition: &str,
@@ -2034,6 +2042,30 @@ mod tests {
             let (blob, len) = context.open("crash_resize", b"blob").await.unwrap();
             assert_eq!(len, 3);
             assert_eq!(blob.read_at(0, 3).await.unwrap().coalesce(), b"abc");
+        });
+    }
+
+    #[test]
+    fn test_atomic_migration_traverses_the_runtime_storage_stack() {
+        Runner::seeded(0xA701_C001).start(|context| async move {
+            let (ordinary, _) = context.open("migration", b"blob").await.unwrap();
+            ordinary
+                .write_at(0, b"payload", WriteOptions::default())
+                .await
+                .unwrap();
+
+            context.migrate_atomic(ordinary).await.unwrap();
+
+            let (atomic, len) = context.open_atomic("migration", b"blob").await.unwrap();
+            assert_eq!(len, b"payload".len() as u64);
+            assert_eq!(
+                atomic
+                    .read_at(0, b"payload".len())
+                    .await
+                    .unwrap()
+                    .coalesce(),
+                b"payload"
+            );
         });
     }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -179,10 +179,10 @@ stability_scope!(BETA {
     /// mutation interface. The backend owns the ordinary container layout; the atomic identity and
     /// roots live in the blob's logical contents. A name belongs exclusively to either this
     /// interface or ordinary [`Storage`]: it must not be populated or mutated through both.
-    /// Existing names require a complete atomic identity and are never implicitly converted. At
-    /// most one independently opened handle for a name may be live: drop that handle and all of
-    /// its clones before reopening the name. Use clones of one returned handle for coordinated
-    /// concurrent access. Atomic namespace
+    /// Existing names require a complete atomic identity and are never implicitly converted; use
+    /// [`AtomicStorage::migrate_atomic`] for an ordinary blob. At most one independently opened
+    /// handle for a name may be live: drop that handle and all of its clones before reopening the
+    /// name. Use clones of one returned handle for coordinated concurrent access. Atomic namespace
     /// and recovery work is serialized across one storage value and its clones. Live operations on
     /// disjoint handles and carried-debt groups may proceed concurrently; operations sharing either
     /// are serialized. If a canceled observer leaves backing work in flight, including when the
@@ -200,6 +200,30 @@ stability_scope!(BETA {
     pub trait AtomicStorage: Storage {
         /// Blob type returned by atomic opens.
         type AtomicBlob: AtomicBlob;
+
+        /// Consume an ordinary blob and durably replace its current name with an atomic blob.
+        ///
+        /// The blob's logical contents are preserved. Pending writes are synchronized before
+        /// migration. The caller must exclude concurrent mutation and must pass the exact current
+        /// generation opened from this storage lineage. Existing handles remain readable after
+        /// replacement, but callers must reopen the migrated name.
+        ///
+        /// Cancellation or a mutable-storage error may leave either layout at the live name. After
+        /// cancellation, retain this storage lineage until its admitted work quiesces, then retry
+        /// with a freshly opened handle. A mutable-storage error is fatal to the storage instance;
+        /// reconstruct the lineage before reopening and retrying. Migration of an already atomic
+        /// blob is idempotent. In the canonical container used by atomic storage, a complete atomic
+        /// identity page at logical offset zero is reserved as the installed-image retry marker.
+        /// An ordinary value in that container that begins with the reserved page is interpreted
+        /// as an already installed image rather than wrapped as application data. Filesystem
+        /// implementations stream through a same-directory replacement inode with bounded memory
+        /// and temporarily require space for a complete copy. The source location must satisfy the
+        /// same witness-size bound as [`AtomicStorage::open_atomic`]. The Tokio filesystem
+        /// implementation supports migration only on Unix.
+        fn migrate_atomic(
+            &self,
+            blob: Self::Blob,
+        ) -> impl std::future::Future<Output = Result<(), Error>> + Send;
 
         /// Open an existing atomic blob or create a new one.
         ///
@@ -327,10 +351,10 @@ stability_scope!(BETA {
         /// Return length, scheme, tag, and validated unfinished bytes from one coherent state.
         ///
         /// This reads, retains, and validates the complete unfinished unit before returning.
-        /// Unbound and variable-width units can span the entire encoded payload and are not limited
-        /// by the publication-recovery suffix budget. Operations requiring the same coherent state
-        /// wait for this validation. Close units or use an appropriately bounded chunk width when
-        /// snapshot cost must be bounded.
+        /// Unbound and variable-width units can span the entire encoded payload, including after
+        /// ordinary-to-atomic migration, and are not limited by the publication-recovery suffix
+        /// budget. Operations requiring the same coherent state wait for this validation. Close
+        /// units or use an appropriately bounded chunk width when snapshot cost must be bounded.
         fn integrity_snapshot(
             &self,
         ) -> impl std::future::Future<Output = Result<IntegritySnapshot, Error>> + Send;

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -90,6 +90,21 @@ impl<S: crate::atomic::Backend> crate::atomic::Backend for Storage<S> {
         self.inner.new_atomic_identifier()
     }
 
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        self.auditor.event(b"migrate_atomic", |hasher| {
+            hasher.update(blob.partition.as_bytes());
+            hasher.update(&blob.name);
+            hasher.update(incarnation);
+        });
+        self.inner
+            .migrate_atomic_backing(blob.inner, incarnation)
+            .await
+    }
+
     async fn open_atomic_existing(
         &self,
         partition: &str,
@@ -264,6 +279,34 @@ mod tests {
         storage1.open("a", b"bc").await.unwrap();
         storage2.open("ab", b"c").await.unwrap();
 
+        assert_ne!(auditor1.state(), auditor2.state());
+    }
+
+    #[tokio::test]
+    async fn test_audited_migration_binds_the_incarnation() {
+        let auditor1 = Arc::new(Auditor::default());
+        let storage1 = AuditedStorage::new(MemStorage::new(test_pool()), auditor1.clone());
+        let auditor2 = Arc::new(Auditor::default());
+        let storage2 = AuditedStorage::new(MemStorage::new(test_pool()), auditor2.clone());
+
+        let (blob1, _) = storage1.open("partition", b"blob").await.unwrap();
+        let (blob2, _) = storage2.open("partition", b"blob").await.unwrap();
+        blob1
+            .write_at(0, b"payload", WriteOptions::default())
+            .await
+            .unwrap();
+        blob2
+            .write_at(0, b"payload", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(auditor1.state(), auditor2.state());
+
+        crate::atomic::Backend::migrate_atomic_backing(&storage1, blob1, [1; 16])
+            .await
+            .unwrap();
+        crate::atomic::Backend::migrate_atomic_backing(&storage2, blob2, [2; 16])
+            .await
+            .unwrap();
         assert_ne!(auditor1.state(), auditor2.state());
     }
 

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -23,6 +23,8 @@ enum Op {
     Resize,
     Remove,
     Scan,
+    Migrate,
+    MigratePostCommit,
 }
 
 /// Selects how retained bytes are arranged when a write is partially preserved.
@@ -77,6 +79,12 @@ pub struct Config {
 
     /// Failure rate for `scan` operations.
     pub scan_rate: Option<f64>,
+
+    /// Failure rate before an atomic migration mutates storage.
+    pub migrate_rate: Option<f64>,
+
+    /// Failure rate after an atomic migration has committed its replacement.
+    pub migrate_post_commit_rate: Option<f64>,
 }
 
 impl Config {
@@ -90,6 +98,8 @@ impl Config {
             Op::Resize => self.resize_rate,
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
+            Op::Migrate => self.migrate_rate,
+            Op::MigratePostCommit => self.migrate_post_commit_rate,
         }
         .unwrap_or(0.0)
     }
@@ -151,6 +161,18 @@ impl Config {
     /// Set the scan failure rate.
     pub const fn scan(mut self, rate: f64) -> Self {
         self.scan_rate = Some(rate);
+        self
+    }
+
+    /// Set the failure rate before an atomic migration mutates storage.
+    pub const fn migrate(mut self, rate: f64) -> Self {
+        self.migrate_rate = Some(rate);
+        self
+    }
+
+    /// Set the failure rate after an atomic migration commits its replacement.
+    pub const fn migrate_post_commit(mut self, rate: f64) -> Self {
+        self.migrate_post_commit_rate = Some(rate);
         self
     }
 }
@@ -459,10 +481,24 @@ impl<S: crate::Storage> Storage<S> {
         Blob::new(
             self.ctx.clone(),
             self.pending.clone(),
+            Arc::new(key),
             generation,
             inner,
             size,
         )
+    }
+
+    fn retire_generation(&self, key: &FileKey, generation: &Arc<FileGeneration>) {
+        let mut generations = self.generations.lock();
+        if generations
+            .get(key)
+            .and_then(Weak::upgrade)
+            .is_some_and(|current| Arc::ptr_eq(&current, generation))
+        {
+            generations.remove(key);
+        }
+        drop(generations);
+        clear_pending(&self.pending, generation);
     }
 
     fn retire_names(&self, partition: &str, name: Option<&[u8]>) {
@@ -591,6 +627,26 @@ impl<S: crate::atomic::Backend> crate::atomic::Backend for Storage<S> {
         self.inner.new_atomic_identifier()
     }
 
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        if self.ctx.should_fail(Op::Migrate) {
+            return Err(injected_io_error().into());
+        }
+        let key = blob.key.clone();
+        let generation = blob.generation.clone();
+        self.inner
+            .migrate_atomic_backing(blob.inner, incarnation)
+            .await?;
+        self.retire_generation(key.as_ref(), &generation);
+        if self.ctx.should_fail(Op::MigratePostCommit) {
+            return Err(injected_io_error().into());
+        }
+        Ok(())
+    }
+
     async fn open_atomic_existing(
         &self,
         partition: &str,
@@ -610,6 +666,7 @@ pub struct Blob<B: crate::Blob> {
     inner: B,
     ctx: Oracle,
     pending: PendingMutations<B>,
+    key: Arc<FileKey>,
     generation: Arc<FileGeneration>,
     /// Tracked size for partial resize support.
     size: Arc<AtomicU64>,
@@ -619,6 +676,7 @@ impl<B: crate::Blob> Blob<B> {
     fn new(
         ctx: Oracle,
         pending: PendingMutations<B>,
+        key: Arc<FileKey>,
         generation: Arc<FileGeneration>,
         inner: B,
         size: u64,
@@ -627,6 +685,7 @@ impl<B: crate::Blob> Blob<B> {
             inner,
             ctx,
             pending,
+            key,
             generation,
             size: Arc::new(AtomicU64::new(size)),
         }
@@ -820,7 +879,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
 mod tests {
     use super::*;
     use crate::{
-        Blob as _, BufferPool, BufferPoolConfig, Storage as _,
+        AtomicBlob as _, AtomicStorage as _, Blob as _, BufferPool, BufferPoolConfig, Storage as _,
         storage::{memory::Storage as MemStorage, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
@@ -961,6 +1020,7 @@ mod tests {
         let blob = Blob::new(
             h.storage.ctx.clone(),
             pending.clone(),
+            Arc::new(("partition".to_string(), b"overlap".to_vec())),
             Arc::new(FileGeneration::new()),
             gated,
             4,
@@ -1025,6 +1085,7 @@ mod tests {
         let blob = Blob::new(
             h.storage.ctx.clone(),
             pending.clone(),
+            Arc::new(("partition".to_string(), b"late-record".to_vec())),
             Arc::new(FileGeneration::new()),
             gated,
             5,
@@ -1599,6 +1660,59 @@ mod tests {
             .await
             .unwrap();
         assert!(h.storage.pending.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_atomic_migration_precommit_fault_preserves_ordinary_blob() {
+        let pre = Harness::new(Config::default().migrate(1.0));
+        let (ordinary, _) = pre.storage.open("migration", b"pre").await.unwrap();
+        ordinary
+            .write_at(0, b"ordinary", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        assert!(pre.storage.migrate_atomic(ordinary).await.is_err());
+        let (ordinary, len) = pre.storage.open("migration", b"pre").await.unwrap();
+        assert_eq!(len, b"ordinary".len() as u64);
+        assert_eq!(
+            ordinary
+                .read_at(0, b"ordinary".len())
+                .await
+                .unwrap()
+                .coalesce(),
+            b"ordinary"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_atomic_migration_postcommit_fault_is_retryable() {
+        let post = Harness::new(Config::default().migrate_post_commit(1.0));
+        let (ordinary, _) = post.storage.open("migration", b"post").await.unwrap();
+        ordinary
+            .write_at(0, b"atomic", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        assert!(post.storage.migrate_atomic(ordinary).await.is_err());
+        let (atomic, len) = post
+            .storage
+            .open_atomic("migration", b"post")
+            .await
+            .unwrap();
+        assert_eq!(len, b"atomic".len() as u64);
+        assert_eq!(
+            atomic.read_at(0, b"atomic".len()).await.unwrap().coalesce(),
+            b"atomic"
+        );
+        drop(atomic);
+
+        post.config.write().migrate_post_commit_rate = None;
+        let (retry, _) = post.storage.open("migration", b"post").await.unwrap();
+        post.storage.migrate_atomic(retry).await.unwrap();
+        let (_, len) = post
+            .storage
+            .open_atomic("migration", b"post")
+            .await
+            .unwrap();
+        assert_eq!(len, b"atomic".len() as u64);
     }
 
     #[tokio::test]

--- a/runtime/src/storage/header.rs
+++ b/runtime/src/storage/header.rs
@@ -465,8 +465,9 @@ stability_scope!(BETA {
 
     /// Reject a resolved ordinary container that cannot back atomic storage in place.
     ///
-    /// Legacy layouts remain supported through ordinary [`crate::Storage`], but atomic recovery
-    /// must never reinterpret their logical payload as its own identity and root region.
+    /// Legacy layouts remain supported through ordinary [`crate::Storage`] and explicit
+    /// migration, but atomic recovery must never reinterpret their logical payload as its own
+    /// identity and root region.
     pub(crate) fn require_atomic_layout(
         data_offset: u64,
         partition: &str,
@@ -515,27 +516,6 @@ pub(crate) mod tests {
         let mut raw = v0_header(blob_version).encode().to_vec();
         raw.extend_from_slice(payload);
         raw
-    }
-
-    /// A V0 blob whose payload begins with a complete fresh atomic prefix.
-    pub(crate) fn v0_atomic_lookalike_bytes() -> Vec<u8> {
-        const INCARNATION: [u8; 16] = [0x11; 16];
-        const IDENTITY_DOMAIN: &[u8] = b"_COMMONWARE_RUNTIME_ATOMIC_INCARNATION";
-
-        let mut payload = vec![0; crate::atomic::DATA_OFFSET as usize];
-        payload[..7].copy_from_slice(b"CWUNOID");
-        payload[7] = 1;
-        payload[8..24].copy_from_slice(&INCARNATION);
-        let mut checksum_input = IDENTITY_DOMAIN.to_vec();
-        checksum_input.extend_from_slice(&payload[..24]);
-        let checksum = commonware_cryptography::Crc32::checksum(&checksum_input);
-        payload[24..28].copy_from_slice(&checksum.to_be_bytes());
-        let identity = payload[..crate::atomic::IDENTITY_PAGE_LEN as usize]
-            .try_into()
-            .unwrap();
-        assert_eq!(crate::atomic::decode_identity(identity), Some(INCARNATION));
-        payload.extend_from_slice(b"ordinary tail");
-        v0_blob_bytes(crate::DEFAULT_BLOB_VERSION, &payload)
     }
 
     /// Raw bytes of a V1 blob with the given version, followed by `payload`.

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -244,6 +244,7 @@ impl crate::Storage for Storage {
             std::fs::read_dir(&path).map_err(|_| Error::PartitionMissing(partition.into()))?;
 
         let mut blobs = Vec::new();
+        let mut removed_stage = false;
         for entry in entries {
             let entry = entry.map_err(|_| Error::ReadFailed)?;
             let file_type = entry.file_type().map_err(|_| Error::ReadFailed)?;
@@ -253,6 +254,17 @@ impl crate::Storage for Storage {
             }
 
             let file_name = entry.file_name();
+            if super::migration::is_stage_file_name(&file_name) {
+                // An interrupted migration can leave one full-size non-authoritative stage.
+                // Scanning is a namespace recovery point, so reclaim it instead of leaking the
+                // abandoned copy or exposing its reserved name.
+                match fs::remove_file(entry.path()) {
+                    Ok(()) => removed_stage = true,
+                    Err(error) if error.kind() == ErrorKind::NotFound => {}
+                    Err(error) => return Err(Error::Io(error.into())),
+                }
+                continue;
+            }
             if let Some(name) = file_name.to_str() {
                 // Reject anything that isn't canonical lowercase hex (no `0x`
                 // prefix, no whitespace) since `from_hex` is lenient and
@@ -265,6 +277,10 @@ impl crate::Storage for Storage {
                 blobs.push(decoded);
             }
         }
+        if removed_stage {
+            sync_dir(&path)?;
+        }
+
         Ok(blobs)
     }
 }
@@ -278,6 +294,25 @@ impl crate::atomic::Backend for Storage {
 
     fn atomic_resources(&self) -> crate::atomic::AtomicResources {
         self.atomic_resources.clone()
+    }
+
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        let partition = blob.partition.clone();
+        let name = blob.name.clone();
+        let source = blob.file.clone();
+        let root = self.storage_directory.clone();
+        let migration = tokio::task::spawn_blocking(move || {
+            super::migration::migrate_live(&root, &partition, &name, &source, incarnation)
+        });
+        match migration.await {
+            Ok(result) => result,
+            Err(error) if error.is_panic() => std::panic::resume_unwind(error.into_panic()),
+            Err(_) => Err(Error::Closed),
+        }
     }
 
     async fn open_atomic_existing(
@@ -638,7 +673,10 @@ mod tests {
     #[tokio::test]
     async fn test_atomic_rejects_v0_ordinary_lookalikes_without_mutation() {
         let storage_directory = create_test_directory();
-        let original = crate::storage::header::tests::v0_atomic_lookalike_bytes();
+        let mut payload = crate::atomic::migration_prefix([0x11; 16], 0, 0).to_vec();
+        payload.extend_from_slice(b"ordinary tail");
+        let original =
+            crate::storage::header::tests::v0_blob_bytes(crate::DEFAULT_BLOB_VERSION, &payload);
         for (partition, name) in [("v0_atomic_open", b"open"), ("v0_atomic_scan", b"scan")] {
             let partition_path = storage_directory.join(partition);
             std::fs::create_dir_all(&partition_path).unwrap();

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,4 +1,4 @@
-use super::Header;
+use super::{Header, Layout};
 use crate::{Buf, BufferPool, Handle, IoBufs, IoBufsMut, WriteOptions, deterministic::AuditHasher};
 use commonware_formatting::hex;
 use commonware_utils::sync::{AsyncMutex, AsyncRwLock, Mutex, RwLock};
@@ -91,6 +91,11 @@ impl Storage {
 }
 
 impl Storage {
+    fn owns(&self, blob: &Blob) -> bool {
+        Arc::ptr_eq(&self.partitions, &blob.partitions)
+            && Arc::ptr_eq(&self.generations, &blob.generations)
+    }
+
     /// Compute a SHA-256 digest of all blob contents.
     pub fn audit(&self) -> [u8; 32] {
         let partitions = self.partitions.lock();
@@ -467,6 +472,78 @@ impl crate::atomic::Backend for Storage {
         self.atomic_resources.clone()
     }
 
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; crate::atomic::INCARNATION_LEN],
+    ) -> Result<(), crate::Error> {
+        if !self.owns(&blob) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "migration source belongs to another storage instance",
+            )
+            .into());
+        }
+        crate::atomic::validate_atomic_location(&blob.partition, &blob.name)?;
+
+        {
+            let generations = self.generations.lock();
+            blob.ensure_current(&generations)?;
+        }
+        blob.sync_inner()?;
+
+        let key = (blob.partition.clone(), blob.name.clone());
+        let mut generations = self.generations.lock();
+        blob.ensure_current(&generations)?;
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&blob.partition)
+            .and_then(|partition| partition.get_mut(&blob.name))
+            .ok_or_else(|| crate::Error::BlobMissing(blob.partition.clone(), hex(&blob.name)))?;
+        let raw = &content[..Header::resolve_len(content.len() as u64)];
+        let (logical_len, blob_version, data_offset) =
+            Header::parse(raw, content.len() as u64, &(u16::MIN..=u16::MAX))
+                .map_err(|error| error.into_error(&blob.partition, &blob.name))?;
+        let payload_start =
+            usize::try_from(data_offset).map_err(|_| crate::Error::OffsetOverflow)?;
+        if blob_version == crate::DEFAULT_BLOB_VERSION
+            && data_offset == Layout::V1.data_offset()
+            && logical_len >= crate::atomic::IDENTITY_PAGE_LEN
+        {
+            let identity_end = payload_start
+                .checked_add(crate::atomic::IDENTITY_PAGE_LEN as usize)
+                .ok_or(crate::Error::OffsetOverflow)?;
+            let identity = content
+                .get(payload_start..identity_end)
+                .ok_or(crate::Error::BlobInsufficientLength)?
+                .try_into()
+                .expect("the identity page slice has a fixed width");
+            if crate::atomic::decode_identity(identity).is_some() {
+                return Ok(());
+            }
+        }
+
+        let payload_len = usize::try_from(logical_len).map_err(|_| crate::Error::OffsetOverflow)?;
+        let payload_end = payload_start
+            .checked_add(payload_len)
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let payload = content
+            .get(payload_start..payload_end)
+            .ok_or(crate::Error::BlobInsufficientLength)?
+            .to_vec();
+        let (mut replacement, replacement_version) =
+            Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION));
+        debug_assert_eq!(replacement_version, crate::DEFAULT_BLOB_VERSION);
+        let integrity_checksum = commonware_cryptography::Crc32::checksum(&payload);
+        let prefix = crate::atomic::migration_prefix(incarnation, logical_len, integrity_checksum);
+        debug_assert_eq!(prefix.len(), crate::atomic::DATA_OFFSET as usize);
+        replacement.extend_from_slice(&prefix);
+        replacement.extend_from_slice(&payload);
+        *content = replacement;
+        generations.rotate(&key);
+        Ok(())
+    }
+
     async fn open_atomic_existing(
         &self,
         partition: &str,
@@ -509,7 +586,7 @@ impl crate::atomic::Backend for Storage {
 mod tests {
     use super::{Header, *};
     use crate::{
-        AtomicStorage as _, Blob, BufferPoolConfig, Storage as _,
+        AtomicBlob as _, AtomicStorage as _, Blob, BufferPoolConfig, Storage as _,
         storage::{Layout, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
@@ -586,7 +663,10 @@ mod tests {
     #[tokio::test]
     async fn test_atomic_rejects_v0_ordinary_lookalikes_without_mutation() {
         let storage = Storage::new(test_pool());
-        let original = crate::storage::header::tests::v0_atomic_lookalike_bytes();
+        let mut payload = crate::atomic::migration_prefix([0x11; 16], 0, 0).to_vec();
+        payload.extend_from_slice(b"ordinary tail");
+        let original =
+            crate::storage::header::tests::v0_blob_bytes(crate::DEFAULT_BLOB_VERSION, &payload);
 
         for (partition, name) in [("v0_atomic_open", b"open"), ("v0_atomic_scan", b"scan")] {
             storage
@@ -697,6 +777,196 @@ mod tests {
         let (replacement, len) = storage.open("partition", b"removed").await.unwrap();
         assert_eq!(len, 4);
         assert_eq!(replacement.read_at(0, 4).await.unwrap().coalesce(), b"new!");
+    }
+
+    #[tokio::test]
+    async fn test_atomic_migration_normalizes_container_and_retry_is_idempotent() {
+        const VERSION: u16 = 7;
+        let storage = Storage::new(test_pool());
+        let mut payload = crate::atomic::migration_prefix([0xA5; 16], 0, 0).to_vec();
+        payload.extend_from_slice(b"ordinary payload");
+        let (ordinary, _, version) = storage
+            .open_versioned("migration", b"blob", VERSION..=VERSION)
+            .await
+            .unwrap();
+        assert_eq!(version, VERSION);
+        ordinary
+            .write_at(0, payload.clone(), WriteOptions::default())
+            .await
+            .unwrap();
+
+        storage.migrate_atomic(ordinary).await.unwrap();
+        {
+            let partitions = storage.partitions.lock();
+            let content = partitions
+                .get("migration")
+                .and_then(|partition| partition.get(b"blob".as_slice()))
+                .unwrap();
+            assert_eq!(
+                &content[..Layout::V1.data_offset() as usize],
+                Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION))
+                    .0
+                    .as_slice()
+            );
+        }
+        let (atomic, len) = storage.open_atomic("migration", b"blob").await.unwrap();
+        assert_eq!(len, payload.len() as u64);
+        assert_eq!(
+            atomic.read_at(0, payload.len()).await.unwrap().coalesce(),
+            payload.as_slice()
+        );
+        let snapshot = atomic.integrity_snapshot().await.unwrap();
+        assert_eq!(snapshot.scheme, crate::IntegrityScheme::Unbound);
+        let (unit, tail) = snapshot.tail.unwrap();
+        assert_eq!(
+            unit,
+            crate::IntegrityUnit {
+                offset: 0,
+                len: payload.len() as u64,
+            }
+        );
+        assert_eq!(tail.coalesce(), payload.as_slice());
+        drop(atomic);
+
+        let (retry, retry_len, retry_version) = storage
+            .open_versioned(
+                "migration",
+                b"blob",
+                crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION,
+            )
+            .await
+            .unwrap();
+        assert_eq!(retry_len, crate::atomic::DATA_OFFSET + payload.len() as u64);
+        assert_eq!(retry_version, crate::DEFAULT_BLOB_VERSION);
+        storage.migrate_atomic(retry).await.unwrap();
+
+        let (_, backing_len) = storage.open("migration", b"blob").await.unwrap();
+        assert_eq!(
+            backing_len,
+            crate::atomic::DATA_OFFSET + payload.len() as u64
+        );
+
+        let (atomic, _) = storage.open_atomic("migration", b"blob").await.unwrap();
+        let token = atomic.integrity_snapshot().await.unwrap().token;
+        let append = atomic
+            .append_integrity(token, b"!", crate::IntegrityBoundary::Complete, None)
+            .await
+            .unwrap();
+        assert_eq!(append.offset, payload.len() as u64);
+        atomic.sync().await.unwrap();
+        drop(atomic);
+
+        let (atomic, len) = storage.open_atomic("migration", b"blob").await.unwrap();
+        assert_eq!(len, payload.len() as u64 + 1 + 4);
+        let mut completed = payload.to_vec();
+        completed.push(b'!');
+        assert_eq!(
+            atomic
+                .read_integrity(crate::IntegrityUnit {
+                    offset: 0,
+                    len: completed.len() as u64,
+                })
+                .await
+                .unwrap()
+                .coalesce()
+                .as_ref(),
+            completed.as_slice()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_atomic_migration_recognizes_identity_only_canonical_image() {
+        const INCARNATION: [u8; crate::atomic::INCARNATION_LEN] = [0x3C; 16];
+
+        let storage = Storage::new(test_pool());
+        let partition = "identity_only_migration";
+        let name = b"blob";
+        let key = (partition.to_string(), name.to_vec());
+        let prefix = crate::atomic::migration_prefix(INCARNATION, 0, 0);
+        let (ordinary, _, version) = storage
+            .open_versioned(
+                partition,
+                name,
+                crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION,
+            )
+            .await
+            .unwrap();
+        assert_eq!(version, crate::DEFAULT_BLOB_VERSION);
+        ordinary
+            .write_at(
+                0,
+                prefix[..crate::atomic::IDENTITY_PAGE_LEN as usize].to_vec(),
+                WriteOptions::SYNC,
+            )
+            .await
+            .unwrap();
+        let generation = ordinary.generation;
+        drop(ordinary);
+
+        let (ordinary, len) = storage.open(partition, name).await.unwrap();
+        assert_eq!(len, crate::atomic::IDENTITY_PAGE_LEN);
+        storage.migrate_atomic(ordinary).await.unwrap();
+        assert_eq!(
+            storage.generations.lock().current.get(&key),
+            Some(&generation)
+        );
+
+        let (_, len) = storage.open(partition, name).await.unwrap();
+        assert_eq!(len, crate::atomic::IDENTITY_PAGE_LEN);
+        let (_, len) = storage.open_atomic(partition, name).await.unwrap();
+        assert_eq!(len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_atomic_migration_does_not_mistake_a_large_ordinary_payload_for_identity() {
+        let storage = Storage::new(test_pool());
+        let payload = vec![0xA5; crate::atomic::DATA_OFFSET as usize];
+        let (ordinary, _, _) = storage
+            .open_versioned("migration", b"large", 0..=0)
+            .await
+            .unwrap();
+        ordinary
+            .write_at(0, payload.clone(), WriteOptions::default())
+            .await
+            .unwrap();
+
+        storage.migrate_atomic(ordinary).await.unwrap();
+        let (atomic, len) = storage.open_atomic("migration", b"large").await.unwrap();
+        assert_eq!(len, payload.len() as u64);
+        assert_eq!(
+            atomic
+                .read_at(0, payload.len())
+                .await
+                .unwrap()
+                .coalesce()
+                .as_ref(),
+            payload.as_slice()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_atomic_migration_rejects_foreign_and_stale_sources() {
+        let owner = Storage::new(test_pool());
+        let foreign = Storage::new(test_pool());
+        let (foreign_blob, _) = foreign.open("migration", b"foreign").await.unwrap();
+        assert!(owner.migrate_atomic(foreign_blob).await.is_err());
+
+        let (stale, _) = owner.open("migration", b"stale").await.unwrap();
+        owner.remove("migration", Some(b"stale")).await.unwrap();
+        let (replacement, _) = owner.open("migration", b"stale").await.unwrap();
+        replacement
+            .write_at(0, b"replacement", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        assert!(owner.migrate_atomic(stale).await.is_err());
+        assert_eq!(
+            replacement
+                .read_at(0, b"replacement".len())
+                .await
+                .unwrap()
+                .coalesce(),
+            b"replacement"
+        );
     }
 
     #[tokio::test]

--- a/runtime/src/storage/metered.rs
+++ b/runtime/src/storage/metered.rs
@@ -134,6 +134,17 @@ impl<S: crate::atomic::Backend> crate::atomic::Backend for Storage<S> {
         self.inner.new_atomic_identifier()
     }
 
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        // Migration is one backend namespace operation, not application Blob I/O.
+        self.inner
+            .migrate_atomic_backing(blob.inner, incarnation)
+            .await
+    }
+
     async fn open_atomic_existing(
         &self,
         partition: &str,

--- a/runtime/src/storage/migration.rs
+++ b/runtime/src/storage/migration.rs
@@ -1,0 +1,636 @@
+//! Bounded same-directory replacement of an ordinary filesystem blob with an atomic backing.
+
+use super::{Header, Layout};
+use crate::Error;
+use commonware_cryptography::{Crc32, Hasher as _};
+use commonware_formatting::hex;
+use std::{
+    ffi::OsStr,
+    fs::{self, File, Metadata, OpenOptions},
+    io::{self, Seek as _, SeekFrom, Write as _},
+    os::unix::fs::{FileExt, MetadataExt as _},
+    path::{Path, PathBuf},
+};
+
+const COPY_BUFFER_LEN: usize = 1024 * 1024;
+const STAGE_FILE_NAME: &str = ".commonware-atomic-migrate";
+
+#[cfg(test)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum MigrationStep {
+    StageCreated,
+    ChunkCopied(u64),
+    StageSynced,
+    Renamed,
+}
+
+#[cfg(test)]
+fn migration_cut(step: MigrationStep, cut: Option<MigrationStep>) -> Result<(), Error> {
+    if cut == Some(step) {
+        return Err(io::Error::other("migration phase cut").into());
+    }
+    Ok(())
+}
+
+fn invalid_input(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message)
+}
+
+fn valid_file(metadata: &Metadata) -> bool {
+    metadata.file_type().is_file()
+}
+
+fn same_file(left: &Metadata, right: &Metadata) -> bool {
+    left.dev() == right.dev() && left.ino() == right.ino()
+}
+
+fn read_exact_at(file: &File, offset: u64, out: &mut [u8]) -> Result<(), Error> {
+    FileExt::read_exact_at(file, out, offset).map_err(Into::into)
+}
+
+fn has_atomic_identity(file: &File, logical_len: u64, data_offset: u64) -> Result<bool, Error> {
+    if data_offset != Layout::V1.data_offset() || logical_len < crate::atomic::IDENTITY_PAGE_LEN {
+        return Ok(false);
+    }
+    let mut page = [0u8; crate::atomic::IDENTITY_PAGE_LEN as usize];
+    read_exact_at(file, data_offset, &mut page)?;
+    Ok(crate::atomic::decode_identity(&page).is_some())
+}
+
+pub(super) fn stage_path(live_path: &Path) -> io::Result<PathBuf> {
+    live_path
+        .file_name()
+        .ok_or_else(|| invalid_input("migration target has no file name"))?;
+    Ok(live_path.with_file_name(STAGE_FILE_NAME))
+}
+
+/// Returns true only for the canonical hidden name used by migration staging in this directory.
+pub(super) fn is_stage_file_name(name: &OsStr) -> bool {
+    name == OsStr::new(STAGE_FILE_NAME)
+}
+
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+fn discard_stage(stage_path: &Path) -> io::Result<()> {
+    match fs::remove_file(stage_path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn ensure_current_source(live_path: &Path, source_metadata: &Metadata) -> Result<(), Error> {
+    let live_metadata = fs::symlink_metadata(live_path)?;
+    if !valid_file(source_metadata)
+        || !valid_file(&live_metadata)
+        || !same_file(source_metadata, &live_metadata)
+    {
+        return Err(invalid_input("migration source is no longer the live blob").into());
+    }
+    Ok(())
+}
+
+/// Replace the exact live source inode with a V1 inode whose logical bytes use the atomic format.
+///
+/// The caller serializes namespace access and excludes concurrent mutation through other handles.
+/// The source remains open and readable after replacement. A retry against an inode with a complete
+/// atomic identity only makes its directory ancestry durable.
+fn migrate_live_inner(
+    root: &Path,
+    partition: &str,
+    name: &[u8],
+    source: &File,
+    incarnation: [u8; 16],
+    #[cfg(test)] cut: Option<MigrationStep>,
+) -> Result<(), Error> {
+    crate::atomic::validate_atomic_location(partition, name)?;
+    let live_path = root.join(partition).join(hex(name));
+    let parent = live_path
+        .parent()
+        .ok_or_else(|| invalid_input("migration target has no parent directory"))?;
+
+    let source_metadata = source.metadata()?;
+    ensure_current_source(&live_path, &source_metadata)?;
+    source
+        .sync_all()
+        .map_err(|error| Error::BlobSyncFailed(partition.into(), hex(name), error.into()))?;
+
+    let raw_len = source_metadata.len();
+    if Header::missing(raw_len) {
+        return Err(Error::BlobCorrupt(
+            partition.into(),
+            hex(name),
+            "migration source has no complete header".into(),
+        ));
+    }
+    let mut raw = vec![0u8; Header::resolve_len(raw_len)];
+    read_exact_at(source, 0, &mut raw)?;
+    let (logical_len, blob_version, data_offset) =
+        Header::parse(&raw, raw_len, &(u16::MIN..=u16::MAX))
+            .map_err(|error| error.into_error(partition, name))?;
+    if blob_version == crate::DEFAULT_BLOB_VERSION
+        && has_atomic_identity(source, logical_len, data_offset)?
+    {
+        sync_directory(parent)?;
+        return Ok(());
+    }
+
+    let (atomic_header, atomic_version) =
+        Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION));
+    debug_assert_eq!(atomic_version, crate::DEFAULT_BLOB_VERSION);
+    let replacement_data_offset = (atomic_header.len() as u64)
+        .checked_add(crate::atomic::DATA_OFFSET)
+        .ok_or(Error::OffsetOverflow)?;
+    replacement_data_offset
+        .checked_add(logical_len)
+        .ok_or(Error::OffsetOverflow)?;
+
+    let stage_path = stage_path(&live_path)?;
+    discard_stage(&stage_path)?;
+    let mut replacement = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create_new(true)
+        .open(&stage_path)?;
+    #[cfg(test)]
+    migration_cut(MigrationStep::StageCreated, cut)?;
+    replacement.write_all(&atomic_header)?;
+    replacement.seek(SeekFrom::Start(replacement_data_offset))?;
+
+    let buffer_len = usize::try_from(logical_len.min(COPY_BUFFER_LEN as u64))
+        .expect("migration copy chunks fit in usize");
+    let mut buffer = vec![0u8; buffer_len];
+    let mut copied = 0u64;
+    let mut integrity_checksum = Crc32::default();
+    while copied < logical_len {
+        let len = usize::try_from((logical_len - copied).min(COPY_BUFFER_LEN as u64))
+            .expect("migration copy chunks fit in usize");
+        let source_offset = data_offset
+            .checked_add(copied)
+            .ok_or(Error::OffsetOverflow)?;
+        read_exact_at(source, source_offset, &mut buffer[..len])?;
+        integrity_checksum.update(&buffer[..len]);
+        replacement.write_all(&buffer[..len])?;
+        copied = copied
+            .checked_add(len as u64)
+            .ok_or(Error::OffsetOverflow)?;
+        #[cfg(test)]
+        migration_cut(MigrationStep::ChunkCopied(copied), cut)?;
+    }
+    let prefix = crate::atomic::migration_prefix(
+        incarnation,
+        logical_len,
+        integrity_checksum.finalize().1.as_u32(),
+    );
+    replacement.seek(SeekFrom::Start(atomic_header.len() as u64))?;
+    replacement.write_all(&prefix)?;
+    replacement.sync_all()?;
+    #[cfg(test)]
+    migration_cut(MigrationStep::StageSynced, cut)?;
+
+    fs::rename(&stage_path, &live_path)?;
+    #[cfg(test)]
+    migration_cut(MigrationStep::Renamed, cut)?;
+    sync_directory(parent)?;
+    Ok(())
+}
+
+pub(super) fn migrate_live(
+    root: &Path,
+    partition: &str,
+    name: &[u8],
+    source: &File,
+    incarnation: [u8; 16],
+) -> Result<(), Error> {
+    #[cfg(test)]
+    {
+        migrate_live_inner(root, partition, name, source, incarnation, None)
+    }
+    #[cfg(not(test))]
+    {
+        migrate_live_inner(root, partition, name, source, incarnation)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::{Layout, header::tests::v0_blob_bytes};
+    #[cfg(not(feature = "iouring-storage"))]
+    use crate::{
+        AtomicBlob as _, AtomicStorage as _, BufferPool, BufferPoolConfig, Storage as _,
+        storage::tokio::{Config as TokioConfig, Storage as TokioStorage},
+        telemetry::metrics::Registry,
+    };
+    use std::{
+        env,
+        ffi::OsString,
+        os::unix::ffi::OsStringExt,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    static NEXT_DIR: AtomicU64 = AtomicU64::new(0);
+
+    fn test_root(label: &str) -> PathBuf {
+        env::temp_dir().join(format!(
+            "commonware_{label}_{}_{}",
+            std::process::id(),
+            NEXT_DIR.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn source_bytes(v0: bool, version: u16, payload: &[u8]) -> Vec<u8> {
+        if v0 {
+            return v0_blob_bytes(version, payload);
+        }
+        let mut raw = Header::create(&(version..=version)).0;
+        raw.extend_from_slice(payload);
+        raw
+    }
+
+    #[cfg(not(feature = "iouring-storage"))]
+    fn test_pool() -> BufferPool {
+        let mut registry = Registry::default();
+        BufferPool::new(BufferPoolConfig::for_storage(), &mut registry)
+    }
+
+    #[test]
+    fn migration_streams_v0_and_v1_payloads_and_retry_is_inode_stable() {
+        const VERSION: u16 = 7;
+        const INCARNATION: [u8; 16] = [0x3C; 16];
+        for v0 in [true, false] {
+            for len in [
+                0,
+                1,
+                COPY_BUFFER_LEN - 1,
+                COPY_BUFFER_LEN,
+                COPY_BUFFER_LEN + 1,
+            ] {
+                let root = test_root("atomic_migration");
+                let partition = "partition";
+                let name = if v0 {
+                    b"v0".as_slice()
+                } else {
+                    b"v1".as_slice()
+                };
+                let parent = root.join(partition);
+                fs::create_dir_all(&parent).unwrap();
+                let live_path = parent.join(hex(name));
+                let payload = (0u8..=255).cycle().take(len).collect::<Vec<_>>();
+                let original = source_bytes(v0, VERSION, &payload);
+                fs::write(&live_path, &original).unwrap();
+                let source = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&live_path)
+                    .unwrap();
+                let source_inode = source.metadata().unwrap().ino();
+                let prefix = crate::atomic::migration_prefix(
+                    INCARNATION,
+                    payload.len() as u64,
+                    Crc32::checksum(&payload),
+                );
+
+                migrate_live(&root, partition, name, &source, INCARNATION).unwrap();
+
+                let migrated = fs::read(&live_path).unwrap();
+                assert_eq!(
+                    migrated.len(),
+                    Layout::V1.data_offset() as usize
+                        + crate::atomic::DATA_OFFSET as usize
+                        + payload.len()
+                );
+                let (logical_len, version, data_offset) = Header::parse(
+                    &migrated[..Layout::V1.data_offset() as usize],
+                    migrated.len() as u64,
+                    &(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION),
+                )
+                .unwrap();
+                assert_eq!(
+                    logical_len as usize,
+                    crate::atomic::DATA_OFFSET as usize + payload.len()
+                );
+                assert_eq!(version, crate::DEFAULT_BLOB_VERSION);
+                assert_eq!(data_offset, Layout::V1.data_offset());
+                assert_eq!(
+                    &migrated[..data_offset as usize],
+                    Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION))
+                        .0
+                        .as_slice()
+                );
+                let prefix_start = data_offset as usize;
+                assert_eq!(
+                    &migrated[prefix_start..prefix_start + prefix.len()],
+                    &prefix
+                );
+                assert_eq!(&migrated[prefix_start + prefix.len()..], &payload);
+                assert_ne!(source_inode, fs::metadata(&live_path).unwrap().ino());
+
+                let mut old = vec![0u8; original.len()];
+                read_exact_at(&source, 0, &mut old).unwrap();
+                assert_eq!(old, original);
+
+                let replacement = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(&live_path)
+                    .unwrap();
+                let replacement_inode = replacement.metadata().unwrap().ino();
+                migrate_live(&root, partition, name, &replacement, [0xA5; 16]).unwrap();
+                assert_eq!(replacement_inode, fs::metadata(&live_path).unwrap().ino());
+                assert_eq!(fs::read(&live_path).unwrap(), migrated);
+                assert!(!stage_path(&live_path).unwrap().exists());
+
+                fs::remove_dir_all(root).unwrap();
+            }
+        }
+    }
+
+    #[cfg(not(feature = "iouring-storage"))]
+    #[tokio::test]
+    async fn migration_phase_cuts_retry_through_a_fresh_storage_lineage() {
+        const VERSION: u16 = 7;
+        const INCARNATION: [u8; 16] = [0x3C; 16];
+        let payload = (0u8..=255)
+            .cycle()
+            .take(COPY_BUFFER_LEN + 1)
+            .collect::<Vec<_>>();
+        let ordinary = source_bytes(true, VERSION, &payload);
+        let atomic_header =
+            Header::create(&(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION)).0;
+        let prefix = crate::atomic::migration_prefix(
+            INCARNATION,
+            payload.len() as u64,
+            Crc32::checksum(&payload),
+        );
+        let mut atomic = atomic_header.clone();
+        atomic.extend_from_slice(&prefix);
+        atomic.extend_from_slice(&payload);
+        let steps = [
+            MigrationStep::StageCreated,
+            MigrationStep::ChunkCopied(COPY_BUFFER_LEN as u64),
+            MigrationStep::ChunkCopied((COPY_BUFFER_LEN + 1) as u64),
+            MigrationStep::StageSynced,
+            MigrationStep::Renamed,
+        ];
+
+        for cut in steps {
+            let root = test_root("atomic_migration_phase_cut");
+            let partition = "partition";
+            let name = b"blob";
+            let parent = root.join(partition);
+            fs::create_dir_all(&parent).unwrap();
+            let live_path = parent.join(hex(name));
+            fs::write(&live_path, &ordinary).unwrap();
+            let source = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(&live_path)
+                .unwrap();
+            let ordinary_inode = source.metadata().unwrap().ino();
+            let stage = stage_path(&live_path).unwrap();
+            let result =
+                migrate_live_inner(&root, partition, name, &source, INCARNATION, Some(cut));
+            assert!(result.is_err(), "cut {cut:?} completed migration");
+
+            if cut != MigrationStep::Renamed {
+                assert_eq!(fs::read(&live_path).unwrap(), ordinary);
+                let staged = fs::read(&stage).unwrap();
+                match cut {
+                    MigrationStep::StageCreated => assert!(staged.is_empty()),
+                    MigrationStep::ChunkCopied(copied) => {
+                        let payload_start =
+                            atomic_header.len() + crate::atomic::DATA_OFFSET as usize;
+                        assert_eq!(
+                            staged.len(),
+                            payload_start + usize::try_from(copied).unwrap()
+                        );
+                        assert_eq!(&staged[..atomic_header.len()], &atomic_header);
+                        assert!(
+                            staged[atomic_header.len()..payload_start]
+                                .iter()
+                                .all(|byte| *byte == 0)
+                        );
+                        assert_eq!(
+                            &staged[payload_start..],
+                            &payload[..usize::try_from(copied).unwrap()]
+                        );
+                    }
+                    MigrationStep::StageSynced => assert_eq!(staged, atomic),
+                    MigrationStep::Renamed => unreachable!(),
+                }
+            } else {
+                assert!(!stage.exists());
+                assert_ne!(fs::metadata(&live_path).unwrap().ino(), ordinary_inode);
+                assert_eq!(fs::read(&live_path).unwrap(), atomic);
+            }
+            drop(source);
+
+            let storage = TokioStorage::new(
+                TokioConfig::new(root.clone(), 2 * COPY_BUFFER_LEN),
+                test_pool(),
+            );
+            let (fresh, _, _) = storage
+                .open_versioned(partition, name, u16::MIN..=u16::MAX)
+                .await
+                .unwrap();
+            storage.migrate_atomic(fresh).await.unwrap();
+            assert!(!stage.exists());
+            let (blob, len) = storage.open_atomic(partition, name).await.unwrap();
+            assert_eq!(len as usize, payload.len());
+            assert_eq!(
+                blob.read_at(0, payload.len())
+                    .await
+                    .unwrap()
+                    .coalesce()
+                    .as_ref(),
+                payload
+            );
+            blob.append(b"!").await.unwrap();
+            blob.sync().await.unwrap();
+            drop(blob);
+            drop(storage);
+
+            let storage = TokioStorage::new(
+                TokioConfig::new(root.clone(), 2 * COPY_BUFFER_LEN),
+                test_pool(),
+            );
+            let (blob, len) = storage.open_atomic(partition, name).await.unwrap();
+            assert_eq!(len as usize, payload.len() + 1);
+            let mut expected = payload.clone();
+            expected.push(b'!');
+            assert_eq!(
+                blob.read_at(0, expected.len())
+                    .await
+                    .unwrap()
+                    .coalesce()
+                    .as_ref(),
+                expected
+            );
+            drop(blob);
+            drop(storage);
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+
+    #[test]
+    fn migration_recognizes_identity_only_canonical_image() {
+        const INSTALLED_INCARNATION: [u8; 16] = [0x3C; 16];
+        const RETRY_INCARNATION: [u8; 16] = [0xA5; 16];
+
+        let root = test_root("atomic_identity_only_migration");
+        let partition = "partition";
+        let name = b"blob";
+        let parent = root.join(partition);
+        fs::create_dir_all(&parent).unwrap();
+        let live_path = parent.join(hex(name));
+        let prefix = crate::atomic::migration_prefix(INSTALLED_INCARNATION, 0, 0);
+        let original = source_bytes(
+            false,
+            crate::DEFAULT_BLOB_VERSION,
+            &prefix[..crate::atomic::IDENTITY_PAGE_LEN as usize],
+        );
+        fs::write(&live_path, &original).unwrap();
+        let source = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live_path)
+            .unwrap();
+        let source_inode = source.metadata().unwrap().ino();
+
+        migrate_live(&root, partition, name, &source, RETRY_INCARNATION).unwrap();
+
+        assert_eq!(source_inode, fs::metadata(&live_path).unwrap().ino());
+        assert_eq!(fs::read(&live_path).unwrap(), original);
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn migration_wraps_identity_prefixed_noncanonical_container() {
+        const VERSION: u16 = 7;
+        const INCARNATION: [u8; 16] = [0x3C; 16];
+        let root = test_root("atomic_identity_prefixed_migration");
+        let partition = "partition";
+        let name = b"blob";
+        let parent = root.join(partition);
+        fs::create_dir_all(&parent).unwrap();
+        let live_path = parent.join(hex(name));
+        let mut payload = crate::atomic::migration_prefix([0xA5; 16], 0, 0).to_vec();
+        payload.extend_from_slice(b"ordinary payload");
+        fs::write(&live_path, source_bytes(false, VERSION, &payload)).unwrap();
+        let source = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live_path)
+            .unwrap();
+
+        migrate_live(&root, partition, name, &source, INCARNATION).unwrap();
+
+        let migrated = fs::read(&live_path).unwrap();
+        let (logical_len, version, data_offset) = Header::parse(
+            &migrated[..Layout::V1.data_offset() as usize],
+            migrated.len() as u64,
+            &(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION),
+        )
+        .unwrap();
+        assert_eq!(version, crate::DEFAULT_BLOB_VERSION);
+        assert_eq!(
+            logical_len,
+            crate::atomic::DATA_OFFSET + payload.len() as u64
+        );
+        let payload_start = data_offset as usize + crate::atomic::DATA_OFFSET as usize;
+        assert_eq!(&migrated[payload_start..], payload.as_slice());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn migration_discards_a_prior_stage_and_rejects_a_stale_source() {
+        let root = test_root("atomic_migration_stage");
+        let parent = root.join("partition");
+        fs::create_dir_all(&parent).unwrap();
+        let live_path = parent.join(hex(b"blob"));
+        fs::write(&live_path, source_bytes(false, 3, b"old")).unwrap();
+        let stale = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live_path)
+            .unwrap();
+        let stage = stage_path(&live_path).unwrap();
+        fs::write(&stage, b"abandoned partial replacement").unwrap();
+
+        let replacement = source_bytes(false, 3, b"new");
+        let replacement_path = parent.join("replacement");
+        fs::write(&replacement_path, &replacement).unwrap();
+        fs::rename(&replacement_path, &live_path).unwrap();
+        assert!(migrate_live(&root, "partition", b"blob", &stale, [0; 16],).is_err());
+        assert_eq!(fs::read(&live_path).unwrap(), replacement);
+        assert!(
+            stage.exists(),
+            "stale rejection must not touch another operation's stage"
+        );
+
+        let current = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live_path)
+            .unwrap();
+        migrate_live(&root, "partition", b"blob", &current, [0; 16]).unwrap();
+        assert!(!stage.exists());
+
+        fs::create_dir(&stage).unwrap();
+        assert!(discard_stage(&stage).is_err());
+        fs::remove_dir(&stage).unwrap();
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn migration_rejects_incomplete_source_layouts() {
+        let root = test_root("atomic_migration_invalid_source");
+        let partition = "partition";
+        let parent = root.join(partition);
+        fs::create_dir_all(&parent).unwrap();
+        let live_path = parent.join(hex(b"blob"));
+        fs::write(&live_path, []).unwrap();
+        let source = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&live_path)
+            .unwrap();
+
+        assert!(matches!(
+            migrate_live(&root, partition, b"blob", &source, [0; 16],),
+            Err(Error::BlobCorrupt(_, _, _))
+        ));
+        let mut byte = [0];
+        assert!(read_exact_at(&source, 0, &mut byte).is_err());
+
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn stage_names_are_exact() {
+        let stage = stage_path(Path::new("/tmp/626c6f62")).unwrap();
+        let stage_name = stage.file_name().unwrap();
+        assert_eq!(stage_name, OsStr::new(STAGE_FILE_NAME));
+        assert!(is_stage_file_name(stage_name));
+
+        let long_name = "ab".repeat(115);
+        let other_stage = stage_path(Path::new("/tmp").join(long_name).as_path()).unwrap();
+        assert_eq!(other_stage, stage);
+        for name in [
+            ".commonware-atomic-migrate-",
+            ".commonware-atomic-migrate-626c6f62",
+            ".commonware-atomic-migrate-ABC0",
+            ".commonware-atomic-migrate-xyz",
+            ".commonware-atomic-migrate0",
+            "commonware-atomic-migrate-626c6f62",
+            "626c6f62",
+        ] {
+            assert!(!is_stage_file_name(OsStr::new(name)), "{name}");
+        }
+        assert!(!is_stage_file_name(&OsString::from_vec(vec![0xff])));
+    }
+}

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -62,6 +62,9 @@ stability_scope!(BETA {
     mod header;
     pub(crate) use header::{Header, Layout};
 
+    #[cfg(unix)]
+    mod migration;
+
     /// Validate that a partition name contains only allowed characters.
     ///
     /// Partition names must only contain alphanumeric characters, dashes ('-'),
@@ -167,6 +170,14 @@ pub(crate) mod tests {
             let mut identifier = [self.tag; 16];
             identifier[8..].copy_from_slice(&ordinal.to_be_bytes());
             identifier
+        }
+
+        async fn migrate_atomic_backing(
+            &self,
+            blob: Self::Blob,
+            incarnation: [u8; 16],
+        ) -> Result<(), Error> {
+            crate::atomic::Backend::migrate_atomic_backing(&self.inner, blob, incarnation).await
         }
 
         async fn open_atomic_existing(

--- a/runtime/src/storage/tokio/blob.rs
+++ b/runtime/src/storage/tokio/blob.rs
@@ -110,6 +110,21 @@ impl Blob {
         }
     }
 
+    #[cfg(unix)]
+    pub(super) fn partition(&self) -> &str {
+        &self.partition
+    }
+
+    #[cfg(unix)]
+    pub(super) fn name(&self) -> &[u8] {
+        &self.name
+    }
+
+    #[cfg(unix)]
+    pub(super) fn file(&self) -> Arc<File> {
+        self.file.clone()
+    }
+
     fn sync_inner(file: &File, partition: &str, name: &[u8]) -> Result<(), Error> {
         // Data durability is the contract. `sync_data` covers the bytes and metadata required to
         // retrieve them, including file size, while avoiding timestamp-only journal commits.

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -36,6 +36,15 @@ async fn sync_dir(path: &Path) -> Result<(), Error> {
     })
 }
 
+#[cfg(unix)]
+async fn remove_migration_stage(path: &Path) -> Result<bool, Error> {
+    match fs::remove_file(path).await {
+        Ok(()) => Ok(true),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(Error::Io(error.into())),
+    }
+}
+
 /// Configuration for a [`Storage`].
 ///
 /// `storage_directory` must be owned by exactly one independently constructed [`Storage`] lineage
@@ -247,12 +256,22 @@ impl crate::Storage for Storage {
             .await
             .map_err(|_| Error::PartitionMissing(partition.into()))?;
         let mut blobs = Vec::new();
+        #[cfg(unix)]
+        let mut removed_stage = false;
         while let Some(entry) = entries.next_entry().await.map_err(|_| Error::ReadFailed)? {
             let file_type = entry.file_type().await.map_err(|_| Error::ReadFailed)?;
             if !file_type.is_file() {
                 return Err(Error::PartitionCorrupt(partition.into()));
             }
             let file_name = entry.file_name();
+            #[cfg(unix)]
+            if super::migration::is_stage_file_name(&file_name) {
+                // An interrupted migration can leave one full-size non-authoritative stage.
+                // Scanning is a namespace recovery point, so reclaim it instead of leaking the
+                // abandoned copy or exposing its reserved name.
+                removed_stage |= remove_migration_stage(&entry.path()).await?;
+                continue;
+            }
             if let Some(name) = file_name.to_str() {
                 // Reject anything that isn't canonical lowercase hex (no `0x`
                 // prefix, no whitespace) since `from_hex` is lenient and
@@ -264,6 +283,10 @@ impl crate::Storage for Storage {
 
                 blobs.push(decoded);
             }
+        }
+        #[cfg(unix)]
+        if removed_stage {
+            sync_dir(&path).await?;
         }
         Ok(blobs)
     }
@@ -278,6 +301,44 @@ impl crate::atomic::Backend for Storage {
 
     fn atomic_resources(&self) -> crate::atomic::AtomicResources {
         self.atomic_resources.clone()
+    }
+
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        #[cfg(not(unix))]
+        {
+            let _ = (blob, incarnation);
+            return Err(std::io::Error::new(
+                ErrorKind::Unsupported,
+                "atomic migration requires Unix inode identity",
+            )
+            .into());
+        }
+
+        #[cfg(unix)]
+        {
+            let partition = blob.partition().to_string();
+            let name = blob.name().to_vec();
+            let source = blob.file();
+            let root = self.cfg.storage_directory.clone();
+            let migration_partition = partition.clone();
+            let migration_name = name.clone();
+            let migration = tokio::task::spawn_blocking(move || {
+                super::migration::migrate_live(
+                    &root,
+                    &migration_partition,
+                    &migration_name,
+                    &source,
+                    incarnation,
+                )
+            });
+            migration
+                .await
+                .expect("an admitted atomic migration task is not externally abortable")
+        }
     }
 
     async fn open_atomic_existing(
@@ -328,12 +389,14 @@ impl crate::atomic::Backend for Storage {
 mod tests {
     use super::{Header, *};
     use crate::{
-        AtomicStorage as _, Blob, BufferPoolConfig, Storage as _, WriteOptions,
+        AtomicBlob as _, AtomicStorage as _, Blob, BufferPoolConfig, Storage as _, WriteOptions,
         storage::{Layout, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
     use commonware_utils::sys_rng;
     use rand::RngExt as _;
+    #[cfg(unix)]
+    use std::os::unix::fs::MetadataExt as _;
     use std::{
         env,
         sync::atomic::{AtomicU64, Ordering},
@@ -367,6 +430,26 @@ mod tests {
         let config = Config::new(storage_directory, 2 * 1024 * 1024);
         let storage = Storage::new(config, test_pool());
         run_storage_tests(storage).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_migration_stage_cleanup_is_classified() {
+        let root = atomic_test_directory("storage_tokio_atomic_stage_cleanup");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let missing = root.join("missing");
+        assert!(!remove_migration_stage(&missing).await.unwrap());
+
+        let file = root.join("file");
+        std::fs::write(&file, b"stage").unwrap();
+        assert!(remove_migration_stage(&file).await.unwrap());
+        assert!(!file.exists());
+
+        let directory = root.join("directory");
+        std::fs::create_dir(&directory).unwrap();
+        assert!(remove_migration_stage(&directory).await.is_err());
+        let _ = std::fs::remove_dir_all(root);
     }
 
     #[tokio::test]
@@ -432,7 +515,10 @@ mod tests {
     async fn test_atomic_rejects_v0_ordinary_lookalikes_without_mutation() {
         let storage_directory = atomic_test_directory("storage_tokio_atomic_v0_lookalike");
         let _ = std::fs::remove_dir_all(&storage_directory);
-        let original = crate::storage::header::tests::v0_atomic_lookalike_bytes();
+        let mut payload = crate::atomic::migration_prefix([0x11; 16], 0, 0).to_vec();
+        payload.extend_from_slice(b"ordinary tail");
+        let original =
+            crate::storage::header::tests::v0_blob_bytes(crate::DEFAULT_BLOB_VERSION, &payload);
         for (partition, name) in [("v0_atomic_open", b"open"), ("v0_atomic_scan", b"scan")] {
             let partition_path = storage_directory.join(partition);
             std::fs::create_dir_all(&partition_path).unwrap();
@@ -465,6 +551,190 @@ mod tests {
         ));
 
         drop(storage);
+        let _ = std::fs::remove_dir_all(storage_directory);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_atomic_backend_normalizes_container_and_retries_without_replacing_again() {
+        const VERSION: u16 = 7;
+        let storage_directory = atomic_test_directory("storage_tokio_atomic_migration");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+        let payload = (0u8..=255).cycle().take(160_003).collect::<Vec<_>>();
+        let (blob, _, version) = storage
+            .open_versioned("partition", b"blob", VERSION..=VERSION)
+            .await
+            .unwrap();
+        assert_eq!(version, VERSION);
+        blob.write_at(0, payload.clone(), WriteOptions::default())
+            .await
+            .unwrap();
+        let old = blob.clone();
+        let live_path = storage_directory.join("partition").join(hex(b"blob"));
+        let ordinary_inode = std::fs::metadata(&live_path).unwrap().ino();
+        let incarnation = [0x3C; 16];
+        let prefix = crate::atomic::migration_prefix(
+            incarnation,
+            payload.len() as u64,
+            commonware_cryptography::Crc32::checksum(&payload),
+        );
+
+        {
+            let _namespace = storage
+                .atomic_resources
+                .namespace
+                .clone()
+                .lock_owned()
+                .await;
+            crate::atomic::Backend::migrate_atomic_backing(&storage, blob, incarnation)
+                .await
+                .unwrap();
+        }
+
+        let migrated = std::fs::read(&live_path).unwrap();
+        let (logical_len, migrated_version, data_offset) = Header::parse(
+            &migrated[..Layout::V1.data_offset() as usize],
+            migrated.len() as u64,
+            &(crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION),
+        )
+        .unwrap();
+        assert_eq!(migrated_version, crate::DEFAULT_BLOB_VERSION);
+        assert_eq!(data_offset, Layout::V1.data_offset());
+        assert_eq!(logical_len as usize, prefix.len() + payload.len());
+        assert_eq!(
+            &migrated[data_offset as usize..data_offset as usize + prefix.len()],
+            &prefix
+        );
+        assert_eq!(&migrated[data_offset as usize + prefix.len()..], &payload);
+        assert_ne!(ordinary_inode, std::fs::metadata(&live_path).unwrap().ino());
+        let old_read = old.read_at(0, payload.len()).await.unwrap().coalesce();
+        assert_eq!(old_read.as_ref(), payload.as_slice());
+
+        let (retry, retry_len, retry_version) = storage
+            .open_versioned(
+                "partition",
+                b"blob",
+                crate::DEFAULT_BLOB_VERSION..=crate::DEFAULT_BLOB_VERSION,
+            )
+            .await
+            .unwrap();
+        assert_eq!(retry_len as usize, prefix.len() + payload.len());
+        assert_eq!(retry_version, crate::DEFAULT_BLOB_VERSION);
+        let migrated_inode = std::fs::metadata(&live_path).unwrap().ino();
+        {
+            let _namespace = storage
+                .atomic_resources
+                .namespace
+                .clone()
+                .lock_owned()
+                .await;
+            crate::atomic::Backend::migrate_atomic_backing(&storage, retry, [0xA5; 16])
+                .await
+                .unwrap();
+        }
+        assert_eq!(migrated_inode, std::fs::metadata(&live_path).unwrap().ino());
+        assert_eq!(std::fs::read(&live_path).unwrap(), migrated);
+
+        let _ = std::fs::remove_dir_all(storage_directory);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_atomic_storage_migration_preserves_public_value() {
+        const VERSION: u16 = 7;
+        let storage_directory = atomic_test_directory("storage_tokio_public_atomic_migration");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+        let payload = (0u8..=255).cycle().take(160_003).collect::<Vec<_>>();
+        let (ordinary, _, version) = storage
+            .open_versioned("partition", b"blob", VERSION..=VERSION)
+            .await
+            .unwrap();
+        assert_eq!(version, VERSION);
+        ordinary
+            .write_at(0, payload.clone(), WriteOptions::default())
+            .await
+            .unwrap();
+        let prior = ordinary.clone();
+
+        storage.migrate_atomic(ordinary).await.unwrap();
+        let (atomic, len) = storage.open_atomic("partition", b"blob").await.unwrap();
+        assert_eq!(len, payload.len() as u64);
+        assert_eq!(atomic.tag().await.unwrap(), [0; crate::ATOMIC_BLOB_TAG_LEN]);
+        let migrated = atomic.read_at(0, payload.len()).await.unwrap().coalesce();
+        assert_eq!(migrated.as_ref(), payload.as_slice());
+        let snapshot = atomic.integrity_snapshot().await.unwrap();
+        assert_eq!(snapshot.scheme, crate::IntegrityScheme::Unbound);
+        let (unit, tail) = snapshot.tail.unwrap();
+        assert_eq!(
+            unit,
+            crate::IntegrityUnit {
+                offset: 0,
+                len: payload.len() as u64,
+            }
+        );
+        assert_eq!(tail.coalesce().as_ref(), payload.as_slice());
+        let old = prior.read_at(0, payload.len()).await.unwrap().coalesce();
+        assert_eq!(old.as_ref(), payload.as_slice());
+
+        let token = atomic.integrity_snapshot().await.unwrap().token;
+        let append = atomic
+            .append_integrity(token, b"!", crate::IntegrityBoundary::Complete, None)
+            .await
+            .unwrap();
+        assert_eq!(append.offset, payload.len() as u64);
+        atomic.sync().await.unwrap();
+        drop(atomic);
+
+        let (atomic, len) = storage.open_atomic("partition", b"blob").await.unwrap();
+        assert_eq!(len, payload.len() as u64 + 1 + 4);
+        let mut completed = payload.clone();
+        completed.push(b'!');
+        assert_eq!(
+            atomic
+                .read_integrity(crate::IntegrityUnit {
+                    offset: 0,
+                    len: completed.len() as u64,
+                })
+                .await
+                .unwrap()
+                .coalesce()
+                .as_ref(),
+            completed.as_slice()
+        );
+
+        let _ = std::fs::remove_dir_all(storage_directory);
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_scan_discards_atomic_migration_stage() {
+        let storage_directory = atomic_test_directory("storage_tokio_atomic_migration_scan");
+        let _ = std::fs::remove_dir_all(&storage_directory);
+        let storage = Storage::new(
+            Config::new(storage_directory.clone(), 2 * 1024 * 1024),
+            test_pool(),
+        );
+        let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+        blob.sync().await.unwrap();
+        let partition_path = storage_directory.join("partition");
+        let stage =
+            crate::storage::migration::stage_path(&partition_path.join(hex(b"blob"))).unwrap();
+        std::fs::write(&stage, b"abandoned migration stage").unwrap();
+
+        assert_eq!(
+            storage.scan("partition").await.unwrap(),
+            vec![b"blob".to_vec()]
+        );
+        assert!(!stage.exists());
+
         let _ = std::fs::remove_dir_all(storage_directory);
     }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -923,6 +923,14 @@ impl crate::atomic::Backend for Context {
         crate::atomic::Backend::atomic_resources(&self.storage)
     }
 
+    async fn migrate_atomic_backing(
+        &self,
+        blob: Self::Blob,
+        incarnation: [u8; 16],
+    ) -> Result<(), Error> {
+        crate::atomic::Backend::migrate_atomic_backing(&self.storage, blob, incarnation).await
+    }
+
     async fn open_atomic_existing(
         &self,
         partition: &str,
@@ -946,8 +954,9 @@ impl crate::BufferPooler for Context {
 mod tests {
     use super::*;
     use crate::{
-        AtomicBlob as _, AtomicStorage as _, BatchOperation, Metrics, Network, Resolver,
-        Runner as _, Sink, Stream, telemetry::metrics::raw::Counter, tokio::telemetry,
+        AtomicBlob as _, AtomicStorage as _, BatchOperation, Blob as _, Metrics, Network, Resolver,
+        Runner as _, Sink, Storage as _, Stream, WriteOptions, telemetry::metrics::raw::Counter,
+        tokio::telemetry,
     };
     use bytes::Bytes;
     use std::{
@@ -1156,6 +1165,33 @@ mod tests {
             !returned_early,
             "a returned Context kept the Tokio runtime alive after Runner::start"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_atomic_migration_runs_through_tokio_context() {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        Runner::new(cfg).start(|context| async move {
+            let (ordinary, _) = context.open("migration", b"blob").await.unwrap();
+            ordinary
+                .write_at(0, b"payload", WriteOptions::default())
+                .await
+                .unwrap();
+            context.migrate_atomic(ordinary).await.unwrap();
+
+            let (atomic, len) = context.open_atomic("migration", b"blob").await.unwrap();
+            assert_eq!(len, b"payload".len() as u64);
+            assert_eq!(
+                atomic
+                    .read_at(0, b"payload".len())
+                    .await
+                    .unwrap()
+                    .coalesce(),
+                b"payload"
+            );
+        });
+        let _ = std::fs::remove_dir_all(storage_directory);
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Adds explicit ordinary-to-atomic migration on top of the core storage contract in #4490 and the remaining backend integrations in #4502. `AtomicStorage::migrate_atomic` converts an existing ordinary V0 or V1 blob while preserving its logical payload and installs the canonical default V1 container plus the atomic logical prefix.

This is layer 3 of 6 in the atomic blob stack. The production layers are separate review units but one atomic-storage release unit: merge them in order and do not release the core without this migration path.

The layer owns the entire migration capability:

- the public API and private backend hook across every runtime and wrapper;
- the migration-only committed root spelling and canonical prefix encoder;
- in-memory generation replacement;
- the bounded same-directory Unix stage, copy, checksum, sync, rename, and directory-sync engine; and
- stage cleanup, cancellation-safe ownership, metering, auditing, and injected precommit/postcommit failures.

## Migration contract

Migration synchronizes the source, verifies the exact live generation, and holds atomic-lineage exclusion plus the shared namespace lock through replacement. Filesystem work proceeds independently of the waiting observer after admission, so cancellation cannot expose an unfenced retry.

Only a complete atomic identity in the canonical default V1 container is classified as already installed. V0 and non-default V1 sources are wrapped even when their logical payload begins with valid-looking identity bytes. Retries are idempotent after rename or directory-sync ambiguity, and stale source handles cannot replace a newer generation.

## Review focus

- Container parsing preserves the logical payload across V0, default V1, and non-default V1 inputs.
- The committed root spelling lands with its sole producer, rather than leaking protocol grammar into the core PR.
- The Unix replacement order is source sync, bounded copy, stage sync, atomic rename, then parent-directory sync.
- Memory, Tokio, io_uring, deterministic, audited, metered, and faulty implementations expose one coherent all-or-nothing backend expansion.

## Diff size

- Production code: `+602 / -27 LOC`
- Tests and test infrastructure: `+1010 / -29 LOC`
- Total: `+1612 / -56 LOC`

Counts are physical diff lines, including comments and blank lines. Test-only files, hooks, and lines inside `#[cfg(test)]` modules are counted as tests; everything else is counted as production code.
